### PR TITLE
chore: increase PR build unit test timeout

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -44,7 +44,7 @@ jobs:
             displayName: check for strictNullChecks violations
             timeoutInMinutes: 5
 
-          - script: yarn test --ci
+          - script: yarn test --ci --runInBand
             displayName: run unit tests
             timeoutInMinutes: 10
 

--- a/build.yaml
+++ b/build.yaml
@@ -44,9 +44,9 @@ jobs:
             displayName: check for strictNullChecks violations
             timeoutInMinutes: 5
 
-          - script: yarn test --ci --runInBand
+          - script: yarn test --ci
             displayName: run unit tests
-            timeoutInMinutes: 10
+            timeoutInMinutes: 15
 
           - task: PublishTestResults@2
             inputs:


### PR DESCRIPTION
#### Description of changes

We've recently been seeing some timeouts in CI/PR build unit test steps, occasionally on the mac agents and more consistently on the linux agents we recently switched to. There doesn't seem to be any evidence that they're getting stuck, it seems that we've just added more tests since we established the timeout.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: n/a
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
