### PR TITLE
feat(android-left-nav): Introduce basic left nav types

### DIFF
--- a/src/common/stores/store-names.ts
+++ b/src/common/stores/store-names.ts
@@ -22,4 +22,6 @@ export enum StoreNames {
     PermissionsStateStore,
     DebugToolsNavStore,
     AndroidSetupStore,
+    LeftNavStore,
+    ContentPanelStore,
 }

--- a/src/electron/data/left-nav-store-data.ts
+++ b/src/electron/data/left-nav-store-data.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type LeftNavStoreData<KeyT> = {
+    selectedKey: KeyT;
+};

--- a/src/electron/platform/android/types/left-nav-item-key.ts
+++ b/src/electron/platform/android/types/left-nav-item-key.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TestKey } from 'electron/platform/android/types/test-key';
+
+export type LeftNavItemKey = TestKey | 'overview';

--- a/src/electron/platform/android/types/test-key.ts
+++ b/src/electron/platform/android/types/test-key.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// the following are just examples for the moment (this comment will self-destruct when real values are added)
+export type TestKey = 'automated-checks' | 'needs-review';

--- a/src/electron/props/left-nav-props.ts
+++ b/src/electron/props/left-nav-props.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { LeftNavItem } from 'electron/types/left-nav-item';
+
+export type LeftNavProps<KeyT> = {
+    selectedKey: KeyT;
+    items: LeftNavItem<KeyT>[];
+};

--- a/src/electron/stores/left-nav-store.ts
+++ b/src/electron/stores/left-nav-store.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BaseStoreImpl } from 'background/stores/base-store-impl';
+import { StoreNames } from 'common/stores/store-names';
+import { LeftNavStoreData } from 'electron/data/left-nav-store-data';
+
+export class LeftNavStore<KeyT> extends BaseStoreImpl<LeftNavStoreData<KeyT>> {
+    constructor(private readonly defaultKey: KeyT) {
+        super(StoreNames.LeftNavStore);
+    }
+
+    public getDefaultState(): LeftNavStoreData<KeyT> {
+        return {
+            selectedKey: this.defaultKey,
+        };
+    }
+
+    protected addActionListeners(): void {}
+}

--- a/src/electron/types/left-nav-item.ts
+++ b/src/electron/types/left-nav-item.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { LeftNavItemKey } from 'electron/platform/android/types/left-nav-item-key';
+
+export type LeftNavItem<KeyT> = {
+    key: KeyT;
+    displayName: string;
+    onSelect: () => void;
+};


### PR DESCRIPTION
## Description

Add basic types to support the left nav bar infrastructure.

The general idea is that the nav bar is designed using a generic value for the keys of its items so that different nav bars can be created for android and hopefully web eventually.

An assumption inherent in this model is that the contents of the (soon to be added) content pane will always be in sync with the selection in the nav bar, so they can both be driven from the same store (LeftNavStore).

And TestKey and LeftNavKey are different because not all items in the left nav bar will necessarily activate tests.