### PR TITLE
feat(android-setup): set default device connect port to 62442 

### DIFF
--- a/src/electron/flux/store/device-store.ts
+++ b/src/electron/flux/store/device-store.ts
@@ -3,6 +3,7 @@
 import { BaseStoreImpl } from 'background/stores/base-store-impl';
 import { StoreNames } from 'common/stores/store-names';
 
+import { defaultAdbPortNumber } from 'electron/platform/android/appium-service-configurator';
 import { ConnectedDevicePayload, PortPayload } from '../action/device-action-payloads';
 import { DeviceActions } from '../action/device-actions';
 import { DeviceConnectState } from '../types/device-connect-state';
@@ -17,7 +18,7 @@ export class DeviceStore extends BaseStoreImpl<DeviceStoreData> {
         return {
             deviceConnectState: DeviceConnectState.Default,
             connectedDevice: null,
-            port: null,
+            port: defaultAdbPortNumber,
         };
     }
 

--- a/src/electron/platform/android/appium-service-configurator.ts
+++ b/src/electron/platform/android/appium-service-configurator.ts
@@ -17,9 +17,8 @@ type AdbDevice = {
 
 const servicePackageName: string = 'com.microsoft.accessibilityinsightsforandroidservice';
 
+export const defaultAdbPortNumber: number = 62442;
 export class AppiumServiceConfigurator implements AndroidServiceConfigurator {
-    private readonly portNumber: number = 62442;
-
     constructor(private readonly adb: ADB, private readonly apkLocator: AndroidServiceApkLocator) {}
 
     public getConnectedDevices = async (): Promise<Array<DeviceInfo>> => {
@@ -85,11 +84,11 @@ export class AppiumServiceConfigurator implements AndroidServiceConfigurator {
 
     public setTcpForwarding = async (deviceId: string): Promise<void> => {
         this.adb.setDeviceId(deviceId);
-        await this.adb.forwardPort(this.portNumber, this.portNumber);
+        await this.adb.forwardPort(defaultAdbPortNumber, defaultAdbPortNumber);
     };
 
     public removeTcpForwarding = async (deviceId: string): Promise<void> => {
         this.adb.setDeviceId(deviceId);
-        await this.adb.removePortForward(this.portNumber);
+        await this.adb.removePortForward(defaultAdbPortNumber);
     };
 }


### PR DESCRIPTION
#### Description of changes

We currently support two parallel experiences for setting up Android devices. The first is the original 'manual-port-selection' experience in master today. The second is an in-progress automatic setup process that assumes the port 62442 for now. Our UI is shared amongst both experiences and uses the port number set in the device-store. Until we deprecate the old experience / remove the old store, we need a way to use 62442 in cases where the auto-setup feature flag is on. Out of the options:
- update the device-store from an adb step
- consume different ports in the UI (deviceStoreData.port referenced in >= 3 places)
- 'update the store data' in a higher UI component when the new experience is on
- set the default value in the store data to match

This PR uses the final approach for now.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
