### PR TITLE
feat(android-setup): add android setup UI component for detect-permissions

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-types.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-types.ts
@@ -24,8 +24,4 @@ export type AndroidSetupPageDeps = {
     startTesting: () => void;
 } & FolderPickerDeps;
 
-// 'Partial' is used to allow missing step IDs as they get implemented.
-// Once all step IDs have components, we should remove 'Partial'
-export type AndroidSetupStepComponentProvider = Partial<
-    Record<AndroidSetupStepId, AndroidSetupStep>
->;
+export type AndroidSetupStepComponentProvider = Record<AndroidSetupStepId, AndroidSetupStep>;

--- a/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
@@ -3,6 +3,7 @@
 import { AndroidSetupStepComponentProvider } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { DetectAdbStep } from 'electron/views/device-connect-view/components/android-setup/detect-adb-step';
 import { DetectDevicesStep } from 'electron/views/device-connect-view/components/android-setup/detect-devices-step';
+import { DetectPermissionsStep } from 'electron/views/device-connect-view/components/android-setup/detect-permissions-step';
 import { DetectServiceStep } from 'electron/views/device-connect-view/components/android-setup/detect-service-step';
 import { InstallingServiceStep } from 'electron/views/device-connect-view/components/android-setup/installing-service-step';
 import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
@@ -21,6 +22,7 @@ export const defaultAndroidSetupComponents: AndroidSetupStepComponentProvider = 
     'prompt-install-service': PromptInstallServiceStep,
     'prompt-install-failed': PromptInstallFailedStep,
     'prompt-grant-permissions': PromptGrantPermissionsStep,
+    'detect-permissions': DetectPermissionsStep,
     'installing-service': InstallingServiceStep,
     'detect-devices': DetectDevicesStep,
     'detect-service': DetectServiceStep,

--- a/src/electron/views/device-connect-view/components/android-setup/detect-permissions-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/detect-permissions-step.tsx
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import * as React from 'react';
+import { AndroidSetupSpinnerStep } from './android-setup-spinner-step';
+import { CommonAndroidSetupStepProps } from './android-setup-types';
+
+export const DetectPermissionsStep = NamedFC<CommonAndroidSetupStepProps>(
+    'DetectPermissionsStep',
+    (props: CommonAndroidSetupStepProps) => {
+        return (
+            <main>
+                <AndroidSetupSpinnerStep deps={props.deps} spinnerLabel="Checking permissions..." />
+            </main>
+        );
+    },
+);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-permissions-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-permissions-step.test.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DetectDevicesStep renders 1`] = `
+<main>
+  <AndroidSetupSpinnerStep
+    deps={
+      Object {
+        "LinkComponent": [Function],
+        "androidSetupActionCreator": null,
+        "androidSetupStepComponentProvider": null,
+        "closeApp": null,
+        "showOpenFileDialog": null,
+        "startTesting": null,
+      }
+    }
+    spinnerLabel="Checking permissions..."
+  />
+</main>
+`;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/android-setup-step-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/android-setup-step-container.test.tsx
@@ -2,20 +2,23 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import { AndroidSetupStepContainer } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-container';
+import { AndroidSetupStepComponentProvider } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { render, shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
 
 describe('AndroidSetupStepContainer', () => {
+    const provider = {
+        'detect-adb': NamedFC('DetectTestComponent', p => (
+            <>test component A {p.androidSetupStoreData.currentStepId}</>
+        )),
+        'prompt-locate-adb': NamedFC('PromptTestComponent', p => (
+            <>test component B {p.androidSetupStoreData.currentStepId}</>
+        )),
+    } as AndroidSetupStepComponentProvider;
+
     const props = new AndroidSetupStepPropsBuilder('detect-adb')
-        .withDep('androidSetupStepComponentProvider', {
-            'detect-adb': NamedFC('DetectTestComponent', p => (
-                <>test component A {p.androidSetupStoreData.currentStepId}</>
-            )),
-            'prompt-locate-adb': NamedFC('PromptTestComponent', p => (
-                <>test component B {p.androidSetupStoreData.currentStepId}</>
-            )),
-        })
+        .withDep('androidSetupStepComponentProvider', provider)
         .build();
 
     it('passes common props and deps through', () => {

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/detect-permissions-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/detect-permissions-step.test.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DetectPermissionsStep } from 'electron/views/device-connect-view/components/android-setup/detect-permissions-step';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
+
+describe('DetectDevicesStep', () => {
+    const props = new AndroidSetupStepPropsBuilder('detect-permissions').build();
+
+    it('renders', () => {
+        const rendered = shallow(<DetectPermissionsStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

This PR adds a spinner UI component for the state machine step 'detect-permissions', which was missing. We don't expect to stay on steps like these for long, but are adding spinner UIs for now. This allows the workflow to continue to the start-testing dialog.

out of scope - it might make sense to further consolidate the spinner dialogs into a single component so we don't need to write new classes / tests when the only change is the spinner label. Will revisit in a separate PR if spinners stay

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
