### PR TITLE
feat(android-setup): add actions to prompt-choose-device-step

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -40,16 +40,6 @@ export class PromptChooseDeviceStep extends React.Component<
     }
 
     public render(): JSX.Element {
-        const onNextButton = () => {
-            // To be implemented in future feature work
-            console.log(`androidSetupActionCreator.next()`);
-        };
-
-        const onRescanButton = () => {
-            // To be implemented in future feature work
-            console.log(`androidSetupActionCreator.rescan()`);
-        };
-
         // Available devices will be retrieved from store in future feature work
         const devices: DeviceInfo[] = [
             {
@@ -76,7 +66,11 @@ export class PromptChooseDeviceStep extends React.Component<
             children: (
                 <>
                     <p>{devices.length} Android devices or emulators connected</p>
-                    <DefaultButton text="Rescan" onClick={onRescanButton} />
+                    <DefaultButton
+                        data-automation-id={'rescan'}
+                        text="Rescan"
+                        onClick={this.props.deps.androidSetupActionCreator.rescan}
+                    />
                     <DetailsList
                         setKey={'devices'}
                         compact={true}
@@ -114,7 +108,7 @@ export class PromptChooseDeviceStep extends React.Component<
             rightFooterButtonProps: {
                 text: 'Next',
                 disabled: this.state.selectedDevice === null,
-                onClick: onNextButton,
+                onClick: _ => this.props.deps.androidSetupActionCreator.next(),
             },
         };
 

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`PromptChooseDeviceStep renders per snapshot 1`] = `
        Android devices or emulators connected
     </p>
     <CustomizedDefaultButton
+      data-automation-id="rescan"
       onClick={[Function]}
       text="Rescan"
     />

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
@@ -11,11 +12,14 @@ import { IMock, Mock, Times } from 'typemoq';
 describe('PromptChooseDeviceStep', () => {
     let props: CommonAndroidSetupStepProps;
     let closeAppMock: IMock<typeof props.deps.closeApp>;
+    let actionMessageCreatorMock: IMock<AndroidSetupActionCreator>;
 
     beforeEach(() => {
         closeAppMock = Mock.ofInstance(() => {});
+        actionMessageCreatorMock = Mock.ofType(AndroidSetupActionCreator);
         props = new AndroidSetupStepPropsBuilder('prompt-choose-device')
             .withDep('closeApp', closeAppMock.object)
+            .withDep('androidSetupActionCreator', actionMessageCreatorMock.object)
             .build();
     });
 
@@ -29,6 +33,20 @@ describe('PromptChooseDeviceStep', () => {
         const rendered = shallow(<PromptChooseDeviceStep {...props} />);
         rendered.find(AndroidSetupStepLayout).prop('leftFooterButtonProps').onClick(stubEvent);
         closeAppMock.verify(m => m(), Times.once());
+    });
+
+    it('passes rescan dep through', () => {
+        const rendered = shallow(<PromptChooseDeviceStep {...props} />);
+        const rescanButton = rendered.find({ 'data-automation-id': 'rescan' });
+        rescanButton.simulate('click');
+        actionMessageCreatorMock.verify(m => m.rescan(), Times.once());
+    });
+
+    it('passes next dep through', () => {
+        const stubEvent = {} as React.MouseEvent<HTMLButtonElement>;
+        const rendered = shallow(<PromptChooseDeviceStep {...props} />);
+        rendered.find(AndroidSetupStepLayout).prop('rightFooterButtonProps').onClick(stubEvent);
+        actionMessageCreatorMock.verify(m => m.next(), Times.once());
     });
 
     it('next button becomes enabled after device is selected', () => {


### PR DESCRIPTION
#### Description of changes

This PR links button invocations to their associated actions for the prompt-choose-device step.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
