### PR TITLE
feat(web-compliance): bundle LICENSE and NOTICE into unified packages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -287,6 +287,10 @@ module.exports = function (grunt) {
         if (productCategory === 'electron') {
             productCategorySpecificCopyFiles.push(
                 {
+                    src: 'src/electron/resources/license_en.txt',
+                    dest: `${dropExtensionPath}/LICENSE`,
+                },
+                {
                     src: androidServiceBin.apkPath,
                     // This should be kept in sync with android-service-apk.ts
                     dest: path.join(dropExtensionPath, 'android-service', 'android-service.apk'),
@@ -300,6 +304,11 @@ module.exports = function (grunt) {
                     ),
                 },
             );
+        } else {
+            productCategorySpecificCopyFiles.push({
+                src: 'LICENSE',
+                dest: `${dropExtensionPath}/LICENSE`,
+            });
         }
 
         grunt.config.merge({
@@ -362,12 +371,6 @@ module.exports = function (grunt) {
                         {
                             cwd: extensionPath,
                             src: ['**/*.html'],
-                            dest: dropExtensionPath,
-                            expand: true,
-                        },
-                        {
-                            cwd: '.',
-                            src: ['LICENSE'],
                             dest: dropExtensionPath,
                             expand: true,
                         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -365,6 +365,12 @@ module.exports = function (grunt) {
                             dest: dropExtensionPath,
                             expand: true,
                         },
+                        {
+                            cwd: '.',
+                            src: ['LICENSE'],
+                            dest: dropExtensionPath,
+                            expand: true,
+                        },
                         ...productCategorySpecificCopyFiles,
                     ],
                 },
@@ -471,6 +477,7 @@ module.exports = function (grunt) {
     grunt.registerMultiTask('configure-electron-builder', function () {
         grunt.task.requires('drop:' + this.target);
         const { dropPath, electronIconBaseName, fullName, appId, publishUrl } = this.data;
+        const productDir = `${dropPath}/product`;
 
         const outElectronBuilderConfigFile = path.join(dropPath, 'electron-builder.yml');
         const srcElectronBuilderConfigFile = path.join(
@@ -486,7 +493,6 @@ module.exports = function (grunt) {
         config.appId = appId;
         config.directories.app = dropPath;
         config.directories.output = `${dropPath}/packed`;
-        config.extraResources[0].from = `${dropPath}/product/android-service`;
         config.extraMetadata.version = version;
         config.win.icon = `src/${electronIconBaseName}.ico`;
         // electron-builder infers the linux icon from the mac one
@@ -497,6 +503,10 @@ module.exports = function (grunt) {
         // This is necessary for the AppImage to display using our brand icon
         // See electron-userland/electron-builder#3547 and AppImage/AppImageKit#678
         config.linux.artifactName = fullName.replace(/ (- )?/g, '_') + '.${ext}';
+
+        for (fileset of [...config.extraResources, ...config.extraFiles]) {
+            fileset.from = fileset.from.replace(/TARGET_SPECIFIC_PRODUCT_DIR/g, productDir);
+        }
 
         const configFileContent = yaml.safeDump(config);
         grunt.file.write(outElectronBuilderConfigFile, configFileContent);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -508,6 +508,21 @@ module.exports = function (grunt) {
             fileset.from = fileset.from.replace(/TARGET_SPECIFIC_PRODUCT_DIR/g, productDir);
         }
 
+        // Manually copying the license files is a workaround for electron-builder #1495.
+        // On win/linux builds these are automatically included, but in Mac they are omitted.
+        if (process.platform === 'darwin') {
+            config.extraFiles.push(
+                {
+                    from: 'node_modules/electron/dist/LICENSE',
+                    to: 'LICENSE.electron.txt',
+                },
+                {
+                    from: 'node_modules/electron/dist/LICENSES.chromium.html',
+                    to: 'LICENSES.chromium.html',
+                },
+            );
+        }
+
         const configFileContent = yaml.safeDump(config);
         grunt.file.write(outElectronBuilderConfigFile, configFileContent);
         grunt.log.writeln(`generated ${outElectronBuilderConfigFile} from target config`);

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Accessibility Insights for Android(TM)
+
 Copyright (c) Microsoft Corporation
 All rights reserved.
 
@@ -8,3 +10,5 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Android is a trademark of Google LLC.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-Accessibility Insights for Android(TM)
-
 Copyright (c) Microsoft Corporation
 All rights reserved.
 
@@ -10,5 +8,3 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-Android is a trademark of Google LLC.

--- a/src/electron/electron-builder/electron-builder.template.yaml
+++ b/src/electron/electron-builder/electron-builder.template.yaml
@@ -19,8 +19,12 @@ files:
 # to be able to pass the APK it contains as a file to adb; extraResources end up on the user's
 # machine as files as-is, but files get bundled together into a shared .asar archive.
 extraResources:
-    - from: TARGET_SPECIFIC
+    - from: 'TARGET_SPECIFIC_PRODUCT_DIR/android-service'
       to: 'android-service'
+
+extraFiles:
+    - from: 'TARGET_SPECIFIC_PRODUCT_DIR'
+      filter: ['LICENSE', 'NOTICE.*']
 
 extraMetadata:
     main: product/bundle/main.bundle.js

--- a/src/electron/electron-builder/electron-builder.template.yaml
+++ b/src/electron/electron-builder/electron-builder.template.yaml
@@ -25,12 +25,6 @@ extraResources:
 extraFiles:
     - from: 'TARGET_SPECIFIC_PRODUCT_DIR'
       filter: ['LICENSE', 'NOTICE.*']
-    # Manually copying the license files is a workaround for electron-builder #1495.
-    # On win/linux builds these are automatically included, but in Mac they are apparently omitted.
-    - from: 'node_modules/electron/dist/LICENSE'
-      to: 'LICENSE.electron.txt'
-    - from: 'node_modules/electron/dist/LICENSES.chromium.html'
-      to: 'LICENSES.chromium.html'
 
 extraMetadata:
     main: product/bundle/main.bundle.js

--- a/src/electron/electron-builder/electron-builder.template.yaml
+++ b/src/electron/electron-builder/electron-builder.template.yaml
@@ -25,6 +25,12 @@ extraResources:
 extraFiles:
     - from: 'TARGET_SPECIFIC_PRODUCT_DIR'
       filter: ['LICENSE', 'NOTICE.*']
+    # Manually copying the license files is a workaround for electron-builder #1495.
+    # On win/linux builds these are automatically included, but in Mac they are apparently omitted.
+    - from: 'node_modules/electron/dist/LICENSE'
+      to: 'LICENSE.electron.txt'
+    - from: 'node_modules/electron/dist/LICENSES.chromium.html'
+      to: 'LICENSES.chromium.html'
 
 extraMetadata:
     main: product/bundle/main.bundle.js


### PR DESCRIPTION
#### Description of changes

This PR ensures that all of our platform distributions bundle all of the following LICENSE/NOTICE files:

* `LICENSE` (our own LICENSE, identical to the text that is bundled into each platform installer already)
* `NOTICE.html` (our NOTICE file, generated by Component Governance as of #3249)
* `LICENSE.electron.txt` (Electron's LICENSE, from the electron package; kept as-is per CELA guidance)
* `LICENSES.chromium.txt` (Chromium's LICENSES, from the electron package; kept as-is per CELA guidance)
* `resources/android-service/NOTICE.txt` ([Accessibility Insights for Android Service](https://github.com/microsoft/accessibility-insights-for-android-service)'s NOTICE file, to cover its transitive gradle dependencies)

#### Motivation

On all platforms, our electron packages are missing our NOTICE.html file. This bundles it into the application content root (on win/linux, the main install directory, on Mac, the "Content" directory under there)

Same for our LICENSE file (we do bundle it into the installers for each platform, but I also included it here as a file since it was the same process as NOTICE and we might want to include a link to it in a later "About" panel feature)

On Mac, long-outstanding issue https://github.com/electron-userland/electron-builder/issues/1495 means that we're *also* missing LICENSE.electron.txt and LICENSES.chromium.html. In the issue, the electron-builder maintainer [commented](https://github.com/electron-userland/electron-builder/issues/1495#issuecomment-296532959) that missing the chromium licenses "is ok" and closed the bug; our legal department disagrees and is very clear that we need to distribute the chromium licenses file alongside all our distributions.

#### Testing:

* [x] Linux: me to verify that the AppImage container contains all the files (it contains one additional/extra copy of our LICENSE file as "license.txt" because that's how electron-builder bundles it; we're okay with that)
* [x] Windows: me to verify that installing from the exe results in an installation directory containing all the files
* [x] Mac: @waabid to verify that installing from the dmg results in an installation directory whose Contents directory contains all the files

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1761407
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
