### PR TITLE
feat(android-setup): UI for prompt-configuring-port-forwarding-failed-step

### DIFF
--- a/src/electron/platform/android/setup/android-setup-step-id.ts
+++ b/src/electron/platform/android/setup/android-setup-step-id.ts
@@ -13,4 +13,5 @@ export type AndroidSetupStepId =
     | 'detect-permissions'
     | 'prompt-grant-permissions'
     | 'configuring-port-forwarding'
+    | 'prompt-configuring-port-forwarding-failed'
     | 'prompt-connected-start-testing';

--- a/src/electron/platform/android/setup/android-setup-steps-configs.ts
+++ b/src/electron/platform/android/setup/android-setup-steps-configs.ts
@@ -46,5 +46,6 @@ export const allAndroidSetupStepConfigs: AndroidSetupStepConfigs = {
     'detect-permissions': detectPermissions,
     'prompt-grant-permissions': promptGrantPermissions,
     'configuring-port-forwarding': null, // to be implemented in future feature work
+    'prompt-configuring-port-forwarding-failed': null, // to be implemented in future feature work
     'prompt-connected-start-testing': promptConnectedStartTesting,
 };

--- a/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
@@ -8,6 +8,7 @@ import { DetectPermissionsStep } from 'electron/views/device-connect-view/compon
 import { DetectServiceStep } from 'electron/views/device-connect-view/components/android-setup/detect-service-step';
 import { InstallingServiceStep } from 'electron/views/device-connect-view/components/android-setup/installing-service-step';
 import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
+import { PromptConfiguringPortForwardingFailedStep } from 'electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step';
 import { PromptConnectToDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step';
 import { PromptConnectedStartTestingStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step';
 import { PromptGrantPermissionsStep } from 'electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step';
@@ -28,5 +29,6 @@ export const defaultAndroidSetupComponents: AndroidSetupStepComponentProvider = 
     'detect-devices': DetectDevicesStep,
     'detect-service': DetectServiceStep,
     'configuring-port-forwarding': ConfiguringPortForwardingStep,
+    'prompt-configuring-port-forwarding-failed': PromptConfiguringPortForwardingFailedStep,
     'prompt-connected-start-testing': PromptConnectedStartTestingStep,
 };

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.scss
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../../../common/styles/fonts.scss';
+
+.device-description {
+    margin-top: 16px;
+    margin-bottom: 16px;
+}

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import {
+    DeviceDescription,
+    DeviceDescriptionProps,
+} from 'electron/views/device-connect-view/components/android-setup/device-description';
+import { PrimaryButton } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
+import { CommonAndroidSetupStepProps } from './android-setup-types';
+import * as styles from './prompt-install-failed-step.scss';
+
+export const tryAgainAutomationId = 'try-again';
+export const PromptConfiguringPortForwardingFailedStep = NamedFC<CommonAndroidSetupStepProps>(
+    'PromptConfiguringPortForwardingFailedStep',
+    (props: CommonAndroidSetupStepProps) => {
+        const { LinkComponent } = props.deps;
+
+        const layoutProps: AndroidSetupStepLayoutProps = {
+            headerText: 'Port forwarding failed',
+            moreInfoLink: (
+                <LinkComponent href="https://aka.ms/accessibility-insights-for-android/portForwarding">
+                    Troubleshooting port forwarding problems
+                </LinkComponent>
+            ),
+            leftFooterButtonProps: {
+                text: 'Cancel',
+                onClick: _ => props.deps.androidSetupActionCreator.cancel(),
+            },
+            rightFooterButtonProps: {
+                text: 'Next',
+                disabled: true,
+                onClick: null,
+            },
+        };
+
+        const descriptionProps: DeviceDescriptionProps = {
+            ...props.androidSetupStoreData.selectedDevice,
+            className: styles.deviceDescription,
+        };
+
+        return (
+            <AndroidSetupStepLayout {...layoutProps}>
+                <>
+                    We were unable to configure port forwarding from Accessibility Insights for
+                    Android Service on your device. Please reconnect your device and try again.
+                </>
+                <DeviceDescription {...descriptionProps}></DeviceDescription>
+                <PrimaryButton
+                    data-automation-id={tryAgainAutomationId}
+                    text="Try again"
+                    onClick={props.deps.androidSetupActionCreator.next}
+                />
+            </AndroidSetupStepLayout>
+        );
+    },
+);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-configuring-port-forwarding-failed-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-configuring-port-forwarding-failed-step.test.tsx.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PromptConfiguringPortForwardingFailedStep renders with device 1`] = `
+<AndroidSetupStepLayout
+  headerText="Port forwarding failed"
+  leftFooterButtonProps={
+    Object {
+      "onClick": [Function],
+      "text": "Cancel",
+    }
+  }
+  moreInfoLink={
+    <LinkComponent
+      href="https://aka.ms/accessibility-insights-for-android/portForwarding"
+    >
+      Troubleshooting port forwarding problems
+    </LinkComponent>
+  }
+  rightFooterButtonProps={
+    Object {
+      "disabled": true,
+      "onClick": null,
+      "text": "Next",
+    }
+  }
+>
+  <React.Fragment>
+    We were unable to configure port forwarding from Accessibility Insights for Android Service on your device. Please reconnect your device and try again.
+  </React.Fragment>
+  <DeviceDescription
+    className="deviceDescription"
+    friendlyName="Super-Duper Gadget"
+    id="1"
+    isEmulator={false}
+  />
+  <CustomizedPrimaryButton
+    data-automation-id="try-again"
+    onClick={[Function]}
+    text="Try again"
+  />
+</AndroidSetupStepLayout>
+`;
+
+exports[`PromptConfiguringPortForwardingFailedStep renders with emulator 1`] = `
+<AndroidSetupStepLayout
+  headerText="Port forwarding failed"
+  leftFooterButtonProps={
+    Object {
+      "onClick": [Function],
+      "text": "Cancel",
+    }
+  }
+  moreInfoLink={
+    <LinkComponent
+      href="https://aka.ms/accessibility-insights-for-android/portForwarding"
+    >
+      Troubleshooting port forwarding problems
+    </LinkComponent>
+  }
+  rightFooterButtonProps={
+    Object {
+      "disabled": true,
+      "onClick": null,
+      "text": "Next",
+    }
+  }
+>
+  <React.Fragment>
+    We were unable to configure port forwarding from Accessibility Insights for Android Service on your device. Please reconnect your device and try again.
+  </React.Fragment>
+  <DeviceDescription
+    className="deviceDescription"
+    friendlyName="Emulator Extraordinaire"
+    id="1"
+    isEmulator={true}
+  />
+  <CustomizedPrimaryButton
+    data-automation-id="try-again"
+    onClick={[Function]}
+    text="Try again"
+  />
+</AndroidSetupStepLayout>
+`;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.test.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
+import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
+import {
+    PromptConfiguringPortForwardingFailedStep,
+    tryAgainAutomationId,
+} from 'electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
+import { IMock, Mock, Times } from 'typemoq';
+
+describe('PromptConfiguringPortForwardingFailedStep', () => {
+    let props: CommonAndroidSetupStepProps;
+    let androidSetupActionCreatorMock: IMock<AndroidSetupActionCreator>;
+
+    beforeEach(() => {
+        androidSetupActionCreatorMock = Mock.ofType(AndroidSetupActionCreator);
+        props = new AndroidSetupStepPropsBuilder('prompt-configuring-port-forwarding-failed')
+            .withDep('androidSetupActionCreator', androidSetupActionCreatorMock.object)
+            .build();
+    });
+
+    it('renders with device', () => {
+        const selectedDevice: DeviceInfo = {
+            isEmulator: false,
+            friendlyName: 'Super-Duper Gadget',
+            id: '1',
+        };
+
+        props.androidSetupStoreData.selectedDevice = selectedDevice;
+
+        const rendered = shallow(<PromptConfiguringPortForwardingFailedStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('renders with emulator', () => {
+        const selectedDevice: DeviceInfo = {
+            isEmulator: true,
+            friendlyName: 'Emulator Extraordinaire',
+            id: '1',
+        };
+
+        props.androidSetupStoreData.selectedDevice = selectedDevice;
+
+        const rendered = shallow(<PromptConfiguringPortForwardingFailedStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('routes try again button to next action', () => {
+        const rendered = shallow(<PromptConfiguringPortForwardingFailedStep {...props} />);
+        const button = rendered.find({ 'data-automation-id': tryAgainAutomationId });
+        button.simulate('click');
+        androidSetupActionCreatorMock.verify(m => m.next(), Times.once());
+    });
+});


### PR DESCRIPTION
#### Description of changes

Adds a new UI for when setting up port forwarding fails based on the similar UI for when installing the service fails.

screenshot of proposed UI for error screen (in actual use there will be a device name to the right of the icon, it's missing here because I skipped directly to the new step for testing):

![image](https://user-images.githubusercontent.com/376284/84954691-ba046300-b0aa-11ea-90e5-e0601e3cfff9.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
