### PR TITLE
feat(axe-core-4.0.2): update extension and reporter axe-dependency to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
         "accessibility-insights-for-android-service-bin": "^1.2.1",
         "appium-adb": "^8.7.2",
         "applicationinsights-js": "^1.0.21",
-        "axe-core": "4.0.1",
+        "axe-core": "4.0.2",
         "axios": "^0.20.0",
         "classnames": "^2.2.6",
         "electron": "8.4.1",

--- a/src/reports/package/root/package.json
+++ b/src/reports/package/root/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/Microsoft/accessibility-insights-web"
     },
     "dependencies": {
-        "axe-core": "4.0.1",
+        "axe-core": "4.0.2",
         "classnames": "^2.2.6",
         "lodash": "^4.17.20",
         "luxon": "^1.25.0",

--- a/src/tests/end-to-end/tests/details-view/headings.test.ts
+++ b/src/tests/end-to-end/tests/details-view/headings.test.ts
@@ -73,9 +73,7 @@ describe('Details View -> Assessment -> Headings', () => {
                     headingsPage,
                     detailsViewSelectors.mainContent,
                 );
-                // Note: long-term, length should be 0. The 1 is here as a temporary workaround
-                // for issue https://github.com/dequelabs/axe-core/issues/2459
-                expect(results).toHaveLength(1);
+                expect(results).toHaveLength(0);
             },
         );
     });

--- a/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
+++ b/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
@@ -46,10 +46,7 @@ describe('Details View -> Assessment -> Reflow', () => {
         it.each([true, false])(
             `should pass accessibility validation with high contrast mode=%s`,
             async highContrastMode => {
-                await scanForA11yIssuesWithHighContrast(
-                    highContrastMode,
-                    componentName === 'hamburger button' ? 0 : 1,
-                );
+                await scanForA11yIssuesWithHighContrast(highContrastMode);
             },
         );
 
@@ -65,24 +62,18 @@ describe('Details View -> Assessment -> Reflow', () => {
             it.each([true, false])(
                 `should pass accessibility validation with command bar menu open and high contrast mode=%s`,
                 async highContrastMode => {
-                    await scanForA11yIssuesWithHighContrast(highContrastMode, 1);
+                    await scanForA11yIssuesWithHighContrast(highContrastMode);
                 },
             );
         });
     });
 
-    async function scanForA11yIssuesWithHighContrast(
-        highContrastMode: boolean,
-        expectedFailures: number,
-    ): Promise<void> {
+    async function scanForA11yIssuesWithHighContrast(highContrastMode: boolean): Promise<void> {
         await browser.setHighContrastMode(highContrastMode);
         await detailsViewPage.waitForHighContrastMode(highContrastMode);
 
         const results = await scanForAccessibilityIssues(detailsViewPage, '*');
-        // Note: long-term, expectedFailures should always be 0 and it should not
-        // be passed in as a parameter. It's here as a temporary workaround for
-        // issue https://github.com/dequelabs/axe-core/issues/2459
-        expect(results).toHaveLength(expectedFailures);
+        expect(results).toHaveLength(0);
     }
 
     async function setButtonExpandedState(

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -256,7 +256,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
           >
             axe-core
           </a>
-           4.0.1
+           4.0.2
         </div>
       </div>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2301,10 +2301,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.1.tgz#e337c2ed1e6fe73920166d8b0b0b352e1b50d8ae"
-  integrity sha512-OSCABHvSNDleKqJP7DUwEBvMVbr/gtOj2vCDoKKz967fxe9WqtCZLo3IRNOO2fJcu+eSFsu8aAToHfIY7sPLaw==
+axe-core@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.2.tgz#c7cf7378378a51fcd272d3c09668002a4990b1cb"
+  integrity sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==
 
 axios@^0.19.2:
   version "0.19.2"


### PR DESCRIPTION
#### Description of changes

This PR updates our axe-core dependencies to 4.0.2 ([release notes here](https://github.com/dequelabs/axe-core/releases/tag/v4.0.2)).

Out of scope / upcoming in future PRs:
- updating/understanding this reference to axe-core: https://github.com/microsoft/accessibility-insights-web/blob/5711dddefc0da424604f6ca74404c91272cd4ad7/src/packages/accessibility-insights-ui/root/package.json#L11 I'm not sure the UI package should need axe-core, need to explore
- updating the [usage section](https://github.com/microsoft/accessibility-insights-web/blob/master/src/reports/package/root/README.md#usage) of the reporter's README. The package references are easy to change but the usage script is broken (see #3410)
- re-introducing the `link-name` rule now that it's fixed in axe-core

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
