### PR TITLE
feat(command-bar-reflow): create CommandBarButtonsMenu component

### DIFF
--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -10,7 +10,7 @@ export type CommandBarButtonsMenuProps = CommandBarProps;
 export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
     'CommandBarButtonsMenu',
     props => {
-        const onRenderItem = (item: IOverflowSetItemProps) => {
+        const onRenderItem = (item: IOverflowSetItemProps): JSX.Element => {
             return item.onRender(props);
         };
 

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -8,10 +8,10 @@ import * as React from 'react';
 export type CommandBarButtonsMenuProps = CommandBarProps;
 
 export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
-    'DetailsListIssuesView',
+    'CommandBarButtonsMenu',
     props => {
         const onRenderItem = (item: IOverflowSetItemProps) => {
-            item.onRender(props);
+            return item.onRender(props);
         };
 
         const onRenderOverflowButton = (overflow: IOverflowSetItemProps[]): JSX.Element => {
@@ -20,7 +20,7 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
                     ariaLabel="More items"
                     role="menuitem"
                     menuIconProps={{ iconName: 'More' }}
-                    menuProps={{ items: overflow! }}
+                    menuProps={{ items: overflow }}
                 />
             );
         };

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
+import { CommandBarButton, IOverflowSetItemProps, OverflowSet } from 'office-ui-fabric-react';
+import * as React from 'react';
+
+export type CommandBarButtonsMenuProps = CommandBarProps;
+
+export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
+    'DetailsListIssuesView',
+    props => {
+        const onRenderItem = (item: IOverflowSetItemProps) => {
+            item.onRender(props);
+        };
+
+        const onRenderOverflowButton = (overflow: IOverflowSetItemProps[]): JSX.Element => {
+            return (
+                <CommandBarButton
+                    ariaLabel="More items"
+                    role="menuitem"
+                    menuIconProps={{ iconName: 'More' }}
+                    menuProps={{ items: overflow! }}
+                />
+            );
+        };
+
+        const overflowItems = [
+            {
+                key: 'export report',
+                onRender: () => props.switcherNavConfiguration.ReportExportComponentFactory(props),
+            },
+            {
+                key: 'start over',
+                onRender: () => props.switcherNavConfiguration.StartOverComponentFactory(props),
+            },
+        ];
+
+        return (
+            <OverflowSet
+                onRenderItem={onRenderItem}
+                overflowItems={overflowItems}
+                onRenderOverflowButton={onRenderOverflowButton}
+            />
+        );
+    },
+);

--- a/src/common/fabric-icons.ts
+++ b/src/common/fabric-icons.ts
@@ -53,6 +53,7 @@ export function initializeFabricIcons(): void {
             ladybugSolid: '\uF44A',
             mail: '\uE715',
             medical: '\uEAD4',
+            more: '\uE712',
             offlineStorage: '\uEC8C',
             play: '\uE768',
             refresh: '\uE72C',

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CommandBarButtonsMenu renders CommandBarButtonsMenu 1`] = `
+<StyledOverflowSetBase
+  onRenderItem={[Function]}
+  onRenderOverflowButton={[Function]}
+  overflowItems={
+    Array [
+      Object {
+        "key": "export report",
+        "onRender": [Function],
+      },
+      Object {
+        "key": "start over",
+        "onRender": [Function],
+      },
+    ]
+  }
+/>
+`;
+
+exports[`CommandBarButtonsMenu renders overflow button 1`] = `
+<CustomizedCommandBarButton
+  ariaLabel="More items"
+  menuIconProps={
+    Object {
+      "iconName": "More",
+    }
+  }
+  menuProps={
+    Object {
+      "items": Array [
+        Object {
+          "key": "item 1",
+        },
+        Object {
+          "key": "item 2",
+        },
+      ],
+    }
+  }
+  role="menuitem"
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
@@ -52,9 +52,9 @@ describe('CommandBarButtonsMenu', () => {
         const overflowItems: IOverflowSetItemProps[] = renderedProps.overflowItems;
         const onRenderItem: (props: IOverflowSetItemProps) => JSX.Element =
             renderedProps.onRenderItem;
-        expect(overflowItems).not.toBeUndefined();
+        expect(overflowItems).toBeDefined();
         expect(overflowItems).toHaveLength(2);
-        expect(onRenderItem).not.toBeUndefined();
+        expect(onRenderItem).toBeDefined();
 
         overflowItems.forEach(item => {
             onRenderItem(item);
@@ -75,7 +75,7 @@ describe('CommandBarButtonsMenu', () => {
         ];
         const wrapper = shallow(<CommandBarButtonsMenu {...commandBarButtonsMenuProps} />);
         const onRenderOverflowButton = wrapper.getElement().props.onRenderOverflowButton;
-        expect(onRenderOverflowButton).not.toBeUndefined();
+        expect(onRenderOverflowButton).toBeDefined();
 
         expect(onRenderOverflowButton(overflowItems)).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    CommandBarButtonsMenu,
+    CommandBarButtonsMenuProps,
+} from 'DetailsView/components/command-bar-buttons-menu';
+import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
+import { shallow } from 'enzyme';
+import { IOverflowSetItemProps } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { IMock, Mock, Times } from 'typemoq';
+import {
+    DetailsViewCommandBarProps,
+    // tslint:disable-next-line: ordered-imports
+    ReportExportComponentFactory,
+    StartOverComponentFactory,
+} from '../../../../../DetailsView/components/details-view-command-bar';
+
+describe('CommandBarButtonsMenu', () => {
+    let reportExportComponentFactory: IMock<ReportExportComponentFactory>;
+    let startOverComponentFactory: IMock<StartOverComponentFactory>;
+    let commandBarButtonsMenuProps: CommandBarButtonsMenuProps;
+
+    beforeEach(() => {
+        reportExportComponentFactory = Mock.ofType<ReportExportComponentFactory>();
+        startOverComponentFactory = Mock.ofType<StartOverComponentFactory>();
+        commandBarButtonsMenuProps = {
+            switcherNavConfiguration: {
+                ReportExportComponentFactory: reportExportComponentFactory.object,
+                StartOverComponentFactory: startOverComponentFactory.object,
+            } as DetailsViewSwitcherNavConfiguration,
+        } as DetailsViewCommandBarProps;
+    });
+
+    it('renders CommandBarButtonsMenu', () => {
+        const wrapper = shallow(<CommandBarButtonsMenu {...commandBarButtonsMenuProps} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    it('renders child buttons', () => {
+        reportExportComponentFactory
+            .setup(r => r(commandBarButtonsMenuProps))
+            .returns(() => <></>)
+            .verifiable(Times.once());
+        startOverComponentFactory
+            .setup(s => s(commandBarButtonsMenuProps))
+            .returns(() => <></>)
+            .verifiable(Times.once());
+
+        const wrapper = shallow(<CommandBarButtonsMenu {...commandBarButtonsMenuProps} />);
+        const renderedProps = wrapper.getElement().props;
+        const overflowItems: IOverflowSetItemProps[] = renderedProps.overflowItems;
+        const onRenderItem: (props: IOverflowSetItemProps) => JSX.Element =
+            renderedProps.onRenderItem;
+        expect(overflowItems).not.toBeUndefined();
+        expect(overflowItems).toHaveLength(2);
+        expect(onRenderItem).not.toBeUndefined();
+
+        overflowItems.forEach(item => {
+            onRenderItem(item);
+        });
+
+        reportExportComponentFactory.verifyAll();
+        startOverComponentFactory.verifyAll();
+    });
+
+    it('renders overflow button', () => {
+        const overflowItems: IOverflowSetItemProps[] = [
+            {
+                key: 'item 1',
+            },
+            {
+                key: 'item 2',
+            },
+        ];
+        const wrapper = shallow(<CommandBarButtonsMenu {...commandBarButtonsMenuProps} />);
+        const onRenderOverflowButton = wrapper.getElement().props.onRenderOverflowButton;
+        expect(onRenderOverflowButton).not.toBeUndefined();
+
+        expect(onRenderOverflowButton(overflowItems)).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Create component for ... button (not currently used) with menu that currently renders the command bar buttons as-is:
<img width="163" alt="elipses menu" src="https://user-images.githubusercontent.com/55459788/85902450-eb6ee400-b7b8-11ea-9448-528fe3a71f4d.PNG">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1739635
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
