### PR TITLE
feat(android-setup): add actions to prompt-grant-permissions-step

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
@@ -11,20 +11,11 @@ import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-s
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 import * as styles from './prompt-grant-permissions-step.scss';
 
+export const tryAgainAutomationId = 'try-again';
 export const PromptGrantPermissionsStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptGrantPermissionsStep',
     (props: CommonAndroidSetupStepProps) => {
         const { LinkComponent } = props.deps;
-
-        const onCancelButton = () => {
-            // To be implemented in future feature work
-            console.log(`androidSetupActionCreator.cancel()`);
-        };
-
-        const onTryAgain = () => {
-            // To be implemented in future feature work
-            console.log(`androidSetupActionCreator.checkPermissions()`);
-        };
 
         const layoutProps: AndroidSetupStepLayoutProps = {
             headerText: 'Grant permissions on your device',
@@ -35,7 +26,7 @@ export const PromptGrantPermissionsStep = NamedFC<CommonAndroidSetupStepProps>(
             ),
             leftFooterButtonProps: {
                 text: 'Cancel',
-                onClick: onCancelButton,
+                onClick: _ => props.deps.androidSetupActionCreator.cancel(),
             },
             rightFooterButtonProps: {
                 text: 'Next',
@@ -56,7 +47,11 @@ export const PromptGrantPermissionsStep = NamedFC<CommonAndroidSetupStepProps>(
                     on and has permission to access your device and capture screenshots.
                 </>
                 <DeviceDescription {...descriptionProps}></DeviceDescription>
-                <PrimaryButton text="Try again" onClick={onTryAgain} />
+                <PrimaryButton
+                    text="Try again"
+                    data-automation-id={tryAgainAutomationId}
+                    onClick={props.deps.androidSetupActionCreator.next}
+                />
             </AndroidSetupStepLayout>
         );
     },

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`PromptGrantPermissionsStep renders with device 1`] = `
     isEmulator={false}
   />
   <CustomizedPrimaryButton
+    data-automation-id="try-again"
     onClick={[Function]}
     text="Try again"
   />
@@ -74,6 +75,7 @@ exports[`PromptGrantPermissionsStep renders with emulator 1`] = `
     isEmulator={true}
   />
   <CustomizedPrimaryButton
+    data-automation-id="try-again"
     onClick={[Function]}
     text="Try again"
   />

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
@@ -1,17 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
-import { PromptGrantPermissionsStep } from 'electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step';
+import {
+    PromptGrantPermissionsStep,
+    tryAgainAutomationId,
+} from 'electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
+import { IMock, Mock, Times } from 'typemoq';
 
 describe('PromptGrantPermissionsStep', () => {
     let props: CommonAndroidSetupStepProps;
+    let androidSetupActionCreatorMock: IMock<AndroidSetupActionCreator>;
 
     beforeEach(() => {
-        props = new AndroidSetupStepPropsBuilder('prompt-grant-permissions').build();
+        androidSetupActionCreatorMock = Mock.ofType(AndroidSetupActionCreator);
+        props = new AndroidSetupStepPropsBuilder('prompt-grant-permissions')
+            .withDep('androidSetupActionCreator', androidSetupActionCreatorMock.object)
+            .build();
     });
 
     it('renders with device', () => {
@@ -38,5 +47,11 @@ describe('PromptGrantPermissionsStep', () => {
 
         const rendered = shallow(<PromptGrantPermissionsStep {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('calls next action when try again button is selected', () => {
+        const rendered = shallow(<PromptGrantPermissionsStep {...props} />);
+        rendered.find({ 'data-automation-id': tryAgainAutomationId }).simulate('click');
+        androidSetupActionCreatorMock.verify(m => m.next(), Times.once());
     });
 });


### PR DESCRIPTION
#### Description of changes

One of several PRs to link button selection to actions in the android-setup steps.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
