### PR TITLE
feat(needs-review): Adding subtitle, fixing dividers in ad hoc panel

### DIFF
--- a/src/ad-hoc-visualizations/needs-review/visualization.tsx
+++ b/src/ad-hoc-visualizations/needs-review/visualization.tsx
@@ -27,7 +27,7 @@ export const NeedsReviewAdHocVisualization: VisualizationConfiguration = {
         subtitle: (
             <>
                 <i>Needs review</i> automated checks will highlight elements that might have an
-                accessibility issue. Examine each instance to determine if there is an Accessibility
+                accessibility issue. Examine each instance to determine if there is an accessibility
                 issue.
             </>
         ),

--- a/src/ad-hoc-visualizations/needs-review/visualization.tsx
+++ b/src/ad-hoc-visualizations/needs-review/visualization.tsx
@@ -24,6 +24,13 @@ export const NeedsReviewAdHocVisualization: VisualizationConfiguration = {
     getTestStatus: data => data.enabled,
     displayableData: {
         title: 'Needs review',
+        subtitle: (
+            <>
+                <i>Needs review</i> automated checks will highlight elements that might have an
+                accessibility issue. Examine each instance to determine if there is an Accessibility
+                issue.
+            </>
+        ),
         enableMessage: 'Running needs review checks...',
         toggleLabel: 'Show elements needing review',
         linkToDetailsViewText: 'List view and filtering',

--- a/src/popup/components/ad-hoc-tools-panel.tsx
+++ b/src/popup/components/ad-hoc-tools-panel.tsx
@@ -23,14 +23,9 @@ export const AdHocToolsPanel = NamedFC<AdHocToolsPanelProps>('AdHocToolsPanel', 
         );
 
         const totalRows = 3;
-        const totalIterableRows = totalRows - 1; // we treat the last row differently
 
         const result = flatMap(toggles, (toggle, index) => {
-            if (index === 0) {
-                return [toggle, getDivider()];
-            }
-
-            if (index % totalIterableRows === 0) {
+            if ((index + 1) % totalRows === 0 || index === toggles.length - 1) {
                 return [toggle];
             }
 

--- a/src/tests/unit/tests/popup/components/__snapshots__/ad-hoc-tools-panel.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/ad-hoc-tools-panel.test.tsx.snap
@@ -50,3 +50,60 @@ exports[`AdHocToolsPanelTest adhoc panel matches snapshot 1`] = `
   </div>
 </div>
 `;
+
+exports[`AdHocToolsPanelTest adhoc panel with needs review sixth toggle matches snapshot 1`] = `
+<div
+  className="main-section adHocToolsPanel"
+>
+  <main
+    className="adHocToolsGrid"
+  >
+    <div>
+      first
+    </div>
+    <span
+      className="divider"
+    />
+    <div>
+      second
+    </div>
+    <span
+      className="divider"
+    />
+    <div>
+      third
+    </div>
+    <div>
+      fourth
+    </div>
+    <span
+      className="divider"
+    />
+    <div>
+      fifth
+    </div>
+    <span
+      className="divider"
+    />
+    <div>
+      sixth
+    </div>
+  </main>
+  <div
+    className="adHocToolsPanelFooter"
+    role="navigation"
+  >
+    <StyledLinkBase
+      className="link"
+      id="back-to-launchpad-link"
+      onClick={null}
+    >
+      <StyledIconBase
+        className="backToLaunchPadIcon"
+        iconName="back"
+      />
+      Back to launch pad
+    </StyledLinkBase>
+  </div>
+</div>
+`;

--- a/src/tests/unit/tests/popup/components/ad-hoc-tools-panel.test.tsx
+++ b/src/tests/unit/tests/popup/components/ad-hoc-tools-panel.test.tsx
@@ -11,7 +11,7 @@ import { Mock, Times } from 'typemoq';
 describe('AdHocToolsPanelTest', () => {
     const diagnosticViewToggleFactoryMock = Mock.ofType(DiagnosticViewToggleFactory);
 
-    beforeEach(() => {
+    test('adhoc panel matches snapshot', () => {
         diagnosticViewToggleFactoryMock
             .setup(factory => factory.createTogglesForAdHocToolsPanel())
             .returns(() => [
@@ -21,9 +21,26 @@ describe('AdHocToolsPanelTest', () => {
                 <div key="fourth">fourth</div>,
                 <div key="fifth">fifth</div>,
             ]);
+        const props: AdHocToolsPanelProps = {
+            backLinkHandler: null,
+            diagnosticViewToggleFactory: diagnosticViewToggleFactoryMock.object,
+        };
+
+        const wrapper = shallow(<AdHocToolsPanel {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
     });
 
-    test('adhoc panel matches snapshot', () => {
+    test('adhoc panel with needs review sixth toggle matches snapshot', () => {
+        diagnosticViewToggleFactoryMock
+            .setup(factory => factory.createTogglesForAdHocToolsPanel())
+            .returns(() => [
+                <div key="first">first</div>,
+                <div key="second">second</div>,
+                <div key="third">third</div>,
+                <div key="fourth">fourth</div>,
+                <div key="fifth">fifth</div>,
+                <div key="sixth">sixth</div>,
+            ]);
         const props: AdHocToolsPanelProps = {
             backLinkHandler: null,
             diagnosticViewToggleFactory: diagnosticViewToggleFactoryMock.object,


### PR DESCRIPTION
#### Description of changes

Adding subtitle to Needs review page in details view.  

Also, fixing divider issue in ad hoc tools panel (previously, second to last divider was missing when needs review was enabled).  Now dividers are generated as expected irrespective of whether there are five or six items in the panel.  



<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [Link to work item](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/1741820)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
