### PR TITLE
fix: tests in assessments show collapsed/expanded state for ATs

### DIFF
--- a/src/DetailsView/components/base-left-nav.tsx
+++ b/src/DetailsView/components/base-left-nav.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { Button, INav, INavButtonProps, INavLink, Nav } from 'office-ui-fabric-react';
+import { NavLinkButton } from 'DetailsView/components/nav-link-button';
+import { INav, INavLink, LinkBase, Nav } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export type onBaseLeftNavItemClick = (
-    event: React.MouseEvent<HTMLElement>,
+    event: React.MouseEvent<HTMLElement | LinkBase, MouseEvent>,
     item: BaseLeftNavLink,
 ) => void;
 export type onBaseLeftNavItemRender = (link: BaseLeftNavLink) => JSX.Element;
@@ -27,59 +28,24 @@ export interface BaseLeftNavLinkProps {
     renderIcon: (link: BaseLeftNavLink) => JSX.Element;
 }
 
-export class BaseLeftNav extends React.Component<BaseLeftNavProps> {
-    public static pivotItemsClassName = 'details-view-test-nav-area';
-    public render(): JSX.Element {
-        const { selectedKey, links, setNavComponentRef } = this.props;
+export const BaseLeftNav = NamedFC<BaseLeftNavProps>('BaseLeftNav', props => {
+    const { selectedKey, links, setNavComponentRef } = props;
+    const pivotItemsClassName = 'details-view-test-nav-area';
 
-        return (
-            <Nav
-                className={BaseLeftNav.pivotItemsClassName}
-                selectedKey={selectedKey}
-                groups={[
-                    {
-                        links,
-                    },
-                ]}
-                linkAs={LinkButton}
-                onRenderLink={this.onRenderLink}
-                onLinkClick={this.onNavLinkClick}
-                styles={{
-                    chevronButton: 'hidden',
-                }}
-                componentRef={setNavComponentRef}
-            />
-        );
-    }
-
-    protected onNavLinkClick = (
-        event: React.MouseEvent<HTMLElement>,
-        item: BaseLeftNavLink,
-    ): void => {
-        if (item) {
-            item.onClickNavLink(event, item);
-        }
-    };
-
-    protected onRenderLink = (link: BaseLeftNavLink): JSX.Element => {
-        return link.onRenderNavLink(link);
-    };
-}
-
-interface BaseNavButtonProps extends INavButtonProps {
-    link: BaseLeftNavLink;
-}
-
-const LinkButton = NamedFC<BaseNavButtonProps>('LinkButton', props => {
-    const link = props.link;
     return (
-        <Button
-            aria-expanded={link.isExpanded}
-            tabIndex={0}
-            title={link.title}
-            onClick={e => link.onClickNavLink(e as any, link)}
-        >
-            {link.onRenderNavLink(link)}
-        </Button>
+        <Nav
+            className={pivotItemsClassName}
+            selectedKey={selectedKey}
+            groups={[
+                {
+                    links,
+                },
+            ]}
+            linkAs={NavLinkButton}
+            styles={{
+                chevronButton: 'hidden',
+            }}
+            componentRef={setNavComponentRef}
+        />
     );
 });

--- a/src/DetailsView/components/base-left-nav.tsx
+++ b/src/DetailsView/components/base-left-nav.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { INav, INavLink, Nav } from 'office-ui-fabric-react';
+import { NamedFC } from 'common/react/named-fc';
+import { Button, INav, INavButtonProps, INavLink, Nav } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export type onBaseLeftNavItemClick = (
@@ -40,6 +41,7 @@ export class BaseLeftNav extends React.Component<BaseLeftNavProps> {
                         links,
                     },
                 ]}
+                linkAs={LinkButton}
                 onRenderLink={this.onRenderLink}
                 onLinkClick={this.onNavLinkClick}
                 styles={{
@@ -63,3 +65,21 @@ export class BaseLeftNav extends React.Component<BaseLeftNavProps> {
         return link.onRenderNavLink(link);
     };
 }
+
+interface BaseNavButtonProps extends INavButtonProps {
+    link: BaseLeftNavLink;
+}
+
+const LinkButton = NamedFC<BaseNavButtonProps>('LinkButton', props => {
+    const link = props.link;
+    return (
+        <Button
+            aria-expanded={link.isExpanded}
+            tabIndex={0}
+            title={link.title}
+            onClick={e => link.onClickNavLink(e as any, link)}
+        >
+            {link.onRenderNavLink(link)}
+        </Button>
+    );
+});

--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -102,7 +102,6 @@
                 border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle $neutral-0;
                 border-top: 0px;
                 border-bottom: 0px;
-                text-align: center;
             }
             .ms-Button-label {
                 color: $neutral-100;
@@ -111,6 +110,7 @@
                 color: $secondary-text;
                 background: $neutral-0;
                 border-color: $neutral-20;
+                text-align: center;
             }
             &.is-selected {
                 a,

--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -221,6 +221,9 @@ export class LeftNavLinkBuilder {
             ...baselink,
             status,
             title: `${index}: ${name} (${narratorTestStatus})`,
+            // title: `${index}: ${name} (${narratorTestStatus}) ${
+            //     isExpanded ? 'expanded' : 'collapsed'
+            // }`,
             links: [gettingStartedLink, ...requirementLinks],
             isExpanded: isExpanded,
             testType: assessment.visualizationType,

--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -221,9 +221,6 @@ export class LeftNavLinkBuilder {
             ...baselink,
             status,
             title: `${index}: ${name} (${narratorTestStatus})`,
-            // title: `${index}: ${name} (${narratorTestStatus}) ${
-            //     isExpanded ? 'expanded' : 'collapsed'
-            // }`,
             links: [gettingStartedLink, ...requirementLinks],
             isExpanded: isExpanded,
             testType: assessment.visualizationType,

--- a/src/DetailsView/components/nav-link-button.scss
+++ b/src/DetailsView/components/nav-link-button.scss
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
-button.nav-link-button {
-    &:hover,
-    &:active,
-    &:focus,
-    &:active:hover {
-        text-decoration: none;
+a,
+button {
+    &.nav-link-button {
+        &:hover,
+        &:active,
+        &:focus,
+        &:active:hover {
+            text-decoration: none;
+        }
     }
 }

--- a/src/DetailsView/components/nav-link-button.scss
+++ b/src/DetailsView/components/nav-link-button.scss
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+@import '../../common/styles/common.scss';
 a,
 button {
     &.nav-link-button {
+        width: calc(100% - #{$pivotItemLeftBorderWidth});
         &:hover,
         &:active,
         &:focus,

--- a/src/DetailsView/components/nav-link-button.scss
+++ b/src/DetailsView/components/nav-link-button.scss
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+button.nav-link-button {
+    &:hover,
+    &:active,
+    &:focus,
+    &:active:hover {
+        text-decoration: none;
+    }
+}

--- a/src/DetailsView/components/nav-link-button.tsx
+++ b/src/DetailsView/components/nav-link-button.tsx
@@ -15,10 +15,10 @@ export const NavLinkButton = NamedFC<NavLinkButtonProps>('NavLinkButton', props 
     return (
         <Link
             aria-expanded={link.isExpanded}
-            title={link.title}
+            title={link.title || link.name}
             onClick={e => link.onClickNavLink(e, link)}
             className={css(styles.navLinkButton, props.className)}
-            href={link.forceAnchor === true ? '#' : undefined}
+            href={link.forceAnchor === true ? 'javascript:void(0)' : undefined}
         >
             {link.onRenderNavLink(link)}
         </Link>

--- a/src/DetailsView/components/nav-link-button.tsx
+++ b/src/DetailsView/components/nav-link-button.tsx
@@ -18,6 +18,7 @@ export const NavLinkButton = NamedFC<NavLinkButtonProps>('NavLinkButton', props 
             title={link.title}
             onClick={e => link.onClickNavLink(e, link)}
             className={css(styles.navLinkButton, props.className)}
+            href={link.forceAnchor === true ? '#' : undefined}
         >
             {link.onRenderNavLink(link)}
         </Link>

--- a/src/DetailsView/components/nav-link-button.tsx
+++ b/src/DetailsView/components/nav-link-button.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { BaseLeftNavLink } from 'DetailsView/components/base-left-nav';
+import * as styles from 'DetailsView/components/nav-link-button.scss';
+import { css, INavButtonProps, Link } from 'office-ui-fabric-react';
+import * as React from 'react';
+
+export interface NavLinkButtonProps extends INavButtonProps {
+    link: BaseLeftNavLink;
+}
+
+export const NavLinkButton = NamedFC<NavLinkButtonProps>('NavLinkButton', props => {
+    const link = props.link;
+    return (
+        <Link
+            aria-expanded={link.isExpanded}
+            title={link.title}
+            onClick={e => link.onClickNavLink(e, link)}
+            className={css(styles.navLinkButton, props.className)}
+        >
+            {link.onRenderNavLink(link)}
+        </Link>
+    );
+});

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/base-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/base-left-nav.test.tsx.snap
@@ -13,8 +13,7 @@ exports[`BaseLeftNav should render 1`] = `
       },
     ]
   }
-  onLinkClick={[Function]}
-  onRenderLink={[Function]}
+  linkAs={[Function]}
   selectedKey="some key"
   styles={
     Object {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavLinkButton renders 1`] = `
+<StyledLinkBase
+  aria-expanded={true}
+  className="navLinkButton some class name"
+  onClick={[Function]}
+  title="some title"
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
@@ -1,16 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NavLinkButton renders as anchor tag 1`] = `
+exports[`NavLinkButton renders as button element 1`] = `
 <StyledLinkBase
   aria-expanded={true}
   className="navLinkButton some class name"
-  href="#"
   onClick={[Function]}
   title="some title"
 />
 `;
 
-exports[`NavLinkButton renders as button element 1`] = `
+exports[`NavLinkButton renders with href set 1`] = `
+<StyledLinkBase
+  aria-expanded={true}
+  className="navLinkButton some class name"
+  href="javascript:void(0)"
+  onClick={[Function]}
+  title="some title"
+/>
+`;
+
+exports[`NavLinkButton renders with using name instead of title 1`] = `
 <StyledLinkBase
   aria-expanded={true}
   className="navLinkButton some class name"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
@@ -1,6 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NavLinkButton renders 1`] = `
+exports[`NavLinkButton renders as anchor tag 1`] = `
+<StyledLinkBase
+  aria-expanded={true}
+  className="navLinkButton some class name"
+  href="#"
+  onClick={[Function]}
+  title="some title"
+/>
+`;
+
+exports[`NavLinkButton renders as button element 1`] = `
 <StyledLinkBase
   aria-expanded={true}
   className="navLinkButton some class name"

--- a/src/tests/unit/tests/DetailsView/components/base-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/base-left-nav.test.tsx
@@ -1,28 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NavLinkButton } from 'DetailsView/components/nav-link-button';
 import { shallow } from 'enzyme';
+import { Nav } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { Mock, MockBehavior } from 'typemoq';
-
 import {
     BaseLeftNav,
     BaseLeftNavLink,
     BaseLeftNavProps,
-    onBaseLeftNavItemRender,
 } from '../../../../../DetailsView/components/base-left-nav';
-
-class TestableBaseLeftNav extends BaseLeftNav {
-    public getOnNavLinkClick(): (
-        event: React.MouseEvent<HTMLElement>,
-        item: BaseLeftNavLink,
-    ) => void {
-        return this.onNavLinkClick;
-    }
-
-    public getOnRenderLink(): (link: BaseLeftNavLink) => JSX.Element {
-        return this.onRenderLink;
-    }
-}
 
 describe('BaseLeftNav', () => {
     it('should render', () => {
@@ -34,45 +20,6 @@ describe('BaseLeftNav', () => {
 
         const actual = shallow(<BaseLeftNav {...props} />);
         expect(actual.getElement()).toMatchSnapshot();
-    });
-
-    it('render side-effect: onNavLinkClick with null item', () => {
-        const props = {} as BaseLeftNavProps;
-        const actual = new TestableBaseLeftNav(props);
-
-        const onLinkClickCallback = actual.getOnNavLinkClick();
-        onLinkClickCallback(null, null);
-    });
-
-    it('render side-effect: onNavLinkClick with item', () => {
-        const props = {} as BaseLeftNavProps;
-        const actual = new TestableBaseLeftNav(props);
-        const eventStub = {} as React.MouseEvent<HTMLElement>;
-        const onClickNavLinkMock = Mock.ofInstance((event, item) => null, MockBehavior.Strict);
-        const itemStub = {
-            onClickNavLink: onClickNavLinkMock.object,
-        } as BaseLeftNavLink;
-        const onLinkClickCallback = actual.getOnNavLinkClick();
-
-        onClickNavLinkMock.setup(ocnlm => ocnlm(eventStub, itemStub)).verifiable();
-
-        onLinkClickCallback(eventStub, itemStub);
-
-        onClickNavLinkMock.verifyAll();
-    });
-
-    it('render side-effect: onRenderLink with item', () => {
-        const props = {} as BaseLeftNavProps;
-        const actual = new TestableBaseLeftNav(props);
-        const elemnentStub = {} as JSX.Element;
-        const onRenderNavLinkMock = Mock.ofType<onBaseLeftNavItemRender>(null, MockBehavior.Strict);
-        const itemStub = {
-            onRenderNavLink: onRenderNavLinkMock.object,
-        } as BaseLeftNavLink;
-        const onRenderLinkCallback = actual.getOnRenderLink();
-
-        onRenderNavLinkMock.setup(ocnlm => ocnlm(itemStub)).returns(() => elemnentStub);
-
-        expect(onRenderLinkCallback(itemStub)).toEqual(elemnentStub);
+        expect(actual.find(Nav).prop('linkAs')).toEqual(NavLinkButton);
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/nav-link-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/nav-link-button.test.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    onBaseLeftNavItemClick,
+    onBaseLeftNavItemRender,
+} from 'DetailsView/components/base-left-nav';
+import { NavLinkButton, NavLinkButtonProps } from 'DetailsView/components/nav-link-button';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { Mock } from 'typemoq';
+
+describe('NavLinkButton', () => {
+    test('renders', () => {
+        const onClickNavLinkMock = Mock.ofType<onBaseLeftNavItemClick>();
+        const onRenderNavLink = Mock.ofType<onBaseLeftNavItemRender>();
+        const props: NavLinkButtonProps = {
+            link: {
+                isExpanded: true,
+                title: 'some title',
+                onClickNavLink: onClickNavLinkMock.object,
+                onRenderNavLink: onRenderNavLink.object,
+            },
+            className: 'some class name',
+        } as NavLinkButtonProps;
+
+        const testSubject = shallow(<NavLinkButton {...props} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/nav-link-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/nav-link-button.test.tsx
@@ -7,22 +7,33 @@ import {
 import { NavLinkButton, NavLinkButtonProps } from 'DetailsView/components/nav-link-button';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Mock } from 'typemoq';
+import { IMock, Mock } from 'typemoq';
 
 describe('NavLinkButton', () => {
-    test('renders', () => {
-        const onClickNavLinkMock = Mock.ofType<onBaseLeftNavItemClick>();
-        const onRenderNavLink = Mock.ofType<onBaseLeftNavItemRender>();
-        const props: NavLinkButtonProps = {
+    let onClickNavLinkMock: IMock<onBaseLeftNavItemClick>;
+    let onRenderNavLinkMock: IMock<onBaseLeftNavItemRender>;
+    let props: NavLinkButtonProps;
+    beforeEach(() => {
+        onClickNavLinkMock = Mock.ofType<onBaseLeftNavItemClick>();
+        onRenderNavLinkMock = Mock.ofType<onBaseLeftNavItemRender>();
+        props = {
             link: {
                 isExpanded: true,
                 title: 'some title',
                 onClickNavLink: onClickNavLinkMock.object,
-                onRenderNavLink: onRenderNavLink.object,
+                onRenderNavLink: onRenderNavLinkMock.object,
             },
             className: 'some class name',
         } as NavLinkButtonProps;
+    });
 
+    test('renders as button element', () => {
+        const testSubject = shallow(<NavLinkButton {...props} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    test('renders as anchor tag', () => {
+        props.link.forceAnchor = true;
         const testSubject = shallow(<NavLinkButton {...props} />);
         expect(testSubject.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/DetailsView/components/nav-link-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/nav-link-button.test.tsx
@@ -32,8 +32,14 @@ describe('NavLinkButton', () => {
         expect(testSubject.getElement()).toMatchSnapshot();
     });
 
-    test('renders as anchor tag', () => {
+    test('renders with href set', () => {
         props.link.forceAnchor = true;
+        const testSubject = shallow(<NavLinkButton {...props} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    test('renders with using name instead of title', () => {
+        props.link.name = 'some name';
         const testSubject = shallow(<NavLinkButton {...props} />);
         expect(testSubject.getElement()).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

Due to #3100, we have to render the link component ourselves in the nav. 

Here is a gif of the resulting work (with NVDA).

Left is Insider, right is local build.
![customnavlinkbutton](https://user-images.githubusercontent.com/32555133/87842149-0fc15c00-c85f-11ea-83d1-e72d03eb4be5.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3100 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
