### PR TITLE
fix: use # instead of javascript void in nav button

### DIFF
--- a/src/DetailsView/components/nav-link-button.tsx
+++ b/src/DetailsView/components/nav-link-button.tsx
@@ -18,7 +18,7 @@ export const NavLinkButton = NamedFC<NavLinkButtonProps>('NavLinkButton', props 
             title={link.title || link.name}
             onClick={e => link.onClickNavLink(e, link)}
             className={css(styles.navLinkButton, props.className)}
-            href={link.forceAnchor === true ? 'javascript:void(0)' : undefined}
+            href={link.forceAnchor === true ? '#' : undefined}
         >
             {link.onRenderNavLink(link)}
         </Link>

--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -56,7 +56,7 @@ export class ExtensionDetailsViewController implements DetailsViewController {
             changeInfo.url != null &&
             !changeInfo.url
                 .toLocaleLowerCase()
-                .endsWith(this.getDetailsUrlWithExtensionId(targetTabId).toLocaleLowerCase())
+                .includes(this.getDetailsUrlWithExtensionId(targetTabId).toLocaleLowerCase())
         );
     }
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`NavLinkButton renders with href set 1`] = `
 <StyledLinkBase
   aria-expanded={true}
   className="navLinkButton some class name"
-  href="javascript:void(0)"
+  href="#"
   onClick={[Function]}
   title="some title"
 />

--- a/src/tests/unit/tests/background/extension-details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/extension-details-view-controller.test.ts
@@ -221,6 +221,35 @@ describe('ExtensionDetailsViewController', () => {
         browserAdapterMock.verifyAll();
     });
 
+    test('showDetailsView after details tab has # at end', async () => {
+        const targetTabId = 5;
+        const detailsViewTabId = 10;
+
+        setupCreateDetailsView(targetTabId, detailsViewTabId);
+
+        // call show details once
+        await testSubject.showDetailsView(targetTabId);
+
+        browserAdapterMock.reset();
+
+        // update details tab
+        const extensionId = 'ext_id';
+        browserAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
+        onUpdateTabCallback(
+            detailsViewTabId,
+            { url: 'chromeExt://ext_Id/detailsView/detailsView.html?tabId=' + targetTabId + '#' },
+            null,
+        );
+
+        setupCreateDetailsViewForAnyUrl(Times.never());
+        setupSwitchToTab(detailsViewTabId);
+
+        // call show details second time
+        await testSubject.showDetailsView(targetTabId);
+
+        browserAdapterMock.verifyAll();
+    });
+
     test('showDetailsView after details tab title update', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;


### PR DESCRIPTION
#### Description of changes

Using href="#" is preferred over javascript void as the latter violates our content security policy in manifest, which could potentially cause issues with publishing as well. Using '#' by itself broke our navigation in details view and this fixes that as well.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
