### PR TITLE
feat(android-setup): add UI for configuring-port-forwarding step

### DIFF
--- a/src/electron/platform/android/setup/android-setup-step-id.ts
+++ b/src/electron/platform/android/setup/android-setup-step-id.ts
@@ -12,4 +12,5 @@ export type AndroidSetupStepId =
     | 'prompt-install-failed'
     | 'detect-permissions'
     | 'prompt-grant-permissions'
+    | 'configuring-port-forwarding'
     | 'prompt-connected-start-testing';

--- a/src/electron/platform/android/setup/android-setup-steps-configs.ts
+++ b/src/electron/platform/android/setup/android-setup-steps-configs.ts
@@ -45,5 +45,6 @@ export const allAndroidSetupStepConfigs: AndroidSetupStepConfigs = {
     'prompt-install-failed': promptInstallService,
     'detect-permissions': detectPermissions,
     'prompt-grant-permissions': promptGrantPermissions,
+    'configuring-port-forwarding': null, // to be implemented in future feature work
     'prompt-connected-start-testing': promptConnectedStartTesting,
 };

--- a/src/electron/views/device-connect-view/components/android-setup/configuring-port-forwarding-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/configuring-port-forwarding-step.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import * as React from 'react';
+import { AndroidSetupSpinnerStep } from './android-setup-spinner-step';
+import { CommonAndroidSetupStepProps } from './android-setup-types';
+
+export const ConfiguringPortForwardingStep = NamedFC<CommonAndroidSetupStepProps>(
+    'ConfiguringPortForwardingStep',
+    (props: CommonAndroidSetupStepProps) => {
+        return <AndroidSetupSpinnerStep deps={props.deps} spinnerLabel="Configuring ports..." />;
+    },
+);

--- a/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AndroidSetupStepComponentProvider } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
+import { ConfiguringPortForwardingStep } from 'electron/views/device-connect-view/components/android-setup/configuring-port-forwarding-step';
 import { DetectAdbStep } from 'electron/views/device-connect-view/components/android-setup/detect-adb-step';
 import { DetectDevicesStep } from 'electron/views/device-connect-view/components/android-setup/detect-devices-step';
 import { DetectPermissionsStep } from 'electron/views/device-connect-view/components/android-setup/detect-permissions-step';
@@ -26,5 +27,6 @@ export const defaultAndroidSetupComponents: AndroidSetupStepComponentProvider = 
     'installing-service': InstallingServiceStep,
     'detect-devices': DetectDevicesStep,
     'detect-service': DetectServiceStep,
+    'configuring-port-forwarding': ConfiguringPortForwardingStep,
     'prompt-connected-start-testing': PromptConnectedStartTestingStep,
 };

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/configuring-port-forwarding-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/configuring-port-forwarding-step.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfiguringPortForwardingStep renders 1`] = `
+<AndroidSetupSpinnerStep
+  deps={
+    Object {
+      "LinkComponent": [Function],
+      "androidSetupActionCreator": null,
+      "androidSetupStepComponentProvider": null,
+      "closeApp": null,
+      "showOpenFileDialog": null,
+      "startTesting": null,
+    }
+  }
+  spinnerLabel="Configuring ports..."
+/>
+`;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/configuring-port-forwarding-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/configuring-port-forwarding-step.test.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ConfiguringPortForwardingStep } from 'electron/views/device-connect-view/components/android-setup/configuring-port-forwarding-step';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
+
+describe('ConfiguringPortForwardingStep', () => {
+    const props = new AndroidSetupStepPropsBuilder('configuring-port-forwarding').build();
+
+    it('renders', () => {
+        const rendered = shallow(<ConfiguringPortForwardingStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Adds a new loading spinner screen UI for the step where we configure port forwarding in ADB.

![screenshot of new loading spinner](https://user-images.githubusercontent.com/376284/84947086-80c5f600-b09e-11ea-91ae-0352243f49f7.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
