### PR TITLE
fix(android-setup): Address UI feedback from Nate

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.scss
@@ -6,6 +6,11 @@
     overflow: hidden;
 }
 
+.device-count {
+    margin-top: 22px;
+    margin-bottom: 14px;
+}
+
 .checkmark-cell {
     align-self: center;
 }

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -47,7 +47,9 @@ export class PromptChooseDeviceStep extends React.Component<
             headerText: 'Choose which device to use',
             children: (
                 <>
-                    <p>{devices.length} Android devices or emulators connected</p>
+                    <div className={styles.deviceCount}>
+                        {items.length} Android devices or emulators connected
+                    </div>
                     <DefaultButton
                         data-automation-id={'rescan'}
                         text="Rescan"

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -27,7 +27,9 @@ export class PromptChooseDeviceStep extends React.Component<
     private selection: ISelection;
     constructor(props) {
         super(props);
-        this.state = { selectedDevice: null };
+
+        const listItems = this.getListItems();
+        this.state = { selectedDevice: listItems.length > 0 ? listItems[0] : null };
 
         this.selection = new Selection({
             onSelectionChanged: () => {
@@ -37,18 +39,19 @@ export class PromptChooseDeviceStep extends React.Component<
                 }
             },
         });
+
+        this.selectItemZeroInList(listItems);
     }
 
     public render(): JSX.Element {
-        const devices: DeviceInfo[] = this.props.androidSetupStoreData.availableDevices;
-        const items = devices.map(m => ({ metadata: m }));
+        const listItems = this.getListItems();
 
         const layoutProps: AndroidSetupStepLayoutProps = {
             headerText: 'Choose which device to use',
             children: (
                 <>
                     <div className={styles.deviceCount}>
-                        {items.length} Android devices or emulators connected
+                        {listItems.length} Android devices or emulators connected
                     </div>
                     <DefaultButton
                         data-automation-id={'rescan'}
@@ -60,7 +63,7 @@ export class PromptChooseDeviceStep extends React.Component<
                         compact={true}
                         ariaLabel="android devices"
                         className={styles.phoneList}
-                        items={items}
+                        items={listItems}
                         selection={this.selection}
                         selectionMode={SelectionMode.single}
                         checkboxVisibility={CheckboxVisibility.always}
@@ -100,5 +103,20 @@ export class PromptChooseDeviceStep extends React.Component<
         };
 
         return <AndroidSetupStepLayout {...layoutProps}></AndroidSetupStepLayout>;
+    }
+
+    private getListItems(): any {
+        const devices: DeviceInfo[] = this.props.androidSetupStoreData.availableDevices;
+        const items = devices.map(m => ({ metadata: m }));
+        return items;
+    }
+
+    private selectItemZeroInList(items: any): void {
+        if (items.length > 0) {
+            this.selection.setChangeEvents(false, true);
+            this.selection.setItems(items, false);
+            this.selection.selectToIndex(0);
+            this.selection.setChangeEvents(true, true);
+        }
     }
 }

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -28,9 +28,6 @@ export class PromptChooseDeviceStep extends React.Component<
     constructor(props) {
         super(props);
 
-        const listItems = this.getListItems();
-        this.state = { selectedDevice: listItems.length > 0 ? listItems[0] : null };
-
         this.selection = new Selection({
             onSelectionChanged: () => {
                 const details = this.selection.getSelection();
@@ -40,7 +37,7 @@ export class PromptChooseDeviceStep extends React.Component<
             },
         });
 
-        this.selectItemZeroInList(listItems);
+        this.setInitialListState();
     }
 
     public render(): JSX.Element {
@@ -107,16 +104,23 @@ export class PromptChooseDeviceStep extends React.Component<
 
     private getListItems(): any {
         const devices: DeviceInfo[] = this.props.androidSetupStoreData.availableDevices;
-        const items = devices.map(m => ({ metadata: m }));
-        return items;
+        const listItems = devices.map(m => ({ metadata: m }));
+        return listItems;
     }
 
-    private selectItemZeroInList(items: any): void {
-        if (items.length > 0) {
+    private setInitialListState(): void {
+        const listItems = this.getListItems();
+        let selectedDevice = null;
+
+        if (listItems.length > 0) {
+            // We always select index 0 in the list.
             this.selection.setChangeEvents(false, true);
-            this.selection.setItems(items, false);
+            this.selection.setItems(listItems, false);
             this.selection.selectToIndex(0);
             this.selection.setChangeEvents(true, true);
+            selectedDevice = listItems[0];
         }
+
+        this.state = { selectedDevice: selectedDevice };
     }
 }

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss
@@ -3,6 +3,6 @@
 @import '../../../../../common/styles/fonts.scss';
 
 .device-description {
-    margin-top: 16px;
+    margin-top: 14px;
     margin-bottom: 16px;
 }

--- a/src/tests/electron/tests/android-setup-multiple-devices.test.ts
+++ b/src/tests/electron/tests/android-setup-multiple-devices.test.ts
@@ -31,7 +31,7 @@ describe('Android setup - multiple devices ', () => {
     it('initial component state is correct', async () => {
         const [closeId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
         expect(await dialog.isEnabled(getAutomationIdSelector(closeId))).toBe(true);
-        expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(false);
+        expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(true);
         expect(await dialog.isEnabled(getAutomationIdSelector('rescan'))).toBe(true);
         const devices = await dialog.client.$$(
             getAutomationIdSelector(deviceDescriptionAutomationId),

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`PromptChooseDeviceStep renders per snapshot 1`] = `
   }
   rightFooterButtonProps={
     Object {
-      "disabled": true,
+      "disabled": false,
       "onClick": [Function],
       "text": "Next",
     }
@@ -69,17 +69,50 @@ exports[`PromptChooseDeviceStep renders per snapshot 1`] = `
           "_anchoredIndex": 0,
           "_canSelectItem": [Function],
           "_changeEventSuppressionCount": 0,
-          "_exemptedCount": 0,
-          "_exemptedIndices": Object {},
+          "_exemptedCount": 1,
+          "_exemptedIndices": Object {
+            "0": true,
+          },
           "_getKey": [Function],
+          "_hasChanged": false,
           "_isModal": false,
-          "_items": Array [],
-          "_keyToIndexMap": Object {},
+          "_items": Array [
+            Object {
+              "metadata": Object {
+                "friendlyName": "Phone 1",
+                "id": "1",
+                "isEmulator": true,
+              },
+            },
+            Object {
+              "metadata": Object {
+                "friendlyName": "Phone 2",
+                "id": "2",
+                "isEmulator": false,
+              },
+            },
+            Object {
+              "metadata": Object {
+                "friendlyName": "Phone 3",
+                "id": "3",
+                "isEmulator": true,
+              },
+            },
+          ],
+          "_keyToIndexMap": Object {
+            "0": 0,
+            "1": 1,
+            "2": 2,
+          },
           "_onSelectionChanged": [Function],
           "_selectedItems": null,
           "_unselectableCount": 0,
-          "_unselectableIndices": Object {},
-          "count": 0,
+          "_unselectableIndices": Object {
+            "0": false,
+            "1": false,
+            "2": false,
+          },
+          "count": 1,
           "mode": 2,
         }
       }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
@@ -18,10 +18,12 @@ exports[`PromptChooseDeviceStep renders per snapshot 1`] = `
   }
 >
   <React.Fragment>
-    <p>
+    <div
+      className="deviceCount"
+    >
       3
        Android devices or emulators connected
-    </p>
+    </div>
     <CustomizedDefaultButton
       data-automation-id="rescan"
       onClick={[Function]}

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
@@ -68,15 +68,18 @@ describe('PromptChooseDeviceStep', () => {
         const expectedDevice: DeviceInfo = props.androidSetupStoreData.availableDevices[0];
         const stubEvent = {} as React.MouseEvent<HTMLButtonElement>;
         const rendered = mount(<PromptChooseDeviceStep {...props} />);
-        rendered.find('DeviceDescription').at(0).simulate('click');
         rendered.find(AndroidSetupStepLayout).prop('rightFooterButtonProps').onClick(stubEvent);
         actionMessageCreatorMock.verify(m => m.setSelectedDevice(expectedDevice), Times.once());
     });
 
-    it('next button becomes enabled after device is selected', () => {
+    it('next button is disabled on entry if no devices are in list (not expected in production)', () => {
+        props.androidSetupStoreData.availableDevices = [];
         const rendered = mount(<PromptChooseDeviceStep {...props} />);
         expect(rendered.find('button').at(2).props().disabled).toBeTruthy();
-        rendered.find('DeviceDescription').at(0).simulate('click');
+    });
+
+    it('next button is enabled on entry if devices are in list', () => {
+        const rendered = mount(<PromptChooseDeviceStep {...props} />);
         expect(rendered.find('button').at(2).props().disabled).toBeUndefined();
     });
 });


### PR DESCRIPTION
#### Description of changes

Nate pointed out some minor variations between the figma and the implementation of the android setup:
1. The intent of the "choose device" step was to auto-select the first item in the list when we enter the dialog. Actual implementation requires the user to choose a device, which makes the initial list of devices see to be offset far more than is expected.
2. Vertical spacing in the "choose device step looks slightly larger than other steps
3. Vertical spacing in the "start testing" step looks slightly larger than other steps

The changes are:
1. In the "start testing step", reduce the vertical spacing between the header and the body by 2 logical pixels.
2. In the choose-device step, the vertical space above the device count is set to 24px by the `margin-top` property of the `layoutContent` style. I tried unsuccessfully to override this style, and ultimately changed the paragraph to a div and explicitly set both the top and bottom margins via a new style. Updated the snapshot.
3. Auto-select the first item in the "choose device" step. Note that this _always_ picks the first item, even if you're looping back to this display after starting with a different device. Updated the tests and the snapshot.

I'd normally have 3 PRs for this, but since 3 issues were flagged in a single issue, there's a single PR. Also, there were several "false starts" in the intermediate commits that should be ignored.

Screenshot of old "start testing" step (on left) and new "start testing" step (on right). The new version decreases the spacing above the device by 2 logical pixels (although you have to look very closely to notice it):
![image](https://user-images.githubusercontent.com/45672944/87207694-5f34e480-c2c1-11ea-9941-21bfc9989d7c.png)

Screenshot of old "choose-device" step on initial state (on left) and new "choose-device" step on initial state (on right). The new version selects the first item in list, enables the Next button automatically, and decreases the spacing above "2 Android devices or emulators connected" by 2 logical pixels (although you have to look very closely to notice it):
![image](https://user-images.githubusercontent.com/45672944/87207531-ea61aa80-c2c0-11ea-80ef-ab5df73298f7.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2988 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
