### PR TITLE
fix: Revert 0e5ccae

### DIFF
--- a/src/tests/unit/tests/views/content/__snapshots__/content-link.test.tsx.snap
+++ b/src/tests/unit/tests/views/content/__snapshots__/content-link.test.tsx.snap
@@ -3,26 +3,26 @@
 exports[`ContentLink render null when reference is not defined 1`] = `""`;
 
 exports[`ContentLink renders from content, only have the icon 1`] = `
-"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" aria-label=\\"Guidance\\" onClick={[Function: onClick]}>
+"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" onClick={[Function: onClick]}>
   <StyledIconBase iconName=\\"test icon 1\\" />
 </NewTabLink>"
 `;
 
 exports[`ContentLink renders from path, only have the icon 1`] = `
-"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" aria-label=\\"Guidance\\" onClick={[Function: onClick]}>
+"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" onClick={[Function: onClick]}>
   <StyledIconBase iconName=\\"test icon 2\\" />
 </NewTabLink>"
 `;
 
 exports[`ContentLink renders with both text and icon 1`] = `
-"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" aria-label=\\"Guidance\\" onClick={[Function: onClick]}>
+"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" onClick={[Function: onClick]}>
   <StyledIconBase iconName=\\"test icon\\" />
   test
 </NewTabLink>"
 `;
 
 exports[`ContentLink renders with only text 1`] = `
-"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" aria-label=\\"Guidance\\" onClick={[Function: onClick]}>
+"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" onClick={[Function: onClick]}>
   test
 </NewTabLink>"
 `;

--- a/src/views/content/content-link.tsx
+++ b/src/views/content/content-link.tsx
@@ -37,7 +37,6 @@ export const ContentLink = NamedFC<ContentLinkProps>(
             <NewTabLink
                 href={`/insights.html#/content/${contentPath}`}
                 title="Guidance"
-                aria-label="Guidance"
                 onClick={ev => openContentPage(ev, contentPath)}
             >
                 {icon}


### PR DESCRIPTION
#### Description of changes

I accidentally pushed commit 0e5ccaec125c68297618a2b7d9ffb87dba96a641 directly to master. This reverts it.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
