### PR TITLE
fix(android-setup): fix padding in prompt-connected-start-testing

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.scss
@@ -44,9 +44,12 @@
         flex-basis: auto;
 
         width: 100%;
-        margin-top: 24px;
         font-size: $fontSizeM;
         line-height: 16px;
+
+        p {
+            margin-top: 24px;
+        }
     }
 
     .footer {

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.tsx
@@ -42,10 +42,10 @@ export const PromptConfiguringPortForwardingFailedStep = NamedFC<CommonAndroidSe
 
         return (
             <AndroidSetupStepLayout {...layoutProps}>
-                <>
+                <p>
                     We were unable to configure port forwarding from Accessibility Insights for
                     Android Service on your device. Please reconnect your device and try again.
-                </>
+                </p>
                 <DeviceDescription {...descriptionProps}></DeviceDescription>
                 <PrimaryButton
                     data-automation-id={tryAgainAutomationId}

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.scss
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 @import '../../../../../common/styles/fonts.scss';
 
-.device-description {
-    margin-top: 16px;
-    margin-bottom: 16px;
+.detect-button {
+    margin-top: 24px;
 }

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
@@ -5,6 +5,7 @@ import { PrimaryButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
+import * as styles from './prompt-connect-to-device-step.scss';
 
 export const detectDeviceAutomationId = 'detect-device';
 export const PromptConnectToDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
@@ -35,6 +36,7 @@ export const PromptConnectToDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
                 <PrimaryButton
                     data-automation-id={detectDeviceAutomationId}
                     text="Detect my device"
+                    className={styles.detectButton}
                     onClick={props.deps.androidSetupActionCreator.next}
                 />
             </AndroidSetupStepLayout>

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
@@ -12,6 +12,7 @@ import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 
+export const rescanAutomationId = 'prompt-connected-start-testing-rescan-button';
 export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptConnectedStartTestingStep',
     (props: CommonAndroidSetupStepProps) => {
@@ -45,7 +46,7 @@ export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepPro
             <AndroidSetupStepLayout {...layoutProps}>
                 <DeviceDescription {...descriptionProps}></DeviceDescription>
                 <DefaultButton
-                    className={styles.rescanButton}
+                    data-automation-id={rescanAutomationId}
                     text="Rescan devices"
                     onClick={props.deps.androidSetupActionCreator.rescan}
                 />

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
@@ -42,10 +42,10 @@ export const PromptGrantPermissionsStep = NamedFC<CommonAndroidSetupStepProps>(
 
         return (
             <AndroidSetupStepLayout {...layoutProps}>
-                <>
+                <p>
                     Be sure the Accessibility Insights for Android Service on your device is turned
                     on and has permission to access your device and capture screenshots.
-                </>
+                </p>
                 <DeviceDescription {...descriptionProps}></DeviceDescription>
                 <PrimaryButton
                     text="Try again"

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.tsx
@@ -42,11 +42,11 @@ export const PromptInstallFailedStep = NamedFC<CommonAndroidSetupStepProps>(
 
         return (
             <AndroidSetupStepLayout {...layoutProps}>
-                <>
+                <p>
                     We were unable to install the latest version of Accessibility Insights for
                     Android Service on your device. You can try installing the service yourself,
                     from your device, or choose one of the options below.
-                </>
+                </p>
                 <DeviceDescription {...descriptionProps}></DeviceDescription>
                 <PrimaryButton
                     data-automation-id={tryAgainAutomationId}

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-install-service-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-install-service-step.tsx
@@ -35,10 +35,10 @@ export const PromptInstallServiceStep = NamedFC<CommonAndroidSetupStepProps>(
 
         return (
             <AndroidSetupStepLayout {...layoutProps}>
-                <>
+                <p>
                     It looks like the Accessibility Insights for Android Service on your device is
                     either missing or out of date. We'll need to install the latest version.
-                </>
+                </p>
                 <DeviceDescription {...descriptionProps}></DeviceDescription>
                 <PrimaryButton
                     text="Install"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-configuring-port-forwarding-failed-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-configuring-port-forwarding-failed-step.test.tsx.snap
@@ -24,9 +24,9 @@ exports[`PromptConfiguringPortForwardingFailedStep renders with device 1`] = `
     }
   }
 >
-  <React.Fragment>
+  <p>
     We were unable to configure port forwarding from Accessibility Insights for Android Service on your device. Please reconnect your device and try again.
-  </React.Fragment>
+  </p>
   <DeviceDescription
     className="deviceDescription"
     friendlyName="Super-Duper Gadget"
@@ -65,9 +65,9 @@ exports[`PromptConfiguringPortForwardingFailedStep renders with emulator 1`] = `
     }
   }
 >
-  <React.Fragment>
+  <p>
     We were unable to configure port forwarding from Accessibility Insights for Android Service on your device. Please reconnect your device and try again.
-  </React.Fragment>
+  </p>
   <DeviceDescription
     className="deviceDescription"
     friendlyName="Emulator Extraordinaire"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connect-to-device-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connect-to-device-step.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`PromptConnectToDeviceStep renders per snapshot 1`] = `
   }
 >
   <CustomizedPrimaryButton
+    className="detectButton"
     data-automation-id="detect-device"
     onClick={[Function]}
     text="Detect my device"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`PromptConnectedStartTestingStep renders with device 1`] = `
     isEmulator={false}
   />
   <CustomizedDefaultButton
-    className="rescanButton"
+    data-automation-id="prompt-connected-start-testing-rescan-button"
     onClick={[Function]}
     text="Rescan devices"
   />
@@ -71,7 +71,7 @@ exports[`PromptConnectedStartTestingStep renders with emulator 1`] = `
     isEmulator={true}
   />
   <CustomizedDefaultButton
-    className="rescanButton"
+    data-automation-id="prompt-connected-start-testing-rescan-button"
     onClick={[Function]}
     text="Rescan devices"
   />

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
@@ -24,9 +24,9 @@ exports[`PromptGrantPermissionsStep renders with device 1`] = `
     }
   }
 >
-  <React.Fragment>
+  <p>
     Be sure the Accessibility Insights for Android Service on your device is turned on and has permission to access your device and capture screenshots.
-  </React.Fragment>
+  </p>
   <DeviceDescription
     className="deviceDescription"
     friendlyName="Super-Duper Gadget"
@@ -65,9 +65,9 @@ exports[`PromptGrantPermissionsStep renders with emulator 1`] = `
     }
   }
 >
-  <React.Fragment>
+  <p>
     Be sure the Accessibility Insights for Android Service on your device is turned on and has permission to access your device and capture screenshots.
-  </React.Fragment>
+  </p>
   <DeviceDescription
     className="deviceDescription"
     friendlyName="Emulator Extraordinaire"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-failed-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-failed-step.test.tsx.snap
@@ -24,9 +24,9 @@ exports[`PromptInstallFailedStep renders with device 1`] = `
     }
   }
 >
-  <React.Fragment>
+  <p>
     We were unable to install the latest version of Accessibility Insights for Android Service on your device. You can try installing the service yourself, from your device, or choose one of the options below.
-  </React.Fragment>
+  </p>
   <DeviceDescription
     className="deviceDescription"
     friendlyName="Super-Duper Gadget"
@@ -65,9 +65,9 @@ exports[`PromptInstallFailedStep renders with emulator 1`] = `
     }
   }
 >
-  <React.Fragment>
+  <p>
     We were unable to install the latest version of Accessibility Insights for Android Service on your device. You can try installing the service yourself, from your device, or choose one of the options below.
-  </React.Fragment>
+  </p>
   <DeviceDescription
     className="deviceDescription"
     friendlyName="Emulator Extraordinaire"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-service-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-service-step.test.tsx.snap
@@ -17,9 +17,9 @@ exports[`PromptInstallServiceStep renders with device 1`] = `
     }
   }
 >
-  <React.Fragment>
+  <p>
     It looks like the Accessibility Insights for Android Service on your device is either missing or out of date. We'll need to install the latest version.
-  </React.Fragment>
+  </p>
   <DeviceDescription
     className="deviceDescription"
     friendlyName="Super-Duper Gadget"
@@ -51,9 +51,9 @@ exports[`PromptInstallServiceStep renders with emulator 1`] = `
     }
   }
 >
-  <React.Fragment>
+  <p>
     It looks like the Accessibility Insights for Android Service on your device is either missing or out of date. We'll need to install the latest version.
-  </React.Fragment>
+  </p>
   <DeviceDescription
     className="deviceDescription"
     friendlyName="Emulator Extraordinaire"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
@@ -4,8 +4,10 @@ import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-
 import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
-import { PromptConnectedStartTestingStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step';
-import * as styles from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss';
+import {
+    PromptConnectedStartTestingStep,
+    rescanAutomationId,
+} from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
@@ -70,7 +72,7 @@ describe('PromptConnectedStartTestingStep', () => {
 
     it('handles the rescan button with the rescan action', () => {
         const rendered = shallow(<PromptConnectedStartTestingStep {...props} />);
-        rendered.find(`.${styles.rescanButton}`).simulate('click');
+        rendered.find({ 'data-automation-id': rescanAutomationId }).simulate('click');
         androidSetupActionCreatorMock.verify(m => m.rescan(), Times.once());
     });
 });


### PR DESCRIPTION
#### Description of changes

This PR adjusts the padding in the prompt-connected-start-testing step to match the figma.

It involves updates to a bunch of other components because previously, everything used a 24px margin between step layout header and content, but this particular fix requires a 16px margin. Oops.

I considered pushing back and just accepting a 24px margin, but it wasn't *that* big a deal to have it match the figma, and it does look a little nicer this way imo.

Verified no visual change on any other steps. Before and after of the impacted prompt-connected-start-testing step:

**Before**
![image](https://user-images.githubusercontent.com/376284/85476011-0d275b80-b56c-11ea-955f-145da2c52a80.png)

**After**
![image](https://user-images.githubusercontent.com/376284/85475908-cd607400-b56b-11ea-9eac-a5187ccf7bfb.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
