### PR TITLE
feat(needs-review): Un-breaking the export report button in assessments

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -155,14 +155,9 @@ export class DetailsViewCommandBar extends React.Component<
     private focusReportExportButton = () => this.exportDialogCloseFocus?.focus();
 
     private renderExportButton = () => {
-        const config = this.props.visualizationConfigurationFactory.getConfiguration(
-            this.props.selectedTest,
+        const showButton = this.props.switcherNavConfiguration.shouldShowReportExportButton(
+            this.props,
         );
-        const scanData = config.getStoreData(this.props.visualizationStoreData.tests);
-        const isEnabled = config.getTestStatus(scanData);
-
-        const showButton =
-            config.shouldShowExportReport(this.props.unifiedScanResultStoreData) && isEnabled;
 
         if (!showButton) {
             return null;

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -23,6 +23,7 @@ import { ExportDialogDeps } from 'DetailsView/components/export-dialog';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { ReportExportButton } from 'DetailsView/components/report-export-button';
 import { ReportExportDialogFactoryProps } from 'DetailsView/components/report-export-dialog-factory';
+import { ShouldShowReportExportButtonProps } from 'DetailsView/components/should-show-report-export-button';
 import { StartOverFactoryProps } from 'DetailsView/components/start-over-component-factory';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
@@ -155,8 +156,15 @@ export class DetailsViewCommandBar extends React.Component<
     private focusReportExportButton = () => this.exportDialogCloseFocus?.focus();
 
     private renderExportButton = () => {
+        const shouldShowReportExportButtonProps: ShouldShowReportExportButtonProps = {
+            visualizationConfigurationFactory: this.props.visualizationConfigurationFactory,
+            selectedTest: this.props.selectedTest,
+            unifiedScanResultStoreData: this.props.unifiedScanResultStoreData,
+            visualizationStoreData: this.props.visualizationStoreData,
+        };
+
         const showButton = this.props.switcherNavConfiguration.shouldShowReportExportButton(
-            this.props,
+            shouldShowReportExportButtonProps,
         );
 
         if (!showButton) {

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -17,6 +17,11 @@ import {
     getReportExportDialogForFastPass,
 } from 'DetailsView/components/report-export-dialog-factory';
 import {
+    ShouldShowReportExportButton,
+    shouldShowReportExportButtonForAssessment,
+    shouldShowReportExportButtonForFastpass,
+} from 'DetailsView/components/should-show-report-export-button';
+import {
     getStartOverComponentForAssessment,
     getStartOverComponentForFastPass,
 } from 'DetailsView/components/start-over-component-factory';
@@ -58,6 +63,7 @@ type InternalLeftNavProps = AssessmentLeftNavProps | FastPassLeftNavProps;
 export type DetailsViewSwitcherNavConfiguration = Readonly<{
     CommandBar: ReactFCWithDisplayName<CommandBarProps>;
     ReportExportDialogFactory: ReportExportDialogFactory;
+    shouldShowReportExportButton: ShouldShowReportExportButton;
     StartOverComponentFactory: StartOverComponentFactory;
     LeftNav: ReactFCWithDisplayName<LeftNavProps>;
     getSelectedDetailsView: (props: GetSelectedDetailsViewProps) => VisualizationType;
@@ -68,6 +74,7 @@ export type DetailsViewSwitcherNavConfiguration = Readonly<{
 type InternalDetailsViewSwitcherNavConfiguration = Readonly<{
     CommandBar: ReactFCWithDisplayName<CommandBarProps>;
     ReportExportDialogFactory: ReportExportDialogFactory;
+    shouldShowReportExportButton: ShouldShowReportExportButton;
     StartOverComponentFactory: StartOverComponentFactory;
     LeftNav: ReactFCWithDisplayName<InternalLeftNavProps>;
     getSelectedDetailsView: (props: GetSelectedDetailsViewProps) => VisualizationType;
@@ -85,6 +92,7 @@ const detailsViewSwitcherNavs: {
     [DetailsViewPivotType.assessment]: {
         CommandBar: AssessmentCommandBar,
         ReportExportDialogFactory: getReportExportDialogForAssessment,
+        shouldShowReportExportButton: shouldShowReportExportButtonForAssessment,
         StartOverComponentFactory: getStartOverComponentForAssessment,
         LeftNav: AssessmentLeftNav,
         getSelectedDetailsView: getAssessmentSelectedDetailsView,
@@ -94,6 +102,7 @@ const detailsViewSwitcherNavs: {
     [DetailsViewPivotType.fastPass]: {
         CommandBar: AutomatedChecksCommandBar,
         ReportExportDialogFactory: getReportExportDialogForFastPass,
+        shouldShowReportExportButton: shouldShowReportExportButtonForFastpass,
         StartOverComponentFactory: getStartOverComponentForFastPass,
         LeftNav: FastPassLeftNav,
         getSelectedDetailsView: getFastPassSelectedDetailsView,

--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -5,6 +5,7 @@ import {
     ExportDialogWithLocalState,
     ExportDialogWithLocalStateProps,
 } from 'DetailsView/components/export-dialog-with-local-state';
+import { ShouldShowReportExportButtonProps } from 'DetailsView/components/should-show-report-export-button';
 import * as React from 'react';
 
 export type ReportExportDialogFactoryProps = CommandBarProps & {
@@ -54,7 +55,18 @@ export function getReportExportDialogForAssessment(
 export function getReportExportDialogForFastPass(
     props: ReportExportDialogFactoryProps,
 ): JSX.Element {
-    if (props.switcherNavConfiguration.shouldShowReportExportButton(props) !== true) {
+    const shouldShowReportExportButtonProps: ShouldShowReportExportButtonProps = {
+        visualizationConfigurationFactory: props.visualizationConfigurationFactory,
+        selectedTest: props.selectedTest,
+        unifiedScanResultStoreData: props.unifiedScanResultStoreData,
+        visualizationStoreData: props.visualizationStoreData,
+    };
+
+    if (
+        props.switcherNavConfiguration.shouldShowReportExportButton(
+            shouldShowReportExportButtonProps,
+        ) !== true
+    ) {
         return null;
     }
 

--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -54,14 +54,7 @@ export function getReportExportDialogForAssessment(
 export function getReportExportDialogForFastPass(
     props: ReportExportDialogFactoryProps,
 ): JSX.Element {
-    const config = props.visualizationConfigurationFactory.getConfiguration(props.selectedTest);
-    const scanData = config.getStoreData(props.visualizationStoreData.tests);
-    const isEnabled = config.getTestStatus(scanData);
-
-    const shouldShowExportReportButton =
-        config.shouldShowExportReport(props.unifiedScanResultStoreData) && isEnabled;
-
-    if (shouldShowExportReportButton !== true) {
+    if (props.switcherNavConfiguration.shouldShowReportExportButton(props) !== true) {
         return null;
     }
 

--- a/src/DetailsView/components/should-show-report-export-button.ts
+++ b/src/DetailsView/components/should-show-report-export-button.ts
@@ -1,16 +1,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// import { VisualizationType } from 'common/types/visualization-type';
-import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
 
-export type ShouldShowReportExportButton = (props: CommandBarProps) => boolean;
+export interface ShouldShowReportExportButtonProps {
+    visualizationConfigurationFactory: VisualizationConfigurationFactory;
+    selectedTest: VisualizationType;
+    unifiedScanResultStoreData: UnifiedScanResultStoreData;
+    visualizationStoreData: VisualizationStoreData;
+}
 
-export function shouldShowReportExportButtonForAssessment(props: CommandBarProps): boolean {
+export type ShouldShowReportExportButton = (props: ShouldShowReportExportButtonProps) => boolean;
+
+export function shouldShowReportExportButtonForAssessment(
+    props: ShouldShowReportExportButtonProps,
+): boolean {
     return true;
 }
 
-export function shouldShowReportExportButtonForFastpass(props: CommandBarProps): boolean {
+export function shouldShowReportExportButtonForFastpass(
+    props: ShouldShowReportExportButtonProps,
+): boolean {
     const config = props.visualizationConfigurationFactory.getConfiguration(props.selectedTest);
 
     const shouldShow = config.shouldShowExportReport(props.unifiedScanResultStoreData);

--- a/src/DetailsView/components/should-show-report-export-button.ts
+++ b/src/DetailsView/components/should-show-report-export-button.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// import { VisualizationType } from 'common/types/visualization-type';
+import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
+
+export type ShouldShowReportExportButton = (props: CommandBarProps) => boolean;
+
+export function shouldShowReportExportButtonForAssessment(props: CommandBarProps): boolean {
+    return true;
+}
+
+export function shouldShowReportExportButtonForFastpass(props: CommandBarProps): boolean {
+    const config = props.visualizationConfigurationFactory.getConfiguration(props.selectedTest);
+
+    const shouldShow = config.shouldShowExportReport(props.unifiedScanResultStoreData);
+
+    const scanData = config.getStoreData(props.visualizationStoreData.tests);
+    const isEnabled = config.getTestStatus(scanData);
+
+    return shouldShow && isEnabled;
+}

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -201,7 +201,6 @@ export class AssessmentBuilder {
             getNotificationMessage: getNotificationMessage,
             getSwitchToTargetTabOnScan: this.getSwitchToTargetTabOnScan(requirements),
             getInstanceIdentiferGenerator: this.getInstanceIdentifier(requirements),
-            shouldShowExportReport: () => true,
         };
 
         this.buildRequirementReportDescription(requirements);
@@ -306,7 +305,6 @@ export class AssessmentBuilder {
             getNotificationMessage: getNotificationMessage,
             getSwitchToTargetTabOnScan: AssessmentBuilder.getSwitchToTargetTabOnScan(requirements),
             getInstanceIdentiferGenerator: AssessmentBuilder.getInstanceIdentifier(requirements),
-            shouldShowExportReport: () => true,
         } as AssessmentVisualizationConfiguration;
 
         AssessmentBuilder.buildRequirementReportDescription(requirements);

--- a/src/common/configs/assessment-visualization-configuration.ts
+++ b/src/common/configs/assessment-visualization-configuration.ts
@@ -3,7 +3,6 @@
 import { ToggleActionPayload } from 'background/actions/action-payloads';
 import { UniquelyIdentifiableInstances } from 'background/instance-identifier-generator';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
-import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { CommonTestViewProps } from '../../DetailsView/components/test-view';
 import { Analyzer } from '../../injected/analyzers/analyzer';
 import { AnalyzerProvider } from '../../injected/analyzers/analyzer-provider';
@@ -49,5 +48,4 @@ export interface AssessmentVisualizationConfiguration {
     getInstanceIdentiferGenerator: (
         testStep?: string,
     ) => (instance: UniquelyIdentifiableInstances) => string;
-    shouldShowExportReport: (unifiedScanResultStoreData: UnifiedScanResultStoreData) => boolean;
 }

--- a/src/common/configs/visualization-configuration-factory.ts
+++ b/src/common/configs/visualization-configuration-factory.ts
@@ -56,6 +56,7 @@ export class VisualizationConfigurationFactory {
                     toggleLabel: null,
                     linkToDetailsViewText: null,
                 },
+                shouldShowExportReport: null,
             };
             const config = assessment.getVisualizationConfiguration();
             return { ...config, ...defaults };

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -14,18 +14,115 @@ exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = 
       </StyledLinkBase>
     </StyledTooltipHostBase>
   </div>
-  <CommandBarButtonsMenu deps={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} visualizationStoreData={{...}} unifiedScanResultStoreData={{...}} visualizationConfigurationFactory={[Function: function () {
-                      var args = [];
-                      for (var _i = 0; _i < arguments.length; _i++) {
-                          args[_i] = arguments[_i];
-                      }
-                      _this._interceptor.removeInvocation(invocation_1);
-                      var method = new MethodInfo(target, p);
-                      var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
-                      _this._interceptor.intercept(methodInvocation);
-                      return methodInvocation.returnValue;
-                  }]} selectedTest={-1} renderExportReportButton={[Function]} buttonRef={[Function: buttonRef]} />
+  <CommandBarButtonsMenu deps={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} renderExportReportButton={[Function]} buttonRef={[Function: buttonRef]} />
 </div>"
+`;
+
+exports[`DetailsViewCommandBar renders with export button, with start over 1`] = `
+<div
+  className="detailsViewCommandBar"
+>
+  <div
+    aria-labelledby="switch-to-target"
+    className="detailsViewTargetPage"
+  >
+    <span
+      id="switch-to-target"
+    >
+      Target page: 
+    </span>
+    <StyledTooltipHostBase
+      content="Switch to target page: command-bar-test-tab-title"
+      styles={
+        Object {
+          "root": Object {
+            "display": "inline-block",
+            "minWidth": 0,
+          },
+        }
+      }
+    >
+      <StyledLinkBase
+        aria-label="Switch to target page: command-bar-test-tab-title"
+        className="insights-link targetPageLink"
+        onClick={[Function]}
+        role="link"
+      >
+        <span
+          className="targetPageTitle"
+        >
+          command-bar-test-tab-title
+        </span>
+      </StyledLinkBase>
+    </StyledTooltipHostBase>
+  </div>
+  <div
+    className="detailsViewCommandButtons"
+  >
+    <ReportExportButton
+      buttonRef={[Function]}
+      showReportExportDialog={[Function]}
+    />
+    <CustomizedActionButton>
+      Start Over Component
+    </CustomizedActionButton>
+  </div>
+  <div>
+    Export dialog
+  </div>
+</div>
+`;
+
+exports[`DetailsViewCommandBar renders with export button, without start over 1`] = `
+<div
+  className="detailsViewCommandBar"
+>
+  <div
+    aria-labelledby="switch-to-target"
+    className="detailsViewTargetPage"
+  >
+    <span
+      id="switch-to-target"
+    >
+      Target page: 
+    </span>
+    <StyledTooltipHostBase
+      content="Switch to target page: command-bar-test-tab-title"
+      styles={
+        Object {
+          "root": Object {
+            "display": "inline-block",
+            "minWidth": 0,
+          },
+        }
+      }
+    >
+      <StyledLinkBase
+        aria-label="Switch to target page: command-bar-test-tab-title"
+        className="insights-link targetPageLink"
+        onClick={[Function]}
+        role="link"
+      >
+        <span
+          className="targetPageTitle"
+        >
+          command-bar-test-tab-title
+        </span>
+      </StyledLinkBase>
+    </StyledTooltipHostBase>
+  </div>
+  <div
+    className="detailsViewCommandButtons"
+  >
+    <ReportExportButton
+      buttonRef={[Function]}
+      showReportExportDialog={[Function]}
+    />
+  </div>
+  <div>
+    Export dialog
+  </div>
+</div>
 `;
 
 exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
@@ -66,182 +163,6 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
       </StyledLinkBase>
     </StyledTooltipHostBase>
   </div>
-  <div>
-    Export dialog
-  </div>
-</div>
-`;
-
-exports[`DetailsViewCommandBar renders with start over = false, enabled = false, shouldShowExportReport = false 1`] = `
-<div
-  className="detailsViewCommandBar"
->
-  <div
-    aria-labelledby="switch-to-target"
-    className="detailsViewTargetPage"
-  >
-    <span
-      id="switch-to-target"
-    >
-      Target page: 
-    </span>
-    <StyledTooltipHostBase
-      content="Switch to target page: command-bar-test-tab-title"
-      styles={
-        Object {
-          "root": Object {
-            "display": "inline-block",
-            "minWidth": 0,
-          },
-        }
-      }
-    >
-      <StyledLinkBase
-        aria-label="Switch to target page: command-bar-test-tab-title"
-        className="insights-link targetPageLink"
-        onClick={[Function]}
-        role="link"
-      >
-        <span
-          className="targetPageTitle"
-        >
-          command-bar-test-tab-title
-        </span>
-      </StyledLinkBase>
-    </StyledTooltipHostBase>
-  </div>
-  <div>
-    Export dialog
-  </div>
-</div>
-`;
-
-exports[`DetailsViewCommandBar renders with start over = false, enabled = false, shouldShowExportReport = true 1`] = `
-<div
-  className="detailsViewCommandBar"
->
-  <div
-    aria-labelledby="switch-to-target"
-    className="detailsViewTargetPage"
-  >
-    <span
-      id="switch-to-target"
-    >
-      Target page: 
-    </span>
-    <StyledTooltipHostBase
-      content="Switch to target page: command-bar-test-tab-title"
-      styles={
-        Object {
-          "root": Object {
-            "display": "inline-block",
-            "minWidth": 0,
-          },
-        }
-      }
-    >
-      <StyledLinkBase
-        aria-label="Switch to target page: command-bar-test-tab-title"
-        className="insights-link targetPageLink"
-        onClick={[Function]}
-        role="link"
-      >
-        <span
-          className="targetPageTitle"
-        >
-          command-bar-test-tab-title
-        </span>
-      </StyledLinkBase>
-    </StyledTooltipHostBase>
-  </div>
-  <div>
-    Export dialog
-  </div>
-</div>
-`;
-
-exports[`DetailsViewCommandBar renders with start over = false, enabled = true, shouldShowExportReport = false 1`] = `
-<div
-  className="detailsViewCommandBar"
->
-  <div
-    aria-labelledby="switch-to-target"
-    className="detailsViewTargetPage"
-  >
-    <span
-      id="switch-to-target"
-    >
-      Target page: 
-    </span>
-    <StyledTooltipHostBase
-      content="Switch to target page: command-bar-test-tab-title"
-      styles={
-        Object {
-          "root": Object {
-            "display": "inline-block",
-            "minWidth": 0,
-          },
-        }
-      }
-    >
-      <StyledLinkBase
-        aria-label="Switch to target page: command-bar-test-tab-title"
-        className="insights-link targetPageLink"
-        onClick={[Function]}
-        role="link"
-      >
-        <span
-          className="targetPageTitle"
-        >
-          command-bar-test-tab-title
-        </span>
-      </StyledLinkBase>
-    </StyledTooltipHostBase>
-  </div>
-  <div>
-    Export dialog
-  </div>
-</div>
-`;
-
-exports[`DetailsViewCommandBar renders with start over = false, enabled = true, shouldShowExportReport = true 1`] = `
-<div
-  className="detailsViewCommandBar"
->
-  <div
-    aria-labelledby="switch-to-target"
-    className="detailsViewTargetPage"
-  >
-    <span
-      id="switch-to-target"
-    >
-      Target page: 
-    </span>
-    <StyledTooltipHostBase
-      content="Switch to target page: command-bar-test-tab-title"
-      styles={
-        Object {
-          "root": Object {
-            "display": "inline-block",
-            "minWidth": 0,
-          },
-        }
-      }
-    >
-      <StyledLinkBase
-        aria-label="Switch to target page: command-bar-test-tab-title"
-        className="insights-link targetPageLink"
-        onClick={[Function]}
-        role="link"
-      >
-        <span
-          className="targetPageTitle"
-        >
-          command-bar-test-tab-title
-        </span>
-      </StyledLinkBase>
-    </StyledTooltipHostBase>
-  </div>
   <div
     className="detailsViewCommandButtons"
   >
@@ -256,7 +177,7 @@ exports[`DetailsViewCommandBar renders with start over = false, enabled = true, 
 </div>
 `;
 
-exports[`DetailsViewCommandBar renders with start over = true, enabled = false, shouldShowExportReport = false 1`] = `
+exports[`DetailsViewCommandBar renders without export button, with start over 1`] = `
 <div
   className="detailsViewCommandBar"
 >
@@ -307,7 +228,7 @@ exports[`DetailsViewCommandBar renders with start over = true, enabled = false, 
 </div>
 `;
 
-exports[`DetailsViewCommandBar renders with start over = true, enabled = false, shouldShowExportReport = true 1`] = `
+exports[`DetailsViewCommandBar renders without export button, without start over 1`] = `
 <div
   className="detailsViewCommandBar"
 >
@@ -344,119 +265,6 @@ exports[`DetailsViewCommandBar renders with start over = true, enabled = false, 
         </span>
       </StyledLinkBase>
     </StyledTooltipHostBase>
-  </div>
-  <div
-    className="detailsViewCommandButtons"
-  >
-    <CustomizedActionButton>
-      Start Over Component
-    </CustomizedActionButton>
-  </div>
-  <div>
-    Export dialog
-  </div>
-</div>
-`;
-
-exports[`DetailsViewCommandBar renders with start over = true, enabled = true, shouldShowExportReport = false 1`] = `
-<div
-  className="detailsViewCommandBar"
->
-  <div
-    aria-labelledby="switch-to-target"
-    className="detailsViewTargetPage"
-  >
-    <span
-      id="switch-to-target"
-    >
-      Target page: 
-    </span>
-    <StyledTooltipHostBase
-      content="Switch to target page: command-bar-test-tab-title"
-      styles={
-        Object {
-          "root": Object {
-            "display": "inline-block",
-            "minWidth": 0,
-          },
-        }
-      }
-    >
-      <StyledLinkBase
-        aria-label="Switch to target page: command-bar-test-tab-title"
-        className="insights-link targetPageLink"
-        onClick={[Function]}
-        role="link"
-      >
-        <span
-          className="targetPageTitle"
-        >
-          command-bar-test-tab-title
-        </span>
-      </StyledLinkBase>
-    </StyledTooltipHostBase>
-  </div>
-  <div
-    className="detailsViewCommandButtons"
-  >
-    <CustomizedActionButton>
-      Start Over Component
-    </CustomizedActionButton>
-  </div>
-  <div>
-    Export dialog
-  </div>
-</div>
-`;
-
-exports[`DetailsViewCommandBar renders with start over = true, enabled = true, shouldShowExportReport = true 1`] = `
-<div
-  className="detailsViewCommandBar"
->
-  <div
-    aria-labelledby="switch-to-target"
-    className="detailsViewTargetPage"
-  >
-    <span
-      id="switch-to-target"
-    >
-      Target page: 
-    </span>
-    <StyledTooltipHostBase
-      content="Switch to target page: command-bar-test-tab-title"
-      styles={
-        Object {
-          "root": Object {
-            "display": "inline-block",
-            "minWidth": 0,
-          },
-        }
-      }
-    >
-      <StyledLinkBase
-        aria-label="Switch to target page: command-bar-test-tab-title"
-        className="insights-link targetPageLink"
-        onClick={[Function]}
-        role="link"
-      >
-        <span
-          className="targetPageTitle"
-        >
-          command-bar-test-tab-title
-        </span>
-      </StyledLinkBase>
-    </StyledTooltipHostBase>
-  </div>
-  <div
-    className="detailsViewCommandButtons"
-  >
-    <ReportExportButton
-      buttonRef={[Function]}
-      showReportExportDialog={[Function]}
-    />
-    <CustomizedActionButton>
-      Start Over Component
-    </CustomizedActionButton>
   </div>
   <div>
     Export dialog

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
-import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
-import {
-    ScanMetadata,
-    UnifiedScanResultStoreData,
-} from 'common/types/store-data/unified-data-interface';
-import { ScanData, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import {
     DetailsViewSwitcherNavConfiguration,
@@ -30,18 +24,13 @@ describe('DetailsViewCommandBar', () => {
     const thePageTitle = 'command-bar-test-tab-title';
     const thePageUrl = 'command-bar-test-url';
     const reportExportDialogStub = <div>Export dialog</div>;
-    const selectedTest = -1;
-    const scanDataStub = {} as ScanData;
-    const visualizationStoreDataStub = { tests: {} } as VisualizationStoreData;
-    const unifiedScanResultStoreDataStub = {} as UnifiedScanResultStoreData;
 
     let tabStoreData: TabStoreData;
     let startOverComponent: JSX.Element;
     let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
     let isCommandBarCollapsed: boolean;
+    let showReportExportButton: boolean;
     let reportExportDialogFactory: IMock<ReportExportDialogFactory>;
-    let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
-    let visualizationConfigurationMock: IMock<VisualizationConfiguration>;
 
     beforeEach(() => {
         detailsViewActionMessageCreatorMock = Mock.ofType(
@@ -55,11 +44,7 @@ describe('DetailsViewCommandBar', () => {
         } as TabStoreData;
         startOverComponent = null;
         isCommandBarCollapsed = false;
-        visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
-        visualizationConfigurationMock = Mock.ofType<VisualizationConfiguration>();
-        visualizationConfigurationFactoryMock
-            .setup(m => m.getConfiguration(selectedTest))
-            .returns(() => visualizationConfigurationMock.object);
+        showReportExportButton = true;
     });
 
     function getProps(): DetailsViewCommandBarProps {
@@ -73,6 +58,7 @@ describe('DetailsViewCommandBar', () => {
         const switcherNavConfiguration: DetailsViewSwitcherNavConfiguration = {
             CommandBar: CommandBarStub,
             ReportExportDialogFactory: reportExportDialogFactory.object,
+            shouldShowReportExportButton: p => showReportExportButton,
             StartOverComponentFactory: p => startOverComponent,
             LeftNav: LeftNavStub,
         } as DetailsViewSwitcherNavConfiguration;
@@ -93,30 +79,24 @@ describe('DetailsViewCommandBar', () => {
             narrowModeStatus: {
                 isCommandBarCollapsed,
             },
-            visualizationStoreData: visualizationStoreDataStub,
-            unifiedScanResultStoreData: unifiedScanResultStoreDataStub,
-            visualizationConfigurationFactory: visualizationConfigurationFactoryMock.object,
-            selectedTest: selectedTest,
         } as DetailsViewCommandBarProps;
     }
 
-    test.each`
-        startOver | enabled  | shouldShow
-        ${true}   | ${true}  | ${true}
-        ${true}   | ${true}  | ${false}
-        ${true}   | ${false} | ${true}
-        ${true}   | ${false} | ${false}
-        ${false}  | ${true}  | ${true}
-        ${false}  | ${true}  | ${false}
-        ${false}  | ${false} | ${true}
-        ${false}  | ${false} | ${false}
-    `(
-        'renders with start over = $startOver, enabled = $enabled, shouldShowExportReport = $shouldShow',
-        ({ startOver, enabled, shouldShow }) => {
-            setupVisualizationConfigurationMock(enabled, shouldShow);
-            testOnPivot(startOver);
-        },
-    );
+    test('renders with export button, with start over', () => {
+        testOnPivot(true, true);
+    });
+
+    test('renders without export button, without start over', () => {
+        testOnPivot(false, false);
+    });
+
+    test('renders with export button, without start over', () => {
+        testOnPivot(true, false);
+    });
+
+    test('renders without export button, with start over', () => {
+        testOnPivot(false, true);
+    });
 
     test('renders null when tab closed', () => {
         tabStoreData.isClosed = true;
@@ -143,7 +123,9 @@ describe('DetailsViewCommandBar', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    function testOnPivot(renderStartOver: boolean): void {
+    function testOnPivot(renderExportResults: boolean, renderStartOver: boolean): void {
+        showReportExportButton = renderExportResults;
+
         if (renderStartOver) {
             startOverComponent = <ActionButton>Start Over Component</ActionButton>;
         }
@@ -171,17 +153,5 @@ describe('DetailsViewCommandBar', () => {
     ): void {
         const argMatcher = isNil(expectedProps) ? It.isAny() : It.isObjectWith(expectedProps);
         reportExportDialogFactory.setup(r => r(argMatcher)).returns(() => reportExportDialogStub);
-    }
-
-    function setupVisualizationConfigurationMock(enabled: boolean, shouldShow: boolean): void {
-        visualizationConfigurationMock
-            .setup(m => m.getStoreData(visualizationStoreDataStub.tests))
-            .returns(() => scanDataStub);
-        visualizationConfigurationMock
-            .setup(m => m.getTestStatus(scanDataStub))
-            .returns(() => enabled);
-        visualizationConfigurationMock
-            .setup(m => m.shouldShowExportReport(unifiedScanResultStoreDataStub))
-            .returns(() => shouldShow);
     }
 });

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
-import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -10,18 +8,18 @@ import {
     ScanMetadata,
     TargetAppData,
     ToolData,
-    UnifiedScanResultStoreData,
 } from 'common/types/store-data/unified-data-interface';
-import { ScanData, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { DetailsViewCommandBarDeps } from 'DetailsView/components/details-view-command-bar';
+import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import {
     getReportExportDialogForAssessment,
     getReportExportDialogForFastPass,
     ReportExportDialogFactoryProps,
 } from 'DetailsView/components/report-export-dialog-factory';
+import { ShouldShowReportExportButton } from 'DetailsView/components/should-show-report-export-button';
 import { ReportGenerator } from 'reports/report-generator';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('ReportExportDialogFactory', () => {
     const theDate = new Date(Date.UTC(2019, 2, 12, 9, 0));
@@ -32,10 +30,6 @@ describe('ReportExportDialogFactory', () => {
     const theGeneratorOutput = 'generator output';
     const thePageUrl = 'test page url';
     const isOpen: boolean = true;
-    const selectedTest = -1;
-    const scanDataStub = {} as ScanData;
-    const unifiedScanResultStoreData = {} as UnifiedScanResultStoreData;
-    const visualizationStoreData = { tests: {} } as VisualizationStoreData;
 
     let assessmentsProviderMock: IMock<AssessmentsProvider>;
     let featureFlagStoreData: FeatureFlagStoreData;
@@ -47,10 +41,9 @@ describe('ReportExportDialogFactory', () => {
     let scanMetadata: ScanMetadata;
     let deps: DetailsViewCommandBarDeps;
     let dismissExportDialogMock: IMock<() => void>;
+    let shouldShowReportExportButtonMock: IMock<ShouldShowReportExportButton>;
     let afterDialogDismissedMock: IMock<() => void>;
     let props: ReportExportDialogFactoryProps;
-    let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
-    let visualizationConfigurationMock: IMock<VisualizationConfiguration>;
 
     beforeEach(() => {
         featureFlagStoreData = {};
@@ -71,6 +64,7 @@ describe('ReportExportDialogFactory', () => {
         reportGeneratorMock = Mock.ofType(ReportGenerator, MockBehavior.Loose);
         dismissExportDialogMock = Mock.ofInstance(() => null);
         afterDialogDismissedMock = Mock.ofInstance(() => null);
+        shouldShowReportExportButtonMock = Mock.ofInstance(() => true);
         cardsViewData = null;
         deps = {
             detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
@@ -78,11 +72,9 @@ describe('ReportExportDialogFactory', () => {
             reportGenerator: reportGeneratorMock.object,
             getDateFromTimestamp: value => theDate,
         } as DetailsViewCommandBarDeps;
-        visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
-        visualizationConfigurationMock = Mock.ofType<VisualizationConfiguration>();
-        visualizationConfigurationFactoryMock
-            .setup(m => m.getConfiguration(selectedTest))
-            .returns(() => visualizationConfigurationMock.object);
+        const switcherNavConfiguration = {
+            shouldShowReportExportButton: shouldShowReportExportButtonMock.object,
+        } as DetailsViewSwitcherNavConfiguration;
 
         props = {
             deps,
@@ -91,13 +83,10 @@ describe('ReportExportDialogFactory', () => {
             assessmentsProvider: assessmentsProviderMock.object,
             cardsViewData,
             scanMetadata,
+            switcherNavConfiguration,
             isOpen,
             dismissExportDialog: dismissExportDialogMock.object,
             afterDialogDismissed: afterDialogDismissedMock.object,
-            visualizationStoreData: visualizationStoreData,
-            unifiedScanResultStoreData: unifiedScanResultStoreData,
-            visualizationConfigurationFactory: visualizationConfigurationFactoryMock.object,
-            selectedTest: selectedTest,
         } as ReportExportDialogFactoryProps;
     });
 
@@ -116,16 +105,10 @@ describe('ReportExportDialogFactory', () => {
             .verifiable(Times.once());
     }
 
-    function setupShouldShowReportExportButton(enabled: boolean, shouldShow: boolean): void {
-        visualizationConfigurationMock
-            .setup(m => m.getStoreData(visualizationStoreData.tests))
-            .returns(() => scanDataStub);
-        visualizationConfigurationMock
-            .setup(m => m.getTestStatus(scanDataStub))
-            .returns(() => enabled);
-        visualizationConfigurationMock
-            .setup(m => m.shouldShowExportReport(unifiedScanResultStoreData))
-            .returns(() => shouldShow);
+    function setupShouldShowReportExportButton(showReportExportButton: boolean): void {
+        shouldShowReportExportButtonMock
+            .setup(s => s(It.isAny()))
+            .returns(() => showReportExportButton);
     }
 
     describe('getReportExportDialogForAssessment', () => {
@@ -186,29 +169,21 @@ describe('ReportExportDialogFactory', () => {
     });
 
     describe('getReportExportDialogForFastPass', () => {
-        test.each`
-            enabled  | shouldShow
-            ${true}  | ${false}
-            ${false} | ${true}
-            ${false} | ${false}
-        `(
-            'renders as null when shouldShowReportExportButton returns false with test enabled = $enabled and shouldShowExportReport = $shouldShow',
-            ({ enabled, shouldShow }) => {
-                setupShouldShowReportExportButton(enabled, shouldShow);
-                const dialog = getReportExportDialogForFastPass(props);
+        test('renders as null when shouldShowReportExportButton returns falls', () => {
+            setupShouldShowReportExportButton(false);
+            const dialog = getReportExportDialogForFastPass(props);
 
-                expect(dialog).toBeNull();
-            },
-        );
+            expect(dialog).toBeNull();
+        });
 
         test('expected properties are set', () => {
-            setupShouldShowReportExportButton(true, true);
+            setupShouldShowReportExportButton(true);
             const dialog = getReportExportDialogForFastPass(props);
             expect(dialog).toMatchSnapshot();
         });
 
         test('htmlGenerator calls reportGenerator', () => {
-            setupShouldShowReportExportButton(true, true);
+            setupShouldShowReportExportButton(true);
             const dialog = getReportExportDialogForFastPass(props);
 
             dialog.props.htmlGenerator(theDescription);
@@ -217,14 +192,14 @@ describe('ReportExportDialogFactory', () => {
         });
 
         test('updatePersistedDescription returns null', () => {
-            setupShouldShowReportExportButton(true, true);
+            setupShouldShowReportExportButton(true);
             const dialog = getReportExportDialogForFastPass(props);
 
             expect(dialog.props.updatePersistedDescription('test string')).toBeNull();
         });
 
         test('getExportDescription returns empty string', () => {
-            setupShouldShowReportExportButton(true, true);
+            setupShouldShowReportExportButton(true);
             const expectedDescription = '';
 
             const dialog = getReportExportDialogForFastPass(props);
@@ -232,7 +207,7 @@ describe('ReportExportDialogFactory', () => {
         });
 
         test('dismissExportDialog called', () => {
-            setupShouldShowReportExportButton(true, true);
+            setupShouldShowReportExportButton(true);
 
             const dialog = getReportExportDialogForFastPass(props);
 

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -17,7 +17,10 @@ import {
     getReportExportDialogForFastPass,
     ReportExportDialogFactoryProps,
 } from 'DetailsView/components/report-export-dialog-factory';
-import { ShouldShowReportExportButton } from 'DetailsView/components/should-show-report-export-button';
+import {
+    ShouldShowReportExportButton,
+    ShouldShowReportExportButtonProps,
+} from 'DetailsView/components/should-show-report-export-button';
 import { ReportGenerator } from 'reports/report-generator';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
@@ -44,6 +47,7 @@ describe('ReportExportDialogFactory', () => {
     let shouldShowReportExportButtonMock: IMock<ShouldShowReportExportButton>;
     let afterDialogDismissedMock: IMock<() => void>;
     let props: ReportExportDialogFactoryProps;
+    let shouldShowReportExportButtonProps: ShouldShowReportExportButtonProps;
 
     beforeEach(() => {
         featureFlagStoreData = {};
@@ -88,6 +92,13 @@ describe('ReportExportDialogFactory', () => {
             dismissExportDialog: dismissExportDialogMock.object,
             afterDialogDismissed: afterDialogDismissedMock.object,
         } as ReportExportDialogFactoryProps;
+
+        shouldShowReportExportButtonProps = {
+            visualizationConfigurationFactory: props.visualizationConfigurationFactory,
+            selectedTest: props.selectedTest,
+            unifiedScanResultStoreData: props.unifiedScanResultStoreData,
+            visualizationStoreData: props.visualizationStoreData,
+        } as ShouldShowReportExportButtonProps;
     });
 
     function setAssessmentReportGenerator(): void {
@@ -106,7 +117,9 @@ describe('ReportExportDialogFactory', () => {
     }
 
     function setupShouldShowReportExportButton(showReportExportButton: boolean): void {
-        shouldShowReportExportButtonMock.setup(s => s(props)).returns(() => showReportExportButton);
+        shouldShowReportExportButtonMock
+            .setup(s => s(shouldShowReportExportButtonProps))
+            .returns(() => showReportExportButton);
     }
 
     describe('getReportExportDialogForAssessment', () => {

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -19,7 +19,7 @@ import {
 } from 'DetailsView/components/report-export-dialog-factory';
 import { ShouldShowReportExportButton } from 'DetailsView/components/should-show-report-export-button';
 import { ReportGenerator } from 'reports/report-generator';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('ReportExportDialogFactory', () => {
     const theDate = new Date(Date.UTC(2019, 2, 12, 9, 0));
@@ -106,9 +106,7 @@ describe('ReportExportDialogFactory', () => {
     }
 
     function setupShouldShowReportExportButton(showReportExportButton: boolean): void {
-        shouldShowReportExportButtonMock
-            .setup(s => s(It.isAny()))
-            .returns(() => showReportExportButton);
+        shouldShowReportExportButtonMock.setup(s => s(props)).returns(() => showReportExportButton);
     }
 
     describe('getReportExportDialogForAssessment', () => {

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -3,12 +3,7 @@
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
-import {
-    ScanData,
-    TestsEnabledState,
-    VisualizationStoreData,
-} from 'common/types/store-data/visualization-store-data';
-import { VisualizationType } from 'common/types/visualization-type';
+import { ScanData, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import {
     CommandBarProps,
     DetailsViewCommandBarProps,

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import {
+    ScanData,
+    TestsEnabledState,
+    VisualizationStoreData,
+} from 'common/types/store-data/visualization-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import {
+    CommandBarProps,
+    DetailsViewCommandBarProps,
+} from 'DetailsView/components/details-view-command-bar';
+import {
+    shouldShowReportExportButtonForAssessment,
+    shouldShowReportExportButtonForFastpass,
+} from 'DetailsView/components/should-show-report-export-button';
+import { IMock, Mock } from 'typemoq';
+
+describe('ShouldShowReportExportButton', () => {
+    let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
+    let visualizationConfigurationMock: IMock<VisualizationConfiguration>;
+
+    const visualizationStoreData = { tests: {} } as VisualizationStoreData;
+    const unifiedScanResultStoreData = {} as UnifiedScanResultStoreData;
+    const scanData = {} as ScanData;
+    const selectedTest = -1;
+
+    beforeEach(() => {
+        visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
+        visualizationConfigurationMock = Mock.ofType<VisualizationConfiguration>();
+        visualizationConfigurationFactoryMock
+            .setup(m => m.getConfiguration(selectedTest))
+            .returns(() => visualizationConfigurationMock.object);
+    });
+
+    function getProps(): DetailsViewCommandBarProps {
+        return {
+            visualizationStoreData: visualizationStoreData,
+            unifiedScanResultStoreData: unifiedScanResultStoreData,
+            visualizationConfigurationFactory: visualizationConfigurationFactoryMock.object,
+            selectedTest: selectedTest,
+            deps: null,
+            featureFlagStoreData: null,
+            tabStoreData: null,
+            assessmentStoreData: null,
+            assessmentsProvider: null,
+            rightPanelConfiguration: null,
+            cardsViewData: null,
+            switcherNavConfiguration: null,
+            scanMetadata: null,
+            narrowModeStatus: null,
+        } as DetailsViewCommandBarProps;
+    }
+
+    function setupVisualizationConfigurationMock(shouldShow: boolean, enabled: boolean): void {
+        visualizationConfigurationMock
+            .setup(m => m.getStoreData(visualizationStoreData.tests))
+            .returns(() => scanData);
+        visualizationConfigurationMock.setup(m => m.getTestStatus(scanData)).returns(() => enabled);
+        visualizationConfigurationMock
+            .setup(m => m.shouldShowExportReport(unifiedScanResultStoreData))
+            .returns(() => shouldShow);
+    }
+
+    describe('shouldShowReportExportButtonForAssessment', () => {
+        test('returns true', () => {
+            const props = {} as CommandBarProps;
+            const shouldShowButton = shouldShowReportExportButtonForAssessment(props);
+
+            expect(shouldShowButton).toBe(true);
+        });
+    });
+
+    describe('shouldShowReportExportButtonForFastpass', () => {
+        test('returns false if shouldShow is false, test is not enabled', () => {
+            setupVisualizationConfigurationMock(false, false);
+            const props = getProps();
+            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
+            expect(shouldShowButton).toBe(false);
+        });
+
+        test('returns false if shouldShow is false, test is enabled', () => {
+            setupVisualizationConfigurationMock(false, true);
+            const props = getProps();
+            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
+            expect(shouldShowButton).toBe(false);
+        });
+
+        test('returns false if shouldShow is true, test is not enabled', () => {
+            setupVisualizationConfigurationMock(true, false);
+            const props = getProps();
+            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
+            expect(shouldShowButton).toBe(false);
+        });
+
+        test('returns true if shouldShow is true, test is enabled', () => {
+            setupVisualizationConfigurationMock(true, true);
+            const props = getProps();
+            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
+            expect(shouldShowButton).toBe(true);
+        });
+    });
+});

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -112,7 +112,6 @@ describe('AssessmentBuilderTest', () => {
             vizStoreData.assessments.manualAssessmentKeyAssessment.stepStatus[testRequirement],
         ).toBe(true);
 
-        expect(config.shouldShowExportReport(null)).toBe(true);
         expect(config.getIdentifier(selectedRequirementKey)).toBe(requirement.key);
         expect(config.visualizationInstanceProcessor()).toBe(
             VisualizationInstanceProcessor.nullProcessor,
@@ -292,7 +291,6 @@ describe('AssessmentBuilderTest', () => {
         expect(vizStoreData.assessments.headingsAssessment.enabled).toBe(true);
         expect(vizStoreData.assessments.headingsAssessment.stepStatus[testRequirement]).toBe(true);
 
-        expect(config.shouldShowExportReport(null)).toBe(true);
         expect(config.getStoreData(vizStoreData)).toEqual(scanData);
         expect(config.telemetryProcessor(telemetryFactoryStub as TelemetryDataFactory)).toEqual(
             telemetryFactoryStub.forAssessmentRequirementScan,


### PR DESCRIPTION
#### Description of changes
In a previous commit, I did not realize that the logic I was using for subjective omission of the 'export report' button in Fastpass was causing that button to always be omitted in assessments.  This PR fixes that, and returns to the previous design where a separate function is used to determine if the button should show in Fastpass and assessments.  The new logic to exclude the button sometimes is still used, but now only applies to Fastpass.  

[The previous PR that introduced the issue](https://github.com/microsoft/accessibility-insights-web/pull/3203)
<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS

![export report fix](https://user-images.githubusercontent.com/33770444/89588679-22053900-d812-11ea-8b26-6bc641d657aa.gif)
Gif of a user navigating to Needs review from Automated checks and running a Needs review scan, showing that the 'Export result' button does not appear in Needs review.  The user navigates back to Automated checks, where the button does not appear until the user runs an Automated checks scan.  Navigating back to the Needs review test makes the button disappear.  The user then switches to Assessments, where the button is present, regardless of what part of the Assessment the user navigates to.  
