### PR TITLE
fix(firefox): fix details view gear menu options launching extra windows

### DIFF
--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -39,7 +39,6 @@ export interface BrowserAdapter {
     sendMessageToFrames(message: any): Promise<void>;
     executeScriptInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]>;
     insertCSSInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void>;
-    getRunTimeId(): string;
     createNotification(options: Notifications.CreateNotificationOptions): Promise<string>;
     getRuntimeLastError(): chrome.runtime.LastError | undefined;
     isAllowedFileSchemeAccess(): Promise<boolean>;

--- a/src/common/browser-adapters/webextension-browser-adapter.ts
+++ b/src/common/browser-adapters/webextension-browser-adapter.ts
@@ -53,10 +53,6 @@ export abstract class WebExtensionBrowserAdapter
         chrome.windows.onFocusChanged.addListener(callback);
     }
 
-    public getRunTimeId(): string {
-        return chrome.runtime.id;
-    }
-
     public tabsQuery(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]> {
         return browser.tabs.query(query);
     }

--- a/src/tests/unit/tests/background/extension-details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/extension-details-view-controller.test.ts
@@ -147,7 +147,9 @@ describe('ExtensionDetailsViewController', () => {
         browserAdapterMock.reset();
 
         // update details tab
-        browserAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => 'ext_id');
+        browserAdapterMock
+            .setup(adapter => adapter.getUrl(It.isAny()))
+            .returns(suffix => `browser://mock_ext_id${suffix}`);
 
         onUpdateTabCallback(
             detailsViewTabId,
@@ -176,8 +178,10 @@ describe('ExtensionDetailsViewController', () => {
         browserAdapterMock.reset();
 
         // update details tab
-        const extensionId = 'ext_id';
-        browserAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
+        browserAdapterMock
+            .setup(adapter => adapter.getUrl(It.isAny()))
+            .returns(suffix => `browser://mock_ext_id${suffix}`);
+
         onUpdateTabCallback(
             detailsViewTabId,
             { url: 'chromeExt://ext_id/DetailsView/detailsView.html?tabId=90' },
@@ -204,11 +208,13 @@ describe('ExtensionDetailsViewController', () => {
         browserAdapterMock.reset();
 
         // update details tab
-        const extensionId = 'ext_id';
-        browserAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
+        browserAdapterMock
+            .setup(adapter => adapter.getUrl(It.isAny()))
+            .returns(suffix => `browser://mock_ext_id${suffix}`);
+
         onUpdateTabCallback(
             detailsViewTabId,
-            { url: 'chromeExt://ext_Id/detailsView/detailsView.html?tabId=' + targetTabId },
+            { url: 'browser://MOCK_EXT_ID/detailsView/detailsView.html?tabId=' + targetTabId },
             null,
         );
 
@@ -233,11 +239,16 @@ describe('ExtensionDetailsViewController', () => {
         browserAdapterMock.reset();
 
         // update details tab
-        const extensionId = 'ext_id';
-        browserAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
+        browserAdapterMock
+            .setup(adapter => adapter.getUrl(It.isAny()))
+            .returns(suffix => `browser://mock_ext_id${suffix}`);
+
         onUpdateTabCallback(
             detailsViewTabId,
-            { url: 'chromeExt://ext_Id/detailsView/detailsView.html?tabId=' + targetTabId + '#' },
+            {
+                url:
+                    'browser://MOCK_EXT_ID/detailsView/detailsView.html?tabId=' + targetTabId + '#',
+            },
             null,
         );
 


### PR DESCRIPTION
#### Description of changes

Previously, in Firefox, selecting "Settings" or "Preview Features" from the gear menu in the details page would always launch an extra new details view window, in addition to opening the panel it's supposed to.

The root cause is that the actions that handle those menu item presses are the same actions that handle the similar item presses in the popup page's gear menu; they choose whether to launch a new details view window or not as part of responding to the request by checking whether the ExtensionDetailsViewController already knows about a details view tab being open for a given target tab ID, and opening a new details view tab if not. However, the tracking mechanism the control uses for detecting those details view tabs being open is based on looking for tab-update events with URL properties that match the output of this function:

```typescript
private getDetailsUrlWithExtensionId(tabId: number): string {
        return `${this.browserAdapter.getRunTimeId()}${this.getDetailsUrl(tabId)}`;
}
```

This works in Chrome because the extension URL prefix is based on the runtime ID. However, in Firefox, the runtime ID and the extension URL prefix are not necessarily related to one another (in particular, they are completely distinct for unpacked extensions), so the controller never "notices" that a details view tab was opened; this means that it thinks it has to launch a new one every time.

This PR updates the logic to use `getUrl(...)` instead of trying to format the URL manually using `getRunTimeId()`. Since this was the only point where we actually used `getRunTimeId()`, I removed it from the `BrowserAdapter` interface.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: part of #445
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
