### PR TITLE
feat(cli-summary-report): Generate an empty summary report

### DIFF
--- a/src/reports/components/report-sections/report-body.tsx
+++ b/src/reports/components/report-sections/report-body.tsx
@@ -1,49 +1,56 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
 import { ReportSectionFactory, SectionProps } from './report-section-factory';
 
-export type ReportBodyProps = {
-    sectionFactory: ReportBodySectionFactory;
-} & SectionProps;
+export type ReportBodyProps<SectionPropsType = SectionProps> = {
+    sectionFactory: ReportBodySectionFactory<SectionPropsType>;
+} & SectionPropsType;
 
-export type ReportBodySectionFactory = Omit<ReportSectionFactory, 'HeadSection'>;
+export type ReportBodySectionFactory<SectionPropsType = SectionProps> = Omit<
+    ReportSectionFactory<SectionPropsType>,
+    'HeadSection'
+>;
 
-export const ReportBody = NamedFC<ReportBodyProps>('ReportBody', props => {
-    const { sectionFactory, ...sectionProps } = props;
-    const {
-        BodySection,
-        ContentContainer,
-        HeaderSection,
-        TitleSection,
-        SummarySection,
-        DetailsSection,
-        ResultsContainer,
-        FailedInstancesSection,
-        PassedChecksSection,
-        NotApplicableChecksSection,
-        FooterSection,
-        FooterText,
-    } = sectionFactory;
+export class ReportBody<SectionPropsType = SectionProps> extends React.Component<
+    ReportBodyProps<SectionPropsType>
+> {
+    public render(): JSX.Element {
+        const sectionFactory = this.props.sectionFactory;
+        const sectionProps: SectionPropsType = this.props;
+        const {
+            BodySection,
+            ContentContainer,
+            HeaderSection,
+            TitleSection,
+            SummarySection,
+            DetailsSection,
+            ResultsContainer,
+            FailedInstancesSection,
+            PassedChecksSection,
+            NotApplicableChecksSection,
+            FooterSection,
+            FooterText,
+        } = sectionFactory;
 
-    return (
-        <BodySection>
-            <HeaderSection {...sectionProps} />
-            <ContentContainer>
-                <TitleSection />
-                <SummarySection {...sectionProps} />
-                <DetailsSection {...sectionProps} />
-                <ResultsContainer {...sectionProps}>
-                    <FailedInstancesSection {...sectionProps} />
-                    <PassedChecksSection {...sectionProps} />
-                    <NotApplicableChecksSection {...sectionProps} />
-                </ResultsContainer>
-            </ContentContainer>
-            <FooterSection>
-                <FooterText {...sectionProps} />
-            </FooterSection>
-        </BodySection>
-    );
-});
+        return (
+            <BodySection>
+                <HeaderSection {...sectionProps} />
+                <ContentContainer>
+                    <TitleSection />
+                    <SummarySection {...sectionProps} />
+                    <DetailsSection {...sectionProps} />
+                    <ResultsContainer {...sectionProps}>
+                        <FailedInstancesSection {...sectionProps} />
+                        <PassedChecksSection {...sectionProps} />
+                        <NotApplicableChecksSection {...sectionProps} />
+                    </ResultsContainer>
+                </ContentContainer>
+                <FooterSection>
+                    <FooterText {...sectionProps} />
+                </FooterSection>
+            </BodySection>
+        );
+    }
+}

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -29,18 +29,18 @@ export type SectionProps = {
     scanMetadata: ScanMetadata;
 };
 
-export type ReportSectionFactory = {
+export type ReportSectionFactory<SectionPropsType = SectionProps> = {
     HeadSection: ReactFCWithDisplayName;
     BodySection: ReactFCWithDisplayName;
     ContentContainer: ReactFCWithDisplayName;
-    HeaderSection: ReactFCWithDisplayName<SectionProps>;
+    HeaderSection: ReactFCWithDisplayName<SectionPropsType>;
     TitleSection: ReactFCWithDisplayName;
-    SummarySection: ReactFCWithDisplayName<SectionProps>;
-    DetailsSection: ReactFCWithDisplayName<SectionProps>;
-    ResultsContainer: ReactFCWithDisplayName<SectionProps>;
-    FailedInstancesSection: ReactFCWithDisplayName<SectionProps>;
-    PassedChecksSection: ReactFCWithDisplayName<SectionProps>;
-    NotApplicableChecksSection: ReactFCWithDisplayName<SectionProps>;
+    SummarySection: ReactFCWithDisplayName<SectionPropsType>;
+    DetailsSection: ReactFCWithDisplayName<SectionPropsType>;
+    ResultsContainer: ReactFCWithDisplayName<SectionPropsType>;
+    FailedInstancesSection: ReactFCWithDisplayName<SectionPropsType>;
+    PassedChecksSection: ReactFCWithDisplayName<SectionPropsType>;
+    NotApplicableChecksSection: ReactFCWithDisplayName<SectionPropsType>;
     FooterSection: ReactFCWithDisplayName;
-    FooterText: ReactFCWithDisplayName<Pick<SectionProps, 'scanMetadata'>>;
+    FooterText: ReactFCWithDisplayName<SectionPropsType>;
 };

--- a/src/reports/components/report-sections/summary-report-section-factory.tsx
+++ b/src/reports/components/report-sections/summary-report-section-factory.tsx
@@ -13,6 +13,7 @@ import {
     SummaryScanResults,
 } from 'reports/package/accessibilityInsightsReport';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
+import { NullComponent } from 'common/components/null-component';
 
 export type SummaryReportSectionProps = {
     scanDetails: CrawlSummaryDetails;
@@ -26,14 +27,14 @@ export const SummaryReportSectionFactory: ReportSectionFactory<SummaryReportSect
     HeadSection: ReportHead,
     BodySection,
     ContentContainer,
-    HeaderSection: null,
+    HeaderSection: NullComponent,
     TitleSection,
-    SummarySection: null,
-    DetailsSection: null,
+    SummarySection: NullComponent,
+    DetailsSection: NullComponent,
     ResultsContainer,
-    FailedInstancesSection: null,
-    PassedChecksSection: null,
-    NotApplicableChecksSection: null,
+    FailedInstancesSection: NullComponent,
+    PassedChecksSection: NullComponent,
+    NotApplicableChecksSection: NullComponent,
     FooterSection: ReportFooter,
     FooterText,
 };

--- a/src/reports/components/report-sections/summary-report-section-factory.tsx
+++ b/src/reports/components/report-sections/summary-report-section-factory.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ReportHead } from 'reports/components/report-head';
+import { BodySection } from './body-section';
+import { ContentContainer } from './content-container';
+import { FooterText } from './footer-text';
+import { ReportFooter } from './report-footer';
+import { ReportSectionFactory } from './report-section-factory';
+import { ResultsContainer } from './results-container';
+import { TitleSection } from './title-section';
+import {
+    CrawlSummaryDetails,
+    SummaryScanResults,
+} from 'reports/package/accessibilityInsightsReport';
+import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
+
+export type SummaryReportSectionProps = {
+    scanDetails: CrawlSummaryDetails;
+    toUtcString: (date: Date) => string;
+    getCollapsibleScript: () => string;
+    scanMetadata: ScanMetadata;
+    results: SummaryScanResults;
+};
+
+export const SummaryReportSectionFactory: ReportSectionFactory<SummaryReportSectionProps> = {
+    HeadSection: ReportHead,
+    BodySection,
+    ContentContainer,
+    HeaderSection: null,
+    TitleSection,
+    SummarySection: null,
+    DetailsSection: null,
+    ResultsContainer,
+    FailedInstancesSection: null,
+    PassedChecksSection: null,
+    NotApplicableChecksSection: null,
+    FooterSection: ReportFooter,
+    FooterText,
+};

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -38,16 +38,18 @@ declare namespace AccessibilityInsightsReport {
         errorDescription: string,
     }
 
+    export type SummaryScanResults = {
+        failed: SummaryScanResult[],
+        passed: SummaryScanResult[],
+        unscannable: SummaryScanError[],
+    };
+
     export type SummaryReportParameters = {
         serviceName: string;
         axeVersion: string;
         userAgent: string;
         crawlDetails: CrawlSummaryDetails;
-        results: {
-            failed: SummaryScanResult[],
-            passed: SummaryScanResult[],
-            unscannable: SummaryScanError[],
-        }
+        results: SummaryScanResults;
     };
 
     export type Reporter = {

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -26,36 +26,33 @@ declare namespace AccessibilityInsightsReport {
         durationSeconds: number,
     }
 
-    export type FailedScanResult = {
-        url: string, // Should we have pageTitle? Maybe for accessibile link names?
+    export type SummaryScanResult = {
+        url: string,
         numFailures: number,
         reportLocation: string,
     }
 
-    export type PassedScanResult = {
-        url: string,
-        reportLocation: string,
-    }
-
-    export type UnscannableScanResult = {
+    export type SummaryScanError = {
         url: string,
         errorType: string,
-        errorDescription: string, // Link to error log?
+        errorDescription: string,
     }
 
-    export type CrawlSummaryReportParameters = {
+    export type SummaryReportParameters = {
         serviceName: string;
+        axeVersion: string;
+        userAgent: string;
         crawlDetails: CrawlSummaryDetails;
         results: {
-            failed: FailedScanResult[],
-            passed: PassedScanResult[],
-            unscannable: UnscannableScanResult[],
+            failed: SummaryScanResult[],
+            passed: SummaryScanResult[],
+            unscannable: SummaryScanError[],
         }
     };
 
     export type Reporter = {
         fromAxeResult: (parameters: AxeReportParameters) => Report;
-        fromCrawlResults: (parameters: CrawlSummaryReportParameters) => Report;
+        fromSummaryResults: (parameters: SummaryReportParameters) => Report;
     };
 
     export type ReporterFactory = () => Reporter;

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -19,8 +19,43 @@ declare namespace AccessibilityInsightsReport {
         scanContext: ScanContext;
     }
 
+    export type CrawlSummaryDetails = {
+        baseUrl: string,
+        scanStart: Date,
+        scanComplete: Date,
+        durationSeconds: number,
+    }
+
+    export type FailedScanResult = {
+        url: string, // Should we have pageTitle? Maybe for accessibile link names?
+        numFailures: number,
+        reportLocation: string,
+    }
+
+    export type PassedScanResult = {
+        url: string,
+        reportLocation: string,
+    }
+
+    export type UnscannableScanResult = {
+        url: string,
+        errorType: string,
+        errorDescription: string, // Link to error log?
+    }
+
+    export type CrawlSummaryReportParameters = {
+        serviceName: string;
+        crawlDetails: CrawlSummaryDetails;
+        results: {
+            failed: FailedScanResult[],
+            passed: PassedScanResult[],
+            unscannable: UnscannableScanResult[],
+        }
+    };
+
     export type Reporter = {
         fromAxeResult: (parameters: AxeReportParameters) => Report;
+        fromCrawlResults: (parameters: CrawlSummaryReportParameters) => Report;
     };
 
     export type ReporterFactory = () => Reporter;

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -24,8 +24,9 @@ import { getPropertyConfiguration } from '../../common/configs/unified-result-pr
 import { DateProvider } from '../../common/date-provider';
 import { initializeFabricIcons } from '../../common/fabric-icons';
 import { GetGuidanceTagsFromGuidanceLinks } from '../../common/get-guidance-tags-from-guidance-links';
-import { AxeReportParameters, ReporterFactory } from './accessibilityInsightsReport';
+import { AxeReportParameters, ReporterFactory, SummaryReportParameters } from './accessibilityInsightsReport';
 import { Reporter } from './reporter';
+import { SummaryResultsReport } from 'reports/package/summary-results-report';
 
 const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
     const {
@@ -91,9 +92,22 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
     return new AxeResultsReport(deps, parameters, toolData);
 };
 
+const summaryResultsReportGenerator = (parameters: SummaryReportParameters) => {
+    const { serviceName, axeVersion, userAgent } = parameters;
+
+    const toolData = createToolData(
+        serviceName,
+        '',
+        'axe-core',
+        axeVersion,
+        userAgent,
+    );
+    return new SummaryResultsReport(parameters, toolData);
+};
+
 initializeFabricIcons();
 
 export const reporterFactory: ReporterFactory = () => {
 
-    return new Reporter(axeResultsReportGenerator);
+    return new Reporter(axeResultsReportGenerator, summaryResultsReportGenerator);
 };

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -27,6 +27,8 @@ import { GetGuidanceTagsFromGuidanceLinks } from '../../common/get-guidance-tags
 import { AxeReportParameters, ReporterFactory, SummaryReportParameters } from './accessibilityInsightsReport';
 import { Reporter } from './reporter';
 import { SummaryResultsReport } from 'reports/package/summary-results-report';
+import { SummaryReportSectionFactory } from 'reports/components/report-sections/summary-report-section-factory';
+import { SummaryReportHtmlGenerator } from 'reports/summary-report-html-generator';
 
 const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
     const {
@@ -102,7 +104,24 @@ const summaryResultsReportGenerator = (parameters: SummaryReportParameters) => {
         axeVersion,
         userAgent,
     );
-    return new SummaryResultsReport(parameters, toolData);
+
+    const sectionFactory = {
+        ...SummaryReportSectionFactory,
+        FooterTextForService,
+    };
+
+    const reportHtmlGenerator = new SummaryReportHtmlGenerator(
+        sectionFactory,
+        new ReactStaticRenderer(),
+        getDefaultAddListenerForCollapsibleSection,
+        DateProvider.getUTCStringFromDate,
+    );
+
+    const deps = {
+        reportHtmlGenerator,
+    }
+
+    return new SummaryResultsReport(deps, parameters, toolData);
 };
 
 initializeFabricIcons();

--- a/src/reports/package/reporter.ts
+++ b/src/reports/package/reporter.ts
@@ -2,13 +2,22 @@
 // Licensed under the MIT License.
 import AccessibilityInsightsReport from './accessibilityInsightsReport';
 import { AxeResultsReport } from './axe-results-report';
+import { SummaryResultsReport } from 'reports/package/summary-results-report';
 
 export type AxeResultsReportGenerator = (parameters: AccessibilityInsightsReport.AxeReportParameters) => AxeResultsReport;
+export type SummaryResultsReportGenerator = (parameters: AccessibilityInsightsReport.SummaryReportParameters) => SummaryResultsReport;
 
 export class Reporter implements AccessibilityInsightsReport.Reporter {
-    constructor(private readonly axeResultsReportGenerator: AxeResultsReportGenerator) { }
+    constructor(
+        private readonly axeResultsReportGenerator: AxeResultsReportGenerator,
+        private readonly summaryResultsReportGenerator: SummaryResultsReportGenerator
+    ) { }
 
     public fromAxeResult(parameters: AccessibilityInsightsReport.AxeReportParameters): AxeResultsReport {
         return this.axeResultsReportGenerator(parameters);
+    }
+
+    public fromSummaryResults(parameters: AccessibilityInsightsReport.SummaryReportParameters): SummaryResultsReport {
+        return this.summaryResultsReportGenerator(parameters);
     }
 }

--- a/src/reports/package/root/package.json
+++ b/src/reports/package/root/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "temp-accessibility-insights-report",
-    "version": "0.1.0",
+    "name": "accessibility-insights-report",
+    "version": "2.0.0",
     "description": "Accessibility Insights Report",
     "license": "MIT",
     "repository": {

--- a/src/reports/package/root/package.json
+++ b/src/reports/package/root/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "accessibility-insights-report",
-    "version": "2.0.0",
+    "name": "temp-accessibility-insights-report",
+    "version": "0.1.0",
     "description": "Accessibility Insights Report",
     "license": "MIT",
     "repository": {

--- a/src/reports/package/summary-results-report.ts
+++ b/src/reports/package/summary-results-report.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {  ToolData } from 'common/types/store-data/unified-data-interface';
+import AccessibilityInsightsReport from './accessibilityInsightsReport';
+
+export class SummaryResultsReport implements AccessibilityInsightsReport.Report {
+    constructor(
+        private readonly parameters: AccessibilityInsightsReport.SummaryReportParameters,
+        private readonly toolInfo: ToolData,
+    ) { }
+
+    public asHTML(): string {
+        return '<div>The Report!</div>';
+    }
+}

--- a/src/reports/package/summary-results-report.ts
+++ b/src/reports/package/summary-results-report.ts
@@ -1,15 +1,41 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import {  ToolData } from 'common/types/store-data/unified-data-interface';
+import {  ToolData, ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import AccessibilityInsightsReport from './accessibilityInsightsReport';
+import { SummaryReportHtmlGenerator } from 'reports/summary-report-html-generator';
+
+export type SummaryResultsReportDeps = {
+    reportHtmlGenerator: SummaryReportHtmlGenerator;
+};
 
 export class SummaryResultsReport implements AccessibilityInsightsReport.Report {
     constructor(
+        private readonly deps: SummaryResultsReportDeps,
         private readonly parameters: AccessibilityInsightsReport.SummaryReportParameters,
         private readonly toolInfo: ToolData,
     ) { }
 
     public asHTML(): string {
-        return '<div>The Report!</div>';
+        const reportHtmlGenerator = this.deps.reportHtmlGenerator;
+        const { results, crawlDetails } = this.parameters;
+
+        const targetAppInfo = {
+            name: null,
+            url: crawlDetails.baseUrl,
+        };
+
+        const scanMetadata: ScanMetadata = {
+            targetAppInfo: targetAppInfo,
+            toolData: this.toolInfo,
+            timestamp: null,
+        };
+
+        const html = reportHtmlGenerator.generateHtml(
+            crawlDetails,
+            scanMetadata,
+            results,
+        );
+
+        return html;
     }
 }

--- a/src/reports/summary-report-html-generator.tsx
+++ b/src/reports/summary-report-html-generator.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { noCardInteractionsSupported } from 'common/components/cards/card-interaction-support';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { NullComponent } from 'common/components/null-component';
+import { PropertyConfiguration } from 'common/configs/unified-result-property-configurations';
+import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { CardsViewModel } from 'common/types/store-data/card-view-model';
+import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
+import * as React from 'react';
+
+import { ReportBody, ReportBodyProps } from './components/report-sections/report-body';
+import { ReportCollapsibleContainerControl } from './components/report-sections/report-collapsible-container';
+import {
+    ReportSectionFactory,
+    SectionDeps,
+    SectionProps,
+} from './components/report-sections/report-section-factory';
+import { ReactStaticRenderer } from './react-static-renderer';
+import { SummaryReportSectionProps } from 'reports/components/report-sections/summary-report-section-factory';
+import {
+    CrawlSummaryDetails,
+    SummaryScanResults,
+} from 'reports/package/accessibilityInsightsReport';
+
+export class SummaryReportHtmlGenerator {
+    constructor(
+        private readonly sectionFactory: ReportSectionFactory<SummaryReportSectionProps>,
+        private readonly reactStaticRenderer: ReactStaticRenderer,
+        private readonly getCollapsibleScript: () => string,
+        private readonly utcDateConverter: (scanDate: Date) => string,
+    ) {}
+
+    public generateHtml(
+        scanDetails: CrawlSummaryDetails,
+        scanMetadata: ScanMetadata,
+        results: SummaryScanResults,
+    ): string {
+        const HeadSection = this.sectionFactory.HeadSection;
+        const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(<HeadSection />);
+
+        const detailsProps: SummaryReportSectionProps = {
+            scanDetails,
+            scanMetadata,
+            results,
+            toUtcString: this.utcDateConverter,
+            getCollapsibleScript: this.getCollapsibleScript,
+        };
+
+        const props: ReportBodyProps<SummaryReportSectionProps> = {
+            sectionFactory: this.sectionFactory,
+            ...detailsProps,
+        };
+
+        const bodyElement: JSX.Element = <ReportBody<SummaryReportSectionProps> {...props} />;
+        const bodyMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(bodyElement);
+
+        return '<!DOCTYPE html><html lang="en">' + headMarkup + bodyMarkup + '</html>';
+    }
+}

--- a/src/tests/unit/tests/reports/__snapshots__/summary-report-html-generator.test.tsx.snap
+++ b/src/tests/unit/tests/reports/__snapshots__/summary-report-html-generator.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReportHtmlGenerator generateHtml 1`] = `"<!DOCTYPE html><html lang=\\"en\\"><head-markup /><body-markup /></html>"`;

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
@@ -101,6 +101,22 @@ exports[`ReportBody renders 1`] = `
         "violations": Array [],
       }
     }
+    sectionFactory={
+      Object {
+        "BodySection": [Function],
+        "ContentContainer": [Function],
+        "DetailsSection": [Function],
+        "FailedInstancesSection": [Function],
+        "FooterSection": [Function],
+        "FooterText": [Function],
+        "HeaderSection": [Function],
+        "NotApplicableChecksSection": [Function],
+        "PassedChecksSection": [Function],
+        "ResultsContainer": [Function],
+        "SummarySection": [Function],
+        "TitleSection": [Function],
+      }
+    }
     shouldAlertFailuresCount={false}
     targetAppInfo={
       Object {
@@ -224,6 +240,22 @@ exports[`ReportBody renders 1`] = `
           "violations": Array [],
         }
       }
+      sectionFactory={
+        Object {
+          "BodySection": [Function],
+          "ContentContainer": [Function],
+          "DetailsSection": [Function],
+          "FailedInstancesSection": [Function],
+          "FooterSection": [Function],
+          "FooterText": [Function],
+          "HeaderSection": [Function],
+          "NotApplicableChecksSection": [Function],
+          "PassedChecksSection": [Function],
+          "ResultsContainer": [Function],
+          "SummarySection": [Function],
+          "TitleSection": [Function],
+        }
+      }
       shouldAlertFailuresCount={false}
       targetAppInfo={
         Object {
@@ -343,6 +375,22 @@ exports[`ReportBody renders 1`] = `
           "targetPageUrl": "url:target-page",
           "timestamp": "today",
           "violations": Array [],
+        }
+      }
+      sectionFactory={
+        Object {
+          "BodySection": [Function],
+          "ContentContainer": [Function],
+          "DetailsSection": [Function],
+          "FailedInstancesSection": [Function],
+          "FooterSection": [Function],
+          "FooterText": [Function],
+          "HeaderSection": [Function],
+          "NotApplicableChecksSection": [Function],
+          "PassedChecksSection": [Function],
+          "ResultsContainer": [Function],
+          "SummarySection": [Function],
+          "TitleSection": [Function],
         }
       }
       shouldAlertFailuresCount={false}
@@ -466,6 +514,22 @@ exports[`ReportBody renders 1`] = `
           "violations": Array [],
         }
       }
+      sectionFactory={
+        Object {
+          "BodySection": [Function],
+          "ContentContainer": [Function],
+          "DetailsSection": [Function],
+          "FailedInstancesSection": [Function],
+          "FooterSection": [Function],
+          "FooterText": [Function],
+          "HeaderSection": [Function],
+          "NotApplicableChecksSection": [Function],
+          "PassedChecksSection": [Function],
+          "ResultsContainer": [Function],
+          "SummarySection": [Function],
+          "TitleSection": [Function],
+        }
+      }
       shouldAlertFailuresCount={false}
       targetAppInfo={
         Object {
@@ -585,6 +649,22 @@ exports[`ReportBody renders 1`] = `
             "targetPageUrl": "url:target-page",
             "timestamp": "today",
             "violations": Array [],
+          }
+        }
+        sectionFactory={
+          Object {
+            "BodySection": [Function],
+            "ContentContainer": [Function],
+            "DetailsSection": [Function],
+            "FailedInstancesSection": [Function],
+            "FooterSection": [Function],
+            "FooterText": [Function],
+            "HeaderSection": [Function],
+            "NotApplicableChecksSection": [Function],
+            "PassedChecksSection": [Function],
+            "ResultsContainer": [Function],
+            "SummarySection": [Function],
+            "TitleSection": [Function],
           }
         }
         shouldAlertFailuresCount={false}
@@ -708,6 +788,22 @@ exports[`ReportBody renders 1`] = `
             "violations": Array [],
           }
         }
+        sectionFactory={
+          Object {
+            "BodySection": [Function],
+            "ContentContainer": [Function],
+            "DetailsSection": [Function],
+            "FailedInstancesSection": [Function],
+            "FooterSection": [Function],
+            "FooterText": [Function],
+            "HeaderSection": [Function],
+            "NotApplicableChecksSection": [Function],
+            "PassedChecksSection": [Function],
+            "ResultsContainer": [Function],
+            "SummarySection": [Function],
+            "TitleSection": [Function],
+          }
+        }
         shouldAlertFailuresCount={false}
         targetAppInfo={
           Object {
@@ -827,6 +923,22 @@ exports[`ReportBody renders 1`] = `
             "targetPageUrl": "url:target-page",
             "timestamp": "today",
             "violations": Array [],
+          }
+        }
+        sectionFactory={
+          Object {
+            "BodySection": [Function],
+            "ContentContainer": [Function],
+            "DetailsSection": [Function],
+            "FailedInstancesSection": [Function],
+            "FooterSection": [Function],
+            "FooterText": [Function],
+            "HeaderSection": [Function],
+            "NotApplicableChecksSection": [Function],
+            "PassedChecksSection": [Function],
+            "ResultsContainer": [Function],
+            "SummarySection": [Function],
+            "TitleSection": [Function],
           }
         }
         shouldAlertFailuresCount={false}
@@ -951,6 +1063,22 @@ exports[`ReportBody renders 1`] = `
           "targetPageUrl": "url:target-page",
           "timestamp": "today",
           "violations": Array [],
+        }
+      }
+      sectionFactory={
+        Object {
+          "BodySection": [Function],
+          "ContentContainer": [Function],
+          "DetailsSection": [Function],
+          "FailedInstancesSection": [Function],
+          "FooterSection": [Function],
+          "FooterText": [Function],
+          "HeaderSection": [Function],
+          "NotApplicableChecksSection": [Function],
+          "PassedChecksSection": [Function],
+          "ResultsContainer": [Function],
+          "SummarySection": [Function],
+          "TitleSection": [Function],
         }
       }
       shouldAlertFailuresCount={false}

--- a/src/tests/unit/tests/reports/package/reporter.test.ts
+++ b/src/tests/unit/tests/reports/package/reporter.test.ts
@@ -1,22 +1,44 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AxeReportParameters } from 'reports/package/accessibilityInsightsReport';
+import { AxeReportParameters, SummaryReportParameters } from 'reports/package/accessibilityInsightsReport';
 import { AxeResultsReport } from 'reports/package/axe-results-report';
-import { AxeResultsReportGenerator, Reporter } from 'reports/package/reporter';
-import { Mock } from 'typemoq';
+import { AxeResultsReportGenerator, Reporter, SummaryResultsReportGenerator } from 'reports/package/reporter';
+import { Mock, IMock } from 'typemoq';
+import { SummaryResultsReport } from 'reports/package/summary-results-report';
 
 describe('Reporter', () => {
-    const mockRequest = Mock.ofType<AxeReportParameters>();
-    const mockReport = Mock.ofType<AxeResultsReport>();
-    const mockGenerator = Mock.ofType<AxeResultsReportGenerator>();
-    mockGenerator
-        .setup(gen => gen(mockRequest.object))
-        .returns(() => mockReport.object);
+    let mockReport: IMock<AxeResultsReport>;
+    let mockSummaryReport: IMock<SummaryResultsReport>;
+    let mockGenerator: IMock<AxeResultsReportGenerator>;
+    let mockSummaryGenerator: IMock<SummaryResultsReportGenerator>;
+    
+    const axeReportParameters = {} as AxeReportParameters;
+    const summaryReportParameters = {} as SummaryReportParameters;
+
+    let reporter: Reporter;
+
+    beforeEach(() => {
+        mockReport = Mock.ofType<AxeResultsReport>();
+        mockSummaryReport = Mock.ofType<SummaryResultsReport>();
+        mockGenerator = Mock.ofType<AxeResultsReportGenerator>();
+        mockSummaryGenerator = Mock.ofType<SummaryResultsReportGenerator>();
+        mockGenerator
+            .setup(gen => gen(axeReportParameters))
+            .returns(() => mockReport.object);
+        mockSummaryGenerator
+            .setup(gen => gen(summaryReportParameters))
+            .returns(() => mockSummaryReport.object);
+        
+        reporter = new Reporter(mockGenerator.object, mockSummaryGenerator.object);
+    });
 
     it('returns an AxeResultsReport', () => {
-        const reporter = new Reporter(mockGenerator.object);
-
-        const report = reporter.fromAxeResult(mockRequest.object);
+        const report = reporter.fromAxeResult(axeReportParameters);
         expect(report).toBe(mockReport.object);
+    });
+
+    it('returns a SummaryResultsReport', () => {
+        const report = reporter.fromSummaryResults(summaryReportParameters);
+        expect(report).toBe(mockSummaryReport.object);
     });
 });

--- a/src/tests/unit/tests/reports/package/summary-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/summary-results-report.test.ts
@@ -1,25 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AxeResults } from 'axe-core';
-import { CardSelectionViewData } from 'common/get-card-selection-view-data';
-import { getCardViewData } from 'common/rule-based-view-model-provider';
-import { CardsViewModel } from 'common/types/store-data/card-view-model';
-import { ToolData, UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
-import { ConvertScanResultsToUnifiedResultsDelegate } from 'injected/adapters/scan-results-to-unified-results';
-import { convertScanResultsToUnifiedRules } from 'injected/adapters/scan-results-to-unified-rules';
-import { AxeReportParameters, SummaryReportParameters, CrawlSummaryDetails, SummaryScanResult, SummaryScanError } from 'reports/package/accessibilityInsightsReport';
-import { AxeResultsReport, AxeResultsReportDeps } from 'reports/package/axe-results-report';
-import { ReportHtmlGenerator } from 'reports/report-html-generator';
-import { ScanResults } from 'scanner/iruleresults';
-import { ResultDecorator } from 'scanner/result-decorator';
-import { Mock, MockBehavior } from 'typemoq';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
+import { SummaryReportParameters, CrawlSummaryDetails, SummaryScanResult, SummaryScanError, SummaryScanResults } from 'reports/package/accessibilityInsightsReport';
 import { SummaryResultsReport } from 'reports/package/summary-results-report';
+import { SummaryReportHtmlGenerator } from 'reports/summary-report-html-generator';
+import { Mock } from 'typemoq';
 
 describe('SummaryResultsReport', () => {
     const baseUrl = 'https://the.page';
     const toolDataStub: ToolData = {
         applicationProperties: { name: 'some app' },
     } as ToolData;
+    const targetAppInfoStub = {
+        name: null,
+        url: baseUrl,
+    };
+    const scanMetadataStub = {
+        toolData: toolDataStub,
+        targetAppInfo: targetAppInfoStub,
+        timestamp: null,
+    };
 
     const crawlDetails: CrawlSummaryDetails = {
         baseUrl: baseUrl,
@@ -28,44 +28,51 @@ describe('SummaryResultsReport', () => {
         durationSeconds: 42,
     };
 
-    const failedScanResults: SummaryScanResult[] = [
-        {
-            url: `${baseUrl}/failed`,
-            numFailures: 1,
-            reportLocation: 'failed report link',
-        }
-    ];
-    const passedScanResults: SummaryScanResult[] = [
-        {
-            url: `${baseUrl}/passed`,
-            numFailures: 0,
-            reportLocation: 'passed report link',
-        }
-    ];
-    const scanErrors: SummaryScanError[] = [
-        {
-            url: `${baseUrl}/error`,
-            errorType: 'error name',
-            errorDescription: 'error description',
-        }
-    ];
+    const results: SummaryScanResults  = {
+        failed: [
+            {
+                url: `${baseUrl}/failed`,
+                numFailures: 1,
+                reportLocation: 'failed report link',
+            }
+        ],
+        passed: [
+            {
+                url: `${baseUrl}/passed`,
+                numFailures: 0,
+                reportLocation: 'passed report link',
+            }
+        ],
+        unscannable: [
+            {
+                url: `${baseUrl}/error`,
+                errorType: 'error name',
+                errorDescription: 'error description',
+            }
+        ]
+    };
 
     const parameters: SummaryReportParameters = {
         serviceName: 'service name',
         axeVersion: 'axe version',
         userAgent: 'browser spec',
         crawlDetails,
-        results: {
-            failed: failedScanResults,
-            passed: passedScanResults,
-            unscannable: scanErrors,
-        }
+        results,
     };
 
     const expectedHTML = '<div>The Report!</div>';
 
+    const mockHtmlGenerator = Mock.ofType<SummaryReportHtmlGenerator>();
+    mockHtmlGenerator
+        .setup(hg => hg.generateHtml(crawlDetails, scanMetadataStub, results))
+        .returns(() => expectedHTML);
+
+    const deps = {
+        reportHtmlGenerator: mockHtmlGenerator.object,
+    }
+
     it('returns HTML', () => {
-        const report = new SummaryResultsReport(parameters, toolDataStub);
+        const report = new SummaryResultsReport(deps, parameters, toolDataStub);
 
         const html = report.asHTML();
 

--- a/src/tests/unit/tests/reports/package/summary-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/summary-results-report.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AxeResults } from 'axe-core';
+import { CardSelectionViewData } from 'common/get-card-selection-view-data';
+import { getCardViewData } from 'common/rule-based-view-model-provider';
+import { CardsViewModel } from 'common/types/store-data/card-view-model';
+import { ToolData, UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
+import { ConvertScanResultsToUnifiedResultsDelegate } from 'injected/adapters/scan-results-to-unified-results';
+import { convertScanResultsToUnifiedRules } from 'injected/adapters/scan-results-to-unified-rules';
+import { AxeReportParameters, SummaryReportParameters, CrawlSummaryDetails, SummaryScanResult, SummaryScanError } from 'reports/package/accessibilityInsightsReport';
+import { AxeResultsReport, AxeResultsReportDeps } from 'reports/package/axe-results-report';
+import { ReportHtmlGenerator } from 'reports/report-html-generator';
+import { ScanResults } from 'scanner/iruleresults';
+import { ResultDecorator } from 'scanner/result-decorator';
+import { Mock, MockBehavior } from 'typemoq';
+import { SummaryResultsReport } from 'reports/package/summary-results-report';
+
+describe('SummaryResultsReport', () => {
+    const baseUrl = 'https://the.page';
+    const toolDataStub: ToolData = {
+        applicationProperties: { name: 'some app' },
+    } as ToolData;
+
+    const crawlDetails: CrawlSummaryDetails = {
+        baseUrl: baseUrl,
+        scanStart: new Date(2019, 1, 2, 3),
+        scanComplete: new Date(2019, 4, 5, 6),
+        durationSeconds: 42,
+    };
+
+    const failedScanResults: SummaryScanResult[] = [
+        {
+            url: `${baseUrl}/failed`,
+            numFailures: 1,
+            reportLocation: 'failed report link',
+        }
+    ];
+    const passedScanResults: SummaryScanResult[] = [
+        {
+            url: `${baseUrl}/passed`,
+            numFailures: 0,
+            reportLocation: 'passed report link',
+        }
+    ];
+    const scanErrors: SummaryScanError[] = [
+        {
+            url: `${baseUrl}/error`,
+            errorType: 'error name',
+            errorDescription: 'error description',
+        }
+    ];
+
+    const parameters: SummaryReportParameters = {
+        serviceName: 'service name',
+        axeVersion: 'axe version',
+        userAgent: 'browser spec',
+        crawlDetails,
+        results: {
+            failed: failedScanResults,
+            passed: passedScanResults,
+            unscannable: scanErrors,
+        }
+    };
+
+    const expectedHTML = '<div>The Report!</div>';
+
+    it('returns HTML', () => {
+        const report = new SummaryResultsReport(parameters, toolDataStub);
+
+        const html = report.asHTML();
+
+        expect(html).toEqual(expectedHTML);
+    });
+});


### PR DESCRIPTION
#### Description of changes

Creates the necessary classes and factories to generate an empty summary report. Also refactors ReportBody and ReportSectionFactory to accept section components with a props type besides SectionProps.

Currently, this creates an empty report with title and footer:

<img width="577" alt="empty summary report" src="https://user-images.githubusercontent.com/55459788/92284147-4a865e80-eeb6-11ea-8f0e-25da8c4b45ed.PNG">


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1767138
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
