### PR TITLE
chore: move platform-agnostic build tasks from mac to linux

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -10,11 +10,16 @@ pr: # pr does not trigger CI builds
         include:
             - '*' # must quote since "*" is a YAML reserved character; we want a string
 
+variables:
+    windowsImage: 'windows-2019'
+    macImage: 'macOS-10.15'
+    linuxImage: 'ubuntu-18.04'
+
 jobs:
     - job: 'unit_tests_and_lints'
 
       pool:
-          vmImage: 'macOS-10.15'
+          vmImage: $(linuxImage)
 
       steps:
           - template: pipeline/install-node-prerequisites.yaml
@@ -69,7 +74,7 @@ jobs:
 
     - job: 'publish_build_drops'
       pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: $(linuxImage)
       steps:
           - template: pipeline/install-node-prerequisites.yaml
 
@@ -101,9 +106,9 @@ jobs:
             displayName: publish drop
             timeoutInMinutes: 5
 
-    - job: 'e2e_web_mac'
+    - job: 'e2e_web_linux'
       pool:
-          vmImage: macOS-10.15
+          vmImage: $(linuxImage)
       steps:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/e2e-test-from-agent.yaml
@@ -111,7 +116,7 @@ jobs:
 
     - job: 'e2e_unified_mac'
       pool:
-          vmImage: macOS-10.15
+          vmImage: $(macImage)
       steps:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/unified/unified-e2e-test-interactive.yaml
@@ -119,7 +124,7 @@ jobs:
 
     - job: 'e2e_unified_linux'
       pool:
-          vmImage: ubuntu-18.04
+          vmImage: $(linuxImage)
       steps:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/unified/unified-e2e-test-linux.yaml
@@ -127,7 +132,7 @@ jobs:
 
     - job: 'e2e_unified_windows'
       pool:
-          vmImage: windows-2019
+          vmImage: $(windowsImage)
       steps:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/unified/unified-e2e-test-interactive.yaml

--- a/build.yaml
+++ b/build.yaml
@@ -111,7 +111,7 @@ jobs:
           vmImage: $(linuxImage)
       steps:
           - template: pipeline/install-node-prerequisites.yaml
-          - template: pipeline/e2e-test-from-agent.yaml
+          - template: pipeline/e2e-test-from-docker.yaml
           - template: pipeline/e2e-test-publish-results.yaml
 
     - job: 'e2e_unified_mac'

--- a/pipeline/build-package.template.yaml
+++ b/pipeline/build-package.template.yaml
@@ -8,7 +8,7 @@ jobs:
     - job: 'build_and_publish_package'
 
       pool:
-          vmImage: 'macOS-10.15'
+          vmImage: 'ubuntu-18.04'
 
       steps:
           - template: install-node-prerequisites.yaml


### PR DESCRIPTION
#### Description of changes

In the last month or two we've seen disproportionately many timeout and performance issues on Mac agents vs other platforms. This PR experiments with moving platform-agnostic build steps (most notably, web E2Es and the unit_tests_and_lints PR build job) from mac agents to linux ones.

This sacrifices some best-casse PR build performance (~11min to ~14min) to gain reliability

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
