### PR TITLE
chore: add scss:build step to yarn fastpass

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "copyright:check": "license-check-and-add check -f copyright-header.config.json",
         "copyright:fix": "license-check-and-add add -f copyright-header.config.json",
         "download:electron-mirror": "node ./pipeline/scripts/download-electron-mirror.js",
-        "fastpass": "npm-run-all --print-label --parallel copyright:check lint:check format:check null:check && grunt ada-cat",
+        "fastpass": "npm-run-all --print-label scss:build --parallel copyright:check lint:check format:check null:check && grunt ada-cat",
         "fastpass:fix": "npm-run-all --print-label --serial scss:clean copyright:fix lint:fix format:fix",
         "format:check": "prettier --config prettier.config.js --check \"**/*\"",
         "format:fix": "prettier --config prettier.config.js --write \"**/*\"",


### PR DESCRIPTION
#### Description of changes

The addition of `yarn null:check` to `yarn fastpass` means that fastpass now relies on `yarn scss:build` having happened first; since that step is relatively quick to execute anyway, this PR adds it to `yarn fastpass` to avoid users having to remember to do it manually.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
