### PR TITLE
test: E2E tests for reflow components

### DIFF
--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -20,6 +20,7 @@ export const detailsViewSelectors = {
 
     testNavLink: (testName: string): string => `div [name="${testName}"]`,
     requirementNavLink: (requirementName: string): string => `div [name="${requirementName}"] a`,
+    gettingStartedNavLink: 'div [name="Getting Started"]',
 
     visualHelperToggle: getAutomationIdSelector(visualHelperToggleAutomationId),
 
@@ -36,6 +37,15 @@ export const detailsViewSelectors = {
     settingsButton: 'button[name="Settings"]',
 
     automatedChecksResultSection: getAutomationIdSelector(resultSectionAutomationId),
+
+    commandBarMenuButton: 'button[aria-label="More items"]',
+    commandBarMenuButtonExpanded: (expanded: boolean) =>
+        `button[aria-label="More items"][aria-expanded=${expanded}`,
+
+    assessmentNavHamburgerButton:
+        'button[aria-label="Assessment - all tests and requirements list"]',
+    assessmentNavHamburgerButtonExpanded: (expanded: boolean) =>
+        `button[aria-label="Assessment - all tests and requirements list"][aria-expanded=${expanded}]`,
 };
 
 export const fastPassAutomatedChecksSelectors = {

--- a/src/tests/end-to-end/common/page-controllers/details-view-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/details-view-page.ts
@@ -31,6 +31,11 @@ export class DetailsViewPage extends Page {
         await this.clickSelector('button[title="Assessment"]');
     }
 
+    public async closeNavTestLink(testName: string): Promise<void> {
+        await this.clickSelector(detailsViewSelectors.testNavLink(testName));
+        await this.waitForSelectorToDisappear(detailsViewSelectors.gettingStartedNavLink);
+    }
+
     public async navigateToTestRequirement(
         testName: string,
         requirementName: string,
@@ -39,6 +44,13 @@ export class DetailsViewPage extends Page {
         await this.waitForSelectorXPath(`//div[@name="${requirementName}"]`);
         await this.clickSelector(detailsViewSelectors.requirementNavLink(requirementName));
         await this.waitForSelectorXPath(`//h1[text()="${requirementName}"]`);
+    }
+
+    public async navigateToGettingStarted(testName: string): Promise<void> {
+        await this.clickSelector(detailsViewSelectors.testNavLink(testName));
+        await this.waitForSelectorXPath(`//div[@name="Getting Started"]`);
+        await this.clickSelector(detailsViewSelectors.gettingStartedNavLink);
+        await this.waitForSelectorXPath(`//h1/span[text()="${testName}"]`);
     }
 
     public async waitForVisualHelperState(

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -316,6 +316,10 @@ export class Page {
         return await withTracing(this.underlyingPage.tracing, wrappedFunction);
     }
 
+    public async setViewport(width: number, height: number): Promise<void> {
+        await this.underlyingPage.setViewport({ width, height });
+    }
+
     private async screenshotOnError<T>(wrappedFunction: () => Promise<T>): Promise<T> {
         return await screenshotOnError(
             path => this.underlyingPage.screenshot({ path, fullPage: true }),

--- a/src/tests/end-to-end/tests/details-view/headings.test.ts
+++ b/src/tests/end-to-end/tests/details-view/headings.test.ts
@@ -18,11 +18,6 @@ describe('Details View -> Assessment -> Headings', () => {
         });
 
         headingsPage = (await browser.newAssessment()).detailsViewPage;
-
-        await headingsPage.navigateToTestRequirement('Headings', 'Heading function');
-        await headingsPage.waitForVisualHelperState('Off', {
-            timeout: DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
-        });
     });
 
     afterAll(async () => {
@@ -32,17 +27,54 @@ describe('Details View -> Assessment -> Headings', () => {
         }
     });
 
-    it.each([true, false])(
-        'should pass accessibility validation with highContrastMode=%s',
-        async highContrastMode => {
-            await browser.setHighContrastMode(highContrastMode);
-            await headingsPage.waitForHighContrastMode(highContrastMode);
+    describe('Requirement page', () => {
+        beforeAll(async () => {
+            await headingsPage.navigateToTestRequirement('Headings', 'Heading function');
+            await headingsPage.waitForVisualHelperState('Off', {
+                timeout: DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
+            });
+        });
 
-            const results = await scanForAccessibilityIssues(
-                headingsPage,
-                detailsViewSelectors.mainContent,
-            );
-            expect(results).toHaveLength(0);
-        },
-    );
+        afterAll(async () => {
+            await headingsPage.closeNavTestLink('Headings');
+        });
+
+        it.each([true, false])(
+            'should pass accessibility validation with highContrastMode=%s',
+            async highContrastMode => {
+                await browser.setHighContrastMode(highContrastMode);
+                await headingsPage.waitForHighContrastMode(highContrastMode);
+
+                const results = await scanForAccessibilityIssues(
+                    headingsPage,
+                    detailsViewSelectors.mainContent,
+                );
+                expect(results).toHaveLength(0);
+            },
+        );
+    });
+
+    describe('Getting started page', () => {
+        beforeAll(async () => {
+            await headingsPage.navigateToGettingStarted('Headings');
+        });
+
+        afterAll(async () => {
+            await headingsPage.closeNavTestLink('Headings');
+        });
+
+        it.each([true, false])(
+            'Getting started page should pass accessibility validation with highContrastMode=%s',
+            async highContrastMode => {
+                await browser.setHighContrastMode(highContrastMode);
+                await headingsPage.waitForHighContrastMode(highContrastMode);
+
+                const results = await scanForAccessibilityIssues(
+                    headingsPage,
+                    detailsViewSelectors.mainContent,
+                );
+                expect(results).toHaveLength(0);
+            },
+        );
+    });
 });

--- a/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
+++ b/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
@@ -40,10 +40,7 @@ describe('Details View -> Assessment -> Reflow', () => {
             async highContrastMode => {
                 await browser.setHighContrastMode(highContrastMode);
 
-                const results = await scanForAccessibilityIssues(
-                    detailsViewPage,
-                    detailsViewSelectors.mainContent,
-                );
+                const results = await scanForAccessibilityIssues(detailsViewPage, '*');
                 expect(results).toHaveLength(0);
             },
         );
@@ -58,10 +55,7 @@ describe('Details View -> Assessment -> Reflow', () => {
                     detailsViewSelectors.commandBarMenuButtonExpanded(true),
                 );
 
-                const results = await scanForAccessibilityIssues(
-                    detailsViewPage,
-                    detailsViewSelectors.mainContent,
-                );
+                const results = await scanForAccessibilityIssues(detailsViewPage, '*');
                 expect(results).toHaveLength(0);
 
                 // Close menu before next test
@@ -87,10 +81,7 @@ describe('Details View -> Assessment -> Reflow', () => {
             async highContrastMode => {
                 await browser.setHighContrastMode(highContrastMode);
 
-                const results = await scanForAccessibilityIssues(
-                    detailsViewPage,
-                    detailsViewSelectors.mainContent,
-                );
+                const results = await scanForAccessibilityIssues(detailsViewPage, '*');
                 expect(results).toHaveLength(0);
             },
         );
@@ -107,10 +98,7 @@ describe('Details View -> Assessment -> Reflow', () => {
                     detailsViewSelectors.assessmentNavHamburgerButtonExpanded(true),
                 );
 
-                const results = await scanForAccessibilityIssues(
-                    detailsViewPage,
-                    detailsViewSelectors.mainContent,
-                );
+                const results = await scanForAccessibilityIssues(detailsViewPage, '*');
                 expect(results).toHaveLength(0);
 
                 // Close panel before next test

--- a/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
+++ b/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { narrowModeThresholds } from 'DetailsView/components/narrow-mode-detector';
+import { Browser } from '../../common/browser';
+import { launchBrowser } from '../../common/browser-factory';
+import { detailsViewSelectors } from '../../common/element-identifiers/details-view-selectors';
+import { DetailsViewPage } from '../../common/page-controllers/details-view-page';
+import { scanForAccessibilityIssues } from '../../common/scan-for-accessibility-issues';
+
+describe('Details View -> Assessment -> Reflow', () => {
+    let browser: Browser;
+    let detailsViewPage: DetailsViewPage;
+    const height = 400;
+
+    beforeAll(async () => {
+        browser = await launchBrowser({
+            suppressFirstTimeDialog: true,
+            addExtraPermissionsToManifest: 'fake-activeTab',
+        });
+
+        detailsViewPage = (await browser.newAssessment()).detailsViewPage;
+    });
+
+    afterAll(async () => {
+        if (browser) {
+            await browser.close();
+            browser = undefined;
+        }
+    });
+
+    describe('With command bar collapsed', () => {
+        beforeEach(async () => {
+            const width = narrowModeThresholds.collapseCommandBarThreshold - 1;
+            await detailsViewPage.setViewport(width, height);
+            await detailsViewPage.waitForSelector(detailsViewSelectors.commandBarMenuButton);
+        });
+
+        it.each([true, false])(
+            `should pass accessibility validation with high contrast mode=%s`,
+            async highContrastMode => {
+                await browser.setHighContrastMode(highContrastMode);
+
+                const results = await scanForAccessibilityIssues(
+                    detailsViewPage,
+                    detailsViewSelectors.mainContent,
+                );
+                expect(results).toHaveLength(0);
+            },
+        );
+
+        it.each([true, false])(
+            `should pass accessibility validation with command bar menu open and high contrast mode=%s`,
+            async highContrastMode => {
+                await browser.setHighContrastMode(highContrastMode);
+
+                await detailsViewPage.clickSelector(detailsViewSelectors.commandBarMenuButton);
+                await detailsViewPage.waitForSelector(
+                    detailsViewSelectors.commandBarMenuButtonExpanded(true),
+                );
+
+                const results = await scanForAccessibilityIssues(
+                    detailsViewPage,
+                    detailsViewSelectors.mainContent,
+                );
+                expect(results).toHaveLength(0);
+
+                // Close menu before next test
+                await detailsViewPage.clickSelector(detailsViewSelectors.commandBarMenuButton);
+                await detailsViewPage.waitForSelector(
+                    detailsViewSelectors.commandBarMenuButtonExpanded(false),
+                );
+            },
+        );
+    });
+
+    describe('With left nav collapsed', () => {
+        beforeEach(async () => {
+            const width = narrowModeThresholds.collapseHeaderAndNavThreshold - 1;
+            await detailsViewPage.setViewport(width, height);
+            await detailsViewPage.waitForSelector(
+                detailsViewSelectors.assessmentNavHamburgerButton,
+            );
+        });
+
+        it.each([true, false])(
+            `should pass accessibility validation with high contrast mode=%s`,
+            async highContrastMode => {
+                await browser.setHighContrastMode(highContrastMode);
+
+                const results = await scanForAccessibilityIssues(
+                    detailsViewPage,
+                    detailsViewSelectors.mainContent,
+                );
+                expect(results).toHaveLength(0);
+            },
+        );
+
+        it.each([true, false])(
+            `should pass accessibility validation with hamburger menu panel open and high contrast mode=%s`,
+            async highContrastMode => {
+                await browser.setHighContrastMode(highContrastMode);
+
+                await detailsViewPage.clickSelector(
+                    detailsViewSelectors.assessmentNavHamburgerButton,
+                );
+                await detailsViewPage.waitForSelector(
+                    detailsViewSelectors.assessmentNavHamburgerButtonExpanded(true),
+                );
+
+                const results = await scanForAccessibilityIssues(
+                    detailsViewPage,
+                    detailsViewSelectors.mainContent,
+                );
+                expect(results).toHaveLength(0);
+
+                // Close panel before next test
+                await detailsViewPage.clickSelector(
+                    detailsViewSelectors.assessmentNavHamburgerButton,
+                );
+                await detailsViewPage.waitForSelector(
+                    detailsViewSelectors.assessmentNavHamburgerButtonExpanded(false),
+                );
+            },
+        );
+    });
+});


### PR DESCRIPTION
#### Description of changes

Add E2E test cases to run the A11ySelfValidator on new reflow UI components, including:
- Hamburger button and panel
- Command bar "..." button and menu
- Getting started pages

We found several A11y bugs in these components during feature validation that these E2E tests would have caught, so this will prevent regressions for those fixes.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
