### PR TITLE
fix(android-setup): fix scroll behavior with many devices/small size/high text zoom

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.scss
@@ -11,7 +11,7 @@
 
     box-sizing: border-box;
     width: 100%;
-    height: 100%;
+    min-height: 100%; // can exceed 100% at high text scaling
     padding-left: 32px;
     padding-right: 32px;
     padding-bottom: 32px;

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.scss
@@ -3,8 +3,7 @@
 .phone-list {
     -webkit-app-region: no-drag;
     margin-top: 20px;
-    overflow-x: hidden;
-    max-height: 120px;
+    overflow: hidden;
 }
 
 .checkmark-cell {

--- a/src/electron/views/device-connect-view/components/device-connect-body.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-body.scss
@@ -3,7 +3,8 @@
 @import '../../../../common/styles/fonts.scss';
 
 .device-connect-body {
-    margin: 16px 32px;
+    padding: 16px 32px;
+    box-sizing: border-box;
 
     h2 {
         font-family: $fontFamily;

--- a/src/electron/views/device-connect-view/components/device-connect-view-container.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-view-container.scss
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-.device-connect-view {
+.window-container {
     -webkit-app-region: drag;
 
     display: flex;
@@ -8,8 +8,16 @@
     height: 100%;
     width: 100%;
 
-    .main-content-wrapper {
+    .content-scroll-container {
         flex: 1 1 auto;
+
+        -webkit-app-region: no-drag; // Scrollbars need to be interactable
         overflow: auto;
+
+        .content-container {
+            min-width: 100%;
+            min-height: 100%;
+            -webkit-app-region: drag;
+        }
     }
 }

--- a/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
@@ -16,9 +16,9 @@ import { AndroidSetupStepContainer } from 'electron/views/device-connect-view/co
 import * as React from 'react';
 import { DeviceStoreData } from '../../../flux/types/device-store-data';
 import { WindowTitle, WindowTitleDeps } from '../../common/window-title/window-title';
-import { deviceConnectView, mainContentWrapper } from '../device-connect-view.scss';
 import { AndroidSetupPageDeps } from './android-setup/android-setup-types';
 import { DeviceConnectBody, DeviceConnectBodyDeps } from './device-connect-body';
+import * as styles from './device-connect-view-container.scss';
 
 export type DeviceConnectViewContainerDeps = TelemetryPermissionDialogDeps &
     DeviceConnectBodyDeps &
@@ -39,7 +39,7 @@ export const DeviceConnectViewContainer = NamedFC<DeviceConnectViewContainerProp
     'DeviceConnectViewContainer',
     props => {
         return (
-            <div className={deviceConnectView}>
+            <div className={styles.windowContainer}>
                 <WindowTitle
                     pageTitle={'Connect to your Android device'}
                     deps={props.deps}
@@ -47,18 +47,20 @@ export const DeviceConnectViewContainer = NamedFC<DeviceConnectViewContainerProp
                 >
                     <HeaderIcon invertColors deps={props.deps} />
                 </WindowTitle>
-                <div className={mainContentWrapper}>
-                    <FlaggedComponent
-                        featureFlagStoreData={props.featureFlagStoreData}
-                        deps={props.deps}
-                        featureFlag={UnifiedFeatureFlags.adbSetupView}
-                        enableJSXElement={<AndroidSetupStepContainer {...props} />}
-                        disableJSXElement={productionDeviceConnectBody(props)}
-                    ></FlaggedComponent>
-                    <TelemetryPermissionDialog
-                        deps={props.deps}
-                        isFirstTime={props.userConfigurationStoreData.isFirstTime}
-                    />
+                <div className={styles.contentScrollContainer}>
+                    <div className={styles.contentContainer}>
+                        <FlaggedComponent
+                            featureFlagStoreData={props.featureFlagStoreData}
+                            deps={props.deps}
+                            featureFlag={UnifiedFeatureFlags.adbSetupView}
+                            enableJSXElement={<AndroidSetupStepContainer {...props} />}
+                            disableJSXElement={productionDeviceConnectBody(props)}
+                        ></FlaggedComponent>
+                        <TelemetryPermissionDialog
+                            deps={props.deps}
+                            isFirstTime={props.userConfigurationStoreData.isFirstTime}
+                        />
+                    </div>
                 </div>
             </div>
         );

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DeviceConnectViewContainer renders 1`] = `
 <div
-  className="deviceConnectView"
+  className="windowContainer"
 >
   <WindowTitle
     deps={Object {}}
@@ -20,53 +20,57 @@ exports[`DeviceConnectViewContainer renders 1`] = `
     />
   </WindowTitle>
   <div
-    className="mainContentWrapper"
+    className="contentScrollContainer"
   >
-    <FlaggedComponent
-      deps={Object {}}
-      disableJSXElement={
-        <DeviceConnectBody
-          deps={Object {}}
-          viewState={
-            Object {
-              "connectedDevice": undefined,
-              "deviceConnectState": 0,
+    <div
+      className="contentContainer"
+    >
+      <FlaggedComponent
+        deps={Object {}}
+        disableJSXElement={
+          <DeviceConnectBody
+            deps={Object {}}
+            viewState={
+              Object {
+                "connectedDevice": undefined,
+                "deviceConnectState": 0,
+              }
             }
-          }
-        />
-      }
-      enableJSXElement={
-        <AndroidSetupStepContainer
-          androidSetupStoreData={
-            Object {
-              "currentStepId": "detect-adb",
+          />
+        }
+        enableJSXElement={
+          <AndroidSetupStepContainer
+            androidSetupStoreData={
+              Object {
+                "currentStepId": "detect-adb",
+              }
             }
-          }
-          deps={Object {}}
-          deviceStoreData={
-            Object {
-              "deviceConnectState": 0,
+            deps={Object {}}
+            deviceStoreData={
+              Object {
+                "deviceConnectState": 0,
+              }
             }
-          }
-          userConfigurationStoreData={
-            Object {
-              "isFirstTime": true,
+            userConfigurationStoreData={
+              Object {
+                "isFirstTime": true,
+              }
             }
-          }
-          windowStateStoreData={
-            Object {
-              "currentWindowState": "customSize",
-              "routeId": "deviceConnectView",
+            windowStateStoreData={
+              Object {
+                "currentWindowState": "customSize",
+                "routeId": "deviceConnectView",
+              }
             }
-          }
-        />
-      }
-      featureFlag="adbSetupView"
-    />
-    <TelemetryPermissionDialog
-      deps={Object {}}
-      isFirstTime={true}
-    />
+          />
+        }
+        featureFlag="adbSetupView"
+      />
+      <TelemetryPermissionDialog
+        deps={Object {}}
+        isFirstTime={true}
+      />
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
#### Description of changes

This PR implements the scrollbar behavior from the figma (also addresses a related bug bash onenote issue). Specifically, it:

* prevents the "choose device" list from showing its own scrollbar, in favor of a whole-dialog one
* fixes bottom buttons getting cut off when scrollbar is visible
* fixes outer scrollbar not being interactable (because it was rendering for a `-webkit-app-region: drag` component)

This PR is impacted by an issue where, in general, if a component inside a scrollable container is set to `-webkit-app-region: drag`, the scrollable container won't respond to mousewheel/middle-mouse scrolling when the mouse is over that inner component (instead, the window itself intercepts those events for drag handling). That means we had to choose whether to make the static background of the dialog window-draggable vs making it interact more normally with the scrollbar. Per offline discussion with @ferBonnin , we're going with the former for now, so this PR introduces a new layer of div (so the outer one with the scrollbar can be no-drag, enabling interaction with the scrollbar, but the inner one can still be drag).

This makes a minor update to the old device-connect-body for compatibility with the new container. It does not visually modify the old view; in particular, it neither fixes nor further regresses the pre-existing issues where the old view doesn't reflow appropriately to high text zoom / low window height.

Low-window-size choose device view, before (note multiple scrollbars and buttons cut off at bottom):
![image](https://user-images.githubusercontent.com/376284/85807988-6f1cc800-b708-11ea-8220-1e29b65c8067.png)

after (note single scrollbar only, with buttons at bottom not being cut off):
![image](https://user-images.githubusercontent.com/376284/85807968-61674280-b708-11ea-983d-ce9a17d0caae.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
