### PR TITLE
fix(firefox): excessive spacing around overview summary bar

### DIFF
--- a/src/reports/components/outcome-summary-bar.scss
+++ b/src/reports/components/outcome-summary-bar.scss
@@ -16,8 +16,9 @@ $outcome-not-applicable-color: $neutral-outcome;
 
 .outcome-summary-bar {
     $outcome-summary-icon-size: 16px;
-    flex: 0 0 100%;
     display: flex;
+    flex-grow: 0;
+    flex-shrink: 0;
     flex-direction: row;
     flex-wrap: wrap;
     align-items: center;


### PR DESCRIPTION
#### Description of changes

The outcome summary bar was using `flex-basis: 100%`, which is intended to imply that child elements should use the height of the containing element by default. This is wrong; we don't want the summary bar to be the height of the whole overview panel. Firefox was doing the right thing (by respecting this incorrect `flex-basis` value), where Chromium for some reason ignores the bogus value.

No visual impact in Chromium.

In Firefox, before (all the content is there if you scroll way down):

![screenshot showing buggy spacing in firefox](https://user-images.githubusercontent.com/376284/88963922-8f472600-d276-11ea-9905-daf0ae7a1f90.png)

after:

![screenshot showing overview page rendering as-designed in firefox](https://user-images.githubusercontent.com/376284/88963861-7c345600-d276-11ea-86e2-4e58b002c103.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: part of #445
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
