### PR TITLE
refactor: move details view toggle style to module

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -259,20 +259,6 @@ body {
                 b {
                     font-weight: 600;
                 }
-                .details-view-toggle {
-                    margin-bottom: 0;
-                    margin-top: 12px;
-                    height: 40px;
-                    background-color: $neutral-4;
-                    .ms-Toggle-label {
-                        float: left;
-                        margin: 5px 8px 5px 8px;
-                        color: $neutral-100;
-                    }
-                    .ms-Toggle-innerContainer {
-                        margin: 10px 0px 10px 0px;
-                    }
-                }
             }
         }
     }

--- a/src/DetailsView/components/static-content-common.scss
+++ b/src/DetailsView/components/static-content-common.scss
@@ -18,3 +18,20 @@
         font-size: 16px;
     }
 }
+
+.details-view-toggle {
+    margin-bottom: 0;
+    margin-top: 12px;
+    height: 40px;
+    background-color: $neutral-4;
+    :global {
+        .ms-Toggle-label {
+            float: left;
+            margin: 5px 8px 5px 8px;
+            color: $neutral-100;
+        }
+        .ms-Toggle-innerContainer {
+            margin: 10px 0px 10px 0px;
+        }
+    }
+}

--- a/src/DetailsView/components/static-content-details-view.tsx
+++ b/src/DetailsView/components/static-content-details-view.tsx
@@ -34,7 +34,7 @@ export const StaticContentDetailsView = NamedFC<StaticContentDetailsViewProps>(
                     checked={props.visualizationEnabled}
                     onClick={props.onToggleClick}
                     label={props.toggleLabel}
-                    className="details-view-toggle"
+                    className={styles.detailsViewToggle}
                     visualizationName={props.title}
                 />
                 <ContentInclude deps={props.deps} content={props.content} />

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/static-content-details-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/static-content-details-view.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`StaticContentDetailsViewTest renders content page component 1`] = `
                         return methodInvocation.returnValue;
                     }]} iconName=\\"info\\" />
   </h1>
-  <VisualizationToggle checked={true} onClick={[Function: proxy]} label=\\"my test toggle label\\" className=\\"details-view-toggle\\" visualizationName=\\"my test title\\" />
+  <VisualizationToggle checked={true} onClick={[Function: proxy]} label=\\"my test toggle label\\" className=\\"detailsViewToggle\\" visualizationName=\\"my test title\\" />
   <ContentInclude deps={[undefined]} content={[Function: function () {
                       var args = [];
                       for (var _i = 0; _i < arguments.length; _i++) {


### PR DESCRIPTION
#### Description of changes

Looks unchanged/correct:
![image](https://user-images.githubusercontent.com/32555133/89590835-a13c4200-d7fd-11ea-8ff7-c5b80dba26f0.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
