### PR TITLE
Chore: Add null checks

### DIFF
--- a/src/electron/common/get-electron-icon-path.ts
+++ b/src/electron/common/get-electron-icon-path.ts
@@ -4,8 +4,15 @@ import { ConfigAccessor } from 'common/configuration/configuration-types';
 import { OSType } from 'electron/window-management/platform-info';
 import * as path from 'path';
 
-export function getElectronIconPath(config: ConfigAccessor, os: OSType): string {
+export function getElectronIconPath(config: ConfigAccessor, os: OSType): string | null {
     const baseIconPath = config.getOption('electronIconBaseName');
+    if (baseIconPath == null) {
+        console.log(
+            "The function getElectronIconPath received an undefined value for the option 'electronIconBaseName'",
+        );
+        return null;
+    }
+
     const iconBaseName = path.join(__dirname, '..', baseIconPath);
     const iconExtension = os === OSType.Windows ? 'ico' : os === OSType.Mac ? 'icns' : 'png';
     return `${iconBaseName}.${iconExtension}`;

--- a/src/electron/window-management/platform-info.ts
+++ b/src/electron/window-management/platform-info.ts
@@ -2,23 +2,40 @@
 // Licensed under the MIT License.
 
 export enum OSType {
+    Unsupported,
     Windows,
     Linux,
     Mac,
 }
+
 export class PlatformInfo {
     constructor(private readonly currentProcess: NodeJS.Process) {}
 
     public getOs(): OSType {
-        if (this.currentProcess.platform === 'win32') {
-            return OSType.Windows;
-        } else if (this.currentProcess.platform === 'linux') {
-            return OSType.Linux;
-        } else if (this.currentProcess.platform === 'darwin') {
-            return OSType.Mac;
+        switch (this.currentProcess.platform) {
+            case 'win32':
+                return OSType.Windows;
+            case 'linux':
+                return OSType.Linux;
+            case 'darwin':
+                return OSType.Mac;
+            case 'aix':
+            case 'android':
+            case 'cygwin':
+            case 'freebsd':
+            case 'netbsd':
+            case 'openbsd':
+            case 'sunos':
+                return OSType.Unsupported;
+            default:
+                this.onUnsupportedOS(this.currentProcess.platform);
         }
+    }
 
-        return null;
+    // The following function ensures  exhaustiveness checking where it is used in a switch statement
+    // See https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
+    private onUnsupportedOS(platform: never): never {
+        throw Error(`Unexpected OS: ${platform}`);
     }
 
     public isMac(): boolean {

--- a/src/tests/unit/tests/electron/common/get-electron-icon-path.test.ts
+++ b/src/tests/unit/tests/electron/common/get-electron-icon-path.test.ts
@@ -36,4 +36,27 @@ describe('getElectronIconPath', () => {
         configMock.verifyAll();
         pathJoinMock.verifyAll();
     });
+
+    it.each([
+        [`.ico`, OSType.Windows],
+        [`.icns`, OSType.Mac],
+        [`.png`, OSType.Linux],
+    ])('returns null when config option is not set', (extension: string, os: OSType) => {
+        const configMock = Mock.ofType(FileSystemConfiguration, MockBehavior.Strict);
+        configMock
+            .setup(m => m.getOption('electronIconBaseName'))
+            .returns(_ => undefined)
+            .verifiable();
+
+        const consoleMock = GlobalMock.ofInstance(console.log, 'log', console, MockBehavior.Strict);
+        consoleMock.setup(m => m(It.isAnyString())).verifiable();
+
+        GlobalScope.using(consoleMock).with(() => {
+            const actual = getElectronIconPath(configMock.object, os);
+            expect(actual).toBeNull();
+        });
+
+        configMock.verifyAll();
+        consoleMock.verifyAll();
+    });
 });

--- a/src/tests/unit/tests/electron/window-management/platform-info.test.ts
+++ b/src/tests/unit/tests/electron/window-management/platform-info.test.ts
@@ -21,6 +21,13 @@ describe(PlatformInfo, () => {
             { platformName: 'linux', osType: OSType.Linux },
             { platformName: 'darwin', osType: OSType.Mac },
             { platformName: 'win32', osType: OSType.Windows },
+            { platformName: 'aix', osType: OSType.Unsupported },
+            { platformName: 'android', osType: OSType.Unsupported },
+            { platformName: 'freebsd', osType: OSType.Unsupported },
+            { platformName: 'openbsd', osType: OSType.Unsupported },
+            { platformName: 'sunos', osType: OSType.Unsupported },
+            { platformName: 'cygwin', osType: OSType.Unsupported },
+            { platformName: 'netbsd', osType: OSType.Unsupported },
         ] as GetOsTestCase[])('validate getOs %o', (testCase: GetOsTestCase) => {
             processMock.setup(p => p.platform).returns(() => testCase.platformName);
 

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -35,6 +35,7 @@
         "./src/DetailsView/components/test-status-choice-group.tsx",
         "./src/Devtools/inspect-handler.ts",
         "./src/Devtools/target-page-inspector.ts",
+        "./src/electron/common/get-electron-icon-path.ts",
         "./src/ad-hoc-visualizations/issues/get-notification-message.ts",
         "./src/assessments/audio-video-only/test-steps/test-steps.ts",
         "./src/assessments/auto-pass-if-no-results.ts",


### PR DESCRIPTION
Most changes should be self explanitory.

In platform-info.ts, there was a choice of whether or not to extend OSType to include all the possible values of the NodeJS Platform type and then use [exhaustiveness checking](https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking) to ensure all possible values are handled.I chose the exhaustiveness checking approach because it can be caught at compile time rather than during unit testing.

#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
