### PR TITLE
docs(axe-core-4.0.2): update reporter README

### DIFF
--- a/src/reports/package/root/README.md
+++ b/src/reports/package/root/README.md
@@ -11,7 +11,7 @@ self-contained HTML files in the same format as
 
 ## Usage
 
-Before using accessibility-insights-report, you will need to run an [axe](https://github.com/dequelabs/axe-core) accessibility scan to produce some axe results to convert. Typically, you would do this by using an axe integration library for your favorite browser automation tool ([@axe-core/puppeteer](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/puppeteer), [@axe-core/webdriverjs-webdriverjs](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/webdriverjs), [cypress-axe](https://github.com/avanslaars/cypress-axe)).
+Before using accessibility-insights-report, you will need to run an [axe](https://github.com/dequelabs/axe-core) accessibility scan to produce some axe results to convert. Typically, you would do this by using an axe integration library for your favorite browser automation tool ([@axe-core/puppeteer](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/puppeteer), [@axe-core/webdriverjs](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/webdriverjs), [cypress-axe](https://github.com/avanslaars/cypress-axe)).
 
 accessibility-insights-report exports a factory that can be used to create a report object and output its results as HTML.
 


### PR DESCRIPTION
#### Description of changes

This PR updates references to axe-core integration packages (the old packages are being deprecated). We also amend the usage script to catch up with some changes to reporter package (the current script is broken).

I was able to run a node script like this one locally using jest, but the example wasn't self-contained. I had to pick a longer timeout and include some module remapping to commonjs modules (similar to [web file here](https://github.com/microsoft/accessibility-insights-web/blob/5711dddefc0da424604f6ca74404c91272cd4ad7/src/tests/jest.common.config.js#L6)). This produced the reporter file so everything plumbs through. However, locally the produced HTML had some syntax errors; checking if I'm missing something. The report looks correct when I use it from `accessibility-insights-scan` [via the cli tool](https://www.npmjs.com/package/accessibility-insights-scan). 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
