### PR TITLE
fix(android-setup): Connect cancel button in "start testing" step

### DIFF
--- a/src/electron/platform/android/setup/steps/prompt-connected-start-testing.ts
+++ b/src/electron/platform/android/setup/steps/prompt-connected-start-testing.ts
@@ -5,6 +5,9 @@ import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-
 
 export const promptConnectedStartTesting: AndroidSetupStepConfig = deps => ({
     actions: {
+        cancel: () => {
+            deps.stepTransition('prompt-choose-device');
+        },
         rescan: () => {
             deps.stepTransition('detect-adb');
         },

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-connected-start-testing.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-connected-start-testing.test.ts
@@ -10,8 +10,18 @@ describe('Android setup step: promptConnectedStartTesting', () => {
     it('has expected properties', () => {
         const deps = {} as AndroidSetupStepConfigDeps;
         const step = promptConnectedStartTesting(deps);
-        checkExpectedActionsAreDefined(step, ['rescan']);
+        checkExpectedActionsAreDefined(step, ['cancel', 'rescan']);
         expect(step.onEnter).not.toBeDefined();
+    });
+
+    it('cancel transitions to prompt-choose-device', async () => {
+        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
+        depsMock.setup(m => m.stepTransition('prompt-choose-device')).verifiable(Times.once());
+
+        const step = promptConnectedStartTesting(depsMock.object);
+        step.actions.cancel();
+
+        depsMock.verifyAll();
     });
 
     it('rescan transitions to detect-adb as expected', () => {


### PR DESCRIPTION
#### Description of changes
The cancel button in the "start testing" dialog wasn't hooked up inside the step. This hooks it up, following the same pattern of #2929 

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
