### PR TITLE
feat(cli-summary-report): Summary report summary section

### DIFF
--- a/src/reports/components/outcome-summary-bar.scss
+++ b/src/reports/components/outcome-summary-bar.scss
@@ -64,7 +64,8 @@ $outcome-not-applicable-color: $neutral-outcome;
         }
         background-color: $outcome-pass-color;
     }
-    .inapplicable {
+    .inapplicable,
+    .unscannable {
         @extend .block;
         @include inapplicable-icon-styles(
             $outcome-summary-icon-size,
@@ -98,5 +99,8 @@ $outcome-not-applicable-color: $neutral-outcome;
         border-top-right-radius: 2px;
         border-bottom-right-radius: 2px;
         margin-right: 0px;
+    }
+    .label {
+        font-weight: normal;
     }
 }

--- a/src/reports/components/outcome-summary-bar.tsx
+++ b/src/reports/components/outcome-summary-bar.tsx
@@ -18,6 +18,7 @@ export type OutcomeSummaryBarProps = {
     allOutcomeTypes: OutcomeType[];
     iconStyleInverted?: boolean;
     countSuffix?: string;
+    textLabel?: boolean;
 };
 
 export const OutcomeSummaryBar = NamedFC<OutcomeSummaryBarProps>('OutcomeSummaryBar', props => {
@@ -43,6 +44,14 @@ export const OutcomeSummaryBar = NamedFC<OutcomeSummaryBarProps>('OutcomeSummary
             .join(', ');
     };
 
+    const getTextLabel = (outcomeType: OutcomeType) => {
+        if (props.textLabel !== true) {
+            return null;
+        }
+        const outcomePastTense = outcomeTypeSemantics[outcomeType].pastTense;
+        return <div className={'label'}>{` ${outcomePastTense}`}</div>;
+    };
+
     return (
         <div className="outcome-summary-bar" aria-label={getLabel()} role="img">
             {props.allOutcomeTypes.map((outcomeType, index) => {
@@ -51,6 +60,7 @@ export const OutcomeSummaryBar = NamedFC<OutcomeSummaryBarProps>('OutcomeSummary
                     iconStyleInverted === true ? outcomeIconMapInverted : outcomeIconMap;
                 const outcomeIcon = iconMap[outcomeType];
                 const count = props.outcomeStats[outcomeType];
+                const outcomePastTense = outcomeTypeSemantics[outcomeType].pastTense;
 
                 return (
                     <div key={outcomeType} style={{ flexGrow: count }}>
@@ -58,6 +68,7 @@ export const OutcomeSummaryBar = NamedFC<OutcomeSummaryBarProps>('OutcomeSummary
                             <span aria-hidden="true">{outcomeIcon}</span>
                             {count}
                             {countSuffix}
+                            {getTextLabel(outcomeType)}
                         </span>
                     </div>
                 );

--- a/src/reports/components/outcome-type.tsx
+++ b/src/reports/components/outcome-type.tsx
@@ -8,11 +8,12 @@ import * as React from 'react';
 
 import { InstanceOutcomeType } from './instance-outcome-type';
 import { RequirementOutcomeType } from './requirement-outcome-type';
+import { UrlOutcomeType } from 'reports/components/url-outcome-type';
 
 export type OutcomeUnits = 'percentage' | 'requirements';
 
 export type OutcomeStats = { [OT in OutcomeType]: number };
-export type OutcomeType = RequirementOutcomeType | InstanceOutcomeType;
+export type OutcomeType = RequirementOutcomeType | InstanceOutcomeType | UrlOutcomeType;
 
 export interface OutcomeTypeSemantic {
     pastTense: string;
@@ -24,6 +25,7 @@ export const outcomeTypeSemantics: { [OT in OutcomeType]: OutcomeTypeSemantic } 
     fail: { pastTense: 'Failed' },
     inapplicable: { pastTense: 'Not applicable' },
     review: { pastTense: 'Needs review' },
+    unscannable: { pastTense: 'Not scanned' },
 };
 
 export const outcomeIconMap: { [OT in OutcomeType]: JSX.Element } = {
@@ -32,6 +34,7 @@ export const outcomeIconMap: { [OT in OutcomeType]: JSX.Element } = {
     fail: <CrossIcon />,
     inapplicable: <InapplicableIcon />,
     review: <CircleIcon />,
+    unscannable: <InapplicableIcon />,
 };
 
 export const outcomeIconMapInverted: { [OT in OutcomeType]: JSX.Element } = {
@@ -40,4 +43,5 @@ export const outcomeIconMapInverted: { [OT in OutcomeType]: JSX.Element } = {
     fail: <CrossIconInverted />,
     inapplicable: <InapplicableIconInverted />,
     review: <CircleIcon />,
+    unscannable: <InapplicableIconInverted />,
 };

--- a/src/reports/components/report-sections/summary-report-section-factory.tsx
+++ b/src/reports/components/report-sections/summary-report-section-factory.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ReportHead } from 'reports/components/report-head';
 import { BodySection } from './body-section';
 import { ContentContainer } from './content-container';
 import { FooterText } from './footer-text';

--- a/src/reports/components/report-sections/summary-report-section-factory.tsx
+++ b/src/reports/components/report-sections/summary-report-section-factory.tsx
@@ -15,6 +15,8 @@ import {
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { NullComponent } from 'common/components/null-component';
 import { SummaryReportHeaderSection } from 'reports/components/report-sections/summary-report-header-section';
+import { SummaryReportSummarySection } from 'reports/components/report-sections/summary-report-summary-section';
+import { SummaryReportHead } from 'reports/components/summary-report-head';
 
 export type SummaryReportSectionProps = {
     scanDetails: CrawlSummaryDetails;
@@ -25,12 +27,12 @@ export type SummaryReportSectionProps = {
 };
 
 export const SummaryReportSectionFactory: ReportSectionFactory<SummaryReportSectionProps> = {
-    HeadSection: ReportHead,
+    HeadSection: SummaryReportHead,
     BodySection,
     ContentContainer,
     HeaderSection: SummaryReportHeaderSection,
     TitleSection,
-    SummarySection: NullComponent,
+    SummarySection: SummaryReportSummarySection,
     DetailsSection: NullComponent,
     ResultsContainer,
     FailedInstancesSection: NullComponent,

--- a/src/reports/components/report-sections/summary-report-summary-section.scss
+++ b/src/reports/components/report-sections/summary-report-summary-section.scss
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+@import './common-mixins.scss';
+
+.summary-report-summary-section {
+    @include boxShadow();
+
+    background-color: $neutral-0;
+    padding: 20px;
+    margin-bottom: 24px;
+
+    h2 {
+        margin-bottom: 16px !important;
+    }
+    .failure-instances {
+        margin-top: 40px;
+    }
+}

--- a/src/reports/components/report-sections/summary-report-summary-section.tsx
+++ b/src/reports/components/report-sections/summary-report-summary-section.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+import { NamedFC } from 'common/react/named-fc';
+import { InstanceOutcomeType } from '../instance-outcome-type';
+import { OutcomeSummaryBar } from '../outcome-summary-bar';
+import { SummaryReportSectionProps } from 'reports/components/report-sections/summary-report-section-factory';
+import { OutcomeChip } from 'reports/components/outcome-chip';
+
+export const SummaryReportSummarySection = NamedFC<SummaryReportSectionProps>(
+    'BaseSummarySection',
+    props => {
+        const { results } = props;
+
+        const numFailed = results.failed.length;
+        const numPassed = results.passed.length;
+        const numUnscannable = results.unscannable.length;
+
+        const getTotalUrls = () => {
+            const totalUrls = numFailed + numPassed + numUnscannable;
+
+            return (
+                <>
+                    <h2>URLs</h2>
+                    {totalUrls} total URLs discovered
+                </>
+            );
+        };
+
+        const getSummaryBar = () => {
+            const countSummary: { [type in InstanceOutcomeType]: number } = {
+                fail: numFailed,
+                pass: numPassed,
+                inapplicable: numUnscannable,
+                review: 0, // never used
+            };
+
+            return (
+                <OutcomeSummaryBar
+                    outcomeStats={countSummary}
+                    iconStyleInverted={true}
+                    allOutcomeTypes={['fail', 'inapplicable', 'pass']}
+                />
+            );
+        };
+
+        const getFailedInstances = () => {
+            let failedInstances = 0;
+            results.failed.forEach(
+                failedScanResult => (failedInstances += failedScanResult.numFailures),
+            );
+
+            return (
+                <div className="failure-instances">
+                    <h2>Failure Instances</h2>
+                    <OutcomeChip count={failedInstances} outcomeType={'fail'} /> Failure instances
+                    were detected
+                </div>
+            );
+        };
+
+        return (
+            <div className="summary-report-summary-section">
+                {getTotalUrls()}
+                {getSummaryBar()}
+                {getFailedInstances()}
+            </div>
+        );
+    },
+);

--- a/src/reports/components/report-sections/summary-report-summary-section.tsx
+++ b/src/reports/components/report-sections/summary-report-summary-section.tsx
@@ -32,8 +32,8 @@ export const SummaryReportSummarySection = NamedFC<SummaryReportSectionProps>(
         const getSummaryBar = () => {
             const countSummary: { [type in UrlOutcomeType]: number } = {
                 fail: numFailed,
-                pass: numPassed,
                 unscannable: numUnscannable,
+                pass: numPassed,
             };
 
             return (

--- a/src/reports/components/report-sections/summary-report-summary-section.tsx
+++ b/src/reports/components/report-sections/summary-report-summary-section.tsx
@@ -7,6 +7,7 @@ import { InstanceOutcomeType } from '../instance-outcome-type';
 import { OutcomeSummaryBar } from '../outcome-summary-bar';
 import { SummaryReportSectionProps } from 'reports/components/report-sections/summary-report-section-factory';
 import { OutcomeChip } from 'reports/components/outcome-chip';
+import { allUrlOutcomeTypes, UrlOutcomeType } from 'reports/components/url-outcome-type';
 
 export const SummaryReportSummarySection = NamedFC<SummaryReportSectionProps>(
     'BaseSummarySection',
@@ -29,18 +30,18 @@ export const SummaryReportSummarySection = NamedFC<SummaryReportSectionProps>(
         };
 
         const getSummaryBar = () => {
-            const countSummary: { [type in InstanceOutcomeType]: number } = {
+            const countSummary: { [type in UrlOutcomeType]: number } = {
                 fail: numFailed,
                 pass: numPassed,
-                inapplicable: numUnscannable,
-                review: 0, // never used
+                unscannable: numUnscannable,
             };
 
             return (
                 <OutcomeSummaryBar
                     outcomeStats={countSummary}
                     iconStyleInverted={true}
-                    allOutcomeTypes={['fail', 'inapplicable', 'pass']}
+                    allOutcomeTypes={allUrlOutcomeTypes}
+                    textLabel={true}
                 />
             );
         };

--- a/src/reports/components/summary-report-head.tsx
+++ b/src/reports/components/summary-report-head.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { title } from 'content/strings/application';
+import * as React from 'react';
+
+import * as bundledStyles from '../../DetailsView/bundled-details-view-styles';
+import * as summaryReportStyles from '../summary-report.styles';
+
+export const SummaryReportHead = NamedFC('SummaryReportHead', () => {
+    // tslint:disable: react-no-dangerous-html
+    return (
+        <head>
+            <meta charSet="UTF-8" />
+            <title>{title} automated checks result</title>
+            <style dangerouslySetInnerHTML={{ __html: summaryReportStyles.styleSheet }} />
+            <style dangerouslySetInnerHTML={{ __html: bundledStyles.styleSheet }} />
+        </head>
+    );
+});

--- a/src/reports/components/url-outcome-type.ts
+++ b/src/reports/components/url-outcome-type.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export type UrlOutcomeType = 'pass' | 'fail' | 'unscannable';
+export const allUrlOutcomeTypes: UrlOutcomeType[] = ['fail', 'pass', 'unscannable'];

--- a/src/reports/components/url-outcome-type.ts
+++ b/src/reports/components/url-outcome-type.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 export type UrlOutcomeType = 'pass' | 'fail' | 'unscannable';
-export const allUrlOutcomeTypes: UrlOutcomeType[] = ['fail', 'pass', 'unscannable'];
+export const allUrlOutcomeTypes: UrlOutcomeType[] = ['fail', 'unscannable', 'pass'];

--- a/src/reports/summary-report.scss
+++ b/src/reports/summary-report.scss
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../common/styles/root-level-only/color-definitions.scss';
+@import '../common/styles/root-level-only/global-styles.scss';
+@import '../common/components/guidance-tags.scss';
+@import '../common/icons/icon.scss';
+@import '../common/styles/colors.scss';
+@import '../common/styles/common.scss';
+@import '../common/styles/fonts.scss';
+@import './components/instance-details.scss';
+@import './components/outcome.scss';
+@import './components/report-sections/body-section.scss';
+@import './components/report-sections/common-mixins.scss';
+@import './components/report-sections/content-container.scss';
+@import './components/report-sections/details-section.scss';
+@import './components/report-sections/footer-section.scss';
+@import './components/report-sections/header-section.scss';
+@import './components/report-sections/title-section.scss';
+@import './components/report-sections/results-container.scss';
+@import './components/report-sections/summary-report-summary-section.scss';
+
+$outcome-pass-summary-color: $positive-outcome;
+$outcome-fail-summary-color: $negative-outcome;
+$outcome-incomplete-summary-consistent-foreground: $always-white;
+$outcome-incomplete-summary-background: $neutral-outcome;
+$outcome-incomplete-border-color: $incomplete-color;
+$outcome-not-applicable-summary-color: $neutral-outcome;
+
+@media screen and (max-width: 640px) {
+    .outcome-past-tense {
+        display: none;
+    }
+}
+
+.result-section {
+    padding-bottom: 58px;
+
+    .title-container[aria-level='2'] {
+        .collapsible-control::before {
+            position: relative;
+            bottom: 2px;
+            margin-right: 14px;
+        }
+    }
+}
+
+.collapsible-container {
+    @mixin transform($property) {
+        -webkit-transform: $property;
+        -ms-transform: $property;
+        transform: $property;
+    }
+
+    &:not(.collapsible-rule-details-group) {
+        .collapsible-control {
+            padding-left: 2px;
+            padding-right: 16px;
+
+            position: relative;
+        }
+    }
+
+    %common-control-chevron {
+        display: inline-block;
+        border-right: 1px solid $secondary-text;
+        border-bottom: 1px solid $secondary-text;
+        min-width: 7px;
+        width: 7px;
+        height: 7px;
+        content: '';
+        transform-origin: 50% 50%;
+        transition: transform 0.1s linear 0s;
+    }
+
+    .collapsible-control {
+        font-family: 'Segoe UI Web (West European)', 'Segoe UI', '-apple-system', BlinkMacSystemFont,
+            Roboto, 'Helvetica Neue', Helvetica, Ubuntu, Arial, sans-serif, 'Apple Color Emoji',
+            'Segoe UI Emoji', 'Segoe UI Symbol';
+        background-color: transparent;
+        cursor: pointer;
+        border: none;
+
+        display: flex;
+        align-items: baseline;
+
+        width: 100%;
+
+        &:hover {
+            background-color: $neutral-alpha-4;
+        }
+    }
+
+    .collapsible-control[aria-expanded='false']:before {
+        @extend %common-control-chevron;
+        @include transform(rotate(-45deg));
+    }
+
+    .collapsible-control[aria-expanded='true']:before {
+        @extend %common-control-chevron;
+        @include transform(rotate(45deg));
+    }
+
+    .collapsible-content {
+        &[aria-hidden='true'] {
+            display: none;
+        }
+    }
+}

--- a/src/reports/summary-report.styles.ts
+++ b/src/reports/summary-report.styles.ts
@@ -1,0 +1,3 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export const styleSheet = `<<CSS:../reports/summary-report.css>>`;

--- a/src/tests/unit/tests/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
@@ -191,3 +191,81 @@ exports[`OutcomeSummaryBar show by percentage 1`] = `
   </div>
 </div>
 `;
+
+exports[`OutcomeSummaryBar show with text label 1`] = `
+<div
+  aria-label="42 Passed, 13 Failed, 7 Incomplete"
+  className="outcome-summary-bar"
+  role="img"
+>
+  <div
+    style={
+      Object {
+        "flexGrow": 42,
+      }
+    }
+  >
+    <span
+      className="pass summary-bar-left-edge"
+    >
+      <span
+        aria-hidden="true"
+      >
+        <CheckIcon />
+      </span>
+      42
+      <div
+        className="label"
+      >
+         Passed
+      </div>
+    </span>
+  </div>
+  <div
+    style={
+      Object {
+        "flexGrow": 13,
+      }
+    }
+  >
+    <span
+      className="fail"
+    >
+      <span
+        aria-hidden="true"
+      >
+        <CrossIcon />
+      </span>
+      13
+      <div
+        className="label"
+      >
+         Failed
+      </div>
+    </span>
+  </div>
+  <div
+    style={
+      Object {
+        "flexGrow": 7,
+      }
+    }
+  >
+    <span
+      className="incomplete summary-bar-right-edge"
+    >
+      <span
+        aria-hidden="true"
+      >
+        <CircleIcon />
+      </span>
+      7
+      <div
+        className="label"
+      >
+         Incomplete
+      </div>
+    </span>
+  </div>
+</div>
+`;

--- a/src/tests/unit/tests/reports/components/__snapshots__/summary-report-head.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/summary-report-head.test.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SummaryReportHead renders 1`] = `
+<head>
+  <meta
+    charSet="UTF-8"
+  />
+  <title>
+    Accessibility Insights for Web
+     automated checks result
+  </title>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<<CSS:../reports/summary-report.css>>",
+      }
+    }
+  />
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<<CSS:detailsView.css>>",
+      }
+    }
+  />
+</head>
+`;

--- a/src/tests/unit/tests/reports/components/outcome-summary-bar.test.tsx
+++ b/src/tests/unit/tests/reports/components/outcome-summary-bar.test.tsx
@@ -37,4 +37,11 @@ describe('OutcomeSummaryBar', () => {
 
         expect(wrapper.getElement()).toMatchSnapshot();
     });
+
+    it('show with text label', () => {
+        const props: OutcomeSummaryBarProps = { outcomeStats, allOutcomeTypes, textLabel: true };
+        const wrapper = shallow(<OutcomeSummaryBar {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
 });

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-report-summary-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-report-summary-section.test.tsx.snap
@@ -15,8 +15,8 @@ exports[`SummaryReportSummarySection BaseSummarySection: failure only 1`] = `
     allOutcomeTypes={
       Array [
         "fail",
-        "pass",
         "unscannable",
+        "pass",
       ]
     }
     iconStyleInverted={true}
@@ -59,8 +59,8 @@ exports[`SummaryReportSummarySection BaseSummarySection: failures + passes only 
     allOutcomeTypes={
       Array [
         "fail",
-        "pass",
         "unscannable",
+        "pass",
       ]
     }
     iconStyleInverted={true}
@@ -103,8 +103,8 @@ exports[`SummaryReportSummarySection BaseSummarySection: failures + unscannable 
     allOutcomeTypes={
       Array [
         "fail",
-        "pass",
         "unscannable",
+        "pass",
       ]
     }
     iconStyleInverted={true}
@@ -147,8 +147,8 @@ exports[`SummaryReportSummarySection BaseSummarySection: failures + unscannable 
     allOutcomeTypes={
       Array [
         "fail",
-        "pass",
         "unscannable",
+        "pass",
       ]
     }
     iconStyleInverted={true}
@@ -191,8 +191,8 @@ exports[`SummaryReportSummarySection BaseSummarySection: passes only 1`] = `
     allOutcomeTypes={
       Array [
         "fail",
-        "pass",
         "unscannable",
+        "pass",
       ]
     }
     iconStyleInverted={true}
@@ -235,8 +235,8 @@ exports[`SummaryReportSummarySection BaseSummarySection: unscannable + passes on
     allOutcomeTypes={
       Array [
         "fail",
-        "pass",
         "unscannable",
+        "pass",
       ]
     }
     iconStyleInverted={true}
@@ -279,8 +279,8 @@ exports[`SummaryReportSummarySection BaseSummarySection: unscannable only 1`] = 
     allOutcomeTypes={
       Array [
         "fail",
-        "pass",
         "unscannable",
+        "pass",
       ]
     }
     iconStyleInverted={true}

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-report-summary-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-report-summary-section.test.tsx.snap
@@ -15,19 +15,19 @@ exports[`SummaryReportSummarySection BaseSummarySection: failure only 1`] = `
     allOutcomeTypes={
       Array [
         "fail",
-        "inapplicable",
         "pass",
+        "unscannable",
       ]
     }
     iconStyleInverted={true}
     outcomeStats={
       Object {
         "fail": 2,
-        "inapplicable": 0,
         "pass": 0,
-        "review": 0,
+        "unscannable": 0,
       }
     }
+    textLabel={true}
   />
   <div
     className="failure-instances"
@@ -59,19 +59,19 @@ exports[`SummaryReportSummarySection BaseSummarySection: failures + passes only 
     allOutcomeTypes={
       Array [
         "fail",
-        "inapplicable",
         "pass",
+        "unscannable",
       ]
     }
     iconStyleInverted={true}
     outcomeStats={
       Object {
         "fail": 2,
-        "inapplicable": 0,
         "pass": 2,
-        "review": 0,
+        "unscannable": 0,
       }
     }
+    textLabel={true}
   />
   <div
     className="failure-instances"
@@ -103,19 +103,19 @@ exports[`SummaryReportSummarySection BaseSummarySection: failures + unscannable 
     allOutcomeTypes={
       Array [
         "fail",
-        "inapplicable",
         "pass",
+        "unscannable",
       ]
     }
     iconStyleInverted={true}
     outcomeStats={
       Object {
         "fail": 2,
-        "inapplicable": 3,
         "pass": 2,
-        "review": 0,
+        "unscannable": 3,
       }
     }
+    textLabel={true}
   />
   <div
     className="failure-instances"
@@ -147,19 +147,19 @@ exports[`SummaryReportSummarySection BaseSummarySection: failures + unscannable 
     allOutcomeTypes={
       Array [
         "fail",
-        "inapplicable",
         "pass",
+        "unscannable",
       ]
     }
     iconStyleInverted={true}
     outcomeStats={
       Object {
         "fail": 2,
-        "inapplicable": 3,
         "pass": 0,
-        "review": 0,
+        "unscannable": 3,
       }
     }
+    textLabel={true}
   />
   <div
     className="failure-instances"
@@ -191,19 +191,19 @@ exports[`SummaryReportSummarySection BaseSummarySection: passes only 1`] = `
     allOutcomeTypes={
       Array [
         "fail",
-        "inapplicable",
         "pass",
+        "unscannable",
       ]
     }
     iconStyleInverted={true}
     outcomeStats={
       Object {
         "fail": 0,
-        "inapplicable": 0,
         "pass": 2,
-        "review": 0,
+        "unscannable": 0,
       }
     }
+    textLabel={true}
   />
   <div
     className="failure-instances"
@@ -235,19 +235,19 @@ exports[`SummaryReportSummarySection BaseSummarySection: unscannable + passes on
     allOutcomeTypes={
       Array [
         "fail",
-        "inapplicable",
         "pass",
+        "unscannable",
       ]
     }
     iconStyleInverted={true}
     outcomeStats={
       Object {
         "fail": 0,
-        "inapplicable": 3,
         "pass": 2,
-        "review": 0,
+        "unscannable": 3,
       }
     }
+    textLabel={true}
   />
   <div
     className="failure-instances"
@@ -279,19 +279,19 @@ exports[`SummaryReportSummarySection BaseSummarySection: unscannable only 1`] = 
     allOutcomeTypes={
       Array [
         "fail",
-        "inapplicable",
         "pass",
+        "unscannable",
       ]
     }
     iconStyleInverted={true}
     outcomeStats={
       Object {
         "fail": 0,
-        "inapplicable": 3,
         "pass": 0,
-        "review": 0,
+        "unscannable": 3,
       }
     }
+    textLabel={true}
   />
   <div
     className="failure-instances"

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-report-summary-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-report-summary-section.test.tsx.snap
@@ -1,0 +1,309 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SummaryReportSummarySection BaseSummarySection: failure only 1`] = `
+<div
+  className="summary-report-summary-section"
+>
+  <React.Fragment>
+    <h2>
+      URLs
+    </h2>
+    2
+     total URLs discovered
+  </React.Fragment>
+  <OutcomeSummaryBar
+    allOutcomeTypes={
+      Array [
+        "fail",
+        "inapplicable",
+        "pass",
+      ]
+    }
+    iconStyleInverted={true}
+    outcomeStats={
+      Object {
+        "fail": 2,
+        "inapplicable": 0,
+        "pass": 0,
+        "review": 0,
+      }
+    }
+  />
+  <div
+    className="failure-instances"
+  >
+    <h2>
+      Failure Instances
+    </h2>
+    <OutcomeChip
+      count={3}
+      outcomeType="fail"
+    />
+     Failure instances were detected
+  </div>
+</div>
+`;
+
+exports[`SummaryReportSummarySection BaseSummarySection: failures + passes only 1`] = `
+<div
+  className="summary-report-summary-section"
+>
+  <React.Fragment>
+    <h2>
+      URLs
+    </h2>
+    4
+     total URLs discovered
+  </React.Fragment>
+  <OutcomeSummaryBar
+    allOutcomeTypes={
+      Array [
+        "fail",
+        "inapplicable",
+        "pass",
+      ]
+    }
+    iconStyleInverted={true}
+    outcomeStats={
+      Object {
+        "fail": 2,
+        "inapplicable": 0,
+        "pass": 2,
+        "review": 0,
+      }
+    }
+  />
+  <div
+    className="failure-instances"
+  >
+    <h2>
+      Failure Instances
+    </h2>
+    <OutcomeChip
+      count={3}
+      outcomeType="fail"
+    />
+     Failure instances were detected
+  </div>
+</div>
+`;
+
+exports[`SummaryReportSummarySection BaseSummarySection: failures + unscannable + passes 1`] = `
+<div
+  className="summary-report-summary-section"
+>
+  <React.Fragment>
+    <h2>
+      URLs
+    </h2>
+    7
+     total URLs discovered
+  </React.Fragment>
+  <OutcomeSummaryBar
+    allOutcomeTypes={
+      Array [
+        "fail",
+        "inapplicable",
+        "pass",
+      ]
+    }
+    iconStyleInverted={true}
+    outcomeStats={
+      Object {
+        "fail": 2,
+        "inapplicable": 3,
+        "pass": 2,
+        "review": 0,
+      }
+    }
+  />
+  <div
+    className="failure-instances"
+  >
+    <h2>
+      Failure Instances
+    </h2>
+    <OutcomeChip
+      count={3}
+      outcomeType="fail"
+    />
+     Failure instances were detected
+  </div>
+</div>
+`;
+
+exports[`SummaryReportSummarySection BaseSummarySection: failures + unscannable only 1`] = `
+<div
+  className="summary-report-summary-section"
+>
+  <React.Fragment>
+    <h2>
+      URLs
+    </h2>
+    5
+     total URLs discovered
+  </React.Fragment>
+  <OutcomeSummaryBar
+    allOutcomeTypes={
+      Array [
+        "fail",
+        "inapplicable",
+        "pass",
+      ]
+    }
+    iconStyleInverted={true}
+    outcomeStats={
+      Object {
+        "fail": 2,
+        "inapplicable": 3,
+        "pass": 0,
+        "review": 0,
+      }
+    }
+  />
+  <div
+    className="failure-instances"
+  >
+    <h2>
+      Failure Instances
+    </h2>
+    <OutcomeChip
+      count={3}
+      outcomeType="fail"
+    />
+     Failure instances were detected
+  </div>
+</div>
+`;
+
+exports[`SummaryReportSummarySection BaseSummarySection: passes only 1`] = `
+<div
+  className="summary-report-summary-section"
+>
+  <React.Fragment>
+    <h2>
+      URLs
+    </h2>
+    2
+     total URLs discovered
+  </React.Fragment>
+  <OutcomeSummaryBar
+    allOutcomeTypes={
+      Array [
+        "fail",
+        "inapplicable",
+        "pass",
+      ]
+    }
+    iconStyleInverted={true}
+    outcomeStats={
+      Object {
+        "fail": 0,
+        "inapplicable": 0,
+        "pass": 2,
+        "review": 0,
+      }
+    }
+  />
+  <div
+    className="failure-instances"
+  >
+    <h2>
+      Failure Instances
+    </h2>
+    <OutcomeChip
+      count={0}
+      outcomeType="fail"
+    />
+     Failure instances were detected
+  </div>
+</div>
+`;
+
+exports[`SummaryReportSummarySection BaseSummarySection: unscannable + passes only 1`] = `
+<div
+  className="summary-report-summary-section"
+>
+  <React.Fragment>
+    <h2>
+      URLs
+    </h2>
+    5
+     total URLs discovered
+  </React.Fragment>
+  <OutcomeSummaryBar
+    allOutcomeTypes={
+      Array [
+        "fail",
+        "inapplicable",
+        "pass",
+      ]
+    }
+    iconStyleInverted={true}
+    outcomeStats={
+      Object {
+        "fail": 0,
+        "inapplicable": 3,
+        "pass": 2,
+        "review": 0,
+      }
+    }
+  />
+  <div
+    className="failure-instances"
+  >
+    <h2>
+      Failure Instances
+    </h2>
+    <OutcomeChip
+      count={0}
+      outcomeType="fail"
+    />
+     Failure instances were detected
+  </div>
+</div>
+`;
+
+exports[`SummaryReportSummarySection BaseSummarySection: unscannable only 1`] = `
+<div
+  className="summary-report-summary-section"
+>
+  <React.Fragment>
+    <h2>
+      URLs
+    </h2>
+    3
+     total URLs discovered
+  </React.Fragment>
+  <OutcomeSummaryBar
+    allOutcomeTypes={
+      Array [
+        "fail",
+        "inapplicable",
+        "pass",
+      ]
+    }
+    iconStyleInverted={true}
+    outcomeStats={
+      Object {
+        "fail": 0,
+        "inapplicable": 3,
+        "pass": 0,
+        "review": 0,
+      }
+    }
+  />
+  <div
+    className="failure-instances"
+  >
+    <h2>
+      Failure Instances
+    </h2>
+    <OutcomeChip
+      count={0}
+      outcomeType="fail"
+    />
+     Failure instances were detected
+  </div>
+</div>
+`;

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-section.test.tsx.snap
@@ -160,8 +160,8 @@ exports[`SummarySection BaseSummarySection: not applicable only 1`] = `
     outcomeStats={
       Object {
         "fail": 0,
-        "inapplicable": 0,
-        "pass": 2,
+        "inapplicable": 3,
+        "pass": 0,
         "review": 0,
       }
     }

--- a/src/tests/unit/tests/reports/components/report-sections/summary-report-summary-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/summary-report-summary-section.test.tsx
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import {
+    SummaryScanResults,
+    SummaryScanResult,
+    SummaryScanError,
+} from 'reports/package/accessibilityInsightsReport';
+import { SummaryReportSummarySection } from 'reports/components/report-sections/summary-report-summary-section';
+import { SummaryReportSectionProps } from 'reports/components/report-sections/summary-report-section-factory';
+
+describe('SummaryReportSummarySection', () => {
+    const violations = [
+        {
+            url: 'https://url.com/failed1',
+            numFailures: 1,
+            reportLocation: 'failed report link 1',
+        },
+        {
+            url: 'https://url.com/failed2',
+            numFailures: 2,
+            reportLocation: 'failed report link 2',
+        },
+    ];
+    const passes = [{}, {}] as SummaryScanResult[];
+    const unscannable = [{}, {}, {}] as SummaryScanError[];
+    const scenarios: [string, SummaryScanResults][] = [
+        [
+            'failure only',
+            {
+                failed: violations,
+                passed: [],
+                unscannable: [],
+            },
+        ],
+        [
+            'unscannable only',
+            {
+                failed: [],
+                passed: [],
+                unscannable: unscannable,
+            },
+        ],
+        [
+            'passes only',
+            {
+                failed: [],
+                passed: passes,
+                unscannable: [],
+            },
+        ],
+        [
+            'failures + unscannable only',
+            {
+                failed: violations,
+                passed: [],
+                unscannable: unscannable,
+            },
+        ],
+        [
+            'failures + passes only',
+            {
+                failed: violations,
+                passed: passes,
+                unscannable: [],
+            },
+        ],
+        [
+            'unscannable + passes only',
+            {
+                failed: [],
+                passed: passes,
+                unscannable: unscannable,
+            },
+        ],
+        [
+            'failures + unscannable + passes',
+            {
+                failed: violations,
+                passed: passes,
+                unscannable: unscannable,
+            },
+        ],
+    ];
+
+    it.each(scenarios)('BaseSummarySection: %s', (_, results) => {
+        const props = {
+            results,
+        } as SummaryReportSectionProps;
+        const wrapper = shallow(<SummaryReportSummarySection {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/reports/components/report-sections/summary-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/summary-section.test.tsx
@@ -42,8 +42,8 @@ describe('SummarySection', () => {
             {
                 cards: {
                     fail: noViolations,
-                    pass: passes,
-                    inapplicable: noNonApplicable,
+                    pass: noPasses,
+                    inapplicable: nonApplicable,
                 },
             } as CardsViewModel,
         ],

--- a/src/tests/unit/tests/reports/components/summary-report-head.test.tsx
+++ b/src/tests/unit/tests/reports/components/summary-report-head.test.tsx
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { SummaryReportHead } from 'reports/components/summary-report-head';
+
+describe('SummaryReportHead', () => {
+    it('renders', () => {
+        const wrapper = shallow(<SummaryReportHead />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Create summary section for summary report to match the figma:

<img width="738" alt="summary report summary section" src="https://user-images.githubusercontent.com/55459788/92660763-eeee1380-f2af-11ea-858f-90f6084a2be1.PNG">

- Added a new bundled stylesheet for summary report and a ReportHead component to use it in the report
- Some refactoring in OutcomeSummaryBar to add the text labels for each section
- Fix an existing typo in SummarySection unit test

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1767138
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
