### PR TITLE
feat(android-setup): add automation ids around android content

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-step-container.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-step-container.tsx
@@ -12,6 +12,10 @@ export class AndroidSetupStepContainer extends React.Component<CommonAndroidSetu
         const Component = this.props.deps.androidSetupStepComponentProvider[
             this.props.androidSetupStoreData.currentStepId
         ];
-        return <Component {...this.props} />;
+        return (
+            <div data-automation-id={`${this.props.androidSetupStoreData.currentStepId}-content`}>
+                <Component {...this.props} />
+            </div>
+        );
     }
 }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-step-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-step-container.test.tsx.snap
@@ -1,31 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AndroidSetupStepContainer passes common props and deps through 1`] = `
-<DetectTestComponent
-  androidSetupStoreData={
-    Object {
-      "currentStepId": "detect-adb",
+<div
+  data-automation-id="detect-adb-content"
+>
+  <DetectTestComponent
+    androidSetupStoreData={
+      Object {
+        "currentStepId": "detect-adb",
+      }
     }
-  }
-  deps={
-    Object {
-      "LinkComponent": [Function],
-      "androidSetupActionCreator": null,
-      "androidSetupStepComponentProvider": Object {
-        "detect-adb": [Function],
-        "prompt-locate-adb": [Function],
-      },
-      "closeApp": null,
-      "showOpenFileDialog": null,
-      "startTesting": null,
+    deps={
+      Object {
+        "LinkComponent": [Function],
+        "androidSetupActionCreator": null,
+        "androidSetupStepComponentProvider": Object {
+          "detect-adb": [Function],
+          "prompt-locate-adb": [Function],
+        },
+        "closeApp": null,
+        "showOpenFileDialog": null,
+        "startTesting": null,
+      }
     }
-  }
-  userConfigurationStoreData={
-    Object {
-      "adbLocation": undefined,
+    userConfigurationStoreData={
+      Object {
+        "adbLocation": undefined,
+      }
     }
-  }
-/>
+  />
+</div>
 `;
 
 exports[`AndroidSetupStepContainer renders different step 1`] = `"test component B prompt-locate-adb"`;


### PR DESCRIPTION
#### Description of changes

In preparation for e2e tests it would be helpful to know what dialog is visible. This adds automation ids around the android setup content. I originally added individual ids to each component leveraging AndroidSetupStepLayout as a new prop but this seemed simpler. Once this PR is in e2e tests can use the id to wait for a particular dialog and then target elements using native tag selectors and/or explicit ids depending on what the test writer prefers.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
