### PR TITLE
fix: add ariaLabel for content button

### DIFF
--- a/src/tests/unit/tests/views/content/__snapshots__/content-panel-button.test.tsx.snap
+++ b/src/tests/unit/tests/views/content/__snapshots__/content-panel-button.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`ContentPanelButton renders from content 1`] = `
 <CustomizedActionButton
+  ariaLabel="info and examples"
   iconProps={
     Object {
       "iconName": "iconName",
@@ -15,6 +16,7 @@ exports[`ContentPanelButton renders from content 1`] = `
 
 exports[`ContentPanelButton renders from path 1`] = `
 <CustomizedActionButton
+  ariaLabel="info and examples"
   iconProps={
     Object {
       "iconName": "iconName",

--- a/src/views/content/content-panel-button.tsx
+++ b/src/views/content/content-panel-button.tsx
@@ -33,7 +33,11 @@ export const ContentPanelButton = NamedFC<ContentPanelButtonProps>(
             contentActionMessageCreator.openContentPanel(ev, contentPath, contentTitle);
 
         return (
-            <ActionButton iconProps={{ iconName }} onClick={onClick}>
+            <ActionButton
+                iconProps={{ iconName }}
+                onClick={onClick}
+                ariaLabel={'info and examples'}
+            >
                 {children}
             </ActionButton>
         );


### PR DESCRIPTION
#### Description of changes

In the reflow UI, the content button has no visible text label like it does in the old UI, so it needs an aria-Label

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
