### PR TITLE
chore: address deprecated button warning in unified dev console

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
@@ -6,7 +6,7 @@ import {
     DeviceDescriptionProps,
 } from 'electron/views/device-connect-view/components/android-setup/device-description';
 import * as styles from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss';
-import { Button, DefaultButton } from 'office-ui-fabric-react';
+import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
@@ -6,7 +6,7 @@ import {
     DeviceDescriptionProps,
 } from 'electron/views/device-connect-view/components/android-setup/device-description';
 import * as styles from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss';
-import { Button } from 'office-ui-fabric-react';
+import { Button, DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
@@ -43,7 +43,7 @@ export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepPro
         return (
             <AndroidSetupStepLayout {...layoutProps}>
                 <DeviceDescription {...descriptionProps}></DeviceDescription>
-                <Button
+                <DefaultButton
                     className={styles.rescanButton}
                     text="Rescan devices"
                     onClick={props.deps.androidSetupActionCreator.rescan}

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`PromptConnectedStartTestingStep renders with device 1`] = `
     id="1"
     isEmulator={false}
   />
-  <Button
+  <CustomizedDefaultButton
     className="rescanButton"
     onClick={[Function]}
     text="Rescan devices"
@@ -68,7 +68,7 @@ exports[`PromptConnectedStartTestingStep renders with emulator 1`] = `
     id="1"
     isEmulator={true}
   />
-  <Button
+  <CustomizedDefaultButton
     className="rescanButton"
     onClick={[Function]}
     text="Rescan devices"


### PR DESCRIPTION
#### Description of changes

Fixes this warning in the dev console when hitting the prompt-connected-start-testing-step:

`warn.js:13 The Button component has been deprecated. Use specific variants instead. (PrimaryButton, DefaultButton, IconButton, ActionButton, etc.)`

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
