### PR TITLE
Chore: Change output format for tools\strict-null-checks\find.js

### DIFF
--- a/tools/strict-null-checks/find.js
+++ b/tools/strict-null-checks/find.js
@@ -49,13 +49,14 @@ forStrictNullCheckEligibleFiles(repoRoot, () => {}, { includeTests }).then(async
     }
     for (const pair of out) {
         console.log(
-            toFormattedFilePath(pair[0]) +
-                (printDependedOnCount ? ` — Depended on by **${pair[1]}** files` : ''),
+            toFormattedFilePath(pair[0]),
+            // + (printDependedOnCount ? ` — Depended on by **${pair[1]}** files` : ''),
         );
     }
 });
 
 function toFormattedFilePath(file) {
     // return `"./${path.relative(srcRoot, file)}",`;
-    return `- [ ] \`"./${path.relative(srcRoot, file)}"\``;
+    const relativePath = path.relative(srcRoot, file).replace(/\\/g, '/');
+    return `"./src/${relativePath}",`;
 }


### PR DESCRIPTION
#### Description of changes

    This makes it easier to copy file paths directly into tsconfig.strictNullChecks.json.

    - Remove the '- [ ]' prefix
    - Remove '`' chars from output
    - add 'src/' to the relative path to match the addition of '/src' to the search path earlier in the code
    - Add commas at the end of lines for json formatting
    - Remove the suffix with the dependency count (I only saw the dependency count ever be 0)
