### PR TITLE
feat(trusted-tester-bugs): Add outline to requirement link on focus

### DIFF
--- a/src/DetailsView/components/assessment-view.scss
+++ b/src/DetailsView/components/assessment-view.scss
@@ -34,6 +34,11 @@
             overflow-y: auto;
             overflow-x: hidden;
             border-right: 1px solid $neutral-8;
+            a:focus {
+                @media screen and (-ms-high-contrast: active) {
+                    border: 3px highlighttext solid !important;
+                }
+            }
         }
     }
     .assessment-requirements-title {


### PR DESCRIPTION
#### Description of changes
The issue was that there is no focus inicator on the focused req link. This PR add a outline on the focused link.

before: 
![image](https://user-images.githubusercontent.com/15974344/86072768-3b5ade80-ba37-11ea-91b4-f24d035ed8e6.png)
after:
![image](https://user-images.githubusercontent.com/15974344/86072783-43b31980-ba37-11ea-9ca5-4ca03e237b1e.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
