### PR TITLE
fix(android-setup): fix aria-label on adb path text field

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
@@ -42,7 +42,7 @@ export const FolderPicker = NamedFC<FolderPickerProps>(
                 </p>
                 <div className={styles.pickerControl}>
                     <TextField
-                        placeholder="Enter a path..."
+                        placeholder="adb path"
                         ariaLabel="Enter a path"
                         aria-describedby={instructionsId}
                         className={styles.textField}

--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
@@ -43,7 +43,7 @@ export const FolderPicker = NamedFC<FolderPickerProps>(
                 <div className={styles.pickerControl}>
                     <TextField
                         placeholder="Enter a path..."
-                        aria-label="Enter a path"
+                        ariaLabel="Enter a path"
                         aria-describedby={instructionsId}
                         className={styles.textField}
                         iconProps={{ iconName: 'FabricFolder' }}

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/folder-picker.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/folder-picker.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`FolderPicker renders per snapshot 1`] = `
         }
       }
       onChange={[Function]}
-      placeholder="Enter a path..."
+      placeholder="adb path"
       value="/path/to/folder"
     />
     <CustomizedPrimaryButton

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/folder-picker.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/folder-picker.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`FolderPicker renders per snapshot 1`] = `
   >
     <StyledTextFieldBase
       aria-describedby="folder-picker-instructions__1"
-      aria-label="Enter a path"
+      ariaLabel="Enter a path"
       className="textField"
       iconProps={
         Object {


### PR DESCRIPTION
#### Description of changes

Fluent UI has its own `ariaLabel` prop for `TextField`s, but not its own `aria-describedby`, so the casing has to be different for applying them (oops). React does provide an `aria-label` (which is why this wasn't a compile error), but Fluent ignores it in favor of its own property.

NVDA now reads the control (when empty) as "Enter a path  edit  Select the folder containing adb. We'll use it to connect to your device.  Enter a path...  blank" - that is, it repeats the label and placeholder text. Would like confirmation from @ferBonnin / @RobGallo on whether this feels reasonable or if it's too redundant

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
