### PR TITLE
feat(command-bar-reflow): requirement view navigation button

### DIFF
--- a/src/DetailsView/components/getting-started-view.tsx
+++ b/src/DetailsView/components/getting-started-view.tsx
@@ -3,17 +3,16 @@
 import { Requirement } from 'assessments/types/requirement';
 import { NamedFC } from 'common/react/named-fc';
 import { VisualizationType } from 'common/types/visualization-type';
-import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import * as styles from 'DetailsView/components/getting-started-view.scss';
-import { DefaultButton, Icon } from 'office-ui-fabric-react';
+import {
+    NextRequirementButton,
+    NextRequirementButtonDeps,
+} from 'DetailsView/components/next-requirement-button';
 import * as React from 'react';
 import { ContentLink, ContentLinkDeps } from 'views/content/content-link';
 import { ContentPageComponent } from 'views/content/content-page';
 
-export type GettingStartedViewDeps = ContentLinkDeps & {
-    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-};
-
+export type GettingStartedViewDeps = ContentLinkDeps & NextRequirementButtonDeps;
 export interface GettingStartedViewProps {
     deps: GettingStartedViewDeps;
     gettingStartedContent: JSX.Element;
@@ -24,14 +23,6 @@ export interface GettingStartedViewProps {
 }
 
 export const GettingStartedView = NamedFC<GettingStartedViewProps>('GettingStartedView', props => {
-    const selectNextRequirement = (event: React.MouseEvent<HTMLElement>) => {
-        props.deps.detailsViewActionMessageCreator.selectRequirement(
-            event,
-            props.nextRequirement.key,
-            props.currentTest,
-        );
-    };
-
     return (
         <div className={styles.gettingStartedView}>
             <div>
@@ -42,15 +33,12 @@ export const GettingStartedView = NamedFC<GettingStartedViewProps>('GettingStart
                 <h2 className={styles.gettingStartedTitle}>Getting Started</h2>
                 {props.gettingStartedContent}
             </div>
-            <DefaultButton
-                text={props.nextRequirement.name}
+            <NextRequirementButton
+                nextRequirement={props.nextRequirement}
+                currentTest={props.currentTest}
                 className={styles.nextRequirementButton}
-                onClick={selectNextRequirement}
-            >
-                <span>
-                    <Icon iconName="ChevronRight" />
-                </span>
-            </DefaultButton>
+                deps={props.deps}
+            />
         </div>
     );
 });

--- a/src/DetailsView/components/next-requirement-button.tsx
+++ b/src/DetailsView/components/next-requirement-button.tsx
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Requirement } from 'assessments/types/requirement';
+import { NamedFC } from 'common/react/named-fc';
+import { VisualizationType } from 'common/types/visualization-type';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { DefaultButton, Icon } from 'office-ui-fabric-react';
+import * as React from 'react';
+export type NextRequirementButtonDeps = {
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+};
+
+export type NextRequirementButtonProps = {
+    deps: NextRequirementButtonDeps;
+    nextRequirement: Requirement;
+    currentTest: VisualizationType;
+    className?: string;
+};
+
+export const NextRequirementButton = NamedFC<NextRequirementButtonProps>(
+    'NextRequirementButton',
+    props => {
+        if (props.nextRequirement == null) {
+            return null;
+        }
+
+        const selectNextRequirement = (event: React.MouseEvent<HTMLElement>) => {
+            props.deps.detailsViewActionMessageCreator.selectRequirement(
+                event,
+                props.nextRequirement.key,
+                props.currentTest,
+            );
+        };
+
+        return (
+            <DefaultButton
+                text={props.nextRequirement.name}
+                className={props.className}
+                onClick={selectNextRequirement}
+            >
+                <span>
+                    <Icon iconName="ChevronRight" />
+                </span>
+            </DefaultButton>
+        );
+    },
+);

--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -45,6 +45,7 @@ export const ReflowAssessmentView = NamedFC<ReflowAssessmentViewProps>(
             const nextRequirement = props.assessmentTestResult
                 .getRequirementResults()
                 .find(req => req.definition.order === 1).definition;
+
             return (
                 <GettingStartedView
                     deps={props.deps}
@@ -61,6 +62,11 @@ export const ReflowAssessmentView = NamedFC<ReflowAssessmentViewProps>(
             const selectedRequirement: RequirementResult = props.assessmentTestResult.getRequirementResult(
                 props.assessmentNavState.selectedTestSubview,
             );
+
+            const nextRequirement = props.assessmentTestResult
+                .getRequirementResults()
+                .find(req => req.definition.order === selectedRequirement.definition.order + 1)
+                ?.definition;
 
             return (
                 <RequirementView
@@ -80,6 +86,7 @@ export const ReflowAssessmentView = NamedFC<ReflowAssessmentViewProps>(
                     assessmentData={props.assessmentData}
                     currentTarget={props.currentTarget}
                     prevTarget={props.prevTarget}
+                    nextRequirement={nextRequirement}
                 />
             );
         };

--- a/src/DetailsView/components/requirement-view.scss
+++ b/src/DetailsView/components/requirement-view.scss
@@ -6,6 +6,16 @@
     margin: 0px 18px;
     padding-left: 6px;
     padding-top: 1vh;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: space-between;
+
+    .next-requirement-button {
+        align-self: flex-end;
+        margin-bottom: 1vh;
+        margin-top: 1vh;
+    }
 
     .main-content {
         margin-top: 10px;

--- a/src/DetailsView/components/requirement-view.tsx
+++ b/src/DetailsView/components/requirement-view.tsx
@@ -20,6 +20,7 @@ import {
     AssessmentViewUpdateHandlerProps,
 } from 'DetailsView/components/assessment-view-update-handler';
 import { RequirementTableSection } from 'DetailsView/components/left-nav/requirement-table-section';
+import { NextRequirementButton } from 'DetailsView/components/next-requirement-button';
 import { RequirementInstructions } from 'DetailsView/components/requirement-instructions';
 import {
     RequirementViewTitle,
@@ -53,6 +54,7 @@ export interface RequirementViewProps {
     assessmentData: AssessmentData;
     currentTarget: Tab;
     prevTarget: PersistedTabInfo;
+    nextRequirement: Requirement;
 }
 
 export class RequirementView extends React.Component<RequirementViewProps> {
@@ -105,33 +107,43 @@ export class RequirementView extends React.Component<RequirementViewProps> {
 
         return (
             <div className={styles.requirementView}>
-                <RequirementViewTitle
-                    deps={this.props.deps}
-                    name={this.props.requirement.name}
-                    guidanceLinks={this.props.requirement.guidanceLinks}
-                    infoAndExamples={this.props.requirement.infoAndExamples}
-                />
-                <div className={styles.mainContent}>
-                    {this.props.requirement.description}
-                    {visualHelperToggle}
-                    <RequirementInstructions howToTest={this.props.requirement.howToTest} />
-                    <RequirementTableSection
-                        requirement={requirement}
-                        assessmentNavState={this.props.assessmentNavState}
-                        instancesMap={this.props.instancesMap}
-                        manualRequirementResultMap={this.props.manualRequirementResultMap}
-                        assessmentInstanceTableHandler={this.props.assessmentInstanceTableHandler}
-                        assessmentsProvider={this.props.assessmentsProvider}
-                        featureFlagStoreData={this.props.featureFlagStoreData}
-                        pathSnippetStoreData={this.props.pathSnippetStoreData}
-                        scanningInProgress={this.props.scanningInProgress}
-                        selectedRequirementHasVisualHelper={requirementHasVisualHelper}
-                        isRequirementScanned={this.props.isRequirementScanned}
-                        assessmentDefaultMessageGenerator={
-                            this.props.assessmentDefaultMessageGenerator
-                        }
+                <div>
+                    <RequirementViewTitle
+                        deps={this.props.deps}
+                        name={this.props.requirement.name}
+                        guidanceLinks={this.props.requirement.guidanceLinks}
+                        infoAndExamples={this.props.requirement.infoAndExamples}
                     />
+                    <div className={styles.mainContent}>
+                        {this.props.requirement.description}
+                        {visualHelperToggle}
+                        <RequirementInstructions howToTest={this.props.requirement.howToTest} />
+                        <RequirementTableSection
+                            requirement={requirement}
+                            assessmentNavState={this.props.assessmentNavState}
+                            instancesMap={this.props.instancesMap}
+                            manualRequirementResultMap={this.props.manualRequirementResultMap}
+                            assessmentInstanceTableHandler={
+                                this.props.assessmentInstanceTableHandler
+                            }
+                            assessmentsProvider={this.props.assessmentsProvider}
+                            featureFlagStoreData={this.props.featureFlagStoreData}
+                            pathSnippetStoreData={this.props.pathSnippetStoreData}
+                            scanningInProgress={this.props.scanningInProgress}
+                            selectedRequirementHasVisualHelper={requirementHasVisualHelper}
+                            isRequirementScanned={this.props.isRequirementScanned}
+                            assessmentDefaultMessageGenerator={
+                                this.props.assessmentDefaultMessageGenerator
+                            }
+                        />
+                    </div>
                 </div>
+                <NextRequirementButton
+                    deps={this.props.deps}
+                    nextRequirement={this.props.nextRequirement}
+                    currentTest={this.props.assessmentNavState.selectedTestType}
+                    className={styles.nextRequirementButton}
+                />
             </div>
         );
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/getting-started-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/getting-started-view.test.tsx.snap
@@ -14,37 +14,7 @@ exports[`GettingStartedViewTest renders with content from props 1`] = `
         some title
       </span>
       <ContentLink
-        deps={
-          Object {
-            "detailsViewActionMessageCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "addPathForValidation": [Function],
-              "cancelStartOver": [Function],
-              "cancelStartOverAllAssessments": [Function],
-              "changeAssessmentVisualizationState": [Function],
-              "changeManualRequirementStatus": [Function],
-              "changeManualTestStatus": [Function],
-              "clearPathSnippetData": [Function],
-              "closePreviewFeaturesPanel": [Function],
-              "closeScopingPanel": [Function],
-              "closeSettingsPanel": [Function],
-              "continuePreviousAssessment": [Function],
-              "copyIssueDetailsClicked": [Function],
-              "dispatcher": undefined,
-              "editFailureInstance": [Function],
-              "leftNavPanelExpanded": [Function],
-              "removeFailureInstance": [Function],
-              "rescanVisualization": [Function],
-              "setAllUrlsPermissionState": [Function],
-              "setFeatureFlag": [Function],
-              "startOverAllAssessments": [Function],
-              "switchToTargetTab": [Function],
-              "telemetryFactory": undefined,
-              "undoManualRequirementStatusChange": [Function],
-              "undoManualTestStatusChange": [Function],
-            },
-          }
-        }
+        deps={Object {}}
         iconName="info"
         reference={
           Object {
@@ -62,15 +32,15 @@ exports[`GettingStartedViewTest renders with content from props 1`] = `
       test-getting-started-content
     </div>
   </div>
-  <CustomizedDefaultButton
+  <NextRequirementButton
     className="nextRequirementButton"
-    onClick={[Function]}
-  >
-    <span>
-      <StyledIconBase
-        iconName="ChevronRight"
-      />
-    </span>
-  </CustomizedDefaultButton>
+    currentTest={-1}
+    deps={Object {}}
+    nextRequirement={
+      Object {
+        "key": "some requirement key",
+      }
+    }
+  />
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/next-requirement-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/next-requirement-button.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NextRequirementButton renders 1`] = `
+<CustomizedDefaultButton
+  onClick={[Function]}
+>
+  <span>
+    <StyledIconBase
+      iconName="ChevronRight"
+    />
+  </span>
+</CustomizedDefaultButton>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AssessmentViewTest render for gettting started 1`] = `
+exports[`AssessmentViewTest render for getting started 1`] = `
 <React.Fragment>
   <TargetChangeDialog
     deps={Object {}}
@@ -86,6 +86,18 @@ exports[`AssessmentViewTest render for requirement 1`] = `
     }
     isRequirementEnabled={true}
     isRequirementScanned={true}
+    nextRequirement={
+      Object {
+        "description": <div>
+          test-description
+        </div>,
+        "howToTest": <p>
+          how-to-test-stub
+        </p>,
+        "name": "test-requirement-name-2",
+        "order": 2,
+      }
+    }
     pathSnippetStoreData={
       Object {
         "path": null,
@@ -106,6 +118,74 @@ exports[`AssessmentViewTest render for requirement 1`] = `
         </p>,
         "name": "test-requirement-name",
         "order": 1,
+      }
+    }
+    scanningInProgress={true}
+  />
+</React.Fragment>
+`;
+
+exports[`AssessmentViewTest render for requirement where nextRequirement is null 1`] = `
+<React.Fragment>
+  <TargetChangeDialog
+    deps={Object {}}
+    newTab={
+      Object {
+        "id": 5,
+      }
+    }
+    prevTab={
+      Object {
+        "id": 4,
+      }
+    }
+  />
+  <RequirementView
+    assessmentData={Object {}}
+    assessmentInstanceTableHandler={
+      Object {
+        "changeRequirementStatus": null,
+      }
+    }
+    assessmentNavState={
+      Object {
+        "selectedTestSubview": "requirement",
+        "selectedTestType": -1,
+      }
+    }
+    currentTarget={
+      Object {
+        "id": 5,
+      }
+    }
+    deps={Object {}}
+    featureFlagStoreData={
+      Object {
+        "some feature flag": true,
+      }
+    }
+    isRequirementEnabled={true}
+    isRequirementScanned={true}
+    pathSnippetStoreData={
+      Object {
+        "path": null,
+      }
+    }
+    prevTarget={
+      Object {
+        "id": 4,
+      }
+    }
+    requirement={
+      Object {
+        "description": <div>
+          test-description
+        </div>,
+        "howToTest": <p>
+          how-to-test-stub
+        </p>,
+        "name": "test-requirement-name-2",
+        "order": 2,
       }
     }
     scanningInProgress={true}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-view.test.tsx.snap
@@ -4,7 +4,79 @@ exports[`RequirementViewTest renders with content from props 1`] = `
 <div
   className="requirementView"
 >
-  <RequirementViewTitle
+  <div>
+    <RequirementViewTitle
+      deps={
+        Object {
+          "assessmentViewUpdateHandler": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          },
+        }
+      }
+      name="test-requirement-name"
+    />
+    <div
+      className="mainContent"
+    >
+      <div>
+        test-description
+      </div>
+      <div>
+        test-visual-helper-toggle
+      </div>
+      <RequirementInstructions
+        howToTest={
+          <p>
+            how-to-test-stub
+          </p>
+        }
+      />
+      <RequirementTableSection
+        assessmentInstanceTableHandler={
+          Object {
+            "changeRequirementStatus": null,
+          }
+        }
+        assessmentNavState={
+          Object {
+            "selectedTestSubview": "test-requirement-name",
+            "selectedTestType": 0,
+          }
+        }
+        assessmentsProvider={
+          proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          }
+        }
+        featureFlagStoreData={
+          Object {
+            "some feature flag": true,
+          }
+        }
+        instancesMap={Object {}}
+        isRequirementScanned={true}
+        manualRequirementResultMap={
+          Object {
+            "some manual test step result id": null,
+          }
+        }
+        pathSnippetStoreData={
+          Object {
+            "path": null,
+          }
+        }
+        requirement={
+          Object {
+            "getVisualHelperToggle": [Function],
+          }
+        }
+        selectedRequirementHasVisualHelper={true}
+      />
+    </div>
+  </div>
+  <NextRequirementButton
+    className="nextRequirementButton"
+    currentTest={0}
     deps={
       Object {
         "assessmentViewUpdateHandler": proxy {
@@ -12,65 +84,6 @@ exports[`RequirementViewTest renders with content from props 1`] = `
         },
       }
     }
-    name="test-requirement-name"
   />
-  <div
-    className="mainContent"
-  >
-    <div>
-      test-description
-    </div>
-    <div>
-      test-visual-helper-toggle
-    </div>
-    <RequirementInstructions
-      howToTest={
-        <p>
-          how-to-test-stub
-        </p>
-      }
-    />
-    <RequirementTableSection
-      assessmentInstanceTableHandler={
-        Object {
-          "changeRequirementStatus": null,
-        }
-      }
-      assessmentNavState={
-        Object {
-          "selectedTestSubview": "test-requirement-name",
-          "selectedTestType": 0,
-        }
-      }
-      assessmentsProvider={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        }
-      }
-      featureFlagStoreData={
-        Object {
-          "some feature flag": true,
-        }
-      }
-      instancesMap={Object {}}
-      isRequirementScanned={true}
-      manualRequirementResultMap={
-        Object {
-          "some manual test step result id": null,
-        }
-      }
-      pathSnippetStoreData={
-        Object {
-          "path": null,
-        }
-      }
-      requirement={
-        Object {
-          "getVisualHelperToggle": [Function],
-        }
-      }
-      selectedRequirementHasVisualHelper={true}
-    />
-  </div>
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/getting-started-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/getting-started-view.test.tsx
@@ -1,30 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Requirement } from 'assessments/types/requirement';
-import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import {
     GettingStartedView,
     GettingStartedViewDeps,
     GettingStartedViewProps,
 } from 'DetailsView/components/getting-started-view';
 import { shallow } from 'enzyme';
-import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { IMock, Mock } from 'typemoq';
 import { ContentPageComponent } from 'views/content/content-page';
 
 describe('GettingStartedViewTest', () => {
-    let messageCreatorMock: IMock<DetailsViewActionMessageCreator>;
-    let eventStub: React.MouseEvent<HTMLElement>;
     let props: GettingStartedViewProps;
 
     beforeEach(() => {
-        messageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator);
-        eventStub = {} as React.MouseEvent<HTMLElement>;
         props = {
-            deps: {
-                detailsViewActionMessageCreator: messageCreatorMock.object,
-            } as GettingStartedViewDeps,
+            deps: {} as GettingStartedViewDeps,
             gettingStartedContent: <div>test-getting-started-content</div>,
             title: 'some title',
             guidance: { pageTitle: 'some page title' } as ContentPageComponent,
@@ -38,17 +29,5 @@ describe('GettingStartedViewTest', () => {
     it('renders with content from props', () => {
         const rendered = shallow(<GettingStartedView {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
-    });
-
-    it('validate next requirement button', () => {
-        messageCreatorMock
-            .setup(mock =>
-                mock.selectRequirement(eventStub, props.nextRequirement.key, props.currentTest),
-            )
-            .verifiable();
-
-        const rendered = shallow(<GettingStartedView {...props} />);
-        rendered.find(DefaultButton).prop('onClick')(eventStub);
-        messageCreatorMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/next-requirement-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/next-requirement-button.test.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Requirement } from 'assessments/types/requirement';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import {
+    NextRequirementButton,
+    NextRequirementButtonDeps,
+    NextRequirementButtonProps,
+} from 'DetailsView/components/next-requirement-button';
+import { shallow } from 'enzyme';
+import { DefaultButton } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { IMock, Mock } from 'typemoq';
+describe('NextRequirementButton', () => {
+    let messageCreatorMock: IMock<DetailsViewActionMessageCreator>;
+    let eventStub: React.MouseEvent<HTMLElement>;
+    let props: NextRequirementButtonProps;
+
+    beforeEach(() => {
+        messageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator);
+        eventStub = {} as React.MouseEvent<HTMLElement>;
+        props = {
+            deps: {
+                detailsViewActionMessageCreator: messageCreatorMock.object,
+            } as NextRequirementButtonDeps,
+            nextRequirement: {
+                key: 'some requirement key',
+            } as Requirement,
+            currentTest: -1,
+        };
+    });
+
+    it('renders', () => {
+        const rendered = shallow(<NextRequirementButton {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('validate next requirement button', () => {
+        messageCreatorMock
+            .setup(mock =>
+                mock.selectRequirement(eventStub, props.nextRequirement.key, props.currentTest),
+            )
+            .verifiable();
+
+        const rendered = shallow(<NextRequirementButton {...props} />);
+        rendered.find(DefaultButton).prop('onClick')(eventStub);
+        messageCreatorMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -5,9 +5,7 @@ import { AssessmentTestResult } from 'common/assessment/assessment-test-result';
 import { RequirementData, RequirementResult } from 'common/assessment/requirement';
 import {
     AssessmentData,
-    GettingStarted,
     gettingStartedSubview,
-    RequirementName,
 } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { PathSnippetStoreData } from 'common/types/store-data/path-snippet-store-data';
@@ -21,61 +19,73 @@ import {
 } from '../../../../../DetailsView/components/reflow-assessment-view';
 
 describe('AssessmentViewTest', () => {
-    test('render for requirement', () => {
-        const props = generateProps('requirement');
-        const rendered = shallow(<ReflowAssessmentView {...props} />);
-        expect(rendered.getElement()).toMatchSnapshot();
-    });
+    let assessmentDataStub = {} as AssessmentData;
 
-    test('render for gettting started', () => {
-        const props = generateProps(gettingStartedSubview);
-        const rendered = shallow(<ReflowAssessmentView {...props} />);
-        expect(rendered.getElement()).toMatchSnapshot();
-    });
+    let requirementStub: Requirement;
+    let requirementStubTwo: Requirement;
+    let requirementResultStub: RequirementResult;
+    let requirementResultStubTwo: RequirementResult;
+    let assessmentTestResultStub: AssessmentTestResult;
 
-    function generateProps(subview: RequirementName | GettingStarted): ReflowAssessmentViewProps {
-        const assessmentDataStub = {} as AssessmentData;
+    let assessmentInstanceTableHandlerStub: AssessmentInstanceTableHandler;
 
-        const requirementStub = {
+    let featureFlagStoreDataStub: FeatureFlagStoreData;
+    let pathSnippetStoreDataStub: PathSnippetStoreData;
+
+    let reflowProps: ReflowAssessmentViewProps;
+
+    beforeEach(() => {
+        assessmentDataStub = {} as AssessmentData;
+
+        requirementStub = {
             name: 'test-requirement-name',
             description: <div>test-description</div>,
             howToTest: <p>how-to-test-stub</p>,
             order: 1,
         } as Requirement;
-        const requirementResultStub: RequirementResult = {
+        requirementStubTwo = {
+            name: 'test-requirement-name-2',
+            description: <div>test-description</div>,
+            howToTest: <p>how-to-test-stub</p>,
+            order: 2,
+        } as Requirement;
+        requirementResultStub = {
             definition: requirementStub,
             data: { isStepScanned: true } as RequirementData,
         };
-        const assessmentTestResultStub: AssessmentTestResult = {
+        requirementResultStubTwo = {
+            definition: requirementStubTwo,
+            data: { isStepScanned: true } as RequirementData,
+        };
+        assessmentTestResultStub = {
             definition: {
                 gettingStarted: <h1>Hello</h1>,
                 title: 'some title',
                 guidance: { pageTitle: 'some page title' },
             },
             getRequirementResult: _ => requirementResultStub,
-            getRequirementResults: () => [requirementResultStub],
+            getRequirementResults: () => [requirementResultStub, requirementResultStubTwo],
             visualizationType: -1,
         } as AssessmentTestResult;
 
-        const assessmentInstanceTableHandlerStub = {
+        assessmentInstanceTableHandlerStub = {
             changeRequirementStatus: null,
         } as AssessmentInstanceTableHandler;
 
-        const featureFlagStoreDataStub: FeatureFlagStoreData = {
+        featureFlagStoreDataStub = {
             'some feature flag': true,
         };
-        const pathSnippetStoreDataStub = {
+        pathSnippetStoreDataStub = {
             path: null,
         } as PathSnippetStoreData;
 
-        const reflowProps = {
+        reflowProps = {
             deps: {} as ReflowAssessmentViewDeps,
             prevTarget: { id: 4 },
             currentTarget: { id: 5 },
             scanningInProgress: true,
             selectedRequirementIsEnabled: true,
             assessmentNavState: {
-                selectedTestSubview: subview,
                 selectedTestType: -1,
             },
             assessmentData: assessmentDataStub,
@@ -84,6 +94,24 @@ describe('AssessmentViewTest', () => {
             featureFlagStoreData: featureFlagStoreDataStub,
             pathSnippetStoreData: pathSnippetStoreDataStub,
         } as ReflowAssessmentViewProps;
-        return reflowProps;
-    }
+    });
+
+    test('render for requirement', () => {
+        reflowProps.assessmentNavState.selectedTestSubview = 'requirement';
+        const rendered = shallow(<ReflowAssessmentView {...reflowProps} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    test('render for getting started', () => {
+        reflowProps.assessmentNavState.selectedTestSubview = gettingStartedSubview;
+        const rendered = shallow(<ReflowAssessmentView {...reflowProps} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    test('render for requirement where nextRequirement is null', () => {
+        reflowProps.assessmentNavState.selectedTestSubview = 'requirement';
+        reflowProps.assessmentTestResult.getRequirementResult = _ => requirementResultStubTwo;
+        const rendered = shallow(<ReflowAssessmentView {...reflowProps} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
 });

--- a/src/tests/unit/tests/DetailsView/components/requirement-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/requirement-view.test.tsx
@@ -38,7 +38,6 @@ describe('RequirementViewTest', () => {
     let featureFlagStoreDataStub: FeatureFlagStoreData;
     let pathSnippetStoreDataStub: PathSnippetStoreData;
     let updateHandlerMock: IMock<AssessmentViewUpdateHandler>;
-
     beforeEach(() => {
         requirementStub = {
             name: 'test-requirement-name',


### PR DESCRIPTION
#### Description of changes

Note: the button is gone for the last requirement in the test.

Example of what it looks like:
![requirementviewnavbutton](https://user-images.githubusercontent.com/32555133/87207831-c783c600-c2c1-11ea-9b1b-8fb03ce7ed60.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
