### PR TITLE
feat(axe-core-4.0.1): bump version of accessibility-insights-report

### DIFF
--- a/src/reports/package/root/package.json
+++ b/src/reports/package/root/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-report",
-    "version": "1.0.3",
+    "version": "2.0.0",
     "description": "Accessibility Insights Report",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
#### Description of changes

As part of the update to axe-core 4.0, we've removed several deprecated rules in #3262. Since a consumer of the report package can no longer rely on the current source to properly display those deprecated rules, we've designated this as a major update to the package. Users using axe 3.0 will want to remain on the 1.x version of the accessibility-insights-reporter package.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
