### PR TITLE
fix: background color should extend for entire right panel

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -193,6 +193,7 @@ div.insights-file-issue-details-dialog-container {
 #details-container {
     display: flex;
     flex-direction: column;
+    height: 100%;
 
     .ms-Nav-compositeLink a {
         border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle $neutral-0;
@@ -244,6 +245,7 @@ div.insights-file-issue-details-dialog-container {
         grid-template-rows: 1fr;
         width: 100%;
         min-height: 0;
+        height: 100%;
         &.reflow-ui {
             grid-template-columns: $detailsViewReflowLeftNavWidth 1fr;
         }
@@ -462,6 +464,7 @@ div.insights-file-issue-details-dialog-container {
         .details-view-body-content-pane {
             display: flex;
             flex-direction: column;
+            height: 100%;
             &.reflow-ui {
                 word-break: break-word;
             }

--- a/src/DetailsView/details-view-body.scss
+++ b/src/DetailsView/details-view-body.scss
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+.details-view-body {
+    height: 100%;
+}

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -8,9 +8,9 @@ import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { FluentSideNav, FluentSideNavDeps } from 'DetailsView/components/left-nav/fluent-side-nav';
+import * as styles from 'DetailsView/details-view-body.scss';
 import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';
-
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { DropdownClickHandler } from '../common/dropdown-click-handler';
 import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
@@ -82,7 +82,7 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
         });
 
         return (
-            <div className="details-view-body">
+            <div className={styles.detailsViewBody}>
                 {this.renderCommandBar()}
                 <div className={bodyLayoutClassName}>
                     {this.renderNavBar()}

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DetailsViewBody render render 1`] = `
 <div
-  className="details-view-body"
+  className="detailsViewBody"
 >
   <test
     assessmentStoreData={


### PR DESCRIPTION
#### Description of changes

Setting the height to 100% for the containers allow them to take the entire space necessary for the background to extend.

Before:
![image](https://user-images.githubusercontent.com/32555133/84940316-84547f80-b094-11ea-86be-355c48d26c2c.png)

After:
![image](https://user-images.githubusercontent.com/32555133/84940360-93d3c880-b094-11ea-93f5-78a31bbf3c79.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
