### PR TITLE
feat(command-bar-reflow): navigation bar colors in high contrast mode

### DIFF
--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -9,15 +9,15 @@
         li {
             :global {
                 .is-selected {
-                    background-color: $communication-tint-20;
+                    background-color: $nav-link-selected;
                     a,
                     button {
-                        background-color: $communication-tint-20 !important;
+                        background-color: $nav-link-selected !important;
                     }
                 }
                 .is-expanded,
                 .is-expanded + ul {
-                    background-color: $communication-tint-40;
+                    background-color: $nav-link-expanded;
                     .index-circle {
                         color: $neutral-0;
                         background: $index-circle-background;

--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -29,7 +29,7 @@
             > div:hover {
                 a,
                 button {
-                    background-color: $nav-link-hover !important;
+                    background-color: $nav-link-hover;
                 }
             }
         }

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -87,6 +87,8 @@ $pill: var(--pill);
 $screenshot-image-outline: var(--screenshot-image-outline);
 $spinner-text: var(--spinner-text);
 $nav-link-hover: var(--nav-link-hover);
+$nav-link-selected: var(--nav-link-selected);
+$nav-link-expanded: var(--nav-link-expanded);
 
 // Consistent colors that don't vary with high contrast mode. Use sparingly.
 $always-white: var(--white);

--- a/src/common/styles/root-level-only/color-definitions.scss
+++ b/src/common/styles/root-level-only/color-definitions.scss
@@ -86,6 +86,8 @@
     --pill: var(--primary-text);
     --spinner-text: var(--communication-primary);
     --nav-link-hover: var(--neutral-alpha-8);
+    --nav-link-selected: var(--communication-tint-20);
+    --nav-link-expanded: var(--communication-tint-40);
 
     // Landmark colors
     --landmark-contentinfo: #00a88c;
@@ -153,5 +155,7 @@
         --screenshot-image-outline: var(--white);
         --spinner-text: var(--communication-tint-40);
         --nav-link-hover: #2a2a2a;
+        --nav-link-selected: var(--communication-tint-40);
+        --nav-link-expanded: transparent;
     }
 }


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

Fixes #2914 color contrast issues in high contrast mode.
- Expanding a test group in high contrast mode does not change the background color of the test group (same as in Production Version 2.18.2)
- Hovering a selected test/requirement does not change the background color in both regular and high contrast modes (same as in Production Version 2.18.2)
- Selected test/requirement in high contrast mode is the same color as in Production Version 2.18.2 for both FastPass and Assessment

Gifs of expanding, selecting, and hovering tests and requirements in regular and high contrast modes
![hover-nav-bar](https://user-images.githubusercontent.com/48259897/86980451-ae9bd900-c138-11ea-9192-5115136200e1.gif) ![hover-nav-bar-HC](https://user-images.githubusercontent.com/48259897/86980461-b5c2e700-c138-11ea-8c03-f1afcf3933f7.gif)

Gifs of selecting and hovering FastPass tests in regular and high contrast modes
![hover-nav-bar-fastpass](https://user-images.githubusercontent.com/48259897/86980466-b9566e00-c138-11ea-814c-b439092d5efd.gif) ![hover-nav-bar-fastpass-HC](https://user-images.githubusercontent.com/48259897/86980467-bbb8c800-c138-11ea-9192-ffae9836ce21.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2914
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
