### PR TITLE
feat(axe-core-4.0.1): update approach for testing axe.commons

### DIFF
--- a/src/tests/unit/tests/scanner/axe-utils.test.ts
+++ b/src/tests/unit/tests/scanner/axe-utils.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as axe from 'axe-core';
-import { GlobalMock, GlobalScope, IGlobalMock, It, MockBehavior, Times } from 'typemoq';
+import { GlobalMock, GlobalScope, IGlobalMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
+import { withAxeCommonsMocked } from 'tests/unit/tests/scanner/mock-axe-utils';
 import * as AxeUtils from '../../../../scanner/axe-utils';
 import { setAxeGlobalTreeTo } from '../../common/axe-internals';
 
@@ -28,34 +28,22 @@ describe('AxeUtils', () => {
     });
 
     describe('getAccessibleText', () => {
-        const accessibleTextMock = GlobalMock.ofInstance(
-            axe.commons.text.accessibleText,
-            'accessibleText',
-            axe.commons.text,
+        it.each([true, false])(
+            'calls axe.commons.text.accessibleText with given node & isLabelledByContext %p',
+            isLabelledByContext => {
+                const accessibleTextMock = Mock.ofInstance(
+                    (node, context) => '',
+                    MockBehavior.Strict,
+                );
+                const elementStub = {} as HTMLElement;
+                accessibleTextMock
+                    .setup(m => m(It.isValue(elementStub), isLabelledByContext))
+                    .verifiable(Times.once());
+                withAxeCommonsMocked('text', { accessibleText: accessibleTextMock.object }, () => {
+                    AxeUtils.getAccessibleText(elementStub, isLabelledByContext);
+                });
+            },
         );
-        it('should call mock when labelledbycontext true', () => {
-            GlobalScope.using(accessibleTextMock).with(() => {
-                const elementStub = {} as HTMLElement;
-                const isLabelledByContext = true;
-                accessibleTextMock
-                    .setup(m => m(It.isValue(elementStub), isLabelledByContext))
-                    .verifiable(Times.once());
-                AxeUtils.getAccessibleText(elementStub, isLabelledByContext);
-            });
-            accessibleTextMock.verifyAll();
-        });
-
-        it('should call mock when labelledbycontext false', () => {
-            GlobalScope.using(accessibleTextMock).with(() => {
-                const elementStub = {} as HTMLElement;
-                const isLabelledByContext = false;
-                accessibleTextMock
-                    .setup(m => m(It.isValue(elementStub), isLabelledByContext))
-                    .verifiable(Times.once());
-                AxeUtils.getAccessibleText(elementStub, isLabelledByContext);
-            });
-            accessibleTextMock.verifyAll();
-        });
     });
 
     describe('getAccessibleDescription', () => {

--- a/src/tests/unit/tests/scanner/axe-utils.test.ts
+++ b/src/tests/unit/tests/scanner/axe-utils.test.ts
@@ -42,6 +42,7 @@ describe('AxeUtils', () => {
                 withAxeCommonsMocked('text', { accessibleText: accessibleTextMock.object }, () => {
                     AxeUtils.getAccessibleText(elementStub, isLabelledByContext);
                 });
+                accessibleTextMock.verifyAll();
             },
         );
     });

--- a/src/tests/unit/tests/scanner/custom-rules/css-content-rule.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/css-content-rule.test.ts
@@ -71,7 +71,8 @@ describe('verify matches', () => {
                     isVisible: axeVisibilityMock.object,
                 },
                 () => {
-                    testSemantics(divElementFixture, isVisibleParam);
+                    const result = cssContentConfiguration.rule.matches(divElementFixture, null);
+                    expect(result).toBe(isVisibleParam);
                 },
                 [getComputedStyleMock],
             );
@@ -108,15 +109,11 @@ describe('verify matches', () => {
                     isVisible: axeVisibilityMock.object,
                 },
                 () => {
-                    testSemantics(divElementFixture, testCaseParameters.testExpectation);
+                    const result = cssContentConfiguration.rule.matches(divElementFixture, null);
+                    expect(result).toBe(testCaseParameters.testExpectation);
                 },
                 [getComputedStyleMock],
             );
         },
     );
-
-    function testSemantics(elements: HTMLElement, expectedResult: boolean): void {
-        const result = cssContentConfiguration.rule.matches(elements, null);
-        expect(result).toBe(expectedResult);
-    }
 });

--- a/src/tests/unit/tests/scanner/custom-rules/custom-widget-check.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/custom-widget-check.test.ts
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 import * as Axe from 'axe-core';
 import { difference, map } from 'lodash';
-import { Mock, MockBehavior } from 'typemoq';
-
 import { customWidgetConfiguration } from '../../../../../scanner/custom-rules/custom-widget';
 import { ICheckConfiguration } from '../../../../../scanner/iruleresults';
 
@@ -26,18 +24,8 @@ describe('custom-widget check', () => {
 });
 
 describe('custom-widget check', () => {
-    const axeTextFunctionBackup: (node: Element) => string = axe.commons.text.accessibleText;
-    const textFunctionMock = Mock.ofInstance((node: Element, isLabelledByContext: boolean) => {
-        return '';
-    }, MockBehavior.Strict);
-
     beforeEach(() => {
         context._data = null;
-    });
-
-    afterEach(() => {
-        axe.commons.text.accessibleText = axeTextFunctionBackup;
-        textFunctionMock.reset();
     });
 
     it('creates expected data object', () => {
@@ -74,15 +62,11 @@ describe('custom-widget check', () => {
 
     it('returns accessibleName data', () => {
         fixture.innerHTML = `
-            <div id="myElement" />
+            <div id="myElement" />my text
             `;
+        axe._tree = axe.utils.getFlattenedTree(document.documentElement);
 
         const node = fixture.querySelector('#myElement');
-
-        axe.commons.text.accessibleText = textFunctionMock.object;
-
-        textFunctionMock.setup(m => m(node, false)).returns(() => 'my text');
-
         expect(customWidgetConfiguration.checks[0].evaluate.call(context, node)).toBeTruthy();
         expect(context._data.accessibleName).toEqual('my text');
     });

--- a/src/tests/unit/tests/scanner/custom-rules/unique-landmark.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/unique-landmark.test.ts
@@ -25,7 +25,9 @@ describe('unique-landmark', () => {
     });
 
     it('should not match because not a landmark', () => {
-        const node = document.createElement('h1');
+        fixture.innerHTML = `<h1>header</h1>`;
+        const node = fixture.querySelector(`h1`);
+        axe._tree = axe.utils.getFlattenedTree(document.documentElement);
         expect(uniqueLandmarkConfiguration.rule.matches(node, null)).toBe(false);
     });
 

--- a/src/tests/unit/tests/scanner/mock-axe-utils.ts
+++ b/src/tests/unit/tests/scanner/mock-axe-utils.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as axe from 'axe-core';
+import { cloneDeep } from 'lodash';
+import { GlobalMock, GlobalScope, IGlobalMock, Times } from 'typemoq';
+
+export function withAxeCommonsMocked(
+    property: string,
+    overrideMocks: {
+        [key: string]: any;
+    },
+    testFunction: () => void,
+    otherMocks: IGlobalMock<any>[] = [],
+): void {
+    const origAxeProperties = cloneDeep(axe.commons[property]);
+    const commonsMock = GlobalMock.ofInstance(axe.commons, 'commons', axe);
+    GlobalScope.using(commonsMock, ...otherMocks).with(() => {
+        const testStub = {
+            ...origAxeProperties,
+            ...overrideMocks,
+        };
+
+        commonsMock
+            .setup(m => m[property])
+            .returns(() => testStub)
+            .verifiable(Times.atLeastOnce());
+
+        testFunction();
+        commonsMock.verifyAll();
+    });
+}


### PR DESCRIPTION
#### Description of changes

Between axe 3 and 4, several modules in axe.commons.* [were refactored](https://github.com/dequelabs/axe-core/pull/2147). See below for details. This PR updates the way we mock axe.commons and test axe functionality so that:
- we add a utility function that can be used to mock axe.commons.* types*
- in some cases, we add missing usage of `getFlattenedTree` to ensure axe.commons.* works correctly in contexts outside of `axe.run`. 

These changes should pass in both axe 3 and axe 4. The current tests in master fail in axe 4.0.1.

details:
*The resulting axe.js we consume in 4.0.1 introduces (via webpack + es modules) `Object.defineProperty` with its default `configurable = false` behavior to populate the module's transitive imports. (See definition of `__webpack_require__.d` [here](https://cdn.jsdelivr.net/npm/axe-core@4.0.1/axe.js)). This contrasts with the pre-ES-module approach of simple assignment. Because `configurable` is set to false, the properties defined this way are [immutable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty). Tests that attempt to use `=` or `Object.defineProperty` (as typemoq does [here](https://github.com/florinn/typemoq/blob/0721689785fe533e68fe455280288980020c7eac/src/GlobalScope.ts#L46)) fail; for instance, `axe-utils.test.ts` fails with `1: TypeError: Cannot redefine property: accessibleText`. The workaround includes minimal changes to allow tests to continue running, including redefining `axe.commons` and switching some cases of mock-usage to integration-tests that use axe directly. Existing issues that discuss this in more detail are at https://github.com/webpack/webpack/pull/7132 (unmerged) and https://github.com/webpack/webpack/issues/6979

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
