### PR TITLE
feat(android-setup): prompt-connected-start-testing step UI

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-types.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-types.ts
@@ -20,6 +20,7 @@ export type AndroidSetupPageDeps = {
     androidSetupStepComponentProvider: AndroidSetupStepComponentProvider;
     LinkComponent: LinkComponentType;
     closeApp: () => void;
+    startTesting: () => void;
 };
 
 // 'Partial' is used to allow missing step IDs as they get implemented.

--- a/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
@@ -7,6 +7,7 @@ import { DetectServiceStep } from 'electron/views/device-connect-view/components
 import { InstallingServiceStep } from 'electron/views/device-connect-view/components/android-setup/installing-service-step';
 import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
 import { PromptConnectToDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step';
+import { PromptConnectedStartTestingStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step';
 import { PromptInstallFailedStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-failed-step';
 import { PromptInstallServiceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
 import { PromptLocateAdbStep } from 'electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step';
@@ -21,4 +22,5 @@ export const defaultAndroidSetupComponents: AndroidSetupStepComponentProvider = 
     'installing-service': InstallingServiceStep,
     'detect-devices': DetectDevicesStep,
     'detect-service': DetectServiceStep,
+    'prompt-connected-start-testing': PromptConnectedStartTestingStep,
 };

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../../../common/styles/fonts.scss';
+
+.device-description {
+    margin-top: 16px;
+    margin-bottom: 16px;
+}

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss
@@ -6,3 +6,7 @@
     margin-top: 16px;
     margin-bottom: 16px;
 }
+
+.rescan-button {
+    margin-top: 16px;
+}

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import {
+    DeviceDescription,
+    DeviceDescriptionProps,
+} from 'electron/views/device-connect-view/components/android-setup/device-description';
+import * as styles from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss';
+import { Button } from 'office-ui-fabric-react';
+import * as React from 'react';
+
+import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
+import { CommonAndroidSetupStepProps } from './android-setup-types';
+
+export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepProps>(
+    'PromptConnectedStartTestingStep',
+    (props: CommonAndroidSetupStepProps) => {
+        const { LinkComponent } = props.deps;
+
+        const onRescanButton = () => {
+            // To be implemented in future feature work
+            console.log(`androidSetupActionCreator.rescanDevices()`);
+        };
+
+        const layoutProps: AndroidSetupStepLayoutProps = {
+            headerText: 'Connected and ready to go!',
+            moreInfoLink: (
+                <LinkComponent href="https://aka.ms/accessibility-insights-for-android/otherDevice">
+                    How do I connect a different device?
+                </LinkComponent>
+            ),
+            leftFooterButtonProps: {
+                text: 'Cancel',
+                onClick: props.deps.androidSetupActionCreator.cancel,
+            },
+            rightFooterButtonProps: {
+                text: 'Start testing',
+                disabled: false,
+                onClick: props.deps.startTesting,
+            },
+        };
+
+        const descriptionProps: DeviceDescriptionProps = {
+            ...props.androidSetupStoreData.selectedDevice,
+            className: styles.deviceDescription,
+        };
+
+        return (
+            <AndroidSetupStepLayout {...layoutProps}>
+                <DeviceDescription {...descriptionProps}></DeviceDescription>
+                <Button text="Rescan device" onClick={onRescanButton} />
+            </AndroidSetupStepLayout>
+        );
+    },
+);

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
@@ -48,7 +48,11 @@ export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepPro
         return (
             <AndroidSetupStepLayout {...layoutProps}>
                 <DeviceDescription {...descriptionProps}></DeviceDescription>
-                <Button text="Rescan device" onClick={onRescanButton} />
+                <Button
+                    className={styles.rescanButton}
+                    text="Rescan devices"
+                    onClick={onRescanButton}
+                />
             </AndroidSetupStepLayout>
         );
     },

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -440,6 +440,11 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             null,
         );
 
+        const startTesting = () => {
+            windowStateActionCreator.setRoute({ routeId: 'resultsView' });
+            windowFrameActionCreator.maximize();
+        };
+
         const deps: RootContainerRendererDeps = {
             ipcRendererShim: ipcRendererShim,
             userConfigurationStore,
@@ -470,6 +475,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             reportExportServiceProvider: ReportExportServiceProviderImpl,
             androidSetupStepComponentProvider: defaultAndroidSetupComponents,
             closeApp: ipcRendererShim.closeWindow,
+            startTesting: startTesting,
         };
 
         window.insightsUserConfiguration = new UserConfigurationController(interpreter);

--- a/src/tests/unit/common/android-setup-step-props-builder.tsx
+++ b/src/tests/unit/common/android-setup-step-props-builder.tsx
@@ -24,6 +24,7 @@ export class AndroidSetupStepPropsBuilder extends BaseDataBuilder<CommonAndroidS
                 androidSetupActionCreator: null,
                 androidSetupStepComponentProvider: null,
                 closeApp: null,
+                startTesting: null,
             },
         };
     }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-step-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-step-container.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`AndroidSetupStepContainer passes common props and deps through 1`] = `
         "prompt-locate-adb": [Function],
       },
       "closeApp": null,
+      "startTesting": null,
     }
   }
   userConfigurationStoreData={

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-devices-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-devices-step.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`DetectDevicesStep renders 1`] = `
         "androidSetupActionCreator": null,
         "androidSetupStepComponentProvider": null,
         "closeApp": null,
+        "startTesting": null,
       }
     }
     spinnerLabel="Scanning for devices..."

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-service-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-service-step.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`DetectServiceStep renders 1`] = `
         "androidSetupActionCreator": null,
         "androidSetupStepComponentProvider": null,
         "closeApp": null,
+        "startTesting": null,
       }
     }
     disableCancel={true}

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/installing-service-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/installing-service-step.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`InstallingServiceStep renders 1`] = `
         "androidSetupActionCreator": null,
         "androidSetupStepComponentProvider": null,
         "closeApp": null,
+        "startTesting": null,
       }
     }
     spinnerLabel="Installing on your device..."

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PromptConnectedStartTestingStep renders with device 1`] = `
+<AndroidSetupStepLayout
+  headerText="Connected and ready to go!"
+  leftFooterButtonProps={
+    Object {
+      "onClick": [Function],
+      "text": "Cancel",
+    }
+  }
+  moreInfoLink={
+    <LinkComponent
+      href="https://aka.ms/accessibility-insights-for-android/otherDevice"
+    >
+      How do I connect a different device?
+    </LinkComponent>
+  }
+  rightFooterButtonProps={
+    Object {
+      "disabled": false,
+      "onClick": [Function],
+      "text": "Start testing",
+    }
+  }
+>
+  <DeviceDescription
+    className="deviceDescription"
+    description="Super-Duper Gadget"
+    isEmulator={false}
+  />
+  <Button
+    className="rescanButton"
+    onClick={[Function]}
+    text="Rescan devices"
+  />
+</AndroidSetupStepLayout>
+`;
+
+exports[`PromptConnectedStartTestingStep renders with emulator 1`] = `
+<AndroidSetupStepLayout
+  headerText="Connected and ready to go!"
+  leftFooterButtonProps={
+    Object {
+      "onClick": [Function],
+      "text": "Cancel",
+    }
+  }
+  moreInfoLink={
+    <LinkComponent
+      href="https://aka.ms/accessibility-insights-for-android/otherDevice"
+    >
+      How do I connect a different device?
+    </LinkComponent>
+  }
+  rightFooterButtonProps={
+    Object {
+      "disabled": false,
+      "onClick": [Function],
+      "text": "Start testing",
+    }
+  }
+>
+  <DeviceDescription
+    className="deviceDescription"
+    description="Emulator Extraordinaire"
+    isEmulator={true}
+  />
+  <Button
+    className="rescanButton"
+    onClick={[Function]}
+    text="Rescan devices"
+  />
+</AndroidSetupStepLayout>
+`;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
+import { DeviceMetadata } from 'electron/flux/types/device-metadata';
+import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
+import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
+import { PromptConnectedStartTestingStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
+import { IMock, It, Mock, MockBehavior } from 'typemoq';
+
+describe('PromptConnectedStartTestingStep', () => {
+    let props: CommonAndroidSetupStepProps;
+    let startTestingMock: IMock<typeof props.deps.startTesting>;
+    const mockCancelAction = Mock.ofInstance(_ => {}, MockBehavior.Strict);
+    let sampleAndroidSetupActionCreator: AndroidSetupActionCreator;
+
+    beforeEach(() => {
+        startTestingMock = Mock.ofInstance(() => {});
+        mockCancelAction.setup(m => m(It.isAny())).verifiable();
+        sampleAndroidSetupActionCreator = {
+            cancel: mockCancelAction.object,
+        } as AndroidSetupActionCreator;
+        props = new AndroidSetupStepPropsBuilder('prompt-connected-start-testing')
+            .withDep('startTesting', startTestingMock.object)
+            .withDep('androidSetupActionCreator', sampleAndroidSetupActionCreator)
+            .build();
+    });
+
+    it('renders with device', () => {
+        const selectedDevice: DeviceMetadata = {
+            isEmulator: false,
+            description: 'Super-Duper Gadget',
+        };
+
+        props.androidSetupStoreData.selectedDevice = selectedDevice;
+
+        const rendered = shallow(<PromptConnectedStartTestingStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('renders with emulator', () => {
+        const selectedDevice: DeviceMetadata = {
+            isEmulator: true,
+            description: 'Emulator Extraordinaire',
+        };
+
+        props.androidSetupStoreData.selectedDevice = selectedDevice;
+
+        const rendered = shallow(<PromptConnectedStartTestingStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('passes startTesting dep through', () => {
+        const stubEvent = {} as React.MouseEvent<HTMLButtonElement>;
+        const rendered = shallow(<PromptConnectedStartTestingStep {...props} />);
+        rendered.find(AndroidSetupStepLayout).prop('rightFooterButtonProps').onClick(stubEvent);
+        startTestingMock.verifyAll();
+    });
+
+    it('handles the cancel button with the cancel action', () => {
+        const rendered = shallow(<PromptConnectedStartTestingStep {...props} />);
+
+        const stubEvent = {} as React.MouseEvent<HTMLButtonElement>;
+        rendered.find(AndroidSetupStepLayout).prop('leftFooterButtonProps').onClick(stubEvent);
+
+        mockCancelAction.verifyAll();
+    });
+});


### PR DESCRIPTION
#### Description of changes
Created the dialog for the prompt-connected-start-testing step, with Cancel and Start Testing functionality. Have the "rescan devices" button, per the spec, but the functionality of the onClick will be updated in later feature work (per comment in `prompt-choose-device-step.tsx` line 26

Image of the UI
![image](https://user-images.githubusercontent.com/19158512/84459700-efc5c980-ac1c-11ea-9ab6-89586bd3aa8f.png)

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [X] Addresses an existing issue: https://dev.azure.com/mseng/1ES/_workitems/edit/1724351
- [X] Ran `yarn fastpass`
- [X] Added/updated relevant unit test(s) (and ran `yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [X] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
