### PR TITLE
fix: updated text case for "Getting started" titles and nav links

### DIFF
--- a/src/DetailsView/components/getting-started-view.tsx
+++ b/src/DetailsView/components/getting-started-view.tsx
@@ -30,7 +30,7 @@ export const GettingStartedView = NamedFC<GettingStartedViewProps>('GettingStart
                     <span className={styles.gettingStartedHeaderTitle}>{props.title}</span>
                     <ContentLink deps={props.deps} reference={props.guidance} iconName="info" />
                 </h1>
-                <h2 className={styles.gettingStartedTitle}>Getting Started</h2>
+                <h2 className={styles.gettingStartedTitle}>Getting started</h2>
                 {props.gettingStartedContent}
             </div>
             <NextRequirementButton

--- a/src/DetailsView/components/left-nav/getting-started-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/getting-started-nav-link.tsx
@@ -9,6 +9,6 @@ export type GettingStartedNavLinkProps = {};
 export const GettingStartedNavLink = NamedFC<GettingStartedNavLinkProps>(
     'GettingStartedNavLink',
     _ => {
-        return <span className={styles.gettingStarted}>Getting Started</span>;
+        return <span className={styles.gettingStarted}>Getting started</span>;
     },
 );

--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -272,7 +272,7 @@ export class LeftNavLinkBuilder {
         return {
             testType,
             ...this.buildBaseLink(
-                'Getting Started',
+                'Getting started',
                 generateReflowAssessmentTestKey(testType, gettingStartedSubview),
                 0,
                 renderGettingStartedLink,

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -21,7 +21,7 @@ export const detailsViewSelectors = {
 
     testNavLink: (testName: string): string => `div [name="${testName}"]`,
     requirementNavLink: (requirementName: string): string => `div [name="${requirementName}"] a`,
-    gettingStartedNavLink: 'div [name="Getting Started"]',
+    gettingStartedNavLink: 'div [name="Getting started"]',
 
     visualHelperToggle: getAutomationIdSelector(visualHelperToggleAutomationId),
 

--- a/src/tests/end-to-end/common/page-controllers/details-view-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/details-view-page.ts
@@ -49,7 +49,7 @@ export class DetailsViewPage extends Page {
 
     public async navigateToGettingStarted(testName: string): Promise<void> {
         await this.clickSelector(detailsViewSelectors.testNavLink(testName));
-        await this.waitForSelector(`//div[@name="Getting Started"]`);
+        await this.waitForSelector(`//div[@name="Getting started"]`);
         await this.clickSelector(detailsViewSelectors.gettingStartedNavLink);
         await this.waitForSelector(`//h1/span[text()="${testName}"]`);
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/getting-started-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/getting-started-view.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`GettingStartedViewTest renders with content from props 1`] = `
     <h2
       className="gettingStartedTitle"
     >
-      Getting Started
+      Getting started
     </h2>
     <div>
       test-getting-started-content

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/getting-started-nav-link.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/getting-started-nav-link.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`GettingStartedNavLink renders 1`] = `
 <span
   className="gettingStarted"
 >
-  Getting Started
+  Getting started
 </span>
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
@@ -331,7 +331,7 @@ describe('LeftNavBuilder', () => {
                     testType: visualizationType,
                 };
                 const expectedGettingStartedLink = {
-                    name: 'Getting Started',
+                    name: 'Getting started',
                     key: `${VisualizationType[visualizationType]}: ${gettingStartedSubview}`,
                     forceAnchor: true,
                     url: '',


### PR DESCRIPTION
#### Description of changes

Changed the text case for all instances of "Getting Started" navigation links and page titles to be in sentence case instead of title case to address issue: #3310   

This helps to make these text elements more consistent with other similar elements.
!["Getting started" text highlighted under "Automated checks" section of Assessment](https://user-images.githubusercontent.com/9934135/92991997-6b9e0f00-f4b5-11ea-981f-2a8bc1fdc39d.png)

!["Getting started" nav link and header text highlighted under "Headings" section of Assessment](https://user-images.githubusercontent.com/9934135/92992022-98522680-f4b5-11ea-9f62-ba17049b6632.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
