### PR TITLE
Bump ts-loader to 8.0.1 by hand

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
         "spectron": "^10.0.1",
         "terser-webpack-plugin": "^3.0.6",
         "ts-jest": "^26.1.2",
-        "ts-loader": "^8.0.0",
+        "ts-loader": "^8.0.1",
         "tslint": "^5.20.1",
         "tslint-microsoft-contrib": "6.2.0",
         "typed-scss-modules": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10876,10 +10876,10 @@ ts-jest@^26.1.2:
     semver "7.x"
     yargs-parser "18.x"
 
-ts-loader@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.0.tgz#faf4b1617dcc4a24c2925d92c5b19e9c6621064d"
-  integrity sha512-giEW167rtK1V6eX/DnXEtOgcawwoIp6hqznqYNNSmraUZOq36zMhwBq12JMlYhxf50BC58bscsTSKKtE42zAuw==
+ts-loader@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.1.tgz#9670dcbce2a8c8506d01a37fee042350d02c8c21"
+  integrity sha512-I9Nmly0ufJoZRMuAT9d5ijsC2B7oSPvUnOJt/GhgoATlPGYfa17VicDKPcqwUCrHpOkCxr/ybLYwbnS4cOxmvQ==
   dependencies:
     chalk "^2.3.0"
     enhanced-resolve "^4.0.0"


### PR DESCRIPTION
#### Description of changes

The PR build for the dependabot PR failed to report its results to GitHub and there was no way to get the build to rerun from GitHub.

I updated the package by running
$yarn upgrade ts-loader

I modified package.json by hand.
