### PR TITLE
feat(android-left-nav): fix up selection css in left nav

### DIFF
--- a/src/DetailsView/components/base-left-nav.scss
+++ b/src/DetailsView/components/base-left-nav.scss
@@ -5,14 +5,34 @@
 .details-view-test-nav-area {
     box-sizing: border-box;
     overflow-x: hidden;
-    max-height: calc(
-        100vh - #{detailsViewNavPivotsHeight} - #{$detailsViewHeaderBarHeight} - #{$detailsViewCommandBarHeight}
-    );
     a {
         padding-right: 0px;
         &:focus {
             @media screen and (-ms-high-contrast: active) {
                 border: 3px highlighttext solid;
+            }
+        }
+    }
+
+    li {
+        :global {
+            .is-selected {
+                background-color: $nav-link-selected;
+                a,
+                button {
+                    background-color: $nav-link-selected !important;
+                }
+            }
+            .is-expanded,
+            .is-expanded + ul {
+                background-color: $nav-link-expanded;
+            }
+        }
+
+        :global(.ms-Nav-compositeLink):hover {
+            a,
+            button {
+                background-color: $nav-link-hover;
             }
         }
     }

--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -5,31 +5,6 @@
 @import '../../../common/styles/common.scss';
 
 .left-nav {
-    li {
-        :global {
-            .is-selected {
-                background-color: $nav-link-selected;
-                a,
-                button {
-                    background-color: $nav-link-selected !important;
-                }
-            }
-            .is-expanded,
-            .is-expanded + ul {
-                background-color: $nav-link-expanded;
-            }
-        }
-
-        > div:hover {
-            a,
-            button {
-                background-color: $nav-link-hover;
-            }
-        }
-    }
-}
-
-.left-nav {
     overflow-y: auto;
     border-right: 1px solid $neutral-8;
     z-index: 100;


### PR DESCRIPTION
#### Description of changes

Some of the details view (i.e. web) specific left nav css should not be so. This brings that css into the basic left nav css. Note: the naming is not great here, since we refer to the basic left nav css as `details-view-test-nav-area` which should be more generic.

I **did** validate that my web extension behaved the same as what we have in staging.

Screen-caps (after adding needs review locally): 
![image](https://user-images.githubusercontent.com/32555133/95122965-1cd74400-0706-11eb-9760-b34b677869fc.png)
![image](https://user-images.githubusercontent.com/32555133/95122996-295b9c80-0706-11eb-9dd1-42139ac2ca69.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
