### PR TITLE
chore: cleaning up css for target page changed dialog

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -24,49 +24,8 @@ body {
     overflow: hidden;
 }
 
-.target-change-dialog-modal {
-    .ms-Overlay {
-        background-color: $neutral-alpha-60;
-    }
-}
-
 .hidden {
     display: none !important;
-}
-
-div.insights-dialog-main-override.target-change-dialog,
-div.insights-dialog-main-override.insights-file-issue-details-dialog-container {
-    border-radius: 6px;
-    box-shadow: 0 0 10px 0 $neutral-alpha-60;
-    .ms-Dialog-title {
-        font-weight: $fontWeightSemiBold;
-    }
-    .target-change-dialog-button-container {
-        display: flex;
-        height: 40px;
-        justify-content: flex-end;
-
-        .action-cancel-button-col {
-            text-align: right;
-            padding-left: 0px;
-            margin-top: 4px;
-            margin-bottom: 24px;
-        }
-        button {
-            padding: 0;
-            height: 32px;
-        }
-        .continue-button {
-            button {
-                width: 140px;
-            }
-        }
-        .restart-button {
-            button {
-                width: 85px;
-            }
-        }
-    }
 }
 
 div.insights-dialog-main-override {

--- a/src/DetailsView/components/target-change-dialog.scss
+++ b/src/DetailsView/components/target-change-dialog.scss
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+@import '../../common/styles/common.scss';
+
+.target-change-dialog-modal {
+    :global(.ms-Overlay) {
+        background-color: $neutral-alpha-60;
+    }
+}
+
+.target-change-dialog {
+    border-radius: 6px;
+    box-shadow: 0 0 10px 0 $neutral-alpha-60;
+    :global(.ms-Dialog-title) {
+        font-weight: $fontWeightSemiBold;
+    }
+    .target-change-dialog-button-container {
+        display: flex;
+        height: 40px;
+        justify-content: flex-end;
+
+        .action-cancel-button-col {
+            text-align: right;
+            padding-left: 0px;
+            margin-top: 4px;
+            margin-bottom: 24px;
+        }
+        .action-cancel-button-col + .action-cancel-button-col {
+            margin-left: 8px;
+        }
+        button {
+            padding: 0;
+            height: 32px;
+        }
+        .continue-button {
+            button {
+                width: 140px;
+            }
+        }
+        .restart-button {
+            button {
+                width: 85px;
+            }
+        }
+    }
+}

--- a/src/DetailsView/components/target-change-dialog.tsx
+++ b/src/DetailsView/components/target-change-dialog.tsx
@@ -7,6 +7,7 @@ import { NewTabLink } from 'common/components/new-tab-link';
 import { Tab } from 'common/itab';
 import { PersistedTabInfo } from 'common/types/store-data/assessment-result-data';
 import { UrlParser } from 'common/url-parser';
+import * as styles from 'DetailsView/components/target-change-dialog.scss';
 import { isEmpty } from 'lodash';
 import { DefaultButton, DialogFooter, DialogType, Link, TooltipHost } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -37,8 +38,11 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
                     title: 'Assessment in progress',
                 }}
                 modalProps={{
-                    className: 'target-change-dialog-modal',
-                    containerClassName: 'insights-dialog-main-override target-change-dialog',
+                    className: styles.targetChangeDialogModal,
+                    containerClassName: css(
+                        'insights-dialog-main-override',
+                        styles.targetChangeDialog,
+                    ),
                     subtitleAriaId: 'target-change-dialog-description',
                 }}
             >
@@ -57,8 +61,8 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
                 </div>
 
                 <DialogFooter>
-                    <div className="target-change-dialog-button-container">
-                        <div className="button ms-Grid-col  action-cancel-button-col continue-button">
+                    <div className={styles.targetChangeDialogButtonContainer}>
+                        <div className={css(styles.actionCancelButtonCol, styles.continueButton)}>
                             <DefaultButton
                                 autoFocus={true}
                                 text="Continue previous"
@@ -68,7 +72,7 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
                                 }
                             />
                         </div>
-                        <div className="button ms-Grid-col  action-cancel-button-col restart-button">
+                        <div className={css(styles.actionCancelButtonCol, styles.restartButton)}>
                             <DefaultButton
                                 text="Start new"
                                 onClick={
@@ -90,7 +94,7 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
                 id={'previous-target-page-link'}
                 calloutProps={{ gapSpace: 0 }}
             >
-                <NewTabLink role="link" className="target-page-link" href={tab.url}>
+                <NewTabLink role="link" href={tab.url}>
                     {tab.title}
                 </NewTabLink>
             </TooltipHost>
@@ -108,7 +112,7 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
                     as="a" // force Link to use an anchor tag in order have proper dom structure
                     tabIndex={0}
                     role="link"
-                    className={css('insights-link', 'target-page-link')}
+                    className={css('insights-link')}
                     onClick={this.props.deps.detailsViewActionMessageCreator.switchToTargetTab}
                 >
                     {tab.title}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
@@ -11,8 +11,8 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   hidden={false}
   modalProps={
     Object {
-      "className": "target-change-dialog-modal",
-      "containerClassName": "insights-dialog-main-override target-change-dialog",
+      "className": "targetChangeDialogModal",
+      "containerClassName": "insights-dialog-main-override targetChangeDialog",
       "subtitleAriaId": "target-change-dialog-description",
     }
   }
@@ -31,7 +31,6 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         id="previous-target-page-link"
       >
         <NewTabLink
-          className="target-page-link"
           role="link"
         />
       </StyledTooltipHostBase>
@@ -47,7 +46,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <StyledLinkBase
           as="a"
-          className="insights-link target-page-link"
+          className="insights-link"
           onClick={[Function]}
           role="link"
           tabIndex={0}
@@ -69,10 +68,10 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   </div>
   <StyledDialogFooterBase>
     <div
-      className="target-change-dialog-button-container"
+      className="targetChangeDialogButtonContainer"
     >
       <div
-        className="button ms-Grid-col  action-cancel-button-col continue-button"
+        className="actionCancelButtonCol continueButton"
       >
         <CustomizedDefaultButton
           autoFocus={true}
@@ -81,7 +80,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         />
       </div>
       <div
-        className="button ms-Grid-col  action-cancel-button-col restart-button"
+        className="actionCancelButtonCol restartButton"
       >
         <CustomizedDefaultButton
           onClick={[Function]}
@@ -104,8 +103,8 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   hidden={false}
   modalProps={
     Object {
-      "className": "target-change-dialog-modal",
-      "containerClassName": "insights-dialog-main-override target-change-dialog",
+      "className": "targetChangeDialogModal",
+      "containerClassName": "insights-dialog-main-override targetChangeDialog",
       "subtitleAriaId": "target-change-dialog-description",
     }
   }
@@ -125,7 +124,6 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         id="previous-target-page-link"
       >
         <NewTabLink
-          className="target-page-link"
           href="https://www.abc.com"
           role="link"
         >
@@ -144,7 +142,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <StyledLinkBase
           as="a"
-          className="insights-link target-page-link"
+          className="insights-link"
           onClick={[Function]}
           role="link"
           tabIndex={0}
@@ -166,10 +164,10 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   </div>
   <StyledDialogFooterBase>
     <div
-      className="target-change-dialog-button-container"
+      className="targetChangeDialogButtonContainer"
     >
       <div
-        className="button ms-Grid-col  action-cancel-button-col continue-button"
+        className="actionCancelButtonCol continueButton"
       >
         <CustomizedDefaultButton
           autoFocus={true}
@@ -178,7 +176,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         />
       </div>
       <div
-        className="button ms-Grid-col  action-cancel-button-col restart-button"
+        className="actionCancelButtonCol restartButton"
       >
         <CustomizedDefaultButton
           onClick={[Function]}
@@ -201,8 +199,8 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   hidden={false}
   modalProps={
     Object {
-      "className": "target-change-dialog-modal",
-      "containerClassName": "insights-dialog-main-override target-change-dialog",
+      "className": "targetChangeDialogModal",
+      "containerClassName": "insights-dialog-main-override targetChangeDialog",
       "subtitleAriaId": "target-change-dialog-description",
     }
   }
@@ -222,7 +220,6 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         id="previous-target-page-link"
       >
         <NewTabLink
-          className="target-page-link"
           href="https://www.abc.com"
           role="link"
         >
@@ -241,7 +238,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <StyledLinkBase
           as="a"
-          className="insights-link target-page-link"
+          className="insights-link"
           onClick={[Function]}
           role="link"
           tabIndex={0}
@@ -263,10 +260,10 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   </div>
   <StyledDialogFooterBase>
     <div
-      className="target-change-dialog-button-container"
+      className="targetChangeDialogButtonContainer"
     >
       <div
-        className="button ms-Grid-col  action-cancel-button-col continue-button"
+        className="actionCancelButtonCol continueButton"
       >
         <CustomizedDefaultButton
           autoFocus={true}
@@ -275,7 +272,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         />
       </div>
       <div
-        className="button ms-Grid-col  action-cancel-button-col restart-button"
+        className="actionCancelButtonCol restartButton"
       >
         <CustomizedDefaultButton
           onClick={[Function]}
@@ -298,8 +295,8 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   hidden={false}
   modalProps={
     Object {
-      "className": "target-change-dialog-modal",
-      "containerClassName": "insights-dialog-main-override target-change-dialog",
+      "className": "targetChangeDialogModal",
+      "containerClassName": "insights-dialog-main-override targetChangeDialog",
       "subtitleAriaId": "target-change-dialog-description",
     }
   }
@@ -319,7 +316,6 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         id="previous-target-page-link"
       >
         <NewTabLink
-          className="target-page-link"
           href="https://www.abc.com"
           role="link"
         >
@@ -338,7 +334,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <StyledLinkBase
           as="a"
-          className="insights-link target-page-link"
+          className="insights-link"
           onClick={[Function]}
           role="link"
           tabIndex={0}
@@ -360,10 +356,10 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   </div>
   <StyledDialogFooterBase>
     <div
-      className="target-change-dialog-button-container"
+      className="targetChangeDialogButtonContainer"
     >
       <div
-        className="button ms-Grid-col  action-cancel-button-col continue-button"
+        className="actionCancelButtonCol continueButton"
       >
         <CustomizedDefaultButton
           autoFocus={true}
@@ -372,7 +368,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         />
       </div>
       <div
-        className="button ms-Grid-col  action-cancel-button-col restart-button"
+        className="actionCancelButtonCol restartButton"
       >
         <CustomizedDefaultButton
           onClick={[Function]}
@@ -395,8 +391,8 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   hidden={false}
   modalProps={
     Object {
-      "className": "target-change-dialog-modal",
-      "containerClassName": "insights-dialog-main-override target-change-dialog",
+      "className": "targetChangeDialogModal",
+      "containerClassName": "insights-dialog-main-override targetChangeDialog",
       "subtitleAriaId": "target-change-dialog-description",
     }
   }
@@ -416,7 +412,6 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         id="previous-target-page-link"
       >
         <NewTabLink
-          className="target-page-link"
           href="https://www.abc.com"
           role="link"
         >
@@ -435,7 +430,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <StyledLinkBase
           as="a"
-          className="insights-link target-page-link"
+          className="insights-link"
           onClick={[Function]}
           role="link"
           tabIndex={0}
@@ -457,10 +452,10 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   </div>
   <StyledDialogFooterBase>
     <div
-      className="target-change-dialog-button-container"
+      className="targetChangeDialogButtonContainer"
     >
       <div
-        className="button ms-Grid-col  action-cancel-button-col continue-button"
+        className="actionCancelButtonCol continueButton"
       >
         <CustomizedDefaultButton
           autoFocus={true}
@@ -469,7 +464,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         />
       </div>
       <div
-        className="button ms-Grid-col  action-cancel-button-col restart-button"
+        className="actionCancelButtonCol restartButton"
       >
         <CustomizedDefaultButton
           onClick={[Function]}


### PR DESCRIPTION
#### Description of changes

Just cleaning up some css from details view for this dialog.
![targetpagechangedialogcss](https://user-images.githubusercontent.com/32555133/85905704-f4fc4a00-b7c0-11ea-880a-a89b0bd4bdb0.gif)

Above gif shows unchanged css.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
