### PR TITLE
fix(android-setup): Display the current application in the "connected" dialog

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
@@ -38,6 +38,7 @@ export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepPro
         const descriptionProps: DeviceDescriptionProps = {
             ...props.androidSetupStoreData.selectedDevice,
             className: styles.deviceDescription,
+            currentApplication: props.androidSetupStoreData.applicationName,
         };
 
         return (

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`PromptConnectedStartTestingStep renders with device 1`] = `
 >
   <DeviceDescription
     className="deviceDescription"
+    currentApplication="super-cool app"
     friendlyName="Super-Duper Gadget"
     id="1"
     isEmulator={false}
@@ -64,6 +65,7 @@ exports[`PromptConnectedStartTestingStep renders with emulator 1`] = `
 >
   <DeviceDescription
     className="deviceDescription"
+    currentApplication="super-cool app"
     friendlyName="Emulator Extraordinaire"
     id="1"
     isEmulator={true}

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
@@ -12,6 +12,7 @@ import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-st
 import { IMock, Mock, Times } from 'typemoq';
 
 describe('PromptConnectedStartTestingStep', () => {
+    const testApp: string = 'super-cool app';
     let props: CommonAndroidSetupStepProps;
     let startTestingMock: IMock<typeof props.deps.startTesting>;
     let androidSetupActionCreatorMock: IMock<AndroidSetupActionCreator>;
@@ -33,6 +34,7 @@ describe('PromptConnectedStartTestingStep', () => {
         };
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;
+        props.androidSetupStoreData.applicationName = testApp;
 
         const rendered = shallow(<PromptConnectedStartTestingStep {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
@@ -46,6 +48,7 @@ describe('PromptConnectedStartTestingStep', () => {
         };
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;
+        props.androidSetupStoreData.applicationName = testApp;
 
         const rendered = shallow(<PromptConnectedStartTestingStep {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();


### PR DESCRIPTION
#### Description of changes
The "connected" dialog is supposed to display the current application, but the data wasn't being initialized from the store. This adds the data from the store so that it gets displayed in the UI.

UI before the change (no application name):
![image](https://user-images.githubusercontent.com/45672944/85311764-c43bae00-b46a-11ea-89ba-e6faf3b8cd9d.png)

UI after the change (has application name):
![image](https://user-images.githubusercontent.com/45672944/85311466-53949180-b46a-11ea-9700-45a6fe388ff6.png)

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
