### PR TITLE
feat(command-bar-reflow): Render start over dropdown on the left in ... menu

### DIFF
--- a/src/DetailsView/components/command-bar-buttons-menu.scss
+++ b/src/DetailsView/components/command-bar-buttons-menu.scss
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+.command-bar-buttons-menu-button {
+    height: inherit;
+}
+
+.command-bar-buttons-submenu {
+    button {
+        height: 36px;
+    }
+}

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -4,6 +4,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { CommandBarButton, IOverflowSetItemProps, OverflowSet } from 'office-ui-fabric-react';
 import * as React from 'react';
+import * as styles from './command-bar-buttons-menu.scss';
 
 export type CommandBarButtonsMenuProps = CommandBarProps;
 
@@ -20,7 +21,8 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
                     ariaLabel="More items"
                     role="menuitem"
                     menuIconProps={{ iconName: 'More' }}
-                    menuProps={{ items: overflow }}
+                    menuProps={{ items: overflow, className: styles.commandBarButtonsSubmenu }}
+                    className={styles.commandBarButtonsMenuButton}
                 />
             );
         };

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -32,7 +32,11 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
             },
             {
                 key: 'start over',
-                onRender: () => props.switcherNavConfiguration.StartOverComponentFactory(props),
+                onRender: () =>
+                    props.switcherNavConfiguration.StartOverComponentFactory({
+                        ...props,
+                        dropdownDirection: 'left',
+                    }),
             },
         ];
 

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
+import { StartOverFactoryProps } from 'DetailsView/components/start-over-component-factory';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
@@ -33,7 +34,7 @@ export type CommandBarProps = DetailsViewCommandBarProps;
 
 export type ReportExportComponentFactory = (props: CommandBarProps) => JSX.Element;
 
-export type StartOverComponentFactory = (props: CommandBarProps) => JSX.Element;
+export type StartOverComponentFactory = (props: StartOverFactoryProps) => JSX.Element;
 
 export interface DetailsViewCommandBarProps {
     deps: DetailsViewCommandBarDeps;
@@ -107,6 +108,10 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
     }
 
     private renderStartOverComponent(): JSX.Element {
-        return this.props.switcherNavConfiguration.StartOverComponentFactory(this.props);
+        const startOverFactoryProps: StartOverFactoryProps = {
+            ...this.props,
+            dropdownDirection: 'down',
+        };
+        return this.props.switcherNavConfiguration.StartOverComponentFactory(startOverFactoryProps);
     }
 }

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -15,6 +15,7 @@ export function getStartOverComponentForAssessment(props: CommandBarProps): JSX.
         test: selectedTest,
         requirementKey: props.assessmentStoreData.assessmentNavState.selectedTestSubview,
         rightPanelConfiguration: props.rightPanelConfiguration,
+        dropdownDirection: 'down',
     };
 
     return <StartOverDropdown {...startOverProps} />;

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -1,11 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
-import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
-import { StartOverDropdown, StartOverProps } from 'DetailsView/components/start-over-dropdown';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { DetailsRightPanelConfiguration } from 'DetailsView/components/details-view-right-panel';
+import {
+    DropdownDirection,
+    StartOverDeps,
+    StartOverDropdown,
+    StartOverProps,
+} from 'DetailsView/components/start-over-dropdown';
 import * as React from 'react';
 
-export function getStartOverComponentForAssessment(props: CommandBarProps): JSX.Element {
+export type StartOverFactoryProps = {
+    deps: StartOverDeps;
+    assessmentStoreData: AssessmentStoreData;
+    assessmentsProvider: AssessmentsProvider;
+    rightPanelConfiguration: DetailsRightPanelConfiguration;
+    visualizationStoreData: VisualizationStoreData;
+    dropdownDirection: DropdownDirection;
+};
+
+export function getStartOverComponentForAssessment(props: StartOverFactoryProps): JSX.Element {
     const selectedTest = props.assessmentStoreData.assessmentNavState.selectedTestType;
     const test = props.assessmentsProvider.forType(selectedTest);
     const deps = props.deps;
@@ -15,7 +32,7 @@ export function getStartOverComponentForAssessment(props: CommandBarProps): JSX.
         test: selectedTest,
         requirementKey: props.assessmentStoreData.assessmentNavState.selectedTestSubview,
         rightPanelConfiguration: props.rightPanelConfiguration,
-        dropdownDirection: 'down',
+        dropdownDirection: props.dropdownDirection,
     };
 
     return <StartOverDropdown {...startOverProps} />;
@@ -23,7 +40,7 @@ export function getStartOverComponentForAssessment(props: CommandBarProps): JSX.
 
 export const startOverAutomationId = 'start-over';
 
-export function getStartOverComponentForFastPass(props: CommandBarProps): JSX.Element {
+export function getStartOverComponentForFastPass(props: StartOverFactoryProps): JSX.Element {
     const selectedTest = props.visualizationStoreData.selectedFastPassDetailsView;
     const detailsViewActionMessageCreator = props.deps.detailsViewActionMessageCreator;
 

--- a/src/DetailsView/components/start-over-dropdown.tsx
+++ b/src/DetailsView/components/start-over-dropdown.tsx
@@ -28,10 +28,10 @@ export interface StartOverProps {
     test: VisualizationType;
     requirementKey: string;
     rightPanelConfiguration: DetailsRightPanelConfiguration;
-    dropdownDirection: keyof typeof dropdownDirectionConfigs;
+    dropdownDirection: DropdownDirection;
 }
 
-const dropdownDirectionConfigs = {
+const dropdownDirections = {
     down: {
         directionalHint: DirectionalHint.bottomAutoEdge,
         iconName: 'ChevronDown',
@@ -41,6 +41,8 @@ const dropdownDirectionConfigs = {
         iconName: 'ChevronRight',
     },
 };
+
+export type DropdownDirection = keyof typeof dropdownDirections;
 
 export class StartOverDropdown extends React.Component<StartOverProps, StartOverState> {
     constructor(props: StartOverProps) {
@@ -53,6 +55,7 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
     }
 
     public render(): JSX.Element {
+        const direction = this.props.dropdownDirection;
         return (
             <div>
                 <InsightsCommandButton
@@ -63,7 +66,7 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
                     ariaLabel="start over menu"
                     onClick={this.openDropdown}
                     menuIconProps={{
-                        iconName: dropdownDirectionConfigs[this.props.dropdownDirection].iconName,
+                        iconName: dropdownDirections[direction].iconName,
                     }}
                 />
                 {this.renderContextMenu()}
@@ -77,14 +80,14 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
             return null;
         }
 
+        const direction = this.props.dropdownDirection;
+
         return (
             <ContextualMenu
                 onDismiss={() => this.dismissDropdown()}
                 target={this.state.target}
                 items={this.getMenuItems()}
-                directionalHint={
-                    dropdownDirectionConfigs[this.props.dropdownDirection].directionalHint
-                }
+                directionalHint={dropdownDirections[direction].directionalHint}
             />
         );
     }

--- a/src/DetailsView/components/start-over-dropdown.tsx
+++ b/src/DetailsView/components/start-over-dropdown.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IPoint } from '@uifabric/utilities';
-import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react';
+import { ContextualMenu, DirectionalHint, IContextualMenuItem } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
@@ -28,7 +28,19 @@ export interface StartOverProps {
     test: VisualizationType;
     requirementKey: string;
     rightPanelConfiguration: DetailsRightPanelConfiguration;
+    dropdownDirection: keyof typeof dropdownDirectionConfigs;
 }
+
+const dropdownDirectionConfigs = {
+    down: {
+        directionalHint: DirectionalHint.bottomAutoEdge,
+        iconName: 'ChevronDown',
+    },
+    left: {
+        directionalHint: DirectionalHint.leftTopEdge,
+        iconName: 'ChevronRight',
+    },
+};
 
 export class StartOverDropdown extends React.Component<StartOverProps, StartOverState> {
     constructor(props: StartOverProps) {
@@ -51,7 +63,7 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
                     ariaLabel="start over menu"
                     onClick={this.openDropdown}
                     menuIconProps={{
-                        iconName: 'ChevronDown',
+                        iconName: dropdownDirectionConfigs[this.props.dropdownDirection].iconName,
                     }}
                 />
                 {this.renderContextMenu()}
@@ -70,6 +82,9 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
                 onDismiss={() => this.dismissDropdown()}
                 target={this.state.target}
                 items={this.getMenuItems()}
+                directionalHint={
+                    dropdownDirectionConfigs[this.props.dropdownDirection].directionalHint
+                }
             />
         );
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`CommandBarButtonsMenu renders CommandBarButtonsMenu 1`] = `
 exports[`CommandBarButtonsMenu renders overflow button 1`] = `
 <CustomizedCommandBarButton
   ariaLabel="More items"
+  className="commandBarButtonsMenuButton"
   menuIconProps={
     Object {
       "iconName": "More",
@@ -29,6 +30,7 @@ exports[`CommandBarButtonsMenu renders overflow button 1`] = `
   }
   menuProps={
     Object {
+      "className": "commandBarButtonsSubmenu",
       "items": Array [
         Object {
           "key": "item 1",

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`StartOverComponentFactory getStartOverComponentForAssessments renders 1
 />
 `;
 
-exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders scanResults is not null, scanning is false => component matches snapshot 1`] = `
+exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders scanning is false => component matches snapshot 1`] = `
 <InsightsCommandButton
   data-automation-id="start-over"
   disabled={false}
@@ -25,25 +25,10 @@ exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders
 </InsightsCommandButton>
 `;
 
-exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders scanResults is not null, scanning is true => component matches snapshot 1`] = `
+exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders scanning is true => component matches snapshot 1`] = `
 <InsightsCommandButton
   data-automation-id="start-over"
   disabled={true}
-  iconProps={
-    Object {
-      "iconName": "Refresh",
-    }
-  }
-  onClick={[Function]}
->
-  Start over
-</InsightsCommandButton>
-`;
-
-exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders scanResults is null => component matches snapshot 1`] = `
-<InsightsCommandButton
-  data-automation-id="start-over"
-  disabled={false}
   iconProps={
     Object {
       "iconName": "Refresh",

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`StartOverComponentFactory getStartOverComponentForAssessments renders 1`] = `
 <StartOverDropdown
   deps={Object {}}
+  dropdownDirection="down"
   requirementKey="test step"
   test={6}
   testName="the title"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`StartOverDropdownTest render ContextualMenu 1`] = `
     text="Start over"
   />
   <StyledWithResponsiveMode
+    directionalHint={7}
     items={
       Array [
         Object {
@@ -62,6 +63,7 @@ exports[`StartOverDropdownTest render ContextualMenu with only one option 1`] = 
     text="Start over"
   />
   <StyledWithResponsiveMode
+    directionalHint={7}
     items={
       Array [
         Object {
@@ -80,7 +82,7 @@ exports[`StartOverDropdownTest render ContextualMenu with only one option 1`] = 
 exports[`StartOverDropdownTest render GenericDialog for start over a test 1`] = `
 "<div>
   <InsightsCommandButton iconProps={{...}} text=\\"Start over\\" ariaLabel=\\"start over menu\\" onClick={[Function]} menuIconProps={{...}} />
-  <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} />
+  <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} directionalHint={7} />
   <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the test name test. Are you sure you want to start over?\\" onCancelButtonClick={[Function]} onPrimaryButtonClick={[Function]} primaryButtonText=\\"Start over\\" />
 </div>"
 `;
@@ -88,7 +90,46 @@ exports[`StartOverDropdownTest render GenericDialog for start over a test 1`] = 
 exports[`StartOverDropdownTest render GenericDialog for start over the whole assessment 1`] = `
 "<div>
   <InsightsCommandButton iconProps={{...}} text=\\"Start over\\" ariaLabel=\\"start over menu\\" onClick={[Function]} menuIconProps={{...}} />
-  <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} />
+  <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} directionalHint={7} />
   <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the Assessment. This will clear results and progress of all tests and requirements. Are you sure you want to start over?\\" onCancelButtonClick={[Function]} onPrimaryButtonClick={[Function]} primaryButtonText=\\"Start over\\" />
 </div>"
+`;
+
+exports[`StartOverDropdownTest render with dropdown on left 1`] = `
+<div>
+  <InsightsCommandButton
+    ariaLabel="start over menu"
+    iconProps={
+      Object {
+        "iconName": "Refresh",
+      }
+    }
+    menuIconProps={
+      Object {
+        "iconName": "ChevronRight",
+      }
+    }
+    onClick={[Function]}
+    text="Start over"
+  />
+  <StyledWithResponsiveMode
+    directionalHint={8}
+    items={
+      Array [
+        Object {
+          "key": "assessment",
+          "name": "Start over Assessment",
+          "onClick": [Function],
+        },
+        Object {
+          "key": "test",
+          "name": "Start over test name",
+          "onClick": [Function],
+        },
+      ]
+    }
+    onDismiss={[Function]}
+    target="test target"
+  />
+</div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
@@ -5,6 +5,7 @@ import {
     CommandBarButtonsMenuProps,
 } from 'DetailsView/components/command-bar-buttons-menu';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
+import { StartOverFactoryProps } from 'DetailsView/components/start-over-component-factory';
 import { shallow } from 'enzyme';
 import { IOverflowSetItemProps } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -42,8 +43,13 @@ describe('CommandBarButtonsMenu', () => {
             .setup(r => r(commandBarButtonsMenuProps))
             .returns(() => <></>)
             .verifiable(Times.once());
+
+        const startOverFactoryProps: StartOverFactoryProps = {
+            ...commandBarButtonsMenuProps,
+            dropdownDirection: 'left',
+        };
         startOverComponentFactory
-            .setup(s => s(commandBarButtonsMenuProps))
+            .setup(s => s(startOverFactoryProps))
             .returns(() => <></>)
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -85,23 +85,14 @@ describe('StartOverComponentFactory', () => {
 
     describe('getStartOverComponentPropsForFastPass', () => {
         describe('renders', () => {
-            test('scanResults is null => component matches snapshot', () => {
+            test('scanning is false => component matches snapshot', () => {
                 const props = getProps(false);
                 const rendered = getStartOverComponentForFastPass(props);
 
                 expect(rendered).toMatchSnapshot();
             });
 
-            test('scanResults is not null, scanning is false => component matches snapshot', () => {
-                setScanResult();
-                const props = getProps(false);
-                const rendered = getStartOverComponentForFastPass(props);
-
-                expect(rendered).toMatchSnapshot();
-            });
-
-            test('scanResults is not null, scanning is true => component matches snapshot', () => {
-                setScanResult();
+            test('scanning is true => component matches snapshot', () => {
                 scanning = 'some string';
                 const props = getProps(false);
                 const rendered = getStartOverComponentForFastPass(props);

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -7,23 +7,17 @@ import {
     AssessmentNavState,
     AssessmentStoreData,
 } from 'common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import {
-    CommandBarProps,
-    DetailsViewCommandBarDeps,
-    DetailsViewCommandBarProps,
-} from 'DetailsView/components/details-view-command-bar';
-import {
     getStartOverComponentForAssessment,
     getStartOverComponentForFastPass,
+    StartOverFactoryProps,
 } from 'DetailsView/components/start-over-component-factory';
+import { StartOverDeps } from 'DetailsView/components/start-over-dropdown';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { ScanResults } from 'scanner/iruleresults';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
@@ -31,24 +25,20 @@ describe('StartOverComponentFactory', () => {
     const theTitle = 'the title';
     const theTestStep = 'test step';
     const theTestType = VisualizationType.ColorSensoryAssessment;
+    const dropdownDirection = 'down';
 
     let assessment: Readonly<Assessment>;
     let assessmentsProviderMock: IMock<AssessmentsProvider>;
-    let featureFlagStoreData: FeatureFlagStoreData;
     let assessmentStoreData: AssessmentStoreData;
-    let visualizationScanResultData: VisualizationScanResultData;
-    let scanResult: ScanResults;
     let scanning: string;
 
     beforeEach(() => {
         assessmentsProviderMock = Mock.ofType<AssessmentsProvider>(undefined, MockBehavior.Loose);
-        featureFlagStoreData = {};
-        scanResult = null;
         scanning = null;
     });
 
-    function getProps(isForAssessment: boolean): DetailsViewCommandBarProps {
-        const deps = {} as DetailsViewCommandBarDeps;
+    function getProps(isForAssessment: boolean): StartOverFactoryProps {
+        const deps = {} as StartOverDeps;
 
         let visualizationStoreData: VisualizationStoreData = null;
         let selectedTestType: VisualizationType = null;
@@ -67,11 +57,6 @@ describe('StartOverComponentFactory', () => {
                 scanning,
             } as VisualizationStoreData;
         }
-        visualizationScanResultData = {
-            issues: {
-                scanResult: scanResult,
-            },
-        } as VisualizationScanResultData;
 
         assessmentStoreData = {
             assessmentNavState: {
@@ -82,16 +67,11 @@ describe('StartOverComponentFactory', () => {
 
         return {
             deps,
-            featureFlagStoreData,
             assessmentStoreData,
             assessmentsProvider: assessmentsProviderMock.object,
-            visualizationScanResultData,
             visualizationStoreData,
-        } as DetailsViewCommandBarProps;
-    }
-
-    function setScanResult(): void {
-        scanResult = {} as ScanResults;
+            dropdownDirection,
+        } as StartOverFactoryProps;
     }
 
     describe('getStartOverComponentForAssessments', () => {
@@ -139,7 +119,7 @@ describe('StartOverComponentFactory', () => {
                 const props = getProps(false);
                 props.deps.detailsViewActionMessageCreator = actionMessageCreatorMock.object;
 
-                const Wrapper = NamedFC<CommandBarProps>(
+                const Wrapper = NamedFC<StartOverFactoryProps>(
                     'WrappedStartOver',
                     getStartOverComponentForFastPass,
                 );

--- a/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
@@ -35,6 +35,7 @@ describe('StartOverDropdownTest', () => {
             rightPanelConfiguration: {
                 GetStartOverContextualMenuItemKeys: () => ['assessment', 'test'],
             } as DetailsRightPanelConfiguration,
+            dropdownDirection: 'down',
         };
     });
 
@@ -81,6 +82,16 @@ describe('StartOverDropdownTest', () => {
             .find(elem => elem.key === 'assessment')
             .onClick();
         expect(rendered.debug()).toMatchSnapshot();
+    });
+
+    it('render with dropdown on left', () => {
+        const props: StartOverProps = {
+            ...defaultProps,
+            dropdownDirection: 'left',
+        };
+        const rendered = shallow(<StartOverDropdown {...props} />);
+        rendered.find(InsightsCommandButton).simulate('click', event);
+        expect(rendered.getElement()).toMatchSnapshot();
     });
 
     it('should dismiss the start test over dialog', () => {


### PR DESCRIPTION
#### Description of changes

- Add a dropdownDirection property to StartOverDropdown so we can render the dropdown either below or to the left of the button
- Render below if the button is in the command bar
- Render to the left if the button is in the ... menu
- Fix some styling issues in the command bar ... menu

CommandBarMenuButton is still not in use yet, but here's a demonstration of the component with the existing command buttons for comparison:

![left dropdown](https://user-images.githubusercontent.com/55459788/86060446-8fef6100-ba19-11ea-8298-e40abb0adaf7.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1739635
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
