### PR TITLE
feat(cli-summary-report): add summary report header bar

### DIFF
--- a/src/electron/views/report/unified-header-section.tsx
+++ b/src/electron/views/report/unified-header-section.tsx
@@ -2,17 +2,13 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import { androidAppTitle } from 'content/strings/application';
-import { BrandWhite } from 'icons/brand/white/brand-white';
 import * as React from 'react';
-import * as styles from 'reports/components/report-sections/header-section.scss';
+import { HeaderBar } from 'reports/components/header-bar';
 
 export const UnifiedHeaderSection = NamedFC('UnifiedHeaderSection', () => {
     return (
         <header>
-            <div className={styles.reportHeaderBar}>
-                <BrandWhite />
-                <div className={styles.headerText}>{androidAppTitle}</div>
-            </div>
+            <HeaderBar headerText={androidAppTitle} />
         </header>
     );
 });

--- a/src/reports/components/header-bar.scss
+++ b/src/reports/components/header-bar.scss
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+@import '../../common/styles/common.scss';
+@import '../../common/styles/fonts.scss';
+
+.report-header-bar {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    flex-wrap: nowrap;
+
+    background-color: $ada-brand-color;
+    height: $detailsViewHeaderBarHeight;
+    width: 100%;
+
+    :global(.header-icon) {
+        flex-shrink: 0;
+        margin-left: 16px;
+        height: 22px;
+        width: 22px;
+    }
+
+    .header-text {
+        margin-left: 8px;
+
+        color: $header-bar-title-color;
+
+        flex-shrink: 1;
+        @include ellipsedText();
+        @include text-style-header-s;
+    }
+}

--- a/src/reports/components/header-bar.tsx
+++ b/src/reports/components/header-bar.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { BrandWhite } from 'icons/brand/white/brand-white';
+import * as React from 'react';
+import * as styles from './header-bar.scss';
+
+export type HeaderBarProps = {
+    headerText: string;
+};
+
+export const HeaderBar = NamedFC<HeaderBarProps>('HeaderBar', props => {
+    return (
+        <div className={styles.reportHeaderBar}>
+            <BrandWhite />
+            <div className={styles.headerText}>{props.headerText}</div>
+        </div>
+    );
+});

--- a/src/reports/components/report-sections/header-section.scss
+++ b/src/reports/components/report-sections/header-section.scss
@@ -4,34 +4,6 @@
 @import '../../../common/styles/common.scss';
 @import '../../../common/styles/fonts.scss';
 
-.report-header-bar {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-    flex-wrap: nowrap;
-
-    background-color: $ada-brand-color;
-    height: $detailsViewHeaderBarHeight;
-    width: 100%;
-
-    :global(.header-icon) {
-        flex-shrink: 0;
-        margin-left: 16px;
-        height: 22px;
-        width: 22px;
-    }
-
-    .header-text {
-        margin-left: 8px;
-
-        color: $header-bar-title-color;
-
-        flex-shrink: 1;
-        @include ellipsedText();
-        @include text-style-header-s;
-    }
-}
-
 .report-header-command-bar {
     height: 40px;
     width: 100%;

--- a/src/reports/components/report-sections/header-section.tsx
+++ b/src/reports/components/report-sections/header-section.tsx
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import { TargetAppData } from 'common/types/store-data/unified-data-interface';
-import { productName } from 'content/strings/application';
-import { BrandWhite } from 'icons/brand/white/brand-white';
 import * as React from 'react';
 import { NewTabLinkWithConfirmationDialog } from 'reports/components/new-tab-link-confirmation-dialog';
 import * as styles from './header-section.scss';
+import { HeaderBar } from 'reports/components/header-bar';
+import { productName } from 'content/strings/application';
 
 export interface HeaderSectionProps {
     targetAppInfo: TargetAppData;
@@ -15,10 +15,7 @@ export interface HeaderSectionProps {
 export const HeaderSection = NamedFC<HeaderSectionProps>('HeaderSection', ({ targetAppInfo }) => {
     return (
         <header>
-            <div className={styles.reportHeaderBar}>
-                <BrandWhite />
-                <div className={styles.headerText}>{productName}</div>
-            </div>
+            <HeaderBar headerText={productName} />
             <div className={styles.reportHeaderCommandBar}>
                 <div className={styles.targetPage}>
                     Target page:&nbsp;

--- a/src/reports/components/report-sections/summary-report-header-section.tsx
+++ b/src/reports/components/report-sections/summary-report-header-section.tsx
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import * as React from 'react';
+import { HeaderBar } from 'reports/components/header-bar';
+import { brand } from 'content/strings/application';
+
+export const SummaryReportHeaderSection = NamedFC('SummaryReportHeaderSection', () => {
+    return (
+        <header>
+            <HeaderBar headerText={brand} />
+        </header>
+    );
+});

--- a/src/reports/components/report-sections/summary-report-section-factory.tsx
+++ b/src/reports/components/report-sections/summary-report-section-factory.tsx
@@ -14,6 +14,7 @@ import {
 } from 'reports/package/accessibilityInsightsReport';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { NullComponent } from 'common/components/null-component';
+import { SummaryReportHeaderSection } from 'reports/components/report-sections/summary-report-header-section';
 
 export type SummaryReportSectionProps = {
     scanDetails: CrawlSummaryDetails;
@@ -27,7 +28,7 @@ export const SummaryReportSectionFactory: ReportSectionFactory<SummaryReportSect
     HeadSection: ReportHead,
     BodySection,
     ContentContainer,
-    HeaderSection: NullComponent,
+    HeaderSection: SummaryReportHeaderSection,
     TitleSection,
     SummarySection: NullComponent,
     DetailsSection: NullComponent,

--- a/src/tests/unit/tests/electron/report/__snapshots__/unified-header-section.test.tsx.snap
+++ b/src/tests/unit/tests/electron/report/__snapshots__/unified-header-section.test.tsx.snap
@@ -2,15 +2,8 @@
 
 exports[`HeaderSection renders 1`] = `
 <header>
-  <div
-    className="reportHeaderBar"
-  >
-    <BrandWhite />
-    <div
-      className="headerText"
-    >
-      Accessibility Insights for Android
-    </div>
-  </div>
+  <HeaderBar
+    headerText="Accessibility Insights for Android"
+  />
 </header>
 `;

--- a/src/tests/unit/tests/reports/components/__snapshots__/header-bar.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/header-bar.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HeaderBar renders 1`] = `
+<div
+  className="reportHeaderBar"
+>
+  <BrandWhite />
+  <div
+    className="headerText"
+  >
+    header text
+  </div>
+</div>
+`;

--- a/src/tests/unit/tests/reports/components/header-bar.test.tsx
+++ b/src/tests/unit/tests/reports/components/header-bar.test.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { HeaderBar } from 'reports/components/header-bar';
+
+describe('HeaderBar', () => {
+    it('renders', () => {
+        const headerText = 'header text';
+        const wrapper = shallow(<HeaderBar headerText={headerText} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/header-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/header-section.test.tsx.snap
@@ -2,16 +2,9 @@
 
 exports[`HeaderSection renders 1`] = `
 <header>
-  <div
-    className="reportHeaderBar"
-  >
-    <BrandWhite />
-    <div
-      className="headerText"
-    >
-      Accessibility Insights for Web
-    </div>
-  </div>
+  <HeaderBar
+    headerText="Accessibility Insights for Web"
+  />
   <div
     className="reportHeaderCommandBar"
   >

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-report-header-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-report-header-section.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SummaryReportHeaderSection renders 1`] = `
+<header>
+  <HeaderBar
+    headerText="Accessibility Insights"
+  />
+</header>
+`;

--- a/src/tests/unit/tests/reports/components/report-sections/summary-report-header-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/summary-report-header-section.test.tsx
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { SummaryReportHeaderSection } from 'reports/components/report-sections/summary-report-header-section';
+
+describe('SummaryReportHeaderSection', () => {
+    it('renders', () => {
+        const wrapper = shallow(<SummaryReportHeaderSection />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Extract the blue header bar from ReportHeader as a seperate component and add it to the summary report:

<img width="598" alt="summary report header" src="https://user-images.githubusercontent.com/55459788/92536094-a837e500-f1ed-11ea-9553-6a639ff705b6.png">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1767138
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
