### PR TITLE
feat(android-setup-e2e): Add contrast tests for detect-devices spinner

### DIFF
--- a/src/tests/electron/tests/android-setup-prompt-connect-to-device.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-connect-to-device.test.ts
@@ -12,6 +12,7 @@ import { AndroidSetupViewController } from 'tests/electron/common/view-controlle
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
 import {
     commonAdbConfigs,
+    delayAllCommands,
     setupMockAdb,
     simulateNoDevicesConnected,
 } from '../../miscellaneous/mock-adb/setup-mock-adb';
@@ -48,7 +49,15 @@ describe('Android setup - prompt-connect-to-device ', () => {
         await dialog.waitForDialogVisible('prompt-choose-device');
     });
 
-    it('should pass accessibility validation in both contrast modes', async () => {
+    it('detect device spinner should pass accessibility validation an all contrast modes', async () => {
+        await setupMockAdb(delayAllCommands(3000, simulateNoDevicesConnected(defaultDeviceConfig)));
+        await dialog.client.click(getAutomationIdSelector(detectDeviceAutomationId));
+        await dialog.waitForDialogVisible('detect-devices');
+        await scanForAccessibilityIssuesInAllModes(app);
+        await dialog.waitForDialogVisible('prompt-connect-to-device'); // Let mock-adb finish
+    });
+
+    it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });
 });


### PR DESCRIPTION
#### Description of changes
Add an E2E test to validate the contrast in the detect-devices spinner

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1749052](https://mseng.visualstudio.com/1ES/_workitems/edit/1749052)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
