### PR TITLE
fix: add landmarks for command bar and switcher

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -92,7 +92,7 @@ export class DetailsViewCommandBar extends React.Component<
         }
 
         return (
-            <div className={styles.detailsViewCommandBar}>
+            <div className={styles.detailsViewCommandBar} role="region" aria-label="command bar">
                 {this.renderTargetPageInfo()}
                 {this.renderFarItems()}
                 {this.renderExportDialog()}

--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -78,7 +78,11 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
 
     public render(): JSX.Element {
         return (
-            <div className={this.props.styles.switcherClassName}>
+            <div
+                className={this.props.styles.switcherClassName}
+                role="region"
+                aria-label="activity"
+            >
                 <Dropdown
                     className={this.props.styles.dropdownClassName}
                     ariaLabel="select activity"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = `
-"<div className=\\"detailsViewCommandBar\\">
+"<div className=\\"detailsViewCommandBar\\" role=\\"region\\" aria-label=\\"command bar\\">
   <div className=\\"detailsViewTargetPage\\" aria-labelledby=\\"switch-to-target\\">
     <span id=\\"switch-to-target\\">
       Target page: 
@@ -21,7 +21,9 @@ exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = 
 
 exports[`DetailsViewCommandBar renders with export button, with start over 1`] = `
 <div
+  aria-label="command bar"
   className="detailsViewCommandBar"
+  role="region"
 >
   <div
     aria-labelledby="switch-to-target"
@@ -141,7 +143,9 @@ exports[`DetailsViewCommandBar renders with export button, with start over 1`] =
 
 exports[`DetailsViewCommandBar renders with export button, without start over 1`] = `
 <div
+  aria-label="command bar"
   className="detailsViewCommandBar"
+  role="region"
 >
   <div
     aria-labelledby="switch-to-target"
@@ -258,7 +262,9 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
 
 exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
 <div
+  aria-label="command bar"
   className="detailsViewCommandBar"
+  role="region"
 >
   <div
     aria-labelledby="switch-to-target"
@@ -374,7 +380,7 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
 `;
 
 exports[`DetailsViewCommandBar renders with start assessment over dialog open 1`] = `
-"<div className=\\"detailsViewCommandBar\\">
+"<div className=\\"detailsViewCommandBar\\" role=\\"region\\" aria-label=\\"command bar\\">
   <div className=\\"detailsViewTargetPage\\" aria-labelledby=\\"switch-to-target\\">
     <span id=\\"switch-to-target\\">
       Target page: 
@@ -395,7 +401,7 @@ exports[`DetailsViewCommandBar renders with start assessment over dialog open 1`
 `;
 
 exports[`DetailsViewCommandBar renders with start test over dialog open 1`] = `
-"<div className=\\"detailsViewCommandBar\\">
+"<div className=\\"detailsViewCommandBar\\" role=\\"region\\" aria-label=\\"command bar\\">
   <div className=\\"detailsViewTargetPage\\" aria-labelledby=\\"switch-to-target\\">
     <span id=\\"switch-to-target\\">
       Target page: 
@@ -417,7 +423,9 @@ exports[`DetailsViewCommandBar renders with start test over dialog open 1`] = `
 
 exports[`DetailsViewCommandBar renders without export button, with start over 1`] = `
 <div
+  aria-label="command bar"
   className="detailsViewCommandBar"
+  role="region"
 >
   <div
     aria-labelledby="switch-to-target"
@@ -533,7 +541,9 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
 
 exports[`DetailsViewCommandBar renders without export button, without start over 1`] = `
 <div
+  aria-label="command bar"
   className="detailsViewCommandBar"
+  role="region"
 >
   <div
     aria-labelledby="switch-to-target"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
@@ -20,7 +20,7 @@ Array [
 `;
 
 exports[`Switcher renders Switcher itself matches snapshot 1`] = `
-"<div className=\\"header-switcher\\">
+"<div className=\\"header-switcher\\" role=\\"region\\" aria-label=\\"activity\\">
   <StyledWithResponsiveMode className=\\"header-switcher-dropdown\\" ariaLabel=\\"select activity\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function]} onRenderTitle={[Function]} onChange={[Function]} options={{...}} />
 </div>"
 `;


### PR DESCRIPTION
#### Description of changes

Make sure the command bar and switcher are in a landmark (styling looks weird because I downloaded the page to use the visualizer on it, the actual extension page looks the same):

<img width="563" alt="landmarks" src="https://user-images.githubusercontent.com/55459788/92025125-edeb3e00-ed13-11ea-97b3-e59bc7a3c5a2.PNG">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3153 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
