### PR TITLE
feat(reflow-command-bar): ellipsis for target page link

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.scss
+++ b/src/DetailsView/components/details-view-command-bar.scss
@@ -32,3 +32,14 @@
         flex: 1 1 auto;
     }
 }
+
+.target-page-title {
+    width: 100%;
+    text-overflow: ellipsis;
+    display: inline-block;
+    overflow: hidden;
+}
+
+.target-page-link {
+    width: 100%;
+}

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -66,18 +66,20 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
     private renderTargetPageInfo(): JSX.Element {
         const targetPageTitle: string = this.props.scanMetadata.targetAppInfo.name;
         const tooltipContent = `Switch to target page: ${targetPageTitle}`;
-        const hostStyles: Partial<ITooltipHostStyles> = { root: { display: 'inline-block' } };
+        const hostStyles: Partial<ITooltipHostStyles> = {
+            root: { display: 'inline-block', minWidth: 0 },
+        };
         return (
             <div className={styles.detailsViewTargetPage} aria-labelledby="switch-to-target">
                 <span id="switch-to-target">Target page:&nbsp;</span>
                 <TooltipHost content={tooltipContent} styles={hostStyles}>
                     <Link
                         role="link"
-                        className={css('insights-link', 'target-page-link')}
+                        className={css('insights-link', styles.targetPageLink)}
                         onClick={this.props.deps.detailsViewActionMessageCreator.switchToTargetTab}
                         aria-label={tooltipContent}
                     >
-                        {targetPageTitle}
+                        <span className={styles.targetPageTitle}>{targetPageTitle}</span>
                     </Link>
                 </TooltipHost>
             </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -7,8 +7,10 @@ exports[`DetailsViewCommandBar renders with export button, with start over 1`] =
       Target page: 
     </span>
     <StyledTooltipHostBase content=\\"Switch to target page: command-bar-test-tab-title\\" styles={{...}}>
-      <StyledLinkBase role=\\"link\\" className=\\"insights-link target-page-link\\" onClick={[Function: proxy]} aria-label=\\"Switch to target page: command-bar-test-tab-title\\">
-        command-bar-test-tab-title
+      <StyledLinkBase role=\\"link\\" className=\\"insights-link targetPageLink\\" onClick={[Function: proxy]} aria-label=\\"Switch to target page: command-bar-test-tab-title\\">
+        <span className=\\"targetPageTitle\\">
+          command-bar-test-tab-title
+        </span>
       </StyledLinkBase>
     </StyledTooltipHostBase>
   </div>
@@ -30,8 +32,10 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
       Target page: 
     </span>
     <StyledTooltipHostBase content=\\"Switch to target page: command-bar-test-tab-title\\" styles={{...}}>
-      <StyledLinkBase role=\\"link\\" className=\\"insights-link target-page-link\\" onClick={[Function: proxy]} aria-label=\\"Switch to target page: command-bar-test-tab-title\\">
-        command-bar-test-tab-title
+      <StyledLinkBase role=\\"link\\" className=\\"insights-link targetPageLink\\" onClick={[Function: proxy]} aria-label=\\"Switch to target page: command-bar-test-tab-title\\">
+        <span className=\\"targetPageTitle\\">
+          command-bar-test-tab-title
+        </span>
       </StyledLinkBase>
     </StyledTooltipHostBase>
   </div>
@@ -50,8 +54,10 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
       Target page: 
     </span>
     <StyledTooltipHostBase content=\\"Switch to target page: command-bar-test-tab-title\\" styles={{...}}>
-      <StyledLinkBase role=\\"link\\" className=\\"insights-link target-page-link\\" onClick={[Function: proxy]} aria-label=\\"Switch to target page: command-bar-test-tab-title\\">
-        command-bar-test-tab-title
+      <StyledLinkBase role=\\"link\\" className=\\"insights-link targetPageLink\\" onClick={[Function: proxy]} aria-label=\\"Switch to target page: command-bar-test-tab-title\\">
+        <span className=\\"targetPageTitle\\">
+          command-bar-test-tab-title
+        </span>
       </StyledLinkBase>
     </StyledTooltipHostBase>
   </div>
@@ -70,8 +76,10 @@ exports[`DetailsViewCommandBar renders without export button, without start over
       Target page: 
     </span>
     <StyledTooltipHostBase content=\\"Switch to target page: command-bar-test-tab-title\\" styles={{...}}>
-      <StyledLinkBase role=\\"link\\" className=\\"insights-link target-page-link\\" onClick={[Function: proxy]} aria-label=\\"Switch to target page: command-bar-test-tab-title\\">
-        command-bar-test-tab-title
+      <StyledLinkBase role=\\"link\\" className=\\"insights-link targetPageLink\\" onClick={[Function: proxy]} aria-label=\\"Switch to target page: command-bar-test-tab-title\\">
+        <span className=\\"targetPageTitle\\">
+          command-bar-test-tab-title
+        </span>
       </StyledLinkBase>
     </StyledTooltipHostBase>
   </div>


### PR DESCRIPTION
#### Description of changes

Makes sure the target page is shortened using ellipsis when there is not enough room.

![ellipsistargetpagelink](https://user-images.githubusercontent.com/32555133/85903047-46550b00-b7ba-11ea-8988-db7d8c07d9b6.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
