### PR TITLE
test(android-setup): fix mock-adb forward exiting before server is set up

### DIFF
--- a/src/tests/miscellaneous/mock-adb/app/port-forward-server.js
+++ b/src/tests/miscellaneous/mock-adb/app/port-forward-server.js
@@ -52,7 +52,7 @@ async function waitForReadyMessage(testServerProcess) {
             reject(new Error('Timeout: child port-forwarding server never sent ready message'));
         };
 
-        const timeoutId = setTimeout(onTimeout, portForwardProcessStartTimeoutMs);
+        timeoutId = setTimeout(onTimeout, portForwardProcessStartTimeoutMs);
         testServerProcess.on('message', onMessage);
     });
 }

--- a/src/tests/miscellaneous/mock-adb/app/port-forward-server.js
+++ b/src/tests/miscellaneous/mock-adb/app/port-forward-server.js
@@ -4,30 +4,82 @@ const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const process = require('process');
+const { startMockService } = require('../../mock-service-for-android/mock-service');
 
 // This is helpful for debugging, but causes us to not be able to exit before "detached" child
 // process (the "correct" behavior), so we leave it off except when debugging mock-adb itself
 const LOG_DETACHED_PROCESS = false;
 
 const portForwardSentinelArgument = '__PORT_FORWARD_SERVER';
+const portForwardProcessReadyMessage = 'PORT_FORWARD_PROCESS_READY';
+const portForwardProcessStartTimeoutMs = 10000;
 
 function portFile(port, fileExtension) {
     return path.join(path.dirname(process.execPath), `test-server-${port}.${fileExtension}`);
 }
 
-function startDetachedPortForwardServer(port, path) {
-    const testServerProcess = child_process.spawn(
-        process.argv[0],
-        [process.argv[1], portForwardSentinelArgument, port, path],
+// Returns whether argv indicated it *should* be handled as a port server
+async function tryHandleAsPortForwardServer(argv) {
+    if (argv[2] !== portForwardSentinelArgument) {
+        return false;
+    }
+
+    const port = parseInt(process.argv[3], 10);
+    const path = process.argv[4];
+
+    await startMockService(port, path);
+
+    process.send(portForwardProcessReadyMessage);
+    return true;
+}
+
+async function waitForReadyMessage(testServerProcess) {
+    return new Promise((resolve, reject) => {
+        let canceled = false;
+
+        const onMessage = message => {
+            if (message === portForwardProcessReadyMessage) {
+                testServerProcess.off('message', onMessage);
+                clearTimeout(timeoutId);
+                resolve();
+            }
+        };
+
+        const onTimeout = () => {
+            canceled = true;
+            testServerProcess.off('message', onMessage);
+            reject(new Error('Timeout: child port-forwarding server never sent ready message'));
+        };
+
+        const timeoutId = setTimeout(onTimeout, portForwardProcessStartTimeoutMs);
+        testServerProcess.on('message', onMessage);
+    });
+}
+
+async function startDetachedPortForwardServer(port, path) {
+    const testServerProcess = child_process.fork(
+        process.argv[1],
+        [portForwardSentinelArgument, port, path],
         {
             detached: true, // avoid having test server exit when adb exits
-            stdio: LOG_DETACHED_PROCESS ? ['ignore', 'pipe', 'pipe'] : 'ignore',
+            stdio: LOG_DETACHED_PROCESS
+                ? ['ignore', 'pipe', 'pipe', 'ipc']
+                : ['ignore', 'ignore', 'ignore', 'ipc'],
         },
     );
     if (LOG_DETACHED_PROCESS) {
         testServerProcess.stderr.pipe(fs.createWriteStream(portFile(port, 'err'), { flags: 'a' }));
         testServerProcess.stdout.pipe(fs.createWriteStream(portFile(port, 'out'), { flags: 'a' }));
     }
+
+    try {
+        await waitForReadyMessage(testServerProcess);
+    } catch (e) {
+        testServerProcess.kill();
+        throw e;
+    }
+
+    testServerProcess.disconnect();
     testServerProcess.unref(); // avoid having adb wait for test server before exiting
 
     const pidFile = portFile(port, 'pid');
@@ -59,7 +111,7 @@ function stopDetachedPortForwardServer(port) {
 }
 
 module.exports = {
-    portForwardSentinelArgument,
     startDetachedPortForwardServer,
     stopDetachedPortForwardServer,
+    tryHandleAsPortForwardServer,
 };

--- a/src/tests/miscellaneous/mock-adb/app/port-forward-server.js
+++ b/src/tests/miscellaneous/mock-adb/app/port-forward-server.js
@@ -35,18 +35,19 @@ async function tryHandleAsPortForwardServer(argv) {
 
 async function waitForReadyMessage(testServerProcess) {
     return new Promise((resolve, reject) => {
-        let canceled = false;
+        let timeoutId = null;
 
         const onMessage = message => {
             if (message === portForwardProcessReadyMessage) {
                 testServerProcess.off('message', onMessage);
-                clearTimeout(timeoutId);
+                if (timeoutId != null) {
+                    clearTimeout(timeoutId);
+                }
                 resolve();
             }
         };
 
         const onTimeout = () => {
-            canceled = true;
             testServerProcess.off('message', onMessage);
             reject(new Error('Timeout: child port-forwarding server never sent ready message'));
         };

--- a/src/tests/miscellaneous/mock-service-for-android/mock-service.js
+++ b/src/tests/miscellaneous/mock-service-for-android/mock-service.js
@@ -3,13 +3,16 @@
 const express = require('express');
 
 function startMockService(port, path) {
-    const options = { extensions: 'json' };
+    return new Promise(resolve => {
+        const options = { extensions: 'json' };
 
-    const app = express();
-    app.use('/AccessibilityInsights', express.static(path, options));
+        const app = express();
+        app.use('/AccessibilityInsights', express.static(path, options));
 
-    app.listen(parseInt(port, 10), 'localhost', () => {
-        console.log(`Running mock Accessibility Insights Service for Android on port ${port}`);
+        app.listen(parseInt(port, 10), 'localhost', () => {
+            console.log(`Running mock Accessibility Insights Service for Android on port ${port}`);
+            resolve();
+        });
     });
 }
 


### PR DESCRIPTION
#### Description of changes

@karanbirsingh noted an issue with mock-adb where tests were getting confused by `adb forward` returning before the test server it initializes was fully set up and listening.

This PR addresses that by adding an IPC "ready" message that the test server process sends after express.js is initialized and setting up `adb forward`'s handler to wait for that message before it returns.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
