### PR TITLE
tools: fix broken debug tools view

### DIFF
--- a/src/debug-tools/components/debug-tools-view.tsx
+++ b/src/debug-tools/components/debug-tools-view.tsx
@@ -18,6 +18,7 @@ import {
     DebugToolsNavState,
 } from 'debug-tools/components/debug-tools-nav';
 import { NarrowModeDetector } from 'DetailsView/components/narrow-mode-detector';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './debug-tools-view.scss';
 
@@ -34,6 +35,10 @@ export interface DebugToolsViewProps {
 }
 
 export const DebugTools = NamedFC<DebugToolsViewProps>('DebugToolsView', ({ deps, storeState }) => {
+    if (!deps.storesHub.hasStoreData()) {
+        return <Spinner size={SpinnerSize.large} label="Loading" />;
+    }
+
     const headerProps: Omit<HeaderProps, 'isNarrowMode'> = { deps };
     return (
         <div className={styles.debugToolsContainer}>

--- a/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
@@ -1,6 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DebugToolsView renders 1`] = `
+exports[`DebugToolsView renders when storesHub.hasStoresData = false 1`] = `
+<StyledSpinnerBase
+  label="Loading"
+  size={3}
+/>
+`;
+
+exports[`DebugToolsView renders when storesHub.hasStoresData = true 1`] = `
 <div
   className="debugToolsContainer"
 >
@@ -9,7 +16,10 @@ exports[`DebugToolsView renders 1`] = `
     childrenProps={
       Object {
         "deps": Object {
-          "storesHub": null,
+          "storesHub": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "stores": undefined,
+          },
         },
       }
     }
@@ -19,7 +29,10 @@ exports[`DebugToolsView renders 1`] = `
     className="nav"
     deps={
       Object {
-        "storesHub": null,
+        "storesHub": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "stores": undefined,
+        },
       }
     }
     state={
@@ -36,7 +49,10 @@ exports[`DebugToolsView renders 1`] = `
   <CurrentView
     deps={
       Object {
-        "storesHub": null,
+        "storesHub": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "stores": undefined,
+        },
       }
     }
     storeState={

--- a/src/tests/unit/tests/debug-tools/components/debug-tools-view.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/debug-tools-view.test.tsx
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
+import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import {
@@ -9,24 +11,36 @@ import {
 } from 'debug-tools/components/debug-tools-view';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { IMock, Mock } from 'typemoq';
 
+//
 describe('DebugToolsView', () => {
-    it('renders', () => {
-        const deps = {
-            storesHub: null,
-        } as DebugToolsViewDeps;
+    describe('renders', () => {
+        let storesHubMock: IMock<ClientStoresHub<DebugToolsViewState>>;
 
-        const storeState = {
-            userConfigurationStoreData: {
-                isFirstTime: true,
-            } as UserConfigurationStoreData,
-            featureFlagStoreData: {
-                reflowUI: true,
-            } as FeatureFlagStoreData,
-        } as DebugToolsViewState;
+        beforeEach(() => {
+            storesHubMock = Mock.ofType<ClientStoresHub<DebugToolsViewState>>(BaseClientStoresHub);
+        });
 
-        const wrapped = shallow(<DebugTools deps={deps} storeState={storeState} />);
+        it.each([true, false])('when storesHub.hasStoresData = %s', hasStoreData => {
+            storesHubMock.setup(hub => hub.hasStoreData()).returns(() => hasStoreData);
 
-        expect(wrapped.getElement()).toMatchSnapshot();
+            const deps = {
+                storesHub: storesHubMock.object,
+            } as DebugToolsViewDeps;
+
+            const storeState = {
+                userConfigurationStoreData: {
+                    isFirstTime: true,
+                } as UserConfigurationStoreData,
+                featureFlagStoreData: {
+                    reflowUI: true,
+                } as FeatureFlagStoreData,
+            } as DebugToolsViewState;
+
+            const wrapped = shallow(<DebugTools deps={deps} storeState={storeState} />);
+
+            expect(wrapped.getElement()).toMatchSnapshot();
+        });
     });
 });


### PR DESCRIPTION
#### Description of changes

I notice the debug tools view got broken:

```
Uncaught TypeError: Cannot read property 'reflowUI' of undefined
    at DebugToolsView (webpack-internal:///./src/debug-tools/components/debug-tools-view.tsx:8)
    at renderWithHooks (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:14803)
    at mountIndeterminateComponent (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:17482)
    at beginWork (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:18596)
    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:188)
    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:237)
    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:292)
    at beginWork$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:23203)
    at performUnitOfWork (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:22157)
    at workLoopSync (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:22130)
```

This is due to not checking the store data before using it on `DebugTools`.

Adding a guard clause to check if we actually have data before using it. If we don't, rendering a spinner.

**Note** I'm wondering if this is guard clause is something we should put on the `withStoreSubscription` HOC instead on the wrapped components.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
