### PR TITLE
refactor: remove illusion of type safety from visual instance processor

### DIFF
--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -324,10 +324,8 @@ export class AssessmentBuilder {
 
     private static getVisualizationInstanceProcessor(
         requirements: Requirement[],
-    ): (requirement: string) => VisualizationInstanceProcessorCallback<PropertyBags, PropertyBags> {
-        return (
-            requirementKey: string,
-        ): VisualizationInstanceProcessorCallback<PropertyBags, PropertyBags> => {
+    ): (requirement: string) => VisualizationInstanceProcessorCallback {
+        return (requirementKey: string): VisualizationInstanceProcessorCallback => {
             const requirementConfig = AssessmentBuilder.getRequirementConfig(
                 requirements,
                 requirementKey,

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -25,7 +25,6 @@ import { AssessmentTestView } from 'DetailsView/components/assessment-test-view'
 import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { DecoratedAxeNodeResult } from 'injected/scanner-utils';
 import {
-    PropertyBags,
     VisualizationInstanceProcessor,
     VisualizationInstanceProcessorCallback,
 } from 'injected/visualization-instance-processor';

--- a/src/assessments/types/requirement.ts
+++ b/src/assessments/types/requirement.ts
@@ -16,10 +16,7 @@ import {
 import { Analyzer } from 'injected/analyzers/analyzer';
 import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { DecoratedAxeNodeResult } from 'injected/scanner-utils';
-import {
-    PropertyBags,
-    VisualizationInstanceProcessorCallback,
-} from 'injected/visualization-instance-processor';
+import { VisualizationInstanceProcessorCallback } from 'injected/visualization-instance-processor';
 import { Drawer } from 'injected/visualization/drawer';
 import { DrawerProvider } from 'injected/visualization/drawer-provider';
 import { IColumn } from 'office-ui-fabric-react';
@@ -50,10 +47,7 @@ export interface Requirement {
     // present for the purposes of instance lists or getInitialManualTestStatus. By default, all
     // results support visualization.
     isVisualizationSupportedForResult?: (result: DecoratedAxeNodeResult) => boolean;
-    visualizationInstanceProcessor?: VisualizationInstanceProcessorCallback<
-        PropertyBags,
-        PropertyBags
-    >;
+    visualizationInstanceProcessor?: VisualizationInstanceProcessorCallback;
     getDrawer?: (provider: DrawerProvider, featureFlagStoreData?: FeatureFlagStoreData) => Drawer;
     getNotificationMessage?: (selectorMap: DictionaryStringTo<any>) => string;
     doNotScanByDefault?: boolean;

--- a/src/common/configs/assessment-visualization-configuration.ts
+++ b/src/common/configs/assessment-visualization-configuration.ts
@@ -6,10 +6,7 @@ import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { CommonTestViewProps } from '../../DetailsView/components/test-view';
 import { Analyzer } from '../../injected/analyzers/analyzer';
 import { AnalyzerProvider } from '../../injected/analyzers/analyzer-provider';
-import {
-    PropertyBags,
-    VisualizationInstanceProcessorCallback,
-} from '../../injected/visualization-instance-processor';
+import { VisualizationInstanceProcessorCallback } from '../../injected/visualization-instance-processor';
 import { Drawer } from '../../injected/visualization/drawer';
 import { DrawerProvider } from '../../injected/visualization/drawer-provider';
 import { DictionaryStringTo } from '../../types/common-types';
@@ -35,9 +32,7 @@ export interface AssessmentVisualizationConfiguration {
     telemetryProcessor?: TelemetryProcessor<IAnalyzerTelemetryCallback>;
     getAnalyzer: (analyzerProvider: AnalyzerProvider, testStep?: string) => Analyzer;
     getIdentifier: (testStep?: string) => string;
-    visualizationInstanceProcessor: (
-        testStep?: string,
-    ) => VisualizationInstanceProcessorCallback<PropertyBags, PropertyBags>;
+    visualizationInstanceProcessor: (testStep?: string) => VisualizationInstanceProcessorCallback;
     getNotificationMessage: (
         selectorMap: DictionaryStringTo<any>,
         testStep?: string,

--- a/src/injected/drawing-initiator.ts
+++ b/src/injected/drawing-initiator.ts
@@ -8,10 +8,7 @@ import {
     AssessmentVisualizationInstance,
     AxeResultsWithFrameLevel,
 } from './frameCommunicators/html-element-axe-results-helper';
-import {
-    PropertyBags,
-    VisualizationInstanceProcessorCallback,
-} from './visualization-instance-processor';
+import { VisualizationInstanceProcessorCallback } from './visualization-instance-processor';
 
 export class DrawingInitiator {
     private drawingController: DrawingController;
@@ -25,7 +22,7 @@ export class DrawingInitiator {
         featureFlagStoreData: FeatureFlagStoreData,
         selectorMap: DictionaryStringTo<AssessmentVisualizationInstance>,
         configId: string,
-        processor: VisualizationInstanceProcessorCallback<PropertyBags, PropertyBags>,
+        processor: VisualizationInstanceProcessorCallback,
     ): void {
         if (selectorMap == null) {
             return;

--- a/src/injected/frameCommunicators/html-element-axe-results-helper.ts
+++ b/src/injected/frameCommunicators/html-element-axe-results-helper.ts
@@ -5,7 +5,6 @@ import { HTMLElementUtils } from '../../common/html-element-utils';
 import { Logger } from '../../common/logging/logger';
 import { DictionaryStringTo } from '../../types/common-types';
 import { HtmlElementAxeResults } from '../scanner-utils';
-import { PartialTabOrderPropertyBag, TabOrderPropertyBag } from '../tab-order-property-bag';
 
 export interface HTMLIFrameResult {
     frame: HTMLIFrameElement;
@@ -19,7 +18,7 @@ export interface AxeResultsWithFrameLevel extends HtmlElementAxeResults {
 export interface AssessmentVisualizationInstance extends AxeResultsWithFrameLevel {
     isFailure: boolean;
     isVisualizationEnabled: boolean;
-    propertyBag?: PartialTabOrderPropertyBag | TabOrderPropertyBag;
+    propertyBag?: any;
 }
 
 export class HtmlElementAxeResultsHelper {

--- a/src/injected/frameCommunicators/html-element-axe-results-helper.ts
+++ b/src/injected/frameCommunicators/html-element-axe-results-helper.ts
@@ -5,6 +5,7 @@ import { HTMLElementUtils } from '../../common/html-element-utils';
 import { Logger } from '../../common/logging/logger';
 import { DictionaryStringTo } from '../../types/common-types';
 import { HtmlElementAxeResults } from '../scanner-utils';
+import { PartialTabOrderPropertyBag, TabOrderPropertyBag } from '../tab-order-property-bag';
 
 export interface HTMLIFrameResult {
     frame: HTMLIFrameElement;
@@ -18,7 +19,7 @@ export interface AxeResultsWithFrameLevel extends HtmlElementAxeResults {
 export interface AssessmentVisualizationInstance extends AxeResultsWithFrameLevel {
     isFailure: boolean;
     isVisualizationEnabled: boolean;
-    propertyBag?: any;
+    propertyBag?: PartialTabOrderPropertyBag | TabOrderPropertyBag;
 }
 
 export class HtmlElementAxeResultsHelper {

--- a/src/injected/visualization-instance-processor.ts
+++ b/src/injected/visualization-instance-processor.ts
@@ -1,27 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentVisualizationInstance } from './frameCommunicators/html-element-axe-results-helper';
-import { PartialTabOrderPropertyBag, TabOrderPropertyBag } from './tab-order-property-bag';
 
-export interface VisualizationPropertyBag<T> extends AssessmentVisualizationInstance {
-    propertyBag?: T;
-}
-
-export type VisualizationInstanceProcessorCallback<Raw, Processed> = (
-    instances: VisualizationPropertyBag<Raw>[],
-) => VisualizationPropertyBag<Processed>[];
-
-export type PropertyBags = PartialTabOrderPropertyBag | TabOrderPropertyBag;
+export type VisualizationInstanceProcessorCallback = (
+    instances: AssessmentVisualizationInstance[],
+) => AssessmentVisualizationInstance[];
 
 export class VisualizationInstanceProcessor {
-    public static nullProcessor: VisualizationInstanceProcessorCallback<null, null> = instances => {
+    public static nullProcessor: VisualizationInstanceProcessorCallback = instances => {
         return instances;
     };
 
-    public static addOrder: VisualizationInstanceProcessorCallback<
-        PartialTabOrderPropertyBag,
-        TabOrderPropertyBag
-    > = instances => {
+    public static addOrder: VisualizationInstanceProcessorCallback = instances => {
         instances.sort(
             (instanceA, instanceB) =>
                 instanceA.propertyBag.timestamp - instanceB.propertyBag.timestamp,

--- a/src/tests/unit/tests/injected/drawing-initiator.test.ts
+++ b/src/tests/unit/tests/injected/drawing-initiator.test.ts
@@ -10,10 +10,7 @@ import {
 } from '../../../../injected/drawing-controller';
 import { DrawingInitiator } from '../../../../injected/drawing-initiator';
 import { AssessmentVisualizationInstance } from '../../../../injected/frameCommunicators/html-element-axe-results-helper';
-import {
-    PropertyBags,
-    VisualizationInstanceProcessorCallback,
-} from '../../../../injected/visualization-instance-processor';
+import { VisualizationInstanceProcessorCallback } from '../../../../injected/visualization-instance-processor';
 import { DictionaryStringTo } from '../../../../types/common-types';
 
 class DrawingControllerStub extends DrawingController {
@@ -22,7 +19,7 @@ class DrawingControllerStub extends DrawingController {
 
 describe('DrawingInitiatorTest', () => {
     let drawingControllerMock: IMock<DrawingController>;
-    let processorMock: IMock<VisualizationInstanceProcessorCallback<PropertyBags, PropertyBags>>;
+    let processorMock: IMock<VisualizationInstanceProcessorCallback>;
     let testObject: DrawingInitiator;
 
     beforeEach(() => {

--- a/src/tests/unit/tests/injected/visualization-instance-processor.test.ts
+++ b/src/tests/unit/tests/injected/visualization-instance-processor.test.ts
@@ -1,14 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentVisualizationInstance } from '../../../../injected/frameCommunicators/html-element-axe-results-helper';
-import {
-    PartialTabOrderPropertyBag,
-    TabOrderPropertyBag,
-} from '../../../../injected/tab-order-property-bag';
-import {
-    VisualizationInstanceProcessor,
-    VisualizationPropertyBag,
-} from '../../../../injected/visualization-instance-processor';
+import { VisualizationInstanceProcessor } from '../../../../injected/visualization-instance-processor';
 
 describe('VisualizationInstanceProcessorTest', () => {
     test('nullProcessor', () => {
@@ -19,7 +12,7 @@ describe('VisualizationInstanceProcessorTest', () => {
     });
 
     test('addOrder', () => {
-        const initialInstances: VisualizationPropertyBag<PartialTabOrderPropertyBag>[] = [
+        const initialInstances: AssessmentVisualizationInstance[] = [
             {
                 ...createNullifiedAssessmenVisualizationInstance(),
                 propertyBag: {
@@ -33,7 +26,7 @@ describe('VisualizationInstanceProcessorTest', () => {
                 },
             },
         ];
-        const expectedInstances: VisualizationPropertyBag<TabOrderPropertyBag>[] = [
+        const expectedInstances: AssessmentVisualizationInstance[] = [
             {
                 ...createNullifiedAssessmenVisualizationInstance(),
                 propertyBag: {


### PR DESCRIPTION
#### Description of changes

Assessment visualizers are able to configure an `VisualizationInstanceProcessorCallback` to post-process visualization data after it's generated and before it's used for displaying things. This callback generally involves data from the visualization instances' `propertyBag`s, which are `any`-typed.

Previously, the `VisualizationInstanceProcessorCallback` was generic with type parameters representing the "true" `propertyBag` types the individual processor expected. However, the use sites for the processor never actually took this into account; they always blindly assumed that the processor's type parameter was "the union of all the property bag types understood by any existing processor" (`PropertyBags`), and always blindly passed in visualization instances regardless of whether their `propertyBag`s actually structurally matched any of the `PropertyBags` types.

This PR removes the generic parameter and supporting types, since they aren't actually adding any type safety. (this happens to fix a half dozen null-strictness issues around the mistyping of the `nullProcessor`, but I think the refactor is an improvement regardless)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
