### PR TITLE
refactor: clean up generic details view dialog styles

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -26,20 +26,6 @@ body {
     display: none !important;
 }
 
-div.insights-dialog-main-override {
-    width: 75%;
-    max-width: 500px;
-    @media screen and (max-width: 500px) {
-        min-width: 240px;
-        width: 75%;
-    }
-
-    user-select: text;
-    .start-over-dialog-body {
-        font-size: 16px;
-    }
-}
-
 .issue-filing-dialog {
     .ms-Dialog-title {
         font-size: 21px;
@@ -53,18 +39,6 @@ div.insights-dialog-main-override {
         font-weight: 400;
         font-size: 15px;
         color: $secondary-text;
-    }
-}
-
-div.insights-file-issue-details-dialog-container {
-    max-width: 370px;
-
-    .ms-Dialog-content p {
-        margin-block-start: 4px;
-    }
-
-    .ms-Dialog-actions {
-        margin-top: 24px;
     }
 }
 

--- a/src/DetailsView/components/common-dialog-styles.scss
+++ b/src/DetailsView/components/common-dialog-styles.scss
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+div.insights-dialog-main-override {
+    width: 75%;
+    max-width: 500px;
+    @media screen and (max-width: 500px) {
+        min-width: 240px;
+        width: 75%;
+    }
+
+    user-select: text;
+    .dialog-body {
+        font-size: 16px;
+    }
+}

--- a/src/DetailsView/components/generic-dialog.tsx
+++ b/src/DetailsView/components/generic-dialog.tsx
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react';
-import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react';
+import * as styles from 'DetailsView/components/common-dialog-styles.scss';
+import {
+    DefaultButton,
+    Dialog,
+    DialogFooter,
+    DialogType,
+    PrimaryButton,
+} from 'office-ui-fabric-react';
 import * as React from 'react';
-
 import { NamedFC } from '../../common/react/named-fc';
 
 export type GenericDialogProps = {
@@ -34,10 +39,10 @@ export const GenericDialog = NamedFC<GenericDialogProps>('GenericDialog', props 
             }}
             modalProps={{
                 isBlocking: false,
-                containerClassName: 'insights-dialog-main-override',
+                containerClassName: styles.insightsDialogMainOverride,
             }}
         >
-            <div className={'start-over-dialog-body'}>{messageText}</div>
+            <div className={styles.dialogBody}>{messageText}</div>
             <DialogFooter>
                 <PrimaryButton onClick={onPrimaryButtonClick} text={primaryButtonText} />
                 <DefaultButton onClick={onCancelButtonClick} text={'Cancel'} autoFocus={true} />

--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ToolData } from 'common/types/store-data/unified-data-interface';
+import * as styles from 'DetailsView/components/common-dialog-styles.scss';
 import { cloneDeep, isEqual } from 'lodash';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react';
 import * as React from 'react';
-
-import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { IssueFilingActionMessageCreator } from '../../common/message-creators/issue-filing-action-message-creator';
 import { UserConfigMessageCreator } from '../../common/message-creators/user-config-message-creator';
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
@@ -79,7 +79,7 @@ export class IssueFilingDialog extends React.Component<
                 }}
                 modalProps={{
                     isBlocking: false,
-                    containerClassName: 'insights-dialog-main-override',
+                    containerClassName: styles.insightsDialogMainOverride,
                     className: 'issue-filing-dialog',
                 }}
                 onDismiss={onClose}

--- a/src/DetailsView/components/target-change-dialog.tsx
+++ b/src/DetailsView/components/target-change-dialog.tsx
@@ -7,6 +7,7 @@ import { NewTabLink } from 'common/components/new-tab-link';
 import { Tab } from 'common/itab';
 import { PersistedTabInfo } from 'common/types/store-data/assessment-result-data';
 import { UrlParser } from 'common/url-parser';
+import * as commonDialogStyles from 'DetailsView/components/common-dialog-styles.scss';
 import * as styles from 'DetailsView/components/target-change-dialog.scss';
 import { isEmpty } from 'lodash';
 import { DefaultButton, DialogFooter, DialogType, Link, TooltipHost } from 'office-ui-fabric-react';
@@ -40,7 +41,7 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
                 modalProps={{
                     className: styles.targetChangeDialogModal,
                     containerClassName: css(
-                        'insights-dialog-main-override',
+                        commonDialogStyles.insightsDialogMainOverride,
                         styles.targetChangeDialog,
                     ),
                     subtitleAriaId: 'target-change-dialog-description',

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-dialog.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`GenericDialogTest should render 1`] = `
 "<StyledWithResponsiveMode hidden={false} onDismiss={[Function: onCancelButtonClick]} dialogContentProps={{...}} modalProps={{...}}>
-  <div className=\\"start-over-dialog-body\\">
+  <div className=\\"dialogBody\\">
     test message
   </div>
   <StyledDialogFooterBase>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have ch
   modalProps={
     Object {
       "className": "issue-filing-dialog",
-      "containerClassName": "insights-dialog-main-override",
+      "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
   }
@@ -95,7 +95,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have no
   modalProps={
     Object {
       "className": "issue-filing-dialog",
-      "containerClassName": "insights-dialog-main-override",
+      "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
   }
@@ -176,7 +176,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have change
   modalProps={
     Object {
       "className": "issue-filing-dialog",
-      "containerClassName": "insights-dialog-main-override",
+      "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
   }
@@ -257,7 +257,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have not ch
   modalProps={
     Object {
       "className": "issue-filing-dialog",
-      "containerClassName": "insights-dialog-main-override",
+      "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
   }
@@ -338,7 +338,7 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
   modalProps={
     Object {
       "className": "issue-filing-dialog",
-      "containerClassName": "insights-dialog-main-override",
+      "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
   }
@@ -419,7 +419,7 @@ exports[`IssueFilingDialog render with isSettingsValid: true 1`] = `
   modalProps={
     Object {
       "className": "issue-filing-dialog",
-      "containerClassName": "insights-dialog-main-override",
+      "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
   }
@@ -500,7 +500,7 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
   modalProps={
     Object {
       "className": "issue-filing-dialog",
-      "containerClassName": "insights-dialog-main-override",
+      "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
   }
@@ -582,7 +582,7 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
   modalProps={
     Object {
       "className": "issue-filing-dialog",
-      "containerClassName": "insights-dialog-main-override",
+      "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
   }
@@ -663,7 +663,7 @@ exports[`IssueFilingDialog render: validate callback (onSelectedServiceChange) s
   modalProps={
     Object {
       "className": "issue-filing-dialog",
-      "containerClassName": "insights-dialog-main-override",
+      "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
   }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   modalProps={
     Object {
       "className": "targetChangeDialogModal",
-      "containerClassName": "insights-dialog-main-override targetChangeDialog",
+      "containerClassName": "insightsDialogMainOverride targetChangeDialog",
       "subtitleAriaId": "target-change-dialog-description",
     }
   }
@@ -104,7 +104,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   modalProps={
     Object {
       "className": "targetChangeDialogModal",
-      "containerClassName": "insights-dialog-main-override targetChangeDialog",
+      "containerClassName": "insightsDialogMainOverride targetChangeDialog",
       "subtitleAriaId": "target-change-dialog-description",
     }
   }
@@ -200,7 +200,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   modalProps={
     Object {
       "className": "targetChangeDialogModal",
-      "containerClassName": "insights-dialog-main-override targetChangeDialog",
+      "containerClassName": "insightsDialogMainOverride targetChangeDialog",
       "subtitleAriaId": "target-change-dialog-description",
     }
   }
@@ -296,7 +296,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   modalProps={
     Object {
       "className": "targetChangeDialogModal",
-      "containerClassName": "insights-dialog-main-override targetChangeDialog",
+      "containerClassName": "insightsDialogMainOverride targetChangeDialog",
       "subtitleAriaId": "target-change-dialog-description",
     }
   }
@@ -392,7 +392,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   modalProps={
     Object {
       "className": "targetChangeDialogModal",
-      "containerClassName": "insights-dialog-main-override targetChangeDialog",
+      "containerClassName": "insightsDialogMainOverride targetChangeDialog",
       "subtitleAriaId": "target-change-dialog-description",
     }
   }


### PR DESCRIPTION
#### Description of changes

Validated the three dialogs that are impacted by this change in details view: start over dialogs, issue filing dialog, and target page changed dialog. No changes were found.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
