### PR TITLE
fix(android-setup): Rescan should use the existing ADB, not make a new one

### DIFF
--- a/src/electron/platform/android/setup/steps/prompt-connected-start-testing.ts
+++ b/src/electron/platform/android/setup/steps/prompt-connected-start-testing.ts
@@ -6,6 +6,6 @@ import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-
 export const promptConnectedStartTesting: AndroidSetupStepConfig = (stepTransition, deps) => ({
     actions: {
         cancel: () => stepTransition('prompt-choose-device'),
-        rescan: () => stepTransition('detect-adb'),
+        rescan: () => stepTransition('detect-devices'),
     },
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-connected-start-testing.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-connected-start-testing.test.ts
@@ -50,7 +50,7 @@ describe('Android setup step: promptConnectedStartTesting', () => {
     });
 
     it('rescan transitions to detect-adb as expected', () => {
-        stepTransitionMock.setup(m => m('detect-adb')).verifiable(Times.once());
+        stepTransitionMock.setup(m => m('detect-devices')).verifiable(Times.once());
 
         const step = promptConnectedStartTesting(
             stepTransitionMock.object,


### PR DESCRIPTION
#### Description of changes
When the user clicks "Rescan" in the "start testing" dialog, the current code goes all the way back to detect-adb, which forces us to create a new ADB object, etc. The correct action is to go back to the detect-devices step and to keep using the existing ADB object.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
