### PR TITLE
feat(android-setup-e2e): Add tests for prompt-connected-start-testing

### DIFF
--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -48,6 +48,10 @@ export class AppController {
         );
         await androidSetupViewController.startTesting();
 
+        return this.waitForAutomatedChecksView();
+    }
+
+    public async waitForAutomatedChecksView(): Promise<AutomatedChecksViewController> {
         const automatedChecksView = new AutomatedChecksViewController(this.client);
         await automatedChecksView.waitForViewVisible();
 

--- a/src/tests/electron/tests/android-setup-prompt-connected-start-testing.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-connected-start-testing.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    leftFooterButtonAutomationId,
+    rightFooterButtonAutomationId,
+} from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
+import { rescanAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
+import { createApplication } from 'tests/electron/common/create-application';
+import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
+import { AndroidSetupViewController } from 'tests/electron/common/view-controllers/android-setup-view-controller';
+import { AppController } from 'tests/electron/common/view-controllers/app-controller';
+import {
+    commonAdbConfigs,
+    delayAllCommands,
+    setupMockAdb,
+} from '../../miscellaneous/mock-adb/setup-mock-adb';
+
+describe('Android setup - prompt-connected-start-testing', () => {
+    const [cancelId, startTestingId] = [
+        leftFooterButtonAutomationId,
+        rightFooterButtonAutomationId,
+    ];
+    const defaultDeviceConfig = commonAdbConfigs['single-device'];
+    let app: AppController;
+    let dialog: AndroidSetupViewController;
+
+    beforeEach(async () => {
+        await setupMockAdb(defaultDeviceConfig);
+        app = await createApplication({ suppressFirstTimeDialog: true });
+        dialog = await app.openAndroidSetupView('prompt-connected-start-testing');
+    });
+
+    afterEach(async () => {
+        if (app != null) {
+            await app.stop();
+        }
+    });
+
+    it('initial component state is correct', async () => {
+        expect(await dialog.isEnabled(getAutomationIdSelector(cancelId))).toBe(true);
+        expect(await dialog.isEnabled(getAutomationIdSelector(startTestingId))).toBe(true);
+        expect(await dialog.isEnabled(getAutomationIdSelector(rescanAutomationId))).toBe(true);
+    });
+
+    it('goes to prompt-choose-device upon cancel', async () => {
+        await setupMockAdb(defaultDeviceConfig);
+        await dialog.client.click(getAutomationIdSelector(cancelId));
+        await dialog.waitForDialogVisible('prompt-choose-device');
+    });
+
+    it('goes to detect-devices upon rescan (same devices)', async () => {
+        await setupMockAdb(delayAllCommands(50, defaultDeviceConfig));
+        await dialog.client.click(getAutomationIdSelector(rescanAutomationId));
+        await dialog.waitForDialogVisible('detect-devices');
+        await dialog.waitForDialogVisible('prompt-connected-start-testing');
+    });
+
+    it('goes to detect-devices upon rescan (different devices)', async () => {
+        await setupMockAdb(delayAllCommands(100, commonAdbConfigs['multiple-devices']));
+        await dialog.client.click(getAutomationIdSelector(rescanAutomationId));
+        await dialog.waitForDialogVisible('detect-devices');
+        await dialog.waitForDialogVisible('prompt-choose-device');
+    });
+
+    it('goes to automated checks upon start testing', async () => {
+        await dialog.client.click(getAutomationIdSelector(startTestingId));
+        await app.waitForAutomatedChecksView();
+    });
+
+    it('should pass accessibility validation in all contrast modes', async () => {
+        await scanForAccessibilityIssuesInAllModes(app);
+    });
+});


### PR DESCRIPTION
#### Description of changes
Tests for the prompt-connected-start-testing dialog. Does not include checks to validate that the expected device is selected (I've created https://mseng.visualstudio.com/1ES/_workitems/edit/1742770 to track this)

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1749062](https://mseng.visualstudio.com/1ES/_workitems/edit/1749062)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
