### PR TITLE
test: fix jest timer usage

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Logger } from 'common/logging/logger';
 import { NamedFC } from 'common/react/named-fc';
 import { OpenDialogOptions, OpenDialogReturnValue } from 'electron';
 import { getId, PrimaryButton, TextField } from 'office-ui-fabric-react';
@@ -8,6 +9,7 @@ import * as styles from './folder-picker.scss';
 
 export type FolderPickerDeps = {
     showOpenFileDialog: (opts: OpenDialogOptions) => Promise<OpenDialogReturnValue>;
+    logger: Logger;
 };
 export type FolderPickerProps = {
     deps: FolderPickerDeps;
@@ -24,12 +26,16 @@ export const FolderPicker = NamedFC<FolderPickerProps>(
         };
 
         const onBrowseButtonClick = async () => {
-            const result = await props.deps.showOpenFileDialog({
-                properties: ['openDirectory'],
-            });
+            try {
+                const result = await props.deps.showOpenFileDialog({
+                    properties: ['openDirectory'],
+                });
 
-            if (!result.canceled && result.filePaths.length > 0) {
-                props.onChange(result.filePaths[0]);
+                if (!result.canceled && result.filePaths.length > 0) {
+                    props.onChange(result.filePaths[0]);
+                }
+            } catch (error) {
+                props.deps.logger.error(`Error from showOpenFileDialog: ${error}`);
             }
         };
 

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -526,6 +526,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             closeApp: ipcRendererShim.closeWindow,
             startTesting: startTesting,
             showOpenFileDialog: ipcRendererShim.showOpenFileDialog,
+            logger,
         };
 
         window.insightsUserConfiguration = new UserConfigurationController(interpreter);

--- a/src/tests/unit/common/android-setup-step-props-builder.tsx
+++ b/src/tests/unit/common/android-setup-step-props-builder.tsx
@@ -26,6 +26,7 @@ export class AndroidSetupStepPropsBuilder extends BaseDataBuilder<CommonAndroidS
                 closeApp: null,
                 startTesting: null,
                 showOpenFileDialog: null,
+                logger: null,
             },
         };
     }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-step-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-step-container.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`AndroidSetupStepContainer passes common props and deps through 1`] = `
           "prompt-locate-adb": [Function],
         },
         "closeApp": null,
+        "logger": null,
         "showOpenFileDialog": null,
         "startTesting": null,
       }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/configuring-port-forwarding-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/configuring-port-forwarding-step.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`ConfiguringPortForwardingStep renders 1`] = `
       "androidSetupActionCreator": null,
       "androidSetupStepComponentProvider": null,
       "closeApp": null,
+      "logger": null,
       "showOpenFileDialog": null,
       "startTesting": null,
     }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-adb-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-adb-step.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`DetectAdbStep renders 1`] = `
       "androidSetupActionCreator": null,
       "androidSetupStepComponentProvider": null,
       "closeApp": null,
+      "logger": null,
       "showOpenFileDialog": null,
       "startTesting": null,
     }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-devices-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-devices-step.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`DetectDevicesStep renders 1`] = `
       "androidSetupActionCreator": null,
       "androidSetupStepComponentProvider": null,
       "closeApp": null,
+      "logger": null,
       "showOpenFileDialog": null,
       "startTesting": null,
     }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-permissions-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-permissions-step.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`DetectDevicesStep renders 1`] = `
       "androidSetupActionCreator": null,
       "androidSetupStepComponentProvider": null,
       "closeApp": null,
+      "logger": null,
       "showOpenFileDialog": null,
       "startTesting": null,
     }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-service-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/detect-service-step.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`DetectServiceStep renders 1`] = `
       "androidSetupActionCreator": null,
       "androidSetupStepComponentProvider": null,
       "closeApp": null,
+      "logger": null,
       "showOpenFileDialog": null,
       "startTesting": null,
     }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/installing-service-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/installing-service-step.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`InstallingServiceStep renders 1`] = `
       "androidSetupActionCreator": null,
       "androidSetupStepComponentProvider": null,
       "closeApp": null,
+      "logger": null,
       "showOpenFileDialog": null,
       "startTesting": null,
     }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-locate-adb-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-locate-adb-step.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`PromptLocateAdbStep rendering renders per snapshot with adbLocation not
         "androidSetupActionCreator": null,
         "androidSetupStepComponentProvider": null,
         "closeApp": null,
+        "logger": null,
         "showOpenFileDialog": null,
         "startTesting": null,
       }
@@ -73,6 +74,7 @@ exports[`PromptLocateAdbStep rendering renders per snapshot with adbLocation set
         "androidSetupActionCreator": null,
         "androidSetupStepComponentProvider": null,
         "closeApp": null,
+        "logger": null,
         "showOpenFileDialog": null,
         "startTesting": null,
       }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/folder-picker.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/folder-picker.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Logger } from 'common/logging/logger';
 import { OpenDialogOptions } from 'electron';
 import {
     FolderPicker,
@@ -10,7 +11,6 @@ import { PrimaryButton, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { tick } from 'tests/unit/common/tick';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { Logger } from 'common/logging/logger';
 
 describe('FolderPicker', () => {
     let loggerMock: IMock<Logger>;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/folder-picker.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/folder-picker.test.tsx
@@ -10,14 +10,18 @@ import { PrimaryButton, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { tick } from 'tests/unit/common/tick';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { Logger } from 'common/logging/logger';
 
 describe('FolderPicker', () => {
+    let loggerMock: IMock<Logger>;
     let props: FolderPickerProps;
 
     beforeEach(() => {
+        loggerMock = Mock.ofType<Logger>();
         props = {
             deps: {
                 showOpenFileDialog: null,
+                logger: loggerMock.object,
             },
             instructionsText: 'some instructions',
             value: '/path/to/folder',
@@ -81,22 +85,27 @@ describe('FolderPicker', () => {
         });
 
         // This is an unexpected case; cancellation of the dialog is not an error
-        it('does not invoke onChange if showOpenFileDialog throws an error', () => {
+        it('does not invoke onChange if showOpenFileDialog throws an error', async () => {
+            const showOpenFileDialogError = new Error('mock error from showOpenFileDialog');
             showOpenFileDialogMock
                 .setup(m => m(expectedShowOpenFileDialogOptions))
-                .returns(() => Promise.reject(new Error('unexpected error')))
+                .returns(() => Promise.reject(showOpenFileDialogError))
                 .verifiable(Times.once());
 
             const rendered = shallow(<FolderPicker {...props} />);
             rendered.find(PrimaryButton).prop('onClick')(stubMouseEvent);
 
-            jest.runAllTimers();
+            await tick();
 
             showOpenFileDialogMock.verifyAll();
             onChangeMock.verify(m => m(It.isAny()), Times.never());
+            loggerMock.verify(
+                m => m.error(It.is(msg => msg.includes(showOpenFileDialogError.message))),
+                Times.once(),
+            );
         });
 
-        it('does not invoke onChange if showOpenFileDialog returns in a cancelled state', () => {
+        it('does not invoke onChange if showOpenFileDialog returns in a cancelled state', async () => {
             showOpenFileDialogMock
                 .setup(m => m(expectedShowOpenFileDialogOptions))
                 .returns(() => Promise.resolve({ canceled: true, filePaths: ['/path/to/adb'] }))
@@ -105,13 +114,13 @@ describe('FolderPicker', () => {
             const rendered = shallow(<FolderPicker {...props} />);
             rendered.find(PrimaryButton).prop('onClick')(stubMouseEvent);
 
-            jest.runAllTimers();
+            await tick();
 
             showOpenFileDialogMock.verifyAll();
             onChangeMock.verify(m => m(It.isAny()), Times.never());
         });
 
-        it('does not invoke onChange if showOpenFileDialog returns without any selected folders', () => {
+        it('does not invoke onChange if showOpenFileDialog returns without any selected folders', async () => {
             showOpenFileDialogMock
                 .setup(m => m(expectedShowOpenFileDialogOptions))
                 .returns(() => Promise.resolve({ canceled: false, filePaths: [] }))
@@ -120,7 +129,7 @@ describe('FolderPicker', () => {
             const rendered = shallow(<FolderPicker {...props} />);
             rendered.find(PrimaryButton).prop('onClick')(stubMouseEvent);
 
-            jest.runAllTimers();
+            await tick();
 
             showOpenFileDialogMock.verifyAll();
             onChangeMock.verify(m => m(It.isAny()), Times.never());


### PR DESCRIPTION
#### Description of changes

(extracted out of #3185)

Updating to the latest Jest version hits legitimate unit test errors of the form "don't use jest.runAllTimers() without first using jest.useFakeTimers()". These were the results of folder-picker.test.ts mis-using jest.runAllTimers(); the tests wanted to use that to clear the PromiseJob queue, but that's not what that function actually does. This corrects the tests to:

* Consistently use await tick() to clear the PromiseJob queue
* Avoid leaking an unhandled promise rejection in a legitimate case by adding a logger dep to the FolderPicker and reporting the error there instead of leaking it (the behavior of not invoking onChange when the error occurs is already correct and tested)
* It also updates drawer.ts, which legitimately uses jest.useFakeTimers(), clean up jest.useFakeTimers() with a corresponding jest.useRealTimers() in an afterEach

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
