### PR TITLE
chore: treat 'already updating extension' failures as partially successful

### DIFF
--- a/deploy/Gruntfile.js
+++ b/deploy/Gruntfile.js
@@ -43,7 +43,20 @@ module.exports = function (grunt) {
                     zip: 'extension.zip',
                 },
             },
-            onError: e => grunt.fail.fatal(e.errorMsg),
+            onError: e => {
+                if (
+                    e.errors.itemError &&
+                    e.errors.itemError[0] &&
+                    e.errors.itemError[0].error_code === 'ITEM_NOT_UPDATABLE'
+                ) {
+                    grunt.log.write(
+                        'Cannot publish due to extension not being updatable. This is likely due to a previous deployment that is pending review. As such, marking this as partially successful.',
+                    );
+                    grunt.log.write('##vso[task.complete result=SucceededWithIssues;]DONE');
+                } else {
+                    grunt.fail.fatal(e.errorMsg);
+                }
+            },
             onExtensionPublished: info => {
                 if (!info.success) {
                     grunt.fail.fatal(JSON.stringify(info));


### PR DESCRIPTION
#### Description of changes

As discussed offline: we currently fail builds when the extension is deployed and it is pending review. Since we want to easily be able to ignore those kind of failures, we will now mark these as partially successful.

Please review the latest builds/releases for the playground extension in ADO to validate.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
