### PR TITLE
feat(reflow-command-bar): Refactor NarrowModeDetector

### DIFF
--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -4,6 +4,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewOverlay } from 'DetailsView/components/details-view-overlay/details-view-overlay';
 import { InteractiveHeader } from 'DetailsView/components/interactive-header';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { DetailsViewBody } from 'DetailsView/details-view-body';
 import { DetailsViewContainerProps } from 'DetailsView/details-view-container';
 import * as React from 'react';
@@ -11,7 +12,7 @@ import * as React from 'react';
 export type DetailsViewContentProps = DetailsViewContainerProps & {
     isSideNavOpen: boolean;
     setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
-    isNarrowMode: boolean;
+    narrowModeStatus: NarrowModeStatus;
 };
 
 export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewContent', props => {
@@ -35,7 +36,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                 navMenu={selectedDetailsViewSwitcherNavConfiguration.leftNavHamburgerButton}
                 isSideNavOpen={props.isSideNavOpen}
                 setSideNavOpen={props.setSideNavOpen}
-                isNarrowMode={props.isNarrowMode}
+                narrowModeStatus={props.narrowModeStatus}
             />
         );
     };
@@ -121,7 +122,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                 scanMetadata={scanMetadata}
                 isSideNavOpen={props.isSideNavOpen}
                 setSideNavOpen={props.setSideNavOpen}
-                isNarrowMode={props.isNarrowMode}
+                narrowModeStatus={props.narrowModeStatus}
             />
         );
     };

--- a/src/DetailsView/components/interactive-header.tsx
+++ b/src/DetailsView/components/interactive-header.tsx
@@ -8,6 +8,7 @@ import { FeatureFlags } from 'common/feature-flags';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { headerSwitcherStyleNames } from 'DetailsView/components/switcher-style-names';
 import * as React from 'react';
 import { Switcher, SwitcherDeps } from './switcher';
@@ -20,7 +21,7 @@ export interface InteractiveHeaderProps {
     tabClosed: boolean;
     selectedPivot: DetailsViewPivotType;
     navMenu: ReactFCWithDisplayName<ExpandCollpaseLeftNavButtonProps>;
-    isNarrowMode: boolean;
+    narrowModeStatus: NarrowModeStatus;
     isSideNavOpen: boolean;
     setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
     showFarItems?: boolean;
@@ -28,12 +29,13 @@ export interface InteractiveHeaderProps {
 }
 
 export const InteractiveHeader = NamedFC<InteractiveHeaderProps>('InteractiveHeader', props => {
+    const isNavCollapsed = props.narrowModeStatus.isHeaderAndNavCollapsed;
     if (props.tabClosed) {
-        return <Header deps={props.deps} isNarrowMode={props.isNarrowMode} />;
+        return <Header deps={props.deps} isNarrowMode={isNavCollapsed} />;
     }
 
     const getNavMenu = () => {
-        if (props.isNarrowMode === false) {
+        if (isNavCollapsed === false) {
             return null;
         }
 
@@ -75,7 +77,7 @@ export const InteractiveHeader = NamedFC<InteractiveHeaderProps>('InteractiveHea
             navMenu={getNavMenu()}
             showHeaderTitle={props.showHeaderTitle}
             showFarItems={props.showFarItems}
-            isNarrowMode={props.isNarrowMode}
+            narrowModeStatus={props.narrowModeStatus}
         ></Header>
     );
 });

--- a/src/DetailsView/components/interactive-header.tsx
+++ b/src/DetailsView/components/interactive-header.tsx
@@ -29,11 +29,11 @@ export interface InteractiveHeaderProps {
 }
 
 export const InteractiveHeader = NamedFC<InteractiveHeaderProps>('InteractiveHeader', props => {
-    const isNavCollapsed = props.narrowModeStatus.isHeaderAndNavCollapsed;
     if (props.tabClosed) {
-        return <Header deps={props.deps} isNarrowMode={isNavCollapsed} />;
+        return <Header deps={props.deps} narrowModeStatus={props.narrowModeStatus} />;
     }
 
+    const isNavCollapsed = props.narrowModeStatus.isHeaderAndNavCollapsed;
     const getNavMenu = () => {
         if (isNavCollapsed === false) {
             return null;

--- a/src/DetailsView/components/left-nav/fluent-side-nav.tsx
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.tsx
@@ -13,6 +13,7 @@ import {
     DetailsViewLeftNavProps,
 } from 'DetailsView/components/left-nav/details-view-left-nav';
 import * as styles from 'DetailsView/components/left-nav/fluent-side-nav.scss';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { INav, PanelType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
@@ -23,7 +24,7 @@ export type FluentSideNavProps = Omit<DetailsViewLeftNavProps, 'setNavComponentR
     tabStoreData: TabStoreData;
     isSideNavOpen: boolean;
     setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
-    isNarrowMode: boolean;
+    narrowModeStatus: NarrowModeStatus;
 };
 
 export class FluentSideNav extends React.Component<FluentSideNavProps> {
@@ -58,7 +59,7 @@ export class FluentSideNav extends React.Component<FluentSideNavProps> {
                     setSideNavOpen={this.props.setSideNavOpen}
                     showFarItems={false}
                     showHeaderTitle={false}
-                    isNarrowMode={this.props.isNarrowMode}
+                    narrowModeStatus={this.props.narrowModeStatus}
                 />
             );
         };
@@ -81,7 +82,9 @@ export class FluentSideNav extends React.Component<FluentSideNavProps> {
 
         const navBarInSideNavContainer = <div id={styles.sideNavContainer}>{navBar}</div>;
 
-        return this.props.isNarrowMode ? navPanel : navBarInSideNavContainer;
+        return this.props.narrowModeStatus.isHeaderAndNavCollapsed
+            ? navPanel
+            : navBarInSideNavContainer;
     }
 
     protected setNavComponentRef(nav: INav): void {
@@ -90,9 +93,9 @@ export class FluentSideNav extends React.Component<FluentSideNavProps> {
 
     private isNavPanelConvertedToNavBar(prevProps: FluentSideNavProps): boolean {
         return (
-            prevProps.isNarrowMode === true &&
+            prevProps.narrowModeStatus.isHeaderAndNavCollapsed === true &&
             prevProps.isSideNavOpen === true &&
-            this.props.isNarrowMode === false
+            this.props.narrowModeStatus.isHeaderAndNavCollapsed === false
         );
     }
 

--- a/src/DetailsView/components/narrow-mode-detector.tsx
+++ b/src/DetailsView/components/narrow-mode-detector.tsx
@@ -4,22 +4,40 @@ import { ReactFCWithDisplayName } from 'common/react/named-fc';
 import * as React from 'react';
 import ReactResizeDetector from 'react-resize-detector';
 
-export type NarrowModeDetectorProps<P = { isNarrowMode: boolean }> = {
+export type NarrowModeStatus = {
+    isHeaderAndNavCollapsed: boolean;
+    isCommandBarCollapsed: boolean;
+};
+
+export type NarrowModeDetectorProps<P = { narrowModeStatus: NarrowModeStatus }> = {
     isNarrowModeEnabled: boolean;
-    Component: ReactFCWithDisplayName<P & { isNarrowMode: boolean }>;
+    Component: ReactFCWithDisplayName<P & { narrowModeStatus: NarrowModeStatus }>;
     childrenProps: P;
 };
 
-const NARROW_MODE_THRESHOLD_IN_PIXEL = 600;
+export const narrowModeThresholds = {
+    collapseHeaderAndNavThreshold: 600,
+    collapseCommandBarThreshold: 960,
+};
 
 export function getNarrowModeComponentWrapper<P>(
     props: NarrowModeDetectorProps<P>,
 ): (dimensions: { width: number }) => JSX.Element {
     return (dimensions: { width: number }) => {
-        const isNarrowMode =
-            props.isNarrowModeEnabled === true && dimensions.width < NARROW_MODE_THRESHOLD_IN_PIXEL;
         const childrenProps = props.childrenProps;
-        return <props.Component {...childrenProps} isNarrowMode={isNarrowMode} />;
+        const isNarrowModeEnabled = props.isNarrowModeEnabled === true;
+
+        const isNarrowerThan = (threshold: number) => dimensions.width < threshold;
+
+        const narrowModeStatus = {
+            isHeaderAndNavCollapsed:
+                isNarrowModeEnabled &&
+                isNarrowerThan(narrowModeThresholds.collapseHeaderAndNavThreshold),
+            isCommandBarCollapsed:
+                isNarrowModeEnabled &&
+                isNarrowerThan(narrowModeThresholds.collapseCommandBarThreshold),
+        };
+        return <props.Component {...childrenProps} narrowModeStatus={narrowModeStatus} />;
     };
 }
 

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -8,6 +8,7 @@ import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { FluentSideNav, FluentSideNavDeps } from 'DetailsView/components/left-nav/fluent-side-nav';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import * as styles from 'DetailsView/details-view-body.scss';
 import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -64,14 +65,13 @@ export interface DetailsViewBodyProps {
     scanMetadata: ScanMetadata;
     isSideNavOpen: boolean;
     setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
-    isNarrowMode: boolean;
+    narrowModeStatus: NarrowModeStatus;
 }
 
 export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
     public render(): JSX.Element {
         const bodyLayoutClassName = classNames({
             'details-view-body-nav-content-layout': true,
-            'narrow-mode': this.props.isNarrowMode,
             'reflow-ui': this.props.featureFlagStoreData[FeatureFlags.reflowUI],
         });
 
@@ -114,7 +114,7 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
                 isSideNavOpen={this.props.isSideNavOpen}
                 setSideNavOpen={this.props.setSideNavOpen}
                 onRightPanelContentSwitch={() => this.props.setSideNavOpen(false)}
-                isNarrowMode={this.props.isNarrowMode}
+                narrowModeStatus={this.props.narrowModeStatus}
                 {...this.props}
             />
         );

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -96,7 +96,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
 
     public render(): JSX.Element {
         if (this.shouldShowNoContentAvailable()) {
-            const headerProps: Omit<HeaderProps, 'isNarrowMode'> = { deps: this.props.deps };
+            const headerProps: Omit<HeaderProps, 'narrowModeStatus'> = { deps: this.props.deps };
             return (
                 <>
                     <NarrowModeDetector

--- a/src/common/components/header.tsx
+++ b/src/common/components/header.tsx
@@ -3,6 +3,7 @@
 import { HeaderIcon, HeaderIconDeps } from 'common/components/header-icon';
 import { NamedFC } from 'common/react/named-fc';
 import { TextContent } from 'content/strings/text-content';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import * as React from 'react';
 import * as styles from './header.scss';
 
@@ -15,7 +16,7 @@ export type HeaderProps = {
     navMenu?: JSX.Element;
     showHeaderTitle?: boolean;
     showFarItems?: boolean;
-    isNarrowMode?: boolean;
+    narrowModeStatus?: NarrowModeStatus;
 };
 
 export const Header = NamedFC<HeaderProps>('Header', props => {
@@ -30,7 +31,8 @@ export const Header = NamedFC<HeaderProps>('Header', props => {
     };
 
     const getHeaderTitle = () => {
-        if (props.showHeaderTitle === false || props.isNarrowMode === true) {
+        const isHeaderCollapsed = props.narrowModeStatus?.isHeaderAndNavCollapsed === true;
+        if (props.showHeaderTitle === false || isHeaderCollapsed) {
             return null;
         } else {
             return <span className={styles.headerTitle}>{applicationTitle}</span>;

--- a/src/debug-tools/components/debug-tools-view.tsx
+++ b/src/debug-tools/components/debug-tools-view.tsx
@@ -39,7 +39,7 @@ export const DebugTools = NamedFC<DebugToolsViewProps>('DebugToolsView', ({ deps
         return <Spinner size={SpinnerSize.large} label="Loading" />;
     }
 
-    const headerProps: Omit<HeaderProps, 'isNarrowMode'> = { deps };
+    const headerProps: Omit<HeaderProps, 'narrowModeStatus'> = { deps };
     return (
         <div className={styles.debugToolsContainer}>
             <NarrowModeDetector

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -57,8 +57,13 @@ exports[` render renders normally 1`] = `
         "logTelemetryToConsole": false,
       }
     }
-    isNarrowMode={false}
     isSideNavOpen={false}
+    narrowModeStatus={
+      Object {
+        "isCommandBarCollapsed": false,
+        "isHeaderAndNavCollapsed": false,
+      }
+    }
     selectedPivot={0}
     setSideNavOpen={[Function]}
     tabClosed={false}
@@ -161,8 +166,13 @@ exports[` render renders normally 1`] = `
         "logTelemetryToConsole": false,
       }
     }
-    isNarrowMode={false}
     isSideNavOpen={false}
+    narrowModeStatus={
+      Object {
+        "isCommandBarCollapsed": false,
+        "isHeaderAndNavCollapsed": false,
+      }
+    }
     pathSnippetStoreData={
       Object {
         "path": null,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/fluent-side-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/fluent-side-nav.test.tsx.snap
@@ -5,8 +5,12 @@ exports[`FluentSideNav render nav bar 1`] = `
   id="sideNavContainer"
 >
   <DetailsViewLeftNav
-    isNarrowMode={false}
     isSideNavOpen={false}
+    narrowModeStatus={
+      Object {
+        "isHeaderAndNavCollapsed": false,
+      }
+    }
     selectedPivot={0}
     setNavComponentRef={[Function]}
     setSideNavOpen={null}
@@ -34,8 +38,12 @@ exports[`FluentSideNav render side nav 1`] = `
   type={8}
 >
   <DetailsViewLeftNav
-    isNarrowMode={true}
     isSideNavOpen={false}
+    narrowModeStatus={
+      Object {
+        "isHeaderAndNavCollapsed": true,
+      }
+    }
     selectedPivot={0}
     setNavComponentRef={[Function]}
     setSideNavOpen={null}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/interactive-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/interactive-header.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InteractiveHeader does render nav menu button if not in narrow mode 1`] = `
+exports[`InteractiveHeader does render nav menu button if header not collapsed 1`] = `
 <Header
   deps={null}
   farItems={
@@ -9,7 +9,6 @@ exports[`InteractiveHeader does render nav menu button if not in narrow mode 1`]
       featureFlagData={null}
     />
   }
-  isNarrowMode={true}
   items={
     <FlaggedComponent
       disableJSXElement={
@@ -30,12 +29,12 @@ exports[`InteractiveHeader does render nav menu button if not in narrow mode 1`]
       featureFlagStoreData={null}
     />
   }
-  navMenu={
-    <test-nav-menu
-      isSideNavOpen={false}
-      setSideNavOpen={null}
-    />
+  narrowModeStatus={
+    Object {
+      "isHeaderAndNavCollapsed": false,
+    }
   }
+  navMenu={null}
 />
 `;
 
@@ -60,7 +59,6 @@ exports[`InteractiveHeader render: tabClosed equals false 1`] = `
       }
     />
   }
-  isNarrowMode={false}
   items={
     <FlaggedComponent
       disableJSXElement={
@@ -89,6 +87,11 @@ exports[`InteractiveHeader render: tabClosed equals false 1`] = `
       }
     />
   }
+  narrowModeStatus={
+    Object {
+      "isHeaderAndNavCollapsed": false,
+    }
+  }
   navMenu={null}
 />
 `;
@@ -100,6 +103,10 @@ exports[`InteractiveHeader render: tabClosed equals true 1`] = `
       "dropdownClickHandler": Object {},
     }
   }
-  isNarrowMode={false}
+  narrowModeStatus={
+    Object {
+      "isHeaderAndNavCollapsed": false,
+    }
+  }
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/interactive-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/interactive-header.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InteractiveHeader does render nav menu button if header not collapsed 1`] = `
+exports[`InteractiveHeader render: isNavCollapsed equals false 1`] = `
 <Header
   deps={null}
   farItems={
@@ -35,6 +35,49 @@ exports[`InteractiveHeader does render nav menu button if header not collapsed 1
     }
   }
   navMenu={null}
+/>
+`;
+
+exports[`InteractiveHeader render: isNavCollapsed equals true 1`] = `
+<Header
+  deps={null}
+  farItems={
+    <GearOptionsButtonComponent
+      deps={null}
+      featureFlagData={null}
+    />
+  }
+  items={
+    <FlaggedComponent
+      disableJSXElement={
+        <Switcher
+          deps={null}
+          pivotKey={2}
+          styles={
+            Object {
+              "dropdownClassName": "headerSwitcherDropdown",
+              "dropdownOptionClassName": "switcherDropdownOption",
+              "switcherClassName": "headerSwitcher",
+            }
+          }
+        />
+      }
+      enableJSXElement={null}
+      featureFlag="reflowUI"
+      featureFlagStoreData={null}
+    />
+  }
+  narrowModeStatus={
+    Object {
+      "isHeaderAndNavCollapsed": true,
+    }
+  }
+  navMenu={
+    <test-nav-menu
+      isSideNavOpen={false}
+      setSideNavOpen={null}
+    />
+  }
 />
 `;
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/narrow-mode-detector.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/narrow-mode-detector.test.tsx.snap
@@ -16,20 +16,13 @@ exports[`NarrowModeDetector render renders ReactResizeDetector  1`] = `
 </ResizeDetector>
 `;
 
-exports[`NarrowModeDetector render renders child component properly when narrow mode is disabled: narrow mode should be false 1`] = `
-<DetailsViewContent
-  isNarrowMode={false}
-/>
-`;
-
-exports[`NarrowModeDetector render renders child component properly when narrow mode is enabled: narrow mode should be false 1`] = `
-<DetailsViewContent
-  isNarrowMode={false}
-/>
-`;
-
-exports[`NarrowModeDetector render renders child component properly when narrow mode is enabled: narrow mode should be true 1`] = `
-<DetailsViewContent
-  isNarrowMode={true}
+exports[`NarrowModeDetector render renders child component properly when narrow mode is disabled: All narrow mode status values should be false 1`] = `
+<TestComponent
+  narrowModeStatus={
+    Object {
+      "isCommandBarCollapsed": false,
+      "isHeaderAndNavCollapsed": false,
+    }
+  }
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
@@ -5,6 +5,7 @@ import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { GenericPanel } from 'DetailsView/components/generic-panel';
 import { DetailsViewLeftNav } from 'DetailsView/components/left-nav/details-view-left-nav';
 import { FluentSideNav, FluentSideNavProps } from 'DetailsView/components/left-nav/fluent-side-nav';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { shallow } from 'enzyme';
 import { INav } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -41,7 +42,9 @@ describe(FluentSideNav, () => {
             tabStoreData,
             isSideNavOpen: false,
             setSideNavOpen: null,
-            isNarrowMode: true,
+            narrowModeStatus: {
+                isHeaderAndNavCollapsed: true,
+            },
         } as FluentSideNavProps;
 
         const wrapper = shallow(
@@ -60,7 +63,9 @@ describe(FluentSideNav, () => {
             tabStoreData,
             isSideNavOpen: false,
             setSideNavOpen: null,
-            isNarrowMode: false,
+            narrowModeStatus: {
+                isHeaderAndNavCollapsed: false,
+            },
         } as FluentSideNavProps;
 
         const wrapper = shallow(
@@ -81,7 +86,9 @@ describe(FluentSideNav, () => {
             tabStoreData,
             isSideNavOpen: false,
             setSideNavOpen: setSideNavOpenMock.object,
-            isNarrowMode: true,
+            narrowModeStatus: {
+                isHeaderAndNavCollapsed: true,
+            },
         } as FluentSideNavProps;
 
         const wrapper = shallow(
@@ -114,14 +121,18 @@ describe(FluentSideNav, () => {
             tabStoreData,
             isSideNavOpen: true,
             setSideNavOpen: null,
-            isNarrowMode: true,
+            narrowModeStatus: {
+                isHeaderAndNavCollapsed: true,
+            },
         } as FluentSideNavProps;
 
         props = {
             tabStoreData,
             isSideNavOpen: false,
             setSideNavOpen: null,
-            isNarrowMode: false,
+            narrowModeStatus: {
+                isHeaderAndNavCollapsed: false,
+            },
         } as FluentSideNavProps;
 
         const wrapper = shallow(

--- a/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
@@ -5,7 +5,6 @@ import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { GenericPanel } from 'DetailsView/components/generic-panel';
 import { DetailsViewLeftNav } from 'DetailsView/components/left-nav/details-view-left-nav';
 import { FluentSideNav, FluentSideNavProps } from 'DetailsView/components/left-nav/fluent-side-nav';
-import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { shallow } from 'enzyme';
 import { INav } from 'office-ui-fabric-react';
 import * as React from 'react';

--- a/src/tests/unit/tests/DetailsView/components/interactive-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/interactive-header.test.tsx
@@ -44,7 +44,7 @@ describe('InteractiveHeader', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    it('does render nav menu button if header not collapsed', () => {
+    it.each([false, true])('render: isNavCollapsed equals %s', isNavCollapsed => {
         const props: InteractiveHeaderProps = {
             dropdownClickHandler: null,
             featureFlagStoreData: null,
@@ -55,7 +55,7 @@ describe('InteractiveHeader', () => {
             selectedPivot: DetailsViewPivotType.assessment,
             navMenu: navMenuStub,
             narrowModeStatus: {
-                isHeaderAndNavCollapsed: false,
+                isHeaderAndNavCollapsed: isNavCollapsed,
             } as NarrowModeStatus,
             isSideNavOpen: false,
             setSideNavOpen: null,

--- a/src/tests/unit/tests/DetailsView/components/interactive-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/interactive-header.test.tsx
@@ -9,6 +9,7 @@ import {
     InteractiveHeaderDeps,
     InteractiveHeaderProps,
 } from 'DetailsView/components/interactive-header';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
@@ -32,7 +33,9 @@ describe('InteractiveHeader', () => {
             } as InteractiveHeaderDeps,
             selectedPivot: DetailsViewPivotType.assessment,
             navMenu: navMenuStub,
-            isNarrowMode: false,
+            narrowModeStatus: {
+                isHeaderAndNavCollapsed: false,
+            } as NarrowModeStatus,
             isSideNavOpen: false,
             setSideNavOpen: null,
         };
@@ -41,7 +44,7 @@ describe('InteractiveHeader', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    it('does render nav menu button if not in narrow mode', () => {
+    it('does render nav menu button if header not collapsed', () => {
         const props: InteractiveHeaderProps = {
             dropdownClickHandler: null,
             featureFlagStoreData: null,
@@ -51,7 +54,9 @@ describe('InteractiveHeader', () => {
             deps: null,
             selectedPivot: DetailsViewPivotType.assessment,
             navMenu: navMenuStub,
-            isNarrowMode: true,
+            narrowModeStatus: {
+                isHeaderAndNavCollapsed: false,
+            } as NarrowModeStatus,
             isSideNavOpen: false,
             setSideNavOpen: null,
         };

--- a/src/tests/unit/tests/DetailsView/components/narrow-mode-detector.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/narrow-mode-detector.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { DetailsViewContent } from 'DetailsView/components/details-view-content';
 import {
     getNarrowModeComponentWrapper,
     NarrowModeDetector,

--- a/src/tests/unit/tests/DetailsView/components/narrow-mode-detector.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/narrow-mode-detector.test.tsx
@@ -39,7 +39,7 @@ describe(NarrowModeDetector, () => {
                     isCommandBarCollapsed: true,
                 },
             };
-            const rendered = getChildComponentWrapper(props, {
+            const rendered = renderChildComponent(props, {
                 width: narrowModeThresholds.collapseHeaderAndNavThreshold - 1,
                 height: 0,
             });
@@ -59,7 +59,7 @@ describe(NarrowModeDetector, () => {
                     isCommandBarCollapsed: true,
                 },
             };
-            const rendered = getChildComponentWrapper(props, {
+            const rendered = renderChildComponent(props, {
                 width: narrowModeThresholds.collapseCommandBarThreshold - 1,
                 height: 0,
             });
@@ -79,7 +79,7 @@ describe(NarrowModeDetector, () => {
                     isCommandBarCollapsed: false,
                 },
             };
-            const rendered = getChildComponentWrapper(props, {
+            const rendered = renderChildComponent(props, {
                 width: narrowModeThresholds.collapseCommandBarThreshold + 1,
                 height: 0,
             });
@@ -104,7 +104,7 @@ describe(NarrowModeDetector, () => {
         });
     });
 
-    function getChildComponentWrapper(
+    function renderChildComponent(
         props: NarrowModeDetectorProps,
         dimensions: { width: number; height: number },
     ): JSX.Element {

--- a/src/tests/unit/tests/DetailsView/components/narrow-mode-detector.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/narrow-mode-detector.test.tsx
@@ -1,53 +1,115 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
 import { DetailsViewContent } from 'DetailsView/components/details-view-content';
 import {
     getNarrowModeComponentWrapper,
     NarrowModeDetector,
     NarrowModeDetectorProps,
+    NarrowModeStatus,
+    narrowModeThresholds,
 } from 'DetailsView/components/narrow-mode-detector';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+
+const TestComponent = NamedFC<{ narrowModeStatus: NarrowModeStatus }>('TestComponent', props => {
+    return <h1>Test component</h1>;
+});
 
 describe(NarrowModeDetector, () => {
     describe('render', () => {
         it('renders ReactResizeDetector ', () => {
             const props: NarrowModeDetectorProps = {
                 isNarrowModeEnabled: false,
-                Component: DetailsViewContent,
+                Component: TestComponent,
                 childrenProps: null,
             };
             const wrapper = shallow(<NarrowModeDetector {...props} />);
             expect(wrapper.getElement()).toMatchSnapshot();
         });
 
-        it('renders child component properly when narrow mode is enabled', () => {
+        it('renders child component properly when header is collapsed', () => {
             const props: NarrowModeDetectorProps = {
                 isNarrowModeEnabled: true,
-                Component: DetailsViewContent,
+                Component: TestComponent,
                 childrenProps: null,
             };
-            const renderFunc = getNarrowModeComponentWrapper(props);
+            const expectedChildProps = {
+                narrowModeStatus: {
+                    isHeaderAndNavCollapsed: true,
+                    isCommandBarCollapsed: true,
+                },
+            };
+            const rendered = getChildComponentWrapper(props, {
+                width: narrowModeThresholds.collapseHeaderAndNavThreshold - 1,
+                height: 0,
+            });
 
-            expect(renderFunc({ width: 10, height: 0 })).toMatchSnapshot(
-                'narrow mode should be true',
-            );
-            expect(renderFunc({ width: 1000, height: 0 })).toMatchSnapshot(
-                'narrow mode should be false',
-            );
+            expect(rendered.props).toEqual(expectedChildProps);
+        });
+
+        it('renders child component properly when command bar is collapsed', () => {
+            const props: NarrowModeDetectorProps = {
+                isNarrowModeEnabled: true,
+                Component: TestComponent,
+                childrenProps: null,
+            };
+            const expectedChildProps = {
+                narrowModeStatus: {
+                    isHeaderAndNavCollapsed: false,
+                    isCommandBarCollapsed: true,
+                },
+            };
+            const rendered = getChildComponentWrapper(props, {
+                width: narrowModeThresholds.collapseCommandBarThreshold - 1,
+                height: 0,
+            });
+
+            expect(rendered.props).toEqual(expectedChildProps);
+        });
+
+        it('renders child component properly when nothing is collapsed', () => {
+            const props: NarrowModeDetectorProps = {
+                isNarrowModeEnabled: true,
+                Component: TestComponent,
+                childrenProps: null,
+            };
+            const expectedChildProps = {
+                narrowModeStatus: {
+                    isHeaderAndNavCollapsed: false,
+                    isCommandBarCollapsed: false,
+                },
+            };
+            const rendered = getChildComponentWrapper(props, {
+                width: narrowModeThresholds.collapseCommandBarThreshold + 1,
+                height: 0,
+            });
+
+            expect(rendered.props).toEqual(expectedChildProps);
         });
 
         it('renders child component properly when narrow mode is disabled', () => {
             const props: NarrowModeDetectorProps = {
                 isNarrowModeEnabled: false,
-                Component: DetailsViewContent,
+                Component: TestComponent,
                 childrenProps: null,
             };
             const renderFunc = getNarrowModeComponentWrapper(props);
 
-            expect(renderFunc({ width: 10, height: 0 })).toMatchSnapshot(
-                'narrow mode should be false',
-            );
+            expect(
+                renderFunc({
+                    width: narrowModeThresholds.collapseHeaderAndNavThreshold - 1,
+                    height: 0,
+                }),
+            ).toMatchSnapshot('All narrow mode status values should be false');
         });
     });
+
+    function getChildComponentWrapper(
+        props: NarrowModeDetectorProps,
+        dimensions: { width: number; height: number },
+    ): JSX.Element {
+        const renderFunc = getNarrowModeComponentWrapper(props);
+        return renderFunc(dimensions);
+    }
 });

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -219,7 +219,10 @@ describe(DetailsViewContent, () => {
             const rendered = shallow(
                 <DetailsViewContent
                     {...props}
-                    isNarrowMode={false}
+                    narrowModeStatus={{
+                        isHeaderAndNavCollapsed: false,
+                        isCommandBarCollapsed: false,
+                    }}
                     isSideNavOpen={false}
                     setSideNavOpen={() => {}}
                 />,

--- a/src/tests/unit/tests/common/components/header.test.tsx
+++ b/src/tests/unit/tests/common/components/header.test.tsx
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { Header, HeaderDeps } from 'common/components/header';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 
 describe('Header', () => {
     it('renders per snapshot', () => {
@@ -52,7 +53,10 @@ describe('Header', () => {
                 applicationTitle,
             },
         } as HeaderDeps;
-        const wrapper = shallow(<Header deps={deps} isNarrowMode={true} />);
+        const narrowModeStatus = {
+            isHeaderAndNavCollapsed: true,
+        } as NarrowModeStatus;
+        const wrapper = shallow(<Header deps={deps} narrowModeStatus={narrowModeStatus} />);
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Description of changes

Refactor NarrowModeDetector to report status with an object instead of a single boolean stating whether or not we are in narrow mode. This will enable us to detect different window widths which will affect different components.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1739634
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
