### PR TITLE
chore: remove stray it.only in injection-action-creator tests

### DIFF
--- a/src/tests/unit/tests/background/actions/injection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/injection-action-creator.test.ts
@@ -25,7 +25,7 @@ describe('InjectionActionCreator', () => {
         injectionStartedMock.verifyAll();
     });
 
-    it.only('handles InjectionCompleted message', () => {
+    it('handles InjectionCompleted message', () => {
         const injectionCompletedMock = createActionMock<void>(null);
         const actionsMock = createActionsMock('injectionCompleted', injectionCompletedMock.object);
         const interpreterMock = createInterpreterMock(


### PR DESCRIPTION
#### Description of changes

There was a stray `it.only` that was causing a unit test to be unintentionally skipped. The test already passed, no change to it required.

(As part of the web-compliance feature, we'll be migrating from TSLint to ESLint, which will finally allow us to start using [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-focused-tests.md) and prevent this class of issue from occurring again)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
