### PR TITLE
chore: add multiple-devices and slow-single-device mock-adb configs

### DIFF
--- a/src/tests/miscellaneous/mock-adb/app/bin.js
+++ b/src/tests/miscellaneous/mock-adb/app/bin.js
@@ -39,6 +39,11 @@ async function main() {
 
     const result = config[inputCommand] != undefined ? config[inputCommand] : defaultResult;
 
+    if (result.delayMs != undefined) {
+        await new Promise(resolve => {
+            setTimeout(resolve, result.delayMs);
+        });
+    }
     if (result.startTestServer != undefined) {
         const { port, path } = result.startTestServer;
         stopDetachedPortForwardServer(port);

--- a/src/tests/miscellaneous/mock-adb/common-adb-configs.js
+++ b/src/tests/miscellaneous/mock-adb/common-adb-configs.js
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 const { apkVersionName } = require('accessibility-insights-for-android-service-bin');
+const cloneDeep = require('lodash/cloneDeep');
 const path = require('path');
 
 const successfulTestServerContentPath = path.join(
@@ -8,38 +9,63 @@ const successfulTestServerContentPath = path.join(
     '../mock-service-for-android/AccessibilityInsights',
 );
 
+function workingDeviceCommands(deviceIds, port) {
+    const output = {
+        'start-server': {},
+        devices: {
+            stdout: 'List of devices attached\n',
+        },
+    };
+
+    for (const id of deviceIds) {
+        const type = id.startsWith('emulator') ? 'emulator' : 'device';
+        output.devices.stdout += `${id}\t${type}\n`;
+    }
+
+    for (const id of deviceIds) {
+        output[`-s ${id} devices`] = { ...output.devices };
+        output[`-s ${id} shell getprop ro.product.model`] = {
+            stdout: `working mock device (${id})`,
+        };
+        output[
+            `-s ${id} shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice`
+        ] = {
+            stdout: `    versionCode=102000 minSdk=24 targetSdk=28\n    versionName=${apkVersionName}`,
+        };
+        output[`-s ${id} shell dumpsys accessibility`] = {
+            stdout:
+                '                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}',
+        };
+        output[`-s ${id} shell dumpsys media_projection`] = {
+            stdout:
+                '(com.microsoft.accessibilityinsightsforandroidservice, uid=12354): TYPE_SCREEN_CAPTURE',
+        };
+        output[`-s ${id} forward tcp:${port} tcp:62442`] = {
+            startTestServer: {
+                port,
+                path: successfulTestServerContentPath,
+            },
+        };
+        output[`-s ${id} forward --remove tcp:${port}`] = {
+            stopTestServer: { port },
+        };
+    }
+
+    return output;
+}
+
+function delayAllCommands(delayMs, commands) {
+    const output = cloneDeep(commands);
+    for (const commandConfig of Object.values(output)) {
+        commandConfig.delayMs = delayMs;
+    }
+    return output;
+}
+
 module.exports = {
     commonAdbConfigs: {
-        'single-device': {
-            'start-server': {},
-            devices: {
-                stdout: 'List of devices attached\ndevice-1\tdevice',
-            },
-            '-s device-1 shell getprop ro.product.model': {
-                stdout: 'mock-adb device 1',
-            },
-            '-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice': {
-                stdout: `    versionCode=102000 minSdk=24 targetSdk=28\n    versionName=${apkVersionName}`,
-            },
-            '-s device-1 shell dumpsys accessibility': {
-                stdout:
-                    '                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}',
-            },
-            '-s device-1 shell dumpsys media_projection': {
-                stdout:
-                    '(com.microsoft.accessibilityinsightsforandroidservice, uid=12354): TYPE_SCREEN_CAPTURE',
-            },
-            '-s device-1 forward tcp:62442 tcp:62442': {
-                startTestServer: {
-                    port: 62442,
-                    path: successfulTestServerContentPath,
-                },
-            },
-            '-s device-1 forward --remove tcp:62442': {
-                stopTestServer: {
-                    port: 62442,
-                },
-            },
-        },
+        'single-device': workingDeviceCommands(['device-1'], 62442),
+        'multiple-devices': workingDeviceCommands(['device-1', 'device-2', 'emulator-3'], 62442),
+        'slow-single-device': delayAllCommands(5000, workingDeviceCommands(['device-1'], 62442)),
     },
 };

--- a/src/tests/miscellaneous/mock-adb/common-adb-configs.js
+++ b/src/tests/miscellaneous/mock-adb/common-adb-configs.js
@@ -23,7 +23,7 @@ function workingDeviceCommands(deviceIds, port) {
     }
 
     for (const id of deviceIds) {
-        output[`-s ${id} devices`] = { ...output.devices };
+        output[`-s ${id} devices`] = cloneDeep(output.devices);
         output[`-s ${id} shell getprop ro.product.model`] = {
             stdout: `working mock device (${id})`,
         };

--- a/src/tests/miscellaneous/mock-adb/setup-mock-adb.d.ts
+++ b/src/tests/miscellaneous/mock-adb/setup-mock-adb.d.ts
@@ -7,6 +7,7 @@ export type MockAdbConfig = {
         stdout?: string;
         stderr?: string;
         exitCode?: number;
+        delayMs?: number;
         startTestServer?: {
             port: number;
             path: string;


### PR DESCRIPTION
#### Description of changes

I wanted to get screenshots of loading spinners in the new android setup flow for filing a bug, so I added a `slow-single-device` config to make that easier. This PR enables:

* `yarn mock-adb slow-single-device`: same as `single-device`, but every adb command is delayed by 5 seconds
* `yarn mock-adb multiple-devices`: fakes having 3 devices (2 physical, 1 emulator) instead of just 1

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
