### PR TITLE
refactor: clean up css pertaining to overview

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -245,6 +245,7 @@ div.insights-file-issue-details-dialog-container {
             align-items: center;
             h2 {
                 font-weight: $normalTitleFontWeight;
+                font-size: 17px;
             }
         }
         .collapsible-content {
@@ -283,17 +284,6 @@ div.insights-file-issue-details-dialog-container {
                     font-size: 21px;
                     color: $neutral-100;
                 }
-                h2 {
-                    font-size: 17px;
-                    color: $neutral-100;
-                }
-                h3 {
-                    margin: 0px;
-                    padding-top: 4px;
-                    font-size: 14px;
-                    color: $neutral-100;
-                    font-weight: $fontWeightSemiBold;
-                }
                 b {
                     font-weight: 600;
                 }
@@ -309,53 +299,6 @@ div.insights-file-issue-details-dialog-container {
                     }
                     .ms-Toggle-innerContainer {
                         margin: 10px 0px 10px 0px;
-                    }
-                }
-                .overview {
-                    display: flex;
-                    flex-direction: row;
-                    flex-wrap: wrap;
-                    padding-left: 32px;
-                    .overview-text-summary-section {
-                        display: flex;
-                        flex-direction: column;
-                        flex: 1 1 50%;
-                        align-items: flex-start;
-                        width: 90%;
-                        margin-right: 32px;
-                        .assessment-report-summary {
-                            margin-top: 40px;
-                            width: 100%;
-                            h2 {
-                                font-weight: 600;
-                                line-height: 32px;
-                                font-size: 21px;
-                                letter-spacing: -0.02em;
-                                color: $primary-text;
-                                margin: 0px;
-                            }
-                            h3 {
-                                margin: 16px 0px 21px 0px;
-                                padding: 0;
-                            }
-                            .assessment-summary-details {
-                                .test-summary {
-                                    padding: 12px 10px;
-                                    .test-summary-display-name {
-                                        font-family: $semiBoldFontFamily;
-                                        font-size: 14px;
-                                        line-height: 20px;
-                                        font-weight: 600;
-                                    }
-                                }
-                            }
-                            .test-details-text {
-                                font-weight: 600;
-                                line-height: 24px;
-                                font-size: 17px;
-                                color: $primary-text;
-                            }
-                        }
                     }
                 }
             }

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -6,8 +6,6 @@
 @import '../../views/content/content.scss';
 @import '../../reports/components/outcome.scss';
 @import '../../reports/components/assessment-report-header.scss';
-@import '../../reports/components/assessment-report-summary.scss';
-@import '../../reports/components/assessment-summary-details.scss';
 @import '../../common/components/toast.scss';
 @import '../../common/components/guidance-tags.scss';
 

--- a/src/DetailsView/components/overview-content/overview-content-container.scss
+++ b/src/DetailsView/components/overview-content/overview-content-container.scss
@@ -10,3 +10,18 @@
         margin-bottom: 40px;
     }
 }
+
+.overview {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    padding-left: 32px;
+    .overview-text-summary-section {
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 50%;
+        align-items: flex-start;
+        width: 90%;
+        margin-right: 32px;
+    }
+}

--- a/src/DetailsView/components/overview-content/overview-content-container.tsx
+++ b/src/DetailsView/components/overview-content/overview-content-container.tsx
@@ -78,9 +78,9 @@ export const OverviewContainer = NamedFC<OverviewContainerProps>('OverviewContai
     );
 
     return (
-        <div className="overview">
+        <div className={styles.overview}>
             <TargetChangeDialog deps={deps} prevTab={prevTarget} newTab={currentTarget} />
-            <section className="overview-text-summary-section">
+            <section className={styles.overviewTextSummarySection}>
                 <OverviewHeading />
                 <AssessmentReportSummary summary={summaryData} />
             </section>

--- a/src/DetailsView/components/overview-content/overview-content-container.tsx
+++ b/src/DetailsView/components/overview-content/overview-content-container.tsx
@@ -54,6 +54,8 @@ export interface OverviewContainerProps {
     featureFlagStoreData: FeatureFlagStoreData;
 }
 
+export const overviewContainerAutomationId = 'overviewContainerAutomationId';
+
 export const OverviewContainer = NamedFC<OverviewContainerProps>('OverviewContainer', props => {
     const { deps, assessmentStoreData, tabStoreData, featureFlagStoreData } = props;
     const {
@@ -78,7 +80,7 @@ export const OverviewContainer = NamedFC<OverviewContainerProps>('OverviewContai
     );
 
     return (
-        <div className={styles.overview}>
+        <div data-automation-id={overviewContainerAutomationId} className={styles.overview}>
             <TargetChangeDialog deps={deps} prevTab={prevTarget} newTab={currentTarget} />
             <section className={styles.overviewTextSummarySection}>
                 <OverviewHeading />

--- a/src/DetailsView/components/overview-content/overview-heading.scss
+++ b/src/DetailsView/components/overview-content/overview-heading.scss
@@ -9,6 +9,8 @@
 }
 
 .overview-heading {
+    margin-bottom: 40px;
+
     h1 {
         font-weight: bold !important;
         line-height: 40px;

--- a/src/DetailsView/components/overview-content/overview-help-section.scss
+++ b/src/DetailsView/components/overview-content/overview-help-section.scss
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-@import '../../../common/styles/colors.scss';
+@import '../../../common/styles/common.scss';
 
 .overview-help-container {
     padding-top: 20px;
@@ -13,7 +13,8 @@
 }
 
 .help-heading {
-    font-size: 17px;
+    @include h3;
+
     padding: 0px;
     margin-block-end: 1em;
     margin-inline-start: 0px;

--- a/src/DetailsView/components/requirement-view.scss
+++ b/src/DetailsView/components/requirement-view.scss
@@ -19,6 +19,10 @@
 
     .main-content {
         margin-top: 10px;
+
+        h3 {
+            @include h3;
+        }
     }
 }
 

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -41,3 +41,8 @@ $fastPassRightPanelMarginTop: 24px !default;
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+@mixin h3 {
+    font-weight: $fontWeightSemiBold;
+    font-size: 17px;
+}

--- a/src/reports/assessment-report.scss
+++ b/src/reports/assessment-report.scss
@@ -6,8 +6,6 @@
 @import '../common/styles/fonts.scss';
 @import './components/outcome.scss';
 @import './components/assessment-report-header.scss';
-@import './components/assessment-report-summary.scss';
-@import './components/assessment-summary-details.scss';
 @import './components/assessment-scan-details.scss';
 @import './components/assessment-report-body-header.scss';
 @import '../common/components/guidance-tags.scss';

--- a/src/reports/components/assessment-report-summary.scss
+++ b/src/reports/components/assessment-report-summary.scss
@@ -1,20 +1,30 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-@import '../../common/styles/fonts.scss';
+@import '../../common/styles/common.scss';
 
 .assessment-report-summary {
     margin-bottom: 40px;
     display: flex;
     flex-direction: column;
+    width: 100%;
+
     h2 {
         font-family: $fontFamily;
         font-size: 21px;
         margin: 0px;
         line-height: 32px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        color: $primary-text;
+        margin: 0px;
     }
-    h3 {
+
+    .test-details-text {
+        @include h3;
+
+        line-height: 24px;
+        color: $primary-text;
         font-family: $fontFamily;
-        font-size: 17px;
         margin: 16px 0px 21px 0px;
     }
 }

--- a/src/reports/components/assessment-report-summary.scss
+++ b/src/reports/components/assessment-report-summary.scss
@@ -8,7 +8,7 @@
     flex-direction: column;
     width: 100%;
 
-    h2 {
+    > h2 {
         font-family: $fontFamily;
         font-size: 21px;
         margin: 0px;

--- a/src/reports/components/assessment-report-summary.tsx
+++ b/src/reports/components/assessment-report-summary.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-
+import * as styles from 'reports/components/assessment-report-summary.scss';
 import { OverviewSummaryReportModel } from '../assessment-report-model';
 import { AssessmentSummaryDetails } from './assessment-summary-details';
 import { OutcomeSummaryBar } from './outcome-summary-bar';
@@ -14,14 +14,14 @@ export interface AssessmentReportSummaryProps {
 export class AssessmentReportSummary extends React.Component<AssessmentReportSummaryProps> {
     public render(): JSX.Element {
         return (
-            <div className="assessment-report-summary">
+            <div className={styles.assessmentReportSummary}>
                 <h2>Summary</h2>
                 <OutcomeSummaryBar
                     outcomeStats={this.props.summary.byPercentage}
                     countSuffix="%"
                     allOutcomeTypes={allRequirementOutcomeTypes}
                 />
-                <h3 className="test-details-text">Test details</h3>
+                <h3 className={styles.testDetailsText}>Test details</h3>
                 {this.renderDetails()}
             </div>
         );

--- a/src/reports/components/assessment-summary-details.scss
+++ b/src/reports/components/assessment-summary-details.scss
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-@import '../../common/styles/colors.scss';
-@import '../../common/styles/fonts.scss';
+@import '../../common/styles/common.scss';
 
 .assessment-summary-details {
     display: flex;
@@ -26,7 +25,7 @@
             .test-summary {
                 display: flex;
                 width: 98%;
-                padding: 2% 1% 2% 1%;
+                padding: 12px 10px;
                 justify-content: space-between;
                 border-bottom: $neutral-alpha-8 solid 1px;
             }
@@ -42,6 +41,7 @@
                 font-size: 14px;
                 line-height: 20px;
                 white-space: nowrap;
+                font-weight: 600;
             }
         }
     }

--- a/src/reports/components/assessment-summary-details.tsx
+++ b/src/reports/components/assessment-summary-details.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-
+import * as styles from 'reports/components/assessment-summary-details.scss';
 import { AssessmentSummaryReportModel } from '../assessment-report-model';
 import { OutcomeChipSet } from './outcome-chip-set';
 import { OutcomeIconSet } from './outcome-icon-set';
@@ -13,8 +13,8 @@ export interface AssessmentSummaryDetailsProps {
 export class AssessmentSummaryDetails extends React.Component<AssessmentSummaryDetailsProps> {
     public render(): JSX.Element {
         return (
-            <div role="table" className="assessment-summary-details">
-                <div role="rowgroup" className="assessment-summary-details-body">
+            <div role="table" className={styles.assessmentSummaryDetails}>
+                <div role="rowgroup" className={styles.assessmentSummaryDetailsBody}>
                     {this.getTestDetailsList(this.props.testSummaries)}
                 </div>
             </div>
@@ -22,21 +22,21 @@ export class AssessmentSummaryDetails extends React.Component<AssessmentSummaryD
     }
 
     private getTestDetailsList(summaries: AssessmentSummaryReportModel[]): JSX.Element[] {
-        return summaries.map(testSummary => (
+        return summaries.map(summary => (
             <div
                 role="row"
-                key={testSummary.displayName}
-                className="assessment-summary-details-row"
+                key={summary.displayName}
+                className={styles.assessmentSummaryDetailsRow}
             >
-                <div className="test-summary">
-                    <div role="cell" className="test-summary-display-name">
-                        {testSummary.displayName}
+                <div className={styles.testSummary}>
+                    <div role="cell" className={styles.testSummaryDisplayName}>
+                        {summary.displayName}
                     </div>
-                    <div role="cell" className="test-summary-status">
-                        {testSummary.pass + testSummary.incomplete + testSummary.fail > 7 ? (
-                            <OutcomeChipSet {...testSummary} />
+                    <div role="cell" className={styles.testSummaryStatus}>
+                        {summary.pass + summary.incomplete + summary.fail > 7 ? (
+                            <OutcomeChipSet {...summary} />
                         ) : (
-                            <OutcomeIconSet {...testSummary} />
+                            <OutcomeIconSet {...summary} />
                         )}
                     </div>
                 </div>

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -6,6 +6,7 @@ import { instanceTableTextContentAutomationId } from 'DetailsView/components/ass
 import { visualHelperToggleAutomationId } from 'DetailsView/components/base-visual-helper-toggle';
 import { settingsPanelAutomationId } from 'DetailsView/components/details-view-overlay/settings-panel/settings-panel';
 import { IframeWarningContainerAutomationId } from 'DetailsView/components/iframe-warning';
+import { overviewContainerAutomationId } from 'DetailsView/components/overview-content/overview-content-container';
 import { overviewHeadingAutomationId } from 'DetailsView/components/overview-content/overview-heading';
 import { startOverAutomationId } from 'DetailsView/components/start-over-component-factory';
 import { failureCountAutomationId } from 'reports/components/outcome-chip';
@@ -48,7 +49,7 @@ export const fastPassAutomatedChecksSelectors = {
 };
 
 export const overviewSelectors = {
-    overview: '.overview',
+    overview: getAutomationIdSelector(overviewContainerAutomationId),
     overviewHeading: getAutomationIdSelector(overviewHeadingAutomationId),
 };
 

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
     prevTab={Object {}}
   />
   <section
-    className="overview-text-summary-section"
+    className="overviewTextSummarySection"
   >
     <OverviewHeading />
     <AssessmentReportSummary />

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`OverviewContainer component is defined and matches snapshot 1`] = `
 <div
   className="overview"
+  data-automation-id="overviewContainerAutomationId"
 >
   <TargetChangeDialog
     deps={

--- a/src/tests/unit/tests/reports/components/__snapshots__/assessment-report-summary.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/assessment-report-summary.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`AssessmentReportSummary render Correct composition 1`] = `
 <div
-  className="assessment-report-summary"
+  className="assessmentReportSummary"
 >
   <h2>
     Summary
@@ -18,7 +18,7 @@ exports[`AssessmentReportSummary render Correct composition 1`] = `
     countSuffix="%"
   />
   <h3
-    className="test-details-text"
+    className="testDetailsText"
   >
     Test details
   </h3>

--- a/src/tests/unit/tests/reports/components/__snapshots__/assessment-summary-details.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/assessment-summary-details.test.tsx.snap
@@ -2,28 +2,28 @@
 
 exports[`AssessmentSummaryDetails render Correct composition 1`] = `
 <div
-  className="assessment-summary-details"
+  className="assessmentSummaryDetails"
   role="table"
 >
   <div
-    className="assessment-summary-details-body"
+    className="assessmentSummaryDetailsBody"
     role="rowgroup"
   >
     <div
-      className="assessment-summary-details-row"
+      className="assessmentSummaryDetailsRow"
       role="row"
     >
       <div
-        className="test-summary"
+        className="testSummary"
       >
         <div
-          className="test-summary-display-name"
+          className="testSummaryDisplayName"
           role="cell"
         >
           Assessment1
         </div>
         <div
-          className="test-summary-status"
+          className="testSummaryStatus"
           role="cell"
         >
           <OutcomeIconSet
@@ -36,20 +36,20 @@ exports[`AssessmentSummaryDetails render Correct composition 1`] = `
       </div>
     </div>
     <div
-      className="assessment-summary-details-row"
+      className="assessmentSummaryDetailsRow"
       role="row"
     >
       <div
-        className="test-summary"
+        className="testSummary"
       >
         <div
-          className="test-summary-display-name"
+          className="testSummaryDisplayName"
           role="cell"
         >
           Assessment2
         </div>
         <div
-          className="test-summary-status"
+          className="testSummaryStatus"
           role="cell"
         >
           <OutcomeIconSet
@@ -67,28 +67,28 @@ exports[`AssessmentSummaryDetails render Correct composition 1`] = `
 
 exports[`AssessmentSummaryDetails render Renders an OutcomeChipSet for 8 items 1`] = `
 <div
-  className="assessment-summary-details"
+  className="assessmentSummaryDetails"
   role="table"
 >
   <div
-    className="assessment-summary-details-body"
+    className="assessmentSummaryDetailsBody"
     role="rowgroup"
   >
     <div
-      className="assessment-summary-details-row"
+      className="assessmentSummaryDetailsRow"
       role="row"
     >
       <div
-        className="test-summary"
+        className="testSummary"
       >
         <div
-          className="test-summary-display-name"
+          className="testSummaryDisplayName"
           role="cell"
         >
           test
         </div>
         <div
-          className="test-summary-status"
+          className="testSummaryStatus"
           role="cell"
         >
           <OutcomeChipSet
@@ -106,28 +106,28 @@ exports[`AssessmentSummaryDetails render Renders an OutcomeChipSet for 8 items 1
 
 exports[`AssessmentSummaryDetails render Renders an OutcomeIconSet for 7 items 1`] = `
 <div
-  className="assessment-summary-details"
+  className="assessmentSummaryDetails"
   role="table"
 >
   <div
-    className="assessment-summary-details-body"
+    className="assessmentSummaryDetailsBody"
     role="rowgroup"
   >
     <div
-      className="assessment-summary-details-row"
+      className="assessmentSummaryDetailsRow"
       role="row"
     >
       <div
-        className="test-summary"
+        className="testSummary"
       >
         <div
-          className="test-summary-display-name"
+          className="testSummaryDisplayName"
           role="cell"
         >
           test
         </div>
         <div
-          className="test-summary-status"
+          className="testSummaryStatus"
           role="cell"
         >
           <OutcomeIconSet


### PR DESCRIPTION
#### Description of changes

Cleans up css pertaining to overview. Required some refactoring around styles in details view generally (which is good since I got to remove some general styles there).

I **did** validate other h2 and h3 elements that would be impacted by the details view changes and things seemed good. This is also why I added the font-size change to the collapsible h2 element.

Before:
![image](https://user-images.githubusercontent.com/32555133/88984225-e7cff080-d281-11ea-955f-f312b55d90dc.png)

After **(note: help text)**:
![image](https://user-images.githubusercontent.com/32555133/88984242-f28a8580-d281-11ea-9dae-245f2636b3f2.png)

Before:
![image](https://user-images.githubusercontent.com/32555133/88984284-0cc46380-d282-11ea-972f-059014894d40.png)

After **(note: instances header)**:
![image](https://user-images.githubusercontent.com/32555133/88984257-fd451a80-d281-11ea-890e-a5ddcb98cf24.png)

Before:
![image](https://user-images.githubusercontent.com/32555133/88984321-25347e00-d282-11ea-99bf-b86a08ef0856.png)

After:
![image](https://user-images.githubusercontent.com/32555133/88984334-2d8cb900-d282-11ea-8f55-ec07c1226a5f.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
