### PR TITLE
Chore: Add null checks

### DIFF
--- a/src/electron/common/get-electron-icon-path.ts
+++ b/src/electron/common/get-electron-icon-path.ts
@@ -4,8 +4,15 @@ import { ConfigAccessor } from 'common/configuration/configuration-types';
 import { OSType } from 'electron/window-management/platform-info';
 import * as path from 'path';
 
-export function getElectronIconPath(config: ConfigAccessor, os: OSType): string {
+export function getElectronIconPath(config: ConfigAccessor, os: OSType): string | null {
     const baseIconPath = config.getOption('electronIconBaseName');
+    if (baseIconPath == null) {
+        console.log(
+            "The function getElectronIconPath received an undefined value for the option 'electronIconBaseName'",
+        );
+        return null;
+    }
+
     const iconBaseName = path.join(__dirname, '..', baseIconPath);
     const iconExtension = os === OSType.Windows ? 'ico' : os === OSType.Mac ? 'icns' : 'png';
     return `${iconBaseName}.${iconExtension}`;

--- a/src/electron/window-management/platform-info.ts
+++ b/src/electron/window-management/platform-info.ts
@@ -2,23 +2,40 @@
 // Licensed under the MIT License.
 
 export enum OSType {
+    Unsupported,
     Windows,
     Linux,
     Mac,
 }
+
 export class PlatformInfo {
     constructor(private readonly currentProcess: NodeJS.Process) {}
 
     public getOs(): OSType {
-        if (this.currentProcess.platform === 'win32') {
-            return OSType.Windows;
-        } else if (this.currentProcess.platform === 'linux') {
-            return OSType.Linux;
-        } else if (this.currentProcess.platform === 'darwin') {
-            return OSType.Mac;
+        switch (this.currentProcess.platform) {
+            case 'win32':
+                return OSType.Windows;
+            case 'linux':
+                return OSType.Linux;
+            case 'darwin':
+                return OSType.Mac;
+            case 'aix':
+            case 'android':
+            case 'cygwin':
+            case 'freebsd':
+            case 'netbsd':
+            case 'openbsd':
+            case 'sunos':
+                return OSType.Unsupported;
+            default:
+                this.onUnsupportedOS(this.currentProcess.platform);
         }
+    }
 
-        return null;
+    // The following function ensures  exhaustiveness checking where it is used in a switch statement
+    // See https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
+    private onUnsupportedOS(platform: never): never {
+        throw Error(`Unexpected OS: ${platform}`);
     }
 
     public isMac(): boolean {

--- a/src/tests/unit/tests/electron/common/get-electron-icon-path.test.ts
+++ b/src/tests/unit/tests/electron/common/get-electron-icon-path.test.ts
@@ -36,4 +36,27 @@ describe('getElectronIconPath', () => {
         configMock.verifyAll();
         pathJoinMock.verifyAll();
     });
+
+    it.each([
+        [`.ico`, OSType.Windows],
+        [`.icns`, OSType.Mac],
+        [`.png`, OSType.Linux],
+    ])('returns null when config option is not set', (extension: string, os: OSType) => {
+        const configMock = Mock.ofType(FileSystemConfiguration, MockBehavior.Strict);
+        configMock
+            .setup(m => m.getOption('electronIconBaseName'))
+            .returns(_ => undefined)
+            .verifiable();
+
+        const consoleMock = GlobalMock.ofInstance(console.log, 'log', console, MockBehavior.Strict);
+        consoleMock.setup(m => m(It.isAnyString())).verifiable();
+
+        GlobalScope.using(consoleMock).with(() => {
+            const actual = getElectronIconPath(configMock.object, os);
+            expect(actual).toBeNull();
+        });
+
+        configMock.verifyAll();
+        consoleMock.verifyAll();
+    });
 });

--- a/src/tests/unit/tests/electron/window-management/platform-info.test.ts
+++ b/src/tests/unit/tests/electron/window-management/platform-info.test.ts
@@ -21,6 +21,13 @@ describe(PlatformInfo, () => {
             { platformName: 'linux', osType: OSType.Linux },
             { platformName: 'darwin', osType: OSType.Mac },
             { platformName: 'win32', osType: OSType.Windows },
+            { platformName: 'aix', osType: OSType.Unsupported },
+            { platformName: 'android', osType: OSType.Unsupported },
+            { platformName: 'freebsd', osType: OSType.Unsupported },
+            { platformName: 'openbsd', osType: OSType.Unsupported },
+            { platformName: 'sunos', osType: OSType.Unsupported },
+            { platformName: 'cygwin', osType: OSType.Unsupported },
+            { platformName: 'netbsd', osType: OSType.Unsupported },
         ] as GetOsTestCase[])('validate getOs %o', (testCase: GetOsTestCase) => {
             processMock.setup(p => p.platform).returns(() => testCase.platformName);
 

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -35,6 +35,7 @@
         "./src/DetailsView/components/test-status-choice-group.tsx",
         "./src/Devtools/inspect-handler.ts",
         "./src/Devtools/target-page-inspector.ts",
+        "./src/electron/common/get-electron-icon-path.ts",
         "./src/ad-hoc-visualizations/issues/get-notification-message.ts",
         "./src/assessments/audio-video-only/test-steps/test-steps.ts",
         "./src/assessments/auto-pass-if-no-results.ts",


### PR DESCRIPTION
#### Description of changes

Most changes should be self explanitory.

In platform-info.ts, there was a choice of whether or not to extend OSType to include all the possible values of the NodeJS Platform type and then use [exhaustiveness checking](https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking) to ensure all possible values are handled.I chose the exhaustiveness checking approach because it can be caught at compile time rather than during unit testing.
