### PR TITLE
feat(android-setup-e2e): Add tests for prompt-install-failed

### DIFF
--- a/src/tests/electron/tests/android-setup-prompt-install-failed.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-failed.test.ts
@@ -40,8 +40,8 @@ describe('Android setup - prompt-install-service-failed ', () => {
     });
 
     it('initial component state is correct', async () => {
-        const [closeId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
-        expect(await dialog.isEnabled(getAutomationIdSelector(closeId))).toBe(true);
+        const [cancel, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
+        expect(await dialog.isEnabled(getAutomationIdSelector(cancel))).toBe(true);
         expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(false);
         expect(await dialog.isEnabled(getAutomationIdSelector(tryAgainAutomationId))).toBe(true);
     });
@@ -56,6 +56,11 @@ describe('Android setup - prompt-install-service-failed ', () => {
         await setupMockAdb(simulateServiceInstallationError(defaultDeviceConfig));
         await dialog.client.click(getAutomationIdSelector(tryAgainAutomationId));
         await dialog.waitForDialogVisible('prompt-install-failed');
+    });
+
+    it('cancel button returns to choose device step', async () => {
+        await dialog.client.click(getAutomationIdSelector(leftFooterButtonAutomationId));
+        await dialog.waitForDialogVisible('prompt-choose-device');
     });
 
     it('should pass accessibility validation in all contrast modes', async () => {

--- a/src/tests/electron/tests/android-setup-prompt-install-failed.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-failed.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    leftFooterButtonAutomationId,
+    rightFooterButtonAutomationId,
+} from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
+import { tryAgainAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step';
+import { installAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
+import { createApplication } from 'tests/electron/common/create-application';
+import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
+import { AndroidSetupViewController } from 'tests/electron/common/view-controllers/android-setup-view-controller';
+import { AppController } from 'tests/electron/common/view-controllers/app-controller';
+import {
+    commonAdbConfigs,
+    delayAllCommands,
+    setupMockAdb,
+    simulateServiceInstallationError,
+    simulateServiceNotInstalled,
+} from '../../miscellaneous/mock-adb/setup-mock-adb';
+
+describe('Android setup - prompt-install-service-failed ', () => {
+    const defaultDeviceConfig = commonAdbConfigs['single-device'];
+    let app: AppController;
+    let dialog: AndroidSetupViewController;
+
+    beforeEach(async () => {
+        await setupMockAdb(simulateServiceNotInstalled(defaultDeviceConfig));
+        app = await createApplication({ suppressFirstTimeDialog: true });
+        dialog = await app.openAndroidSetupView('prompt-install-service');
+        await setupMockAdb(simulateServiceInstallationError(defaultDeviceConfig));
+        await dialog.click(getAutomationIdSelector(installAutomationId));
+        await dialog.waitForDialogVisible('prompt-install-failed');
+    });
+
+    afterEach(async () => {
+        if (app != null) {
+            await app.stop();
+        }
+    });
+
+    it('initial component state is correct', async () => {
+        const [closeId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
+        expect(await dialog.isEnabled(getAutomationIdSelector(closeId))).toBe(true);
+        expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(false);
+        expect(await dialog.isEnabled(getAutomationIdSelector(tryAgainAutomationId))).toBe(true);
+    });
+
+    it('try again button triggers installation, prompts for permission on success', async () => {
+        await setupMockAdb(defaultDeviceConfig);
+        await dialog.client.click(getAutomationIdSelector(tryAgainAutomationId));
+        await dialog.waitForDialogVisible('prompt-grant-permissions');
+    });
+
+    it('install button triggers installation, prompts correctly on failure', async () => {
+        await setupMockAdb(simulateServiceInstallationError(defaultDeviceConfig));
+        await dialog.client.click(getAutomationIdSelector(tryAgainAutomationId));
+        await dialog.waitForDialogVisible('prompt-install-failed');
+    });
+
+    it('should pass accessibility validation in all contrast modes', async () => {
+        await scanForAccessibilityIssuesInAllModes(app);
+    });
+
+    it('installing service spinner should pass accessibility validation in all contrast modes', async () => {
+        await setupMockAdb(
+            delayAllCommands(3000, simulateServiceInstallationError(defaultDeviceConfig)),
+        );
+        await dialog.client.click(getAutomationIdSelector(tryAgainAutomationId));
+        await dialog.waitForDialogVisible('installing-service');
+        await scanForAccessibilityIssuesInAllModes(app);
+        await dialog.waitForDialogVisible('prompt-install-failed'); // Let mock-adb finish
+    });
+});

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -10,6 +10,7 @@ import {
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
 import { AutomatedChecksViewController } from 'tests/electron/common/view-controllers/automated-checks-view-controller';
+import { commonAdbConfigs, setupMockAdb } from 'tests/miscellaneous/mock-adb/setup-mock-adb';
 import { testResourceServerConfig } from '../setup/test-resource-server-config';
 
 describe('AutomatedChecksView', () => {
@@ -17,6 +18,7 @@ describe('AutomatedChecksView', () => {
     let automatedChecksView: AutomatedChecksViewController;
 
     beforeEach(async () => {
+        await setupMockAdb(commonAdbConfigs['single-device']);
         app = await createApplication({ suppressFirstTimeDialog: true });
         automatedChecksView = await app.openAutomatedChecksView();
         await automatedChecksView.waitForScreenshotViewVisible();

--- a/src/tests/electron/tests/first-time-dialog.test.ts
+++ b/src/tests/electron/tests/first-time-dialog.test.ts
@@ -3,11 +3,13 @@
 import { createApplication } from 'tests/electron/common/create-application';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
+import { commonAdbConfigs, setupMockAdb } from 'tests/miscellaneous/mock-adb/setup-mock-adb';
 
 describe('first time dialog', () => {
     let app: AppController;
 
     beforeEach(async () => {
+        await setupMockAdb(commonAdbConfigs['single-device']);
         app = await createApplication({ suppressFirstTimeDialog: false });
         await app.openDeviceConnectionDialog();
     });

--- a/src/tests/electron/tests/unified-settings-panel.test.ts
+++ b/src/tests/electron/tests/unified-settings-panel.test.ts
@@ -6,12 +6,14 @@ import { AppController } from 'tests/electron/common/view-controllers/app-contro
 import { AutomatedChecksViewController } from 'tests/electron/common/view-controllers/automated-checks-view-controller';
 import { CommonSelectors } from 'tests/end-to-end/common/element-identifiers/common-selectors';
 import { settingsPanelSelectors } from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
+import { commonAdbConfigs, setupMockAdb } from 'tests/miscellaneous/mock-adb/setup-mock-adb';
 
 describe('AutomatedChecksView -> Settings Panel', () => {
     let app: AppController;
     let automatedChecksView: AutomatedChecksViewController;
 
     beforeEach(async () => {
+        await setupMockAdb(commonAdbConfigs['single-device']);
         app = await createApplication({ suppressFirstTimeDialog: true });
         automatedChecksView = await app.openAutomatedChecksView();
         await automatedChecksView.waitForViewVisible();


### PR DESCRIPTION
#### Description of changes
Add E2E tests to cover the `prompt-install-failed` and `installing-service` steps.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1749058](https://mseng.visualstudio.com/1ES/_workitems/edit/1749058)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
