### PR TITLE
refactor: clean up css in left nav + requirement link scss

### DIFF
--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -6,17 +6,17 @@
 
 :global(.reflow-ui) {
     .left-nav {
-        :global {
-            .ms-Nav-compositeLink {
-                &.is-selected {
+        li {
+            :global {
+                .is-selected {
                     background-color: $communication-tint-20;
                     a,
                     button {
                         background-color: $communication-tint-20 !important;
                     }
                 }
-                &.is-expanded,
-                &.is-expanded + ul {
+                .is-expanded,
+                .is-expanded + ul {
                     background-color: $communication-tint-40;
                     .index-circle {
                         color: $neutral-0;
@@ -24,11 +24,12 @@
                         border-color: $neutral-0;
                     }
                 }
-                &:hover {
-                    a,
-                    button {
-                        background-color: $nav-link-hover !important;
-                    }
+            }
+
+            > div:hover {
+                a,
+                button {
+                    background-color: $nav-link-hover !important;
                 }
             }
         }

--- a/src/DetailsView/components/requirement-link.scss
+++ b/src/DetailsView/components/requirement-link.scss
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+@import '../../common/styles/colors.scss';
+
 .req-description {
     line-height: initial;
     text-align: left;
@@ -17,4 +20,27 @@
     .req-name {
         margin-right: 3px;
     }
+}
+
+.requirement-link {
+    :global {
+        .status-icon {
+            color: $primary-text;
+            margin-left: 24px;
+            font-size: 18px;
+            &.negative-outcome-icon {
+                color: $negative-outcome;
+            }
+            &.positive-outcome-icon {
+                color: $positive-outcome;
+            }
+        }
+    }
+
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    height: 100%;
+    align-items: center;
+    width: 100%;
 }

--- a/src/DetailsView/components/requirement-link.tsx
+++ b/src/DetailsView/components/requirement-link.tsx
@@ -17,7 +17,7 @@ export interface RequirementLinkProps {
 export class RequirementLink extends React.Component<RequirementLinkProps> {
     public render(): JSX.Element {
         return (
-            <span className={'button-flex-container'} aria-hidden="true">
+            <span className={styles.requirementLink} aria-hidden="true">
                 {this.props.renderRequirementDescription(this)}
                 <StatusIcon status={this.props.status} level="requirement" />
             </span>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-link.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-link.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`RequirementLink renders with index 1`] = `
 <span
   aria-hidden="true"
-  className="button-flex-container"
+  className="requirementLink"
 >
   <span
     className="ms-Button-label reqDescription"
@@ -33,7 +33,7 @@ exports[`RequirementLink renders with index 1`] = `
 exports[`RequirementLink renders without index 1`] = `
 <span
   aria-hidden="true"
-  className="button-flex-container"
+  className="requirementLink"
 >
   <span
     className="ms-Button-label reqDescription"


### PR DESCRIPTION
#### Description of changes

1. removes usages of class we don't control from office fabric in the left nav (ms-compositel link or something)
2. refactors requirement-link styles to separate file. button-flex-container is a class that is being used in a few places and I wanted to ensure that future changes (for status-icon) will not be impacted because of this.

After is left and before is right (sorry): 

![image](https://user-images.githubusercontent.com/32555133/84830917-392c6500-afdf-11ea-8325-2ee3d23b351d.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
