### PR TITLE
fix: clean up outcome summary bar styles

### DIFF
--- a/src/reports/components/outcome-summary-bar.scss
+++ b/src/reports/components/outcome-summary-bar.scss
@@ -38,6 +38,7 @@ $outcome-not-applicable-color: $neutral-outcome;
         height: 16px;
         display: flex;
         align-items: center;
+        margin-right: 4px;
     }
     .count {
         font-weight: 600;
@@ -45,12 +46,11 @@ $outcome-not-applicable-color: $neutral-outcome;
     .fail {
         @extend .block;
         @include cross-icon-styles($outcome-summary-icon-size, 0px, $outcome-fail-color);
-        border-radius: 2px 0 0 2px;
+
         .check-container {
             bottom: -1px;
             margin-right: 8px;
         }
-        margin-right: 4px;
         background-color: $outcome-fail-color;
     }
     .pass {
@@ -62,10 +62,6 @@ $outcome-not-applicable-color: $neutral-outcome;
             margin-left: 4px;
         }
         background-color: $outcome-pass-color;
-        margin-left: 4px;
-        margin-right: 4px;
-        border-top-left-radius: 2px;
-        border-bottom-left-radius: 2px;
     }
     .inapplicable {
         @extend .block;
@@ -74,7 +70,6 @@ $outcome-not-applicable-color: $neutral-outcome;
             0px,
             $outcome-not-applicable-color
         );
-        border-radius: 0 2px 2px 0;
         .check-container {
             bottom: -1px;
             margin-right: 8px;
@@ -91,8 +86,16 @@ $outcome-not-applicable-color: $neutral-outcome;
         }
         background-color: $outcome-incomplete-summary-background;
         color: $outcome-incomplete-summary-consistent-foreground;
-        margin-right: 5px;
         border: 2px $outcome-incomplete-border-color solid;
         height: 12px;
+    }
+    .summary-bar-left-edge {
+        border-top-left-radius: 2px;
+        border-bottom-left-radius: 2px;
+    }
+    .summary-bar-right-edge {
+        border-top-right-radius: 2px;
+        border-bottom-right-radius: 2px;
+        margin-right: 0px;
     }
 }

--- a/src/reports/components/outcome-summary-bar.tsx
+++ b/src/reports/components/outcome-summary-bar.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as classNames from 'classnames';
 import { NamedFC } from 'common/react/named-fc';
 import { kebabCase } from 'lodash';
 import * as React from 'react';
@@ -14,9 +15,19 @@ export type OutcomeSummaryBarProps = {
 };
 
 export const OutcomeSummaryBar = NamedFC<OutcomeSummaryBarProps>('OutcomeSummaryBar', props => {
+    const outcomeTypesCount = props.allOutcomeTypes.length;
+
+    const getClassNames = (outcomeType: OutcomeType, index: number) => {
+        return classNames({
+            [kebabCase(outcomeType)]: true,
+            'summary-bar-left-edge': index === 0,
+            'summary-bar-right-edge': index === outcomeTypesCount - 1,
+        });
+    };
+
     return (
         <div className="outcome-summary-bar">
-            {props.allOutcomeTypes.map(outcomeType => {
+            {props.allOutcomeTypes.map((outcomeType, index) => {
                 const { iconStyleInverted, countSuffix } = props;
                 const iconMap =
                     iconStyleInverted === true ? outcomeIconMapInverted : outcomeIconMap;
@@ -25,7 +36,7 @@ export const OutcomeSummaryBar = NamedFC<OutcomeSummaryBarProps>('OutcomeSummary
 
                 return (
                     <div key={outcomeType} style={{ flexGrow: count }}>
-                        <span className={kebabCase(outcomeType)}>
+                        <span className={getClassNames(outcomeType, index)}>
                             <span aria-hidden="true">{outcomeIcon}</span>
                             {count}
                             {countSuffix}

--- a/src/tests/unit/tests/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`OutcomeSummaryBar render inverted badges 1`] = `
     }
   >
     <span
-      className="pass"
+      className="pass summary-bar-left-edge"
     >
       <span
         aria-hidden="true"
@@ -48,7 +48,7 @@ exports[`OutcomeSummaryBar render inverted badges 1`] = `
     }
   >
     <span
-      className="incomplete"
+      className="incomplete summary-bar-right-edge"
     >
       <span
         aria-hidden="true"
@@ -73,7 +73,7 @@ exports[`OutcomeSummaryBar show by count 1`] = `
     }
   >
     <span
-      className="pass"
+      className="pass summary-bar-left-edge"
     >
       <span
         aria-hidden="true"
@@ -109,7 +109,7 @@ exports[`OutcomeSummaryBar show by count 1`] = `
     }
   >
     <span
-      className="incomplete"
+      className="incomplete summary-bar-right-edge"
     >
       <span
         aria-hidden="true"
@@ -134,7 +134,7 @@ exports[`OutcomeSummaryBar show by percentage 1`] = `
     }
   >
     <span
-      className="pass"
+      className="pass summary-bar-left-edge"
     >
       <span
         aria-hidden="true"
@@ -172,7 +172,7 @@ exports[`OutcomeSummaryBar show by percentage 1`] = `
     }
   >
     <span
-      className="incomplete"
+      className="incomplete summary-bar-right-edge"
     >
       <span
         aria-hidden="true"

--- a/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
@@ -275,7 +275,7 @@ exports[`report package integration with issues 1`] = `
             style="flex-grow:26"
           >
             <span
-              class="fail"
+              class="fail summary-bar-left-edge"
             >
               <span
                 aria-hidden="true"
@@ -337,7 +337,7 @@ exports[`report package integration with issues 1`] = `
             style="flex-grow:49"
           >
             <span
-              class="inapplicable"
+              class="inapplicable summary-bar-right-edge"
             >
               <span
                 aria-hidden="true"
@@ -7519,7 +7519,7 @@ exports[`report package integration with no issues 1`] = `
             style="flex-grow:0"
           >
             <span
-              class="fail"
+              class="fail summary-bar-left-edge"
             >
               <span
                 aria-hidden="true"
@@ -7581,7 +7581,7 @@ exports[`report package integration with no issues 1`] = `
             style="flex-grow:30"
           >
             <span
-              class="inapplicable"
+              class="inapplicable summary-bar-right-edge"
             >
               <span
                 aria-hidden="true"


### PR DESCRIPTION
#### Description of changes

This will fix some inconsistent margins between sections and rounded corners on the wrong side in the outcome summary bar:
![failed section with rounded corners on the wrong side](https://user-images.githubusercontent.com/55459788/87077565-2b31c480-c1d8-11ea-8988-7b44cf7988b3.png)

##### Assessment overview page, before and after (rounded corners on failure section are fixed):
<img width="645" alt="assessment outcome bar before" src="https://user-images.githubusercontent.com/55459788/87077261-b78fb780-c1d7-11ea-9709-f09197194dfb.PNG">
<img width="641" alt="assessment outcome bar after" src="https://user-images.githubusercontent.com/55459788/87077276-be1e2f00-c1d7-11ea-8d37-261831038663.PNG">

##### Fastpass report, before and after (inconsistent margins between sections and rounded corners on passed section are fixed):
<img width="742" alt="fastpass report outcome bar before" src="https://user-images.githubusercontent.com/55459788/87077269-bb233e80-c1d7-11ea-8ea8-3c49b2922b4f.PNG">
<img width="743" alt="fastpass report outcome bar after" src="https://user-images.githubusercontent.com/55459788/87077291-c1b1b600-c1d7-11ea-848f-6a2bc4e917b6.PNG">


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
