### PR TITLE
feat(android-setup): add actions to install-service step

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/prompt-install-service-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-install-service-step.tsx
@@ -11,24 +11,15 @@ import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-s
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 import * as styles from './prompt-install-service-step.scss';
 
+export const installAutomationId = 'install';
 export const PromptInstallServiceStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptInstallServiceStep',
     (props: CommonAndroidSetupStepProps) => {
-        const onCancelButton = () => {
-            // To be implemented in future feature work
-            console.log(`androidSetupActionCreator.cancel()`);
-        };
-
-        const onInstallButton = () => {
-            // To be implemented in future feature work
-            console.log(`androidSetupActionCreator.installService()`);
-        };
-
         const layoutProps: AndroidSetupStepLayoutProps = {
             headerText: 'Let us install the latest version on your device',
             leftFooterButtonProps: {
                 text: 'Cancel',
-                onClick: onCancelButton,
+                onClick: _ => props.deps.androidSetupActionCreator.cancel(),
             },
             rightFooterButtonProps: {
                 text: 'Next',
@@ -49,7 +40,11 @@ export const PromptInstallServiceStep = NamedFC<CommonAndroidSetupStepProps>(
                     either missing or out of date. We'll need to install the latest version.
                 </>
                 <DeviceDescription {...descriptionProps}></DeviceDescription>
-                <PrimaryButton text="Install" onClick={onInstallButton} />
+                <PrimaryButton
+                    text="Install"
+                    data-automation-id={installAutomationId}
+                    onClick={props.deps.androidSetupActionCreator.next}
+                />
             </AndroidSetupStepLayout>
         );
     },

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-service-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-service-step.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`PromptInstallServiceStep renders with device 1`] = `
     isEmulator={false}
   />
   <CustomizedPrimaryButton
+    data-automation-id="install"
     onClick={[Function]}
     text="Install"
   />
@@ -60,6 +61,7 @@ exports[`PromptInstallServiceStep renders with emulator 1`] = `
     isEmulator={true}
   />
   <CustomizedPrimaryButton
+    data-automation-id="install"
     onClick={[Function]}
     text="Install"
   />

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-service-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-service-step.test.tsx
@@ -1,17 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
+import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
-import { PromptInstallServiceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
+import {
+    installAutomationId,
+    PromptInstallServiceStep,
+} from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
+import { IMock, Mock, Times } from 'typemoq';
 
 describe('PromptInstallServiceStep', () => {
     let props: CommonAndroidSetupStepProps;
+    let androidSetupActionCreatorMock: IMock<AndroidSetupActionCreator>;
 
     beforeEach(() => {
-        props = new AndroidSetupStepPropsBuilder('prompt-install-service').build();
+        androidSetupActionCreatorMock = Mock.ofType(AndroidSetupActionCreator);
+        props = new AndroidSetupStepPropsBuilder('prompt-install-service')
+            .withDep('androidSetupActionCreator', androidSetupActionCreatorMock.object)
+            .build();
     });
 
     it('renders with device', () => {
@@ -38,5 +48,18 @@ describe('PromptInstallServiceStep', () => {
 
         const rendered = shallow(<PromptInstallServiceStep {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('calls cancel action when cancel button selected', () => {
+        const rendered = shallow(<PromptInstallServiceStep {...props} />);
+        const stubEvent = {} as React.MouseEvent<HTMLButtonElement>;
+        rendered.find(AndroidSetupStepLayout).prop('leftFooterButtonProps').onClick(stubEvent);
+        androidSetupActionCreatorMock.verify(m => m.cancel(), Times.once());
+    });
+
+    it('handles the install button with the next action', () => {
+        const rendered = shallow(<PromptInstallServiceStep {...props} />);
+        rendered.find({ 'data-automation-id': installAutomationId }).simulate('click');
+        androidSetupActionCreatorMock.verify(m => m.next(), Times.once());
     });
 });


### PR DESCRIPTION
#### Description of changes

Linking up actions to button invoking in install-service dialog step

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
