### PR TITLE
feat(android-setup): add actions to prompt-connected-start-testing-step

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
@@ -17,11 +17,6 @@ export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepPro
     (props: CommonAndroidSetupStepProps) => {
         const { LinkComponent } = props.deps;
 
-        const onRescanButton = () => {
-            // To be implemented in future feature work
-            console.log(`androidSetupActionCreator.rescanDevices()`);
-        };
-
         const layoutProps: AndroidSetupStepLayoutProps = {
             headerText: 'Connected and ready to go!',
             moreInfoLink: (
@@ -31,7 +26,7 @@ export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepPro
             ),
             leftFooterButtonProps: {
                 text: 'Cancel',
-                onClick: props.deps.androidSetupActionCreator.cancel,
+                onClick: _ => props.deps.androidSetupActionCreator.cancel(),
             },
             rightFooterButtonProps: {
                 text: 'Start testing',
@@ -51,7 +46,7 @@ export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepPro
                 <Button
                     className={styles.rescanButton}
                     text="Rescan devices"
-                    onClick={onRescanButton}
+                    onClick={props.deps.androidSetupActionCreator.rescan}
                 />
             </AndroidSetupStepLayout>
         );

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
@@ -9,7 +9,7 @@ import * as styles from 'electron/views/device-connect-view/components/android-s
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 
 describe('PromptConnectedStartTestingStep', () => {
     let props: CommonAndroidSetupStepProps;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
@@ -5,26 +5,23 @@ import { DeviceInfo } from 'electron/platform/android/android-service-configurat
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { PromptConnectedStartTestingStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step';
+import * as styles from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
-import { IMock, It, Mock, MockBehavior } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('PromptConnectedStartTestingStep', () => {
     let props: CommonAndroidSetupStepProps;
     let startTestingMock: IMock<typeof props.deps.startTesting>;
-    const mockCancelAction = Mock.ofInstance(_ => {}, MockBehavior.Strict);
-    let sampleAndroidSetupActionCreator: AndroidSetupActionCreator;
+    let androidSetupActionCreatorMock: IMock<AndroidSetupActionCreator>;
 
     beforeEach(() => {
         startTestingMock = Mock.ofInstance(() => {});
-        mockCancelAction.setup(m => m(It.isAny())).verifiable();
-        sampleAndroidSetupActionCreator = {
-            cancel: mockCancelAction.object,
-        } as AndroidSetupActionCreator;
+        androidSetupActionCreatorMock = Mock.ofType(AndroidSetupActionCreator);
         props = new AndroidSetupStepPropsBuilder('prompt-connected-start-testing')
             .withDep('startTesting', startTestingMock.object)
-            .withDep('androidSetupActionCreator', sampleAndroidSetupActionCreator)
+            .withDep('androidSetupActionCreator', androidSetupActionCreatorMock.object)
             .build();
     });
 
@@ -63,10 +60,14 @@ describe('PromptConnectedStartTestingStep', () => {
 
     it('handles the cancel button with the cancel action', () => {
         const rendered = shallow(<PromptConnectedStartTestingStep {...props} />);
-
         const stubEvent = {} as React.MouseEvent<HTMLButtonElement>;
         rendered.find(AndroidSetupStepLayout).prop('leftFooterButtonProps').onClick(stubEvent);
+        androidSetupActionCreatorMock.verify(m => m.cancel(), Times.once());
+    });
 
-        mockCancelAction.verifyAll();
+    it('handles the rescan button with the rescan action', () => {
+        const rendered = shallow(<PromptConnectedStartTestingStep {...props} />);
+        rendered.find(`.${styles.rescanButton}`).simulate('click');
+        androidSetupActionCreatorMock.verify(m => m.rescan(), Times.once());
     });
 });


### PR DESCRIPTION
#### Description of changes

This PR adds actions for the prompt-connected-start-testing step. This is part of a series of PRs that links up actions for each android setup step.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
