### PR TITLE
feat(command-bar-reflow): fix a11y issue for the '...' dropdown

### DIFF
--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -14,29 +14,39 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
         const overflowItems: IContextualMenuItem[] = [
             {
                 key: 'export report',
-                onRender: () => props.switcherNavConfiguration.ReportExportComponentFactory(props),
+                onRender: () => (
+                    <div role="menuitem">
+                        {props.switcherNavConfiguration.ReportExportComponentFactory(props)}
+                    </div>
+                ),
             },
             {
                 key: 'start over',
-                onRender: () =>
-                    props.switcherNavConfiguration.StartOverComponentFactory({
-                        ...props,
-                        dropdownDirection: 'left',
-                    }),
+                role: 'menuitem',
+                onRender: () => (
+                    <div role="menuitem">
+                        {props.switcherNavConfiguration.StartOverComponentFactory({
+                            ...props,
+                            dropdownDirection: 'left',
+                        })}
+                    </div>
+                ),
             },
         ];
 
         return (
-            <CommandBarButton
-                ariaLabel="More items"
-                className={styles.commandBarButtonsMenu}
-                role="menuitem"
-                menuIconProps={{
-                    iconName: 'More',
-                    className: styles.commandBarButtonsMenuButton,
-                }}
-                menuProps={{ items: overflowItems, className: styles.commandBarButtonsSubmenu }}
-            />
+            <div role="menu">
+                <CommandBarButton
+                    ariaLabel="More items"
+                    className={styles.commandBarButtonsMenu}
+                    role="menuitem"
+                    menuIconProps={{
+                        iconName: 'More',
+                        className: styles.commandBarButtonsMenuButton,
+                    }}
+                    menuProps={{ items: overflowItems, className: styles.commandBarButtonsSubmenu }}
+                />
+            </div>
         );
     },
 );

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -22,7 +22,6 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
             },
             {
                 key: 'start over',
-                role: 'menuitem',
                 onRender: () => (
                     <div role="menuitem">
                         {props.switcherNavConfiguration.StartOverComponentFactory({
@@ -35,18 +34,16 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
         ];
 
         return (
-            <div role="menu">
-                <CommandBarButton
-                    ariaLabel="More items"
-                    className={styles.commandBarButtonsMenu}
-                    role="menuitem"
-                    menuIconProps={{
-                        iconName: 'More',
-                        className: styles.commandBarButtonsMenuButton,
-                    }}
-                    menuProps={{ items: overflowItems, className: styles.commandBarButtonsSubmenu }}
-                />
-            </div>
+            <CommandBarButton
+                ariaLabel="More items"
+                className={styles.commandBarButtonsMenu}
+                role="menu"
+                menuIconProps={{
+                    iconName: 'More',
+                    className: styles.commandBarButtonsMenuButton,
+                }}
+                menuProps={{ items: overflowItems, className: styles.commandBarButtonsSubmenu }}
+            />
         );
     },
 );

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
@@ -25,6 +25,22 @@ exports[`CommandBarButtonsMenu renders CommandBarButtonsMenu 1`] = `
       ],
     }
   }
-  role="menuitem"
+  role="menu"
 />
+`;
+
+exports[`CommandBarButtonsMenu renders child buttons 1`] = `
+<div
+  role="menuitem"
+>
+  <React.Fragment />
+</div>
+`;
+
+exports[`CommandBarButtonsMenu renders child buttons 2`] = `
+<div
+  role="menuitem"
+>
+  <React.Fragment />
+</div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
@@ -59,7 +59,7 @@ describe('CommandBarButtonsMenu', () => {
         expect(overflowItems).toBeDefined();
         expect(overflowItems).toHaveLength(2);
 
-        overflowItems.forEach(item => item.onRender());
+        overflowItems.forEach(item => expect(item.onRender()).toMatchSnapshot());
 
         reportExportComponentFactory.verifyAll();
         startOverComponentFactory.verifyAll();


### PR DESCRIPTION
#### Description of changes

The '...' menu should be treated as a menu since the items inside need to be menuitems. This does that for both.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
