### PR TITLE
fix(android-setup): Use rescan action when trying again

### DIFF
--- a/src/electron/platform/android/setup/android-setup-steps-configs.ts
+++ b/src/electron/platform/android/setup/android-setup-steps-configs.ts
@@ -15,6 +15,7 @@ import { promptConfiguringPortForwardingFailed } from 'electron/platform/android
 import { promptConnectToDevice } from 'electron/platform/android/setup/steps/prompt-connect-to-device';
 import { promptConnectedStartTesting } from 'electron/platform/android/setup/steps/prompt-connected-start-testing';
 import { promptGrantPermissions } from 'electron/platform/android/setup/steps/prompt-grant-permissions';
+import { promptInstallFailed } from 'electron/platform/android/setup/steps/prompt-install-failed';
 import { promptInstallService } from 'electron/platform/android/setup/steps/prompt-install-service';
 import { promptLocateAdb } from 'electron/platform/android/setup/steps/prompt-locate-adb';
 import { waitToStart } from 'electron/platform/android/setup/steps/wait-to-start';
@@ -48,7 +49,7 @@ export const allAndroidSetupStepConfigs: AndroidSetupStepConfigs = {
     'detect-service': detectService,
     'prompt-install-service': promptInstallService,
     'installing-service': installingService,
-    'prompt-install-failed': promptInstallService,
+    'prompt-install-failed': promptInstallFailed,
     'detect-permissions': detectPermissions,
     'prompt-grant-permissions': promptGrantPermissions,
     'configuring-port-forwarding': configuringPortForwarding,

--- a/src/electron/platform/android/setup/steps/prompt-configuring-port-forwarding-failed.ts
+++ b/src/electron/platform/android/setup/steps/prompt-configuring-port-forwarding-failed.ts
@@ -7,7 +7,7 @@ export const promptConfiguringPortForwardingFailed: AndroidSetupStepConfig = ste
     return {
         actions: {
             cancel: () => stepTransition('prompt-choose-device'),
-            next: () => stepTransition('configuring-port-forwarding'),
+            rescan: () => stepTransition('configuring-port-forwarding'),
         },
     };
 };

--- a/src/electron/platform/android/setup/steps/prompt-grant-permissions.ts
+++ b/src/electron/platform/android/setup/steps/prompt-grant-permissions.ts
@@ -6,6 +6,6 @@ import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-
 export const promptGrantPermissions: AndroidSetupStepConfig = stepTransition => ({
     actions: {
         cancel: () => stepTransition('prompt-choose-device'),
-        next: () => stepTransition('detect-permissions'),
+        rescan: () => stepTransition('detect-permissions'),
     },
 });

--- a/src/electron/platform/android/setup/steps/prompt-install-failed.ts
+++ b/src/electron/platform/android/setup/steps/prompt-install-failed.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
+
+export const promptInstallFailed: AndroidSetupStepConfig = stepTransition => ({
+    actions: {
+        cancel: () => stepTransition('prompt-choose-device'),
+        rescan: () => stepTransition('installing-service'),
+    },
+});

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.tsx
@@ -50,7 +50,7 @@ export const PromptConfiguringPortForwardingFailedStep = NamedFC<CommonAndroidSe
                 <PrimaryButton
                     data-automation-id={tryAgainAutomationId}
                     text="Try again"
-                    onClick={props.deps.androidSetupActionCreator.next}
+                    onClick={props.deps.androidSetupActionCreator.rescan}
                 />
             </AndroidSetupStepLayout>
         );

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
@@ -50,7 +50,7 @@ export const PromptGrantPermissionsStep = NamedFC<CommonAndroidSetupStepProps>(
                 <PrimaryButton
                     text="Try again"
                     data-automation-id={tryAgainAutomationId}
-                    onClick={props.deps.androidSetupActionCreator.next}
+                    onClick={props.deps.androidSetupActionCreator.rescan}
                 />
             </AndroidSetupStepLayout>
         );

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.tsx
@@ -51,7 +51,7 @@ export const PromptInstallFailedStep = NamedFC<CommonAndroidSetupStepProps>(
                 <PrimaryButton
                     data-automation-id={tryAgainAutomationId}
                     text="Try again"
-                    onClick={props.deps.androidSetupActionCreator.next}
+                    onClick={props.deps.androidSetupActionCreator.rescan}
                 />
             </AndroidSetupStepLayout>
         );

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-configuring-port-forwarding-failed.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-configuring-port-forwarding-failed.test.ts
@@ -34,7 +34,7 @@ describe('Android setup step: promptConfiguringPortForwardingFailed', () => {
     it('has expected properties', () => {
         const deps = {} as AndroidSetupDeps;
         const step = promptConfiguringPortForwardingFailed(null, deps);
-        checkExpectedActionsAreDefined(step, ['cancel', 'next']);
+        checkExpectedActionsAreDefined(step, ['cancel', 'rescan']);
         expect(step.onEnter).not.toBeDefined();
     });
 
@@ -49,7 +49,7 @@ describe('Android setup step: promptConfiguringPortForwardingFailed', () => {
         step.actions.cancel();
     });
 
-    it('next transitions to configuring-port-forwarding as expected', () => {
+    it('rescan transitions to configuring-port-forwarding as expected', () => {
         stepTransitionMock.setup(m => m('configuring-port-forwarding')).verifiable(Times.once());
 
         const step = promptConfiguringPortForwardingFailed(
@@ -57,6 +57,6 @@ describe('Android setup step: promptConfiguringPortForwardingFailed', () => {
             depsMock.object,
             storeCallbacksMock.object,
         );
-        step.actions.next();
+        step.actions.rescan();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-grant-permissions.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-grant-permissions.test.ts
@@ -34,7 +34,7 @@ describe('Android setup step: promptGrantPermissions', () => {
     it('has expected properties', () => {
         const deps = {} as AndroidSetupDeps;
         const step = promptGrantPermissions(null, deps);
-        checkExpectedActionsAreDefined(step, ['cancel', 'next']);
+        checkExpectedActionsAreDefined(step, ['cancel', 'rescan']);
         expect(step.onEnter).not.toBeDefined();
     });
 
@@ -49,7 +49,7 @@ describe('Android setup step: promptGrantPermissions', () => {
         step.actions.cancel();
     });
 
-    it('onEnter transitions to detect-permissions as expected', () => {
+    it('rescan transitions to detect-permissions as expected', () => {
         stepTransitionMock.setup(m => m('detect-permissions')).verifiable(Times.once());
 
         const step = promptGrantPermissions(
@@ -57,6 +57,6 @@ describe('Android setup step: promptGrantPermissions', () => {
             depsMock.object,
             storeCallbacksMock.object,
         );
-        step.actions.next();
+        step.actions.rescan();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-install-failed.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-install-failed.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
+import { promptInstallFailed } from 'electron/platform/android/setup/steps/prompt-install-failed';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { checkExpectedActionsAreDefined } from './actions-tester';
+
+describe('Android setup step: promptInstallFailed', () => {
+    let depsMock: IMock<AndroidSetupDeps>;
+    let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
+    let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
+
+    beforeEach(() => {
+        depsMock = Mock.ofType<AndroidSetupDeps>(undefined, MockBehavior.Strict);
+        storeCallbacksMock = Mock.ofType<AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+    });
+
+    afterEach(() => {
+        depsMock.verifyAll();
+        storeCallbacksMock.verifyAll();
+        stepTransitionMock.verifyAll();
+    });
+
+    it('has expected properties', () => {
+        const deps = {} as AndroidSetupDeps;
+        const step = promptInstallFailed(null, deps);
+        checkExpectedActionsAreDefined(step, ['cancel', 'rescan']);
+        expect(step.onEnter).not.toBeDefined();
+    });
+
+    it('cancel transitions to prompt-choose-device', async () => {
+        stepTransitionMock.setup(m => m('prompt-choose-device')).verifiable(Times.once());
+
+        const step = promptInstallFailed(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
+        step.actions.cancel();
+    });
+
+    it('rescan transitions to installing-service as expected', () => {
+        stepTransitionMock.setup(m => m('installing-service')).verifiable(Times.once());
+
+        const step = promptInstallFailed(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
+        step.actions.rescan();
+    });
+});

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.test.tsx
@@ -49,10 +49,10 @@ describe('PromptConfiguringPortForwardingFailedStep', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    it('routes try again button to next action', () => {
+    it('routes try again button to rescan action', () => {
         const rendered = shallow(<PromptConfiguringPortForwardingFailedStep {...props} />);
         const button = rendered.find({ 'data-automation-id': tryAgainAutomationId });
         button.simulate('click');
-        androidSetupActionCreatorMock.verify(m => m.next(), Times.once());
+        androidSetupActionCreatorMock.verify(m => m.rescan(), Times.once());
     });
 });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
@@ -49,9 +49,9 @@ describe('PromptGrantPermissionsStep', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    it('calls next action when try again button is selected', () => {
+    it('calls rescan action when try again button is selected', () => {
         const rendered = shallow(<PromptGrantPermissionsStep {...props} />);
         rendered.find({ 'data-automation-id': tryAgainAutomationId }).simulate('click');
-        androidSetupActionCreatorMock.verify(m => m.next(), Times.once());
+        androidSetupActionCreatorMock.verify(m => m.rescan(), Times.once());
     });
 });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.test.tsx
@@ -49,10 +49,10 @@ describe('PromptInstallFailedStep', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    it('routes try again button to next action', () => {
+    it('routes try again button to rescan action', () => {
         const rendered = shallow(<PromptInstallFailedStep {...props} />);
         const button = rendered.find({ 'data-automation-id': tryAgainAutomationId });
         button.simulate('click');
-        androidSetupActionCreatorMock.verify(m => m.next(), Times.once());
+        androidSetupActionCreatorMock.verify(m => m.rescan(), Times.once());
     });
 });


### PR DESCRIPTION
#### Description of changes
2 things caught my eye in the code, so I created this PR to see if we want to fix it:

1. We use the `next` action for the "Try Again" buttons, when we're effectively reverting to an earlier state, so you can argue that the `rescan` action might be more appropriate. The two actions are interchangeable from a functional perspective, so it's merely a question of which is more consistent with the intent of the available actions.
2. We have a 1:1 correlation between stepId, StepConfig, and Components in all but one case. The one exception is that the `prompt-install-service` and `prompt-install-failed` steps share the same same `promptInstallService` StepConfig (although they have different Components). It happens to work in the current implementation, but it seems like a potential for future trouble if we ever need them to deviate, which is exactly how I noticed the overlap. Given how tiny the StepConfig class is, it seems like a reasonable plan to have one dedicated to the `prompt-install-failed` step.

I'm not 100% sure that we want this change, but we can at least discuss it. 

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
