### PR TITLE
feat(android-setup): Add code to set the app name from the device in the setup store

### DIFF
--- a/src/electron/flux/store/android-setup-store.ts
+++ b/src/electron/flux/store/android-setup-store.ts
@@ -28,6 +28,7 @@ export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
             stepTransition: this.stepTransition,
             setSelectedDevice: this.setSelectedDevice,
             setAvailableDevices: this.setAvailableDevices,
+            setApplicationName: this.setApplicationName,
         });
     }
 
@@ -66,5 +67,10 @@ export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
     private setAvailableDevices = (devices: DeviceInfo[]): void => {
         // emitChange will be called from step transition when the step changes
         this.state.availableDevices = devices;
+    };
+
+    private setApplicationName = (appName?: string): void => {
+        // emitChange will be called from step transition when the step changes
+        this.state.applicationName = appName;
     };
 }

--- a/src/electron/flux/types/android-setup-state-machine-types.ts
+++ b/src/electron/flux/types/android-setup-state-machine-types.ts
@@ -14,6 +14,7 @@ export type AndroidSetupStoreCallbacks = {
     stepTransition: AndroidSetupStepTransitionCallback;
     setSelectedDevice: (device: DeviceInfo) => void;
     setAvailableDevices: (devices: DeviceInfo[]) => void;
+    setApplicationName: (appName?: string) => void;
 };
 
 export type AndroidSetupStateMachineFactory = (

--- a/src/electron/flux/types/android-setup-store-data.ts
+++ b/src/electron/flux/types/android-setup-store-data.ts
@@ -10,4 +10,6 @@ export type AndroidSetupStoreData = {
     selectedDevice?: DeviceInfo;
 
     availableDevices?: DeviceInfo[];
+
+    applicationName?: string;
 };

--- a/src/electron/platform/android/setup/android-setup-deps.ts
+++ b/src/electron/platform/android/setup/android-setup-deps.ts
@@ -12,4 +12,5 @@ export type AndroidSetupDeps = {
     installService: () => Promise<boolean>;
     hasExpectedPermissions: () => Promise<boolean>;
     setTcpForwarding: () => Promise<boolean>;
+    getApplicationName: () => Promise<string>;
 };

--- a/src/electron/platform/android/setup/live-android-setup-deps.ts
+++ b/src/electron/platform/android/setup/live-android-setup-deps.ts
@@ -12,6 +12,7 @@ import {
     PackageInfo,
     PermissionInfo,
 } from 'electron/platform/android/android-service-configurator';
+import { DeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
 import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
 
 export class LiveAndroidSetupDeps implements AndroidSetupDeps {
@@ -23,6 +24,7 @@ export class LiveAndroidSetupDeps implements AndroidSetupDeps {
         private readonly configStore: UserConfigurationStore,
         private readonly apkLocator: AndroidServiceApkLocator,
         private readonly userConfigMessageCreator: UserConfigMessageCreator,
+        private readonly fetchDeviceConfig: DeviceConfigFetcher,
         private readonly logger: Logger,
     ) {}
 
@@ -99,6 +101,17 @@ export class LiveAndroidSetupDeps implements AndroidSetupDeps {
             this.logger.log(error);
         }
         return false;
+    };
+
+    public getApplicationName = async (): Promise<string> => {
+        try {
+            const config = await this.fetchDeviceConfig(62442);
+            return config.appIdentifier;
+        } catch (error) {
+            this.logger.log(error);
+        }
+
+        return '';
     };
 
     private async getInstalledVersion(): Promise<string> {

--- a/src/electron/platform/android/setup/steps/configuring-port-forwarding.ts
+++ b/src/electron/platform/android/setup/steps/configuring-port-forwarding.ts
@@ -6,11 +6,18 @@ import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-
 export const configuringPortForwarding: AndroidSetupStepConfig = deps => ({
     actions: {},
     onEnter: async () => {
+        deps.setApplicationName(); // init
+
         const configured = await deps.setTcpForwarding();
-        deps.stepTransition(
-            configured
-                ? 'prompt-connected-start-testing'
-                : 'prompt-configuring-port-forwarding-failed',
-        );
+
+        if (configured === false) {
+            deps.stepTransition('prompt-configuring-port-forwarding-failed');
+            return;
+        }
+
+        // device is good to go; so we can get the current app name
+        const appName = await deps.getApplicationName();
+        deps.setApplicationName(appName);
+        deps.stepTransition('prompt-connected-start-testing');
     },
 });

--- a/src/electron/platform/android/setup/steps/detect-permissions.ts
+++ b/src/electron/platform/android/setup/steps/detect-permissions.ts
@@ -6,18 +6,7 @@ import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-
 export const detectPermissions: AndroidSetupStepConfig = deps => ({
     actions: {},
     onEnter: async () => {
-        deps.setApplicationName(); // init
-
         const detected = await deps.hasExpectedPermissions();
-
-        if (detected === false) {
-            deps.stepTransition('prompt-grant-permissions');
-            return;
-        }
-
-        // device is good to go; so we can get the current app name
-        const appName = await deps.getApplicationName();
-        deps.setApplicationName(appName);
-        deps.stepTransition('configuring-port-forwarding');
+        deps.stepTransition(detected ? 'configuring-port-forwarding' : 'prompt-grant-permissions');
     },
 });

--- a/src/electron/platform/android/setup/steps/detect-permissions.ts
+++ b/src/electron/platform/android/setup/steps/detect-permissions.ts
@@ -6,7 +6,18 @@ import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-
 export const detectPermissions: AndroidSetupStepConfig = deps => ({
     actions: {},
     onEnter: async () => {
+        deps.setApplicationName(); // init
+
         const detected = await deps.hasExpectedPermissions();
-        deps.stepTransition(detected ? 'configuring-port-forwarding' : 'prompt-grant-permissions');
+
+        if (detected === false) {
+            deps.stepTransition('prompt-grant-permissions');
+            return;
+        }
+
+        // device is good to go; so we can get the current app name
+        const appName = await deps.getApplicationName();
+        deps.setApplicationName(appName);
+        deps.stepTransition('configuring-port-forwarding');
     },
 });

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -194,9 +194,12 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
         const dispatcher = new DirectActionMessageDispatcher(interpreter);
         const userConfigMessageCreator = new UserConfigMessageCreator(dispatcher);
 
+        const fetchDeviceConfig = createDeviceConfigFetcher(axios.get);
+
         const apkLocator: AndroidServiceApkLocator = new AndroidServiceApkLocator(
             ipcRendererShim.getAppPath,
         );
+
         const androidSetupStore = new AndroidSetupStore(
             androidSetupActions,
             createAndroidSetupStateMachineFactory(
@@ -205,6 +208,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
                     userConfigurationStore,
                     apkLocator,
                     userConfigMessageCreator,
+                    fetchDeviceConfig,
                     logger,
                 ),
             ),
@@ -258,7 +262,6 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
         ]);
 
         const fetchScanResults = createScanResultsFetcher(axios.get);
-        const fetchDeviceConfig = createDeviceConfigFetcher(axios.get);
 
         const featureFlagsController = new FeatureFlagsController(featureFlagStore, interpreter);
 

--- a/src/tests/unit/tests/electron/flux/store/android-setup-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/android-setup-store.test.ts
@@ -184,6 +184,36 @@ describe('AndroidSetupStore', () => {
         stateMachineFactoryMock.verifyAll();
     });
 
+    it('ensure setApplicationName function results in store update', () => {
+        const appName = 'Star Wars -- Episode Test';
+
+        const initialData: AndroidSetupStoreData = { currentStepId: 'detect-adb' };
+        const expectedData: AndroidSetupStoreData = {
+            currentStepId: 'detect-adb',
+            applicationName: appName,
+        };
+
+        let storeCallbacks: AndroidSetupStoreCallbacks;
+
+        const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
+        stateMachineFactoryMock
+            .setup(m => m(It.isAny()))
+            .callback(sc => (storeCallbacks = sc))
+            .verifiable(Times.once());
+
+        const store = new AndroidSetupStore(
+            new AndroidSetupActions(),
+            stateMachineFactoryMock.object,
+        );
+        store.initialize(initialData);
+
+        storeCallbacks.setApplicationName(appName);
+
+        expect(store.getState()).toEqual(expectedData);
+
+        stateMachineFactoryMock.verifyAll();
+    });
+
     const createAndroidSetupStoreTester = (
         actionToInvoke: keyof AndroidSetupActions,
         stateMachineFactory: AndroidSetupStateMachineFactory,

--- a/src/tests/unit/tests/electron/platform/android/setup/live-android-setup-deps.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/live-android-setup-deps.test.ts
@@ -453,7 +453,7 @@ describe('LiveAndroidSetupDeps', () => {
         verifyAllMocks();
     });
 
-    it('getApplicationName returns epty string on error', async () => {
+    it('getApplicationName returns empty string on error', async () => {
         fetchConfigMock
             .setup(m => m(62442))
             .throws(Error('some error'))

--- a/src/tests/unit/tests/electron/platform/android/setup/live-android-setup-deps.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/live-android-setup-deps.test.ts
@@ -16,6 +16,8 @@ import {
     PackageInfo,
     PermissionInfo,
 } from 'electron/platform/android/android-service-configurator';
+import { DeviceConfig } from 'electron/platform/android/device-config';
+import { DeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
 import { LiveAndroidSetupDeps } from 'electron/platform/android/setup/live-android-setup-deps';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
@@ -27,6 +29,7 @@ describe('LiveAndroidSetupDeps', () => {
     let configStoreMock: IMock<UserConfigurationStore>;
     let apkLocatorMock: IMock<AndroidServiceApkLocator>;
     let configMessageCreatorMock: IMock<UserConfigMessageCreator>;
+    let fetchConfigMock: IMock<DeviceConfigFetcher>;
     let loggerMock: IMock<Logger>;
     let testSubject: LiveAndroidSetupDeps;
 
@@ -42,12 +45,14 @@ describe('LiveAndroidSetupDeps', () => {
             undefined,
             MockBehavior.Strict,
         );
+        fetchConfigMock = Mock.ofInstance((port: number) => new Promise<DeviceConfig>(() => null));
         loggerMock = Mock.ofType<Logger>();
         testSubject = new LiveAndroidSetupDeps(
             serviceConfigFactoryMock.object,
             configStoreMock.object,
             apkLocatorMock.object,
             configMessageCreatorMock.object,
+            fetchConfigMock.object,
             loggerMock.object,
         );
     });
@@ -418,6 +423,25 @@ describe('LiveAndroidSetupDeps', () => {
         verifyAllMocks();
     });
 
+    it('getApplicationName returns app name when successful', async () => {
+        const config: DeviceConfig = {
+            appIdentifier: 'Wonderful App',
+        } as DeviceConfig;
+
+        const p = new Promise<DeviceConfig>(resolve => resolve(config));
+
+        fetchConfigMock
+            .setup(m => m(62442))
+            .returns(() => p)
+            .verifiable();
+
+        const appName = await testSubject.getApplicationName();
+
+        expect(appName).toEqual(config.appIdentifier);
+
+        verifyAllMocks();
+    });
+
     it('setTcpForwarding returns true if no error', async () => {
         serviceConfigMock.setup(m => m.setTcpForwarding(undefined)).verifiable(Times.once());
         await initializeServiceConfig();
@@ -425,6 +449,19 @@ describe('LiveAndroidSetupDeps', () => {
         const success = await testSubject.setTcpForwarding();
 
         expect(success).toBe(true);
+
+        verifyAllMocks();
+    });
+
+    it('getApplicationName returns epty string on error', async () => {
+        fetchConfigMock
+            .setup(m => m(62442))
+            .throws(Error('some error'))
+            .verifiable();
+
+        const appName = await testSubject.getApplicationName();
+
+        expect(appName).toEqual('');
 
         verifyAllMocks();
     });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/configuring-port-forwarding.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/configuring-port-forwarding.test.ts
@@ -15,17 +15,26 @@ describe('Android setup step: configuringPortForwarding', () => {
     });
 
     it('onEnter transitions to prompt-connected-start-testing on success', async () => {
-        const p = new Promise<boolean>(resolve => resolve(true));
+        const appName = 'my app name';
+
+        const tcpForwardingPromise = new Promise<boolean>(resolve => resolve(true));
+        const appNamePromise = new Promise<string>(resolve => resolve(appName));
 
         const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.setTcpForwarding())
-            .returns(_ => p)
+            .returns(_ => tcpForwardingPromise)
             .verifiable(Times.once());
 
+        depsMock.setup(m => m.stepTransition('prompt-connected-start-testing'));
+
         depsMock
-            .setup(m => m.stepTransition('prompt-connected-start-testing'))
+            .setup(m => m.getApplicationName())
+            .returns(_ => appNamePromise)
             .verifiable(Times.once());
+
+        depsMock.setup(m => m.setApplicationName(undefined)).verifiable(Times.once());
+        depsMock.setup(m => m.setApplicationName(appName)).verifiable(Times.once());
 
         const step = configuringPortForwarding(depsMock.object);
         await step.onEnter();
@@ -41,6 +50,8 @@ describe('Android setup step: configuringPortForwarding', () => {
             .setup(m => m.setTcpForwarding())
             .returns(_ => p)
             .verifiable(Times.once());
+
+        depsMock.setup(m => m.setApplicationName(undefined)).verifiable(Times.once());
 
         depsMock
             .setup(m => m.stepTransition('prompt-configuring-port-forwarding-failed'))

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-permissions.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-permissions.test.ts
@@ -3,7 +3,7 @@
 
 import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
 import { detectPermissions } from 'electron/platform/android/setup/steps/detect-permissions';
-import { ExpectedCallType, It, Mock, MockBehavior, Times } from 'typemoq';
+import { Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: detectPermissions', () => {

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-permissions.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-permissions.test.ts
@@ -14,27 +14,16 @@ describe('Android setup step: detectPermissions', () => {
         expect(step.onEnter).toBeDefined();
     });
 
-    it('onEnter transitions to configuring-port-forwarding as expected', async () => {
-        const appName = 'my app name';
-
-        const detectPermissionsPromise = new Promise<boolean>(resolve => resolve(true));
-        const appNamePromise = new Promise<string>(resolve => resolve(appName));
+    it('onEnter transitions to configuring-port-forwarding on success', async () => {
+        const p = new Promise<boolean>(resolve => resolve(true));
 
         const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.hasExpectedPermissions())
-            .returns(_ => detectPermissionsPromise)
+            .returns(_ => p)
             .verifiable(Times.once());
 
         depsMock.setup(m => m.stepTransition('configuring-port-forwarding'));
-
-        depsMock
-            .setup(m => m.getApplicationName())
-            .returns(_ => appNamePromise)
-            .verifiable(Times.once());
-
-        depsMock.setup(m => m.setApplicationName(undefined)).verifiable(Times.once());
-        depsMock.setup(m => m.setApplicationName(appName)).verifiable(Times.once());
 
         const step = detectPermissions(depsMock.object);
         await step.onEnter();
@@ -50,8 +39,6 @@ describe('Android setup step: detectPermissions', () => {
             .setup(m => m.hasExpectedPermissions())
             .returns(_ => p)
             .verifiable(Times.once());
-
-        depsMock.setup(m => m.setApplicationName(undefined)).verifiable(Times.once());
 
         depsMock.setup(m => m.stepTransition('prompt-grant-permissions')).verifiable(Times.once());
 

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-permissions.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-permissions.test.ts
@@ -31,7 +31,7 @@ describe('Android setup step: detectPermissions', () => {
         depsMock.verifyAll();
     });
 
-    it('onEnter transitions to prompt-grant-permissions as expected', async () => {
+    it('onEnter transitions to prompt-grant-permissions on failure', async () => {
         const p = new Promise<boolean>(resolve => resolve(false));
 
         const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);


### PR DESCRIPTION
#### Description of changes

The app name is required for the start testing screen, and it can't be set until after the permissions have been granted. It also can't be set in the onEnter function for the start testing step because the onEnter method is asynchronous, and the UI will therefore be visible possibly before the app name is set.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
