### PR TITLE
feat(android-setup-e2e): Simulate failed service install

### DIFF
--- a/src/tests/electron/tests/android-setup-prompt-connect-to-device.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-connect-to-device.test.ts
@@ -13,7 +13,7 @@ import { AppController } from 'tests/electron/common/view-controllers/app-contro
 import {
     commonAdbConfigs,
     setupMockAdb,
-    simulateNoDevices,
+    simulateNoDevicesConnected,
 } from '../../miscellaneous/mock-adb/setup-mock-adb';
 
 describe('Android setup - prompt-connect-to-device ', () => {
@@ -22,7 +22,7 @@ describe('Android setup - prompt-connect-to-device ', () => {
     let dialog: AndroidSetupViewController;
 
     beforeEach(async () => {
-        await setupMockAdb(simulateNoDevices(defaultDeviceConfig));
+        await setupMockAdb(simulateNoDevicesConnected(defaultDeviceConfig));
         app = await createApplication({ suppressFirstTimeDialog: true });
         dialog = await app.openAndroidSetupView('prompt-connect-to-device');
     });

--- a/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
@@ -13,6 +13,7 @@ import { AppController } from 'tests/electron/common/view-controllers/app-contro
 import {
     commonAdbConfigs,
     setupMockAdb,
+    simulateServiceInstallationError,
     simulateServiceNotInstalled,
 } from '../../miscellaneous/mock-adb/setup-mock-adb';
 
@@ -40,10 +41,16 @@ describe('Android setup - prompt-install-service ', () => {
         expect(await dialog.isEnabled(getAutomationIdSelector(installAutomationId))).toBe(true);
     });
 
-    it('install button triggers installation', async () => {
+    it('install button triggers installation, prompts for permission on success', async () => {
         await setupMockAdb(defaultDeviceConfig);
         await dialog.client.click(getAutomationIdSelector(installAutomationId));
         await dialog.waitForDialogVisible('prompt-grant-permissions');
+    });
+
+    it('install button triggers installation, prompts correctly on failure', async () => {
+        await setupMockAdb(simulateServiceInstallationError(defaultDeviceConfig));
+        await dialog.client.click(getAutomationIdSelector(installAutomationId));
+        await dialog.waitForDialogVisible('prompt-install-failed');
     });
 
     it.each([true, false])(

--- a/src/tests/miscellaneous/mock-adb/common-adb-configs.js
+++ b/src/tests/miscellaneous/mock-adb/common-adb-configs.js
@@ -145,7 +145,7 @@ function cloneWithDisabledPattern(oldConfig, keyPatternToDisable) {
     return newConfig;
 }
 
-function simulateNoDevices(oldConfig) {
+function simulateNoDevicesConnected(oldConfig) {
     return cloneWithDisabledPattern(oldConfig, devicesCommandMatch + '$');
 }
 
@@ -171,7 +171,7 @@ module.exports = {
         'multiple-devices': workingDeviceCommands(['device-1', 'device-2', 'emulator-3'], 62442),
         'slow-single-device': delayAllCommands(5000, workingDeviceCommands(['device-1'], 62442)),
     },
-    simulateNoDevices,
+    simulateNoDevicesConnected,
     simulateServiceInstallationError,
     simulateServiceNotInstalled,
     simulateServiceLacksPermissions,

--- a/src/tests/miscellaneous/mock-adb/common-adb-configs.js
+++ b/src/tests/miscellaneous/mock-adb/common-adb-configs.js
@@ -15,8 +15,38 @@ const serviceInfoCommandMatch =
 const serviceIsRunningCommandMatch = 'shell dumpsys accessibility';
 const portForwardingCommandMatch = 'forward tcp:';
 
+function addDeviceEnumerationCommands(id, output) {
+    output[`-s ${id} ${devicesCommandMatch}`] = cloneDeep(output.devices);
+}
+
+function addDeviceDetailCommands(id, output) {
+    // These commands appear in the order that they get called by appium-adb
+    output[`-s ${id} shell getprop ro.product.model`] = {
+        stdout: `working mock device (${id})`,
+    };
+}
+
+function addDetectServiceCommands(id, output) {
+    // These commands appear in the order that they get called by appium-adb
+    output[`-s ${id} ${serviceInfoCommandMatch}`] = {
+        stdout: `    versionCode=102000 minSdk=24 targetSdk=28\n    versionName=${apkVersionName}`,
+    };
+}
+
+function addCheckPermissionsCommands(id, output) {
+    // These commands appear in the order that they get called by appium-adb
+    output[`-s ${id} ${serviceIsRunningCommandMatch}`] = {
+        stdout:
+            '                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}',
+    };
+    output[`-s ${id} shell dumpsys media_projection`] = {
+        stdout:
+            '(com.microsoft.accessibilityinsightsforandroidservice, uid=12354): TYPE_SCREEN_CAPTURE',
+    };
+}
+
 function addInstallServiceCommands(id, output) {
-    // These commands appear in the order that they get called
+    // These commands appear in the order that they get called by appium-adb
     output[`-s ${id} shell getprop ro.build.version.sdk`] = {
         stdout: '29',
     };
@@ -52,6 +82,18 @@ function addInstallServiceCommands(id, output) {
     };
 }
 
+function addPortForwardingCommands(id, output, port) {
+    output[`-s ${id} ${portForwardingCommandMatch}${port} tcp:62442`] = {
+        startTestServer: {
+            port,
+            path: successfulTestServerContentPath,
+        },
+    };
+    output[`-s ${id} forward --remove tcp:${port}`] = {
+        stopTestServer: { port },
+    };
+}
+
 function workingDeviceCommands(deviceIds, port) {
     const output = {
         'start-server': {},
@@ -66,33 +108,12 @@ function workingDeviceCommands(deviceIds, port) {
     }
 
     for (const id of deviceIds) {
-        output[`-s ${id} ${devicesCommandMatch}`] = cloneDeep(output.devices);
-        output[`-s ${id} shell getprop ro.product.model`] = {
-            stdout: `working mock device (${id})`,
-        };
-        output[`-s ${id} ${serviceInfoCommandMatch}`] = {
-            stdout: `    versionCode=102000 minSdk=24 targetSdk=28\n    versionName=${apkVersionName}`,
-        };
-
+        addDeviceEnumerationCommands(id, output);
+        addDeviceDetailCommands(id, output);
+        addDetectServiceCommands(id, output);
         addInstallServiceCommands(id, output);
-
-        output[`-s ${id} ${serviceIsRunningCommandMatch}`] = {
-            stdout:
-                '                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}',
-        };
-        output[`-s ${id} shell dumpsys media_projection`] = {
-            stdout:
-                '(com.microsoft.accessibilityinsightsforandroidservice, uid=12354): TYPE_SCREEN_CAPTURE',
-        };
-        output[`-s ${id} ${portForwardingCommandMatch}${port} tcp:62442`] = {
-            startTestServer: {
-                port,
-                path: successfulTestServerContentPath,
-            },
-        };
-        output[`-s ${id} forward --remove tcp:${port}`] = {
-            stopTestServer: { port },
-        };
+        addCheckPermissionsCommands(id, output);
+        addPortForwardingCommands(id, output, port);
     }
 
     return output;
@@ -123,7 +144,7 @@ function cloneWithDisabledPattern(oldConfig, keyPatternToDisable) {
     return newConfig;
 }
 
-function simulateNoDevices(oldConfig) {
+function simulateNoDevicesConnected(oldConfig) {
     return cloneWithDisabledPattern(oldConfig, devicesCommandMatch + '$');
 }
 
@@ -145,7 +166,7 @@ module.exports = {
         'multiple-devices': workingDeviceCommands(['device-1', 'device-2', 'emulator-3'], 62442),
         'slow-single-device': delayAllCommands(5000, workingDeviceCommands(['device-1'], 62442)),
     },
-    simulateNoDevices,
+    simulateNoDevicesConnected,
     simulateServiceNotInstalled,
     simulateServiceLacksPermissions,
     simulatePortForwardingError,

--- a/src/tests/miscellaneous/mock-adb/common-adb-configs.js
+++ b/src/tests/miscellaneous/mock-adb/common-adb-configs.js
@@ -14,6 +14,7 @@ const serviceInfoCommandMatch =
     'shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice';
 const serviceIsRunningCommandMatch = 'shell dumpsys accessibility';
 const portForwardingCommandMatch = 'forward tcp:';
+const sdkVersionCommandMatch = 'shell getprop ro.build.version.sdk';
 
 function addDeviceEnumerationCommands(id, output) {
     output[`-s ${id} ${devicesCommandMatch}`] = cloneDeep(output.devices);
@@ -47,7 +48,7 @@ function addCheckPermissionsCommands(id, output) {
 
 function addInstallServiceCommands(id, output) {
     // These commands appear in the order that they get called by appium-adb
-    output[`-s ${id} shell getprop ro.build.version.sdk`] = {
+    output[`-s ${id} ${sdkVersionCommandMatch}`] = {
         stdout: '29',
     };
     output[`-s ${id} shell getprop ro.build.version.release`] = {
@@ -144,12 +145,16 @@ function cloneWithDisabledPattern(oldConfig, keyPatternToDisable) {
     return newConfig;
 }
 
-function simulateNoDevicesConnected(oldConfig) {
+function simulateNoDevices(oldConfig) {
     return cloneWithDisabledPattern(oldConfig, devicesCommandMatch + '$');
 }
 
 function simulateServiceNotInstalled(oldConfig) {
     return cloneWithDisabledPattern(oldConfig, serviceInfoCommandMatch + '$');
+}
+
+function simulateServiceInstallationError(oldConfig) {
+    return cloneWithDisabledPattern(oldConfig, sdkVersionCommandMatch);
 }
 
 function simulateServiceLacksPermissions(oldConfig) {
@@ -166,7 +171,8 @@ module.exports = {
         'multiple-devices': workingDeviceCommands(['device-1', 'device-2', 'emulator-3'], 62442),
         'slow-single-device': delayAllCommands(5000, workingDeviceCommands(['device-1'], 62442)),
     },
-    simulateNoDevicesConnected,
+    simulateNoDevices,
+    simulateServiceInstallationError,
     simulateServiceNotInstalled,
     simulateServiceLacksPermissions,
     simulatePortForwardingError,

--- a/src/tests/miscellaneous/mock-adb/setup-mock-adb.d.ts
+++ b/src/tests/miscellaneous/mock-adb/setup-mock-adb.d.ts
@@ -22,7 +22,7 @@ export async function setupMockAdb(config: MockAdbConfig): Promise<void>;
 
 export type CommonAdbConfigName = 'single-device';
 export const commonAdbConfigs: { [configName in CommonAdbConfigName]: MockAdbConfig };
-export function simulateNoDevices(config: MockAdbConfig): MockAdbConfig;
+export function simulateNoDevicesConnected(config: MockAdbConfig): MockAdbConfig;
 export function simulatePortForwardingError(config: MockAdbConfig): MockAdbConfig;
 export function simulateServiceLacksPermissions(config: MockAdbConfig): MockAdbConfig;
 export function simulateServiceNotInstalled(config: MockAdbConfig): MockAdbConfig;

--- a/src/tests/miscellaneous/mock-adb/setup-mock-adb.d.ts
+++ b/src/tests/miscellaneous/mock-adb/setup-mock-adb.d.ts
@@ -26,3 +26,4 @@ export function simulateNoDevices(config: MockAdbConfig): MockAdbConfig;
 export function simulatePortForwardingError(config: MockAdbConfig): MockAdbConfig;
 export function simulateServiceLacksPermissions(config: MockAdbConfig): MockAdbConfig;
 export function simulateServiceNotInstalled(config: MockAdbConfig): MockAdbConfig;
+export function simulateServiceInstallationError(config: MockAdbConfig): MockAdbConfig;

--- a/src/tests/miscellaneous/mock-adb/setup-mock-adb.js
+++ b/src/tests/miscellaneous/mock-adb/setup-mock-adb.js
@@ -5,7 +5,7 @@ const path = require('path');
 const { promisify } = require('util');
 const {
     commonAdbConfigs,
-    simulateNoDevices,
+    simulateNoDevicesConnected,
     simulateServiceNotInstalled,
     simulateServiceLacksPermissions,
     simulatePortForwardingError,
@@ -33,7 +33,7 @@ module.exports = {
     mockAdbFolder,
     setupMockAdb,
     commonAdbConfigs,
-    simulateNoDevices,
+    simulateNoDevicesConnected,
     simulateServiceNotInstalled,
     simulateServiceLacksPermissions,
     simulatePortForwardingError,

--- a/src/tests/miscellaneous/mock-adb/setup-mock-adb.js
+++ b/src/tests/miscellaneous/mock-adb/setup-mock-adb.js
@@ -7,6 +7,7 @@ const {
     commonAdbConfigs,
     simulateNoDevicesConnected,
     simulateServiceNotInstalled,
+    simulateServiceInstallationError,
     simulateServiceLacksPermissions,
     simulatePortForwardingError,
 } = require('./common-adb-configs');
@@ -35,6 +36,7 @@ module.exports = {
     commonAdbConfigs,
     simulateNoDevicesConnected,
     simulateServiceNotInstalled,
+    simulateServiceInstallationError,
     simulateServiceLacksPermissions,
     simulatePortForwardingError,
 };


### PR DESCRIPTION
#### Description of changes
To test the "installation failed" step, we need to be able to simulate a failed installation. This PR adds this functionality. It also adds to test to exercise it, and it introduces a refactor into common-adb-configs.js to bring a little more structure into building mock-adb-config.json. I validated the common-adb-configs.js changes by running all supported flavors of **yarn mock-adb** both with and without the changes and performing file comparisons of the output files. The results were identical.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: (1748572)[https://mseng.visualstudio.com/1ES/_workitems/edit/1748572]
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
