### PR TITLE
fix: fixes horizontal scroll bar issue when in panel for left nav

### DIFF
--- a/src/DetailsView/components/nav-link-button.scss
+++ b/src/DetailsView/components/nav-link-button.scss
@@ -6,6 +6,7 @@ button {
     &.nav-link-button {
         width: calc(100% - #{$pivotItemLeftBorderWidth});
         padding-left: unset;
+        padding-right: unset;
         &:hover,
         &:active,
         &:focus,


### PR DESCRIPTION
#### Description of changes

The left nav, when in panel form, adds a padding to the right of links. This removes it so we don't see the horizontal scroll bar. 

Before:
![image](https://user-images.githubusercontent.com/32555133/87999333-4c839200-caaf-11ea-89f9-74107210f392.png)

After:
![image](https://user-images.githubusercontent.com/32555133/87999369-68873380-caaf-11ea-84a8-9e5654e78363.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
