### PR TITLE
fix: Add aria-label to outcome summary bar

### DIFF
--- a/src/reports/components/outcome-summary-bar.tsx
+++ b/src/reports/components/outcome-summary-bar.tsx
@@ -5,7 +5,13 @@ import { NamedFC } from 'common/react/named-fc';
 import { kebabCase } from 'lodash';
 import * as React from 'react';
 
-import { outcomeIconMap, outcomeIconMapInverted, OutcomeStats, OutcomeType } from './outcome-type';
+import {
+    outcomeIconMap,
+    outcomeIconMapInverted,
+    OutcomeStats,
+    OutcomeType,
+    outcomeTypeSemantics,
+} from './outcome-type';
 
 export type OutcomeSummaryBarProps = {
     outcomeStats: Partial<OutcomeStats>;
@@ -25,8 +31,20 @@ export const OutcomeSummaryBar = NamedFC<OutcomeSummaryBarProps>('OutcomeSummary
         });
     };
 
+    const getLabel = () => {
+        const { allOutcomeTypes, outcomeStats } = props;
+        const countSuffix = props.countSuffix || '';
+        return allOutcomeTypes
+            .map(outcomeType => {
+                const count = outcomeStats[outcomeType];
+                const outcomePastTense = outcomeTypeSemantics[outcomeType].pastTense;
+                return `${count}${countSuffix} ${outcomePastTense}`;
+            })
+            .join(', ');
+    };
+
     return (
-        <div className="outcome-summary-bar">
+        <div className="outcome-summary-bar" aria-label={getLabel()} role="img">
             {props.allOutcomeTypes.map((outcomeType, index) => {
                 const { iconStyleInverted, countSuffix } = props;
                 const iconMap =

--- a/src/tests/unit/tests/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`OutcomeSummaryBar render inverted badges 1`] = `
 <div
+  aria-label="42 Passed, 13 Failed, 7 Incomplete"
   className="outcome-summary-bar"
+  role="img"
 >
   <div
     style={
@@ -63,7 +65,9 @@ exports[`OutcomeSummaryBar render inverted badges 1`] = `
 
 exports[`OutcomeSummaryBar show by count 1`] = `
 <div
+  aria-label="42 Passed, 13 Failed, 7 Incomplete"
   className="outcome-summary-bar"
+  role="img"
 >
   <div
     style={
@@ -124,7 +128,9 @@ exports[`OutcomeSummaryBar show by count 1`] = `
 
 exports[`OutcomeSummaryBar show by percentage 1`] = `
 <div
+  aria-label="42% Passed, 13% Failed, 7% Incomplete"
   className="outcome-summary-bar"
+  role="img"
 >
   <div
     style={

--- a/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
@@ -269,7 +269,9 @@ exports[`report package integration with issues 1`] = `
           Summary
         </h2>
         <div
+          aria-label="26 Failed, 20 Passed, 49 Not applicable"
           class="outcome-summary-bar"
+          role="img"
         >
           <div
             style="flex-grow:26"
@@ -7513,7 +7515,9 @@ exports[`report package integration with no issues 1`] = `
           Summary
         </h2>
         <div
+          aria-label="0 Failed, 45 Passed, 30 Not applicable"
           class="outcome-summary-bar"
+          role="img"
         >
           <div
             style="flex-grow:0"


### PR DESCRIPTION
#### Description of changes

Currently, NVDA reads this summary bar (in the overview page of assessment and in reports) as "4% 96% 0%."
<img width="641" alt="assessment after" src="https://user-images.githubusercontent.com/55459788/87571443-ecd85180-c67e-11ea-8675-5db579cd726a.PNG">
After this PR, it will read as "graphic 4% passed, 96% incomplete, 0% failed."

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3083
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
