### PR TITLE
fix(android-setup): remove extra main elements in AndroidSetupSpinnerStep UIs

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/detect-devices-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/detect-devices-step.tsx
@@ -8,10 +8,6 @@ import { CommonAndroidSetupStepProps } from './android-setup-types';
 export const DetectDevicesStep = NamedFC<CommonAndroidSetupStepProps>(
     'DetectDevicesStep',
     (props: CommonAndroidSetupStepProps) => {
-        return (
-            <main>
-                <AndroidSetupSpinnerStep deps={props.deps} spinnerLabel="Scanning for devices..." />
-            </main>
-        );
+        return <AndroidSetupSpinnerStep deps={props.deps} spinnerLabel="Scanning for devices..." />;
     },
 );

--- a/src/electron/views/device-connect-view/components/android-setup/detect-permissions-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/detect-permissions-step.tsx
@@ -8,10 +8,6 @@ import { CommonAndroidSetupStepProps } from './android-setup-types';
 export const DetectPermissionsStep = NamedFC<CommonAndroidSetupStepProps>(
     'DetectPermissionsStep',
     (props: CommonAndroidSetupStepProps) => {
-        return (
-            <main>
-                <AndroidSetupSpinnerStep deps={props.deps} spinnerLabel="Checking permissions..." />
-            </main>
-        );
+        return <AndroidSetupSpinnerStep deps={props.deps} spinnerLabel="Checking permissions..." />;
     },
 );

--- a/src/electron/views/device-connect-view/components/android-setup/detect-service-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/detect-service-step.tsx
@@ -9,13 +9,11 @@ export const DetectServiceStep = NamedFC<CommonAndroidSetupStepProps>(
     'DetectServiceStep',
     (props: CommonAndroidSetupStepProps) => {
         return (
-            <main>
-                <AndroidSetupSpinnerStep
-                    deps={props.deps}
-                    spinnerLabel="Scanning for devices..."
-                    disableCancel={true}
-                />
-            </main>
+            <AndroidSetupSpinnerStep
+                deps={props.deps}
+                spinnerLabel="Scanning for devices..."
+                disableCancel={true}
+            />
         );
     },
 );

--- a/src/electron/views/device-connect-view/components/android-setup/installing-service-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/installing-service-step.tsx
@@ -9,12 +9,10 @@ export const InstallingServiceStep = NamedFC<CommonAndroidSetupStepProps>(
     'InstallingServiceStep',
     (props: CommonAndroidSetupStepProps) => {
         return (
-            <main>
-                <AndroidSetupSpinnerStep
-                    deps={props.deps}
-                    spinnerLabel="Installing on your device..."
-                />
-            </main>
+            <AndroidSetupSpinnerStep
+                deps={props.deps}
+                spinnerLabel="Installing on your device..."
+            />
         );
     },
 );

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-devices-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-devices-step.test.tsx.snap
@@ -1,19 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DetectDevicesStep renders 1`] = `
-<main>
-  <AndroidSetupSpinnerStep
-    deps={
-      Object {
-        "LinkComponent": [Function],
-        "androidSetupActionCreator": null,
-        "androidSetupStepComponentProvider": null,
-        "closeApp": null,
-        "showOpenFileDialog": null,
-        "startTesting": null,
-      }
+<AndroidSetupSpinnerStep
+  deps={
+    Object {
+      "LinkComponent": [Function],
+      "androidSetupActionCreator": null,
+      "androidSetupStepComponentProvider": null,
+      "closeApp": null,
+      "showOpenFileDialog": null,
+      "startTesting": null,
     }
-    spinnerLabel="Scanning for devices..."
-  />
-</main>
+  }
+  spinnerLabel="Scanning for devices..."
+/>
 `;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-permissions-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-permissions-step.test.tsx.snap
@@ -1,19 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DetectDevicesStep renders 1`] = `
-<main>
-  <AndroidSetupSpinnerStep
-    deps={
-      Object {
-        "LinkComponent": [Function],
-        "androidSetupActionCreator": null,
-        "androidSetupStepComponentProvider": null,
-        "closeApp": null,
-        "showOpenFileDialog": null,
-        "startTesting": null,
-      }
+<AndroidSetupSpinnerStep
+  deps={
+    Object {
+      "LinkComponent": [Function],
+      "androidSetupActionCreator": null,
+      "androidSetupStepComponentProvider": null,
+      "closeApp": null,
+      "showOpenFileDialog": null,
+      "startTesting": null,
     }
-    spinnerLabel="Checking permissions..."
-  />
-</main>
+  }
+  spinnerLabel="Checking permissions..."
+/>
 `;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-service-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-service-step.test.tsx.snap
@@ -1,20 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DetectServiceStep renders 1`] = `
-<main>
-  <AndroidSetupSpinnerStep
-    deps={
-      Object {
-        "LinkComponent": [Function],
-        "androidSetupActionCreator": null,
-        "androidSetupStepComponentProvider": null,
-        "closeApp": null,
-        "showOpenFileDialog": null,
-        "startTesting": null,
-      }
+<AndroidSetupSpinnerStep
+  deps={
+    Object {
+      "LinkComponent": [Function],
+      "androidSetupActionCreator": null,
+      "androidSetupStepComponentProvider": null,
+      "closeApp": null,
+      "showOpenFileDialog": null,
+      "startTesting": null,
     }
-    disableCancel={true}
-    spinnerLabel="Scanning for devices..."
-  />
-</main>
+  }
+  disableCancel={true}
+  spinnerLabel="Scanning for devices..."
+/>
 `;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/installing-service-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/installing-service-step.test.tsx.snap
@@ -1,19 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InstallingServiceStep renders 1`] = `
-<main>
-  <AndroidSetupSpinnerStep
-    deps={
-      Object {
-        "LinkComponent": [Function],
-        "androidSetupActionCreator": null,
-        "androidSetupStepComponentProvider": null,
-        "closeApp": null,
-        "showOpenFileDialog": null,
-        "startTesting": null,
-      }
+<AndroidSetupSpinnerStep
+  deps={
+    Object {
+      "LinkComponent": [Function],
+      "androidSetupActionCreator": null,
+      "androidSetupStepComponentProvider": null,
+      "closeApp": null,
+      "showOpenFileDialog": null,
+      "startTesting": null,
     }
-    spinnerLabel="Installing on your device..."
-  />
-</main>
+  }
+  spinnerLabel="Installing on your device..."
+/>
 `;


### PR DESCRIPTION
#### Description of changes

Several of the steps that are based on `AndroidSetupSpinnerStep` were wrapping it in a `<main>` element, but it already is based on `AndroidSetupStepLayout` which provides a `<main>` element. This removes the extra landmark.

No visual change.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
