### PR TITLE
fix(android-setup): avoid detect-devices spinning forever on getDevices failure

### DIFF
--- a/src/electron/platform/android/setup/steps/detect-devices.ts
+++ b/src/electron/platform/android/setup/steps/detect-devices.ts
@@ -10,7 +10,10 @@ export const detectDevices: AndroidSetupStepConfig = deps => {
             deps.setSelectedDevice(null);
             deps.setAvailableDevices([]);
 
-            const devices = await deps.getDevices();
+            const devices = await deps.getDevices().catch(e => {
+                deps.logger.error(e);
+                return [];
+            });
 
             switch (devices.length) {
                 case 0: {

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-devices.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-devices.test.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { Logger } from 'common/logging/logger';
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
 import { detectDevices } from 'electron/platform/android/setup/steps/detect-devices';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
-import { Logger } from 'common/logging/logger';
 
 describe('Android setup step: detectDevices', () => {
     let depsMock: IMock<AndroidSetupStepConfigDeps>;

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-devices.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-devices.test.ts
@@ -4,10 +4,23 @@
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
 import { detectDevices } from 'electron/platform/android/setup/steps/detect-devices';
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
+import { Logger } from 'common/logging/logger';
 
 describe('Android setup step: detectDevices', () => {
+    let depsMock: IMock<AndroidSetupStepConfigDeps>;
+    let loggerMock: IMock<Logger>;
+
+    beforeEach(() => {
+        loggerMock = Mock.ofType<Logger>();
+        depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
+        depsMock
+            .setup(m => m.logger)
+            .returns(() => loggerMock.object)
+            .verifiable(Times.atLeast(0));
+    });
+
     it('has expected properties', () => {
         const deps = {} as AndroidSetupStepConfigDeps;
         const step = detectDevices(deps);
@@ -19,7 +32,6 @@ describe('Android setup step: detectDevices', () => {
         const devices: DeviceInfo[] = [];
         const p = new Promise<DeviceInfo[]>(resolve => resolve(devices));
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.getDevices())
             .returns(_ => p)
@@ -44,7 +56,6 @@ describe('Android setup step: detectDevices', () => {
 
         const p = new Promise<DeviceInfo[]>(resolve => resolve(devices));
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.getDevices())
             .returns(_ => p)
@@ -75,7 +86,6 @@ describe('Android setup step: detectDevices', () => {
 
         const p = new Promise<DeviceInfo[]>(resolve => resolve(devices));
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.getDevices())
             .returns(_ => p)
@@ -90,5 +100,25 @@ describe('Android setup step: detectDevices', () => {
         await step.onEnter();
 
         depsMock.verifyAll();
+    });
+
+    it('onEnter transitions to prompt-connect-to-device if getDevices fails', async () => {
+        const getDevicesError = new Error('error from getDevices');
+
+        depsMock
+            .setup(m => m.getDevices())
+            .returns(() => Promise.reject(getDevicesError))
+            .verifiable(Times.once());
+
+        depsMock.setup(m => m.setSelectedDevice(null));
+        depsMock.setup(m => m.setAvailableDevices([])).verifiable(Times.atLeastOnce());
+        depsMock.setup(m => m.stepTransition('prompt-connect-to-device'));
+
+        const step = detectDevices(depsMock.object);
+        await step.onEnter();
+
+        depsMock.verifyAll();
+
+        loggerMock.verify(m => m.error(getDevicesError), Times.once());
     });
 });


### PR DESCRIPTION
#### Description of changes

`getDevices` can fail, eg, if the device falls asleep or is disconnected during the call. If that happens, we don't want the step to spin forever; it should make *some* state transition. I think the ideal would be some sort of generic error step, but for now, the best one available is probably the one with the link about device connection troubleshooting, prompt-connect-to-device (same as the no-devices-connected case)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: from bug bash onenote
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
