### PR TITLE
fix(android-setup): Enable selection from multiple devices

### DIFF
--- a/src/electron/platform/android/setup/android-setup-steps-configs.ts
+++ b/src/electron/platform/android/setup/android-setup-steps-configs.ts
@@ -10,6 +10,7 @@ import { detectDevices } from 'electron/platform/android/setup/steps/detect-devi
 import { detectPermissions } from 'electron/platform/android/setup/steps/detect-permissions';
 import { detectService } from 'electron/platform/android/setup/steps/detect-service';
 import { installingService } from 'electron/platform/android/setup/steps/installing-service';
+import { promptChooseDevice } from 'electron/platform/android/setup/steps/prompt-choose-device';
 import { promptConfiguringPortForwardingFailed } from 'electron/platform/android/setup/steps/prompt-configuring-port-forwarding-failed';
 import { promptConnectToDevice } from 'electron/platform/android/setup/steps/prompt-connect-to-device';
 import { promptConnectedStartTesting } from 'electron/platform/android/setup/steps/prompt-connected-start-testing';
@@ -40,7 +41,7 @@ export const allAndroidSetupStepConfigs: AndroidSetupStepConfigs = {
     'prompt-locate-adb': promptLocateAdb,
     'prompt-connect-to-device': promptConnectToDevice,
     'detect-devices': detectDevices,
-    'prompt-choose-device': promptConnectToDevice,
+    'prompt-choose-device': promptChooseDevice,
     'detect-service': detectService,
     'prompt-install-service': promptInstallService,
     'installing-service': installingService,

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -91,7 +91,7 @@ export class PromptChooseDeviceStep extends React.Component<
                 text: 'Next',
                 disabled: this.state.selectedDevice === null,
                 onClick: _ => {
-                    const selectedDevice = this.state.selectedDevice['metadata'];
+                    const selectedDevice: DeviceInfo = this.state.selectedDevice['metadata'];
                     this.props.deps.androidSetupActionCreator.setSelectedDevice(selectedDevice);
                 },
             },

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -90,7 +90,10 @@ export class PromptChooseDeviceStep extends React.Component<
             rightFooterButtonProps: {
                 text: 'Next',
                 disabled: this.state.selectedDevice === null,
-                onClick: _ => this.props.deps.androidSetupActionCreator.next(),
+                onClick: _ =>
+                    this.props.deps.androidSetupActionCreator.setSelectedDevice(
+                        this.state.selectedDevice,
+                    ),
             },
         };
 

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -90,10 +90,10 @@ export class PromptChooseDeviceStep extends React.Component<
             rightFooterButtonProps: {
                 text: 'Next',
                 disabled: this.state.selectedDevice === null,
-                onClick: _ =>
-                    this.props.deps.androidSetupActionCreator.setSelectedDevice(
-                        this.state.selectedDevice,
-                    ),
+                onClick: _ => {
+                    const selectedDevice = this.state.selectedDevice['metadata'];
+                    this.props.deps.androidSetupActionCreator.setSelectedDevice(selectedDevice);
+                },
             },
         };
 

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
@@ -72,7 +72,7 @@ describe('PromptChooseDeviceStep', () => {
         rendered.find('DeviceDescription').at(0).simulate('click');
         actionMessageCreatorMock
             .setup(m => m.setSelectedDevice(It.isAny()))
-            .callback(value => (actualDevice = value.metadata));
+            .callback(value => (actualDevice = value));
         rendered.find(AndroidSetupStepLayout).prop('rightFooterButtonProps').onClick(stubEvent);
         actionMessageCreatorMock.verify(m => m.setSelectedDevice(It.isAny()), Times.once());
         expect(actualDevice).toEqual(expectedDevice);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
@@ -9,7 +9,7 @@ import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/compo
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
-import { IMock, It, Mock, Times } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 
 describe('PromptChooseDeviceStep', () => {
     let props: CommonAndroidSetupStepProps;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { AndroidSetupStoreData } from 'electron/flux/types/android-setup-store-data';
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('PromptChooseDeviceStep', () => {
     let props: CommonAndroidSetupStepProps;
@@ -63,11 +64,18 @@ describe('PromptChooseDeviceStep', () => {
         actionMessageCreatorMock.verify(m => m.rescan(), Times.once());
     });
 
-    it('passes next dep through', () => {
+    it('passes setSelectedDevice dep through', () => {
+        const expectedDevice: DeviceInfo = props.androidSetupStoreData.availableDevices[0];
+        let actualDevice: DeviceInfo;
         const stubEvent = {} as React.MouseEvent<HTMLButtonElement>;
-        const rendered = shallow(<PromptChooseDeviceStep {...props} />);
+        const rendered = mount(<PromptChooseDeviceStep {...props} />);
+        rendered.find('DeviceDescription').at(0).simulate('click');
+        actionMessageCreatorMock
+            .setup(m => m.setSelectedDevice(It.isAny()))
+            .callback(value => (actualDevice = value.metadata));
         rendered.find(AndroidSetupStepLayout).prop('rightFooterButtonProps').onClick(stubEvent);
-        actionMessageCreatorMock.verify(m => m.next(), Times.once());
+        actionMessageCreatorMock.verify(m => m.setSelectedDevice(It.isAny()), Times.once());
+        expect(actualDevice).toEqual(expectedDevice);
     });
 
     it('next button becomes enabled after device is selected', () => {

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
@@ -66,16 +66,11 @@ describe('PromptChooseDeviceStep', () => {
 
     it('passes setSelectedDevice dep through', () => {
         const expectedDevice: DeviceInfo = props.androidSetupStoreData.availableDevices[0];
-        let actualDevice: DeviceInfo;
         const stubEvent = {} as React.MouseEvent<HTMLButtonElement>;
         const rendered = mount(<PromptChooseDeviceStep {...props} />);
         rendered.find('DeviceDescription').at(0).simulate('click');
-        actionMessageCreatorMock
-            .setup(m => m.setSelectedDevice(It.isAny()))
-            .callback(value => (actualDevice = value));
         rendered.find(AndroidSetupStepLayout).prop('rightFooterButtonProps').onClick(stubEvent);
-        actionMessageCreatorMock.verify(m => m.setSelectedDevice(It.isAny()), Times.once());
-        expect(actualDevice).toEqual(expectedDevice);
+        actionMessageCreatorMock.verify(m => m.setSelectedDevice(expectedDevice), Times.once());
     });
 
     it('next button becomes enabled after device is selected', () => {


### PR DESCRIPTION
#### Description of changes
The "choose device" dialog had some issues:
1. Due to a mapping error, any steps entering the `prompt-choose-device` state pointed to the wrong dialog (I set this incorrectly earlier today).
2. The dialog was calling the `next` action, when the step was expecting the `setSelectedDevice` action. 

  Between these issues, the user couldn't choose between multiple connected devices.

  Fixes were updating the dialog mapping and ensuring that we called `setSelectedDevice` correctly after the user selected a dialog. Tested by running with multiple attached devices and ensuring that the E2E workflow works as expected.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: bug bash
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
