### PR TITLE
feat(android-left-nav): Remove generic key parameter from left nav types

### DIFF
--- a/src/electron/data/left-nav-store-data.ts
+++ b/src/electron/data/left-nav-store-data.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export type LeftNavStoreData<KeyT> = {
-    selectedKey: KeyT;
+import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
+
+export type LeftNavStoreData = {
+    selectedKey: LeftNavItemKey;
 };

--- a/src/electron/platform/android/types/left-nav-item-key.ts
+++ b/src/electron/platform/android/types/left-nav-item-key.ts
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-import { TestKey } from 'electron/platform/android/types/test-key';
-
-export type LeftNavItemKey = TestKey | 'overview';

--- a/src/electron/props/left-nav-props.ts
+++ b/src/electron/props/left-nav-props.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 
 import { LeftNavItem } from 'electron/types/left-nav-item';
+import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 
-export type LeftNavProps<KeyT> = {
-    selectedKey: KeyT;
-    items: LeftNavItem<KeyT>[];
+export type LeftNavProps = {
+    selectedKey: LeftNavItemKey;
+    items: LeftNavItem[];
 };

--- a/src/electron/stores/left-nav-store.ts
+++ b/src/electron/stores/left-nav-store.ts
@@ -4,13 +4,14 @@
 import { BaseStoreImpl } from 'background/stores/base-store-impl';
 import { StoreNames } from 'common/stores/store-names';
 import { LeftNavStoreData } from 'electron/data/left-nav-store-data';
+import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 
-export class LeftNavStore<KeyT> extends BaseStoreImpl<LeftNavStoreData<KeyT>> {
-    constructor(private readonly defaultKey: KeyT) {
+export class LeftNavStore extends BaseStoreImpl<LeftNavStoreData<KeyT>> {
+    constructor(private readonly defaultKey: LeftNavItemKey) {
         super(StoreNames.LeftNavStore);
     }
 
-    public getDefaultState(): LeftNavStoreData<KeyT> {
+    public getDefaultState(): LeftNavStoreData {
         return {
             selectedKey: this.defaultKey,
         };

--- a/src/electron/types/content-page-key.ts
+++ b/src/electron/types/content-page-key.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type ContentPageKey = 'overview';

--- a/src/electron/types/left-nav-item-key.ts
+++ b/src/electron/types/left-nav-item-key.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ContentPageKey } from 'electron/types/content-page-key';
+import { TestKey } from 'electron/types/test-key';
+
+export type LeftNavItemKey = TestKey | ContentPageKey;

--- a/src/electron/types/left-nav-item.ts
+++ b/src/electron/types/left-nav-item.ts
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 import { LeftNavItemKey } from 'electron/platform/android/types/left-nav-item-key';
+import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 
-export type LeftNavItem<KeyT> = {
-    key: KeyT;
+export type LeftNavItem = {
+    key: LeftNavItemKey;
     displayName: string;
     onSelect: () => void;
 };

--- a/src/electron/types/test-key.ts
+++ b/src/electron/types/test-key.ts
@@ -1,5 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// the following are just examples for the moment (this comment will self-destruct when real values are added)
 export type TestKey = 'automated-checks' | 'needs-review';


### PR DESCRIPTION
#### Description of changes

The genericity won't be necessary because it only adds complexity to have different stores and actions based on a key type. Instead, we will have one store that handles all the left nav actions and data, and only specific left nav items will be instantiated based on the need at the time.
