### PR TITLE
fix: unified cards view reflow at 320px width

### DIFF
--- a/src/common/components/cards/cards-visualization-modifier-buttons.scss
+++ b/src/common/components/cards/cards-visualization-modifier-buttons.scss
@@ -2,4 +2,5 @@
 // Licensed under the MIT License.
 .cards-visualization-modifiers-container {
     display: flex;
+    flex-wrap: wrap;
 }

--- a/src/common/components/cards/instance-details-footer.scss
+++ b/src/common/components/cards/instance-details-footer.scss
@@ -31,6 +31,7 @@
         label {
             color: $secondary-text;
             font-size: $fontSizeM;
+            word-break: break-word;
         }
     }
 }

--- a/src/common/components/cards/instance-details-footer.scss
+++ b/src/common/components/cards/instance-details-footer.scss
@@ -31,6 +31,8 @@
         label {
             color: $secondary-text;
             font-size: $fontSizeM;
+
+            overflow-wrap: break-word;
             word-break: break-word;
         }
     }

--- a/src/common/components/cards/instance-details-footer.scss
+++ b/src/common/components/cards/instance-details-footer.scss
@@ -9,7 +9,7 @@
     align-items: center;
 
     background-color: $neutral-2;
-    height: 48px;
+    min-height: 48px;
 
     padding-left: 12px;
 

--- a/src/common/components/cards/rule-resources.scss
+++ b/src/common/components/cards/rule-resources.scss
@@ -20,6 +20,13 @@
 
     line-height: 20px;
 
+    overflow-wrap: break-word;
+    * {
+        // Without width:100%, nested decendants (eg, the "More information" link) won't
+        // respect break-word since the element width will adjust to fit the largest word
+        width: 100%;
+    }
+
     .more-resources-title {
         font-family: $semiBoldFontFamily;
     }

--- a/src/common/components/cards/rule-resources.scss
+++ b/src/common/components/cards/rule-resources.scss
@@ -20,7 +20,7 @@
 
     line-height: 20px;
 
-    word-wrap: break-word;
+    overflow-wrap: break-word;
     word-break: break-word;
 
     .more-resources-title {

--- a/src/common/components/cards/rule-resources.scss
+++ b/src/common/components/cards/rule-resources.scss
@@ -20,12 +20,8 @@
 
     line-height: 20px;
 
-    overflow-wrap: break-word;
-    * {
-        // Without width:100%, nested decendants (eg, the "More information" link) won't
-        // respect break-word since the element width will adjust to fit the largest word
-        width: 100%;
-    }
+    word-wrap: break-word;
+    word-break: break-word;
 
     .more-resources-title {
         font-family: $semiBoldFontFamily;

--- a/src/electron/main/main-window-config.ts
+++ b/src/electron/main/main-window-config.ts
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+const largestSupportedZoomFactor = 4; // 400%
+const smallestSupportedScreenWidth = 1280;
+const smallestSupportedScreenHeight = 1024;
+
 export const mainWindowConfig = {
     defaultWidth: 600,
     defaultHeight: 391,
-    minWidth: 400,
-    minHeight: 300,
+    minWidth: smallestSupportedScreenWidth / largestSupportedZoomFactor,
+    minHeight: smallestSupportedScreenHeight / largestSupportedZoomFactor,
 };


### PR DESCRIPTION
#### Description of changes

The PR addresses a few reflow issues with the unified cards UI at 320px effective width (the bug was reported at 1280x1024 in 400% zoom; per discussion with @ferBonnin, this PR enables the app to resize down to the equivalent 320x256@100%, since we need to support that anyway for 400% users and since it makes testing reflow changes much easier).

Particularly:

* The "expand/collapse" toggle and "visual helper" toggle can now be reflowed onto separate lines, rather than forcing a horizontal scrollbar in the "automated checks" panel
* The "rule resources" card text will now break across lines within words if a word cannot fit in the view (particularly notable for long rule names)
* The highlight status text in the card footer will now break across multiple lines if necessary to avoid the "more actions" button flowing off the right edge of the card (and the footer will stretch upwards to accomodate the reflowed text if necessary)

While I was working here, I also noticed that the breakpoint at which the cards reflow from two-column to one-column is wonky in unified; it decides to do that reflow based on a media query for the total width of the application, and the reflow point is designed for the assorted card views in web and reports where the cards are given the entire width of the screen to play with. On unified, where it has to contend with the screenshot panel, the reflow point doesn't work very well; it allows the content column of the cards to get way too small (3-4 characters wide) before reflowing down to one column. I plan to address this by switching the reflow mechanism from media-query-based to display:flex-on-the-table-rows-based, but that change is much more complicated/scary than these ones and isn't strictly necessary to address the trusted tester bug, so leaving it for a separate PR.

**Before:**
![screenshot highlighting reflow issues fixed by this PR](https://user-images.githubusercontent.com/376284/93503293-dac89880-f8e5-11ea-90af-a76589243fa3.png)

**After:**
![screenshot with highlights around changes described in PR](https://user-images.githubusercontent.com/376284/93502626-fbdcb980-f8e4-11ea-94ec-a6bf4c7c255a.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1765540
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
