### PR TITLE
feat(android-setup): replace DeviceMetadata with DeviceInfo

### DIFF
--- a/src/electron/flux/types/android-setup-store-data.ts
+++ b/src/electron/flux/types/android-setup-store-data.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DeviceMetadata } from 'electron/flux/types/device-metadata';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 
 export type AndroidSetupStoreData = {
     currentStepId: AndroidSetupStepId;
 
     // undefined if no device exists or if no device has been selected
-    selectedDevice?: DeviceMetadata;
+    selectedDevice?: DeviceInfo;
 };

--- a/src/electron/flux/types/device-metadata.ts
+++ b/src/electron/flux/types/device-metadata.ts
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-export type DeviceMetadata = {
-    isEmulator: boolean;
-    description: string;
-    currentApplication?: string;
-};

--- a/src/electron/views/device-connect-view/components/android-setup/device-description.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/device-description.tsx
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 
 import { NamedFC } from 'common/react/named-fc';
-import { DeviceMetadata } from 'electron/flux/types/device-metadata';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import { css, Icon } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './device-description.scss';
 
-export interface DeviceDescriptionProps extends DeviceMetadata {
+export interface DeviceDescriptionProps extends DeviceInfo {
     className?: string;
+    currentApplication?: string;
 }
 
 export const DeviceDescription = NamedFC<DeviceDescriptionProps>('DeviceDescription', props => {
@@ -20,12 +21,12 @@ export const DeviceDescription = NamedFC<DeviceDescriptionProps>('DeviceDescript
     if (props.currentApplication) {
         descriptionAndApp = (
             <div className={styles.deviceAndCurrentApplication}>
-                {props.description}
+                {props.friendlyName}
                 <div className={styles.currentApplication}>{props.currentApplication}</div>
             </div>
         );
     } else {
-        descriptionAndApp = props.description;
+        descriptionAndApp = props.friendlyName;
     }
 
     return (

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DeviceMetadata } from 'electron/flux/types/device-metadata';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import {
     CheckboxVisibility,
     DefaultButton,
@@ -17,7 +17,7 @@ import { DeviceDescription } from './device-description';
 import * as styles from './prompt-choose-device-step.scss';
 
 export type PromptChooseDeviceStepState = {
-    selectedDevice: DeviceMetadata;
+    selectedDevice: DeviceInfo;
 };
 
 export class PromptChooseDeviceStep extends React.Component<
@@ -33,7 +33,7 @@ export class PromptChooseDeviceStep extends React.Component<
             onSelectionChanged: () => {
                 const details = this.selection.getSelection();
                 if (details.length > 0) {
-                    this.setState({ selectedDevice: details[0] as DeviceMetadata });
+                    this.setState({ selectedDevice: details[0] as DeviceInfo });
                 }
             },
         });
@@ -51,17 +51,20 @@ export class PromptChooseDeviceStep extends React.Component<
         };
 
         // Available devices will be retrieved from store in future feature work
-        const devices: DeviceMetadata[] = [
+        const devices: DeviceInfo[] = [
             {
-                description: 'Phone 1',
+                id: '1',
+                friendlyName: 'Phone 1',
                 isEmulator: true,
             },
             {
-                description: 'Phone 2',
+                id: '2',
+                friendlyName: 'Phone 2',
                 isEmulator: false,
             },
             {
-                description: 'Phone 3',
+                id: '3',
+                friendlyName: 'Phone 3',
                 isEmulator: true,
             },
         ];

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
@@ -38,19 +38,22 @@ exports[`PromptChooseDeviceStep renders per snapshot 1`] = `
         Array [
           Object {
             "metadata": Object {
-              "description": "Phone 1",
+              "friendlyName": "Phone 1",
+              "id": "1",
               "isEmulator": true,
             },
           },
           Object {
             "metadata": Object {
-              "description": "Phone 2",
+              "friendlyName": "Phone 2",
+              "id": "2",
               "isEmulator": false,
             },
           },
           Object {
             "metadata": Object {
-              "description": "Phone 3",
+              "friendlyName": "Phone 3",
+              "id": "3",
               "isEmulator": true,
             },
           },

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
@@ -26,7 +26,8 @@ exports[`PromptConnectedStartTestingStep renders with device 1`] = `
 >
   <DeviceDescription
     className="deviceDescription"
-    description="Super-Duper Gadget"
+    friendlyName="Super-Duper Gadget"
+    id="1"
     isEmulator={false}
   />
   <Button
@@ -63,7 +64,8 @@ exports[`PromptConnectedStartTestingStep renders with emulator 1`] = `
 >
   <DeviceDescription
     className="deviceDescription"
-    description="Emulator Extraordinaire"
+    friendlyName="Emulator Extraordinaire"
+    id="1"
     isEmulator={true}
   />
   <Button

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
@@ -29,7 +29,8 @@ exports[`PromptGrantPermissionsStep renders with device 1`] = `
   </React.Fragment>
   <DeviceDescription
     className="deviceDescription"
-    description="Super-Duper Gadget"
+    friendlyName="Super-Duper Gadget"
+    id="1"
     isEmulator={false}
   />
   <CustomizedPrimaryButton
@@ -68,7 +69,8 @@ exports[`PromptGrantPermissionsStep renders with emulator 1`] = `
   </React.Fragment>
   <DeviceDescription
     className="deviceDescription"
-    description="Emulator Extraordinaire"
+    friendlyName="Emulator Extraordinaire"
+    id="1"
     isEmulator={true}
   />
   <CustomizedPrimaryButton

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-failed-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-failed-step.test.tsx.snap
@@ -29,7 +29,8 @@ exports[`PromptInstallFailedStep renders with device 1`] = `
   </React.Fragment>
   <DeviceDescription
     className="deviceDescription"
-    description="Super-Duper Gadget"
+    friendlyName="Super-Duper Gadget"
+    id="1"
     isEmulator={false}
   />
   <CustomizedPrimaryButton
@@ -68,7 +69,8 @@ exports[`PromptInstallFailedStep renders with emulator 1`] = `
   </React.Fragment>
   <DeviceDescription
     className="deviceDescription"
-    description="Emulator Extraordinaire"
+    friendlyName="Emulator Extraordinaire"
+    id="1"
     isEmulator={true}
   />
   <CustomizedPrimaryButton

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-service-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-service-step.test.tsx.snap
@@ -22,7 +22,8 @@ exports[`PromptInstallServiceStep renders with device 1`] = `
   </React.Fragment>
   <DeviceDescription
     className="deviceDescription"
-    description="Super-Duper Gadget"
+    friendlyName="Super-Duper Gadget"
+    id="1"
     isEmulator={false}
   />
   <CustomizedPrimaryButton
@@ -54,7 +55,8 @@ exports[`PromptInstallServiceStep renders with emulator 1`] = `
   </React.Fragment>
   <DeviceDescription
     className="deviceDescription"
-    description="Emulator Extraordinaire"
+    friendlyName="Emulator Extraordinaire"
+    id="1"
     isEmulator={true}
   />
   <CustomizedPrimaryButton

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/device-description.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/device-description.test.tsx
@@ -11,7 +11,8 @@ describe('DeviceDescription', () => {
     it('renders with device', () => {
         const props: DeviceDescriptionProps = {
             isEmulator: false,
-            description: 'Super-Duper Gadget',
+            friendlyName: 'Super-Duper Gadget',
+            id: '0',
         };
 
         const rendered = shallow(<DeviceDescription {...props} />);
@@ -21,7 +22,8 @@ describe('DeviceDescription', () => {
     it('renders with emulator', () => {
         const props: DeviceDescriptionProps = {
             isEmulator: true,
-            description: 'Emulator Extraordinaire',
+            friendlyName: 'Emulator Extraordinaire',
+            id: '1',
         };
 
         const rendered = shallow(<DeviceDescription {...props} />);
@@ -31,8 +33,9 @@ describe('DeviceDescription', () => {
     it('renders with extra classname', () => {
         const props: DeviceDescriptionProps = {
             isEmulator: true,
-            description: 'Simple Emulator',
+            friendlyName: 'Simple Emulator',
             className: 'my-class',
+            id: '2',
         };
 
         const rendered = shallow(<DeviceDescription {...props} />);
@@ -42,8 +45,9 @@ describe('DeviceDescription', () => {
     it('renders with currentApplication', () => {
         const props: DeviceDescriptionProps = {
             isEmulator: false,
-            description: 'Whizbang tablet',
+            friendlyName: 'Whizbang tablet',
             currentApplication: 'Wildlife Manager',
+            id: '3',
         };
 
         const rendered = shallow(<DeviceDescription {...props} />);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
-import { DeviceMetadata } from 'electron/flux/types/device-metadata';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { PromptConnectedStartTestingStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step';
@@ -29,9 +29,10 @@ describe('PromptConnectedStartTestingStep', () => {
     });
 
     it('renders with device', () => {
-        const selectedDevice: DeviceMetadata = {
+        const selectedDevice: DeviceInfo = {
             isEmulator: false,
-            description: 'Super-Duper Gadget',
+            friendlyName: 'Super-Duper Gadget',
+            id: '1',
         };
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;
@@ -41,9 +42,10 @@ describe('PromptConnectedStartTestingStep', () => {
     });
 
     it('renders with emulator', () => {
-        const selectedDevice: DeviceMetadata = {
+        const selectedDevice: DeviceInfo = {
             isEmulator: true,
-            description: 'Emulator Extraordinaire',
+            friendlyName: 'Emulator Extraordinaire',
+            id: '1',
         };
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DeviceMetadata } from 'electron/flux/types/device-metadata';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { PromptGrantPermissionsStep } from 'electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step';
 import { shallow } from 'enzyme';
@@ -15,9 +15,10 @@ describe('PromptGrantPermissionsStep', () => {
     });
 
     it('renders with device', () => {
-        const selectedDevice: DeviceMetadata = {
+        const selectedDevice: DeviceInfo = {
             isEmulator: false,
-            description: 'Super-Duper Gadget',
+            friendlyName: 'Super-Duper Gadget',
+            id: '1',
         };
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;
@@ -27,9 +28,10 @@ describe('PromptGrantPermissionsStep', () => {
     });
 
     it('renders with emulator', () => {
-        const selectedDevice: DeviceMetadata = {
+        const selectedDevice: DeviceInfo = {
             isEmulator: true,
-            description: 'Emulator Extraordinaire',
+            friendlyName: 'Emulator Extraordinaire',
+            id: '1',
         };
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DeviceMetadata } from 'electron/flux/types/device-metadata';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { PromptInstallFailedStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-failed-step';
 import { shallow } from 'enzyme';
@@ -15,9 +15,10 @@ describe('PromptInstallFailedStep', () => {
     });
 
     it('renders with device', () => {
-        const selectedDevice: DeviceMetadata = {
+        const selectedDevice: DeviceInfo = {
             isEmulator: false,
-            description: 'Super-Duper Gadget',
+            friendlyName: 'Super-Duper Gadget',
+            id: '1',
         };
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;
@@ -27,9 +28,10 @@ describe('PromptInstallFailedStep', () => {
     });
 
     it('renders with emulator', () => {
-        const selectedDevice: DeviceMetadata = {
+        const selectedDevice: DeviceInfo = {
             isEmulator: true,
-            description: 'Emulator Extraordinaire',
+            friendlyName: 'Emulator Extraordinaire',
+            id: '1',
         };
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-service-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-service-step.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DeviceMetadata } from 'electron/flux/types/device-metadata';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { PromptInstallServiceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
 import { shallow } from 'enzyme';
@@ -15,9 +15,10 @@ describe('PromptInstallServiceStep', () => {
     });
 
     it('renders with device', () => {
-        const selectedDevice: DeviceMetadata = {
+        const selectedDevice: DeviceInfo = {
             isEmulator: false,
-            description: 'Super-Duper Gadget',
+            friendlyName: 'Super-Duper Gadget',
+            id: '1',
         };
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;
@@ -27,9 +28,10 @@ describe('PromptInstallServiceStep', () => {
     });
 
     it('renders with emulator', () => {
-        const selectedDevice: DeviceMetadata = {
+        const selectedDevice: DeviceInfo = {
             isEmulator: true,
-            description: 'Emulator Extraordinaire',
+            friendlyName: 'Emulator Extraordinaire',
+            id: '1',
         };
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;


### PR DESCRIPTION
#### Description of changes

This PR should have no functional behavior differences. The DeviceMetadata class is removed and replaced with DeviceInfo so we can consolidate. The currentApplication field has been moved out into a prop for now. Because the current application info will come from a different place (the /config API call) than the other ADB information, it makes sense to separate things out. This also allows us to use the device ID in the UI, which will be helpful for sending the appropriate action back to the store.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
