### PR TITLE
feat(compliance-web): Address security warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,11 +61,6 @@ module.exports = {
         'react/jsx-no-target-blank': 'off',
         'react/no-unknown-property': 'off',
         'security/detect-object-injection': 'off',
-        'security/detect-non-literal-regexp': 'off',
-        'security/detect-non-literal-fs-filename': 'off',
-        'security/detect-unsafe-regex': 'off',
-        'security/detect-child-process': 'off',
-        'security/detect-eval-with-expression': 'off',
         'prefer-const': 'off',
         'no-irregular-whitespace': 'off',
         'no-prototype-builtins': 'off',
@@ -79,4 +74,17 @@ module.exports = {
         'no-extra-boolean-cast': 'off',
         'prefer-spread': 'off',
     },
+    overrides: [
+        {
+            files: ['src/tests/**/*'],
+            rules: {
+                // Disable those errors and warnings which are not a threat to test code because the code is not run in production environments
+                'security/detect-non-literal-regexp': 'off',
+                'security/detect-non-literal-fs-filename': 'off',
+                'security/detect-unsafe-regex': 'off',
+                'security/detect-child-process': 'off',
+                'security/detect-eval-with-expression': 'off',
+            },
+        },
+    ],
 };

--- a/src/common/components/fix-instruction-processor.tsx
+++ b/src/common/components/fix-instruction-processor.tsx
@@ -11,11 +11,14 @@ type ColorMatch = {
 export class FixInstructionProcessor {
     private readonly colorValueMatcher = `(#[0-9a-f]{6})`;
     private readonly foregroundColorText = 'foreground color: ';
+    // the following warnings can be disabled because the values are actually constant strings and the string template is used merely for ease of reading
+    // eslint-disable-next-line security/detect-non-literal-regexp
     private readonly foregroundRegExp = new RegExp(
         `${this.foregroundColorText}${this.colorValueMatcher}`,
         'i',
     );
     private readonly backgroundColorText = 'background color: ';
+    // eslint-disable-next-line security/detect-non-literal-regexp
     private readonly backgroundRegExp = new RegExp(
         `${this.backgroundColorText}${this.colorValueMatcher}`,
         'i',

--- a/src/common/configuration/file-system-configuration.ts
+++ b/src/common/configuration/file-system-configuration.ts
@@ -13,25 +13,27 @@ import {
 import * as fs from 'fs';
 import * as path from 'path';
 
+export type ReadFileSync = () => Buffer;
+
 // Note: this is resolved relative to the bundled js file, not the src layout
-const defaultConfigJsonPath = path.join(__dirname, '../insights.config.json');
+const defaultConfigPath = path.join(__dirname, '../insights.config.json');
+// eslint-disable-next-line security/detect-non-literal-fs-filename
+const defaultReadFileSync: ReadFileSync = () => fs.readFileSync(defaultConfigPath);
 
 // Appropriate for contexts without a DOM but with access to the fs module
 // (eg, electron main process)
 export class FileSystemConfiguration implements ConfigAccessor, ConfigMutator {
-    private readonly configJsonPath: string;
+    private readonly readFileSync: ReadFileSync;
     public config: InsightsConfiguration;
 
-    constructor(configJsonPath?: string) {
-        this.configJsonPath = configJsonPath ?? defaultConfigJsonPath;
+    constructor(readFileSync?: ReadFileSync) {
+        this.readFileSync = readFileSync ?? defaultReadFileSync;
         this.reset();
     }
 
     public reset(): ConfigMutator {
         try {
-            // The following warning is disabled because this.configJsonPath is a string literal whose value is set differently only for unit tests
-            // eslint-disable-next-line security/detect-non-literal-fs-filename
-            const configJsonRawContent = fs.readFileSync(this.configJsonPath).toString();
+            const configJsonRawContent = this.readFileSync().toString();
             const configJson = JSON.parse(configJsonRawContent);
             this.config = defaultsDeep(configJson, defaults);
         } catch (e) {

--- a/src/common/configuration/file-system-configuration.ts
+++ b/src/common/configuration/file-system-configuration.ts
@@ -29,6 +29,8 @@ export class FileSystemConfiguration implements ConfigAccessor, ConfigMutator {
 
     public reset(): ConfigMutator {
         try {
+            // The following warning is disabled because this.configJsonPath is a string literal whose value is set differently only for unit tests
+            // eslint-disable-next-line security/detect-non-literal-fs-filename
             const configJsonRawContent = fs.readFileSync(this.configJsonPath).toString();
             const configJson = JSON.parse(configJsonRawContent);
             this.config = defaultsDeep(configJson, defaults);

--- a/src/issue-filing/common/http-query-builder.ts
+++ b/src/issue-filing/common/http-query-builder.ts
@@ -43,6 +43,8 @@ export class HTTPQueryBuilder {
 
         const fullUrl = `${this.baseUrl}?${queryParameters}`;
 
+        // The following warning is thrown incorrectly because the call to 'truncate' is not on the file system
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
         return this.truncate(fullUrl);
     }
 

--- a/src/issue-filing/common/http-query-builder.ts
+++ b/src/issue-filing/common/http-query-builder.ts
@@ -44,6 +44,7 @@ export class HTTPQueryBuilder {
         const fullUrl = `${this.baseUrl}?${queryParameters}`;
 
         // The following warning is thrown incorrectly because the call to 'truncate' is not on the file system
+        // see bug: https://github.com/nodesecurity/eslint-plugin-security/issues/54
         // eslint-disable-next-line security/detect-non-literal-fs-filename
         return this.truncate(fullUrl);
     }

--- a/src/popup/handlers/launch-panel-header-click-handler.ts
+++ b/src/popup/handlers/launch-panel-header-click-handler.ts
@@ -18,6 +18,7 @@ export class LaunchPanelHeaderClickHandler {
         const url: string = item.data;
 
         // the following warning is thrown incorrectly because the call to 'open' is not on the file system
+        // see bug: https://github.com/nodesecurity/eslint-plugin-security/issues/54
         // eslint-disable-next-line security/detect-non-literal-fs-filename
         popupWindow.open(url);
     }

--- a/src/popup/handlers/launch-panel-header-click-handler.ts
+++ b/src/popup/handlers/launch-panel-header-click-handler.ts
@@ -14,7 +14,11 @@ export class LaunchPanelHeaderClickHandler {
         if (item == null) {
             return;
         }
+
         const url: string = item.data;
+
+        // the following warning is thrown incorrectly because the call to 'open' is not on the file system
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
         popupWindow.open(url);
     }
 

--- a/src/tests/unit/tests/common/configuration/file-system-configuration.test.ts
+++ b/src/tests/unit/tests/common/configuration/file-system-configuration.test.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FileSystemConfiguration } from 'common/configuration/file-system-configuration';
+import {
+    FileSystemConfiguration,
+    ReadFileSync,
+} from 'common/configuration/file-system-configuration';
 import * as path from 'path';
+import * as fs from 'fs';
 
 describe('FileSystemConfiguration', () => {
     const configFileWithFullNameSet = path.join(__dirname, 'insights.config.test.json');
@@ -11,27 +15,35 @@ describe('FileSystemConfiguration', () => {
     const defaultName = 'Accessibility Insights for Web';
     const newName = 'New Extension Name';
 
+    const getReadFileSync = (path: string): ReadFileSync => {
+        return () => fs.readFileSync(path);
+    };
+
+    const createFileSystemConfiguration = (path: string): FileSystemConfiguration => {
+        return new FileSystemConfiguration(getReadFileSync(path));
+    };
+
     it('reflects default values if the config file is not present', () => {
-        const config = new FileSystemConfiguration(nonExistentConfigFile);
+        const config = createFileSystemConfiguration(nonExistentConfigFile);
         expect(config.getOption('fullName')).toBe(defaultName);
         expect(config.config.options.fullName).toBe(defaultName);
     });
 
     it('reflects the properties on the config file', () => {
-        const config = new FileSystemConfiguration(configFileWithFullNameSet);
+        const config = createFileSystemConfiguration(configFileWithFullNameSet);
         expect(config.getOption('fullName')).toBe(fullNameFromConfigFile);
         expect(config.config.options.fullName).toBe(fullNameFromConfigFile);
     });
 
     it('prefers explicitly set values to defaults', () => {
-        const config = new FileSystemConfiguration(nonExistentConfigFile);
+        const config = createFileSystemConfiguration(nonExistentConfigFile);
         config.setOption('fullName', newName);
         expect(config.getOption('fullName')).toBe(newName);
         expect(config.config.options.fullName).toBe(newName);
     });
 
     it('prefers explicitly set values to config file properties', () => {
-        const config = new FileSystemConfiguration(configFileWithFullNameSet);
+        const config = createFileSystemConfiguration(configFileWithFullNameSet);
         config.setOption('fullName', newName);
         expect(config.getOption('fullName')).toBe(newName);
         expect(config.config.options.fullName).toBe(newName);


### PR DESCRIPTION
#### Description of changes

Enabled security eslint rules for production code. Maintained disabling the below security eslint rules for code which is not released to production because of the extremely high false positive rate for the security rule set.

- (2) security/detect-non-literal-regexp
- (3) security/detect-non-literal-fs-filename
- (0) security/detect-unsafe-regex
- (0) security/detect-child-process
- (0) security/detect-eval-with-expression

Maintained the disabled rule 'security/detect-object-injection' because there are 295 warnings. Those will be addressed in another PR.
