### PR TITLE
feat(android-setup-e2e): add a11y test for detect-service spinner

### DIFF
--- a/src/tests/electron/tests/android-setup-detect-service-spinner.test.ts
+++ b/src/tests/electron/tests/android-setup-detect-service-spinner.test.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { createApplication } from 'tests/electron/common/create-application';
+import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
+import { AppController } from 'tests/electron/common/view-controllers/app-controller';
+import {
+    commonAdbConfigs,
+    delayAllCommands,
+    setupMockAdb,
+    simulateServiceNotInstalled,
+} from '../../miscellaneous/mock-adb/setup-mock-adb';
+
+describe('Android setup - detect-service', () => {
+    const defaultDeviceConfig = commonAdbConfigs['single-device'];
+    let app: AppController;
+
+    beforeEach(async () => {
+        await setupMockAdb(
+            delayAllCommands(3000, simulateServiceNotInstalled(defaultDeviceConfig)),
+        );
+        app = await createApplication({ suppressFirstTimeDialog: true });
+    });
+
+    afterEach(async () => {
+        if (app != null) {
+            await app.stop();
+        }
+    });
+
+    it('should pass accessibility validation in both contrast modes', async () => {
+        await scanForAccessibilityIssuesInAllModes(app);
+    });
+});

--- a/src/tests/electron/tests/android-setup-detect-service-spinner.test.ts
+++ b/src/tests/electron/tests/android-setup-detect-service-spinner.test.ts
@@ -19,6 +19,7 @@ describe('Android setup - detect-service', () => {
             delayAllCommands(3000, simulateServiceNotInstalled(defaultDeviceConfig)),
         );
         app = await createApplication({ suppressFirstTimeDialog: true });
+        await app.openAndroidSetupView('detect-service');
     });
 
     afterEach(async () => {


### PR DESCRIPTION
#### Description of changes

This checks a11y / HC on the detect-service spinner.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
