### PR TITLE
fix: make overview percent text black when selected

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -161,12 +161,12 @@ div.insights-file-issue-details-dialog-container {
     .ms-Nav-compositeLink.is-selected a {
         background-color: $communication-tint-40;
         border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle $communication-primary;
-        .ms-Button-label {
+        .ms-Button-label,
+        .overview-percent {
             color: $highlighted-text;
         }
-        .overview-percent,
-        .dark-gray {
-            color: $overview-percent-selected;
+        .left-nav-icon {
+            color: $left-nav-icon;
         }
     }
     .ms-DetailsRow,

--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -54,7 +54,7 @@
     z-index: 100;
     background-color: $neutral-0;
     :global {
-        .dark-gray {
+        .left-nav-icon {
             color: $neutral-60;
         }
         .ms-Nav-groupContent {
@@ -118,12 +118,12 @@
                     background-color: $communication-tint-40;
                     border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle
                         $communication-primary;
-                    .ms-Button-label {
+                    .ms-Button-label,
+                    .overview-percent {
                         color: $highlighted-text;
                     }
-                    .overview-percent,
-                    .dark-gray {
-                        color: $overview-percent-selected;
+                    .left-nav-icon {
+                        color: $left-nav-icon;
                     }
                 }
                 a::after,

--- a/src/DetailsView/components/left-nav/left-nav-icon.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-icon.tsx
@@ -12,7 +12,7 @@ export type LeftNavIconProps = {
 
 export const LeftNavStatusIcon = NamedFC<LeftNavIconProps>('LeftNavStatusIcon', props => {
     const { item } = props;
-    const classes = css('dark-gray', props.className);
+    const classes = css('left-nav-icon', props.className);
 
     return <StatusIcon status={item.status} className={classes} level="test" />;
 });

--- a/src/DetailsView/components/left-nav/overview-left-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/overview-left-nav-link.tsx
@@ -13,7 +13,7 @@ export const OverviewLeftNavLink = NamedFC<Pick<BaseLeftNavLinkProps, 'link'>>(
         return (
             <span className={styles.leftNavLinkContainer} aria-hidden="true">
                 <span>
-                    <Icon iconName="home" className={css(styles.linkIcon, 'dark-gray')} />
+                    <Icon iconName="home" className={css(styles.linkIcon, 'left-nav-icon')} />
                 </span>
                 <span className="ms-Button-label overview-label">
                     <span className="overview-name">{link.name}</span>

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -81,7 +81,7 @@ $menu-background: var(--neutral-3);
 $menu-border: var(--menu-border);
 $menu-item-background-active: var(--menu-item-background-active);
 $menu-item-background-hover: var(--menu-item-background-hover);
-$overview-percent-selected: var(--overview-percent-selected);
+$left-nav-icon: var(--left-nav-icon);
 $pill-background: var(--pill-background);
 $pill: var(--pill);
 $screenshot-image-outline: var(--screenshot-image-outline);

--- a/src/common/styles/root-level-only/color-definitions.scss
+++ b/src/common/styles/root-level-only/color-definitions.scss
@@ -81,7 +81,7 @@
     --menu-border: var(--neutral-3);
     --menu-item-background-active: var(--neutral-alpha-8);
     --menu-item-background-hover: var(--neutral-alpha-4);
-    --overview-percent-selected: var(--neutral-55);
+    --left-nav-icon: var(--neutral-55);
     --pill-background: var(--neutral-alpha-8);
     --pill: var(--primary-text);
     --spinner-text: var(--communication-primary);
@@ -149,7 +149,7 @@
         --menu-border: var(--grey);
         --menu-item-background-active: var(--communication-tint-40);
         --menu-item-background-hover: var(--grey);
-        --overview-percent-selected: var(--black);
+        --left-nav-icon: var(--black);
         --pill-background: var(--white);
         --pill: var(--black);
         --screenshot-image-outline: var(--white);

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-icon.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-icon.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`LeftNavIndexIcon render 1`] = `
 
 exports[`LeftNavStatusIcon render 1`] = `
 <StatusIcon
-  className="dark-gray some class"
+  className="left-nav-icon some class"
   level="test"
   status={0}
 />

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/overview-left-nav-link.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/overview-left-nav-link.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OverviewLeftNavLink renders 1`] = `
 >
   <span>
     <StyledIconBase
-      className="linkIcon dark-gray"
+      className="linkIcon left-nav-icon"
       iconName="home"
     />
   </span>


### PR DESCRIPTION
#### Description of changes

Fixes insufficient color contrast with gray text on the new darker background for selected nav items.

Before:
<img width="177" alt="overview percent" src="https://user-images.githubusercontent.com/55459788/87488519-76dbd800-c5f5-11ea-87b1-6969a472c345.PNG">

After:
<img width="179" alt="overview percent black" src="https://user-images.githubusercontent.com/55459788/87488528-7f341300-c5f5-11ea-8beb-da84e22478b5.PNG">

This does not change high contrast mode or the text color when overview is not selected in the nav.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3078 
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
