### PR TITLE
feat(needs-review): Changing links to NewTabLinks

### DIFF
--- a/src/ad-hoc-visualizations/needs-review/visualization.tsx
+++ b/src/ad-hoc-visualizations/needs-review/visualization.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NeedsReviewInstancesSection } from 'common/components/cards/needs-review-instances-section';
+import { NewTabLink } from 'common/components/new-tab-link';
 import { RuleAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import * as React from 'react';
 import { AdHocTestkeys } from '../../common/configs/adhoc-test-keys';
@@ -49,9 +50,9 @@ export const NeedsReviewAdHocVisualization: VisualizationConfiguration = {
                 Sometimes automated checks identify <i>possible</i> accessibility problems that need
                 to be reviewed and verified by a human. Because most accessibility problems can only
                 be discovered through manual testing, we recommend an{' '}
-                <a href="https://accessibilityinsights.io/docs/en/web/getstarted/assessment">
+                <NewTabLink href="https://accessibilityinsights.io/docs/en/web/getstarted/assessment">
                     assessment
-                </a>
+                </NewTabLink>
                 .
             </>
         ),

--- a/src/common/components/cards/how-to-check-text.tsx
+++ b/src/common/components/cards/how-to-check-text.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { NewTabLink } from 'common/components/new-tab-link';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import * as styles from './how-to-check-text.scss';
@@ -16,9 +17,9 @@ export const HowToCheckText = NamedFC<HowToCheckTextProps>('HowToCheckText', pro
             checkText = (
                 <div>
                     Inspect the element using the{' '}
-                    <a href="https://developers.google.com/web/updates/2018/01/devtools">
+                    <NewTabLink href="https://developers.google.com/web/updates/2018/01/devtools">
                         Accessibility pane in the browser Developer Tools
-                    </a>{' '}
+                    </NewTabLink>{' '}
                      to verify that the field's accessible name is complete without its associated{' '}
                     <b>
                         {'<'}label{'>'}
@@ -37,13 +38,13 @@ export const HowToCheckText = NamedFC<HowToCheckTextProps>('HowToCheckText', pro
                         </li>
                         <li list-style-type="disc">
                             If the text is intended to be visible, use{' '}
-                            <a href="https://go.microsoft.com/fwlink/?linkid=2075365">
+                            <NewTabLink href="https://go.microsoft.com/fwlink/?linkid=2075365">
                                 Accessibility Insights for Windows
-                            </a>{' '}
+                            </NewTabLink>{' '}
                             (or the{' '}
-                            <a href="https://developer.paciellogroup.com/resources/contrastanalyser/">
+                            <NewTabLink href="https://developer.paciellogroup.com/resources/contrastanalyser/">
                                 Colour Contrast Analyser
-                            </a>{' '}
+                            </NewTabLink>{' '}
                             if you're testing on a Mac) to manually verify that it has sufficient
                             contrast compared to the background. If the background is an image or
                             gradient, test an area where contrast appears to be lowest.
@@ -72,13 +73,13 @@ export const HowToCheckText = NamedFC<HowToCheckTextProps>('HowToCheckText', pro
                     </li>
                     <li>
                         To measure contrast, use{' '}
-                        <a href="https://go.microsoft.com/fwlink/?linkid=2075365">
+                        <NewTabLink href="https://go.microsoft.com/fwlink/?linkid=2075365">
                             Accessibility Insights for Windows
-                        </a>{' '}
+                        </NewTabLink>{' '}
                         (or the{' '}
-                        <a href="https://developer.paciellogroup.com/resources/contrastanalyser/">
+                        <NewTabLink href="https://developer.paciellogroup.com/resources/contrastanalyser/">
                             Colour Contrast Analyser
-                        </a>{' '}
+                        </NewTabLink>{' '}
                         if you're testing on a Mac).
                     </li>
                 </ul>

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-check-text.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-check-text.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`HowToCheckWebText renders with id=aria-input-field-name 1`] = `
 <div>
   Inspect the element using the
    
-  <a
+  <NewTabLink
     href="https://developers.google.com/web/updates/2018/01/devtools"
   >
     Accessibility pane in the browser Developer Tools
-  </a>
+  </NewTabLink>
    
   to verify that the field's accessible name is complete without its associated
    
@@ -40,19 +40,19 @@ exports[`HowToCheckWebText renders with id=color-contrast 1`] = `
     >
       If the text is intended to be visible, use
        
-      <a
+      <NewTabLink
         href="https://go.microsoft.com/fwlink/?linkid=2075365"
       >
         Accessibility Insights for Windows
-      </a>
+      </NewTabLink>
        
       (or the
        
-      <a
+      <NewTabLink
         href="https://developer.paciellogroup.com/resources/contrastanalyser/"
       >
         Colour Contrast Analyser
-      </a>
+      </NewTabLink>
        
       if you're testing on a Mac) to manually verify that it has sufficient contrast compared to the background. If the background is an image or gradient, test an area where contrast appears to be lowest.
     </li>
@@ -86,19 +86,19 @@ exports[`HowToCheckWebText renders with id=link-in-text-block 1`] = `
   <li>
     To measure contrast, use
      
-    <a
+    <NewTabLink
       href="https://go.microsoft.com/fwlink/?linkid=2075365"
     >
       Accessibility Insights for Windows
-    </a>
+    </NewTabLink>
      
     (or the
      
-    <a
+    <NewTabLink
       href="https://developer.paciellogroup.com/resources/contrastanalyser/"
     >
       Colour Contrast Analyser
-    </a>
+    </NewTabLink>
      
     if you're testing on a Mac).
   </li>


### PR DESCRIPTION
#### Description of changes

This PR changes the html tag used to surround hyperlinks in Needs review from a to the NewTabLink component that we have.  This is better because now links will not appear pre-emptively visited, and when clicked, they open in a new tab.  

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [This work item](https://mseng.visualstudio.com/DefaultCollection/1ES/_workitems/edit/1757264)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS

![new tab link](https://user-images.githubusercontent.com/33770444/89441718-94dfb880-d71b-11ea-98c4-9b9d05c136ab.gif)
Gif of the details view page for Needs review, with blue links visible in the subtitle and how to check resolution help.  When a link in the how to check field is clicked, the link is opened in a new tab. When a link in the subtitle is clicked, the link is opened in a new tab. Both links remain blue. 