### PR TITLE
fix: text change in Settings Issue filing for Azure Boards

### DIFF
--- a/src/issue-filing/services/azure-boards/azure-boards-settings-form.tsx
+++ b/src/issue-filing/services/azure-boards/azure-boards-settings-form.tsx
@@ -65,7 +65,7 @@ export const AzureBoardsSettingsForm = NamedFC<SettingsFormProps<AzureBoardsIssu
                 <Dropdown
                     options={options}
                     placeholder="Select an option"
-                    label="File issue details in:"
+                    label="Select a field for issue details"
                     onChange={onIssueDetailLocationChange}
                     selectedKey={props.settings ? props.settings.issueDetailsField : null}
                 />

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/__snapshots__/azure-boards-settings-form.test.tsx.snap
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/__snapshots__/azure-boards-settings-form.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`AzureBoardsSettingsForm renders settings is null 1`] = `
     value=""
   />
   <StyledWithResponsiveMode
-    label="File issue details in:"
+    label="Select a field for issue details"
     onChange={[Function]}
     options={
       Array [
@@ -40,7 +40,7 @@ exports[`AzureBoardsSettingsForm renders with projectUrl and issueDetailsField 1
     value="some project URL"
   />
   <StyledWithResponsiveMode
-    label="File issue details in:"
+    label="Select a field for issue details"
     onChange={[Function]}
     options={
       Array [


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

As described in #3186, minor text change from "File issue details in:" to "Select a field for issue details"

Screenshot of Azure Boards filing in Settings (same for Accessibility Insights for Web and Accessibility Insights for Android)
![image](https://user-images.githubusercontent.com/48259897/89358193-8c35a680-d677-11ea-8636-e0ef5e9d0737.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3186
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
