### PR TITLE
chore: update unified e2e test timeout to twenty minutes

### DIFF
--- a/pipeline/unified/unified-e2e-test-interactive.yaml
+++ b/pipeline/unified/unified-e2e-test-interactive.yaml
@@ -9,7 +9,7 @@ steps:
     - script: yarn test:unified --ci
       displayName: run unified e2e tests (non-linux)
       condition: and(succeeded(), ne(variables.platform, 'linux'))
-      timeoutInMinutes: 10
+      timeoutInMinutes: 20
 
     - script: xvfb-run --server-args="-screen 0 1024x768x24" yarn test:unified --ci
       displayName: run unified e2e tests (linux)


### PR DESCRIPTION
#### Description of changes

We recently doubled the number of e2e tests in the unified product. We've also noticed mac agents seem to timeout more often recently. The current unified-e2e-test timeout is at 10 minutes & they (particularly on Windows and Mac) often aren't complete in this time. This PR updates the timeout to 20 minutes for Windows & Mac machines. A test of [unified-e2e-reliability](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=12829&view=results) shows a recent pass with mac agents finishing in 19 minutes.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
