### PR TITLE
Chore: Refactor parameters used to configure Android setup state machine steps

### DIFF
--- a/src/electron/flux/store/android-setup-store.ts
+++ b/src/electron/flux/store/android-setup-store.ts
@@ -24,8 +24,7 @@ export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
 
     public initialize(initialState?: AndroidSetupStoreData): void {
         super.initialize(initialState);
-        this.stateMachine = this.createAndroidSetupStateMachine({
-            stepTransition: this.stepTransition,
+        this.stateMachine = this.createAndroidSetupStateMachine(this.stepTransition, {
             setSelectedDevice: this.setSelectedDevice,
             setAvailableDevices: this.setAvailableDevices,
             getScanPort: () => this.state.scanPort,

--- a/src/electron/flux/types/android-setup-state-machine-types.ts
+++ b/src/electron/flux/types/android-setup-state-machine-types.ts
@@ -13,7 +13,6 @@ export type AndroidSetupStepTransitionCallback = (nextStep: AndroidSetupStepId) 
 export type AndroidSetupStoreCallbacks = {
     setSelectedDevice: (device: DeviceInfo) => void;
     setAvailableDevices: (devices: DeviceInfo[]) => void;
-
     getScanPort: () => number | null;
     setScanPort: (scanPort?: number) => void;
     setApplicationName: (appName?: string) => void;

--- a/src/electron/flux/types/android-setup-state-machine-types.ts
+++ b/src/electron/flux/types/android-setup-state-machine-types.ts
@@ -11,14 +11,15 @@ export type AndroidSetupStateMachine = StateMachine<AndroidSetupStepId, AndroidS
 export type AndroidSetupStepTransitionCallback = (nextStep: AndroidSetupStepId) => void;
 
 export type AndroidSetupStoreCallbacks = {
-    stepTransition: AndroidSetupStepTransitionCallback;
     setSelectedDevice: (device: DeviceInfo) => void;
     setAvailableDevices: (devices: DeviceInfo[]) => void;
+
     getScanPort: () => number | null;
     setScanPort: (scanPort?: number) => void;
     setApplicationName: (appName?: string) => void;
 };
 
 export type AndroidSetupStateMachineFactory = (
+    stepTransition: (stepId: AndroidSetupStepId) => void,
     storeCallbacks: AndroidSetupStoreCallbacks,
 ) => AndroidSetupStateMachine;

--- a/src/electron/platform/android/setup/android-setup-state-machine-factory.ts
+++ b/src/electron/platform/android/setup/android-setup-state-machine-factory.ts
@@ -11,10 +11,7 @@ import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setu
 import { StateMachine } from 'electron/platform/android/setup/state-machine/state-machine';
 import { createStateMachineSteps } from 'electron/platform/android/setup/state-machine/state-machine-step-configs';
 import { AndroidSetupDeps } from './android-setup-deps';
-import {
-    allAndroidSetupStepConfigs,
-    AndroidSetupStepConfigDeps,
-} from './android-setup-steps-configs';
+import { allAndroidSetupStepConfigs } from './android-setup-steps-configs';
 import { StateMachineSteps } from './state-machine/state-machine-steps';
 
 type AndroidSetupStepsFactory = (
@@ -22,25 +19,26 @@ type AndroidSetupStepsFactory = (
 ) => StateMachineSteps<AndroidSetupStepId, AndroidSetupActions>;
 
 const stepsFactory = (
-    deps: Omit<AndroidSetupStepConfigDeps, 'stepTransition'>,
+    deps: AndroidSetupDeps,
+    store: AndroidSetupStoreCallbacks,
 ): AndroidSetupStepsFactory => {
     return (stateMachineStepTransition: AndroidSetupStepTransitionCallback) => {
-        const allDeps = {
-            ...deps,
-            stepTransition: stateMachineStepTransition,
-        };
-
-        return createStateMachineSteps(allDeps, allAndroidSetupStepConfigs);
+        return createStateMachineSteps(
+            allAndroidSetupStepConfigs,
+            stateMachineStepTransition,
+            deps,
+            store,
+        );
     };
 };
 
 export const createAndroidSetupStateMachineFactory = (
     deps: AndroidSetupDeps,
 ): AndroidSetupStateMachineFactory => {
-    return (storeCallbacks: AndroidSetupStoreCallbacks) => {
+    return (storeStepTransition, storeCallbacks) => {
         return new StateMachine<AndroidSetupStepId, AndroidSetupActions>(
-            stepsFactory({ ...deps, ...storeCallbacks }),
-            storeCallbacks.stepTransition,
+            stepsFactory(deps, storeCallbacks),
+            storeStepTransition,
             'wait-to-start',
         );
     };

--- a/src/electron/platform/android/setup/android-setup-steps-configs.ts
+++ b/src/electron/platform/android/setup/android-setup-steps-configs.ts
@@ -24,17 +24,18 @@ import {
 } from './state-machine/state-machine-step-configs';
 import { detectAdb } from './steps/detect-adb';
 
-export type AndroidSetupStepConfigDeps = AndroidSetupDeps & AndroidSetupStoreCallbacks;
-
 export type AndroidSetupStepConfig = StateMachineStepConfig<
+    AndroidSetupStepId,
     AndroidSetupActions,
-    AndroidSetupStepConfigDeps
+    AndroidSetupDeps,
+    AndroidSetupStoreCallbacks
 >;
 
 type AndroidSetupStepConfigs = StateMachineStepConfigs<
     AndroidSetupStepId,
     AndroidSetupActions,
-    AndroidSetupStepConfigDeps
+    AndroidSetupDeps,
+    AndroidSetupStoreCallbacks
 >;
 
 export const allAndroidSetupStepConfigs: AndroidSetupStepConfigs = {

--- a/src/electron/platform/android/setup/state-machine/state-machine-step-configs.ts
+++ b/src/electron/platform/android/setup/state-machine/state-machine-step-configs.ts
@@ -6,25 +6,36 @@ import { mapValues } from 'lodash';
 import { ActionBag } from './state-machine-action-callback';
 import { StateMachineStep } from './state-machine-step';
 
-export type StateMachineStepConfig<ActionT extends ActionBag<ActionT>, DepsT> = (
+export type StateMachineStepConfig<
+    StepIdT extends string,
+    ActionT extends ActionBag<ActionT>,
+    DepsT,
+    StoreCallbacksT
+> = (
+    stepTransition: (stepId: StepIdT) => void,
     deps: DepsT,
+    store?: StoreCallbacksT,
 ) => StateMachineStep<ActionT>;
 
 export type StateMachineStepConfigs<
     StepIdT extends string,
     ActionT extends ActionBag<ActionT>,
-    DepsT
+    DepsT,
+    StoreCallbacksT
 > = {
-    [stepId in StepIdT]: StateMachineStepConfig<ActionT, DepsT>;
+    [stepId in StepIdT]: StateMachineStepConfig<StepIdT, ActionT, DepsT, StoreCallbacksT>;
 };
 
 export const createStateMachineSteps = <
     StepIdT extends string,
     ActionT extends ActionBag<ActionT>,
-    DepsT
+    DepsT,
+    StoreCallbacksT
 >(
+    configs: StateMachineStepConfigs<StepIdT, ActionT, DepsT, StoreCallbacksT>,
+    stepTransition: (stepId: StepIdT) => void,
     deps: DepsT,
-    configs: StateMachineStepConfigs<StepIdT, ActionT, DepsT>,
+    storeCallbacks?: StoreCallbacksT,
 ): StateMachineSteps<StepIdT, ActionT> => {
-    return mapValues(configs, config => config && config(deps));
+    return mapValues(configs, config => config && config(stepTransition, deps, storeCallbacks));
 };

--- a/src/electron/platform/android/setup/steps/configuring-port-forwarding.ts
+++ b/src/electron/platform/android/setup/steps/configuring-port-forwarding.ts
@@ -3,28 +3,28 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const configuringPortForwarding: AndroidSetupStepConfig = deps => ({
+export const configuringPortForwarding: AndroidSetupStepConfig = (stepTransition, deps, store) => ({
     actions: {},
     onEnter: async () => {
         try {
-            const existingPort = deps.getScanPort();
+            const existingPort = store.getScanPort();
             if (existingPort != null) {
                 deps.logger.log(`removing old tcp:${existingPort} forwarding`);
                 await deps.removeTcpForwarding(existingPort);
-                deps.setScanPort(null);
-                deps.setApplicationName(null);
+                store.setScanPort(null);
+                store.setApplicationName(null);
             }
 
             const hostPort = await deps.setupTcpForwarding();
             deps.logger.log(`configured forwarding to tcp:${hostPort}`);
             const deviceConfig = await deps.fetchDeviceConfig(hostPort);
 
-            deps.setScanPort(hostPort);
-            deps.setApplicationName(deviceConfig.appIdentifier);
-            deps.stepTransition('prompt-connected-start-testing');
+            store.setScanPort(hostPort);
+            store.setApplicationName(deviceConfig.appIdentifier);
+            stepTransition('prompt-connected-start-testing');
         } catch (e) {
             deps.logger.error(e);
-            deps.stepTransition('prompt-configuring-port-forwarding-failed');
+            stepTransition('prompt-configuring-port-forwarding-failed');
         }
     },
 });

--- a/src/electron/platform/android/setup/steps/detect-adb.ts
+++ b/src/electron/platform/android/setup/steps/detect-adb.ts
@@ -3,10 +3,10 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const detectAdb: AndroidSetupStepConfig = deps => ({
+export const detectAdb: AndroidSetupStepConfig = (stepTransition, deps) => ({
     actions: {},
     onEnter: async () => {
         const detected = await deps.hasAdbPath();
-        deps.stepTransition(detected ? 'detect-devices' : 'prompt-locate-adb');
+        stepTransition(detected ? 'detect-devices' : 'prompt-locate-adb');
     },
 });

--- a/src/electron/platform/android/setup/steps/detect-devices.ts
+++ b/src/electron/platform/android/setup/steps/detect-devices.ts
@@ -3,12 +3,12 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const detectDevices: AndroidSetupStepConfig = deps => {
+export const detectDevices: AndroidSetupStepConfig = (stepTransition, deps, store) => {
     return {
         actions: {},
         onEnter: async () => {
-            deps.setSelectedDevice(null);
-            deps.setAvailableDevices([]);
+            store.setSelectedDevice(null);
+            store.setAvailableDevices([]);
 
             const devices = await deps.getDevices().catch(e => {
                 deps.logger.error(e);
@@ -17,19 +17,19 @@ export const detectDevices: AndroidSetupStepConfig = deps => {
 
             switch (devices.length) {
                 case 0: {
-                    deps.stepTransition('prompt-connect-to-device');
+                    stepTransition('prompt-connect-to-device');
                     break;
                 }
                 case 1: {
                     deps.setSelectedDeviceId(devices[0].id);
-                    deps.setSelectedDevice(devices[0]);
-                    deps.setAvailableDevices(devices);
-                    deps.stepTransition('detect-service');
+                    store.setSelectedDevice(devices[0]);
+                    store.setAvailableDevices(devices);
+                    stepTransition('detect-service');
                     break;
                 }
                 default: {
-                    deps.setAvailableDevices(devices);
-                    deps.stepTransition('prompt-choose-device');
+                    store.setAvailableDevices(devices);
+                    stepTransition('prompt-choose-device');
                     break;
                 }
             }

--- a/src/electron/platform/android/setup/steps/detect-permissions.ts
+++ b/src/electron/platform/android/setup/steps/detect-permissions.ts
@@ -3,10 +3,10 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const detectPermissions: AndroidSetupStepConfig = deps => ({
+export const detectPermissions: AndroidSetupStepConfig = (stepTransition, deps) => ({
     actions: {},
     onEnter: async () => {
         const detected = await deps.hasExpectedPermissions();
-        deps.stepTransition(detected ? 'configuring-port-forwarding' : 'prompt-grant-permissions');
+        stepTransition(detected ? 'configuring-port-forwarding' : 'prompt-grant-permissions');
     },
 });

--- a/src/electron/platform/android/setup/steps/detect-service.ts
+++ b/src/electron/platform/android/setup/steps/detect-service.ts
@@ -3,10 +3,10 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const detectService: AndroidSetupStepConfig = deps => ({
+export const detectService: AndroidSetupStepConfig = (stepTransition, deps) => ({
     actions: {},
     onEnter: async () => {
         const detected = await deps.hasExpectedServiceVersion();
-        deps.stepTransition(detected ? 'detect-permissions' : 'prompt-install-service');
+        stepTransition(detected ? 'detect-permissions' : 'prompt-install-service');
     },
 });

--- a/src/electron/platform/android/setup/steps/installing-service.ts
+++ b/src/electron/platform/android/setup/steps/installing-service.ts
@@ -3,14 +3,14 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const installingService: AndroidSetupStepConfig = deps => ({
+export const installingService: AndroidSetupStepConfig = (stepTransition, deps) => ({
     actions: {
         cancel: () => {
-            deps.stepTransition('prompt-install-service');
+            stepTransition('prompt-install-service');
         },
     },
     onEnter: async () => {
         const installed = await deps.installService();
-        deps.stepTransition(installed ? 'prompt-grant-permissions' : 'prompt-install-failed');
+        stepTransition(installed ? 'prompt-grant-permissions' : 'prompt-install-failed');
     },
 });

--- a/src/electron/platform/android/setup/steps/prompt-choose-device.ts
+++ b/src/electron/platform/android/setup/steps/prompt-choose-device.ts
@@ -4,14 +4,14 @@
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const promptChooseDevice: AndroidSetupStepConfig = deps => {
+export const promptChooseDevice: AndroidSetupStepConfig = (stepTransition, deps, store) => {
     return {
         actions: {
-            rescan: () => deps.stepTransition('detect-devices'),
+            rescan: () => stepTransition('detect-devices'),
             setSelectedDevice: (device: DeviceInfo) => {
                 deps.setSelectedDeviceId(device.id);
-                deps.setSelectedDevice(device);
-                deps.stepTransition('detect-service');
+                store.setSelectedDevice(device);
+                stepTransition('detect-service');
             },
         },
     };

--- a/src/electron/platform/android/setup/steps/prompt-configuring-port-forwarding-failed.ts
+++ b/src/electron/platform/android/setup/steps/prompt-configuring-port-forwarding-failed.ts
@@ -3,13 +3,11 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const promptConfiguringPortForwardingFailed: AndroidSetupStepConfig = deps => {
+export const promptConfiguringPortForwardingFailed: AndroidSetupStepConfig = stepTransition => {
     return {
         actions: {
-            cancel: () => {
-                deps.stepTransition('prompt-choose-device');
-            },
-            next: () => deps.stepTransition('configuring-port-forwarding'),
+            cancel: () => stepTransition('prompt-choose-device'),
+            next: () => stepTransition('configuring-port-forwarding'),
         },
     };
 };

--- a/src/electron/platform/android/setup/steps/prompt-connect-to-device.ts
+++ b/src/electron/platform/android/setup/steps/prompt-connect-to-device.ts
@@ -3,10 +3,10 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const promptConnectToDevice: AndroidSetupStepConfig = deps => {
+export const promptConnectToDevice: AndroidSetupStepConfig = stepTransition => {
     return {
         actions: {
-            next: () => deps.stepTransition('detect-devices'),
+            next: () => stepTransition('detect-devices'),
         },
     };
 };

--- a/src/electron/platform/android/setup/steps/prompt-connected-start-testing.ts
+++ b/src/electron/platform/android/setup/steps/prompt-connected-start-testing.ts
@@ -3,13 +3,9 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const promptConnectedStartTesting: AndroidSetupStepConfig = deps => ({
+export const promptConnectedStartTesting: AndroidSetupStepConfig = (stepTransition, deps) => ({
     actions: {
-        cancel: () => {
-            deps.stepTransition('prompt-choose-device');
-        },
-        rescan: () => {
-            deps.stepTransition('detect-adb');
-        },
+        cancel: () => stepTransition('prompt-choose-device'),
+        rescan: () => stepTransition('detect-adb'),
     },
 });

--- a/src/electron/platform/android/setup/steps/prompt-grant-permissions.ts
+++ b/src/electron/platform/android/setup/steps/prompt-grant-permissions.ts
@@ -3,13 +3,9 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const promptGrantPermissions: AndroidSetupStepConfig = deps => ({
+export const promptGrantPermissions: AndroidSetupStepConfig = stepTransition => ({
     actions: {
-        cancel: () => {
-            deps.stepTransition('prompt-choose-device');
-        },
-        next: () => {
-            deps.stepTransition('detect-permissions');
-        },
+        cancel: () => stepTransition('prompt-choose-device'),
+        next: () => stepTransition('detect-permissions'),
     },
 });

--- a/src/electron/platform/android/setup/steps/prompt-install-service.ts
+++ b/src/electron/platform/android/setup/steps/prompt-install-service.ts
@@ -3,13 +3,9 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const promptInstallService: AndroidSetupStepConfig = deps => ({
+export const promptInstallService: AndroidSetupStepConfig = stepTransition => ({
     actions: {
-        cancel: () => {
-            deps.stepTransition('prompt-choose-device');
-        },
-        next: () => {
-            deps.stepTransition('installing-service');
-        },
+        cancel: () => stepTransition('prompt-choose-device'),
+        next: () => stepTransition('installing-service'),
     },
 });

--- a/src/electron/platform/android/setup/steps/prompt-locate-adb.ts
+++ b/src/electron/platform/android/setup/steps/prompt-locate-adb.ts
@@ -3,12 +3,12 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const promptLocateAdb: AndroidSetupStepConfig = deps => {
+export const promptLocateAdb: AndroidSetupStepConfig = (stepTransition, deps) => {
     return {
         actions: {
             saveAdbPath: (path: string) => {
                 deps.setAdbPath(path);
-                deps.stepTransition('detect-adb');
+                stepTransition('detect-adb');
             },
         },
     };

--- a/src/electron/platform/android/setup/steps/wait-to-start.ts
+++ b/src/electron/platform/android/setup/steps/wait-to-start.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const waitToStart: AndroidSetupStepConfig = deps => {
+export const waitToStart: AndroidSetupStepConfig = stepTransition => {
     return {
         actions: {
-            readyToStart: () => deps.stepTransition('detect-adb'),
+            readyToStart: () => stepTransition('detect-adb'),
         },
     };
 };

--- a/src/tests/unit/tests/electron/flux/store/android-setup-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/android-setup-store.test.ts
@@ -5,6 +5,7 @@ import { AndroidSetupStore } from 'electron/flux/store/android-setup-store';
 import {
     AndroidSetupStateMachine,
     AndroidSetupStateMachineFactory,
+    AndroidSetupStepTransitionCallback,
     AndroidSetupStoreCallbacks,
 } from 'electron/flux/types/android-setup-state-machine-types';
 import { AndroidSetupStoreData } from 'electron/flux/types/android-setup-store-data';
@@ -13,6 +14,7 @@ import { createStoreWithNullParams, StoreTester } from 'tests/unit/common/store-
 import { It, Mock, Times } from 'typemoq';
 
 const mockableStateMachineFactory = (
+    stepTransition: AndroidSetupStepTransitionCallback,
     storeCallbacks: AndroidSetupStoreCallbacks,
 ): AndroidSetupStateMachine => {
     return null;
@@ -39,7 +41,7 @@ describe('AndroidSetupStore', () => {
 
         const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
         stateMachineFactoryMock
-            .setup(m => m(It.isAny()))
+            .setup(m => m(It.isAny(), It.isAny()))
             .returns(_ => stateMachineMock.object)
             .verifiable(Times.once());
 
@@ -69,7 +71,7 @@ describe('AndroidSetupStore', () => {
 
         const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
         stateMachineFactoryMock
-            .setup(m => m(It.isAny()))
+            .setup(m => m(It.isAny(), It.isAny()))
             .returns(_ => stateMachineMock.object)
             .verifiable(Times.once());
 
@@ -88,18 +90,18 @@ describe('AndroidSetupStore', () => {
         const initialData: AndroidSetupStoreData = { currentStepId: 'detect-adb' };
         const expectedData: AndroidSetupStoreData = { currentStepId: 'prompt-choose-device' };
 
-        let storeCallbacks: AndroidSetupStoreCallbacks;
+        let stepTransition: AndroidSetupStepTransitionCallback;
 
         const stateMachineMock = Mock.ofType<AndroidSetupStateMachine>();
         stateMachineMock
             .setup(m => m.invokeAction('cancel', It.isAny()))
-            .callback((action, payload) => storeCallbacks.stepTransition('prompt-choose-device'))
+            .callback((action, payload) => stepTransition('prompt-choose-device'))
             .verifiable(Times.once());
 
         const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
         stateMachineFactoryMock
-            .setup(m => m(It.isAny()))
-            .callback(sc => (storeCallbacks = sc))
+            .setup(m => m(It.isAny(), It.isAny()))
+            .callback(st => (stepTransition = st))
             .returns(_ => stateMachineMock.object)
             .verifiable(Times.once());
 
@@ -127,8 +129,8 @@ describe('AndroidSetupStore', () => {
 
         const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
         stateMachineFactoryMock
-            .setup(m => m(It.isAny()))
-            .callback(sc => (storeCallbacks = sc))
+            .setup(m => m(It.isAny(), It.isAny()))
+            .callback((_, sc) => (storeCallbacks = sc))
             .verifiable(Times.once());
 
         const store = new AndroidSetupStore(
@@ -168,8 +170,8 @@ describe('AndroidSetupStore', () => {
 
         const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
         stateMachineFactoryMock
-            .setup(m => m(It.isAny()))
-            .callback(sc => (storeCallbacks = sc))
+            .setup(m => m(It.isAny(), It.isAny()))
+            .callback((_, sc) => (storeCallbacks = sc))
             .verifiable(Times.once());
 
         const store = new AndroidSetupStore(
@@ -198,8 +200,8 @@ describe('AndroidSetupStore', () => {
 
         const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
         stateMachineFactoryMock
-            .setup(m => m(It.isAny()))
-            .callback(sc => (storeCallbacks = sc))
+            .setup(m => m(It.isAny(), It.isAny()))
+            .callback((_, sc) => (storeCallbacks = sc))
             .verifiable(Times.once());
 
         const store = new AndroidSetupStore(
@@ -228,8 +230,8 @@ describe('AndroidSetupStore', () => {
 
         const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
         stateMachineFactoryMock
-            .setup(m => m(It.isAny()))
-            .callback(sc => (storeCallbacks = sc))
+            .setup(m => m(It.isAny(), It.isAny()))
+            .callback((_, sc) => (storeCallbacks = sc))
             .verifiable(Times.once());
 
         const store = new AndroidSetupStore(

--- a/src/tests/unit/tests/electron/platform/android/setup/state-machine/state-machine-step-configs.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/state-machine/state-machine-step-configs.test.ts
@@ -20,25 +20,39 @@ type MartiniDeps = {
     chillGlass: () => string;
 };
 
+type MartiniStoreCallbacks = {
+    serve: (compliment: string) => void;
+};
+
 type MartiniStep = StateMachineStep<MartiniActions>;
 
 describe('state machine step configs', () => {
+    const stepTransition = (_: MartiniStepId): void => {};
     const martiniDeps = {} as MartiniDeps;
+    const martiniStoreCallbacks = {} as MartiniStoreCallbacks;
 
     it('calls config functions with expected deps', () => {
-        const testDeps = deps => {
+        const testConfig = (st, deps, store) => {
+            expect(st).toBe(stepTransition);
             expect(deps).toBe(martiniDeps);
             expect(deps).toEqual(martiniDeps);
+            expect(store).toBe(martiniStoreCallbacks);
+            expect(deps).toEqual(martiniStoreCallbacks);
             return null;
         };
 
-        const configs: StateMachineStepConfigs<MartiniStepId, MartiniActions, MartiniDeps> = {
-            gin: deps => testDeps(deps),
-            vermouth: deps => testDeps(deps),
-            olives: deps => testDeps(deps),
+        const configs: StateMachineStepConfigs<
+            MartiniStepId,
+            MartiniActions,
+            MartiniDeps,
+            MartiniStoreCallbacks
+        > = {
+            gin: (st, deps, store) => testConfig(st, deps, store),
+            vermouth: (st, deps, store) => testConfig(st, deps, store),
+            olives: (st, deps, store) => testConfig(st, deps, store),
         };
 
-        createStateMachineSteps(martiniDeps, configs);
+        createStateMachineSteps(configs, stepTransition, martiniDeps, martiniStoreCallbacks);
     });
 
     it('handles null config functions gracefully', () => {
@@ -48,14 +62,25 @@ describe('state machine step configs', () => {
             olives: null,
         };
 
-        const configs: StateMachineStepConfigs<MartiniStepId, MartiniActions, MartiniDeps> = {
+        const configs: StateMachineStepConfigs<
+            MartiniStepId,
+            MartiniActions,
+            MartiniDeps,
+            MartiniStoreCallbacks
+        > = {
             gin: null,
             vermouth: null,
             olives: null,
         };
 
         let testSteps: StateMachineSteps<MartiniStepId, MartiniActions>;
-        const testFunc = () => (testSteps = createStateMachineSteps(martiniDeps, configs));
+        const testFunc = () =>
+            (testSteps = createStateMachineSteps(
+                configs,
+                stepTransition,
+                martiniDeps,
+                martiniStoreCallbacks,
+            ));
         expect(testFunc).not.toThrow();
         expect(testSteps).toEqual(expectedSteps);
     });
@@ -73,13 +98,23 @@ describe('state machine step configs', () => {
             },
         };
 
-        const configs: StateMachineStepConfigs<MartiniStepId, MartiniActions, MartiniDeps> = {
-            gin: _ => ginStep,
-            vermouth: _ => vermouthStep,
+        const configs: StateMachineStepConfigs<
+            MartiniStepId,
+            MartiniActions,
+            MartiniDeps,
+            MartiniStoreCallbacks
+        > = {
+            gin: (_, __) => ginStep,
+            vermouth: (_, __) => vermouthStep,
             olives: null,
         };
 
-        const testSteps = createStateMachineSteps(martiniDeps, configs);
+        const testSteps = createStateMachineSteps(
+            configs,
+            stepTransition,
+            martiniDeps,
+            martiniStoreCallbacks,
+        );
 
         expect(testSteps.gin).toBe(ginStep);
         expect(testSteps.gin).toEqual(ginStep);

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-adb.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-adb.test.ts
@@ -1,50 +1,68 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { detectAdb } from 'electron/platform/android/setup/steps/detect-adb';
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: detectAdb', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = detectAdb(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = detectAdb(null, deps);
         checkExpectedActionsAreDefined(step, []);
         expect(step.onEnter).toBeDefined();
     });
 
     it('onEnter transitions to prompt-connect-to-device as expected', async () => {
-        const p = new Promise<boolean>(resolve => resolve(true));
+        const p = Promise.resolve(true);
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.hasAdbPath())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.stepTransition('detect-devices')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('detect-devices')).verifiable(Times.once());
 
-        const step = detectAdb(depsMock.object);
+        const step = detectAdb(stepTransitionMock.object, depsMock.object);
         await step.onEnter();
-
-        depsMock.verifyAll();
     });
 
     it('onEnter transitions to prompt-locate-adb as expected', async () => {
-        const p = new Promise<boolean>(resolve => resolve(false));
+        const p = Promise.resolve(false);
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.hasAdbPath())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.stepTransition('prompt-locate-adb')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-locate-adb')).verifiable(Times.once());
 
-        const step = detectAdb(depsMock.object);
+        const step = detectAdb(stepTransitionMock.object, depsMock.object);
         await step.onEnter();
-
-        depsMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-devices.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-devices.test.ts
@@ -2,49 +2,69 @@
 // Licensed under the MIT License.
 
 import { Logger } from 'common/logging/logger';
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { detectDevices } from 'electron/platform/android/setup/steps/detect-devices';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: detectDevices', () => {
-    let depsMock: IMock<AndroidSetupStepConfigDeps>;
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
     let loggerMock: IMock<Logger>;
 
     beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
         loggerMock = Mock.ofType<Logger>();
-        depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.logger)
             .returns(() => loggerMock.object)
             .verifiable(Times.atLeast(0));
     });
 
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = detectDevices(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = detectDevices(null, deps);
         checkExpectedActionsAreDefined(step, []);
         expect(step.onEnter).toBeDefined();
     });
 
     it('onEnter transitions to prompt-connect-to-device as expected', async () => {
         const devices: DeviceInfo[] = [];
-        const p = new Promise<DeviceInfo[]>(resolve => resolve(devices));
+        const p = Promise.resolve(devices);
 
         depsMock
             .setup(m => m.getDevices())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.setSelectedDevice(null)).verifiable(Times.once());
-        depsMock.setup(m => m.setAvailableDevices([])).verifiable(Times.once());
-        depsMock.setup(m => m.stepTransition('prompt-connect-to-device')).verifiable(Times.once());
+        storeCallbacksMock.setup(m => m.setSelectedDevice(null)).verifiable(Times.once());
+        storeCallbacksMock.setup(m => m.setAvailableDevices([])).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-connect-to-device')).verifiable(Times.once());
 
-        const step = detectDevices(depsMock.object);
+        const step = detectDevices(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         await step.onEnter();
-
-        depsMock.verifyAll();
     });
 
     it('onEnter transitions to detect-service as expected', async () => {
@@ -54,24 +74,26 @@ describe('Android setup step: detectDevices', () => {
             } as DeviceInfo,
         ];
 
-        const p = new Promise<DeviceInfo[]>(resolve => resolve(devices));
+        const p = Promise.resolve(devices);
 
         depsMock
             .setup(m => m.getDevices())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.setSelectedDevice(null)).verifiable(Times.once());
-        depsMock.setup(m => m.setAvailableDevices([])).verifiable(Times.once());
+        storeCallbacksMock.setup(m => m.setSelectedDevice(null)).verifiable(Times.once());
+        storeCallbacksMock.setup(m => m.setAvailableDevices([])).verifiable(Times.once());
         depsMock.setup(m => m.setSelectedDeviceId('device1')).verifiable(Times.once());
-        depsMock.setup(m => m.setSelectedDevice(devices[0])).verifiable(Times.once());
-        depsMock.setup(m => m.setAvailableDevices(devices)).verifiable(Times.once());
-        depsMock.setup(m => m.stepTransition('detect-service')).verifiable(Times.once());
+        storeCallbacksMock.setup(m => m.setSelectedDevice(devices[0])).verifiable(Times.once());
+        storeCallbacksMock.setup(m => m.setAvailableDevices(devices)).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('detect-service')).verifiable(Times.once());
 
-        const step = detectDevices(depsMock.object);
+        const step = detectDevices(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         await step.onEnter();
-
-        depsMock.verifyAll();
     });
 
     it('onEnter transitions to prompt-choose-device as expected', async () => {
@@ -84,22 +106,24 @@ describe('Android setup step: detectDevices', () => {
             } as DeviceInfo,
         ];
 
-        const p = new Promise<DeviceInfo[]>(resolve => resolve(devices));
+        const p = Promise.resolve(devices);
 
         depsMock
             .setup(m => m.getDevices())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.setSelectedDevice(null)).verifiable(Times.once());
-        depsMock.setup(m => m.setAvailableDevices([])).verifiable(Times.once());
-        depsMock.setup(m => m.setAvailableDevices(devices)).verifiable(Times.once());
-        depsMock.setup(m => m.stepTransition('prompt-choose-device')).verifiable(Times.once());
+        storeCallbacksMock.setup(m => m.setSelectedDevice(null)).verifiable(Times.once());
+        storeCallbacksMock.setup(m => m.setAvailableDevices([])).verifiable(Times.once());
+        storeCallbacksMock.setup(m => m.setAvailableDevices(devices)).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-choose-device')).verifiable(Times.once());
 
-        const step = detectDevices(depsMock.object);
+        const step = detectDevices(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         await step.onEnter();
-
-        depsMock.verifyAll();
     });
 
     it('onEnter transitions to prompt-connect-to-device if getDevices fails', async () => {
@@ -110,14 +134,16 @@ describe('Android setup step: detectDevices', () => {
             .returns(() => Promise.reject(getDevicesError))
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.setSelectedDevice(null));
-        depsMock.setup(m => m.setAvailableDevices([])).verifiable(Times.atLeastOnce());
-        depsMock.setup(m => m.stepTransition('prompt-connect-to-device'));
+        storeCallbacksMock.setup(m => m.setSelectedDevice(null));
+        storeCallbacksMock.setup(m => m.setAvailableDevices([])).verifiable(Times.atLeastOnce());
+        stepTransitionMock.setup(m => m('prompt-connect-to-device'));
 
-        const step = detectDevices(depsMock.object);
+        const step = detectDevices(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         await step.onEnter();
-
-        depsMock.verifyAll();
 
         loggerMock.verify(m => m.error(getDevicesError), Times.once());
     });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-permissions.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-permissions.test.ts
@@ -1,50 +1,76 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { detectPermissions } from 'electron/platform/android/setup/steps/detect-permissions';
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: detectPermissions', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = detectPermissions(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = detectPermissions(null, deps);
         checkExpectedActionsAreDefined(step, []);
         expect(step.onEnter).toBeDefined();
     });
 
     it('onEnter transitions to configuring-port-forwarding on success', async () => {
-        const p = new Promise<boolean>(resolve => resolve(true));
+        const p = Promise.resolve(true);
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.hasExpectedPermissions())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.stepTransition('configuring-port-forwarding'));
+        stepTransitionMock.setup(m => m('configuring-port-forwarding'));
 
-        const step = detectPermissions(depsMock.object);
+        const step = detectPermissions(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         await step.onEnter();
-
-        depsMock.verifyAll();
     });
 
     it('onEnter transitions to prompt-grant-permissions on failure', async () => {
-        const p = new Promise<boolean>(resolve => resolve(false));
+        const p = Promise.resolve(false);
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.hasExpectedPermissions())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.stepTransition('prompt-grant-permissions')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-grant-permissions')).verifiable(Times.once());
 
-        const step = detectPermissions(depsMock.object);
+        const step = detectPermissions(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         await step.onEnter();
-
-        depsMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-service.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-service.test.ts
@@ -1,50 +1,76 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { detectService } from 'electron/platform/android/setup/steps/detect-service';
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: detectService', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = detectService(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = detectService(null, deps);
         checkExpectedActionsAreDefined(step, []);
         expect(step.onEnter).toBeDefined();
     });
 
     it('onEnter transitions to detect-permissions as expected', async () => {
-        const p = new Promise<boolean>(resolve => resolve(true));
+        const p = Promise.resolve(true);
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.hasExpectedServiceVersion())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.stepTransition('detect-permissions')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('detect-permissions')).verifiable(Times.once());
 
-        const step = detectService(depsMock.object);
+        const step = detectService(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         await step.onEnter();
-
-        depsMock.verifyAll();
     });
 
     it('onEnter transitions to prompt-install-service as expected', async () => {
-        const p = new Promise<boolean>(resolve => resolve(false));
+        const p = Promise.resolve(false);
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.hasExpectedServiceVersion())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.stepTransition('prompt-install-service')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-install-service')).verifiable(Times.once());
 
-        const step = detectService(depsMock.object);
+        const step = detectService(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         await step.onEnter();
-
-        depsMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/installing-service.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/installing-service.test.ts
@@ -1,60 +1,87 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { installingService } from 'electron/platform/android/setup/steps/installing-service';
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: installingService', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = installingService(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = installingService(null, deps);
         checkExpectedActionsAreDefined(step, ['cancel']);
         expect(step.onEnter).toBeDefined();
     });
 
     it('cancel transitions to prompt-grant-permissions as expected', () => {
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
-        depsMock.setup(m => m.stepTransition('prompt-install-service')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-install-service')).verifiable(Times.once());
 
-        const step = installingService(depsMock.object);
+        const step = installingService(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.cancel();
-
-        depsMock.verifyAll();
     });
 
     it('onEnter transitions to prompt-grant-permissions as expected', async () => {
         const p = new Promise<boolean>(resolve => resolve(true));
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.installService())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.stepTransition('prompt-grant-permissions')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-grant-permissions')).verifiable(Times.once());
 
-        const step = installingService(depsMock.object);
+        const step = installingService(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         await step.onEnter();
-
-        depsMock.verifyAll();
     });
 
     it('onEnter transitions to prompt-install-service as expected', async () => {
         const p = new Promise<boolean>(resolve => resolve(false));
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.installService())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        depsMock.setup(m => m.stepTransition('prompt-install-failed')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-install-failed')).verifiable(Times.once());
 
-        const step = installingService(depsMock.object);
+        const step = installingService(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         await step.onEnter();
-
-        depsMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-choose-device.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-choose-device.test.ts
@@ -1,28 +1,53 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { promptChooseDevice } from 'electron/platform/android/setup/steps/prompt-choose-device';
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: promptChooseDevice', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = promptChooseDevice(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = promptChooseDevice(null, deps);
         checkExpectedActionsAreDefined(step, ['rescan', 'setSelectedDevice']);
         expect(step.onEnter).not.toBeDefined();
     });
 
     it('rescan transitions to detect-adb as expected', () => {
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
-        depsMock.setup(m => m.stepTransition('detect-devices')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('detect-devices')).verifiable(Times.once());
 
-        const step = promptChooseDevice(depsMock.object);
+        const step = promptChooseDevice(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.rescan();
-
-        depsMock.verifyAll();
     });
 
     it('setSelectedDevice transitions to detect-service as expected', () => {
@@ -32,14 +57,15 @@ describe('Android setup step: promptChooseDevice', () => {
             isEmulator: true,
         };
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
-        depsMock.setup(m => m.stepTransition('detect-service')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('detect-service')).verifiable(Times.once());
         depsMock.setup(m => m.setSelectedDeviceId(testDevice.id)).verifiable(Times.once());
-        depsMock.setup(m => m.setSelectedDevice(testDevice)).verifiable(Times.once());
+        storeCallbacksMock.setup(m => m.setSelectedDevice(testDevice)).verifiable(Times.once());
 
-        const step = promptChooseDevice(depsMock.object);
+        const step = promptChooseDevice(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.setSelectedDevice(testDevice);
-
-        depsMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-configuring-port-forwarding-failed.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-configuring-port-forwarding-failed.test.ts
@@ -1,38 +1,62 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { promptConfiguringPortForwardingFailed } from 'electron/platform/android/setup/steps/prompt-configuring-port-forwarding-failed';
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: promptConfiguringPortForwardingFailed', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = promptConfiguringPortForwardingFailed(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = promptConfiguringPortForwardingFailed(null, deps);
         checkExpectedActionsAreDefined(step, ['cancel', 'next']);
         expect(step.onEnter).not.toBeDefined();
     });
 
     it('cancel transitions to prompt-choose-device', async () => {
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
-        depsMock.setup(m => m.stepTransition('prompt-choose-device')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-choose-device')).verifiable(Times.once());
 
-        const step = promptConfiguringPortForwardingFailed(depsMock.object);
+        const step = promptConfiguringPortForwardingFailed(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.cancel();
-
-        depsMock.verifyAll();
     });
 
     it('next transitions to configuring-port-forwarding as expected', () => {
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
-        depsMock
-            .setup(m => m.stepTransition('configuring-port-forwarding'))
-            .verifiable(Times.once());
+        stepTransitionMock.setup(m => m('configuring-port-forwarding')).verifiable(Times.once());
 
-        const step = promptConfiguringPortForwardingFailed(depsMock.object);
+        const step = promptConfiguringPortForwardingFailed(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.next();
-
-        depsMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-connected-start-testing.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-connected-start-testing.test.ts
@@ -1,36 +1,62 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { promptConnectedStartTesting } from 'electron/platform/android/setup/steps/prompt-connected-start-testing';
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: promptConnectedStartTesting', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = promptConnectedStartTesting(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = promptConnectedStartTesting(null, deps);
         checkExpectedActionsAreDefined(step, ['cancel', 'rescan']);
         expect(step.onEnter).not.toBeDefined();
     });
 
     it('cancel transitions to prompt-choose-device', async () => {
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
-        depsMock.setup(m => m.stepTransition('prompt-choose-device')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-choose-device')).verifiable(Times.once());
 
-        const step = promptConnectedStartTesting(depsMock.object);
+        const step = promptConnectedStartTesting(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.cancel();
-
-        depsMock.verifyAll();
     });
 
     it('rescan transitions to detect-adb as expected', () => {
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
-        depsMock.setup(m => m.stepTransition('detect-adb')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('detect-adb')).verifiable(Times.once());
 
-        const step = promptConnectedStartTesting(depsMock.object);
+        const step = promptConnectedStartTesting(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.rescan();
-
-        depsMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-grant-permissions.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-grant-permissions.test.ts
@@ -1,36 +1,62 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { promptGrantPermissions } from 'electron/platform/android/setup/steps/prompt-grant-permissions';
-import { Mock, MockBehavior, Times } from 'typemoq';
-import { checkExpectedActionsAreDefined } from './actions-tester';
+import { checkExpectedActionsAreDefined } from 'tests/unit/tests/electron/platform/android/setup/steps/actions-tester';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('Android setup step: promptGrantPermissions', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = promptGrantPermissions(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = promptGrantPermissions(null, deps);
         checkExpectedActionsAreDefined(step, ['cancel', 'next']);
         expect(step.onEnter).not.toBeDefined();
     });
 
     it('cancel transitions to prompt-choose-device', async () => {
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
-        depsMock.setup(m => m.stepTransition('prompt-choose-device')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-choose-device')).verifiable(Times.once());
 
-        const step = promptGrantPermissions(depsMock.object);
+        const step = promptGrantPermissions(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.cancel();
-
-        depsMock.verifyAll();
     });
 
     it('onEnter transitions to detect-permissions as expected', () => {
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
-        depsMock.setup(m => m.stepTransition('detect-permissions')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('detect-permissions')).verifiable(Times.once());
 
-        const step = promptGrantPermissions(depsMock.object);
+        const step = promptGrantPermissions(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.next();
-
-        depsMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-install-service.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-install-service.test.ts
@@ -1,36 +1,62 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { promptInstallService } from 'electron/platform/android/setup/steps/prompt-install-service';
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: promptInstallService', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = promptInstallService(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = promptInstallService(null, deps);
         checkExpectedActionsAreDefined(step, ['cancel', 'next']);
         expect(step.onEnter).not.toBeDefined();
     });
 
     it('cancel transitions to prompt-choose-device', async () => {
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
-        depsMock.setup(m => m.stepTransition('prompt-choose-device')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('prompt-choose-device')).verifiable(Times.once());
 
-        const step = promptInstallService(depsMock.object);
+        const step = promptInstallService(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.cancel();
-
-        depsMock.verifyAll();
     });
 
     it('onEnter transitions to installing-service as expected', () => {
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
-        depsMock.setup(m => m.stepTransition('installing-service')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('installing-service')).verifiable(Times.once());
 
-        const step = promptInstallService(depsMock.object);
+        const step = promptInstallService(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.next();
-
-        depsMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-locate-adb.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-locate-adb.test.ts
@@ -1,15 +1,39 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { promptLocateAdb } from 'electron/platform/android/setup/steps/prompt-locate-adb';
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: promptLocateAdb', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = promptLocateAdb(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = promptLocateAdb(null, deps);
         checkExpectedActionsAreDefined(step, ['saveAdbPath']);
         expect(step.onEnter).not.toBeDefined();
     });
@@ -17,13 +41,14 @@ describe('Android setup step: promptLocateAdb', () => {
     it('saveAdbPath transitions to prompt-connect-to-device as expected', () => {
         const testPath = 'my test path';
 
-        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock.setup(m => m.setAdbPath(testPath)).verifiable(Times.once());
-        depsMock.setup(m => m.stepTransition('detect-adb')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('detect-adb')).verifiable(Times.once());
 
-        const step = promptLocateAdb(depsMock.object);
+        const step = promptLocateAdb(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
         step.actions.saveAdbPath(testPath);
-
-        depsMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/wait-to-start.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/wait-to-start.test.ts
@@ -1,14 +1,50 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { waitToStart } from 'electron/platform/android/setup/steps/wait-to-start';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: waitToStart', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepConfigDeps;
-        const step = waitToStart(deps);
+        const deps = {} as AndroidSetupDeps;
+        const step = waitToStart(null, deps);
         checkExpectedActionsAreDefined(step, ['readyToStart']);
         expect(step.onEnter).not.toBeDefined();
+    });
+
+    it('transitions to detect-adb on readyToStart', () => {
+        stepTransitionMock.setup(m => m('detect-adb')).verifiable(Times.once());
+
+        const step = waitToStart(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
+        step.actions.readyToStart();
     });
 });


### PR DESCRIPTION
#### Description of changes

Separated the parameters used to configure state machine steps into three parameters instead of one 'deps' parameter.

This has three benefits:

- It makes the purpose of the code clearer. For example, it was confusing as to which methods on the deps used by the step configurators were used to set data in the the store versus the methods which were dependencies needed for the steps to obtain information or affect the system in some way.
- It makes the chaining of 'stepTransition' functions clearer in the Android setup state machine factory code.
- It paves the way for a more obvious, unit-testable mechanism for building the state machine factory from the various components on which it depends. (this will be a subsequent refactor)

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
