### PR TITLE
feat(android-setup): add actions to prompt-connect-to-device-step

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
@@ -6,15 +6,11 @@ import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 
+export const detectDeviceAutomationId = 'detect-device';
 export const PromptConnectToDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptConnectToDeviceStep',
     (props: CommonAndroidSetupStepProps) => {
         const { LinkComponent } = props.deps;
-
-        const onDetectButton = () => {
-            // To be implemented in future feature work
-            console.log(`androidSetupActionCreator.detectDevices()`);
-        };
 
         const layoutProps: AndroidSetupStepLayoutProps = {
             headerText: 'Connect to your Android device',
@@ -36,7 +32,11 @@ export const PromptConnectToDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
 
         return (
             <AndroidSetupStepLayout {...layoutProps}>
-                <PrimaryButton text="Detect my device" onClick={onDetectButton} />
+                <PrimaryButton
+                    data-automation-id={detectDeviceAutomationId}
+                    text="Detect my device"
+                    onClick={props.deps.androidSetupActionCreator.next}
+                />
             </AndroidSetupStepLayout>
         );
     },

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connect-to-device-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connect-to-device-step.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`PromptConnectToDeviceStep renders per snapshot 1`] = `
   }
 >
   <CustomizedPrimaryButton
+    data-automation-id="detect-device"
     onClick={[Function]}
     text="Detect my device"
   />

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.test.tsx
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
-import { PromptConnectToDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step';
+import {
+    detectDeviceAutomationId,
+    PromptConnectToDeviceStep,
+} from 'electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
@@ -11,11 +15,14 @@ import { IMock, Mock, Times } from 'typemoq';
 describe('PromptConnectToDeviceStep', () => {
     let props: CommonAndroidSetupStepProps;
     let closeAppMock: IMock<typeof props.deps.closeApp>;
+    let androidSetupActionCreatorMock: IMock<AndroidSetupActionCreator>;
 
     beforeEach(() => {
         closeAppMock = Mock.ofInstance(() => {});
+        androidSetupActionCreatorMock = Mock.ofType(AndroidSetupActionCreator);
         props = new AndroidSetupStepPropsBuilder('prompt-connect-to-device')
             .withDep('closeApp', closeAppMock.object)
+            .withDep('androidSetupActionCreator', androidSetupActionCreatorMock.object)
             .build();
     });
 
@@ -29,5 +36,11 @@ describe('PromptConnectToDeviceStep', () => {
         const rendered = shallow(<PromptConnectToDeviceStep {...props} />);
         rendered.find(AndroidSetupStepLayout).prop('leftFooterButtonProps').onClick(stubEvent);
         closeAppMock.verify(m => m(), Times.once());
+    });
+
+    it('invokes next action when detect devices selected', () => {
+        const rendered = shallow(<PromptConnectToDeviceStep {...props} />);
+        rendered.find({ 'data-automation-id': detectDeviceAutomationId }).simulate('click');
+        androidSetupActionCreatorMock.verify(m => m.next(), Times.once());
     });
 });


### PR DESCRIPTION
#### Description of changes

This PR links button invocations to their associated actions for the prompt-connect-to-device step.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
