### PR TITLE
feat(trusted-tester-bugs): Add focus indicator to selected dropdown menu item

### DIFF
--- a/src/DetailsView/components/switcher.scss
+++ b/src/DetailsView/components/switcher.scss
@@ -45,6 +45,12 @@
     }
 }
 
+:global(.ms-Dropdown-items .ms-Button:focus) {
+    @media screen and (-ms-high-contrast: active) {
+        border: 2px highlighttext solid !important;
+    }
+}
+
 .switcher-dropdown-option {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
#### Description of changes
This is an issue from OF: there is no diffference between a focused item and a non-focused item in the dropdown component. 
As a workaround I added a border to the focused item under windows high contrast mode.

before:
![1](https://user-images.githubusercontent.com/15974344/85893339-924a8480-b7a7-11ea-8045-81c99cee905d.gif)

after:
![1](https://user-images.githubusercontent.com/15974344/85893425-b5753400-b7a7-11ea-8235-3450ab1fe68e.gif)


<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
