### PR TITLE
chore(deps): bump accessibility-insights-for-android-service-bin from 1.2.0 to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
         "webpack-node-externals": "^2.5.2"
     },
     "dependencies": {
-        "accessibility-insights-for-android-service-bin": "^1.2.0",
+        "accessibility-insights-for-android-service-bin": "^1.2.1",
         "appium-adb": "^8.7.1",
         "applicationinsights-js": "^1.0.21",
         "axe-core": "4.0.1",

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/mock-adb.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/mock-adb.test.ts.snap
@@ -50,7 +50,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -112,7 +112,7 @@ Success
   },
   "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-2 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -174,7 +174,7 @@ Success
   },
   "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s emulator-3 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -259,7 +259,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -344,7 +344,7 @@ Success
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "delayMs": 5000,
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "delayMs": 5000,
@@ -425,7 +425,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -483,7 +483,7 @@ Success
   },
   "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-2 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -541,7 +541,7 @@ Success
   },
   "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s emulator-3 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -620,7 +620,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -700,7 +700,7 @@ Success
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "delayMs": 5000,
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "delayMs": 5000,
@@ -779,7 +779,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -838,7 +838,7 @@ Success
   },
   "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-2 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -897,7 +897,7 @@ Success
   },
   "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s emulator-3 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -979,7 +979,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1060,7 +1060,7 @@ Success
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "delayMs": 5000,
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "delayMs": 5000,
@@ -1145,7 +1145,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1207,7 +1207,7 @@ Success
   },
   "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-2 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1269,7 +1269,7 @@ Success
   },
   "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s emulator-3 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1354,7 +1354,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1439,7 +1439,7 @@ Success
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "delayMs": 5000,
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "delayMs": 5000,
@@ -1523,7 +1523,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1585,7 +1585,7 @@ Success
   },
   "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-2 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1647,7 +1647,7 @@ Success
   },
   "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s emulator-3 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1732,7 +1732,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1816,7 +1816,7 @@ Success
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "delayMs": 5000,
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.2.0",
+    versionName=1.2.1",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "delayMs": 5000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1704,10 +1704,10 @@ accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
-accessibility-insights-for-android-service-bin@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/accessibility-insights-for-android-service-bin/-/accessibility-insights-for-android-service-bin-1.2.0.tgz#41a6921e6d104cdad68c6c5c4cf81958bfb65cf4"
-  integrity sha512-eCklspRjeCP5WUkdoeAFikujzvZLQk8FOyZa568/8GESVDgE4bS16E3RVJpQoEwUxM1TWSGRWP70KshZQuOdAg==
+accessibility-insights-for-android-service-bin@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/accessibility-insights-for-android-service-bin/-/accessibility-insights-for-android-service-bin-1.2.1.tgz#f8a6cdd9aef4ca8e61f86cd54a52938269ec3bf9"
+  integrity sha512-gXKaKRYEubVEeBkqYteMQZdyx9zD5VEnECK9R3yWsECmdTp+KJMWwONL0b4niCm2V4AH+3quo9by+kPfeTUIcg==
 
 acorn-globals@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
#### Description of changes

Main difference is updated `NOTICE.html` replacing `NOTICE.txt` for the web-compliance feature

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1759357
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
