### PR TITLE
feat(web-compliance): generate NOTICE file as part of Unified release build

### DIFF
--- a/pipeline/unified/build-unsigned-release-packages.yaml
+++ b/pipeline/unified/build-unsigned-release-packages.yaml
@@ -28,6 +28,21 @@ steps:
 
     - template: ./unified-e2e-publish-results.yaml
 
+    - task: ComponentGovernanceComponentDetection@0
+      displayName: 'dependency detection (Component Governance)'
+      inputs:
+          detectorsFilter: Yarn
+          ignoreDirectories: 'drop,dist,extension,node_modules'
+          verbosity: Normal
+      timeoutInMinutes: 5
+
+    - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
+      displayName: 'generate NOTICE.html file'
+      inputs:
+          outputfile: '$(System.DefaultWorkingDirectory)/src/NOTICE.html'
+          outputformat: html
+      timeoutInMinutes: 5
+
     - script: yarn build:unified:all --unified-version=$(Build.BuildNumber) --unified-canary-instrumentation-key=$(UnifiedCanaryInstrumentationKey) --unified-insider-instrumentation-key=$(UnifiedInsiderInstrumentationKey) --unified-prod-instrumentation-key=$(UnifiedProdInstrumentationKey)
       displayName: yarn build:unified:all
 

--- a/pipeline/unified/build-unsigned-release-packages.yaml
+++ b/pipeline/unified/build-unsigned-release-packages.yaml
@@ -24,10 +24,6 @@ steps:
 
     - template: ./download-electron-mirror.yaml
 
-    - template: ./unified-e2e-test-interactive.yaml
-
-    - template: ./unified-e2e-publish-results.yaml
-
     - task: ComponentGovernanceComponentDetection@0
       displayName: 'dependency detection (Component Governance)'
       inputs:
@@ -42,6 +38,10 @@ steps:
           outputfile: '$(System.DefaultWorkingDirectory)/src/NOTICE.html'
           outputformat: html
       timeoutInMinutes: 5
+
+    - template: ./unified-e2e-test-interactive.yaml
+
+    - template: ./unified-e2e-publish-results.yaml
 
     - script: yarn build:unified:all --unified-version=$(Build.BuildNumber) --unified-canary-instrumentation-key=$(UnifiedCanaryInstrumentationKey) --unified-insider-instrumentation-key=$(UnifiedInsiderInstrumentationKey) --unified-prod-instrumentation-key=$(UnifiedProdInstrumentationKey)
       displayName: yarn build:unified:all


### PR DESCRIPTION
#### Description of changes

Follows the example from Web's build.yaml to cause the "build" part of unified's release build to generate a NOTICE file using the usual OSPO task as part of the release build.

Out of scope for this PR:
* Updating the electron build process to consume the NOTICE file as part of the electron build output (doing this in a separate PR, since it's feasible to test that part locally using the placeholder NOTICE.html)
* Using the hidden `newExperience` version of the notice generator (it would require extra work to revert that later, and it'll become the default in 1-3 weeks anyway)

#### Pull request checklist
- [x] Addresses an existing issue: 1759353
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
