### PR TITLE
feat(android-setup): Add support to remove port forwarding

### DIFF
--- a/src/electron/platform/android/android-service-configurator.ts
+++ b/src/electron/platform/android/android-service-configurator.ts
@@ -23,6 +23,7 @@ export interface AndroidServiceConfigurator {
     installService(deviceId: string): Promise<void>;
     uninstallService(deviceId: string): Promise<void>;
     setTcpForwarding(deviceId: string): Promise<void>;
+    removeTcpForwarding(deviceId: string): Promise<void>;
 }
 
 export interface AndroidServiceConfiguratorFactory {

--- a/src/electron/platform/android/appium-service-configurator.ts
+++ b/src/electron/platform/android/appium-service-configurator.ts
@@ -17,6 +17,8 @@ type AdbDevice = {
 const servicePackageName: string = 'com.microsoft.accessibilityinsightsforandroidservice';
 
 export class AppiumServiceConfigurator implements AndroidServiceConfigurator {
+    private portNumber: number = 62442;
+
     constructor(private readonly adb: ADB) {}
 
     public getConnectedDevices = async (): Promise<Array<DeviceInfo>> => {
@@ -81,8 +83,12 @@ export class AppiumServiceConfigurator implements AndroidServiceConfigurator {
     };
 
     public setTcpForwarding = async (deviceId: string): Promise<void> => {
-        const port: number = 62442;
         this.adb.setDeviceId(deviceId);
-        await this.adb.forwardPort(port, port);
+        await this.adb.forwardPort(this.portNumber, this.portNumber);
+    };
+
+    public removeTcpForwarding = async (deviceId: string): Promise<void> => {
+        this.adb.setDeviceId(deviceId);
+        await this.adb.removePortForward(this.portNumber);
     };
 }

--- a/src/electron/platform/android/appium-service-configurator.ts
+++ b/src/electron/platform/android/appium-service-configurator.ts
@@ -17,7 +17,7 @@ type AdbDevice = {
 const servicePackageName: string = 'com.microsoft.accessibilityinsightsforandroidservice';
 
 export class AppiumServiceConfigurator implements AndroidServiceConfigurator {
-    private portNumber: number = 62442;
+    private readonly portNumber: number = 62442;
 
     constructor(private readonly adb: ADB) {}
 


### PR DESCRIPTION
#### Description of changes
The unified client will configure the TCP port forwarding during setup, and it was called out that we ought to remove that port forwarding when the client exits. This change adds the appropriate wrapper around appium-adb.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
