### PR TITLE
feat(nav-bar-functionality): render expandable nav links as buttons

### DIFF
--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -10,7 +10,7 @@
             .ms-Nav-compositeLink {
                 &.is-selected {
                     background-color: $communication-tint-20;
-                    a {
+                    button {
                         background-color: $communication-tint-20 !important;
                     }
                 }
@@ -24,7 +24,7 @@
                     }
                 }
                 &:hover {
-                    a {
+                    button {
                         background-color: $nav-link-hover !important;
                     }
                 }
@@ -101,10 +101,11 @@
             margin-top: 0px !important;
         }
         .ms-Nav-compositeLink {
-            a {
+            button {
                 border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle $neutral-0;
                 border-top: 0px;
                 border-bottom: 0px;
+                text-align: center;
             }
             .ms-Button-label {
                 color: $neutral-100;
@@ -122,12 +123,19 @@
                 border-color: $neutral-20;
             }
             &.is-selected {
-                a {
+                button {
                     background-color: $communication-tint-40;
                     border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle
                         $communication-primary;
+                    .ms-Button-label {
+                        color: $highlighted-text;
+                    }
+                    .overview-percent,
+                    .dark-gray {
+                        color: $overview-percent-selected;
+                    }
                 }
-                a::after {
+                button::after {
                     border-left: 0px;
                 }
                 .ms-Button-label {

--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -10,6 +10,7 @@
             .ms-Nav-compositeLink {
                 &.is-selected {
                     background-color: $communication-tint-20;
+                    a,
                     button {
                         background-color: $communication-tint-20 !important;
                     }
@@ -24,6 +25,7 @@
                     }
                 }
                 &:hover {
+                    a,
                     button {
                         background-color: $nav-link-hover !important;
                     }
@@ -101,6 +103,7 @@
             margin-top: 0px !important;
         }
         .ms-Nav-compositeLink {
+            a,
             button {
                 border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle $neutral-0;
                 border-top: 0px;
@@ -123,6 +126,7 @@
                 border-color: $neutral-20;
             }
             &.is-selected {
+                a,
                 button {
                     background-color: $communication-tint-40;
                     border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle
@@ -135,6 +139,7 @@
                         color: $overview-percent-selected;
                     }
                 }
+                a::after,
                 button::after {
                     border-left: 0px;
                 }

--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -312,7 +312,6 @@ export class LeftNavLinkBuilder {
         return {
             name: name,
             key: key,
-            forceAnchor: true,
             url: '',
             index,
             onRenderNavLink: onRenderNavLink,

--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -224,6 +224,7 @@ export class LeftNavLinkBuilder {
             links: [gettingStartedLink, ...requirementLinks],
             isExpanded: isExpanded,
             testType: assessment.visualizationType,
+            forceAnchor: false,
         };
 
         return testLink;
@@ -312,6 +313,7 @@ export class LeftNavLinkBuilder {
         return {
             name: name,
             key: key,
+            forceAnchor: true,
             url: '',
             index,
             onRenderNavLink: onRenderNavLink,

--- a/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
@@ -316,7 +316,7 @@ describe('LeftNavBuilder', () => {
                 const expectedTestLink = {
                     name: assessmentStub.title,
                     key: VisualizationType[visualizationType],
-                    forceAnchor: true,
+                    forceAnchor: false,
                     url: '',
                     index: startingIndexStub + linkIndex,
                     iconProps: {


### PR DESCRIPTION
#### Description of changes

Render expandable links in the left nav as buttons instead of anchor links. This will fix an issue where pressing spacebar while an expandable link is in focus scrolls the nav instead of expanding the link.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1733742
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
