### PR TITLE
feat(needs-review): Making Needs review feature flag public

### DIFF
--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -115,7 +115,7 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
             displayableName: 'Needs review',
             displayableDescription:
                 'Enable a new test to show automated check rules that might have an accessibility issue and need to be reviewed.',
-            isPreviewFeature: false,
+            isPreviewFeature: true,
             forceDefault: false,
         },
     ];

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
@@ -128,6 +128,52 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
                     Enables exporting reports to external services
                   </div>
                 </div>
+                <div
+                  class="generic-toggle-component--{{CSS_MODULE_HASH}}"
+                >
+                  <div
+                    class="toggle-container--{{CSS_MODULE_HASH}}"
+                  >
+                    <div
+                      class="toggle-name--{{CSS_MODULE_HASH}}"
+                    >
+                      Needs review
+                    </div>
+                    <div
+                      class="ms-Toggle is-enabled toggle--{{CSS_MODULE_HASH}} root-000"
+                    >
+                      <div
+                        class="ms-Toggle-innerContainer container-000"
+                      >
+                        <button
+                          aria-checked="false"
+                          aria-label="Needs review"
+                          class="ms-Toggle-background pill-000"
+                          data-is-focusable="true"
+                          id="needsReview"
+                          role="switch"
+                          type="button"
+                        >
+                          <span
+                            class="ms-Toggle-thumb thumb-000"
+                          />
+                        </button>
+                        <label
+                          class="ms-Label ms-Toggle-stateText text-000"
+                          for="needsReview"
+                          id="needsReview-stateText"
+                        >
+                          Off
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="toggle-description--{{CSS_MODULE_HASH}}"
+                  >
+                    Enable a new test to show automated check rules that might have an accessibility issue and need to be reviewed.
+                  </div>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
#### Description of changes
This PR makes the Needs review feature flag visible to the general public!

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS

![image](https://user-images.githubusercontent.com/33770444/89465980-04b46a00-d741-11ea-94aa-884e103c8ec0.png)
Image of the Preview Features panel now with both More export options and Needs review appearing as feature flags. 