### PR TITLE
feat(text-reflow): Landmark guidance table reflow

### DIFF
--- a/src/content/test/landmarks/landmark-table.tsx
+++ b/src/content/test/landmarks/landmark-table.tsx
@@ -27,6 +27,11 @@ type LandmarkTableProps = {
 
 export const LandmarkTable = NamedFC<LandmarkTableProps>('LandmarkTable', ({ markup }) => (
     <table className="landmark-table">
+        <colgroup>
+            <col className="landmark-table-column" />
+            <col className="landmark-table-column" />
+            <col />
+        </colgroup>
         <tr>
             <th>Role</th>
             <th>HTML element</th>

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -14084,6 +14084,15 @@ exports[`Guidance Content pages test/landmarks/guidance matches the snapshot 1`]
             <table
               class="landmark-table"
             >
+              <colgroup>
+                <col
+                  class="landmark-table-column"
+                />
+                <col
+                  class="landmark-table-column"
+                />
+                <col />
+              </colgroup>
               <tbody>
                 <tr>
                   <th>

--- a/src/views/content/content.scss
+++ b/src/views/content/content.scss
@@ -28,6 +28,7 @@
     font-family: $fontFamily;
     font-size: 14px;
     margin: 10px;
+    word-break: break-word;
 
     table {
         font-family: $fontFamily;

--- a/src/views/content/content.scss
+++ b/src/views/content/content.scss
@@ -249,7 +249,14 @@
 
     .landmark-table {
         border-spacing: 5px;
-        padding-left: 32px;
+
+        @media screen and (min-width: 600px) {
+            padding-left: 32px;
+        }
+
+        .landmark-table-column {
+            width: 24%;
+        }
 
         .landmark-role {
             text-align: center;


### PR DESCRIPTION
#### Description of changes
The table for landmark guidance was not properly reflowing. This PR fixes that.

![guide](https://user-images.githubusercontent.com/4615491/84446732-08bd8300-abfb-11ea-9c19-b45c1511ef75.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
