### PR TITLE
fix: wrap urls in summary report

### DIFF
--- a/src/reports/components/report-sections/summary-results-table.scss
+++ b/src/reports/components/report-sections/summary-results-table.scss
@@ -29,6 +29,13 @@
 
     td {
         background-color: $neutral-0;
-        overflow-wrap: break-word;
+
+        &.text-cell {
+            overflow-wrap: break-word;
+        }
+
+        &.url-cell {
+            overflow-wrap: anywhere;
+        }
     }
 }

--- a/src/reports/components/report-sections/summary-results-table.tsx
+++ b/src/reports/components/report-sections/summary-results-table.tsx
@@ -3,29 +3,42 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
+const cellClassNames = {
+    text: 'text-cell',
+    url: 'url-cell',
+};
+
+type CellContentType = keyof typeof cellClassNames;
+
+export type TableColumn = {
+    header: string;
+    contentType: CellContentType;
+};
+
 export type TableRow = (string | JSX.Element)[];
 
 export type SummaryResultsTableProps = {
-    columnHeaders: string[];
     rows: TableRow[];
+    columns: TableColumn[];
     id: string;
-    columnIsUrl: boolean[];
 };
 
 export const SummaryResultsTable = NamedFC<SummaryResultsTableProps>(
     'SummaryResultsTable',
     props => {
+        const { id, columns, rows } = props;
+
         const getHeaderId = (colIndex: number) => {
-            return `${props.id}-header${colIndex}`;
+            return `${id}-header${colIndex}`;
         };
 
         const getTableHeaders = () => {
             return (
                 <tr>
-                    {props.columnHeaders.map((header, index) => {
+                    {columns.map((column, index) => {
                         return (
                             <th key={index} id={getHeaderId(index)}>
-                                {header}
+                                {column.header}
                             </th>
                         );
                     })}
@@ -33,16 +46,20 @@ export const SummaryResultsTable = NamedFC<SummaryResultsTableProps>(
             );
         };
 
+        const getCellClassName = (colIndex: number) => {
+            const contentType = columns[colIndex].contentType;
+            return cellClassNames[contentType];
+        };
+
         const getRow = (row: TableRow, rowIndex: number) => {
             return (
                 <tr key={rowIndex}>
                     {row.map((item, colIndex) => {
-                        const className = props.columnIsUrl[colIndex] ? 'url-cell' : 'text-cell';
                         return (
                             <td
                                 key={colIndex}
                                 headers={getHeaderId(colIndex)}
-                                className={className}
+                                className={getCellClassName(colIndex)}
                             >
                                 {item}
                             </td>
@@ -53,11 +70,11 @@ export const SummaryResultsTable = NamedFC<SummaryResultsTableProps>(
         };
 
         const getTableRows = () => {
-            return props.rows.map(getRow);
+            return rows.map(getRow);
         };
 
         return (
-            <table className="summary-results-table" id={props.id}>
+            <table className="summary-results-table" id={id}>
                 <thead>{getTableHeaders()}</thead>
                 <tbody>{getTableRows()}</tbody>
             </table>

--- a/src/reports/components/report-sections/summary-results-table.tsx
+++ b/src/reports/components/report-sections/summary-results-table.tsx
@@ -9,6 +9,7 @@ export type SummaryResultsTableProps = {
     columnHeaders: string[];
     rows: TableRow[];
     id: string;
+    columnIsUrl: boolean[];
 };
 
 export const SummaryResultsTable = NamedFC<SummaryResultsTableProps>(
@@ -32,12 +33,17 @@ export const SummaryResultsTable = NamedFC<SummaryResultsTableProps>(
             );
         };
 
-        const getRow = (row: TableRow, index: number) => {
+        const getRow = (row: TableRow, rowIndex: number) => {
             return (
-                <tr key={index}>
-                    {row.map((item, index) => {
+                <tr key={rowIndex}>
+                    {row.map((item, colIndex) => {
+                        const className = props.columnIsUrl[colIndex] ? 'url-cell' : 'text-cell';
                         return (
-                            <td key={index} headers={getHeaderId(index)}>
+                            <td
+                                key={colIndex}
+                                headers={getHeaderId(colIndex)}
+                                className={className}
+                            >
                                 {item}
                             </td>
                         );

--- a/src/reports/components/report-sections/url-errors-table.tsx
+++ b/src/reports/components/report-sections/url-errors-table.tsx
@@ -4,7 +4,10 @@ import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { SummaryScanError } from '../../package/accessibilityInsightsReport';
 import { NewTabLink } from 'common/components/new-tab-link';
-import { SummaryResultsTable } from 'reports/components/report-sections/summary-results-table';
+import {
+    SummaryResultsTable,
+    TableColumn,
+} from 'reports/components/report-sections/summary-results-table';
 
 export type UrlErrorsTableProps = {
     errors: SummaryScanError[];
@@ -14,8 +17,11 @@ export type UrlErrorsTableProps = {
 export const UrlErrorsTable = NamedFC<UrlErrorsTableProps>('UrlErrorsTable', props => {
     const errors = props.errors;
 
-    const headers = ['Error type', 'URL', 'Error description'];
-
+    const columns: TableColumn[] = [
+        { header: 'Error type', contentType: 'text' },
+        { header: 'URL', contentType: 'url' },
+        { header: 'Error description', contentType: 'text' },
+    ];
     const rows = errors.map(scanError => {
         const { errorDescription, errorType, url, errorLogLocation } = scanError;
         const urlLink = <NewTabLink href={url}>{url}</NewTabLink>;
@@ -23,14 +29,5 @@ export const UrlErrorsTable = NamedFC<UrlErrorsTableProps>('UrlErrorsTable', pro
         return [errorType, urlLink, errorLogLink];
     });
 
-    const columnIsUrl = [false, true, false];
-
-    return (
-        <SummaryResultsTable
-            columnHeaders={headers}
-            rows={rows}
-            id={props.id}
-            columnIsUrl={columnIsUrl}
-        />
-    );
+    return <SummaryResultsTable columns={columns} rows={rows} id={props.id} />;
 });

--- a/src/reports/components/report-sections/url-errors-table.tsx
+++ b/src/reports/components/report-sections/url-errors-table.tsx
@@ -23,5 +23,14 @@ export const UrlErrorsTable = NamedFC<UrlErrorsTableProps>('UrlErrorsTable', pro
         return [errorType, urlLink, errorLogLink];
     });
 
-    return <SummaryResultsTable columnHeaders={headers} rows={rows} id={props.id} />;
+    const columnIsUrl = [false, true, false];
+
+    return (
+        <SummaryResultsTable
+            columnHeaders={headers}
+            rows={rows}
+            id={props.id}
+            columnIsUrl={columnIsUrl}
+        />
+    );
 });

--- a/src/reports/components/report-sections/url-scan-results-table.tsx
+++ b/src/reports/components/report-sections/url-scan-results-table.tsx
@@ -31,6 +31,15 @@ export const UrlScanResultsTable = NamedFC<UrlScanResultsTableProps>(
             return [`${result.numFailures}`, urlLink, reportLink];
         });
 
-        return <SummaryResultsTable columnHeaders={headers} rows={rows} id={props.id} />;
+        const columnIsUrl = [false, true, false];
+
+        return (
+            <SummaryResultsTable
+                columnHeaders={headers}
+                rows={rows}
+                id={props.id}
+                columnIsUrl={columnIsUrl}
+            />
+        );
     },
 );

--- a/src/reports/components/report-sections/url-scan-results-table.tsx
+++ b/src/reports/components/report-sections/url-scan-results-table.tsx
@@ -4,7 +4,10 @@ import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { SummaryScanResult } from '../../package/accessibilityInsightsReport';
 import { NewTabLink } from 'common/components/new-tab-link';
-import { SummaryResultsTable } from 'reports/components/report-sections/summary-results-table';
+import {
+    SummaryResultsTable,
+    TableColumn,
+} from 'reports/components/report-sections/summary-results-table';
 
 export type UrlScanResultsTableProps = {
     results: SummaryScanResult[];
@@ -18,7 +21,11 @@ export const UrlScanResultsTable = NamedFC<UrlScanResultsTableProps>(
         let failureInstances = 0;
         results.forEach(result => (failureInstances += result.numFailures));
 
-        const headers = [`# failure instances (${failureInstances})`, 'URL', 'Link to report'];
+        const columns: TableColumn[] = [
+            { header: `# failure instances (${failureInstances})`, contentType: 'text' },
+            { header: 'URL', contentType: 'url' },
+            { header: 'Link to report', contentType: 'text' },
+        ];
 
         const rows = results.map(result => {
             const { url, reportLocation, numFailures } = result;
@@ -31,15 +38,6 @@ export const UrlScanResultsTable = NamedFC<UrlScanResultsTableProps>(
             return [`${result.numFailures}`, urlLink, reportLink];
         });
 
-        const columnIsUrl = [false, true, false];
-
-        return (
-            <SummaryResultsTable
-                columnHeaders={headers}
-                rows={rows}
-                id={props.id}
-                columnIsUrl={columnIsUrl}
-            />
-        );
+        return <SummaryResultsTable columns={columns} rows={rows} id={props.id} />;
     },
 );

--- a/src/reports/package/root/package.json
+++ b/src/reports/package/root/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-report",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "Accessibility Insights Report",
     "license": "MIT",
     "repository": {

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-results-table.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-results-table.test.tsx.snap
@@ -27,16 +27,19 @@ exports[` renders 1`] = `
   <tbody>
     <tr>
       <td
+        className="text-cell"
         headers="table-id-header0"
       >
         cell1
       </td>
       <td
+        className="url-cell"
         headers="table-id-header1"
       >
         cell2
       </td>
       <td
+        className="text-cell"
         headers="table-id-header2"
       >
         <div>
@@ -46,16 +49,19 @@ exports[` renders 1`] = `
     </tr>
     <tr>
       <td
+        className="text-cell"
         headers="table-id-header0"
       >
         cell4
       </td>
       <td
+        className="url-cell"
         headers="table-id-header1"
       >
         cell5
       </td>
       <td
+        className="text-cell"
         headers="table-id-header2"
       >
         <div>

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/url-errors-table.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/url-errors-table.test.tsx.snap
@@ -9,6 +9,13 @@ exports[` renders 1`] = `
       "Error description",
     ]
   }
+  columnIsUrl={
+    Array [
+      false,
+      true,
+      false,
+    ]
+  }
   id="table-id"
   rows={
     Array [

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/url-errors-table.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/url-errors-table.test.tsx.snap
@@ -2,18 +2,20 @@
 
 exports[` renders 1`] = `
 <SummaryResultsTable
-  columnHeaders={
+  columns={
     Array [
-      "Error type",
-      "URL",
-      "Error description",
-    ]
-  }
-  columnIsUrl={
-    Array [
-      false,
-      true,
-      false,
+      Object {
+        "contentType": "text",
+        "header": "Error type",
+      },
+      Object {
+        "contentType": "url",
+        "header": "URL",
+      },
+      Object {
+        "contentType": "text",
+        "header": "Error description",
+      },
     ]
   }
   id="table-id"

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/url-scan-results-table.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/url-scan-results-table.test.tsx.snap
@@ -9,6 +9,13 @@ exports[` renders 1`] = `
       "Link to report",
     ]
   }
+  columnIsUrl={
+    Array [
+      false,
+      true,
+      false,
+    ]
+  }
   id="table-id"
   rows={
     Array [

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/url-scan-results-table.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/url-scan-results-table.test.tsx.snap
@@ -2,18 +2,20 @@
 
 exports[` renders 1`] = `
 <SummaryResultsTable
-  columnHeaders={
+  columns={
     Array [
-      "# failure instances (6)",
-      "URL",
-      "Link to report",
-    ]
-  }
-  columnIsUrl={
-    Array [
-      false,
-      true,
-      false,
+      Object {
+        "contentType": "text",
+        "header": "# failure instances (6)",
+      },
+      Object {
+        "contentType": "url",
+        "header": "URL",
+      },
+      Object {
+        "contentType": "text",
+        "header": "Link to report",
+      },
     ]
   }
   id="table-id"

--- a/src/tests/unit/tests/reports/components/report-sections/summary-results-table.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/summary-results-table.test.tsx
@@ -11,8 +11,14 @@ describe(SummaryResultsTable, () => {
             ['cell1', 'cell2', <div>cell3</div>],
             ['cell4', 'cell5', <div>cell6</div>],
         ];
+        const columnIsUrl = [false, true, false];
         const wrapped = shallow(
-            <SummaryResultsTable columnHeaders={headings} rows={rows} id="table-id" />,
+            <SummaryResultsTable
+                columnHeaders={headings}
+                rows={rows}
+                id="table-id"
+                columnIsUrl={columnIsUrl}
+            />,
         );
         expect(wrapped.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/reports/components/report-sections/summary-results-table.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/summary-results-table.test.tsx
@@ -2,23 +2,33 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { SummaryResultsTable } from 'reports/components/report-sections/summary-results-table';
+import {
+    SummaryResultsTable,
+    TableColumn,
+} from 'reports/components/report-sections/summary-results-table';
 
 describe(SummaryResultsTable, () => {
     it('renders', () => {
-        const headings = ['heading1', 'heading2', 'heading3'];
+        const columns: TableColumn[] = [
+            {
+                header: 'heading1',
+                contentType: 'text',
+            },
+            {
+                header: 'heading2',
+                contentType: 'url',
+            },
+            {
+                header: 'heading3',
+                contentType: 'text',
+            },
+        ];
         const rows = [
             ['cell1', 'cell2', <div>cell3</div>],
             ['cell4', 'cell5', <div>cell6</div>],
         ];
-        const columnIsUrl = [false, true, false];
         const wrapped = shallow(
-            <SummaryResultsTable
-                columnHeaders={headings}
-                rows={rows}
-                id="table-id"
-                columnIsUrl={columnIsUrl}
-            />,
+            <SummaryResultsTable columns={columns} rows={rows} id="table-id" />,
         );
         expect(wrapped.getElement()).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

Currently, when we have long URLs in the summary report, they stretch out the results table and can make it longer than everything else on the page:

<img width="543" alt="summary report overflow" src="https://user-images.githubusercontent.com/55459788/94744306-95688a00-032d-11eb-969c-7b79de836dfb.PNG">

This PR will cause long URLs to wrap even if they can't be broken up "by word":

<img width="723" alt="summary report overflow fixed" src="https://user-images.githubusercontent.com/55459788/94744354-ab764a80-032d-11eb-8cb9-05d8629b42de.PNG">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
