### PR TITLE
fix(android-setup): Enable "choose device" dialog on cancel, use real data

### DIFF
--- a/src/electron/platform/android/setup/android-setup-steps-configs.ts
+++ b/src/electron/platform/android/setup/android-setup-steps-configs.ts
@@ -40,7 +40,7 @@ export const allAndroidSetupStepConfigs: AndroidSetupStepConfigs = {
     'prompt-locate-adb': promptLocateAdb,
     'prompt-connect-to-device': promptConnectToDevice,
     'detect-devices': detectDevices,
-    'prompt-choose-device': null,
+    'prompt-choose-device': promptConnectToDevice,
     'detect-service': detectService,
     'prompt-install-service': promptInstallService,
     'installing-service': installingService,

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -40,25 +40,7 @@ export class PromptChooseDeviceStep extends React.Component<
     }
 
     public render(): JSX.Element {
-        // Available devices will be retrieved from store in future feature work
-        const devices: DeviceInfo[] = [
-            {
-                id: '1',
-                friendlyName: 'Phone 1',
-                isEmulator: true,
-            },
-            {
-                id: '2',
-                friendlyName: 'Phone 2',
-                isEmulator: false,
-            },
-            {
-                id: '3',
-                friendlyName: 'Phone 3',
-                isEmulator: true,
-            },
-        ];
-
+        const devices: DeviceInfo[] = this.props.androidSetupStoreData.availableDevices;
         const items = devices.map(m => ({ metadata: m }));
 
         const layoutProps: AndroidSetupStepLayoutProps = {

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
+import { AndroidSetupStoreData } from 'electron/flux/types/android-setup-store-data';
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
@@ -21,6 +22,26 @@ describe('PromptChooseDeviceStep', () => {
             .withDep('closeApp', closeAppMock.object)
             .withDep('androidSetupActionCreator', actionMessageCreatorMock.object)
             .build();
+
+        props.androidSetupStoreData = {
+            availableDevices: [
+                {
+                    id: '1',
+                    friendlyName: 'Phone 1',
+                    isEmulator: true,
+                },
+                {
+                    id: '2',
+                    friendlyName: 'Phone 2',
+                    isEmulator: false,
+                },
+                {
+                    id: '3',
+                    friendlyName: 'Phone 3',
+                    isEmulator: true,
+                },
+            ],
+        } as AndroidSetupStoreData;
     });
 
     it('renders per snapshot', () => {


### PR DESCRIPTION
#### Description of changes
The cancel buttons were connected, but the step they connected to was never enabled. The UX for that step was only displaying test data instead of real data. This PR enables the step with real data. The test for it could potentially be refactored to use the builder, if we want. 

Screenshot using my tethered device:
![image](https://user-images.githubusercontent.com/45672944/85327897-96636300-b484-11ea-858b-4b1b5a4c60b4.png)

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
