### PR TITLE
feat(android-left-nav): improve styling of left nav component

### DIFF
--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -17,11 +17,6 @@
             .is-expanded,
             .is-expanded + ul {
                 background-color: $nav-link-expanded;
-                .index-circle {
-                    color: $neutral-0;
-                    background: $index-circle-background;
-                    border-color: $neutral-0;
-                }
             }
         }
 
@@ -68,20 +63,6 @@
             line-height: 16px;
             font-size: 12px;
         }
-        .index-circle {
-            border: 1px solid;
-            display: inline-block;
-            border-radius: 50%;
-            border: 1px solid;
-            width: 1.5em;
-            line-height: 1.5em;
-            padding: 0.07em;
-            margin-top: 0.23em;
-        }
-        .test-name {
-            padding-left: 10%;
-            display: inline-block;
-        }
         .ms-Nav-navItems {
             margin-top: 0px !important;
         }
@@ -94,12 +75,6 @@
             }
             .ms-Button-label {
                 color: $neutral-100;
-            }
-            .index-circle {
-                color: $secondary-text;
-                background: $neutral-0;
-                border-color: $neutral-20;
-                text-align: center;
             }
             &.is-selected {
                 a,
@@ -121,11 +96,6 @@
                 }
                 .ms-Button-label {
                     color: $always-black;
-                }
-                .index-circle {
-                    color: $neutral-0;
-                    background: $index-circle-background;
-                    border-color: $neutral-0;
                 }
             }
         }

--- a/src/DetailsView/components/left-nav/left-nav-icon.scss
+++ b/src/DetailsView/components/left-nav/left-nav-icon.scss
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+@import '../../../common/styles/common.scss';
+
+:global(.ms-Nav-compositeLink.is-selected),
+li :global(.is-expanded) {
+    .index-circle {
+        color: $neutral-0;
+        background: $index-circle-background;
+        border-color: $neutral-0;
+    }
+}
+
+.index-circle {
+    border: 1px solid;
+    display: inline-block;
+    border-radius: 50%;
+    border: 1px solid $neutral-20;
+    width: 1.5em;
+    line-height: 1.5em;
+    padding: 0.07em;
+    margin-top: 0.23em;
+    color: $secondary-text;
+    background: $neutral-0;
+    text-align: center;
+}

--- a/src/DetailsView/components/left-nav/left-nav-icon.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-icon.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as styles from 'DetailsView/components/left-nav/left-nav-icon.scss';
 import { css, INavLink } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { NamedFC } from '../../../common/react/named-fc';
@@ -20,5 +21,5 @@ export const LeftNavStatusIcon = NamedFC<LeftNavIconProps>('LeftNavStatusIcon', 
 export const LeftNavIndexIcon = NamedFC<LeftNavIconProps>('LeftNavIndexIcon', props => {
     const { item } = props;
 
-    return <span className={'index-circle'}>{item.index}</span>;
+    return <span className={styles.indexCircle}>{item.index}</span>;
 });

--- a/src/DetailsView/components/left-nav/test-view-left-nav-link.scss
+++ b/src/DetailsView/components/left-nav/test-view-left-nav-link.scss
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+.test-name {
+    padding-left: 10%;
+    display: inline-block;
+}

--- a/src/DetailsView/components/left-nav/test-view-left-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/test-view-left-nav-link.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as styles from 'DetailsView/components/left-nav/common-left-nav-link.scss';
+import * as commonStyles from 'DetailsView/components/left-nav/common-left-nav-link.scss';
+import * as styles from 'DetailsView/components/left-nav/test-view-left-nav-link.scss';
 import * as React from 'react';
 import { NamedFC } from '../../../common/react/named-fc';
 import { BaseLeftNavLinkProps } from '../base-left-nav';
@@ -9,9 +10,9 @@ export const TestViewLeftNavLink = NamedFC<BaseLeftNavLinkProps>(
     'TestViewLeftNavLink',
     ({ link, renderIcon }) => {
         return (
-            <span className={styles.leftNavLinkContainer} aria-hidden="true">
+            <span className={commonStyles.leftNavLinkContainer} aria-hidden="true">
                 {renderIcon(link)}
-                <span className={'ms-Button-label test-name'}>{link.name}</span>
+                <span className={styles.testName}>{link.name}</span>
             </span>
         );
     },

--- a/src/electron/views/automated-checks/automated-checks-view.scss
+++ b/src/electron/views/automated-checks/automated-checks-view.scss
@@ -15,6 +15,11 @@
     top: $default-title-height !important;
 }
 
+.application-view {
+    display: flex;
+    height: calc(100% - (#{$default-title-height}));
+}
+
 .automated-checks-view {
     display: flex;
     flex-direction: column;
@@ -24,34 +29,29 @@
     -webkit-app-region: no-drag;
     background-color: $neutral-2;
 
-    .application-view {
+    .automated-checks-panel-container {
         display: flex;
-        height: calc(100% - (#{$default-title-height}));
+        flex-direction: column;
+        overflow: hidden;
+    }
 
-        .automated-checks-panel-container {
-            display: flex;
-            flex-direction: column;
-            overflow: hidden;
+    .automated-checks-panel-layout {
+        display: flex;
+        flex-grow: 1;
+        overflow: hidden;
+        main {
+            margin-top: 16px;
+            margin-bottom: 16px;
+            margin-left: 24px;
+            margin-right: 24px;
         }
-
-        .automated-checks-panel-layout {
-            display: flex;
+        .main-content-wrapper {
+            width: 70%;
             flex-grow: 1;
-            overflow: hidden;
-            main {
-                margin-top: 16px;
-                margin-bottom: 16px;
-                margin-left: 24px;
-                margin-right: 24px;
-            }
-            .main-content-wrapper {
-                width: 70%;
-                flex-grow: 1;
-                flex-shrink: 1;
-                flex-basis: auto;
-                overflow: auto;
-                min-width: 220px;
-            }
+            flex-shrink: 1;
+            flex-basis: auto;
+            overflow: auto;
+            min-width: 220px;
         }
     }
 }

--- a/src/electron/views/automated-checks/automated-checks-view.scss
+++ b/src/electron/views/automated-checks/automated-checks-view.scss
@@ -3,8 +3,13 @@
 @import '../../../common/styles/colors.scss';
 @import '../common/window-title/window-title-const.scss';
 
-:global(.is-mac-os) .settings-panel-layer-host {
-    top: $mac-title-height !important;
+:global(.is-mac-os) {
+    .settings-panel-layer-host {
+        top: $mac-title-height !important;
+    }
+    .application-view {
+        height: calc(100% - (#{$mac-title-height}));
+    }
 }
 .settings-panel-layer-host {
     top: $default-title-height !important;
@@ -21,7 +26,7 @@
 
     .application-view {
         display: flex;
-        height: calc(100% - (#{$mac-title-height}));
+        height: calc(100% - (#{$default-title-height}));
 
         .automated-checks-panel-container {
             display: flex;

--- a/src/electron/views/left-nav/left-nav.scss
+++ b/src/electron/views/left-nav/left-nav.scss
@@ -5,7 +5,7 @@
 .left-nav {
     display: flex;
     flex-direction: column;
-    width: 249px;
+    min-width: 249px;
     border-right: 1px solid $neutral-alpha-8;
     height: 100%;
 

--- a/src/electron/views/left-nav/left-nav.scss
+++ b/src/electron/views/left-nav/left-nav.scss
@@ -14,5 +14,16 @@
         align-items: center;
         height: 40px;
         border-bottom: 1px solid $neutral-alpha-8;
+
+        .rocket-icon {
+            padding-left: 16px;
+            padding-right: 16px;
+            font-size: 18px;
+        }
+
+        h3 {
+            font-size: 17px;
+            font-weight: 600;
+        }
     }
 }

--- a/src/electron/views/left-nav/left-nav.tsx
+++ b/src/electron/views/left-nav/left-nav.tsx
@@ -28,6 +28,11 @@ export const LeftNav = NamedFC<LeftNavProps>('LeftNav', props => {
         onClickNavLink: item.onSelect,
         onRenderNavLink: deps.navLinkRenderer.renderVisualizationLink,
         url: '',
+        index: index + 1,
+        iconProps: {
+            className: 'hidden',
+        },
+        forceAnchor: true,
     }));
 
     return (

--- a/src/electron/views/left-nav/left-nav.tsx
+++ b/src/electron/views/left-nav/left-nav.tsx
@@ -7,6 +7,7 @@ import { NavLinkRenderer } from 'DetailsView/components/left-nav/nav-link-render
 import { LeftNavItem } from 'electron/types/left-nav-item';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 import * as styles from 'electron/views/left-nav/left-nav.scss';
+import { Icon } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export type LeftNavDeps = {
@@ -31,7 +32,10 @@ export const LeftNav = NamedFC<LeftNavProps>('LeftNav', props => {
 
     return (
         <div className={styles.leftNav}>
-            <div className={styles.headerContainer}>FastPass</div>
+            <div className={styles.headerContainer}>
+                <Icon iconName={'Rocket'} className={styles.rocketIcon} />
+                <h3>FastPass</h3>
+            </div>
             <BaseLeftNav selectedKey={props.selectedKey} links={leftLinkItems} />
         </div>
     );

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-icon.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-icon.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`LeftNavIndexIcon render 1`] = `
 <span
-  className="index-circle"
+  className="indexCircle"
 >
   1
 </span>

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/test-view-left-nav-link.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/test-view-left-nav-link.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TestViewLeftNavLink renders 1`] = `
     test-props-renderIcon
   </i>
   <span
-    className="ms-Button-label test-name"
+    className="testName"
   >
     test-props-link-name
   </span>

--- a/src/tests/unit/tests/DetailsView/components/left-nav/test-view-left-nav-link.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/test-view-left-nav-link.test.tsx
@@ -19,7 +19,6 @@ describe('TestViewLeftNavLink', () => {
         };
 
         const wrapper = shallow(<TestViewLeftNavLink {...props} />);
-
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/electron/views/left-nav/__snapshots__/left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/left-nav/__snapshots__/left-nav.test.tsx.snap
@@ -7,7 +7,13 @@ exports[`LeftNav render 1`] = `
   <div
     className="headerContainer"
   >
-    FastPass
+    <StyledIconBase
+      className="rocketIcon"
+      iconName="Rocket"
+    />
+    <h3>
+      FastPass
+    </h3>
   </div>
   <BaseLeftNav
     links={

--- a/src/tests/unit/tests/electron/views/left-nav/__snapshots__/left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/left-nav/__snapshots__/left-nav.test.tsx.snap
@@ -19,6 +19,11 @@ exports[`LeftNav render 1`] = `
     links={
       Array [
         Object {
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 1,
           "key": "automated-checks",
           "name": "some display name",
           "onClickNavLink": [Function],
@@ -26,6 +31,11 @@ exports[`LeftNav render 1`] = `
           "url": "",
         },
         Object {
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 2,
           "key": "needs-review",
           "name": "some display name 2",
           "onClickNavLink": [Function],


### PR DESCRIPTION
#### Description of changes

1. Improve heading styles.
2. Improve styles of list component by using css-modules and sharing css.

Not in this PR: fixing the selection CSS.

Result:
![image](https://user-images.githubusercontent.com/32555133/94977893-c54f9300-04cf-11eb-8c93-71dbda2d8df0.png)

This impacts web as well, and it looks the same after the changes:
![image](https://user-images.githubusercontent.com/32555133/94977880-b23cc300-04cf-11eb-96ae-2c75273ba22a.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
