### PR TITLE
feat(android-setup-e2e): Standardize test practices

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.tsx
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
 import { NamedFC } from 'common/react/named-fc';
+import {
+    leftFooterButtonAutomationId,
+    moreInfoLinkAutomationId,
+    rightFooterButtonAutomationId,
+} from 'electron/views/device-connect-view/components/automation-ids';
 import { DefaultButton, IButtonProps, PrimaryButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './android-setup-step-layout.scss';
@@ -15,9 +20,6 @@ export type AndroidSetupStepLayoutProps = {
     leftFooterButtonProps: AndroidSetupFooterButtonProps;
     rightFooterButtonProps: AndroidSetupFooterButtonProps;
 };
-export const moreInfoLinkAutomationId = 'more-info-link';
-export const leftFooterButtonAutomationId = 'android-left-footer-button';
-export const rightFooterButtonAutomationId = 'android-right-footer-button';
 
 export const AndroidSetupStepLayout = NamedFC<AndroidSetupStepLayoutProps>(
     'AndroidSetupStepLayout',

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
+import { rescanAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import {
     CheckboxVisibility,
     DefaultButton,
@@ -15,8 +16,6 @@ import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-s
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 import { DeviceDescription } from './device-description';
 import * as styles from './prompt-choose-device-step.scss';
-
-export const rescanAutomationId: string = 'rescan';
 
 export type PromptChooseDeviceStepState = {
     selectedDevice: DeviceInfo;

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.tsx
@@ -5,13 +5,13 @@ import {
     DeviceDescription,
     DeviceDescriptionProps,
 } from 'electron/views/device-connect-view/components/android-setup/device-description';
+import { tryAgainAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { PrimaryButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 import * as styles from './prompt-install-failed-step.scss';
 
-export const tryAgainAutomationId = 'try-again';
 export const PromptConfiguringPortForwardingFailedStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptConfiguringPortForwardingFailedStep',
     (props: CommonAndroidSetupStepProps) => {

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
+import { detectDeviceAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { PrimaryButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 import * as styles from './prompt-connect-to-device-step.scss';
 
-export const detectDeviceAutomationId = 'detect-device';
 export const PromptConnectToDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptConnectToDeviceStep',
     (props: CommonAndroidSetupStepProps) => {

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
@@ -9,10 +9,10 @@ import * as styles from 'electron/views/device-connect-view/components/android-s
 import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
+import { rescanAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 
-export const rescanAutomationId = 'prompt-connected-start-testing-rescan-button';
 export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptConnectedStartTestingStep',
     (props: CommonAndroidSetupStepProps) => {

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
@@ -5,13 +5,13 @@ import {
     DeviceDescription,
     DeviceDescriptionProps,
 } from 'electron/views/device-connect-view/components/android-setup/device-description';
+import { tryAgainAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { PrimaryButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 import * as styles from './prompt-grant-permissions-step.scss';
 
-export const tryAgainAutomationId = 'try-again';
 export const PromptGrantPermissionsStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptGrantPermissionsStep',
     (props: CommonAndroidSetupStepProps) => {

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.tsx
@@ -5,13 +5,13 @@ import {
     DeviceDescription,
     DeviceDescriptionProps,
 } from 'electron/views/device-connect-view/components/android-setup/device-description';
+import { tryAgainAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { PrimaryButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 import * as styles from './prompt-install-failed-step.scss';
 
-export const tryAgainAutomationId = 'try-again';
 export const PromptInstallFailedStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptInstallFailedStep',
     (props: CommonAndroidSetupStepProps) => {

--- a/src/electron/views/device-connect-view/components/automation-ids.ts
+++ b/src/electron/views/device-connect-view/components/automation-ids.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const moreInfoLinkAutomationId = 'more-info-link';
+export const detectDeviceAutomationId = 'detect-device';
+export const tryAgainAutomationId = 'try-again';
+export const rescanAutomationId = 'rescan';
+export const leftFooterButtonAutomationId = 'android-left-footer-button';
+export const rightFooterButtonAutomationId = 'android-right-footer-button';

--- a/src/tests/electron/common/view-controllers/android-setup-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/android-setup-view-controller.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
-import { rightFooterButtonAutomationId } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
+import { rightFooterButtonAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { SpectronAsyncClient } from 'tests/electron/common/view-controllers/spectron-async-client';
 import { ViewController } from './view-controller';

--- a/src/tests/electron/common/view-controllers/android-setup-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/android-setup-view-controller.ts
@@ -17,7 +17,8 @@ export class AndroidSetupViewController extends ViewController {
 
     // validates and starts scanning
     public async startTesting(): Promise<void> {
-        await this.client.waitForEnabled(getAutomationIdSelector(rightFooterButtonAutomationId));
-        await this.client.click(getAutomationIdSelector(rightFooterButtonAutomationId));
+        const startTestingId = rightFooterButtonAutomationId;
+        await this.client.waitForEnabled(getAutomationIdSelector(startTestingId));
+        await this.client.click(getAutomationIdSelector(startTestingId));
     }
 }

--- a/src/tests/electron/tests/android-setup-detect-service-spinner.test.ts
+++ b/src/tests/electron/tests/android-setup-detect-service-spinner.test.ts
@@ -28,7 +28,7 @@ describe('Android setup - detect-service', () => {
         }
     });
 
-    it('should pass accessibility validation in both contrast modes', async () => {
+    it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });
 });

--- a/src/tests/electron/tests/android-setup-locate-adb.test.ts
+++ b/src/tests/electron/tests/android-setup-locate-adb.test.ts
@@ -3,7 +3,7 @@
 import {
     leftFooterButtonAutomationId,
     rightFooterButtonAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
+} from 'electron/views/device-connect-view/components/automation-ids';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { createApplication } from 'tests/electron/common/create-application';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';

--- a/src/tests/electron/tests/android-setup-locate-adb.test.ts
+++ b/src/tests/electron/tests/android-setup-locate-adb.test.ts
@@ -51,7 +51,7 @@ describe('Android setup - locate adb', () => {
         await dialog.waitForDialogVisible('prompt-connect-to-device');
     });
 
-    it('should pass accessibility validation in both contrast modes', async () => {
+    it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });
 });

--- a/src/tests/electron/tests/android-setup-locate-adb.test.ts
+++ b/src/tests/electron/tests/android-setup-locate-adb.test.ts
@@ -41,11 +41,11 @@ describe('Android setup - locate adb', () => {
         expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(false);
 
         await setupMockAdb(simulateNoDevicesConnected(commonAdbConfigs['slow-single-device']));
-        await dialog.client.click('input[type="text"]');
+        await dialog.click('input[type="text"]');
         await dialog.client.keys(`${(global as any).rootDir}/drop/mock-adb`);
 
         expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(true);
-        await dialog.client.click(getAutomationIdSelector(nextId));
+        await dialog.click(getAutomationIdSelector(nextId));
         await dialog.waitForDialogVisible('detect-adb');
         await scanForAccessibilityIssuesInAllModes(app);
         await dialog.waitForDialogVisible('prompt-connect-to-device');

--- a/src/tests/electron/tests/android-setup-locate-adb.test.ts
+++ b/src/tests/electron/tests/android-setup-locate-adb.test.ts
@@ -15,6 +15,8 @@ import {
     simulateNoDevicesConnected,
 } from '../../miscellaneous/mock-adb/setup-mock-adb';
 
+const [closeId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
+
 describe('Android setup - locate adb', () => {
     let app: AppController;
     let dialog: AndroidSetupViewController;
@@ -36,7 +38,6 @@ describe('Android setup - locate adb', () => {
     });
 
     it('respects user-provided adb location, detect-adb passes a11y check', async () => {
-        const [closeId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
         expect(await dialog.isEnabled(getAutomationIdSelector(closeId))).toBe(true);
         expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(false);
 

--- a/src/tests/electron/tests/android-setup-port-forwarding.test.ts
+++ b/src/tests/electron/tests/android-setup-port-forwarding.test.ts
@@ -3,8 +3,8 @@
 import {
     leftFooterButtonAutomationId,
     rightFooterButtonAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
-import { tryAgainAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step';
+    tryAgainAutomationId,
+} from 'electron/views/device-connect-view/components/automation-ids';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { createApplication } from 'tests/electron/common/create-application';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';

--- a/src/tests/electron/tests/android-setup-port-forwarding.test.ts
+++ b/src/tests/electron/tests/android-setup-port-forwarding.test.ts
@@ -17,8 +17,9 @@ import {
     simulatePortForwardingError,
 } from '../../miscellaneous/mock-adb/setup-mock-adb';
 
+const [cancelId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
+
 describe('Android setup - prompt-configuring-port-forwarding-failed', () => {
-    const [cancelId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
     const defaultDeviceConfig = commonAdbConfigs['single-device'];
     let app: AppController;
     let dialog: AndroidSetupViewController;

--- a/src/tests/electron/tests/android-setup-port-forwarding.test.ts
+++ b/src/tests/electron/tests/android-setup-port-forwarding.test.ts
@@ -43,7 +43,7 @@ describe('Android setup - prompt-configuring-port-forwarding-failed', () => {
 
     it('goes to prompt-choose-device upon cancel', async () => {
         await setupMockAdb(commonAdbConfigs['multiple-devices']);
-        await dialog.client.click(getAutomationIdSelector(cancelId));
+        await dialog.click(getAutomationIdSelector(cancelId));
         await dialog.waitForDialogVisible('prompt-choose-device');
     });
 
@@ -51,14 +51,14 @@ describe('Android setup - prompt-configuring-port-forwarding-failed', () => {
         await setupMockAdb(
             delayAllCommands(2500, simulatePortForwardingError(defaultDeviceConfig)),
         );
-        await dialog.client.click(getAutomationIdSelector(tryAgainAutomationId));
+        await dialog.click(getAutomationIdSelector(tryAgainAutomationId));
         await dialog.waitForDialogVisible('configuring-port-forwarding');
         await dialog.waitForDialogVisible('prompt-configuring-port-forwarding-failed');
     });
 
     it('try again moves on if port forwarded properly; configuring-port-forwarding a11y test', async () => {
         await setupMockAdb(delayAllCommands(2500, defaultDeviceConfig));
-        await dialog.client.click(getAutomationIdSelector(tryAgainAutomationId));
+        await dialog.click(getAutomationIdSelector(tryAgainAutomationId));
         await dialog.waitForDialogVisible('configuring-port-forwarding');
         await scanForAccessibilityIssuesInAllModes(app);
         await dialog.waitForDialogVisible('prompt-connected-start-testing');

--- a/src/tests/electron/tests/android-setup-prompt-choose-device.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-choose-device.test.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { deviceDescriptionAutomationId } from 'electron/views/device-connect-view/components/android-setup/device-description';
 import {
     leftFooterButtonAutomationId,
+    rescanAutomationId,
     rightFooterButtonAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
-import { deviceDescriptionAutomationId } from 'electron/views/device-connect-view/components/android-setup/device-description';
-import { rescanAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
+} from 'electron/views/device-connect-view/components/automation-ids';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { createApplication } from 'tests/electron/common/create-application';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';

--- a/src/tests/electron/tests/android-setup-prompt-connect-to-device.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-connect-to-device.test.ts
@@ -17,6 +17,8 @@ import {
     simulateNoDevicesConnected,
 } from '../../miscellaneous/mock-adb/setup-mock-adb';
 
+const [closeId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
+
 describe('Android setup - prompt-connect-to-device ', () => {
     const defaultDeviceConfig = commonAdbConfigs['multiple-devices'];
     let app: AppController;
@@ -35,7 +37,6 @@ describe('Android setup - prompt-connect-to-device ', () => {
     });
 
     it('initial component state is correct', async () => {
-        const [closeId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
         expect(await dialog.isEnabled(getAutomationIdSelector(closeId))).toBe(true);
         expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(false);
         expect(await dialog.isEnabled(getAutomationIdSelector(detectDeviceAutomationId))).toBe(

--- a/src/tests/electron/tests/android-setup-prompt-connect-to-device.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-connect-to-device.test.ts
@@ -45,13 +45,13 @@ describe('Android setup - prompt-connect-to-device ', () => {
 
     it('detect button triggers new detection', async () => {
         await setupMockAdb(defaultDeviceConfig);
-        await dialog.client.click(getAutomationIdSelector(detectDeviceAutomationId));
+        await dialog.click(getAutomationIdSelector(detectDeviceAutomationId));
         await dialog.waitForDialogVisible('prompt-choose-device');
     });
 
     it('detect device spinner should pass accessibility validation an all contrast modes', async () => {
         await setupMockAdb(delayAllCommands(3000, simulateNoDevicesConnected(defaultDeviceConfig)));
-        await dialog.client.click(getAutomationIdSelector(detectDeviceAutomationId));
+        await dialog.click(getAutomationIdSelector(detectDeviceAutomationId));
         await dialog.waitForDialogVisible('detect-devices');
         await scanForAccessibilityIssuesInAllModes(app);
         await dialog.waitForDialogVisible('prompt-connect-to-device'); // Let mock-adb finish

--- a/src/tests/electron/tests/android-setup-prompt-connect-to-device.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-connect-to-device.test.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import {
+    detectDeviceAutomationId,
     leftFooterButtonAutomationId,
     rightFooterButtonAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
-import { detectDeviceAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step';
+} from 'electron/views/device-connect-view/components/automation-ids';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { createApplication } from 'tests/electron/common/create-application';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';

--- a/src/tests/electron/tests/android-setup-prompt-connected-start-testing.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-connected-start-testing.test.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 import {
     leftFooterButtonAutomationId,
+    rescanAutomationId,
     rightFooterButtonAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
-import { rescanAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step';
+} from 'electron/views/device-connect-view/components/automation-ids';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { createApplication } from 'tests/electron/common/create-application';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';

--- a/src/tests/electron/tests/android-setup-prompt-connected-start-testing.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-connected-start-testing.test.ts
@@ -16,11 +16,9 @@ import {
     setupMockAdb,
 } from '../../miscellaneous/mock-adb/setup-mock-adb';
 
+const [cancelId, startTestingId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
+
 describe('Android setup - prompt-connected-start-testing', () => {
-    const [cancelId, startTestingId] = [
-        leftFooterButtonAutomationId,
-        rightFooterButtonAutomationId,
-    ];
     const defaultDeviceConfig = commonAdbConfigs['single-device'];
     let app: AppController;
     let dialog: AndroidSetupViewController;

--- a/src/tests/electron/tests/android-setup-prompt-connected-start-testing.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-connected-start-testing.test.ts
@@ -45,26 +45,26 @@ describe('Android setup - prompt-connected-start-testing', () => {
 
     it('goes to prompt-choose-device upon cancel', async () => {
         await setupMockAdb(defaultDeviceConfig);
-        await dialog.client.click(getAutomationIdSelector(cancelId));
+        await dialog.click(getAutomationIdSelector(cancelId));
         await dialog.waitForDialogVisible('prompt-choose-device');
     });
 
     it('goes to detect-devices upon rescan (same devices)', async () => {
         await setupMockAdb(delayAllCommands(50, defaultDeviceConfig));
-        await dialog.client.click(getAutomationIdSelector(rescanAutomationId));
+        await dialog.click(getAutomationIdSelector(rescanAutomationId));
         await dialog.waitForDialogVisible('detect-devices');
         await dialog.waitForDialogVisible('prompt-connected-start-testing');
     });
 
     it('goes to detect-devices upon rescan (different devices)', async () => {
         await setupMockAdb(delayAllCommands(100, commonAdbConfigs['multiple-devices']));
-        await dialog.client.click(getAutomationIdSelector(rescanAutomationId));
+        await dialog.click(getAutomationIdSelector(rescanAutomationId));
         await dialog.waitForDialogVisible('detect-devices');
         await dialog.waitForDialogVisible('prompt-choose-device');
     });
 
     it('goes to automated checks upon start testing', async () => {
-        await dialog.client.click(getAutomationIdSelector(startTestingId));
+        await dialog.click(getAutomationIdSelector(startTestingId));
         await app.waitForAutomatedChecksView();
     });
 

--- a/src/tests/electron/tests/android-setup-prompt-grant-permissions.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-grant-permissions.test.ts
@@ -3,8 +3,8 @@
 import {
     leftFooterButtonAutomationId,
     rightFooterButtonAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
-import { tryAgainAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step';
+    tryAgainAutomationId,
+} from 'electron/views/device-connect-view/components/automation-ids';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { createApplication } from 'tests/electron/common/create-application';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';

--- a/src/tests/electron/tests/android-setup-prompt-grant-permissions.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-grant-permissions.test.ts
@@ -17,8 +17,9 @@ import {
     simulateServiceLacksPermissions,
 } from '../../miscellaneous/mock-adb/setup-mock-adb';
 
+const [cancelId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
+
 describe('Android setup - prompt-grant-permissions', () => {
-    const [cancelId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
     const defaultDeviceConfig = commonAdbConfigs['single-device'];
     let app: AppController;
     let dialog: AndroidSetupViewController;

--- a/src/tests/electron/tests/android-setup-prompt-grant-permissions.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-grant-permissions.test.ts
@@ -64,7 +64,7 @@ describe('Android setup - prompt-grant-permissions', () => {
         await dialog.waitForDialogVisible('prompt-connected-start-testing');
     });
 
-    it('should pass accessibility validation in both contrast modes', async () => {
+    it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });
 });

--- a/src/tests/electron/tests/android-setup-prompt-grant-permissions.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-grant-permissions.test.ts
@@ -43,7 +43,7 @@ describe('Android setup - prompt-grant-permissions', () => {
 
     it('goes to prompt-choose-device upon cancel', async () => {
         await setupMockAdb(commonAdbConfigs['multiple-devices']);
-        await dialog.client.click(getAutomationIdSelector(cancelId));
+        await dialog.click(getAutomationIdSelector(cancelId));
         await dialog.waitForDialogVisible('prompt-choose-device');
     });
 
@@ -51,14 +51,14 @@ describe('Android setup - prompt-grant-permissions', () => {
         await setupMockAdb(
             delayAllCommands(5000, simulateServiceLacksPermissions(defaultDeviceConfig)),
         );
-        await dialog.client.click(getAutomationIdSelector(tryAgainAutomationId));
+        await dialog.click(getAutomationIdSelector(tryAgainAutomationId));
         await dialog.waitForDialogVisible('detect-permissions');
         await dialog.waitForDialogVisible('prompt-grant-permissions');
     });
 
     it('try again moves on if permissions are granted; detect-permissions a11y test', async () => {
         await setupMockAdb(delayAllCommands(2500, defaultDeviceConfig));
-        await dialog.client.click(getAutomationIdSelector(tryAgainAutomationId));
+        await dialog.click(getAutomationIdSelector(tryAgainAutomationId));
         await dialog.waitForDialogVisible('detect-permissions');
         await scanForAccessibilityIssuesInAllModes(app);
         await dialog.waitForDialogVisible('prompt-connected-start-testing');

--- a/src/tests/electron/tests/android-setup-prompt-install-failed.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-failed.test.ts
@@ -48,18 +48,18 @@ describe('Android setup - prompt-install-service-failed ', () => {
 
     it('try again button triggers installation, prompts for permission on success', async () => {
         await setupMockAdb(defaultDeviceConfig);
-        await dialog.client.click(getAutomationIdSelector(tryAgainAutomationId));
+        await dialog.click(getAutomationIdSelector(tryAgainAutomationId));
         await dialog.waitForDialogVisible('prompt-grant-permissions');
     });
 
     it('install button triggers installation, prompts correctly on failure', async () => {
         await setupMockAdb(simulateServiceInstallationError(defaultDeviceConfig));
-        await dialog.client.click(getAutomationIdSelector(tryAgainAutomationId));
+        await dialog.click(getAutomationIdSelector(tryAgainAutomationId));
         await dialog.waitForDialogVisible('prompt-install-failed');
     });
 
     it('cancel button returns to choose device step', async () => {
-        await dialog.client.click(getAutomationIdSelector(leftFooterButtonAutomationId));
+        await dialog.click(getAutomationIdSelector(leftFooterButtonAutomationId));
         await dialog.waitForDialogVisible('prompt-choose-device');
     });
 
@@ -71,7 +71,7 @@ describe('Android setup - prompt-install-service-failed ', () => {
         await setupMockAdb(
             delayAllCommands(3000, simulateServiceInstallationError(defaultDeviceConfig)),
         );
-        await dialog.client.click(getAutomationIdSelector(tryAgainAutomationId));
+        await dialog.click(getAutomationIdSelector(tryAgainAutomationId));
         await dialog.waitForDialogVisible('installing-service');
         await scanForAccessibilityIssuesInAllModes(app);
         await dialog.waitForDialogVisible('prompt-install-failed'); // Let mock-adb finish

--- a/src/tests/electron/tests/android-setup-prompt-install-failed.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-failed.test.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { installAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
 import {
     leftFooterButtonAutomationId,
     rightFooterButtonAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
-import { tryAgainAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step';
-import { installAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
+    tryAgainAutomationId,
+} from 'electron/views/device-connect-view/components/automation-ids';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { createApplication } from 'tests/electron/common/create-application';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';

--- a/src/tests/electron/tests/android-setup-prompt-install-failed.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-failed.test.ts
@@ -19,6 +19,8 @@ import {
     simulateServiceNotInstalled,
 } from '../../miscellaneous/mock-adb/setup-mock-adb';
 
+const [cancelId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
+
 describe('Android setup - prompt-install-service-failed ', () => {
     const defaultDeviceConfig = commonAdbConfigs['single-device'];
     let app: AppController;
@@ -40,8 +42,7 @@ describe('Android setup - prompt-install-service-failed ', () => {
     });
 
     it('initial component state is correct', async () => {
-        const [cancel, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
-        expect(await dialog.isEnabled(getAutomationIdSelector(cancel))).toBe(true);
+        expect(await dialog.isEnabled(getAutomationIdSelector(cancelId))).toBe(true);
         expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(false);
         expect(await dialog.isEnabled(getAutomationIdSelector(tryAgainAutomationId))).toBe(true);
     });

--- a/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
@@ -43,13 +43,13 @@ describe('Android setup - prompt-install-service ', () => {
 
     it('install button triggers installation, prompts for permission on success', async () => {
         await setupMockAdb(defaultDeviceConfig);
-        await dialog.client.click(getAutomationIdSelector(installAutomationId));
+        await dialog.click(getAutomationIdSelector(installAutomationId));
         await dialog.waitForDialogVisible('prompt-grant-permissions');
     });
 
     it('install button triggers installation, prompts correctly on failure', async () => {
         await setupMockAdb(simulateServiceInstallationError(defaultDeviceConfig));
-        await dialog.client.click(getAutomationIdSelector(installAutomationId));
+        await dialog.click(getAutomationIdSelector(installAutomationId));
         await dialog.waitForDialogVisible('prompt-install-failed');
     });
 

--- a/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { installAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
 import {
     leftFooterButtonAutomationId,
     rightFooterButtonAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
-import { installAutomationId } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
+} from 'electron/views/device-connect-view/components/automation-ids';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { createApplication } from 'tests/electron/common/create-application';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';

--- a/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
@@ -53,7 +53,7 @@ describe('Android setup - prompt-install-service ', () => {
         await dialog.waitForDialogVisible('prompt-install-failed');
     });
 
-    it('should pass accessibility validation in both contrast modes', async () => {
+    it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });
 });

--- a/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-install-service.test.ts
@@ -17,6 +17,8 @@ import {
     simulateServiceNotInstalled,
 } from '../../miscellaneous/mock-adb/setup-mock-adb';
 
+const [cancelId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
+
 describe('Android setup - prompt-install-service ', () => {
     const defaultDeviceConfig = commonAdbConfigs['single-device'];
     let app: AppController;
@@ -35,8 +37,7 @@ describe('Android setup - prompt-install-service ', () => {
     });
 
     it('initial component state is correct', async () => {
-        const [closeId, nextId] = [leftFooterButtonAutomationId, rightFooterButtonAutomationId];
-        expect(await dialog.isEnabled(getAutomationIdSelector(closeId))).toBe(true);
+        expect(await dialog.isEnabled(getAutomationIdSelector(cancelId))).toBe(true);
         expect(await dialog.isEnabled(getAutomationIdSelector(nextId))).toBe(false);
         expect(await dialog.isEnabled(getAutomationIdSelector(installAutomationId))).toBe(true);
     });

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -74,7 +74,7 @@ describe('AutomatedChecksView', () => {
         await assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
     });
 
-    it('should pass accessibility validation in both contrast modes', async () => {
+    it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });
 

--- a/src/tests/electron/tests/first-time-dialog.test.ts
+++ b/src/tests/electron/tests/first-time-dialog.test.ts
@@ -20,7 +20,7 @@ describe('first time dialog', () => {
         }
     });
 
-    it('should pass accessibility validation in both contrast modes', async () => {
+    it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });
 });

--- a/src/tests/electron/tests/unified-settings-panel.test.ts
+++ b/src/tests/electron/tests/unified-settings-panel.test.ts
@@ -93,7 +93,7 @@ describe('AutomatedChecksView -> Settings Panel', () => {
             );
         });
 
-        it('should pass accessibility validation in both contrast modes', async () => {
+        it('should pass accessibility validation in all contrast modes', async () => {
             await scanForAccessibilityIssuesInAllModes(app);
         });
     });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connected-start-testing-step.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`PromptConnectedStartTestingStep renders with device 1`] = `
     isEmulator={false}
   />
   <CustomizedDefaultButton
-    data-automation-id="prompt-connected-start-testing-rescan-button"
+    data-automation-id="rescan"
     onClick={[Function]}
     text="Rescan devices"
   />
@@ -71,7 +71,7 @@ exports[`PromptConnectedStartTestingStep renders with emulator 1`] = `
     isEmulator={true}
   />
   <CustomizedDefaultButton
-    data-automation-id="prompt-connected-start-testing-rescan-button"
+    data-automation-id="rescan"
     onClick={[Function]}
     text="Rescan devices"
   />

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
@@ -6,6 +6,7 @@ import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
+import { rescanAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
@@ -59,7 +60,7 @@ describe('PromptChooseDeviceStep', () => {
 
     it('passes rescan dep through', () => {
         const rendered = shallow(<PromptChooseDeviceStep {...props} />);
-        const rescanButton = rendered.find({ 'data-automation-id': 'rescan' });
+        const rescanButton = rendered.find({ 'data-automation-id': rescanAutomationId });
         rescanButton.simulate('click');
         actionMessageCreatorMock.verify(m => m.rescan(), Times.once());
     });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step.test.tsx
@@ -3,10 +3,8 @@
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
-import {
-    PromptConfiguringPortForwardingFailedStep,
-    tryAgainAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step';
+import { PromptConfiguringPortForwardingFailedStep } from 'electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step';
+import { tryAgainAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.test.tsx
@@ -3,10 +3,8 @@
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
-import {
-    detectDeviceAutomationId,
-    PromptConnectToDeviceStep,
-} from 'electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step';
+import { PromptConnectToDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step';
+import { detectDeviceAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.test.tsx
@@ -4,10 +4,8 @@ import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
-import {
-    PromptConnectedStartTestingStep,
-    rescanAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step';
+import { PromptConnectedStartTestingStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step';
+import { rescanAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
@@ -3,10 +3,8 @@
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
-import {
-    PromptGrantPermissionsStep,
-    tryAgainAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step';
+import { PromptGrantPermissionsStep } from 'electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step';
+import { tryAgainAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.test.tsx
@@ -3,10 +3,8 @@
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
-import {
-    PromptInstallFailedStep,
-    tryAgainAutomationId,
-} from 'electron/views/device-connect-view/components/android-setup/prompt-install-failed-step';
+import { PromptInstallFailedStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-failed-step';
+import { tryAgainAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';


### PR DESCRIPTION
#### Description of changes
This standardize some practices that have sort of evolved as we've developed the tests. This includes:

- Use `dialog.click()` instead of `dialog.client.click()`. This gives us snapshots on failures
- Refer to "all contrast modes" instead of "both contrast modes"
- Use aliases for leftFooterButtonAutomationId and rightFooterButtonAutomationId in tests
- Centralize the automation id's for android setup into a single file and update all usages

The one customer-facing change in this PR is the automation ID for the rescan button in the prompt-connected-start-testing dialog. The old automation id was `prompt-connected-start-testing-rescan-button`, while the new automation ID is just `rescan`

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1751559](https://mseng.visualstudio.com/1ES/_workitems/edit/1751559)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
