### PR TITLE
chore: clean up visualization configurations

### DIFF
--- a/src/ad-hoc-visualizations/color/visualization.tsx
+++ b/src/ad-hoc-visualizations/color/visualization.tsx
@@ -9,11 +9,21 @@ import { VisualizationType } from 'common/types/visualization-type';
 import { generateUID } from 'common/uid-generator';
 import { adhoc as content } from 'content/adhoc';
 import { AdhocStaticTestView } from 'DetailsView/components/adhoc-static-test-view';
+import { RuleAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { ScannerUtils } from 'injected/scanner-utils';
 import { VisualizationInstanceProcessor } from 'injected/visualization-instance-processor';
 import * as React from 'react';
 
 const { guidance } = content.color;
+
+const colorRuleAnalyzerConfiguration: RuleAnalyzerConfiguration = {
+    rules: ['select-body'],
+    resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
+    telemetryProcessor: (telemetryFactory: TelemetryDataFactory) => telemetryFactory.forTestScan,
+    key: AdHocTestkeys.Color,
+    testType: VisualizationType.Color,
+    analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
+};
 
 export const ColorAdHocVisualization: VisualizationConfiguration = {
     getTestView: props => <AdhocStaticTestView {...props} />,
@@ -32,17 +42,7 @@ export const ColorAdHocVisualization: VisualizationConfiguration = {
     chromeCommand: '05_toggle-color',
     launchPanelDisplayOrder: 5,
     adhocToolsPanelDisplayOrder: 2,
-    resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
-    getAnalyzer: provider =>
-        provider.createRuleAnalyzer({
-            rules: ['select-body'],
-            resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
-            telemetryProcessor: (telemetryFactory: TelemetryDataFactory) =>
-                telemetryFactory.forTestScan,
-            key: AdHocTestkeys.Color,
-            testType: VisualizationType.Color,
-            analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
-        }),
+    getAnalyzer: provider => provider.createRuleAnalyzer(colorRuleAnalyzerConfiguration),
     getIdentifier: () => AdHocTestkeys.Color,
     visualizationInstanceProcessor: () => VisualizationInstanceProcessor.nullProcessor,
     getNotificationMessage: selectorMap => null,

--- a/src/ad-hoc-visualizations/headings/visualization.tsx
+++ b/src/ad-hoc-visualizations/headings/visualization.tsx
@@ -9,12 +9,22 @@ import { VisualizationType } from 'common/types/visualization-type';
 import { generateUID } from 'common/uid-generator';
 import { adhoc as content } from 'content/adhoc';
 import { AdhocStaticTestView } from 'DetailsView/components/adhoc-static-test-view';
+import { RuleAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { ScannerUtils } from 'injected/scanner-utils';
 import { VisualizationInstanceProcessor } from 'injected/visualization-instance-processor';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 
 const { guidance } = content.headings;
+
+const headingsRuleAnalyzerConfiguration: RuleAnalyzerConfiguration = {
+    rules: ['heading-order'],
+    resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
+    telemetryProcessor: (telemetryFactory: TelemetryDataFactory) => telemetryFactory.forTestScan,
+    key: AdHocTestkeys.Headings,
+    testType: VisualizationType.Headings,
+    analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
+};
 
 export const HeadingsAdHocVisualization: VisualizationConfiguration = {
     getTestView: props => <AdhocStaticTestView {...props} />,
@@ -33,17 +43,7 @@ export const HeadingsAdHocVisualization: VisualizationConfiguration = {
     chromeCommand: '03_toggle-headings',
     launchPanelDisplayOrder: 3,
     adhocToolsPanelDisplayOrder: 3,
-    resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
-    getAnalyzer: provider =>
-        provider.createRuleAnalyzer({
-            rules: ['heading-order'],
-            resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
-            telemetryProcessor: (telemetryFactory: TelemetryDataFactory) =>
-                telemetryFactory.forTestScan,
-            key: AdHocTestkeys.Headings,
-            testType: VisualizationType.Headings,
-            analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
-        }),
+    getAnalyzer: provider => provider.createRuleAnalyzer(headingsRuleAnalyzerConfiguration),
     getIdentifier: () => AdHocTestkeys.Headings,
     visualizationInstanceProcessor: () => VisualizationInstanceProcessor.nullProcessor,
     getNotificationMessage: selectorMap => (isEmpty(selectorMap) ? 'No headings found' : null),

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -10,9 +10,20 @@ import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { VisualizationType } from 'common/types/visualization-type';
 import { generateUID } from 'common/uid-generator';
 import { AdhocIssuesTestView } from 'DetailsView/components/adhoc-issues-test-view';
+import { RuleAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { ScannerUtils } from 'injected/scanner-utils';
 import { VisualizationInstanceProcessor } from 'injected/visualization-instance-processor';
 import * as React from 'react';
+
+const issuesRuleAnalyzerConfiguration: RuleAnalyzerConfiguration = {
+    rules: null,
+    resultProcessor: (scanner: ScannerUtils) => scanner.getFailingInstances,
+    telemetryProcessor: (telemetryFactory: TelemetryDataFactory) =>
+        telemetryFactory.forIssuesAnalyzerScan,
+    key: AdHocTestkeys.Issues,
+    testType: VisualizationType.Issues,
+    analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
+};
 
 export const IssuesAdHocVisualization: VisualizationConfiguration = {
     key: AdHocTestkeys.Issues,
@@ -43,17 +54,8 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     chromeCommand: '01_toggle-issues',
     launchPanelDisplayOrder: 1,
     adhocToolsPanelDisplayOrder: 1,
-    resultProcessor: (scanner: ScannerUtils) => scanner.getFailingInstances,
     getAnalyzer: provider =>
-        provider.createRuleAnalyzerUnifiedScan({
-            rules: null,
-            resultProcessor: (scanner: ScannerUtils) => scanner.getFailingInstances,
-            telemetryProcessor: (telemetryFactory: TelemetryDataFactory) =>
-                telemetryFactory.forIssuesAnalyzerScan,
-            key: AdHocTestkeys.Issues,
-            testType: VisualizationType.Issues,
-            analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
-        }),
+        provider.createRuleAnalyzerUnifiedScan(issuesRuleAnalyzerConfiguration),
     getIdentifier: () => AdHocTestkeys.Issues,
     visualizationInstanceProcessor: () => VisualizationInstanceProcessor.nullProcessor,
     getNotificationMessage: (selectorMap, key, warnings) =>

--- a/src/ad-hoc-visualizations/landmarks/visualization.tsx
+++ b/src/ad-hoc-visualizations/landmarks/visualization.tsx
@@ -9,12 +9,22 @@ import { VisualizationType } from 'common/types/visualization-type';
 import { generateUID } from 'common/uid-generator';
 import { adhoc as content } from 'content/adhoc';
 import { AdhocStaticTestView } from 'DetailsView/components/adhoc-static-test-view';
+import { RuleAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { ScannerUtils } from 'injected/scanner-utils';
 import { VisualizationInstanceProcessor } from 'injected/visualization-instance-processor';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 
 const { guidance } = content.landmarks;
+
+const landmarkRuleAnalyzerConfiguration: RuleAnalyzerConfiguration = {
+    rules: ['unique-landmark'],
+    resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
+    telemetryProcessor: (telemetryFactory: TelemetryDataFactory) => telemetryFactory.forTestScan,
+    key: AdHocTestkeys.Landmarks,
+    testType: VisualizationType.Landmarks,
+    analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
+};
 
 export const LandmarksAdHocVisualization: VisualizationConfiguration = {
     getTestView: props => <AdhocStaticTestView {...props} />,
@@ -33,17 +43,7 @@ export const LandmarksAdHocVisualization: VisualizationConfiguration = {
     chromeCommand: '02_toggle-landmarks',
     launchPanelDisplayOrder: 2,
     adhocToolsPanelDisplayOrder: 4,
-    resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
-    getAnalyzer: provider =>
-        provider.createRuleAnalyzer({
-            rules: ['unique-landmark'],
-            resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
-            telemetryProcessor: (telemetryFactory: TelemetryDataFactory) =>
-                telemetryFactory.forTestScan,
-            key: AdHocTestkeys.Landmarks,
-            testType: VisualizationType.Landmarks,
-            analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
-        }),
+    getAnalyzer: provider => provider.createRuleAnalyzer(landmarkRuleAnalyzerConfiguration),
     getIdentifier: () => AdHocTestkeys.Landmarks,
     visualizationInstanceProcessor: () => VisualizationInstanceProcessor.nullProcessor,
     getNotificationMessage: selectorMap => (isEmpty(selectorMap) ? 'No landmarks found' : null),

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -9,10 +9,19 @@ import { generateUID } from 'common/uid-generator';
 import { adhoc as content } from 'content/adhoc';
 import { createHowToTest } from 'content/adhoc/tabstops/how-to-test';
 import { AdhocStaticTestView } from 'DetailsView/components/adhoc-static-test-view';
+import { FocusAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { VisualizationInstanceProcessor } from 'injected/visualization-instance-processor';
 import * as React from 'react';
 
 const { guidance, extraGuidance } = content.tabstops;
+
+const tabStopVisualizationConfiguration: FocusAnalyzerConfiguration = {
+    key: AdHocTestkeys.TabStops,
+    testType: VisualizationType.TabStops,
+    analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
+    analyzerProgressMessageType: Messages.Visualizations.TabStops.TabbedElementAdded,
+    analyzerTerminatedMessageType: Messages.Visualizations.TabStops.TerminateScan,
+};
 
 export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     getTestView: props => (
@@ -36,13 +45,7 @@ export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     analyzerProgressMessageType: Messages.Visualizations.TabStops.TabbedElementAdded,
     analyzerTerminatedMessageType: Messages.Visualizations.TabStops.TerminateScan,
     getAnalyzer: provider =>
-        provider.createFocusTrackingAnalyzer({
-            key: AdHocTestkeys.TabStops,
-            testType: VisualizationType.TabStops,
-            analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
-            analyzerProgressMessageType: Messages.Visualizations.TabStops.TabbedElementAdded,
-            analyzerTerminatedMessageType: Messages.Visualizations.TabStops.TerminateScan,
-        }),
+        provider.createFocusTrackingAnalyzer(tabStopVisualizationConfiguration),
     getIdentifier: () => AdHocTestkeys.TabStops,
     visualizationInstanceProcessor: () => VisualizationInstanceProcessor.nullProcessor,
     getDrawer: provider => provider.createSVGDrawer(),

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -20,7 +20,7 @@ import {
 import { AssessmentTestView } from 'DetailsView/components/assessment-test-view';
 import { RequirementLink } from 'DetailsView/components/requirement-link';
 import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
-import { DecoratedAxeNodeResult, ScannerUtils } from 'injected/scanner-utils';
+import { DecoratedAxeNodeResult } from 'injected/scanner-utils';
 import {
     PropertyBags,
     VisualizationInstanceProcessor,
@@ -31,7 +31,6 @@ import { cloneDeep } from 'lodash';
 import { IColumn } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { DictionaryStringTo } from 'types/common-types';
-
 import { Assessment, AssistedAssessment, ManualAssessment } from './types/iassessment';
 import { ReportInstanceField } from './types/report-instance-field';
 import { Requirement } from './types/requirement';
@@ -286,7 +285,6 @@ export class AssessmentBuilder {
             enableTest: AssessmentBuilder.enableTest,
             disableTest: AssessmentBuilder.disableTest,
             getTestStatus: AssessmentBuilder.getTestStatus,
-            resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
             telemetryProcessor: factory => factory.forAssessmentRequirementScan,
             ...assessment.visualizationConfiguration,
             key: assessment.storeDataKey,

--- a/src/common/configs/assessment-visualization-configuration.ts
+++ b/src/common/configs/assessment-visualization-configuration.ts
@@ -6,14 +6,12 @@ import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { TestViewProps } from '../../DetailsView/components/test-view';
 import { Analyzer } from '../../injected/analyzers/analyzer';
 import { AnalyzerProvider } from '../../injected/analyzers/analyzer-provider';
-import { HtmlElementAxeResults, ScannerUtils } from '../../injected/scanner-utils';
 import {
     PropertyBags,
     VisualizationInstanceProcessorCallback,
 } from '../../injected/visualization-instance-processor';
 import { Drawer } from '../../injected/visualization/drawer';
 import { DrawerProvider } from '../../injected/visualization/drawer-provider';
-import { ScanResults } from '../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../types/common-types';
 import { IAnalyzerTelemetryCallback } from '../types/analyzer-telemetry-callbacks';
 import { AssessmentData, AssessmentStoreData } from '../types/store-data/assessment-result-data';
@@ -34,9 +32,6 @@ export interface AssessmentVisualizationConfiguration {
         instanceMap?: DictionaryStringTo<any>,
     ) => void;
     analyzerProgressMessageType?: string;
-    resultProcessor?: (
-        scanner: ScannerUtils,
-    ) => (results: ScanResults) => DictionaryStringTo<HtmlElementAxeResults>;
     telemetryProcessor?: TelemetryProcessor<IAnalyzerTelemetryCallback>;
     getAnalyzer: (analyzerProvider: AnalyzerProvider, testStep?: string) => Analyzer;
     getIdentifier: (testStep?: string) => string;

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -24,7 +24,7 @@ import { RequirementLink } from '../../../../DetailsView/components/requirement-
 import { TestViewProps } from '../../../../DetailsView/components/test-view';
 import { AnalyzerConfiguration } from '../../../../injected/analyzers/analyzer';
 import { AnalyzerProvider } from '../../../../injected/analyzers/analyzer-provider';
-import { DecoratedAxeNodeResult, ScannerUtils } from '../../../../injected/scanner-utils';
+import { DecoratedAxeNodeResult } from '../../../../injected/scanner-utils';
 import { VisualizationInstanceProcessor } from '../../../../injected/visualization-instance-processor';
 import { DrawerProvider } from '../../../../injected/visualization/drawer-provider';
 
@@ -179,9 +179,6 @@ describe('AssessmentBuilderTest', () => {
             getDrawer: getDrawerMock.object,
             switchToTargetTabOnScan: true,
         };
-        const scannerStub = {
-            getAllCompletedInstances: {},
-        };
         const telemetryFactoryStub = {
             forAssessmentRequirementScan: {},
         };
@@ -281,9 +278,6 @@ describe('AssessmentBuilderTest', () => {
         config.getDrawer(drawerProviderMock.object, requirement5.key);
 
         expect(config.getStoreData(vizStoreData)).toEqual(scanData);
-        expect(config.resultProcessor(scannerStub as ScannerUtils)).toEqual(
-            scannerStub.getAllCompletedInstances,
-        );
         expect(config.telemetryProcessor(telemetryFactoryStub as TelemetryDataFactory)).toEqual(
             telemetryFactoryStub.forAssessmentRequirementScan,
         );


### PR DESCRIPTION
#### Description of changes

1. Moves inline rule analyzer configurations to private variables making them easier to parse.
2. Removes result processor at visualization configuration level as it is not used.

Validated by doing a quick pass through assessment tests and visualizations.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
