### PR TITLE
feat(command-bar-reflow): Simplify CommandBarButtonsMenu

### DIFF
--- a/src/DetailsView/components/command-bar-buttons-menu.scss
+++ b/src/DetailsView/components/command-bar-buttons-menu.scss
@@ -11,6 +11,7 @@
     button {
         height: 36px;
     }
+    min-width: fit-content;
 }
 
 .command-bar-buttons-menu {

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
-import { CommandBarButton, IOverflowSetItemProps, OverflowSet } from 'office-ui-fabric-react';
+import { CommandBarButton, IContextualMenuItem } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './command-bar-buttons-menu.scss';
 
@@ -11,25 +11,7 @@ export type CommandBarButtonsMenuProps = CommandBarProps;
 export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
     'CommandBarButtonsMenu',
     props => {
-        const onRenderItem = (item: IOverflowSetItemProps): JSX.Element => {
-            return item.onRender(props);
-        };
-
-        const onRenderOverflowButton = (overflow: IOverflowSetItemProps[]): JSX.Element => {
-            return (
-                <CommandBarButton
-                    ariaLabel="More items"
-                    role="menuitem"
-                    menuIconProps={{
-                        iconName: 'More',
-                        className: styles.commandBarButtonsMenuButton,
-                    }}
-                    menuProps={{ items: overflow, className: styles.commandBarButtonsSubmenu }}
-                />
-            );
-        };
-
-        const overflowItems = [
+        const overflowItems: IContextualMenuItem[] = [
             {
                 key: 'export report',
                 onRender: () => props.switcherNavConfiguration.ReportExportComponentFactory(props),
@@ -45,11 +27,15 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
         ];
 
         return (
-            <OverflowSet
-                onRenderItem={onRenderItem}
-                overflowItems={overflowItems}
-                onRenderOverflowButton={onRenderOverflowButton}
+            <CommandBarButton
+                ariaLabel="More items"
                 className={styles.commandBarButtonsMenu}
+                role="menuitem"
+                menuIconProps={{
+                    iconName: 'More',
+                    className: styles.commandBarButtonsMenuButton,
+                }}
+                menuProps={{ items: overflowItems, className: styles.commandBarButtonsSubmenu }}
             />
         );
     },

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
@@ -1,28 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CommandBarButtonsMenu renders CommandBarButtonsMenu 1`] = `
-<StyledOverflowSetBase
-  className="commandBarButtonsMenu"
-  onRenderItem={[Function]}
-  onRenderOverflowButton={[Function]}
-  overflowItems={
-    Array [
-      Object {
-        "key": "export report",
-        "onRender": [Function],
-      },
-      Object {
-        "key": "start over",
-        "onRender": [Function],
-      },
-    ]
-  }
-/>
-`;
-
-exports[`CommandBarButtonsMenu renders overflow button 1`] = `
 <CustomizedCommandBarButton
   ariaLabel="More items"
+  className="commandBarButtonsMenu"
   menuIconProps={
     Object {
       "className": "commandBarButtonsMenuButton",
@@ -34,10 +15,12 @@ exports[`CommandBarButtonsMenu renders overflow button 1`] = `
       "className": "commandBarButtonsSubmenu",
       "items": Array [
         Object {
-          "key": "item 1",
+          "key": "export report",
+          "onRender": [Function],
         },
         Object {
-          "key": "item 2",
+          "key": "start over",
+          "onRender": [Function],
         },
       ],
     }

--- a/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
@@ -55,34 +55,13 @@ describe('CommandBarButtonsMenu', () => {
 
         const wrapper = shallow(<CommandBarButtonsMenu {...commandBarButtonsMenuProps} />);
         const renderedProps = wrapper.getElement().props;
-        const overflowItems: IOverflowSetItemProps[] = renderedProps.overflowItems;
-        const onRenderItem: (props: IOverflowSetItemProps) => JSX.Element =
-            renderedProps.onRenderItem;
+        const overflowItems: IOverflowSetItemProps[] = renderedProps.menuProps?.items;
         expect(overflowItems).toBeDefined();
         expect(overflowItems).toHaveLength(2);
-        expect(onRenderItem).toBeDefined();
 
-        overflowItems.forEach(item => {
-            onRenderItem(item);
-        });
+        overflowItems.forEach(item => item.onRender());
 
         reportExportComponentFactory.verifyAll();
         startOverComponentFactory.verifyAll();
-    });
-
-    it('renders overflow button', () => {
-        const overflowItems: IOverflowSetItemProps[] = [
-            {
-                key: 'item 1',
-            },
-            {
-                key: 'item 2',
-            },
-        ];
-        const wrapper = shallow(<CommandBarButtonsMenu {...commandBarButtonsMenuProps} />);
-        const onRenderOverflowButton = wrapper.getElement().props.onRenderOverflowButton;
-        expect(onRenderOverflowButton).toBeDefined();
-
-        expect(onRenderOverflowButton(overflowItems)).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Description of changes

- Simplify CommandBarButtonsMenu by only rendering the "..." button without using an OverflowSet
  - NVDA now reads "More items submenu" instead of "More items submenu 1 of 1"
- Shorten the menu to remove white space to the right of the buttons
  Before:
  <img width="169" alt="menu original width" src="https://user-images.githubusercontent.com/55459788/86662427-8e85e180-bfa1-11ea-9341-15fc6220a0e0.PNG">
  After:
  <img width="148" alt="shortened ellipses menu" src="https://user-images.githubusercontent.com/55459788/86661958-1cad9800-bfa1-11ea-9c47-b5baa59fb9ac.PNG">


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1696617
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
