### PR TITLE
feat(nav-bar-functionality): Use NarrowModeDetector for all instances of Headers

### DIFF
--- a/src/DetailsView/components/interactive-header.tsx
+++ b/src/DetailsView/components/interactive-header.tsx
@@ -29,7 +29,7 @@ export interface InteractiveHeaderProps {
 
 export const InteractiveHeader = NamedFC<InteractiveHeaderProps>('InteractiveHeader', props => {
     if (props.tabClosed) {
-        return <Header deps={props.deps} />;
+        return <Header deps={props.deps} isNarrowMode={props.isNarrowMode} />;
     }
 
     const getNavMenu = () => {

--- a/src/DetailsView/components/no-content-available/no-content-available-view.tsx
+++ b/src/DetailsView/components/no-content-available/no-content-available-view.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { Header, HeaderDeps } from 'common/components/header';
 import { NamedFC } from 'common/react/named-fc';
+import { NarrowModeDetector } from 'DetailsView/components/narrow-mode-detector';
 import { NoContentAvailable } from 'DetailsView/components/no-content-available/no-content-available';
 import * as React from 'react';
 
@@ -15,7 +16,11 @@ export const NoContentAvailableView = NamedFC<NoContentAvailableViewProps>(
     'NoContentAvailableView',
     ({ deps }) => (
         <>
-            <Header deps={deps} />
+            <NarrowModeDetector
+                isNarrowModeEnabled={true}
+                Component={Header}
+                childrenProps={{ deps: deps }}
+            />
             <NoContentAvailable />
         </>
     ),

--- a/src/debug-tools/components/debug-tools-view.tsx
+++ b/src/debug-tools/components/debug-tools-view.tsx
@@ -42,7 +42,6 @@ export const DebugTools = NamedFC<DebugToolsViewProps>('DebugToolsView', ({ deps
                 Component={Header}
                 childrenProps={headerProps}
             />
-            <Header deps={deps} />
             <DebugToolsNav deps={deps} state={storeState} className={styles.nav} />
             <CurrentView deps={deps} storeState={storeState} />
         </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/interactive-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/interactive-header.test.tsx.snap
@@ -100,5 +100,6 @@ exports[`InteractiveHeader render: tabClosed equals true 1`] = `
       "dropdownClickHandler": Object {},
     }
   }
+  isNarrowMode={false}
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/no-content-available/__snapshots__/no-content-available-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/no-content-available/__snapshots__/no-content-available-view.test.tsx.snap
@@ -2,14 +2,18 @@
 
 exports[`NoContentAvailableView renders 1`] = `
 <React.Fragment>
-  <Header
-    deps={
+  <NarrowModeDetector
+    Component={[Function]}
+    childrenProps={
       Object {
-        "textContent": Object {
-          "applicationTitle": "test-application-title",
+        "deps": Object {
+          "textContent": Object {
+            "applicationTitle": "test-application-title",
+          },
         },
       }
     }
+    isNarrowModeEnabled={true}
   />
   <NoContentAvailable />
 </React.Fragment>

--- a/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
@@ -15,13 +15,6 @@ exports[`DebugToolsView renders 1`] = `
     }
     isNarrowModeEnabled={true}
   />
-  <Header
-    deps={
-      Object {
-        "storesHub": null,
-      }
-    }
-  />
   <ToolsNav
     className="nav"
     deps={

--- a/src/tests/unit/tests/views/page/__snapshots__/page.test.tsx.snap
+++ b/src/tests/unit/tests/views/page/__snapshots__/page.test.tsx.snap
@@ -2,8 +2,14 @@
 
 exports[`page view renders 1`] = `
 <React.Fragment>
-  <Header
-    deps={Object {}}
+  <NarrowModeDetector
+    Component={[Function]}
+    childrenProps={
+      Object {
+        "deps": Object {},
+      }
+    }
+    isNarrowModeEnabled={true}
   />
   <main>
     INSIDE

--- a/src/views/page/page.tsx
+++ b/src/views/page/page.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { Header, HeaderDeps } from 'common/components/header';
 import { NamedFC } from 'common/react/named-fc';
+import { NarrowModeDetector } from 'DetailsView/components/narrow-mode-detector';
 
 export type PageProps = {
     deps: PageDeps;
@@ -14,7 +15,11 @@ export type PageDeps = HeaderDeps;
 export const Page = NamedFC<PageProps>('Page', ({ deps, children }) => {
     return (
         <>
-            <Header deps={deps} />
+            <NarrowModeDetector
+                isNarrowModeEnabled={true}
+                Component={Header}
+                childrenProps={{ deps: deps }}
+            />
             <main>{children}</main>
         </>
     );


### PR DESCRIPTION
#### Description of changes

Use NarrowModeDetector wherever we use the Header component, including content pages and the NoContentAvailable view and fix a few bugs with adding narrow mode detection to the header in other places.

![contentpageheadertitle](https://user-images.githubusercontent.com/55459788/84447178-32c37500-abfc-11ea-9765-b5d6b1a29717.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1724876
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
