### PR TITLE
feat(command-bar-reflow): Collapse command bar at 960px

### DIFF
--- a/src/DetailsView/components/command-bar-buttons-menu.scss
+++ b/src/DetailsView/components/command-bar-buttons-menu.scss
@@ -3,6 +3,10 @@
 
 @import '../../common/styles/common.scss';
 
+.command-bar-buttons-menu-button {
+    font-size: 16px;
+}
+
 .command-bar-buttons-submenu {
     button {
         height: 36px;

--- a/src/DetailsView/components/command-bar-buttons-menu.scss
+++ b/src/DetailsView/components/command-bar-buttons-menu.scss
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-.command-bar-buttons-menu-button {
-    height: inherit;
-}
+@import '../../common/styles/common.scss';
 
 .command-bar-buttons-submenu {
     button {
         height: 36px;
     }
+}
+
+.command-bar-buttons-menu {
+    height: $detailsViewCommandBarHeight;
 }

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -20,7 +20,10 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
                 <CommandBarButton
                     ariaLabel="More items"
                     role="menuitem"
-                    menuIconProps={{ iconName: 'More' }}
+                    menuIconProps={{
+                        iconName: 'More',
+                        className: styles.commandBarButtonsMenuButton,
+                    }}
                     menuProps={{ items: overflow, className: styles.commandBarButtonsSubmenu }}
                 />
             );

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -22,7 +22,6 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
                     role="menuitem"
                     menuIconProps={{ iconName: 'More' }}
                     menuProps={{ items: overflow, className: styles.commandBarButtonsSubmenu }}
-                    className={styles.commandBarButtonsMenuButton}
                 />
             );
         };
@@ -47,6 +46,7 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
                 onRenderItem={onRenderItem}
                 overflowItems={overflowItems}
                 onRenderOverflowButton={onRenderOverflowButton}
+                className={styles.commandBarButtonsMenu}
             />
         );
     },

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -14,6 +14,8 @@ import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
+import { CommandBarButtonsMenu } from 'DetailsView/components/command-bar-buttons-menu';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { StartOverFactoryProps } from 'DetailsView/components/start-over-component-factory';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
@@ -48,6 +50,7 @@ export interface DetailsViewCommandBarProps {
     cardsViewData: CardsViewModel;
     switcherNavConfiguration: DetailsViewSwitcherNavConfiguration;
     scanMetadata: ScanMetadata;
+    narrowModeStatus: NarrowModeStatus;
 }
 
 export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBarProps> {
@@ -59,7 +62,7 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
         return (
             <div className={styles.detailsViewCommandBar}>
                 {this.renderTargetPageInfo()}
-                {this.renderCommandButtons()}
+                {this.renderFarItems()}
             </div>
         );
     }
@@ -87,6 +90,14 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
         );
     }
 
+    private renderFarItems(): JSX.Element {
+        if (this.props.narrowModeStatus.isCommandBarCollapsed) {
+            return this.renderCommandButtonsMenu();
+        } else {
+            return this.renderCommandButtons();
+        }
+    }
+
     private renderCommandButtons(): JSX.Element {
         const reportExportElement: JSX.Element = this.renderExportComponent();
         const startOverElement: JSX.Element = this.renderStartOverComponent();
@@ -101,6 +112,10 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
         }
 
         return null;
+    }
+
+    private renderCommandButtonsMenu(): JSX.Element {
+        return <CommandBarButtonsMenu {...this.props} />;
     }
 
     private renderExportComponent(): JSX.Element {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`CommandBarButtonsMenu renders overflow button 1`] = `
   ariaLabel="More items"
   menuIconProps={
     Object {
+      "className": "commandBarButtonsMenuButton",
       "iconName": "More",
     }
   }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`CommandBarButtonsMenu renders CommandBarButtonsMenu 1`] = `
 <StyledOverflowSetBase
+  className="commandBarButtonsMenu"
   onRenderItem={[Function]}
   onRenderOverflowButton={[Function]}
   overflowItems={
@@ -22,7 +23,6 @@ exports[`CommandBarButtonsMenu renders CommandBarButtonsMenu 1`] = `
 exports[`CommandBarButtonsMenu renders overflow button 1`] = `
 <CustomizedCommandBarButton
   ariaLabel="More items"
-  className="commandBarButtonsMenuButton"
   menuIconProps={
     Object {
       "iconName": "More",

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -7,8 +7,10 @@ exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = 
       Target page: 
     </span>
     <StyledTooltipHostBase content=\\"Switch to target page: command-bar-test-tab-title\\" styles={{...}}>
-      <StyledLinkBase role=\\"link\\" className=\\"insights-link target-page-link\\" onClick={[Function: proxy]} aria-label=\\"Switch to target page: command-bar-test-tab-title\\">
-        command-bar-test-tab-title
+      <StyledLinkBase role=\\"link\\" className=\\"insights-link targetPageLink\\" onClick={[Function: proxy]} aria-label=\\"Switch to target page: command-bar-test-tab-title\\">
+        <span className=\\"targetPageTitle\\">
+          command-bar-test-tab-title
+        </span>
       </StyledLinkBase>
     </StyledTooltipHostBase>
   </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = `
+"<div className=\\"detailsViewCommandBar\\">
+  <div className=\\"detailsViewTargetPage\\" aria-labelledby=\\"switch-to-target\\">
+    <span id=\\"switch-to-target\\">
+      Target page: 
+    </span>
+    <StyledTooltipHostBase content=\\"Switch to target page: command-bar-test-tab-title\\" styles={{...}}>
+      <StyledLinkBase role=\\"link\\" className=\\"insights-link target-page-link\\" onClick={[Function: proxy]} aria-label=\\"Switch to target page: command-bar-test-tab-title\\">
+        command-bar-test-tab-title
+      </StyledLinkBase>
+    </StyledTooltipHostBase>
+  </div>
+  <CommandBarButtonsMenu deps={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} />
+</div>"
+`;
+
 exports[`DetailsViewCommandBar renders with export button, with start over 1`] = `
 "<div className=\\"detailsViewCommandBar\\">
   <div className=\\"detailsViewTargetPage\\" aria-labelledby=\\"switch-to-target\\">

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -25,6 +25,7 @@ describe('DetailsViewCommandBar', () => {
     let startOverComponent: JSX.Element;
     let reportExportComponent: JSX.Element;
     let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
+    let isCommandBarCollapsed: boolean;
 
     beforeEach(() => {
         detailsViewActionMessageCreatorMock = Mock.ofType(
@@ -37,6 +38,7 @@ describe('DetailsViewCommandBar', () => {
         } as TabStoreData;
         startOverComponent = null;
         reportExportComponent = null;
+        isCommandBarCollapsed = false;
     });
 
     function getProps(): DetailsViewCommandBarProps {
@@ -67,6 +69,9 @@ describe('DetailsViewCommandBar', () => {
             tabStoreData,
             switcherNavConfiguration: switcherNavConfiguration,
             scanMetadata: scanMetadata,
+            narrowModeStatus: {
+                isCommandBarCollapsed,
+            },
         } as DetailsViewCommandBarProps;
     }
 
@@ -90,6 +95,15 @@ describe('DetailsViewCommandBar', () => {
         tabStoreData.isClosed = true;
 
         expect(render()).toBeNull();
+    });
+
+    test('renders with buttons collapsed into a menu', () => {
+        isCommandBarCollapsed = true;
+        const props = getProps();
+
+        const rendered = shallow(<DetailsViewCommandBar {...props} />);
+
+        expect(rendered.debug()).toMatchSnapshot();
     });
 
     function testOnPivot(renderExportResults: boolean, renderStartOver: boolean): void {


### PR DESCRIPTION
#### Description of changes

At 960px, hide the command bar buttons and show the "..." menu button instead

![expand and collapse command bar](https://user-images.githubusercontent.com/55459788/86151386-831f4b80-bab3-11ea-9404-b2e0ca4ed86a.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1739634
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
