### PR TITLE
fix(android-setup): use img role for meaningful icon-font images in device descriptors

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/device-description.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/device-description.tsx
@@ -31,7 +31,12 @@ export const DeviceDescription = NamedFC<DeviceDescriptionProps>('DeviceDescript
 
     return (
         <div className={css(styles.content, props.className)}>
-            <Icon iconName={iconName} className={styles.iconContent} ariaLabel={iconAriaLabel} />
+            <Icon
+                iconName={iconName}
+                className={styles.iconContent}
+                ariaLabel={iconAriaLabel}
+                role="img"
+            />
             {descriptionAndApp}
         </div>
     );

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/device-description.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/device-description.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`DeviceDescription renders with currentApplication 1`] = `
     ariaLabel="Device"
     className="iconContent"
     iconName="CellPhone"
+    role="img"
   />
   <div
     className="deviceAndCurrentApplication"
@@ -30,6 +31,7 @@ exports[`DeviceDescription renders with device 1`] = `
     ariaLabel="Device"
     className="iconContent"
     iconName="CellPhone"
+    role="img"
   />
   Super-Duper Gadget
 </div>
@@ -43,6 +45,7 @@ exports[`DeviceDescription renders with emulator 1`] = `
     ariaLabel="Emulator"
     className="iconContent"
     iconName="Devices3"
+    role="img"
   />
   Emulator Extraordinaire
 </div>
@@ -56,6 +59,7 @@ exports[`DeviceDescription renders with extra classname 1`] = `
     ariaLabel="Emulator"
     className="iconContent"
     iconName="Devices3"
+    role="img"
   />
   Simple Emulator
 </div>


### PR DESCRIPTION
#### Description of changes

Adds `role=img` to the icon-font images we use to distinguish devices vs emulators, per the "Images > Image function" requirement's guidance.

No visual change. NVDA previously announced a physical device named "foo" as "device foo", and now announces "graphic device *pause* foo" instead.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
