### PR TITLE
fix(cli-summary-report): use correct footer text in reporter factory

### DIFF
--- a/src/reports/components/report-sections/summary-report-section-factory.tsx
+++ b/src/reports/components/report-sections/summary-report-section-factory.tsx
@@ -1,25 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BodySection } from './body-section';
-import { ContentContainer } from './content-container';
-import { FooterText } from './footer-text';
-import { ReportFooter } from './report-footer';
-import { ReportSectionFactory } from './report-section-factory';
-import { TitleSection } from './title-section';
-import { SummaryScanResults } from 'reports/package/accessibilityInsightsReport';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
-import { NullComponent } from 'common/components/null-component';
-import { SummaryReportHeaderSection } from 'reports/components/report-sections/summary-report-header-section';
-import { SummaryReportSummarySection } from 'reports/components/report-sections/summary-report-summary-section';
-import { SummaryReportHead } from 'reports/components/summary-report-head';
-import { SummaryReportDetailsSection } from 'reports/components/report-sections/summary-report-details-section';
-import { ResultsByUrlContainer } from 'reports/components/report-sections/results-by-url-container';
 import {
     FailedUrlsSection,
     FailedUrlsSectionDeps,
 } from 'reports/components/report-sections/failed-urls-section';
-import { PassedUrlsSection } from 'reports/components/report-sections/passed-urls-section';
 import { NotScannedUrlsSection } from 'reports/components/report-sections/not-scanned-urls-section';
+import { PassedUrlsSection } from 'reports/components/report-sections/passed-urls-section';
+import { ResultsByUrlContainer } from 'reports/components/report-sections/results-by-url-container';
+import { SummaryReportDetailsSection } from 'reports/components/report-sections/summary-report-details-section';
+import { SummaryReportHeaderSection } from 'reports/components/report-sections/summary-report-header-section';
+import { SummaryReportSummarySection } from 'reports/components/report-sections/summary-report-summary-section';
+import { SummaryReportHead } from 'reports/components/summary-report-head';
+import { SummaryScanResults } from 'reports/package/accessibilityInsightsReport';
+import { FooterTextForService } from 'reports/package/footer-text-for-service';
+import { BodySection } from './body-section';
+import { ContentContainer } from './content-container';
+import { ReportFooter } from './report-footer';
+import { ReportSectionFactory } from './report-section-factory';
+import { TitleSection } from './title-section';
 
 export type SectionDeps = FailedUrlsSectionDeps;
 
@@ -52,6 +51,6 @@ export const SummaryReportSectionFactory: ReportSectionFactory<SummaryReportSect
     PassedChecksSection: PassedUrlsSection,
     NotApplicableChecksSection: NotScannedUrlsSection,
     FooterSection: ReportFooter,
-    FooterText,
+    FooterText: FooterTextForService,
     resultSectionsOrder: ['failed', 'notApplicable', 'passed'],
 };

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -62,7 +62,7 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
 
     const sectionFactory: ReportSectionFactory<SectionProps> = {
         ...AutomatedChecksReportSectionFactory,
-        FooterTextForService,
+        FooterText: FooterTextForService,
         HeaderSection: ReporterHeaderSection,
         HeadSection: ReporterHead,
     };
@@ -112,7 +112,7 @@ const summaryResultsReportGenerator = (parameters: SummaryReportParameters) => {
 
     const sectionFactory = {
         ...SummaryReportSectionFactory,
-        FooterTextForService,
+        FooterText: FooterTextForService,
     };
 
     const reportHtmlGenerator = new SummaryReportHtmlGenerator(

--- a/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
@@ -6993,7 +6993,7 @@ exports[`report package integration with issues 1`] = `
       class="report-footer"
       role="contentinfo"
     >
-      This automated checks result was generated using Accessibility Insights Service  (axe-core 3.3.2), a tool that helps debug and find accessibility issues earlier on Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/78.0.3904.108 Safari/537.36. Get more information & download this tool at 
+      This automated checks result was generated using the Accessibility Insights Service that helps find some of the most common accessibility issues. The scan was performed using axe-core 3.3.2 and Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/78.0.3904.108 Safari/537.36. For a complete WCAG 2.1 compliance assessment please visit 
       <a
         class="ms-Link insights-link tool-name-link root-000"
         href="http://aka.ms/AccessibilityInsights"
@@ -10719,7 +10719,7 @@ exports[`report package integration with no issues 1`] = `
       class="report-footer"
       role="contentinfo"
     >
-      This automated checks result was generated using Accessibility Insights Service  (axe-core 3.3.2), a tool that helps debug and find accessibility issues earlier on Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/78.0.3904.108 Safari/537.36. Get more information & download this tool at 
+      This automated checks result was generated using the Accessibility Insights Service that helps find some of the most common accessibility issues. The scan was performed using axe-core 3.3.2 and Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/78.0.3904.108 Safari/537.36. For a complete WCAG 2.1 compliance assessment please visit 
       <a
         class="ms-Link insights-link tool-name-link root-000"
         href="http://aka.ms/AccessibilityInsights"


### PR DESCRIPTION
#### Description of changes

It was noticed that we're not using the correct text for the service report, so this fixes that.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
