### PR TITLE
feat(android-setup): Make feature flag default value true

### DIFF
--- a/src/electron/common/unified-feature-flags.ts
+++ b/src/electron/common/unified-feature-flags.ts
@@ -22,7 +22,7 @@ export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
         },
         {
             id: UnifiedFeatureFlags.showAllFeatureFlags,
-            defaultValue: false,
+            defaultValue: true,
             displayableName: 'Show all feature flags',
             displayableDescription: 'Show all feature flags in the Preview Features panel.',
             isPreviewFeature: false,

--- a/src/electron/common/unified-feature-flags.ts
+++ b/src/electron/common/unified-feature-flags.ts
@@ -22,7 +22,7 @@ export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
         },
         {
             id: UnifiedFeatureFlags.showAllFeatureFlags,
-            defaultValue: true,
+            defaultValue: false,
             displayableName: 'Show all feature flags',
             displayableDescription: 'Show all feature flags in the Preview Features panel.',
             isPreviewFeature: false,
@@ -38,7 +38,7 @@ export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
         },
         {
             id: UnifiedFeatureFlags.adbSetupView,
-            defaultValue: false,
+            defaultValue: true,
             displayableName: 'Enable the new adb experience',
             displayableDescription: 'Enable the new adb setup and installation experience',
             isPreviewFeature: false,

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import * as fs from 'fs';
 import * as path from 'path';
 import { createApplication } from 'tests/electron/common/create-application';
@@ -18,6 +19,7 @@ describe('AutomatedChecksView', () => {
 
     beforeEach(async () => {
         app = await createApplication({ suppressFirstTimeDialog: true });
+        await app.setFeatureFlag(UnifiedFeatureFlags.adbSetupView, false);
         automatedChecksView = await app.openAutomatedChecksView();
         await automatedChecksView.waitForScreenshotViewVisible();
     });

--- a/src/tests/electron/tests/unified-settings-panel.test.ts
+++ b/src/tests/electron/tests/unified-settings-panel.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import { createApplication } from 'tests/electron/common/create-application';
 import { scanForAccessibilityIssues } from 'tests/electron/common/scan-for-accessibility-issues';
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
@@ -13,6 +14,7 @@ describe('AutomatedChecksView -> Settings Panel', () => {
 
     beforeEach(async () => {
         app = await createApplication({ suppressFirstTimeDialog: true });
+        await app.setFeatureFlag(UnifiedFeatureFlags.adbSetupView, false);
         automatedChecksView = await app.openAutomatedChecksView();
         await automatedChecksView.waitForViewVisible();
         await automatedChecksView.openSettingsPanel();

--- a/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
+++ b/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
@@ -23,7 +23,7 @@ describe('FeatureFlagsTest', () => {
             [UnifiedFeatureFlags.logTelemetryToConsole]: false,
             [UnifiedFeatureFlags.showAllFeatureFlags]: false,
             [UnifiedFeatureFlags.exportReport]: true,
-            [UnifiedFeatureFlags.adbSetupView]: false,
+            [UnifiedFeatureFlags.adbSetupView]: true,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Description of changes
Make the adbSetupView feature flag true by default. This also updates 2 sets of existing E2E tests to force the flag to false so that the existing tests can complete as currently written.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1728704](https://mseng.visualstudio.com/1ES/_workitems/edit/1728704)
- [x] Ran `yarn fastpass`
- [x Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above (done in previous commits)
- [x] (UI changes only) Verified usability with NVDA/JAWS (done in previou commits)
