### PR TITLE
feat(command-bar-reflow): dialogs resizing when zoomed in

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -29,14 +29,13 @@ body {
 }
 
 div.insights-dialog-main-override {
-    width: 25% !important;
-    max-width: 25% !important;
-    min-width: 500px !important;
+    width: 75%;
+    max-width: 500px;
     @media screen and (max-width: 500px) {
-        min-width: 256px !important;
-        width: 95% !important;
-        max-width: 100% !important;
+        min-width: 240px;
+        width: 75%;
     }
+
     user-select: text;
     .start-over-dialog-body {
         font-size: 16px;

--- a/src/DetailsView/components/export-dialog.scss
+++ b/src/DetailsView/components/export-dialog.scss
@@ -3,7 +3,7 @@
 
 .export-dialog {
     max-width: 640px;
-    width: 50%;
-    min-width: 320px !important;
+    width: 75%;
+    min-width: 240px !important;
     user-select: text;
 }

--- a/src/DetailsView/components/target-change-dialog.scss
+++ b/src/DetailsView/components/target-change-dialog.scss
@@ -17,14 +17,13 @@
     }
     .target-change-dialog-button-container {
         display: flex;
-        height: 40px;
+        flex-wrap: wrap;
         justify-content: flex-end;
 
         .action-cancel-button-col {
             text-align: right;
             padding-left: 0px;
             margin-top: 4px;
-            margin-bottom: 24px;
         }
         .action-cancel-button-col + .action-cancel-button-col {
             margin-left: 8px;


### PR DESCRIPTION
#### Description of changes

gif of behavior:
![dialogbehavior](https://user-images.githubusercontent.com/32555133/86665283-5633d280-bfa4-11ea-9cf9-49420c7104cc.gif)

Before and After of the target page changed dialog in assessment:
![image](https://user-images.githubusercontent.com/32555133/86665430-79f71880-bfa4-11ea-934d-17b30dd5e556.png)

![image](https://user-images.githubusercontent.com/32555133/86665458-81b6bd00-bfa4-11ea-8279-e015d7f13a35.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
