### PR TITLE
feat(axe-core-4.0.1): Duplicate title string as aria-label for links

### DIFF
--- a/src/DetailsView/components/nav-link-button.tsx
+++ b/src/DetailsView/components/nav-link-button.tsx
@@ -12,10 +12,12 @@ export interface NavLinkButtonProps extends INavButtonProps {
 
 export const NavLinkButton = NamedFC<NavLinkButtonProps>('NavLinkButton', props => {
     const link = props.link;
+    const titleAndAriaLabel = link.title || link.name;
     return (
         <Link
+            aria-label={titleAndAriaLabel}
             aria-expanded={link.isExpanded}
-            title={link.title || link.name}
+            title={titleAndAriaLabel}
             onClick={e => link.onClickNavLink(e, link)}
             className={css(styles.navLinkButton, props.className)}
             href={link.forceAnchor === true ? '#' : undefined}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`NavLinkButton renders as button element 1`] = `
 <StyledLinkBase
   aria-expanded={true}
+  aria-label="some title"
   className="navLinkButton some class name"
   onClick={[Function]}
   title="some title"
@@ -12,6 +13,7 @@ exports[`NavLinkButton renders as button element 1`] = `
 exports[`NavLinkButton renders with href set 1`] = `
 <StyledLinkBase
   aria-expanded={true}
+  aria-label="some title"
   className="navLinkButton some class name"
   href="#"
   onClick={[Function]}
@@ -22,6 +24,7 @@ exports[`NavLinkButton renders with href set 1`] = `
 exports[`NavLinkButton renders with using name instead of title 1`] = `
 <StyledLinkBase
   aria-expanded={true}
+  aria-label="some title"
   className="navLinkButton some class name"
   onClick={[Function]}
   title="some title"

--- a/src/tests/unit/tests/views/content/__snapshots__/content-link.test.tsx.snap
+++ b/src/tests/unit/tests/views/content/__snapshots__/content-link.test.tsx.snap
@@ -3,26 +3,26 @@
 exports[`ContentLink render null when reference is not defined 1`] = `""`;
 
 exports[`ContentLink renders from content, only have the icon 1`] = `
-"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" onClick={[Function: onClick]}>
+"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" aria-label=\\"Guidance\\" onClick={[Function: onClick]}>
   <StyledIconBase iconName=\\"test icon 1\\" />
 </NewTabLink>"
 `;
 
 exports[`ContentLink renders from path, only have the icon 1`] = `
-"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" onClick={[Function: onClick]}>
+"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" aria-label=\\"Guidance\\" onClick={[Function: onClick]}>
   <StyledIconBase iconName=\\"test icon 2\\" />
 </NewTabLink>"
 `;
 
 exports[`ContentLink renders with both text and icon 1`] = `
-"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" onClick={[Function: onClick]}>
+"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" aria-label=\\"Guidance\\" onClick={[Function: onClick]}>
   <StyledIconBase iconName=\\"test icon\\" />
   test
 </NewTabLink>"
 `;
 
 exports[`ContentLink renders with only text 1`] = `
-"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" onClick={[Function: onClick]}>
+"<NewTabLink href=\\"/insights.html#/content/for/testing\\" title=\\"Guidance\\" aria-label=\\"Guidance\\" onClick={[Function: onClick]}>
   test
 </NewTabLink>"
 `;

--- a/src/views/content/content-link.tsx
+++ b/src/views/content/content-link.tsx
@@ -37,6 +37,7 @@ export const ContentLink = NamedFC<ContentLinkProps>(
             <NewTabLink
                 href={`/insights.html#/content/${contentPath}`}
                 title="Guidance"
+                aria-label="Guidance"
                 onClick={ev => openContentPage(ev, contentPath)}
             >
                 {icon}


### PR DESCRIPTION
#### Description of changes

Axe-core 4.0.1 is generating the following error in 2 different places (the guidance link and the assessment completion link) when scanning the current extension:

```
Element does not have text that is visible to screen readers
aria-label attribute does not exist or is empty
aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
Element's default semantics were not overridden with role=\"presentation\"
Element's default semantics were not overridden with role=\"none\"", "selector": [".link-..."]}]}]
```

These links both have the title property set, so it seems odd to assert that the aria-label attribute must also be set (possible false positive in axe-core?). This PR simply sets the aria-label property to whatever the title property is set to, and updates the necessary snapshots.

There will be a separate PR (including an update for the version) in the axe-core-4.0.1 branch, but I created this against master to:
1. Collect this change into a single PR in case it proves to be a false positive in axe-core
2. Reduce the scope of the code change (and its potential impact) when we merge the axe-core-4.0.1 branch into master 

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
