### PR TITLE
fix: update detect service dialog text

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/detect-service-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/detect-service-step.tsx
@@ -11,7 +11,7 @@ export const DetectServiceStep = NamedFC<CommonAndroidSetupStepProps>(
         return (
             <AndroidSetupSpinnerStep
                 deps={props.deps}
-                spinnerLabel="Scanning for devices..."
+                spinnerLabel="Detecting service..."
                 disableCancel={true}
             />
         );

--- a/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
@@ -12,7 +12,6 @@ import { AndroidSetupViewController } from 'tests/electron/common/view-controlle
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
 import {
     commonAdbConfigs,
-    delayAllCommands,
     setupMockAdb,
     simulateServiceInstallationError,
     simulateServiceNotInstalled,
@@ -24,11 +23,9 @@ describe('Android setup - prompt-install-service ', () => {
     let dialog: AndroidSetupViewController;
 
     beforeEach(async () => {
-        await setupMockAdb(
-            delayAllCommands(2500, simulateServiceNotInstalled(defaultDeviceConfig)),
-        );
+        await setupMockAdb(simulateServiceNotInstalled(defaultDeviceConfig));
         app = await createApplication({ suppressFirstTimeDialog: true });
-        dialog = await app.openAndroidSetupView('detect-service');
+        dialog = await app.openAndroidSetupView('prompt-install-service');
     });
 
     afterEach(async () => {
@@ -38,7 +35,6 @@ describe('Android setup - prompt-install-service ', () => {
     });
 
     it('initial component state is correct', async () => {
-        await dialog.waitForDialogVisible('prompt-install-service');
         const [closeId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
         expect(await dialog.isEnabled(getAutomationIdSelector(closeId))).toBe(true);
         expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(false);
@@ -46,22 +42,18 @@ describe('Android setup - prompt-install-service ', () => {
     });
 
     it('install button triggers installation, prompts for permission on success', async () => {
-        await dialog.waitForDialogVisible('prompt-install-service');
         await setupMockAdb(defaultDeviceConfig);
         await dialog.client.click(getAutomationIdSelector(installAutomationId));
         await dialog.waitForDialogVisible('prompt-grant-permissions');
     });
 
     it('install button triggers installation, prompts correctly on failure', async () => {
-        await dialog.waitForDialogVisible('prompt-install-service');
         await setupMockAdb(simulateServiceInstallationError(defaultDeviceConfig));
         await dialog.client.click(getAutomationIdSelector(installAutomationId));
         await dialog.waitForDialogVisible('prompt-install-failed');
     });
 
-    it('spinner & prompt dialogs pass accessibility validation in both contrast modes', async () => {
-        await scanForAccessibilityIssuesInAllModes(app);
-        await dialog.waitForDialogVisible('prompt-install-service');
+    it('should pass accessibility validation in both contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });
 });

--- a/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
@@ -12,6 +12,7 @@ import { AndroidSetupViewController } from 'tests/electron/common/view-controlle
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
 import {
     commonAdbConfigs,
+    delayAllCommands,
     setupMockAdb,
     simulateServiceInstallationError,
     simulateServiceNotInstalled,
@@ -23,9 +24,11 @@ describe('Android setup - prompt-install-service ', () => {
     let dialog: AndroidSetupViewController;
 
     beforeEach(async () => {
-        await setupMockAdb(simulateServiceNotInstalled(defaultDeviceConfig));
+        await setupMockAdb(
+            delayAllCommands(2500, simulateServiceNotInstalled(defaultDeviceConfig)),
+        );
         app = await createApplication({ suppressFirstTimeDialog: true });
-        dialog = await app.openAndroidSetupView('prompt-install-service');
+        dialog = await app.openAndroidSetupView('detect-service');
     });
 
     afterEach(async () => {
@@ -35,6 +38,7 @@ describe('Android setup - prompt-install-service ', () => {
     });
 
     it('initial component state is correct', async () => {
+        await dialog.waitForDialogVisible('prompt-install-service');
         const [closeId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
         expect(await dialog.isEnabled(getAutomationIdSelector(closeId))).toBe(true);
         expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(false);
@@ -42,18 +46,22 @@ describe('Android setup - prompt-install-service ', () => {
     });
 
     it('install button triggers installation, prompts for permission on success', async () => {
+        await dialog.waitForDialogVisible('prompt-install-service');
         await setupMockAdb(defaultDeviceConfig);
         await dialog.client.click(getAutomationIdSelector(installAutomationId));
         await dialog.waitForDialogVisible('prompt-grant-permissions');
     });
 
     it('install button triggers installation, prompts correctly on failure', async () => {
+        await dialog.waitForDialogVisible('prompt-install-service');
         await setupMockAdb(simulateServiceInstallationError(defaultDeviceConfig));
         await dialog.client.click(getAutomationIdSelector(installAutomationId));
         await dialog.waitForDialogVisible('prompt-install-failed');
     });
 
-    it('should pass accessibility validation in both contrast modes', async () => {
+    it('spinner & prompt dialogs pass accessibility validation in both contrast modes', async () => {
+        await scanForAccessibilityIssuesInAllModes(app);
+        await dialog.waitForDialogVisible('prompt-install-service');
         await scanForAccessibilityIssuesInAllModes(app);
     });
 });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-service-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-service-step.test.tsx.snap
@@ -13,6 +13,6 @@ exports[`DetectServiceStep renders 1`] = `
     }
   }
   disableCancel={true}
-  spinnerLabel="Scanning for devices..."
+  spinnerLabel="Detecting service..."
 />
 `;


### PR DESCRIPTION
#### Description of changes

This PR updates outdated text in the step. It had the wrong text from the detect devices step.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
