### PR TITLE
fix: add corrected text for color contrast tests

### DIFF
--- a/src/assessments/adaptable-content/test-steps/contrast.tsx
+++ b/src/assessments/adaptable-content/test-steps/contrast.tsx
@@ -38,9 +38,15 @@ const contrastHowToTest: JSX.Element = (
         <TestAutomaticallyPassedNotice />
         <ol>
             <li>
-                Examine each instance in the target page to identify an area where the text and
-                background are most likely to have a low contrast ratio (e.g., white text on a light
-                gray background).
+                Examine each instance in the target page to determine whether it is text. (Because
+                icons are assessed in
+                <Markup.Term> Contrast {'>'} Graphics </Markup.Term>, they can be marked as{' '}
+                <Markup.Term> Pass </Markup.Term> in this test.)
+            </li>
+            <li>
+                Examine each text instance to identify an area where the text and background are
+                most likely to have a low contrast ratio (e.g., white text on a light gray
+                background).
             </li>
             <li>
                 Use <WindowsContrastCheckerAppLink /> to test the contrast at that area. (If you are

--- a/src/common/components/cards/how-to-check-text.tsx
+++ b/src/common/components/cards/how-to-check-text.tsx
@@ -31,7 +31,7 @@ export const HowToCheckText = NamedFC<HowToCheckTextProps>('HowToCheckText', pro
         }
         case 'color-contrast': {
             checkText = (
-                <div classname={styles.combinationLists}>
+                <div className={styles.combinationLists}>
                     <ul className={styles.multiLineTextYesBullet}>
                         <li list-style-type="disc">
                             If the text is intended to be invisible, it passes.

--- a/src/common/components/cards/how-to-check-text.tsx
+++ b/src/common/components/cards/how-to-check-text.tsx
@@ -34,10 +34,11 @@ export const HowToCheckText = NamedFC<HowToCheckTextProps>('HowToCheckText', pro
                 <div className={styles.combinationLists}>
                     <ul className={styles.multiLineTextYesBullet}>
                         <li list-style-type="disc">
-                            If the text is intended to be invisible, it passes.
+                            If the instance is an icon or other non-text content, ignore it. This
+                            rule applies only to text.
                         </li>
                         <li list-style-type="disc">
-                            If the text is intended to be visible, use{' '}
+                            If the instance is text, use{' '}
                             <NewTabLink href="https://go.microsoft.com/fwlink/?linkid=2075365">
                                 Accessibility Insights for Windows
                             </NewTabLink>{' '}
@@ -54,7 +55,7 @@ export const HowToCheckText = NamedFC<HowToCheckTextProps>('HowToCheckText', pro
                         <li>
                             For detailed test instructions, see{' '}
                             <b>
-                                Assessment {'>'} Text legibility {'>'} Contrast
+                                Assessment {'>'} Adaptable content {'>'} Contrast
                             </b>
                             .
                         </li>

--- a/src/common/components/cards/how-to-check-text.tsx
+++ b/src/common/components/cards/how-to-check-text.tsx
@@ -5,6 +5,7 @@ import { NewTabLink } from 'common/components/new-tab-link';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import * as styles from './how-to-check-text.scss';
+import * as Markup from '../../../assessments/markup';
 
 export interface HowToCheckTextProps {
     id: string;
@@ -54,9 +55,9 @@ export const HowToCheckText = NamedFC<HowToCheckTextProps>('HowToCheckText', pro
                     <ul className={styles.multiLineTextNoBullet}>
                         <li>
                             For detailed test instructions, see{' '}
-                            <b>
+                            <Markup.Term>
                                 Assessment {'>'} Adaptable content {'>'} Contrast
-                            </b>
+                            </Markup.Term>
                             .
                         </li>
                     </ul>

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-check-text.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-check-text.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`HowToCheckWebText renders with id=bogus-name 1`] = `null`;
 
 exports[`HowToCheckWebText renders with id=color-contrast 1`] = `
 <div
-  classname="combinationLists"
+  className="combinationLists"
 >
   <ul
     className="multiLineTextYesBullet"

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-check-text.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-check-text.test.tsx.snap
@@ -63,13 +63,13 @@ exports[`HowToCheckWebText renders with id=color-contrast 1`] = `
     <li>
       For detailed test instructions, see
        
-      <b>
+      <Term>
         Assessment 
         &gt;
          Adaptable content 
         &gt;
          Contrast
-      </b>
+      </Term>
       .
     </li>
   </ul>

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-check-text.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-check-text.test.tsx.snap
@@ -33,12 +33,12 @@ exports[`HowToCheckWebText renders with id=color-contrast 1`] = `
     <li
       list-style-type="disc"
     >
-      If the text is intended to be invisible, it passes.
+      If the instance is an icon or other non-text content, ignore it. This rule applies only to text.
     </li>
     <li
       list-style-type="disc"
     >
-      If the text is intended to be visible, use
+      If the instance is text, use
        
       <NewTabLink
         href="https://go.microsoft.com/fwlink/?linkid=2075365"
@@ -66,7 +66,7 @@ exports[`HowToCheckWebText renders with id=color-contrast 1`] = `
       <b>
         Assessment 
         &gt;
-         Text legibility 
+         Adaptable content 
         &gt;
          Contrast
       </b>


### PR DESCRIPTION
#### Description of changes
Updated the text for the assessment's adaptable content contrast test and fastpass to address issue #3337.

![image](https://user-images.githubusercontent.com/18401275/94090395-55a02080-fdca-11ea-819d-d76de1ce2623.png)

![image](https://user-images.githubusercontent.com/18401275/94090505-9c8e1600-fdca-11ea-926d-6c101e3a9bd5.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3337
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
