### PR TITLE
chore(android-setup): Remove unneeded API: listForwardedPorts

### DIFF
--- a/src/electron/platform/android/adb-wrapper.ts
+++ b/src/electron/platform/android/adb-wrapper.ts
@@ -20,7 +20,6 @@ export interface AdbWrapper {
     uninstallService(deviceId: string, packageName: string): Promise<void>;
     setTcpForwarding(deviceId: string, localPort: number, devicePort: number): Promise<number>;
     removeTcpForwarding(deviceId: string, devicePort: number): Promise<void>;
-    listForwardedPorts(deviceId: string): Promise<string[]>;
 }
 
 export interface AdbWrapperFactory {

--- a/src/electron/platform/android/appium-adb-wrapper.ts
+++ b/src/electron/platform/android/appium-adb-wrapper.ts
@@ -78,9 +78,4 @@ export class AppiumAdbWrapper implements AdbWrapper {
         this.adb.setDeviceId(deviceId);
         await this.adb.removePortForward(localPort);
     };
-
-    public listForwardedPorts = async (deviceId: string): Promise<string[]> => {
-        this.adb.setDeviceId(deviceId);
-        return await this.adb.getForwardList();
-    };
 }

--- a/src/electron/platform/android/setup/android-service-configurator.ts
+++ b/src/electron/platform/android/setup/android-service-configurator.ts
@@ -17,7 +17,6 @@ export interface ServiceConfigurator {
     hasRequiredPermissions(): Promise<boolean>;
     setupTcpForwarding(): Promise<number>;
     removeTcpForwarding(hostPort: number): Promise<void>;
-    listForwardedPorts(): Promise<string[]>;
 }
 
 export class AndroidServiceConfigurator implements ServiceConfigurator {
@@ -99,10 +98,6 @@ export class AndroidServiceConfigurator implements ServiceConfigurator {
 
     public removeTcpForwarding = async (hostPort: number): Promise<void> => {
         return await this.adbWrapper.removeTcpForwarding(this.selectedDeviceId, hostPort);
-    };
-
-    public listForwardedPorts = async (): Promise<string[]> => {
-        return await this.adbWrapper.listForwardedPorts(this.selectedDeviceId);
     };
 
     private async getInstalledVersion(deviceId: string): Promise<string> {

--- a/src/electron/platform/android/setup/port-cleaning-service-configurator.ts
+++ b/src/electron/platform/android/setup/port-cleaning-service-configurator.ts
@@ -41,8 +41,4 @@ export class PortCleaningServiceConfigurator implements ServiceConfigurator {
         await this.innerObject.removeTcpForwarding(hostPort);
         this.portCleaner.removePort(hostPort);
     };
-
-    public listForwardedPorts = async (): Promise<string[]> => {
-        return await this.innerObject.listForwardedPorts();
-    };
 }

--- a/src/tests/unit/tests/electron/platform/android/appium-adb-wrapper.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/appium-adb-wrapper.test.ts
@@ -333,35 +333,6 @@ describe('AppiumAdbWrapper tests', () => {
 
         adbMock.verifyAll();
     });
-
-    it('listForwardedPorts, propagates error', async () => {
-        const expectedMessage: string = 'Thrown during listForwardedPorts';
-        adbMock
-            .setup(m => m.setDeviceId(emulatorId))
-            .throws(new Error(expectedMessage))
-            .verifiable(Times.once());
-
-        await expect(testSubject.listForwardedPorts(emulatorId)).rejects.toThrowError(
-            expectedMessage,
-        );
-
-        adbMock.verifyAll();
-    });
-
-    it('listForwardedPorts, succeeds', async () => {
-        const expectedData: string[] = ['abc', 'mno', 'xyz'];
-        adbMock.setup(m => m.setDeviceId(emulatorId)).verifiable(Times.once());
-        adbMock
-            .setup(m => m.getForwardList())
-            .returns(() => Promise.resolve(expectedData))
-            .verifiable(Times.once());
-
-        const actualData: string[] = await testSubject.listForwardedPorts(emulatorId);
-
-        expect(actualData).toBe(expectedData);
-
-        adbMock.verifyAll();
-    });
     /*
     // For live testing, set ANDROID_HOME or ANDROID_SDK_ROOT to point
     // to your local installation, then add this line just before

--- a/src/tests/unit/tests/electron/platform/android/setup/android-service-configurator.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/android-service-configurator.test.ts
@@ -435,30 +435,4 @@ describe('AndroidServiceConfigurator', () => {
             verifyAllMocks();
         });
     });
-
-    it('listForwardedPorts propagates thrown errors', async () => {
-        const expectedMessage = 'Error thrown during listForwardedPorts';
-        adbWrapperMock
-            .setup(m => m.listForwardedPorts(testDeviceId))
-            .throws(new Error(expectedMessage))
-            .verifiable(Times.once());
-
-        await expect(testSubject.listForwardedPorts()).rejects.toThrowError(expectedMessage);
-
-        verifyAllMocks();
-    });
-
-    it('listForwardedPorts returns info from AdbWrapper', async () => {
-        const expectedData: string[] = ['red', 'blue', 'green'];
-        adbWrapperMock
-            .setup(m => m.listForwardedPorts(testDeviceId))
-            .returns(() => Promise.resolve(expectedData))
-            .verifiable(Times.once());
-
-        const actualDevices = await testSubject.listForwardedPorts();
-
-        expect(actualDevices).toBe(expectedData);
-
-        verifyAllMocks();
-    });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/port-cleaning-service-configurator.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/port-cleaning-service-configurator.test.ts
@@ -118,18 +118,4 @@ describe('PortCleaningServiceConfigurator', () => {
 
         verifyAllMocks();
     });
-
-    it('listForwardedPorts chains through', async () => {
-        const expectedData: string[] = ['Mercury', 'Venus', 'Earth', 'Mars'];
-        innerObjectMock
-            .setup(m => m.listForwardedPorts())
-            .returns(() => Promise.resolve(expectedData))
-            .verifiable(Times.once());
-
-        const actualData = await testSubject.listForwardedPorts();
-
-        expect(actualData).toBe(expectedData);
-
-        verifyAllMocks();
-    });
 });


### PR DESCRIPTION
#### Description of changes
The `SreviceConfigurator.listForwardedPorts` method was recently added as an attempt to fix a timing issue. The actual issue was fixed (and the call to this method removed) in #3005, so this code adds no value and should be removed. 

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
