### PR TITLE
feat(android-setup): placeholder e2e test with adb feature flag on

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.tsx
@@ -13,7 +13,7 @@ export type AndroidSetupStepLayoutProps = {
     leftFooterButtonProps: AndroidSetupFooterButtonProps;
     rightFooterButtonProps: AndroidSetupFooterButtonProps;
 };
-
+export const moreInfoLinkAutomationId = 'more-info-link';
 export const AndroidSetupStepLayout = NamedFC<AndroidSetupStepLayoutProps>(
     'AndroidSetupStepLayout',
     props => {
@@ -22,7 +22,9 @@ export const AndroidSetupStepLayout = NamedFC<AndroidSetupStepLayoutProps>(
 
         const optionalMoreInfoLink =
             props.moreInfoLink == null ? null : (
-                <div className={styles.moreInfoLink}>{props.moreInfoLink}</div>
+                <div className={styles.moreInfoLink} data-automation-id={moreInfoLinkAutomationId}>
+                    {props.moreInfoLink}
+                </div>
             );
 
         return (

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -74,6 +74,14 @@ export class AppController {
         );
     }
 
+    public async setFeatureFlag(flag: string, enabled: boolean): Promise<void> {
+        await this.waitForfeatureFlagInitializer();
+        const action = enabled ? 'enable' : 'disable';
+        await this.app.webContents.executeJavaScript(
+            `window.featureFlagsController.${action}Feature('${flag}')`,
+        );
+    }
+
     private async waitForUserConfigurationInitializer(): Promise<void> {
         await this.client.waitUntil(
             async () => {
@@ -85,6 +93,20 @@ export class AppController {
             },
             DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS,
             'was expecting window.insightsUserConfiguration to be defined',
+        );
+    }
+
+    private async waitForfeatureFlagInitializer(): Promise<void> {
+        await this.client.waitUntil(
+            async () => {
+                const executeOutput = await this.client.executeAsync(done => {
+                    done((window as any).featureFlagsController != null);
+                });
+
+                return executeOutput.status === 0 && executeOutput.value === true;
+            },
+            DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS,
+            'was expecting window.featureFlagsController to be defined',
         );
     }
 }

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -44,7 +44,7 @@ export class AppController {
     }
 
     public async setHighContrastMode(enableHighContrast: boolean): Promise<void> {
-        await this.waitForUserConfigurationInitializer();
+        await this.waitForWindowPropertyInitialized('insightsUserConfiguration');
 
         await this.app.webContents.executeJavaScript(
             `window.insightsUserConfiguration.setHighContrastMode(${enableHighContrast})`,
@@ -67,7 +67,7 @@ export class AppController {
     }
 
     public async setTelemetryState(enableTelemetry: boolean): Promise<void> {
-        await this.waitForUserConfigurationInitializer();
+        await this.waitForWindowPropertyInitialized('insightsUserConfiguration');
 
         await this.app.webContents.executeJavaScript(
             `window.insightsUserConfiguration.setTelemetryState(${enableTelemetry})`,
@@ -75,38 +75,26 @@ export class AppController {
     }
 
     public async setFeatureFlag(flag: string, enabled: boolean): Promise<void> {
-        await this.waitForfeatureFlagInitializer();
+        await this.waitForWindowPropertyInitialized('featureFlagsController');
         const action = enabled ? 'enable' : 'disable';
         await this.app.webContents.executeJavaScript(
             `window.featureFlagsController.${action}Feature('${flag}')`,
         );
     }
 
-    private async waitForUserConfigurationInitializer(): Promise<void> {
+    private async waitForWindowPropertyInitialized(
+        propertyName: 'insightsUserConfiguration' | 'featureFlagsController',
+    ): Promise<void> {
         await this.client.waitUntil(
             async () => {
-                const executeOutput = await this.client.executeAsync(done => {
-                    done((window as any).insightsUserConfiguration != null);
-                });
+                const executeOutput = await this.client.executeAsync((prop, done) => {
+                    done((window as any)[prop] != null);
+                }, propertyName);
 
                 return executeOutput.status === 0 && executeOutput.value === true;
             },
             DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS,
-            'was expecting window.insightsUserConfiguration to be defined',
-        );
-    }
-
-    private async waitForfeatureFlagInitializer(): Promise<void> {
-        await this.client.waitUntil(
-            async () => {
-                const executeOutput = await this.client.executeAsync(done => {
-                    done((window as any).featureFlagsController != null);
-                });
-
-                return executeOutput.status === 0 && executeOutput.value === true;
-            },
-            DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS,
-            'was expecting window.featureFlagsController to be defined',
+            `was expecting window.${propertyName} to be defined`,
         );
     }
 }

--- a/src/tests/electron/tests/automatic-android-setup.test.ts
+++ b/src/tests/electron/tests/automatic-android-setup.test.ts
@@ -33,6 +33,6 @@ describe('AutomaticAndroidSetup', () => {
         const selector = getAutomationIdSelector(moreInfoLinkAutomationId);
         await deviceConnectionController.client.waitForExist(selector);
         const text = await deviceConnectionController.client.getText(selector);
-        expect(text.startsWith('How do I')).toBeTruthy();
+        expect(text.startsWith('How do I')).toBe(true);
     });
 });

--- a/src/tests/electron/tests/automatic-android-setup.test.ts
+++ b/src/tests/electron/tests/automatic-android-setup.test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
+import { moreInfoLinkAutomationId } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
+import { createApplication } from 'tests/electron/common/create-application';
+import { AppController } from 'tests/electron/common/view-controllers/app-controller';
+import { DeviceConnectionDialogController } from 'tests/electron/common/view-controllers/device-connection-dialog-controller';
+describe('AutomaticAndroidSetup', () => {
+    let app: AppController;
+    let deviceConnectionController: DeviceConnectionDialogController;
+
+    beforeEach(async () => {
+        app = await createApplication({ suppressFirstTimeDialog: true });
+        await app.setFeatureFlag(UnifiedFeatureFlags.adbSetupView, true);
+        deviceConnectionController = await app.openDeviceConnectionDialog();
+        await deviceConnectionController.waitForDialogVisible();
+    });
+
+    afterEach(async () => {
+        if (app != null) {
+            await app.stop();
+        }
+    });
+
+    it('should use the expected window title', async () => {
+        expect(await app.getTitle()).toBe(
+            'Accessibility Insights for Android - Connect to your Android device',
+        );
+    });
+
+    it('first dialog has more info link', async () => {
+        const selector = getAutomationIdSelector(moreInfoLinkAutomationId);
+        await deviceConnectionController.client.waitForExist(selector);
+        const text = await deviceConnectionController.client.getText(selector);
+        expect(text.startsWith('How do I')).toBeTruthy();
+    });
+});

--- a/src/tests/electron/tests/device-connection-dialog.test.ts
+++ b/src/tests/electron/tests/device-connection-dialog.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import { createApplication } from 'tests/electron/common/create-application';
 import { DeviceConnectionDialogSelectors } from 'tests/electron/common/element-identifiers/device-connection-dialog-selectors';
 import { scanForAccessibilityIssues } from 'tests/electron/common/scan-for-accessibility-issues';
@@ -12,6 +13,7 @@ describe('device connection dialog', () => {
 
     beforeEach(async () => {
         app = await createApplication({ suppressFirstTimeDialog: true });
+        await app.setFeatureFlag(UnifiedFeatureFlags.adbSetupView, false);
         dialog = await app.openDeviceConnectionDialog();
     });
 

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-step-layout.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-step-layout.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`AndroidSetupStepLayout renders per snapshot (withMoreInfo=true, withHea
   </h1>
   <div
     className="moreInfoLink"
+    data-automation-id="more-info-link"
   >
     <a
       href="https://test"


### PR DESCRIPTION
#### Description of changes

This is a placeholder e2e test that has the feature flag on for adb. One approach we can follow is to add new e2e tests here before we turn the feature flag off entirely. The test assumes that the app will get to prompt-locate-adb or prompt-connect-to-device, which are reasonable assumptions for a dev machine without an emulator running. This assumption/test can be removed once we have more of the adb mock in.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
