### PR TITLE
feat(android-setup): Scan for devices without prompting (golden path)

### DIFF
--- a/src/electron/platform/android/setup/steps/detect-adb.ts
+++ b/src/electron/platform/android/setup/steps/detect-adb.ts
@@ -7,6 +7,6 @@ export const detectAdb: AndroidSetupStepConfig = deps => ({
     actions: {},
     onEnter: async () => {
         const detected = await deps.hasAdbPath();
-        deps.stepTransition(detected ? 'prompt-connect-to-device' : 'prompt-locate-adb');
+        deps.stepTransition(detected ? 'detect-devices' : 'prompt-locate-adb');
     },
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-adb.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-adb.test.ts
@@ -23,7 +23,7 @@ describe('Android setup step: detectAdb', () => {
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.stepTransition('prompt-connect-to-device')).verifiable(Times.once());
+        depsMock.setup(m => m.stepTransition('detect-devices')).verifiable(Times.once());
 
         const step = detectAdb(depsMock.object);
         await step.onEnter();


### PR DESCRIPTION
#### Description of changes
Our "golden path" is when a user has exactly 1 device detected, and we're able to install and configure everything without any user input. In the current code, though, once we detect ADB, we go to prompt-connect-to-device, which interrupts that flow. This simply changes the step that comes after detect-adb. Once we detect devices, detect-devices will route as follows:
No devices found => prompt-connect-to-device
1 device found => detect-service
> 1 device found => prompt-choose-device

I tested this (in combination with #2908), and the golden path is just that--if the service is already installed and has permissions, you start the app, see the spinner for a few seconds, and then you're ready to test. 

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
