### PR TITLE
feat(android-setup): Add prompt-choose-device state machine step

### DIFF
--- a/src/electron/flux/action-creator/android-setup-action-creator.ts
+++ b/src/electron/flux/action-creator/android-setup-action-creator.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 
 export class AndroidSetupActionCreator {
     constructor(private readonly setupActions: AndroidSetupActions) {}
@@ -9,6 +10,6 @@ export class AndroidSetupActionCreator {
     public next = () => this.setupActions.next.invoke();
     public rescan = () => this.setupActions.rescan.invoke();
     public saveAdbPath = (newAdbPath: string) => this.setupActions.saveAdbPath.invoke(newAdbPath);
-    public setSelectedDevice = (selectedDeviceId: string) =>
-        this.setupActions.setSelectedDevice.invoke(selectedDeviceId);
+    public setSelectedDevice = (device: DeviceInfo) =>
+        this.setupActions.setSelectedDevice.invoke(device);
 }

--- a/src/electron/flux/action/android-setup-actions.ts
+++ b/src/electron/flux/action/android-setup-actions.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Action } from 'common/flux/action';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 
 // This class needs only to represent possible simultaneously invokable actions
 // So, for example, the 'next' action may represent 'continue', 'str again', or 'start scanning'
@@ -9,5 +10,5 @@ export class AndroidSetupActions {
     public readonly next = new Action<void>();
     public readonly rescan = new Action<void>();
     public readonly saveAdbPath = new Action<string>();
-    public readonly setSelectedDevice = new Action<string>();
+    public readonly setSelectedDevice = new Action<DeviceInfo>();
 }

--- a/src/electron/flux/store/android-setup-store.ts
+++ b/src/electron/flux/store/android-setup-store.ts
@@ -6,6 +6,7 @@ import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setu
 import { AndroidSetupActions } from '../action/android-setup-actions';
 import { AndroidSetupStoreData } from '../types/android-setup-store-data';
 
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import {
     AndroidSetupStateMachine,
     AndroidSetupStateMachineFactory,
@@ -25,6 +26,8 @@ export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
         super.initialize(initialState);
         this.stateMachine = this.createAndroidSetupStateMachine({
             stepTransition: this.stepTransition,
+            setSelectedDevice: this.setSelectedDevice,
+            setAvailableDevices: this.setAvailableDevices,
         });
     }
 
@@ -53,5 +56,15 @@ export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
     private stepTransition = (nextStep: AndroidSetupStepId): void => {
         this.state.currentStepId = nextStep;
         this.emitChanged();
+    };
+
+    private setSelectedDevice = (device: DeviceInfo): void => {
+        // emitChange will be called from step transition when the step changes
+        this.state.selectedDevice = device;
+    };
+
+    private setAvailableDevices = (devices: DeviceInfo[]): void => {
+        // emitChange will be called from step transition when the step changes
+        this.state.availableDevices = devices;
     };
 }

--- a/src/electron/flux/types/android-setup-state-machine-types.ts
+++ b/src/electron/flux/types/android-setup-state-machine-types.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { StateMachine } from 'electron/platform/android/setup/state-machine/state-machine';
 import { AndroidSetupActions } from '../action/android-setup-actions';
@@ -11,6 +12,8 @@ export type AndroidSetupStepTransitionCallback = (nextStep: AndroidSetupStepId) 
 
 export type AndroidSetupStoreCallbacks = {
     stepTransition: AndroidSetupStepTransitionCallback;
+    setSelectedDevice: (device: DeviceInfo) => void;
+    setAvailableDevices: (devices: DeviceInfo[]) => void;
 };
 
 export type AndroidSetupStateMachineFactory = (

--- a/src/electron/flux/types/android-setup-store-data.ts
+++ b/src/electron/flux/types/android-setup-store-data.ts
@@ -8,4 +8,6 @@ export type AndroidSetupStoreData = {
 
     // undefined if no device exists or if no device has been selected
     selectedDevice?: DeviceInfo;
+
+    availableDevices?: DeviceInfo[];
 };

--- a/src/electron/platform/android/setup/steps/detect-devices.ts
+++ b/src/electron/platform/android/setup/steps/detect-devices.ts
@@ -11,6 +11,9 @@ export const detectDevices: AndroidSetupStepConfig = deps => {
             },
         },
         onEnter: async () => {
+            deps.setSelectedDevice(null);
+            deps.setAvailableDevices([]);
+
             const devices = await deps.getDevices();
 
             switch (devices.length) {
@@ -20,10 +23,12 @@ export const detectDevices: AndroidSetupStepConfig = deps => {
                 }
                 case 1: {
                     deps.setSelectedDeviceId(devices[0].id);
+                    deps.setSelectedDevice(devices[0]);
                     deps.stepTransition('detect-service');
                     break;
                 }
                 default: {
+                    deps.setAvailableDevices(devices);
                     deps.stepTransition('prompt-choose-device');
                     break;
                 }

--- a/src/electron/platform/android/setup/steps/prompt-choose-device.ts
+++ b/src/electron/platform/android/setup/steps/prompt-choose-device.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
+import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
+
+export const promptChooseDevice: AndroidSetupStepConfig = deps => {
+    return {
+        actions: {
+            rescan: () => deps.stepTransition('detect-devices'),
+            setSelectedDevice: (device: DeviceInfo) => {
+                deps.setSelectedDeviceId(device.id);
+                deps.setSelectedDevice(device);
+                deps.stepTransition('detect-service');
+            },
+        },
+    };
+};

--- a/src/tests/unit/tests/electron/flux/action-creator/android-setup-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/android-setup-action-creator.test.ts
@@ -3,6 +3,7 @@
 import { Action } from 'common/flux/action';
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import { IMock, Mock, Times } from 'typemoq';
 
 describe(AndroidSetupActionCreator, () => {
@@ -42,13 +43,19 @@ describe(AndroidSetupActionCreator, () => {
     });
 
     it('invokes setSelectedDevice action on setSelectedDevice', () => {
-        const actionMock = Mock.ofType<Action<string>>();
+        const testDevice: DeviceInfo = {
+            id: 'Robbie',
+            friendlyName: 'Robbie the robot',
+            isEmulator: true,
+        };
+
+        const actionMock = Mock.ofType<Action<DeviceInfo>>();
         androidSetupActionsMock
             .setup(actions => actions.setSelectedDevice)
             .returns(() => actionMock.object);
-        actionMock.setup(s => s.invoke('new-device-id')).verifiable(Times.once());
+        actionMock.setup(s => s.invoke(testDevice)).verifiable(Times.once());
 
-        testSubject.setSelectedDevice('new-device-id');
+        testSubject.setSelectedDevice(testDevice);
         actionMock.verifyAll();
     });
 

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-devices.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-devices.test.ts
@@ -35,6 +35,8 @@ describe('Android setup step: detectDevices', () => {
             .returns(_ => p)
             .verifiable(Times.once());
 
+        depsMock.setup(m => m.setSelectedDevice(null)).verifiable(Times.once());
+        depsMock.setup(m => m.setAvailableDevices([])).verifiable(Times.once());
         depsMock.setup(m => m.stepTransition('prompt-connect-to-device')).verifiable(Times.once());
 
         const step = detectDevices(depsMock.object);
@@ -58,8 +60,11 @@ describe('Android setup step: detectDevices', () => {
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.stepTransition('detect-service')).verifiable(Times.once());
+        depsMock.setup(m => m.setSelectedDevice(null)).verifiable(Times.once());
+        depsMock.setup(m => m.setAvailableDevices([])).verifiable(Times.once());
         depsMock.setup(m => m.setSelectedDeviceId('device1')).verifiable(Times.once());
+        depsMock.setup(m => m.setSelectedDevice(devices[0])).verifiable(Times.once());
+        depsMock.setup(m => m.stepTransition('detect-service')).verifiable(Times.once());
 
         const step = detectDevices(depsMock.object);
         await step.onEnter();
@@ -85,6 +90,9 @@ describe('Android setup step: detectDevices', () => {
             .returns(_ => p)
             .verifiable(Times.once());
 
+        depsMock.setup(m => m.setSelectedDevice(null)).verifiable(Times.once());
+        depsMock.setup(m => m.setAvailableDevices([])).verifiable(Times.once());
+        depsMock.setup(m => m.setAvailableDevices(devices)).verifiable(Times.once());
         depsMock.setup(m => m.stepTransition('prompt-choose-device')).verifiable(Times.once());
 
         const step = detectDevices(depsMock.object);

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-choose-device.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-choose-device.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
+import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import { promptChooseDevice } from 'electron/platform/android/setup/steps/prompt-choose-device';
+import { Mock, MockBehavior, Times } from 'typemoq';
+import { checkExpectedActionsAreDefined } from './actions-tester';
+
+describe('Android setup step: promptChooseDevice', () => {
+    it('has expected properties', () => {
+        const deps = {} as AndroidSetupStepConfigDeps;
+        const step = promptChooseDevice(deps);
+        checkExpectedActionsAreDefined(step, ['rescan', 'setSelectedDevice']);
+        expect(step.onEnter).not.toBeDefined();
+    });
+
+    it('rescan transitions to detect-adb as expected', () => {
+        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
+        depsMock.setup(m => m.stepTransition('detect-devices')).verifiable(Times.once());
+
+        const step = promptChooseDevice(depsMock.object);
+        step.actions.rescan();
+
+        depsMock.verifyAll();
+    });
+
+    it('setSelectedDevice transitions to detect-service as expected', () => {
+        const testDevice: DeviceInfo = {
+            id: 'Hal9000',
+            friendlyName: 'Hal',
+            isEmulator: true,
+        };
+
+        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
+        depsMock.setup(m => m.stepTransition('detect-service')).verifiable(Times.once());
+        depsMock.setup(m => m.setSelectedDeviceId(testDevice.id)).verifiable(Times.once());
+        depsMock.setup(m => m.setSelectedDevice(testDevice)).verifiable(Times.once());
+
+        const step = promptChooseDevice(depsMock.object);
+        step.actions.setSelectedDevice(testDevice);
+
+        depsMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-connected-start-testing.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-connected-start-testing.test.ts
@@ -14,7 +14,7 @@ describe('Android setup step: promptConnectedStartTesting', () => {
         expect(step.onEnter).not.toBeDefined();
     });
 
-    it('onEnter transitions to detect-adb as expected', () => {
+    it('rescan transitions to detect-adb as expected', () => {
         const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock.setup(m => m.stepTransition('detect-adb')).verifiable(Times.once());
 


### PR DESCRIPTION
#### Description of changes

- Add functions to set the current device and available devices in the Android setup store
- Modify setSelectionDevice action to take a DeviceInfo structure
- Update detect-devices step to set available devices in store

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
