### PR TITLE
feat(nav-bar-functionality): add left border to nav in panel

### DIFF
--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -101,6 +101,11 @@
             margin-top: 0px !important;
         }
         .ms-Nav-compositeLink {
+            a {
+                border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle $neutral-0;
+                border-top: 0px;
+                border-bottom: 0px;
+            }
             .ms-Button-label {
                 color: $neutral-100;
             }
@@ -119,6 +124,8 @@
             &.is-selected {
                 a {
                     background-color: $communication-tint-40;
+                    border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle
+                        $communication-primary;
                 }
                 a::after {
                     border-left: 0px;


### PR DESCRIPTION
#### Description of changes

Currently, the thick blue line on the left border of the selected nav link is missing when the nav bar is in a panel. This will add it back in:

<img width="283" alt="nav link left border" src="https://user-images.githubusercontent.com/55459788/84682438-7d8a0900-aeea-11ea-8ca9-71e7ce8d63c6.PNG">


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1733742
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
