### PR TITLE
chore(null): add yarn null:progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "null:autoadd": "node ./tools/strict-null-checks/auto-add.js",
         "null:check": "tsc -p ./tsconfig.strictNullChecks.json",
         "null:find": "node ./tools/strict-null-checks/find.js",
+        "null:progress": "node ./tools/strict-null-checks/progress.js",
         "react-devtools": "react-devtools",
         "scss:build": "tsm \"src/**/*.scss\"",
         "scss:clean": "grunt clean:scss",

--- a/tools/strict-null-checks/eligible-file-finder.js
+++ b/tools/strict-null-checks/eligible-file-finder.js
@@ -28,18 +28,16 @@ const forEachFileInSrc = (srcRoot, options) => {
         });
     });
 };
-module.exports.forEachFileInSrc = forEachFileInSrc;
 
 /**
  * @param {string} repoRoot
  * @param {(file: string) => void} forEach
  * @param {{ includeTests: boolean }} [options]
  */
-module.exports.forStrictNullCheckEligibleFiles = async (repoRoot, forEach, options) => {
+async function forStrictNullCheckEligibleFiles(repoRoot, forEach, options) {
     const srcRoot = path.join(repoRoot, 'src');
 
-    const tsconfig = require(path.join(repoRoot, config.targetTsconfig));
-    const checkedFiles = await getCheckedFiles(tsconfig, repoRoot);
+    const checkedFiles = await getCheckedFiles(repoRoot);
 
     const imports = new Map();
     const getMemoizedImportsForFile = (file, srcRoot) => {
@@ -74,14 +72,17 @@ module.exports.forStrictNullCheckEligibleFiles = async (repoRoot, forEach, optio
                 });
 
             const isEdge = nonCheckedImports.length === 0;
+
             if (isEdge) {
                 forEach(file);
             }
             return isEdge;
         });
-};
+}
 
-async function getCheckedFiles(tsconfigContent, tsconfigDir) {
+async function getCheckedFiles(tsconfigDir) {
+    const tsconfigContent = require(path.join(tsconfigDir, config.targetTsconfig));
+
     const set = new Set(
         tsconfigContent.files.map(f => path.join(tsconfigDir, f).replace(/\\/g, '/')),
     );
@@ -102,3 +103,9 @@ async function getCheckedFiles(tsconfigContent, tsconfigDir) {
     await Promise.all(includes);
     return set;
 }
+
+module.exports = {
+    forEachFileInSrc,
+    forStrictNullCheckEligibleFiles,
+    getCheckedFiles,
+};

--- a/tools/strict-null-checks/progress.js
+++ b/tools/strict-null-checks/progress.js
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// @ts-check
+const { repoRoot } = require('./config');
+const { getCheckedFiles, forEachFileInSrc } = require('./eligible-file-finder');
+
+async function main() {
+    const datestamp = new Date().toDateString();
+    const doneCount = (await getCheckedFiles(repoRoot)).size;
+    const totalCount = (await forEachFileInSrc(`${repoRoot}/src`)).length;
+    const percentage = 100 * (doneCount / totalCount);
+    const formattedPercentage = percentage.toFixed(0) + '%';
+
+    console.log(`## Web strict-null progress\n`);
+    console.log(
+        `**${formattedPercentage}** complete (**${doneCount}**/${totalCount} non-test files)\n`,
+    );
+    console.log(
+        `*Contribute at [#2869](https://github.com/microsoft/accessibility-insights-web/issues/2869). Last update: ${datestamp}*`,
+    );
+}
+
+main();


### PR DESCRIPTION
#### Description of changes

This implements a new script that generates a progress message for use with our standup dashboard. `yarn null:progress` emits stdout like this:

```markdown
## Web strict-null progress

**29%** complete (**387**/1328 non-test files)

*Contribute at [#2869](https://github.com/microsoft/accessibility-insights-web/issues/2869). Last update: Mon Jul 06 2020*
```

...which renders in the dashboard widget like this:

![screenshot of above output as-rendered in dashboard](https://user-images.githubusercontent.com/376284/86670541-9a75a180-bfa9-11ea-99f2-730038d68a71.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2869
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
