### PR TITLE
fix: restore correct behavior of yarn mock-adb * command

### DIFF
--- a/docs/building-unified.md
+++ b/docs/building-unified.md
@@ -37,7 +37,7 @@ Most of the functionality of Unified relies on connecting to a device running th
 ```sh
 # This sets up mock-adb to respond as if a single physical device is connected with a working
 # and current install of Accessibility Insights for Android Service. You can find logs for mock-adb
-# in drop/mock-adb/logs/*
+# in drop\mock-adb\logs\*
 yarn mock-adb single-device
 
 # Start the app like normal. During the "connect a device" flow where it asks you where to find

--- a/docs/building-unified.md
+++ b/docs/building-unified.md
@@ -37,7 +37,7 @@ Most of the functionality of Unified relies on connecting to a device running th
 ```sh
 # This sets up mock-adb to respond as if a single physical device is connected with a working
 # and current install of Accessibility Insights for Android Service. You can find logs for mock-adb
-# in drop\mock-adb\logs\*
+# in drop\mock-adb\logs\default
 yarn mock-adb single-device
 
 # Start the app like normal. During the "connect a device" flow where it asks you where to find

--- a/docs/building-unified.md
+++ b/docs/building-unified.md
@@ -37,8 +37,7 @@ Most of the functionality of Unified relies on connecting to a device running th
 ```sh
 # This sets up mock-adb to respond as if a single physical device is connected with a working
 # and current install of Accessibility Insights for Android Service. You can find logs for mock-adb
-# in drop/mock-adb/logs/* These logs contain the config used to setup mock-adb and the output
-# for each invocation of the executable.
+# in drop/mock-adb/logs/*
 yarn mock-adb single-device
 
 # Start the app like normal. During the "connect a device" flow where it asks you where to find

--- a/docs/building-unified.md
+++ b/docs/building-unified.md
@@ -36,7 +36,9 @@ Most of the functionality of Unified relies on connecting to a device running th
 
 ```sh
 # This sets up mock-adb to respond as if a single physical device is connected with a working
-# and current install of Accessibility Insights for Android Service.
+# and current install of Accessibility Insights for Android Service. You can find logs for mock-adb
+# in drop/mock-adb/logs/* These logs contain the config used to setup mock-adb and the output
+# for each invocation of the executable.
 yarn mock-adb single-device
 
 # Start the app like normal. During the "connect a device" flow where it asks you where to find

--- a/src/tests/miscellaneous/mock-adb/setup-mock-adb-command.js
+++ b/src/tests/miscellaneous/mock-adb/setup-mock-adb-command.js
@@ -24,7 +24,7 @@ if (config == undefined) {
     exitWithUsage();
 }
 
-setupMockAdb(config)
+setupMockAdb(config, 'default')
     .then(() => {
         console.log('Successfully set up mock adb in folder:\n');
         console.log(mockAdbFolder);


### PR DESCRIPTION
#### Description of changes

PR #3120 regressed the behavior of `yarn mock-adb multiple-devices` (or other configs). This PR restores the behavior by adding the missing parameter for the expected log folder.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
