### PR TITLE
(chore): Exclude .vs folder from fastpass scans

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,7 @@
 .github/
 .prettierignore
 .yarnrc
+.vs/
 AppXManifest.xml
 copyright-header.txt
 dist/

--- a/copyright-header.config.json
+++ b/copyright-header.config.json
@@ -4,6 +4,7 @@
         "./.dependabot",
         "./.git",
         "./.github",
+        "./.vs",
         "./.vscode",
         "./dist",
         "./docs/art/ada-cat.ansi256.txt",


### PR DESCRIPTION
#### Description of changes
I often use the branching tools in Visual Studio, but fastpass complains because it tries to scan the files in the .vs folder. This change simply excludes the .vs folder from prettier and linting checks, so that fastpass and Visual Studio can play nicely together.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
