### PR TITLE
fix: close "..." menu when clicking start over fastpass button

### DIFF
--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -1,20 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { DropdownDirection } from 'DetailsView/components/start-over-dropdown';
+import {
+    StartOverComponentFactory,
+    StartOverFactoryProps,
+} from 'DetailsView/components/start-over-component-factory';
 import { CommandBarButton, IButton, IContextualMenuItem, IRefObject } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './command-bar-buttons-menu.scss';
 
 export type CommandBarButtonsMenuProps = {
     renderExportReportButton: () => JSX.Element;
-    renderStartOverButton: (dropdownDirection: DropdownDirection) => JSX.Element;
+    getStartOverProps: () => StartOverFactoryProps;
+    startOverComponentFactory: StartOverComponentFactory;
     buttonRef: IRefObject<IButton>;
 };
 
 export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
     'CommandBarButtonsMenu',
     props => {
+        const startOverFactoryProps = props.getStartOverProps();
         const overflowItems: IContextualMenuItem[] = [
             {
                 key: 'export report',
@@ -22,7 +27,7 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
             },
             {
                 key: 'start over',
-                onRender: () => <div role="menuitem">{props.renderStartOverButton('left')}</div>,
+                ...props.startOverComponentFactory.getStartOverMenuItem(startOverFactoryProps),
             },
         ];
 

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -1,25 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import {
-    StartOverComponentFactory,
-    StartOverFactoryProps,
-} from 'DetailsView/components/start-over-component-factory';
+import { StartOverMenuItem } from 'DetailsView/components/start-over-component-factory';
 import { CommandBarButton, IButton, IContextualMenuItem, IRefObject } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './command-bar-buttons-menu.scss';
 
 export type CommandBarButtonsMenuProps = {
     renderExportReportButton: () => JSX.Element;
-    getStartOverProps: () => StartOverFactoryProps;
-    startOverComponentFactory: StartOverComponentFactory;
+    getStartOverMenuItem: () => StartOverMenuItem;
     buttonRef: IRefObject<IButton>;
 };
 
 export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
     'CommandBarButtonsMenu',
     props => {
-        const startOverFactoryProps = props.getStartOverProps();
         const overflowItems: IContextualMenuItem[] = [
             {
                 key: 'export report',
@@ -27,7 +22,7 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
             },
             {
                 key: 'start over',
-                ...props.startOverComponentFactory.getStartOverMenuItem(startOverFactoryProps),
+                ...props.getStartOverMenuItem(),
             },
         ];
 

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -152,10 +152,7 @@ export class DetailsViewCommandBar extends React.Component<
         return (
             <CommandBarButtonsMenu
                 renderExportReportButton={this.renderExportButton}
-                getStartOverProps={this.getStartOverProps}
-                startOverComponentFactory={
-                    this.props.switcherNavConfiguration.StartOverComponentFactory
-                }
+                getStartOverMenuItem={this.getStartOverMenuItem}
                 buttonRef={ref => {
                     this.exportDialogCloseFocus = ref;
                     this.startOverDialogCloseFocus = ref;
@@ -225,9 +222,17 @@ export class DetailsViewCommandBar extends React.Component<
     }
 
     private renderStartOverButton = () => {
-        return this.props.switcherNavConfiguration.StartOverComponentFactory.getStartOverComponent(
-            this.getStartOverProps(),
-        );
+        const startOverProps = this.getStartOverProps();
+        const startOverComponentFactory = this.props.switcherNavConfiguration
+            .StartOverComponentFactory;
+        return startOverComponentFactory.getStartOverComponent(startOverProps);
+    };
+
+    private getStartOverMenuItem = () => {
+        const startOverProps = this.getStartOverProps();
+        const startOverComponentFactory = this.props.switcherNavConfiguration
+            .StartOverComponentFactory;
+        return startOverComponentFactory.getStartOverMenuItem(startOverProps);
     };
 
     private getStartOverProps = () => {

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -75,8 +75,8 @@ export class DetailsViewCommandBar extends React.Component<
     DetailsViewCommandBarProps,
     DetailsViewCommandBarState
 > {
-    private exportDialogCloseFocus?: IButton;
-    private startOverDialogCloseFocus?: IButton;
+    public exportDialogCloseFocus?: IButton;
+    public startOverDialogCloseFocus?: IButton;
 
     public constructor(props) {
         super(props);
@@ -85,6 +85,7 @@ export class DetailsViewCommandBar extends React.Component<
             startOverDialogState: 'none',
         };
     }
+
     public render(): JSX.Element {
         if (this.props.tabStoreData.isClosed) {
             return null;

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -23,10 +23,7 @@ import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { ReportExportButton } from 'DetailsView/components/report-export-button';
 import { ReportExportDialogFactoryProps } from 'DetailsView/components/report-export-dialog-factory';
 import { ShouldShowReportExportButtonProps } from 'DetailsView/components/should-show-report-export-button';
-import {
-    StartOverFactoryDeps,
-    StartOverFactoryProps,
-} from 'DetailsView/components/start-over-component-factory';
+import { StartOverFactoryDeps } from 'DetailsView/components/start-over-component-factory';
 import {
     dialogClosedState,
     StartOverDialog,
@@ -34,7 +31,6 @@ import {
     StartOverDialogState,
     StartOverDialogType,
 } from 'DetailsView/components/start-over-dialog';
-import { DropdownDirection } from 'DetailsView/components/start-over-dropdown';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
@@ -57,8 +53,6 @@ export type DetailsViewCommandBarState = {
 };
 
 export type ReportExportDialogFactory = (props: ReportExportDialogFactoryProps) => JSX.Element;
-
-export type StartOverComponentFactory = (props: StartOverFactoryProps) => JSX.Element;
 
 export interface DetailsViewCommandBarProps {
     deps: DetailsViewCommandBarDeps;
@@ -139,7 +133,7 @@ export class DetailsViewCommandBar extends React.Component<
 
     private renderCommandButtons(): JSX.Element {
         const reportExportElement: JSX.Element = this.renderExportButton();
-        const startOverElement: JSX.Element = this.renderStartOverComponent('down');
+        const startOverElement: JSX.Element = this.renderStartOverButton();
 
         if (reportExportElement || startOverElement) {
             return (
@@ -157,7 +151,10 @@ export class DetailsViewCommandBar extends React.Component<
         return (
             <CommandBarButtonsMenu
                 renderExportReportButton={this.renderExportButton}
-                renderStartOverButton={this.renderStartOverComponent}
+                getStartOverProps={this.getStartOverProps}
+                startOverComponentFactory={
+                    this.props.switcherNavConfiguration.StartOverComponentFactory
+                }
                 buttonRef={ref => {
                     this.exportDialogCloseFocus = ref;
                     this.startOverDialogCloseFocus = ref;
@@ -226,14 +223,18 @@ export class DetailsViewCommandBar extends React.Component<
         }
     }
 
-    private renderStartOverComponent = (dropdownDirection: DropdownDirection) => {
-        const startOverFactoryProps: StartOverFactoryProps = {
+    private renderStartOverButton = () => {
+        return this.props.switcherNavConfiguration.StartOverComponentFactory.getStartOverComponent(
+            this.getStartOverProps(),
+        );
+    };
+
+    private getStartOverProps = () => {
+        return {
             ...this.props,
-            dropdownDirection,
             openDialog: this.showStartOverDialog,
             buttonRef: ref => (this.startOverDialogCloseFocus = ref),
         };
-        return this.props.switcherNavConfiguration.StartOverComponentFactory(startOverFactoryProps);
     };
 
     private renderStartOverDialog(): JSX.Element {

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -10,7 +10,6 @@ import { AutomatedChecksCommandBar } from 'DetailsView/components/automated-chec
 import {
     CommandBarProps,
     ReportExportDialogFactory,
-    StartOverComponentFactory,
 } from 'DetailsView/components/details-view-command-bar';
 import {
     getReportExportDialogForAssessment,
@@ -22,8 +21,9 @@ import {
     shouldShowReportExportButtonForFastpass,
 } from 'DetailsView/components/should-show-report-export-button';
 import {
-    getStartOverComponentForAssessment,
-    getStartOverComponentForFastPass,
+    AssessmentStartOverFactory,
+    FastpassStartOverFactory,
+    StartOverComponentFactory,
 } from 'DetailsView/components/start-over-component-factory';
 import {
     assessmentWarningConfiguration,
@@ -93,7 +93,7 @@ const detailsViewSwitcherNavs: {
         CommandBar: AssessmentCommandBar,
         ReportExportDialogFactory: getReportExportDialogForAssessment,
         shouldShowReportExportButton: shouldShowReportExportButtonForAssessment,
-        StartOverComponentFactory: getStartOverComponentForAssessment,
+        StartOverComponentFactory: AssessmentStartOverFactory,
         LeftNav: AssessmentLeftNav,
         getSelectedDetailsView: getAssessmentSelectedDetailsView,
         warningConfiguration: assessmentWarningConfiguration,
@@ -103,7 +103,7 @@ const detailsViewSwitcherNavs: {
         CommandBar: AutomatedChecksCommandBar,
         ReportExportDialogFactory: getReportExportDialogForFastPass,
         shouldShowReportExportButton: shouldShowReportExportButtonForFastpass,
-        StartOverComponentFactory: getStartOverComponentForFastPass,
+        StartOverComponentFactory: FastpassStartOverFactory,
         LeftNav: FastPassLeftNav,
         getSelectedDetailsView: getFastPassSelectedDetailsView,
         warningConfiguration: fastpassWarningConfiguration,

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -12,8 +12,9 @@ import {
     StartOverDropdown,
     StartOverProps,
 } from 'DetailsView/components/start-over-dropdown';
-import { IButton, IRefObject } from 'office-ui-fabric-react';
+import { IButton, IContextualMenuItem, IRefObject } from 'office-ui-fabric-react';
 import * as React from 'react';
+import * as styles from './start-over-menu-item.scss';
 
 export type StartOverFactoryDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
@@ -25,18 +26,45 @@ export type StartOverFactoryProps = {
     assessmentsProvider: AssessmentsProvider;
     rightPanelConfiguration: DetailsRightPanelConfiguration;
     visualizationStoreData: VisualizationStoreData;
-    dropdownDirection: DropdownDirection;
     openDialog: (dialogType: StartOverDialogType) => void;
     buttonRef: IRefObject<IButton>;
 };
 
-export function getStartOverComponentForAssessment(props: StartOverFactoryProps): JSX.Element {
+export type StartOverMenuItem = Omit<IContextualMenuItem, 'key'>;
+
+export interface StartOverComponentFactory {
+    getStartOverComponent: (props: StartOverFactoryProps) => JSX.Element;
+    getStartOverMenuItem: (props: StartOverFactoryProps) => StartOverMenuItem;
+}
+
+export const AssessmentStartOverFactory: StartOverComponentFactory = {
+    getStartOverComponent: props => getStartOverComponentForAssessment(props, 'down'),
+    getStartOverMenuItem: props => {
+        return {
+            onRender: () => (
+                <div role="menuitem">{getStartOverComponentForAssessment(props, 'left')}</div>
+            ),
+        };
+    },
+};
+
+export const FastpassStartOverFactory: StartOverComponentFactory = {
+    getStartOverComponent: props => {
+        return <InsightsCommandButton {...getStartOverPropsForFastPass(props)} />;
+    },
+    getStartOverMenuItem: getStartOverPropsForFastPass,
+};
+
+export function getStartOverComponentForAssessment(
+    props: StartOverFactoryProps,
+    dropdownDirection: DropdownDirection,
+): JSX.Element {
     const selectedTest = props.assessmentStoreData.assessmentNavState.selectedTestType;
     const test = props.assessmentsProvider.forType(selectedTest);
     const startOverProps: StartOverProps = {
         testName: test.title,
         rightPanelConfiguration: props.rightPanelConfiguration,
-        dropdownDirection: props.dropdownDirection,
+        dropdownDirection,
         openDialog: props.openDialog,
         buttonRef: props.buttonRef,
     };
@@ -46,20 +74,16 @@ export function getStartOverComponentForAssessment(props: StartOverFactoryProps)
 
 export const startOverAutomationId = 'start-over';
 
-export function getStartOverComponentForFastPass(props: StartOverFactoryProps): JSX.Element {
+export function getStartOverPropsForFastPass(props: StartOverFactoryProps): StartOverMenuItem {
     const selectedTest = props.visualizationStoreData.selectedFastPassDetailsView;
     const detailsViewActionMessageCreator = props.deps.detailsViewActionMessageCreator;
 
-    return (
-        <InsightsCommandButton
-            iconProps={{ iconName: 'Refresh' }}
-            onClick={event =>
-                detailsViewActionMessageCreator.rescanVisualization(selectedTest, event)
-            }
-            disabled={props.visualizationStoreData.scanning !== null}
-            data-automation-id={startOverAutomationId}
-        >
-            Start over
-        </InsightsCommandButton>
-    );
+    return {
+        iconProps: { iconName: 'Refresh', className: styles.startOverMenuItemIcon },
+        onClick: event => detailsViewActionMessageCreator.rescanVisualization(selectedTest, event),
+        disabled: props.visualizationStoreData.scanning !== null,
+        'data-automation-id': startOverAutomationId,
+        text: 'Start over',
+        className: styles.startOverMenuItem,
+    };
 }

--- a/src/DetailsView/components/start-over-menu-item.scss
+++ b/src/DetailsView/components/start-over-menu-item.scss
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+
+.start-over-menu-item {
+    .start-over-menu-item-icon {
+        line-height: 16px;
+    }
+
+    button:disabled {
+        color: $disabled-text;
+        .start-over-menu-item-icon {
+            color: $disabled-text;
+        }
+    }
+    button:active {
+        .start-over-menu-item-icon {
+            color: $primary-text;
+        }
+    }
+    button:hover {
+        background-color: $neutral-0;
+        color: $insights-button-hover;
+        .start-over-menu-item-icon {
+            color: $insights-button-hover;
+        }
+    }
+}

--- a/src/DetailsView/components/start-over-menu-item.scss
+++ b/src/DetailsView/components/start-over-menu-item.scss
@@ -7,7 +7,8 @@
         line-height: 16px;
     }
 
-    button:disabled {
+    button:disabled,
+    button[aria-disabled='true'] {
         color: $disabled-text;
         .start-over-menu-item-icon {
             color: $disabled-text;

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -89,6 +89,7 @@ $spinner-text: var(--spinner-text);
 $nav-link-hover: var(--nav-link-hover);
 $nav-link-selected: var(--nav-link-selected);
 $nav-link-expanded: var(--nav-link-expanded);
+$insights-button-hover: var(--insights-button-hover);
 
 // Consistent colors that don't vary with high contrast mode. Use sparingly.
 $always-white: var(--white);

--- a/src/common/styles/root-level-only/color-definitions.scss
+++ b/src/common/styles/root-level-only/color-definitions.scss
@@ -88,6 +88,7 @@
     --nav-link-hover: var(--neutral-alpha-8);
     --nav-link-selected: var(--communication-tint-20);
     --nav-link-expanded: var(--communication-tint-40);
+    --insights-button-hover: #0179d4;
 
     // Landmark colors
     --landmark-contentinfo: #00a88c;

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`DetailsViewBody render render 1`] = `
           "CommandBar": [Function],
           "LeftNav": [Function],
           "ReportExportDialogFactory": [Function],
-          "StartOverComponentFactory": [Function],
+          "StartOverComponentFactory": Object {},
         }
       }
       tabStoreData={
@@ -425,7 +425,7 @@ exports[`DetailsViewBody render render 1`] = `
             "CommandBar": [Function],
             "LeftNav": [Function],
             "ReportExportDialogFactory": [Function],
-            "StartOverComponentFactory": [Function],
+            "StartOverComponentFactory": Object {},
           }
         }
         tabStoreData={
@@ -736,7 +736,7 @@ exports[`DetailsViewBody render render 1`] = `
                 "CommandBar": [Function],
                 "LeftNav": [Function],
                 "ReportExportDialogFactory": [Function],
-                "StartOverComponentFactory": [Function],
+                "StartOverComponentFactory": Object {},
               }
             }
             tabStoreData={

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`CommandBarButtonsMenu renders CommandBarButtonsMenu 1`] = `
         },
         Object {
           "key": "start over",
-          "onRender": [Function],
         },
       ],
     }
@@ -41,11 +40,7 @@ exports[`CommandBarButtonsMenu renders child buttons 1`] = `
 `;
 
 exports[`CommandBarButtonsMenu renders child buttons 2`] = `
-<div
-  role="menuitem"
->
-  <React.Fragment>
-    Start over button
-  </React.Fragment>
-</div>
+<React.Fragment>
+  Start over button
+</React.Fragment>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = 
       </StyledLinkBase>
     </StyledTooltipHostBase>
   </div>
-  <CommandBarButtonsMenu renderExportReportButton={[Function]} getStartOverProps={[Function]} startOverComponentFactory={{...}} buttonRef={[Function: buttonRef]} />
+  <CommandBarButtonsMenu renderExportReportButton={[Function]} getStartOverMenuItem={[Function]} buttonRef={[Function: buttonRef]} />
   <StartOverDialog deps={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} dialogState=\\"none\\" dismissDialog={[Function]} />
 </div>"
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = 
       </StyledLinkBase>
     </StyledTooltipHostBase>
   </div>
-  <CommandBarButtonsMenu renderExportReportButton={[Function]} renderStartOverButton={[Function]} buttonRef={[Function: buttonRef]} />
+  <CommandBarButtonsMenu renderExportReportButton={[Function]} getStartOverProps={[Function]} startOverComponentFactory={{...}} buttonRef={[Function: buttonRef]} />
   <StartOverDialog deps={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} dialogState=\\"none\\" dismissDialog={[Function]} />
 </div>"
 `;
@@ -123,7 +123,9 @@ exports[`DetailsViewCommandBar renders with export button, with start over 1`] =
         "CommandBar": [Function],
         "LeftNav": [Function],
         "ReportExportDialogFactory": [Function],
-        "StartOverComponentFactory": [Function],
+        "StartOverComponentFactory": Object {
+          "getStartOverComponent": [Function],
+        },
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -238,7 +240,9 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
         "CommandBar": [Function],
         "LeftNav": [Function],
         "ReportExportDialogFactory": [Function],
-        "StartOverComponentFactory": [Function],
+        "StartOverComponentFactory": Object {
+          "getStartOverComponent": [Function],
+        },
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -353,7 +357,9 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
         "CommandBar": [Function],
         "LeftNav": [Function],
         "ReportExportDialogFactory": [Function],
-        "StartOverComponentFactory": [Function],
+        "StartOverComponentFactory": Object {
+          "getStartOverComponent": [Function],
+        },
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -509,7 +515,9 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
         "CommandBar": [Function],
         "LeftNav": [Function],
         "ReportExportDialogFactory": [Function],
-        "StartOverComponentFactory": [Function],
+        "StartOverComponentFactory": Object {
+          "getStartOverComponent": [Function],
+        },
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -616,7 +624,9 @@ exports[`DetailsViewCommandBar renders without export button, without start over
         "CommandBar": [Function],
         "LeftNav": [Function],
         "ReportExportDialogFactory": [Function],
-        "StartOverComponentFactory": [Function],
+        "StartOverComponentFactory": Object {
+          "getStartOverComponent": [Function],
+        },
         "shouldShowReportExportButton": [Function],
       }
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
@@ -1,38 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StartOverComponentFactory getStartOverComponentForAssessments renders 1`] = `
+exports[`StartOverComponentFactory AssessmentStartOverFactory getStartOverComponent 1`] = `
 <StartOverDropdown
   dropdownDirection="down"
   testName="the title"
 />
 `;
 
-exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders scanning is false => component matches snapshot 1`] = `
+exports[`StartOverComponentFactory AssessmentStartOverFactory getStartOverMenuItem 1`] = `ShallowWrapper {}`;
+
+exports[`StartOverComponentFactory FastpassStartOverFactory getStartOverComponent renders scanning is false => component matches snapshot 1`] = `
 <InsightsCommandButton
+  className="startOverMenuItem"
   data-automation-id="start-over"
   disabled={false}
   iconProps={
     Object {
+      "className": "startOverMenuItemIcon",
       "iconName": "Refresh",
     }
   }
   onClick={[Function]}
->
-  Start over
-</InsightsCommandButton>
+  text="Start over"
+/>
 `;
 
-exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders scanning is true => component matches snapshot 1`] = `
+exports[`StartOverComponentFactory FastpassStartOverFactory getStartOverComponent renders scanning is true => component matches snapshot 1`] = `
 <InsightsCommandButton
+  className="startOverMenuItem"
   data-automation-id="start-over"
   disabled={true}
   iconProps={
     Object {
+      "className": "startOverMenuItemIcon",
       "iconName": "Refresh",
     }
   }
   onClick={[Function]}
->
-  Start over
-</InsightsCommandButton>
+  text="Start over"
+/>
+`;
+
+exports[`StartOverComponentFactory FastpassStartOverFactory getStartOverMenuItem renders scanning is false => component matches snapshot 1`] = `
+Object {
+  "className": "startOverMenuItem",
+  "data-automation-id": "start-over",
+  "disabled": false,
+  "iconProps": Object {
+    "className": "startOverMenuItemIcon",
+    "iconName": "Refresh",
+  },
+  "onClick": [Function],
+  "text": "Start over",
+}
+`;
+
+exports[`StartOverComponentFactory FastpassStartOverFactory getStartOverMenuItem renders scanning is true => component matches snapshot 1`] = `
+Object {
+  "className": "startOverMenuItem",
+  "data-automation-id": "start-over",
+  "disabled": true,
+  "iconProps": Object {
+    "className": "startOverMenuItemIcon",
+    "iconName": "Refresh",
+  },
+  "onClick": [Function],
+  "text": "Start over",
+}
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
@@ -7,7 +7,16 @@ exports[`StartOverComponentFactory AssessmentStartOverFactory getStartOverCompon
 />
 `;
 
-exports[`StartOverComponentFactory AssessmentStartOverFactory getStartOverMenuItem 1`] = `ShallowWrapper {}`;
+exports[`StartOverComponentFactory AssessmentStartOverFactory getStartOverMenuItem 1`] = `
+<div
+  role="menuitem"
+>
+  <StartOverDropdown
+    dropdownDirection="left"
+    testName="the title"
+  />
+</div>
+`;
 
 exports[`StartOverComponentFactory FastpassStartOverFactory getStartOverComponent renders scanning is false => component matches snapshot 1`] = `
 <InsightsCommandButton

--- a/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
@@ -4,10 +4,7 @@ import {
     CommandBarButtonsMenu,
     CommandBarButtonsMenuProps,
 } from 'DetailsView/components/command-bar-buttons-menu';
-import {
-    StartOverFactoryProps,
-    StartOverMenuItem,
-} from 'DetailsView/components/start-over-component-factory';
+import { StartOverMenuItem } from 'DetailsView/components/start-over-component-factory';
 import { shallow } from 'enzyme';
 import { IButton, IOverflowSetItemProps, RefObject } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -15,21 +12,15 @@ import { IMock, Mock, Times } from 'typemoq';
 
 describe('CommandBarButtonsMenu', () => {
     let renderExportReportComponentMock: IMock<() => JSX.Element>;
-    let getStartOverMenuItemMock: IMock<(props: StartOverFactoryProps) => StartOverMenuItem>;
-    let getStartOverPropsMock: IMock<() => StartOverFactoryProps>;
+    let getStartOverMenuItemMock: IMock<() => StartOverMenuItem>;
     let commandBarButtonsMenuProps: CommandBarButtonsMenuProps;
 
     beforeEach(() => {
         renderExportReportComponentMock = Mock.ofInstance(() => null);
         getStartOverMenuItemMock = Mock.ofInstance(() => null);
-        getStartOverPropsMock = Mock.ofInstance(() => null);
         commandBarButtonsMenuProps = {
             renderExportReportButton: renderExportReportComponentMock.object,
-            startOverComponentFactory: {
-                getStartOverComponent: null,
-                getStartOverMenuItem: getStartOverMenuItemMock.object,
-            },
-            getStartOverProps: getStartOverPropsMock.object,
+            getStartOverMenuItem: getStartOverMenuItemMock.object,
             buttonRef: {} as RefObject<IButton>,
         } as CommandBarButtonsMenuProps;
     });
@@ -63,13 +54,11 @@ describe('CommandBarButtonsMenu', () => {
     }
 
     function setupStartOverMenuItem(): void {
-        const startOverProps = {} as StartOverFactoryProps;
         const startOverMenuItem = {
             onRender: () => <>Start over button</>,
         };
-        getStartOverPropsMock.setup(g => g()).returns(() => startOverProps);
         getStartOverMenuItemMock
-            .setup(s => s(startOverProps))
+            .setup(s => s())
             .returns(() => startOverMenuItem)
             .verifiable(Times.once());
     }

--- a/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
@@ -4,7 +4,10 @@ import {
     CommandBarButtonsMenu,
     CommandBarButtonsMenuProps,
 } from 'DetailsView/components/command-bar-buttons-menu';
-import { DropdownDirection } from 'DetailsView/components/start-over-dropdown';
+import {
+    StartOverFactoryProps,
+    StartOverMenuItem,
+} from 'DetailsView/components/start-over-component-factory';
 import { shallow } from 'enzyme';
 import { IButton, IOverflowSetItemProps, RefObject } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -12,17 +15,21 @@ import { IMock, Mock, Times } from 'typemoq';
 
 describe('CommandBarButtonsMenu', () => {
     let renderExportReportComponentMock: IMock<() => JSX.Element>;
-    let renderStartOverComponentMock: IMock<(dropdownDirection: DropdownDirection) => JSX.Element>;
+    let getStartOverMenuItemMock: IMock<(props: StartOverFactoryProps) => StartOverMenuItem>;
+    let getStartOverPropsMock: IMock<() => StartOverFactoryProps>;
     let commandBarButtonsMenuProps: CommandBarButtonsMenuProps;
 
     beforeEach(() => {
         renderExportReportComponentMock = Mock.ofInstance(() => null);
-        renderStartOverComponentMock = Mock.ofType<
-            (dropdownDirection: DropdownDirection) => JSX.Element
-        >();
+        getStartOverMenuItemMock = Mock.ofInstance(() => null);
+        getStartOverPropsMock = Mock.ofInstance(() => null);
         commandBarButtonsMenuProps = {
             renderExportReportButton: renderExportReportComponentMock.object,
-            renderStartOverButton: renderStartOverComponentMock.object,
+            startOverComponentFactory: {
+                getStartOverComponent: null,
+                getStartOverMenuItem: getStartOverMenuItemMock.object,
+            },
+            getStartOverProps: getStartOverPropsMock.object,
             buttonRef: {} as RefObject<IButton>,
         } as CommandBarButtonsMenuProps;
     });
@@ -33,15 +40,8 @@ describe('CommandBarButtonsMenu', () => {
     });
 
     it('renders child buttons', () => {
-        renderExportReportComponentMock
-            .setup(r => r())
-            .returns(() => <>Report export button</>)
-            .verifiable(Times.once());
-
-        renderStartOverComponentMock
-            .setup(s => s('left'))
-            .returns(() => <>Start over button</>)
-            .verifiable(Times.once());
+        setupExportReportMenuItem();
+        setupStartOverMenuItem();
 
         const wrapper = shallow(<CommandBarButtonsMenu {...commandBarButtonsMenuProps} />);
         const renderedProps = wrapper.getElement().props;
@@ -52,6 +52,25 @@ describe('CommandBarButtonsMenu', () => {
         overflowItems.forEach(item => expect(item.onRender()).toMatchSnapshot());
 
         renderExportReportComponentMock.verifyAll();
-        renderStartOverComponentMock.verifyAll();
+        getStartOverMenuItemMock.verifyAll();
     });
+
+    function setupExportReportMenuItem(): void {
+        renderExportReportComponentMock
+            .setup(r => r())
+            .returns(() => <>Report export button</>)
+            .verifiable(Times.once());
+    }
+
+    function setupStartOverMenuItem(): void {
+        const startOverProps = {} as StartOverFactoryProps;
+        const startOverMenuItem = {
+            onRender: () => <>Start over button</>,
+        };
+        getStartOverPropsMock.setup(g => g()).returns(() => startOverProps);
+        getStartOverMenuItemMock
+            .setup(s => s(startOverProps))
+            .returns(() => startOverMenuItem)
+            .verifiable(Times.once());
+    }
 });

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -8,6 +8,10 @@ import {
     LeftNavProps,
 } from 'DetailsView/components/details-view-switcher-nav';
 import { ReportExportDialogFactoryProps } from 'DetailsView/components/report-export-dialog-factory';
+import {
+    StartOverComponentFactory,
+    StartOverFactoryProps,
+} from 'DetailsView/components/start-over-component-factory';
 import { shallow } from 'enzyme';
 import { isNil } from 'lodash';
 import { ActionButton } from 'office-ui-fabric-react';
@@ -15,6 +19,7 @@ import * as React from 'react';
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
 import { TabStoreData } from '../../../../../common/types/store-data/tab-store-data';
 import {
+    CommandBarProps,
     DetailsViewCommandBar,
     DetailsViewCommandBarProps,
     ReportExportDialogFactory,
@@ -31,6 +36,7 @@ describe('DetailsViewCommandBar', () => {
     let isCommandBarCollapsed: boolean;
     let showReportExportButton: boolean;
     let reportExportDialogFactory: IMock<ReportExportDialogFactory>;
+    let getStartOverComponent: IMock<(Props: StartOverFactoryProps) => JSX.Element>;
 
     beforeEach(() => {
         detailsViewActionMessageCreatorMock = Mock.ofType(
@@ -38,6 +44,7 @@ describe('DetailsViewCommandBar', () => {
             MockBehavior.Loose,
         );
         reportExportDialogFactory = Mock.ofInstance(props => null);
+        getStartOverComponent = Mock.ofInstance(props => null);
         tabStoreData = {
             title: thePageTitle,
             isClosed: false,
@@ -59,7 +66,9 @@ describe('DetailsViewCommandBar', () => {
             CommandBar: CommandBarStub,
             ReportExportDialogFactory: reportExportDialogFactory.object,
             shouldShowReportExportButton: p => showReportExportButton,
-            StartOverComponentFactory: p => startOverComponent,
+            StartOverComponentFactory: {
+                getStartOverComponent: getStartOverComponent.object,
+            } as StartOverComponentFactory,
             LeftNav: LeftNavStub,
         } as DetailsViewSwitcherNavConfiguration;
         const scanMetadata = {
@@ -148,8 +157,9 @@ describe('DetailsViewCommandBar', () => {
             startOverComponent = <ActionButton>Start Over Component</ActionButton>;
         }
 
-        setupReportExportDialogFactory({ isOpen: false });
         const props = getProps();
+        setupStartOverButtonFactory(props);
+        setupReportExportDialogFactory({ isOpen: false });
 
         const rendered = shallow(<DetailsViewCommandBar {...props} />);
 
@@ -171,5 +181,12 @@ describe('DetailsViewCommandBar', () => {
     ): void {
         const argMatcher = isNil(expectedProps) ? It.isAny() : It.isObjectWith(expectedProps);
         reportExportDialogFactory.setup(r => r(argMatcher)).returns(() => reportExportDialogStub);
+    }
+
+    function setupStartOverButtonFactory(props: CommandBarProps): void {
+        const expectedProps = props as Partial<StartOverFactoryProps>;
+        getStartOverComponent
+            .setup(g => g(It.isObjectWith(expectedProps)))
+            .returns(() => startOverComponent);
     }
 });

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
-import { NamedFC } from 'common/react/named-fc';
 import {
     AssessmentNavState,
     AssessmentStoreData,
@@ -11,13 +10,14 @@ import { VisualizationStoreData } from 'common/types/store-data/visualization-st
 import { VisualizationType } from 'common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import {
-    getStartOverComponentForAssessment,
-    getStartOverComponentForFastPass,
+    AssessmentStartOverFactory,
+    FastpassStartOverFactory,
     StartOverFactoryDeps,
     StartOverFactoryProps,
+    StartOverMenuItem,
 } from 'DetailsView/components/start-over-component-factory';
 import { shallow } from 'enzyme';
-import * as React from 'react';
+import { IContextualMenuItem } from 'office-ui-fabric-react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
@@ -25,7 +25,6 @@ describe('StartOverComponentFactory', () => {
     const theTitle = 'the title';
     const theTestStep = 'test step';
     const theTestType = VisualizationType.ColorSensoryAssessment;
-    const dropdownDirection = 'down';
 
     let assessment: Readonly<Assessment>;
     let assessmentsProviderMock: IMock<AssessmentsProvider>;
@@ -70,58 +69,98 @@ describe('StartOverComponentFactory', () => {
             assessmentStoreData,
             assessmentsProvider: assessmentsProviderMock.object,
             visualizationStoreData,
-            dropdownDirection,
         } as StartOverFactoryProps;
     }
 
-    describe('getStartOverComponentForAssessments', () => {
-        it('renders', () => {
+    describe('AssessmentStartOverFactory', () => {
+        it('getStartOverComponent', () => {
             const props = getProps(true);
-            const rendered = getStartOverComponentForAssessment(props);
+            const rendered = AssessmentStartOverFactory.getStartOverComponent(props);
+
+            expect(rendered).toMatchSnapshot();
+        });
+
+        it('getStartOverMenuItem', () => {
+            const props = getProps(true);
+            const menuItem = AssessmentStartOverFactory.getStartOverMenuItem(props);
+            const rendered = shallow(menuItem.onRender());
 
             expect(rendered).toMatchSnapshot();
         });
     });
 
-    describe('getStartOverComponentPropsForFastPass', () => {
-        describe('renders', () => {
-            test('scanning is false => component matches snapshot', () => {
-                const props = getProps(false);
-                const rendered = getStartOverComponentForFastPass(props);
+    describe('FastpassStartOverFactory', () => {
+        describe.each([
+            [
+                'getStartOverComponent',
+                FastpassStartOverFactory.getStartOverComponent,
+                clickStartOverButton,
+            ],
+            [
+                'getStartOverMenuItem',
+                FastpassStartOverFactory.getStartOverMenuItem,
+                clickStartOverMenuItem,
+            ],
+        ])(
+            '%s',
+            (
+                testName: string,
+                getComponentOrMenuItem: (
+                    props: StartOverFactoryProps,
+                ) => JSX.Element | StartOverMenuItem,
+                clickComponentOrMenuItem: (
+                    item: JSX.Element | StartOverMenuItem,
+                    event: any,
+                ) => void,
+            ) => {
+                describe('renders', () => {
+                    test('scanning is false => component matches snapshot', () => {
+                        const props = getProps(false);
+                        const item = getComponentOrMenuItem(props);
 
-                expect(rendered).toMatchSnapshot();
-            });
+                        expect(item).toMatchSnapshot();
+                    });
 
-            test('scanning is true => component matches snapshot', () => {
-                scanning = 'some string';
-                const props = getProps(false);
-                const rendered = getStartOverComponentForFastPass(props);
+                    test('scanning is true => component matches snapshot', () => {
+                        scanning = 'some string';
+                        const props = getProps(false);
+                        const item = getComponentOrMenuItem(props);
 
-                expect(rendered).toMatchSnapshot();
-            });
-        });
+                        expect(item).toMatchSnapshot();
+                    });
+                });
 
-        describe('user interaction', () => {
-            it('handles action button on click properly', () => {
-                const event = new EventStubFactory().createKeypressEvent() as any;
+                describe('user interaction', () => {
+                    it('handles action button on click properly', () => {
+                        const event = new EventStubFactory().createKeypressEvent() as any;
 
-                const actionMessageCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
+                        const actionMessageCreatorMock = Mock.ofType<
+                            DetailsViewActionMessageCreator
+                        >();
 
-                const props = getProps(false);
-                props.deps.detailsViewActionMessageCreator = actionMessageCreatorMock.object;
+                        const props = getProps(false);
+                        props.deps.detailsViewActionMessageCreator =
+                            actionMessageCreatorMock.object;
 
-                const Wrapper = NamedFC<StartOverFactoryProps>(
-                    'WrappedStartOver',
-                    getStartOverComponentForFastPass,
-                );
-                const wrapped = shallow(<Wrapper {...props} />);
-                wrapped.simulate('click', event);
+                        const item = getComponentOrMenuItem(props);
+                        clickComponentOrMenuItem(item, event);
 
-                actionMessageCreatorMock.verify(
-                    creator => creator.rescanVisualization(theTestType, event),
-                    Times.once(),
-                );
-            });
-        });
+                        actionMessageCreatorMock.verify(
+                            creator => creator.rescanVisualization(theTestType, event),
+                            Times.once(),
+                        );
+                    });
+                });
+            },
+        );
+
+        function clickStartOverButton(startOverButton: JSX.Element, event: any): void {
+            const wrapped = shallow(startOverButton);
+            wrapped.simulate('click', event);
+        }
+
+        function clickStartOverMenuItem(startOverMenuItem: IContextualMenuItem, event: any): void {
+            startOverMenuItem.onClick(event);
+        }
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -85,7 +85,7 @@ describe('StartOverComponentFactory', () => {
             const menuItem = AssessmentStartOverFactory.getStartOverMenuItem(props);
             const rendered = shallow(menuItem.onRender());
 
-            expect(rendered).toMatchSnapshot();
+            expect(rendered.getElement()).toMatchSnapshot();
         });
     });
 
@@ -130,26 +130,21 @@ describe('StartOverComponentFactory', () => {
                     });
                 });
 
-                describe('user interaction', () => {
-                    it('handles action button on click properly', () => {
-                        const event = new EventStubFactory().createKeypressEvent() as any;
+                it('handles action button on click properly', () => {
+                    const event = new EventStubFactory().createKeypressEvent() as any;
 
-                        const actionMessageCreatorMock = Mock.ofType<
-                            DetailsViewActionMessageCreator
-                        >();
+                    const actionMessageCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
 
-                        const props = getProps(false);
-                        props.deps.detailsViewActionMessageCreator =
-                            actionMessageCreatorMock.object;
+                    const props = getProps(false);
+                    props.deps.detailsViewActionMessageCreator = actionMessageCreatorMock.object;
 
-                        const item = getComponentOrMenuItem(props);
-                        clickComponentOrMenuItem(item, event);
+                    const item = getComponentOrMenuItem(props);
+                    clickComponentOrMenuItem(item, event);
 
-                        actionMessageCreatorMock.verify(
-                            creator => creator.rescanVisualization(theTestType, event),
-                            Times.once(),
-                        );
-                    });
+                    actionMessageCreatorMock.verify(
+                        creator => creator.rescanVisualization(theTestType, event),
+                        Times.once(),
+                    );
                 });
             },
         );

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { FluentSideNav } from 'DetailsView/components/left-nav/fluent-side-nav';
+import { StartOverComponentFactory } from 'DetailsView/components/start-over-component-factory';
 import { IMock, Mock } from 'typemoq';
 import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
 import { NamedFC, ReactFCWithDisplayName } from '../../../../common/react/named-fc';
@@ -66,7 +67,7 @@ describe('DetailsViewBody', () => {
             switcherNavConfig = {
                 CommandBar: CommandBarStub,
                 ReportExportDialogFactory: p => null,
-                StartOverComponentFactory: p => null,
+                StartOverComponentFactory: {} as StartOverComponentFactory,
                 LeftNav: LeftNavStub,
             } as DetailsViewSwitcherNavConfiguration;
             configFactoryStub = {} as VisualizationConfigurationFactory;


### PR DESCRIPTION
#### Description of changes

This completes a fix started in #3165 and continued in #3214 to make sure the "..." menu closes when the buttons are clicked. This PR fixes the issue for the Start Over button in fastpass.

Refactors:
- Refactor startOverComponentFactory into an object containing two separate methods, one to create a component to render in the command bar and one to create a menu item to be shown in the "..." menu
- Instead of using IContextualMenuItem's onRender prop to render the Start Over fastpass button in "..." menu, pass all button props directly to the IContextualMenuItem
- Add styling for the Start Over menu item, since it doesn't get the default OF button stylings
- Also add unit tests for focusing buttons after closing dialogs in DetailsViewCommandBar

UI changes:
- Clicking the "start over" button in fastpass now closes the "..." menu and returns focus to the "..." button
- "Start over" item in the "..." menu is focusable, but not clickable, when disabled (this is by design in the Office fabric component, as discussed in [this github issue](https://github.com/microsoft/fluentui/issues/912))

![start over fastpass button refactors](https://user-images.githubusercontent.com/55459788/89841546-0bb7ef80-db28-11ea-8d53-b97dc6c8534c.gif)

![start over fastpass button refactors high contrast](https://user-images.githubusercontent.com/55459788/89841551-0fe40d00-db28-11ea-924e-ca54d77ead1e.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
