### PR TITLE
fix: remove use of defaultConfig from Axe._audit

### DIFF
--- a/src/scanner/axe-extension.d.ts
+++ b/src/scanner/axe-extension.d.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as axe from 'axe-core';
-import { IRuleConfiguration, ICheckConfiguration } from '../scanner/iruleresults';
+import {
+    IRuleConfiguration,
+    ICheckConfiguration,
+    RuleConfiguration,
+} from '../scanner/iruleresults';
 
 declare module 'axe-core/axe' {
     const commons: {
@@ -26,10 +30,8 @@ declare module 'axe-core/axe' {
     };
 
     const _audit: {
-        defaultConfig: {
-            rules: IRuleConfiguration[];
-            checks: ICheckConfiguration[];
-        };
+        rules: IRuleConfiguration[];
+        checks: { [checkId: string]: ICheckConfiguration };
     };
 
     const version: string;

--- a/src/scanner/axe-utils.ts
+++ b/src/scanner/axe-utils.ts
@@ -9,13 +9,17 @@ export type ImageCodedAs = 'Decorative' | 'Meaningful';
 export function getMatchesFromRule(
     ruleId: string,
 ): ((node: any, virtualNode: any) => boolean) | undefined {
-    return axe._audit.defaultConfig.rules.filter(rule => rule.id === ruleId)[0].matches;
+    return axe._audit.rules.filter(rule => rule.id === ruleId)[0].matches;
 }
 
 export function getEvaluateFromCheck(
     checkId: string,
 ): (node: any, options: any, virtualNode: any, context: any) => boolean {
-    return axe._audit.defaultConfig.checks.filter(check => check.id === checkId)[0].evaluate;
+    return axe._audit.checks[checkId].evaluate;
+}
+
+export function getOptionsFromCheck(checkId: string): any {
+    return axe._audit.checks[checkId].options;
 }
 
 export function getAccessibleText(node: HTMLElement, isLabelledByContext: boolean): string {

--- a/src/scanner/custom-rules/text-contrast.ts
+++ b/src/scanner/custom-rules/text-contrast.ts
@@ -9,6 +9,7 @@ export const textContrastConfiguration: RuleConfiguration = {
         {
             id: 'text-contrast',
             evaluate: evaluateTextContrast,
+            options: AxeUtils.getOptionsFromCheck('color-contrast'),
         },
     ],
     rule: {

--- a/src/tests/unit/tests/scanner/axe-utils.test.ts
+++ b/src/tests/unit/tests/scanner/axe-utils.test.ts
@@ -12,6 +12,10 @@ describe('AxeUtils', () => {
             expect(AxeUtils.getMatchesFromRule('color-contrast')).toBeDefined();
         });
 
+        it('color-contrast matches should be a function', () => {
+            expect(AxeUtils.getMatchesFromRule('color-contrast')).toHaveProperty('call');
+        });
+
         it('should fail if rule does not exist', () => {
             expect(() => AxeUtils.getMatchesFromRule('fake-rule')).toThrow();
         });
@@ -22,8 +26,22 @@ describe('AxeUtils', () => {
             expect(AxeUtils.getEvaluateFromCheck('color-contrast')).toBeDefined();
         });
 
+        it('color-contrast evaluate should be a function', () => {
+            expect(AxeUtils.getEvaluateFromCheck('color-contrast')).toHaveProperty('call');
+        });
+
         it('should fail if rule does not exist', () => {
             expect(() => AxeUtils.getEvaluateFromCheck('fake-rule')).toThrow();
+        });
+    });
+
+    describe('getOptionsFromCheck', () => {
+        it('should find color-contrast rule', () => {
+            expect(AxeUtils.getOptionsFromCheck('color-contrast')).toBeDefined();
+        });
+
+        it('should fail if rule does not exist', () => {
+            expect(() => AxeUtils.getOptionsFromCheck('fake-rule')).toThrow();
         });
     });
 

--- a/src/tests/unit/tests/scanner/custom-rules/custom-widget-check.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/custom-widget-check.test.ts
@@ -240,7 +240,7 @@ describe('custom-widget check', () => {
 });
 
 function getCheck(checkId: string): ICheckConfiguration {
-    return axe._audit.defaultConfig.checks.find(elem => elem.id === checkId);
+    return axe._audit.checks[checkId];
 }
 
 function createTestFixture(id: string, content: string): HTMLDivElement {

--- a/src/tests/unit/tests/scanner/custom-rules/unique-landmark-check.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/unique-landmark-check.test.ts
@@ -15,9 +15,7 @@ describe('axe.Check: unique-landmark', () => {
         },
     };
     beforeEach(() => {
-        check = axe._audit.defaultConfig.checks.find(elem => {
-            return elem.id === 'unique-landmark';
-        });
+        check = axe._audit.checks['unique-landmark'];
 
         fixture = createTestFixture('test-fixture', '');
         checkContext._data = null;

--- a/src/tests/unit/tests/scanner/rule-to-links-mappings.test.ts
+++ b/src/tests/unit/tests/scanner/rule-to-links-mappings.test.ts
@@ -11,6 +11,7 @@ describe('ruleToLinkConfiguration', () => {
     const bestPracticeAxeRules: string[] = axe.getRules(['best-practice']).map(rule => rule.ruleId);
 
     it.each(allAxeRules)(`should have a mapping for axe rule %s`, rule => {
+        const config = ruleToLinkConfiguration;
         expect(ruleToLinkConfiguration[rule]).toBeDefined();
     });
 

--- a/src/tests/unit/tests/scanner/rule-to-links-mappings.test.ts
+++ b/src/tests/unit/tests/scanner/rule-to-links-mappings.test.ts
@@ -11,7 +11,6 @@ describe('ruleToLinkConfiguration', () => {
     const bestPracticeAxeRules: string[] = axe.getRules(['best-practice']).map(rule => rule.ruleId);
 
     it.each(allAxeRules)(`should have a mapping for axe rule %s`, rule => {
-        const config = ruleToLinkConfiguration;
         expect(ruleToLinkConfiguration[rule]).toBeDefined();
     });
 


### PR DESCRIPTION
#### Description of changes

In Axe 4.0, the structure of check configurations changed so that the `evaluate` property could be set as either a function or as a string key that references an internal axe function. In `Axe._audit.defaultConfig.checks`, checks may still have a string in place of the evaluate function. We use `defaultConfig` to access the color-contrast evaluate function in our custom text-contrast check, but since that value is now a string instead of a function, the check was failing silently and causing a false negative for the Adaptable content > contrast requirement.

This PR removes uses of `defaultConfig` and instead uses `Axe._audit.checks` or `Axe._audit.rules`, since the checks found here do have the real evaluate function, instead of just a string. This fixes the false negative.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3301
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
