### PR TITLE
feat(android-left-nav): Set 'automated-checks' as default page for the left nav store

### DIFF
--- a/src/electron/flux/store/left-nav-store.ts
+++ b/src/electron/flux/store/left-nav-store.ts
@@ -15,7 +15,7 @@ export class LeftNavStore extends BaseStoreImpl<LeftNavStoreData> {
 
     public getDefaultState(): LeftNavStoreData {
         return {
-            selectedKey: 'overview',
+            selectedKey: 'automated-checks',
         };
     }
 

--- a/src/tests/unit/tests/electron/flux/store/__snapshots__/left-nav-store.test.ts.snap
+++ b/src/tests/unit/tests/electron/flux/store/__snapshots__/left-nav-store.test.ts.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LeftNavStore returns default state 1`] = `undefined`;
+exports[`LeftNavStore returns default state 1`] = `
+Object {
+  "selectedKey": "automated-checks",
+}
+`;

--- a/src/tests/unit/tests/electron/flux/store/left-nav-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/left-nav-store.test.ts
@@ -16,7 +16,9 @@ describe('LeftNavStore', () => {
     });
 
     it('returns default state', () => {
-        const store = new LeftNavStore(null);
+        const actions = new LeftNavActions();
+        const store = new LeftNavStore(actions);
+        store.initialize();
 
         expect(store.getState()).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

This change resulted from a comment in a previous PR. Also fixed unit tests which were not properly initializing the snapshot.
