### PR TITLE
refactor: add extension-telemetry-events to strict null checks config

### DIFF
--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { SingleElementSelector } from './types/store-data/scoping-store-data';
 
 export const POPUP_INITIALIZED: string = 'PopupInitialized';
@@ -213,10 +213,7 @@ export type SetAllUrlsPermissionTelemetryData = {
     permissionState: boolean;
 } & BaseTelemetryData;
 
-export type ScanIncompleteWarningsTelemetryData = Pick<
-    UnifiedScanCompletedPayload,
-    'scanIncompleteWarnings'
->;
+export type ScanIncompleteWarningsTelemetryData = ScanIncompleteWarningId[];
 
 export type TelemetryData =
     | BaseTelemetryData

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -213,7 +213,9 @@ export type SetAllUrlsPermissionTelemetryData = {
     permissionState: boolean;
 } & BaseTelemetryData;
 
-export type ScanIncompleteWarningsTelemetryData = ScanIncompleteWarningId[];
+export type ScanIncompleteWarningsTelemetryData = {
+    scanIncompleteWarnings: ScanIncompleteWarningId[];
+};
 
 export type TelemetryData =
     | BaseTelemetryData

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -97,6 +97,7 @@
         "./src/common/date-provider.ts",
         "./src/common/document-manipulator.ts",
         "./src/common/enum-helper.ts",
+        "./src/common/extension-telemetry-events.ts",
         "./src/common/fabric-icons.ts",
         "./src/common/file-url-provider.ts",
         "./src/common/flux/event-handler-list.ts",


### PR DESCRIPTION
#### Description of changes

Refactors the import from action-payloads so that extension-telemetry-events no longer fails the strict-null-check step. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
