### PR TITLE
fix: Exclude color contrast test results (false positives)

### DIFF
--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -118,7 +118,7 @@ export class RuleInformationProvider {
     }
 
     private includeColorContrastResult = (ruleResultsData: RuleResultsData): boolean => {
-        return false; // Temporarily disble color contrast rule
+        return false; // Temporarily disable color contrast rule
         // return ruleResultsData.props['Confidence in Color Detection'] === 'High';
     };
 

--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -118,7 +118,8 @@ export class RuleInformationProvider {
     }
 
     private includeColorContrastResult = (ruleResultsData: RuleResultsData): boolean => {
-        return ruleResultsData.props['Confidence in Color Detection'] === 'High';
+        return false; // Temporarily disble color contrast rule
+        // return ruleResultsData.props['Confidence in Color Detection'] === 'High';
     };
 
     private includeAllResults = (ruleResultsData: RuleResultsData): boolean => {

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -39,7 +39,7 @@ describe('AutomatedChecksView', () => {
 
     it('displays automated checks results collapsed by default', async () => {
         const ruleGroups = await automatedChecksView.queryRuleGroups();
-        expect(ruleGroups).toHaveLength(4);
+        expect(ruleGroups).toHaveLength(3);
 
         const collapsibleContentElements = await automatedChecksView.queryRuleGroupContents();
         expect(collapsibleContentElements).toHaveLength(0);
@@ -51,7 +51,7 @@ describe('AutomatedChecksView', () => {
     }
 
     it('supports expanding and collapsing rule groups', async () => {
-        expect(await countHighlightBoxes()).toBe(5);
+        expect(await countHighlightBoxes()).toBe(4);
         expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(0);
 
         await automatedChecksView.toggleRuleGroupAtPosition(1);
@@ -145,7 +145,6 @@ describe('AutomatedChecksView', () => {
             { width: 10.7407, height: 6.04167, top: 3.28125, left: 89.2593 },
             { width: 10.7407, height: 6.04167, top: 10.4167, left: 13.4259 },
             { width: 48.6111, height: 4.94792, top: 23.5417, left: 25.6481 },
-            { width: 49.8148, height: 16.4063, top: 30.1042, left: 0 },
         ]);
     });
 

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/rule-resources.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/rule-resources.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`RuleResources renders with {
   url: 'test-url',
   guidanceLinks: [ [length]: 0 ],
-  linkComponent: [Function] {
+  linkComponent: [Function (anonymous)] {
     [length]: 1,
     [name]: '',
     displayName: 'ElectronExternalLink'
@@ -47,7 +47,7 @@ exports[`RuleResources renders with {
 exports[`RuleResources renders with {
   url: 'test-url',
   guidanceLinks: [ { href: 'test-href' }, [length]: 1 ],
-  linkComponent: [Function] {
+  linkComponent: [Function (anonymous)] {
     [length]: 1,
     [name]: '',
     displayName: 'ElectronExternalLink'
@@ -103,7 +103,11 @@ exports[`RuleResources renders with {
 exports[`RuleResources renders with {
   url: 'test-url',
   guidanceLinks: null,
-  linkComponent: [Function] { [length]: 1, [name]: '', displayName: 'NewTabLink' }
+  linkComponent: [Function (anonymous)] {
+    [length]: 1,
+    [name]: '',
+    displayName: 'NewTabLink'
+  }
 } 1`] = `
 <div
   className="ruleMoreResources"
@@ -143,7 +147,7 @@ exports[`RuleResources renders with {
 exports[`RuleResources renders with {
   url: null,
   guidanceLinks: [ [length]: 0 ],
-  linkComponent: [Function] {
+  linkComponent: [Function (anonymous)] {
     [length]: 1,
     [name]: '',
     displayName: 'ElectronExternalLink'
@@ -153,7 +157,11 @@ exports[`RuleResources renders with {
 exports[`RuleResources renders with {
   url: null,
   guidanceLinks: [ { href: 'test-href' }, [length]: 1 ],
-  linkComponent: [Function] { [length]: 1, [name]: '', displayName: 'NewTabLink' }
+  linkComponent: [Function (anonymous)] {
+    [length]: 1,
+    [name]: '',
+    displayName: 'NewTabLink'
+  }
 } 1`] = `
 <div
   className="ruleMoreResources"
@@ -195,5 +203,9 @@ exports[`RuleResources renders with {
 exports[`RuleResources renders with {
   url: null,
   guidanceLinks: null,
-  linkComponent: [Function] { [length]: 1, [name]: '', displayName: 'NewTabLink' }
+  linkComponent: [Function (anonymous)] {
+    [length]: 1,
+    [name]: '',
+    displayName: 'NewTabLink'
+  }
 } 1`] = `null`;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/rule-resources.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/rule-resources.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`RuleResources renders with {
   url: 'test-url',
   guidanceLinks: [ [length]: 0 ],
-  linkComponent: [Function (anonymous)] {
+  linkComponent: [Function] {
     [length]: 1,
     [name]: '',
     displayName: 'ElectronExternalLink'
@@ -47,7 +47,7 @@ exports[`RuleResources renders with {
 exports[`RuleResources renders with {
   url: 'test-url',
   guidanceLinks: [ { href: 'test-href' }, [length]: 1 ],
-  linkComponent: [Function (anonymous)] {
+  linkComponent: [Function] {
     [length]: 1,
     [name]: '',
     displayName: 'ElectronExternalLink'
@@ -103,11 +103,7 @@ exports[`RuleResources renders with {
 exports[`RuleResources renders with {
   url: 'test-url',
   guidanceLinks: null,
-  linkComponent: [Function (anonymous)] {
-    [length]: 1,
-    [name]: '',
-    displayName: 'NewTabLink'
-  }
+  linkComponent: [Function] { [length]: 1, [name]: '', displayName: 'NewTabLink' }
 } 1`] = `
 <div
   className="ruleMoreResources"
@@ -147,7 +143,7 @@ exports[`RuleResources renders with {
 exports[`RuleResources renders with {
   url: null,
   guidanceLinks: [ [length]: 0 ],
-  linkComponent: [Function (anonymous)] {
+  linkComponent: [Function] {
     [length]: 1,
     [name]: '',
     displayName: 'ElectronExternalLink'
@@ -157,11 +153,7 @@ exports[`RuleResources renders with {
 exports[`RuleResources renders with {
   url: null,
   guidanceLinks: [ { href: 'test-href' }, [length]: 1 ],
-  linkComponent: [Function (anonymous)] {
-    [length]: 1,
-    [name]: '',
-    displayName: 'NewTabLink'
-  }
+  linkComponent: [Function] { [length]: 1, [name]: '', displayName: 'NewTabLink' }
 } 1`] = `
 <div
   className="ruleMoreResources"
@@ -203,9 +195,5 @@ exports[`RuleResources renders with {
 exports[`RuleResources renders with {
   url: null,
   guidanceLinks: null,
-  linkComponent: [Function (anonymous)] {
-    [length]: 1,
-    [name]: '',
-    displayName: 'NewTabLink'
-  }
+  linkComponent: [Function] { [length]: 1, [name]: '', displayName: 'NewTabLink' }
 } 1`] = `null`;

--- a/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
@@ -156,7 +156,7 @@ describe('RuleInformationProvider', () => {
             'High',
         );
         const ruleInformation: RuleInformation = provider.getRuleInformation(ruleResult.ruleId);
-        expect(ruleInformation.includeThisResult(ruleResult)).toBe(true);
+        expect(ruleInformation.includeThisResult(ruleResult)).toBe(false); // Revert to true when color contrast is re-enabled
     });
 
     test('ColorContrast includeThisResult returns false when confidence is defined but not High', () => {


### PR DESCRIPTION
#### Description of changes
We've had reports of false positives in the color contrasts test, so we're temporarily excluding the results from the output. This is intended to be a short-term change that will be reverted after we are able to improve the error rate of the results being returned from axe-android.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
