### PR TITLE
feat(android-left-nav): change test view based on selected left nav key

### DIFF
--- a/src/electron/common/content-page-info-factory.ts
+++ b/src/electron/common/content-page-info-factory.ts
@@ -1,8 +1,6 @@
-import { ContentPageInfo, ContentPagesInfo } from 'electron/types/content-page-info';
-import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
+import { ContentPageInfo, ContentPagesInfo } from 'electron/types/content-page-info';
 import { TestConfig } from 'electron/types/test-config';
 
 export const createContentPagesInfo = (configs: TestConfig[]): ContentPagesInfo => {

--- a/src/electron/platform/android/test-configs/android-test-configs.ts
+++ b/src/electron/platform/android/test-configs/android-test-configs.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { automatedChecksTestConfig } from 'electron/platform/android/test-configs/automated-checks/test-config';
+import {
+    automatedChecksTestConfig,
+    needsReviewTestConfig,
+} from 'electron/platform/android/test-configs/automated-checks/test-config';
 import { TestConfig } from 'electron/types/test-config';
 
-export const androidTestConfigs: TestConfig[] = [automatedChecksTestConfig];
+export const androidTestConfigs: TestConfig[] = [automatedChecksTestConfig, needsReviewTestConfig];

--- a/src/electron/platform/android/test-configs/android-test-configs.ts
+++ b/src/electron/platform/android/test-configs/android-test-configs.ts
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {
-    automatedChecksTestConfig,
-    needsReviewTestConfig,
-} from 'electron/platform/android/test-configs/automated-checks/test-config';
+import { automatedChecksTestConfig } from 'electron/platform/android/test-configs/automated-checks/test-config';
+import { needsReviewTestConfig } from 'electron/platform/android/test-configs/needs-review/test-config';
 import { TestConfig } from 'electron/types/test-config';
 
 export const androidTestConfigs: TestConfig[] = [automatedChecksTestConfig, needsReviewTestConfig];

--- a/src/electron/platform/android/test-configs/automated-checks/test-config.tsx
+++ b/src/electron/platform/android/test-configs/automated-checks/test-config.tsx
@@ -1,12 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { HeaderSection } from 'electron/views/automated-checks/components/header-section';
 import * as React from 'react';
 import { TestConfig } from '../../../../types/test-config';
 
 export const automatedChecksTestConfig: TestConfig = {
     key: 'automated-checks',
     title: 'Automated checks',
-    description: <HeaderSection />,
+    description: (
+        <>
+            Automated checks can detect some common accessibility problems such as missing or
+            invalid properties. But most accessibility problems can only be discovered through
+            manual testing.
+        </>
+    ),
+};
+
+export const needsReviewTestConfig: TestConfig = {
+    key: 'needs-review',
+    title: 'Needs review',
+    description: (
+        <>
+            Sometimes automated checks identify <i>possible</i> accessibility problems that need to
+            be reviewed and verified by a human.
+        </>
+    ),
 };

--- a/src/electron/platform/android/test-configs/automated-checks/test-config.tsx
+++ b/src/electron/platform/android/test-configs/automated-checks/test-config.tsx
@@ -15,14 +15,3 @@ export const automatedChecksTestConfig: TestConfig = {
         </>
     ),
 };
-
-export const needsReviewTestConfig: TestConfig = {
-    key: 'needs-review',
-    title: 'Needs review',
-    description: (
-        <>
-            Sometimes automated checks identify <i>possible</i> accessibility problems that need to
-            be reviewed and verified by a human.
-        </>
-    ),
-};

--- a/src/electron/platform/android/test-configs/needs-review/test-config.tsx
+++ b/src/electron/platform/android/test-configs/needs-review/test-config.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as React from 'react';
+import { TestConfig } from '../../../../types/test-config';
+
+export const needsReviewTestConfig: TestConfig = {
+    key: 'needs-review',
+    title: 'Needs review',
+    description: (
+        <>
+            Sometimes automated checks identify <i>possible</i> accessibility problems that need to
+            be reviewed and verified by a human.
+        </>
+    ),
+};

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -1,6 +1,6 @@
-import { FlaggedComponent } from 'common/components/flagged-component';
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FlaggedComponent } from 'common/components/flagged-component';
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { GetCardViewData } from 'common/rule-based-view-model-provider';

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -27,7 +27,6 @@ import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { ContentPageInfo } from 'electron/types/content-page-info';
-import { HeaderSectionProps } from 'electron/views/automated-checks/components/header-section';
 import { TitleBar, TitleBarDeps } from 'electron/views/automated-checks/components/title-bar';
 import { TestView } from 'electron/views/automated-checks/test-view';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
@@ -103,7 +102,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
 
         const scanMetadata: ScanMetadata = this.getScanMetadata(status, unifiedScanResultStoreData);
 
-        const headerSectionProps: HeaderSectionProps = this.getHeaderSectionProps();
+        const contentPageInfo: ContentPageInfo = this.getContentPageInfo();
 
         return (
             <div
@@ -112,7 +111,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
             >
                 <TitleBar
                     deps={this.props.deps}
-                    pageTitle={headerSectionProps.title}
+                    pageTitle={contentPageInfo.title}
                     windowStateStoreData={this.props.windowStateStoreData}
                 ></TitleBar>
                 <div className={styles.applicationView}>
@@ -129,7 +128,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                                         scanMetadata={scanMetadata}
                                         userConfigurationStoreData={userConfigurationStoreData}
                                         cardsViewData={cardsViewData}
-                                        {...headerSectionProps}
+                                        contentPageInfo={contentPageInfo}
                                     />
                                 </main>
                             </div>
@@ -164,16 +163,9 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
         );
     }
 
-    private getHeaderSectionProps(): HeaderSectionProps {
+    private getContentPageInfo(): ContentPageInfo {
         const leftNavSelectedKey = this.props.leftNavStoreData.selectedKey;
-        const contentPageInfo: ContentPageInfo = this.props.deps.contentPagesInfo[
-            leftNavSelectedKey
-        ];
-
-        return {
-            title: contentPageInfo.title,
-            description: contentPageInfo.description,
-        };
+        return this.props.deps.contentPagesInfo[leftNavSelectedKey];
     }
 
     private getConnectedDeviceName(): string {

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -26,9 +26,12 @@ import { LeftNavStoreData } from 'electron/flux/types/left-nav-store-data';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
+import { ContentPageInfo } from 'electron/types/content-page-info';
+import { HeaderSectionProps } from 'electron/views/automated-checks/components/header-section';
 import { TitleBar, TitleBarDeps } from 'electron/views/automated-checks/components/title-bar';
 import { TestView } from 'electron/views/automated-checks/test-view';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
+import { ContentPanelDeps } from 'electron/views/left-nav/content-panel-deps';
 import { LeftNav, LeftNavDeps } from 'electron/views/left-nav/left-nav';
 import { ScreenshotView } from 'electron/views/screenshot/screenshot-view';
 import { ScreenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
@@ -42,6 +45,7 @@ export type AutomatedChecksViewDeps = CommandBarDeps &
     TitleBarDeps &
     CardsViewDeps &
     LeftNavDeps &
+    ContentPanelDeps &
     SettingsPanelDeps & {
         scanActionCreator: ScanActionCreator;
         windowStateActionCreator: WindowStateActionCreator;
@@ -99,6 +103,8 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
 
         const scanMetadata: ScanMetadata = this.getScanMetadata(status, unifiedScanResultStoreData);
 
+        const headerSectionProps: HeaderSectionProps = this.getHeaderSectionProps();
+
         return (
             <div
                 className={styles.automatedChecksView}
@@ -106,7 +112,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
             >
                 <TitleBar
                     deps={this.props.deps}
-                    pageTitle={'Automated checks'}
+                    pageTitle={headerSectionProps.title}
                     windowStateStoreData={this.props.windowStateStoreData}
                 ></TitleBar>
                 <div className={styles.applicationView}>
@@ -123,6 +129,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                                         scanMetadata={scanMetadata}
                                         userConfigurationStoreData={userConfigurationStoreData}
                                         cardsViewData={cardsViewData}
+                                        {...headerSectionProps}
                                     />
                                 </main>
                             </div>
@@ -155,6 +162,18 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                 }
             />
         );
+    }
+
+    private getHeaderSectionProps(): HeaderSectionProps {
+        const leftNavSelectedKey = this.props.leftNavStoreData.selectedKey;
+        const contentPageInfo: ContentPageInfo = this.props.deps.contentPagesInfo[
+            leftNavSelectedKey
+        ];
+
+        return {
+            title: contentPageInfo.title,
+            description: contentPageInfo.description,
+        };
     }
 
     private getConnectedDeviceName(): string {

--- a/src/electron/views/automated-checks/components/header-section.tsx
+++ b/src/electron/views/automated-checks/components/header-section.tsx
@@ -4,15 +4,17 @@ import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import * as styles from './header-section.scss';
 
-export const HeaderSection = NamedFC('HeaderSection', () => {
+export type HeaderSectionProps = {
+    title: string;
+    description: JSX.Element;
+};
+
+export const HeaderSection = NamedFC<HeaderSectionProps>('HeaderSection', props => {
+    const { title, description } = props;
     return (
         <div className={styles.headerSection}>
-            <h1 className={styles.title}>Automated checks</h1>
-            <p className={styles.subtitle}>
-                Automated checks can detect some common accessibility problems such as missing or
-                invalid properties. But most accessibility problems can only be discovered through
-                manual testing.
-            </p>
+            <h1 className={styles.title}>{title}</h1>
+            <p className={styles.subtitle}>{description}</p>
         </div>
     );
 });

--- a/src/electron/views/automated-checks/components/header-section.tsx
+++ b/src/electron/views/automated-checks/components/header-section.tsx
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
+import { ContentPageInfo } from 'electron/types/content-page-info';
 import * as React from 'react';
 import * as styles from './header-section.scss';
 
 export type HeaderSectionProps = {
-    title: string;
-    description: JSX.Element;
+    contentPageInfo: ContentPageInfo;
 };
 
 export const HeaderSection = NamedFC<HeaderSectionProps>('HeaderSection', props => {
-    const { title, description } = props;
+    const { title, description } = props.contentPageInfo;
     return (
         <div className={styles.headerSection}>
             <h1 className={styles.title}>{title}</h1>

--- a/src/electron/views/automated-checks/test-view.tsx
+++ b/src/electron/views/automated-checks/test-view.tsx
@@ -8,7 +8,10 @@ import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { CardsView, CardsViewDeps } from 'DetailsView/components/cards-view';
 import { ScanStatus } from 'electron/flux/types/scan-status';
-import { HeaderSection } from 'electron/views/automated-checks/components/header-section';
+import {
+    HeaderSection,
+    HeaderSectionProps,
+} from 'electron/views/automated-checks/components/header-section';
 import * as React from 'react';
 
 export type TestViewDeps = {} & CardsViewDeps;
@@ -18,15 +21,16 @@ export type TestViewProps = {
     scanMetadata: ScanMetadata;
     cardsViewData: CardsViewModel;
     userConfigurationStoreData: UserConfigurationStoreData;
-};
+} & HeaderSectionProps;
 
 export const TestView = NamedFC<TestViewProps>('TestView', props => {
     const { scanStatus, scanMetadata, cardsViewData, userConfigurationStoreData, deps } = props;
+    const { title, description } = props;
 
     if (scanStatus !== ScanStatus.Completed) {
         return (
             <>
-                <HeaderSection />
+                <HeaderSection title={title} description={description} />
                 <ScanningSpinner
                     isSpinning={scanStatus === ScanStatus.Scanning}
                     label="Scanning..."
@@ -38,7 +42,7 @@ export const TestView = NamedFC<TestViewProps>('TestView', props => {
 
     return (
         <>
-            <HeaderSection />
+            <HeaderSection title={title} description={description} />
             <CardsView
                 deps={deps}
                 scanMetadata={scanMetadata}

--- a/src/electron/views/automated-checks/test-view.tsx
+++ b/src/electron/views/automated-checks/test-view.tsx
@@ -24,8 +24,15 @@ export type TestViewProps = {
 } & HeaderSectionProps;
 
 export const TestView = NamedFC<TestViewProps>('TestView', props => {
-    const { scanStatus, scanMetadata, cardsViewData, userConfigurationStoreData, deps } = props;
-    const { title, description } = props;
+    const {
+        scanStatus,
+        scanMetadata,
+        cardsViewData,
+        userConfigurationStoreData,
+        deps,
+        title,
+        description,
+    } = props;
 
     if (scanStatus !== ScanStatus.Completed) {
         return (

--- a/src/electron/views/automated-checks/test-view.tsx
+++ b/src/electron/views/automated-checks/test-view.tsx
@@ -8,10 +8,8 @@ import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { CardsView, CardsViewDeps } from 'DetailsView/components/cards-view';
 import { ScanStatus } from 'electron/flux/types/scan-status';
-import {
-    HeaderSection,
-    HeaderSectionProps,
-} from 'electron/views/automated-checks/components/header-section';
+import { ContentPageInfo } from 'electron/types/content-page-info';
+import { HeaderSection } from 'electron/views/automated-checks/components/header-section';
 import * as React from 'react';
 
 export type TestViewDeps = {} & CardsViewDeps;
@@ -21,7 +19,8 @@ export type TestViewProps = {
     scanMetadata: ScanMetadata;
     cardsViewData: CardsViewModel;
     userConfigurationStoreData: UserConfigurationStoreData;
-} & HeaderSectionProps;
+    contentPageInfo: ContentPageInfo;
+};
 
 export const TestView = NamedFC<TestViewProps>('TestView', props => {
     const {
@@ -30,14 +29,13 @@ export const TestView = NamedFC<TestViewProps>('TestView', props => {
         cardsViewData,
         userConfigurationStoreData,
         deps,
-        title,
-        description,
+        contentPageInfo,
     } = props;
 
     if (scanStatus !== ScanStatus.Completed) {
         return (
             <>
-                <HeaderSection title={title} description={description} />
+                <HeaderSection contentPageInfo={contentPageInfo} />
                 <ScanningSpinner
                     isSpinning={scanStatus === ScanStatus.Scanning}
                     label="Scanning..."
@@ -49,7 +47,7 @@ export const TestView = NamedFC<TestViewProps>('TestView', props => {
 
     return (
         <>
-            <HeaderSection title={title} description={description} />
+            <HeaderSection contentPageInfo={contentPageInfo} />
             <CardsView
                 deps={deps}
                 scanMetadata={scanMetadata}

--- a/src/electron/views/root-container/root-container-renderer.tsx
+++ b/src/electron/views/root-container/root-container-renderer.tsx
@@ -13,13 +13,10 @@ import {
 } from 'electron/views/root-container/components/root-container';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { ContentPanelDeps } from '../left-nav/content-panel-deps';
 
 export type RootContainerRendererDeps = RootContainerDeps &
     ThemeDeps &
-    PlatformBodyClassModifierDeps &
-    LeftNavDeps &
-    ContentPanelDeps;
+    PlatformBodyClassModifierDeps;
 
 export class RootContainerRenderer {
     constructor(

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -1,5 +1,137 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AutomatedChecksView right content panel info changes when left nav selected key changes 1`] = `
+<TestView
+  cardsViewData={
+    Object {
+      "cards": Object {
+        "fail": Array [
+          Object {
+            "id": "test-fail-id",
+          },
+        ],
+      },
+    }
+  }
+  deps={
+    Object {
+      "contentPagesInfo": Object {
+        "automated-checks": Object {
+          "description": <React.Fragment>
+            test 
+            automated-checks
+             description
+          </React.Fragment>,
+          "title": "test-automated-checks-title",
+        },
+        "needs-review": Object {
+          "description": <React.Fragment>
+            test 
+            needs-review
+             description
+          </React.Fragment>,
+          "title": "test-needs-review-title",
+        },
+      },
+      "getCardSelectionViewData": [Function],
+      "getCardsViewData": [Function],
+      "isResultHighlightUnavailable": [Function],
+      "scanActionCreator": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "deviceActions": undefined,
+        "scanActions": undefined,
+      },
+      "screenshotViewModelProvider": [Function],
+      "toolData": Object {
+        "applicationProperties": Object {
+          "name": "some app",
+        },
+      },
+    }
+  }
+  description={
+    <React.Fragment>
+      test 
+      needs-review
+       description
+    </React.Fragment>
+  }
+  scanMetadata={null}
+  title="test-needs-review-title"
+  userConfigurationStoreData={
+    Object {
+      "isFirstTime": false,
+    }
+  }
+/>
+`;
+
+exports[`AutomatedChecksView right content panel info renders with default/initial value 1`] = `
+<TestView
+  cardsViewData={
+    Object {
+      "cards": Object {
+        "fail": Array [
+          Object {
+            "id": "test-fail-id",
+          },
+        ],
+      },
+    }
+  }
+  deps={
+    Object {
+      "contentPagesInfo": Object {
+        "automated-checks": Object {
+          "description": <React.Fragment>
+            test 
+            automated-checks
+             description
+          </React.Fragment>,
+          "title": "test-automated-checks-title",
+        },
+        "needs-review": Object {
+          "description": <React.Fragment>
+            test 
+            needs-review
+             description
+          </React.Fragment>,
+          "title": "test-needs-review-title",
+        },
+      },
+      "getCardSelectionViewData": [Function],
+      "getCardsViewData": [Function],
+      "isResultHighlightUnavailable": [Function],
+      "scanActionCreator": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "deviceActions": undefined,
+        "scanActions": undefined,
+      },
+      "screenshotViewModelProvider": [Function],
+      "toolData": Object {
+        "applicationProperties": Object {
+          "name": "some app",
+        },
+      },
+    }
+  }
+  description={
+    <React.Fragment>
+      test 
+      automated-checks
+       description
+    </React.Fragment>
+  }
+  scanMetadata={null}
+  title="test-automated-checks-title"
+  userConfigurationStoreData={
+    Object {
+      "isFirstTime": false,
+    }
+  }
+/>
+`;
+
 exports[`AutomatedChecksView when status scan <Completed> 1`] = `
 <div
   className="automatedChecksView"
@@ -8,6 +140,24 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
   <TitleBar
     deps={
       Object {
+        "contentPagesInfo": Object {
+          "automated-checks": Object {
+            "description": <React.Fragment>
+              test 
+              automated-checks
+               description
+            </React.Fragment>,
+            "title": "test-automated-checks-title",
+          },
+          "needs-review": Object {
+            "description": <React.Fragment>
+              test 
+              needs-review
+               description
+            </React.Fragment>,
+            "title": "test-needs-review-title",
+          },
+        },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
         "isResultHighlightUnavailable": [Function],
@@ -24,7 +174,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
         },
       }
     }
-    pageTitle="Automated checks"
+    pageTitle="test-automated-checks-title"
   />
   <div
     className="applicationView"
@@ -34,6 +184,24 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
         <LeftNav
           deps={
             Object {
+              "contentPagesInfo": Object {
+                "automated-checks": Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "title": "test-automated-checks-title",
+                },
+                "needs-review": Object {
+                  "description": <React.Fragment>
+                    test 
+                    needs-review
+                     description
+                  </React.Fragment>,
+                  "title": "test-needs-review-title",
+                },
+              },
               "getCardSelectionViewData": [Function],
               "getCardsViewData": [Function],
               "isResultHighlightUnavailable": [Function],
@@ -75,6 +243,24 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
             }
             deps={
               Object {
+                "contentPagesInfo": Object {
+                  "automated-checks": Object {
+                    "description": <React.Fragment>
+                      test 
+                      automated-checks
+                       description
+                    </React.Fragment>,
+                    "title": "test-automated-checks-title",
+                  },
+                  "needs-review": Object {
+                    "description": <React.Fragment>
+                      test 
+                      needs-review
+                       description
+                    </React.Fragment>,
+                    "title": "test-needs-review-title",
+                  },
+                },
                 "getCardSelectionViewData": [Function],
                 "getCardsViewData": [Function],
                 "isResultHighlightUnavailable": [Function],
@@ -136,6 +322,24 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                 }
                 deps={
                   Object {
+                    "contentPagesInfo": Object {
+                      "automated-checks": Object {
+                        "description": <React.Fragment>
+                          test 
+                          automated-checks
+                           description
+                        </React.Fragment>,
+                        "title": "test-automated-checks-title",
+                      },
+                      "needs-review": Object {
+                        "description": <React.Fragment>
+                          test 
+                          needs-review
+                           description
+                        </React.Fragment>,
+                        "title": "test-needs-review-title",
+                      },
+                    },
                     "getCardSelectionViewData": [Function],
                     "getCardsViewData": [Function],
                     "isResultHighlightUnavailable": [Function],
@@ -191,6 +395,24 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
               }
               deps={
                 Object {
+                  "contentPagesInfo": Object {
+                    "automated-checks": Object {
+                      "description": <React.Fragment>
+                        test 
+                        automated-checks
+                         description
+                      </React.Fragment>,
+                      "title": "test-automated-checks-title",
+                    },
+                    "needs-review": Object {
+                      "description": <React.Fragment>
+                        test 
+                        needs-review
+                         description
+                      </React.Fragment>,
+                      "title": "test-needs-review-title",
+                    },
+                  },
                   "getCardSelectionViewData": [Function],
                   "getCardsViewData": [Function],
                   "isResultHighlightUnavailable": [Function],
@@ -207,6 +429,13 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                   },
                 }
               }
+              description={
+                <React.Fragment>
+                  test 
+                  automated-checks
+                   description
+                </React.Fragment>
+              }
               scanMetadata={
                 Object {
                   "deviceName": "TEST DEVICE",
@@ -222,6 +451,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                 }
               }
               scanStatus={2}
+              title="test-automated-checks-title"
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,
@@ -245,6 +475,24 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
   <SettingsPanel
     deps={
       Object {
+        "contentPagesInfo": Object {
+          "automated-checks": Object {
+            "description": <React.Fragment>
+              test 
+              automated-checks
+               description
+            </React.Fragment>,
+            "title": "test-automated-checks-title",
+          },
+          "needs-review": Object {
+            "description": <React.Fragment>
+              test 
+              needs-review
+               description
+            </React.Fragment>,
+            "title": "test-needs-review-title",
+          },
+        },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
         "isResultHighlightUnavailable": [Function],
@@ -280,6 +528,24 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
   <TitleBar
     deps={
       Object {
+        "contentPagesInfo": Object {
+          "automated-checks": Object {
+            "description": <React.Fragment>
+              test 
+              automated-checks
+               description
+            </React.Fragment>,
+            "title": "test-automated-checks-title",
+          },
+          "needs-review": Object {
+            "description": <React.Fragment>
+              test 
+              needs-review
+               description
+            </React.Fragment>,
+            "title": "test-needs-review-title",
+          },
+        },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
         "isResultHighlightUnavailable": [Function],
@@ -296,7 +562,7 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
         },
       }
     }
-    pageTitle="Automated checks"
+    pageTitle="test-automated-checks-title"
   />
   <div
     className="applicationView"
@@ -306,6 +572,24 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
         <LeftNav
           deps={
             Object {
+              "contentPagesInfo": Object {
+                "automated-checks": Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "title": "test-automated-checks-title",
+                },
+                "needs-review": Object {
+                  "description": <React.Fragment>
+                    test 
+                    needs-review
+                     description
+                  </React.Fragment>,
+                  "title": "test-needs-review-title",
+                },
+              },
               "getCardSelectionViewData": [Function],
               "getCardsViewData": [Function],
               "isResultHighlightUnavailable": [Function],
@@ -347,6 +631,24 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
             }
             deps={
               Object {
+                "contentPagesInfo": Object {
+                  "automated-checks": Object {
+                    "description": <React.Fragment>
+                      test 
+                      automated-checks
+                       description
+                    </React.Fragment>,
+                    "title": "test-automated-checks-title",
+                  },
+                  "needs-review": Object {
+                    "description": <React.Fragment>
+                      test 
+                      needs-review
+                       description
+                    </React.Fragment>,
+                    "title": "test-needs-review-title",
+                  },
+                },
                 "getCardSelectionViewData": [Function],
                 "getCardsViewData": [Function],
                 "isResultHighlightUnavailable": [Function],
@@ -395,6 +697,24 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                 }
                 deps={
                   Object {
+                    "contentPagesInfo": Object {
+                      "automated-checks": Object {
+                        "description": <React.Fragment>
+                          test 
+                          automated-checks
+                           description
+                        </React.Fragment>,
+                        "title": "test-automated-checks-title",
+                      },
+                      "needs-review": Object {
+                        "description": <React.Fragment>
+                          test 
+                          needs-review
+                           description
+                        </React.Fragment>,
+                        "title": "test-needs-review-title",
+                      },
+                    },
                     "getCardSelectionViewData": [Function],
                     "getCardsViewData": [Function],
                     "isResultHighlightUnavailable": [Function],
@@ -437,6 +757,24 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
               }
               deps={
                 Object {
+                  "contentPagesInfo": Object {
+                    "automated-checks": Object {
+                      "description": <React.Fragment>
+                        test 
+                        automated-checks
+                         description
+                      </React.Fragment>,
+                      "title": "test-automated-checks-title",
+                    },
+                    "needs-review": Object {
+                      "description": <React.Fragment>
+                        test 
+                        needs-review
+                         description
+                      </React.Fragment>,
+                      "title": "test-needs-review-title",
+                    },
+                  },
                   "getCardSelectionViewData": [Function],
                   "getCardsViewData": [Function],
                   "isResultHighlightUnavailable": [Function],
@@ -453,8 +791,16 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                   },
                 }
               }
+              description={
+                <React.Fragment>
+                  test 
+                  automated-checks
+                   description
+                </React.Fragment>
+              }
               scanMetadata={null}
               scanStatus={3}
+              title="test-automated-checks-title"
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,
@@ -482,6 +828,24 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
   <SettingsPanel
     deps={
       Object {
+        "contentPagesInfo": Object {
+          "automated-checks": Object {
+            "description": <React.Fragment>
+              test 
+              automated-checks
+               description
+            </React.Fragment>,
+            "title": "test-automated-checks-title",
+          },
+          "needs-review": Object {
+            "description": <React.Fragment>
+              test 
+              needs-review
+               description
+            </React.Fragment>,
+            "title": "test-needs-review-title",
+          },
+        },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
         "isResultHighlightUnavailable": [Function],
@@ -517,6 +881,24 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
   <TitleBar
     deps={
       Object {
+        "contentPagesInfo": Object {
+          "automated-checks": Object {
+            "description": <React.Fragment>
+              test 
+              automated-checks
+               description
+            </React.Fragment>,
+            "title": "test-automated-checks-title",
+          },
+          "needs-review": Object {
+            "description": <React.Fragment>
+              test 
+              needs-review
+               description
+            </React.Fragment>,
+            "title": "test-needs-review-title",
+          },
+        },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
         "isResultHighlightUnavailable": [Function],
@@ -533,7 +915,7 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
         },
       }
     }
-    pageTitle="Automated checks"
+    pageTitle="test-automated-checks-title"
   />
   <div
     className="applicationView"
@@ -543,6 +925,24 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
         <LeftNav
           deps={
             Object {
+              "contentPagesInfo": Object {
+                "automated-checks": Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "title": "test-automated-checks-title",
+                },
+                "needs-review": Object {
+                  "description": <React.Fragment>
+                    test 
+                    needs-review
+                     description
+                  </React.Fragment>,
+                  "title": "test-needs-review-title",
+                },
+              },
               "getCardSelectionViewData": [Function],
               "getCardsViewData": [Function],
               "isResultHighlightUnavailable": [Function],
@@ -584,6 +984,24 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
             }
             deps={
               Object {
+                "contentPagesInfo": Object {
+                  "automated-checks": Object {
+                    "description": <React.Fragment>
+                      test 
+                      automated-checks
+                       description
+                    </React.Fragment>,
+                    "title": "test-automated-checks-title",
+                  },
+                  "needs-review": Object {
+                    "description": <React.Fragment>
+                      test 
+                      needs-review
+                       description
+                    </React.Fragment>,
+                    "title": "test-needs-review-title",
+                  },
+                },
                 "getCardSelectionViewData": [Function],
                 "getCardsViewData": [Function],
                 "isResultHighlightUnavailable": [Function],
@@ -632,6 +1050,24 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                 }
                 deps={
                   Object {
+                    "contentPagesInfo": Object {
+                      "automated-checks": Object {
+                        "description": <React.Fragment>
+                          test 
+                          automated-checks
+                           description
+                        </React.Fragment>,
+                        "title": "test-automated-checks-title",
+                      },
+                      "needs-review": Object {
+                        "description": <React.Fragment>
+                          test 
+                          needs-review
+                           description
+                        </React.Fragment>,
+                        "title": "test-needs-review-title",
+                      },
+                    },
                     "getCardSelectionViewData": [Function],
                     "getCardsViewData": [Function],
                     "isResultHighlightUnavailable": [Function],
@@ -674,6 +1110,24 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
               }
               deps={
                 Object {
+                  "contentPagesInfo": Object {
+                    "automated-checks": Object {
+                      "description": <React.Fragment>
+                        test 
+                        automated-checks
+                         description
+                      </React.Fragment>,
+                      "title": "test-automated-checks-title",
+                    },
+                    "needs-review": Object {
+                      "description": <React.Fragment>
+                        test 
+                        needs-review
+                         description
+                      </React.Fragment>,
+                      "title": "test-needs-review-title",
+                    },
+                  },
                   "getCardSelectionViewData": [Function],
                   "getCardsViewData": [Function],
                   "isResultHighlightUnavailable": [Function],
@@ -690,8 +1144,16 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                   },
                 }
               }
+              description={
+                <React.Fragment>
+                  test 
+                  automated-checks
+                   description
+                </React.Fragment>
+              }
               scanMetadata={null}
               scanStatus={1}
+              title="test-automated-checks-title"
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,
@@ -715,6 +1177,24 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
   <SettingsPanel
     deps={
       Object {
+        "contentPagesInfo": Object {
+          "automated-checks": Object {
+            "description": <React.Fragment>
+              test 
+              automated-checks
+               description
+            </React.Fragment>,
+            "title": "test-automated-checks-title",
+          },
+          "needs-review": Object {
+            "description": <React.Fragment>
+              test 
+              needs-review
+               description
+            </React.Fragment>,
+            "title": "test-needs-review-title",
+          },
+        },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
         "isResultHighlightUnavailable": [Function],
@@ -750,6 +1230,24 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
   <TitleBar
     deps={
       Object {
+        "contentPagesInfo": Object {
+          "automated-checks": Object {
+            "description": <React.Fragment>
+              test 
+              automated-checks
+               description
+            </React.Fragment>,
+            "title": "test-automated-checks-title",
+          },
+          "needs-review": Object {
+            "description": <React.Fragment>
+              test 
+              needs-review
+               description
+            </React.Fragment>,
+            "title": "test-needs-review-title",
+          },
+        },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
         "isResultHighlightUnavailable": [Function],
@@ -766,7 +1264,7 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
         },
       }
     }
-    pageTitle="Automated checks"
+    pageTitle="test-automated-checks-title"
   />
   <div
     className="applicationView"
@@ -776,6 +1274,24 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
         <LeftNav
           deps={
             Object {
+              "contentPagesInfo": Object {
+                "automated-checks": Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "title": "test-automated-checks-title",
+                },
+                "needs-review": Object {
+                  "description": <React.Fragment>
+                    test 
+                    needs-review
+                     description
+                  </React.Fragment>,
+                  "title": "test-needs-review-title",
+                },
+              },
               "getCardSelectionViewData": [Function],
               "getCardsViewData": [Function],
               "isResultHighlightUnavailable": [Function],
@@ -817,6 +1333,24 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
             }
             deps={
               Object {
+                "contentPagesInfo": Object {
+                  "automated-checks": Object {
+                    "description": <React.Fragment>
+                      test 
+                      automated-checks
+                       description
+                    </React.Fragment>,
+                    "title": "test-automated-checks-title",
+                  },
+                  "needs-review": Object {
+                    "description": <React.Fragment>
+                      test 
+                      needs-review
+                       description
+                    </React.Fragment>,
+                    "title": "test-needs-review-title",
+                  },
+                },
                 "getCardSelectionViewData": [Function],
                 "getCardsViewData": [Function],
                 "isResultHighlightUnavailable": [Function],
@@ -865,6 +1399,24 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                 }
                 deps={
                   Object {
+                    "contentPagesInfo": Object {
+                      "automated-checks": Object {
+                        "description": <React.Fragment>
+                          test 
+                          automated-checks
+                           description
+                        </React.Fragment>,
+                        "title": "test-automated-checks-title",
+                      },
+                      "needs-review": Object {
+                        "description": <React.Fragment>
+                          test 
+                          needs-review
+                           description
+                        </React.Fragment>,
+                        "title": "test-needs-review-title",
+                      },
+                    },
                     "getCardSelectionViewData": [Function],
                     "getCardsViewData": [Function],
                     "isResultHighlightUnavailable": [Function],
@@ -907,6 +1459,24 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
               }
               deps={
                 Object {
+                  "contentPagesInfo": Object {
+                    "automated-checks": Object {
+                      "description": <React.Fragment>
+                        test 
+                        automated-checks
+                         description
+                      </React.Fragment>,
+                      "title": "test-automated-checks-title",
+                    },
+                    "needs-review": Object {
+                      "description": <React.Fragment>
+                        test 
+                        needs-review
+                         description
+                      </React.Fragment>,
+                      "title": "test-needs-review-title",
+                    },
+                  },
                   "getCardSelectionViewData": [Function],
                   "getCardsViewData": [Function],
                   "isResultHighlightUnavailable": [Function],
@@ -923,7 +1493,15 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                   },
                 }
               }
+              description={
+                <React.Fragment>
+                  test 
+                  automated-checks
+                   description
+                </React.Fragment>
+              }
               scanMetadata={null}
+              title="test-automated-checks-title"
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,
@@ -947,6 +1525,24 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
   <SettingsPanel
     deps={
       Object {
+        "contentPagesInfo": Object {
+          "automated-checks": Object {
+            "description": <React.Fragment>
+              test 
+              automated-checks
+               description
+            </React.Fragment>,
+            "title": "test-automated-checks-title",
+          },
+          "needs-review": Object {
+            "description": <React.Fragment>
+              test 
+              needs-review
+               description
+            </React.Fragment>,
+            "title": "test-needs-review-title",
+          },
+        },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
         "isResultHighlightUnavailable": [Function],

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -13,6 +13,16 @@ exports[`AutomatedChecksView right content panel info changes when left nav sele
       },
     }
   }
+  contentPageInfo={
+    Object {
+      "description": <React.Fragment>
+        test 
+        needs-review
+         description
+      </React.Fragment>,
+      "title": "test-needs-review-title",
+    }
+  }
   deps={
     Object {
       "contentPagesInfo": Object {
@@ -49,15 +59,7 @@ exports[`AutomatedChecksView right content panel info changes when left nav sele
       },
     }
   }
-  description={
-    <React.Fragment>
-      test 
-      needs-review
-       description
-    </React.Fragment>
-  }
   scanMetadata={null}
-  title="test-needs-review-title"
   userConfigurationStoreData={
     Object {
       "isFirstTime": false,
@@ -79,6 +81,16 @@ exports[`AutomatedChecksView right content panel info renders with default/initi
       },
     }
   }
+  contentPageInfo={
+    Object {
+      "description": <React.Fragment>
+        test 
+        automated-checks
+         description
+      </React.Fragment>,
+      "title": "test-automated-checks-title",
+    }
+  }
   deps={
     Object {
       "contentPagesInfo": Object {
@@ -115,15 +127,7 @@ exports[`AutomatedChecksView right content panel info renders with default/initi
       },
     }
   }
-  description={
-    <React.Fragment>
-      test 
-      automated-checks
-       description
-    </React.Fragment>
-  }
   scanMetadata={null}
-  title="test-automated-checks-title"
   userConfigurationStoreData={
     Object {
       "isFirstTime": false,
@@ -393,6 +397,16 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                   },
                 }
               }
+              contentPageInfo={
+                Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "title": "test-automated-checks-title",
+                }
+              }
               deps={
                 Object {
                   "contentPagesInfo": Object {
@@ -429,13 +443,6 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                   },
                 }
               }
-              description={
-                <React.Fragment>
-                  test 
-                  automated-checks
-                   description
-                </React.Fragment>
-              }
               scanMetadata={
                 Object {
                   "deviceName": "TEST DEVICE",
@@ -451,7 +458,6 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                 }
               }
               scanStatus={2}
-              title="test-automated-checks-title"
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,
@@ -755,6 +761,16 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                   },
                 }
               }
+              contentPageInfo={
+                Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "title": "test-automated-checks-title",
+                }
+              }
               deps={
                 Object {
                   "contentPagesInfo": Object {
@@ -791,16 +807,8 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                   },
                 }
               }
-              description={
-                <React.Fragment>
-                  test 
-                  automated-checks
-                   description
-                </React.Fragment>
-              }
               scanMetadata={null}
               scanStatus={3}
-              title="test-automated-checks-title"
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,
@@ -1108,6 +1116,16 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                   },
                 }
               }
+              contentPageInfo={
+                Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "title": "test-automated-checks-title",
+                }
+              }
               deps={
                 Object {
                   "contentPagesInfo": Object {
@@ -1144,16 +1162,8 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                   },
                 }
               }
-              description={
-                <React.Fragment>
-                  test 
-                  automated-checks
-                   description
-                </React.Fragment>
-              }
               scanMetadata={null}
               scanStatus={1}
-              title="test-automated-checks-title"
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,
@@ -1457,6 +1467,16 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                   },
                 }
               }
+              contentPageInfo={
+                Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "title": "test-automated-checks-title",
+                }
+              }
               deps={
                 Object {
                   "contentPagesInfo": Object {
@@ -1493,15 +1513,7 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                   },
                 }
               }
-              description={
-                <React.Fragment>
-                  test 
-                  automated-checks
-                   description
-                </React.Fragment>
-              }
               scanMetadata={null}
-              title="test-automated-checks-title"
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/test-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/test-view.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`TestView when status scan <Completed> 1`] = `
 <React.Fragment>
-  <HeaderSection />
+  <HeaderSection
+    title="some title"
+  />
   <CardsView
     cardsViewData={
       Object {
@@ -26,7 +28,9 @@ exports[`TestView when status scan <Completed> 1`] = `
 
 exports[`TestView when status scan <Failed> 1`] = `
 <React.Fragment>
-  <HeaderSection />
+  <HeaderSection
+    title="some title"
+  />
   <ScanningSpinner
     aria-live="assertive"
     isSpinning={false}
@@ -37,7 +41,9 @@ exports[`TestView when status scan <Failed> 1`] = `
 
 exports[`TestView when status scan <Scanning> 1`] = `
 <React.Fragment>
-  <HeaderSection />
+  <HeaderSection
+    title="some title"
+  />
   <ScanningSpinner
     aria-live="assertive"
     isSpinning={true}
@@ -48,7 +54,9 @@ exports[`TestView when status scan <Scanning> 1`] = `
 
 exports[`TestView when status scan <undefined> 1`] = `
 <React.Fragment>
-  <HeaderSection />
+  <HeaderSection
+    title="some title"
+  />
   <ScanningSpinner
     aria-live="assertive"
     isSpinning={false}

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/test-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/test-view.test.tsx.snap
@@ -3,7 +3,11 @@
 exports[`TestView when status scan <Completed> 1`] = `
 <React.Fragment>
   <HeaderSection
-    title="some title"
+    contentPageInfo={
+      Object {
+        "title": "some title",
+      }
+    }
   />
   <CardsView
     cardsViewData={
@@ -29,7 +33,11 @@ exports[`TestView when status scan <Completed> 1`] = `
 exports[`TestView when status scan <Failed> 1`] = `
 <React.Fragment>
   <HeaderSection
-    title="some title"
+    contentPageInfo={
+      Object {
+        "title": "some title",
+      }
+    }
   />
   <ScanningSpinner
     aria-live="assertive"
@@ -42,7 +50,11 @@ exports[`TestView when status scan <Failed> 1`] = `
 exports[`TestView when status scan <Scanning> 1`] = `
 <React.Fragment>
   <HeaderSection
-    title="some title"
+    contentPageInfo={
+      Object {
+        "title": "some title",
+      }
+    }
   />
   <ScanningSpinner
     aria-live="assertive"
@@ -55,7 +67,11 @@ exports[`TestView when status scan <Scanning> 1`] = `
 exports[`TestView when status scan <undefined> 1`] = `
 <React.Fragment>
   <HeaderSection
-    title="some title"
+    contentPageInfo={
+      Object {
+        "title": "some title",
+      }
+    }
   />
   <ScanningSpinner
     aria-live="assertive"

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -94,7 +94,7 @@ describe('AutomatedChecksView', () => {
             },
         } as ScreenshotViewModel;
 
-        const contentPagesInfo = createContentPagesInfoStub();
+        const contentPagesInfo = createContentPagesInfo();
 
         screenshotViewModelProviderMock = Mock.ofInstance(screenshotViewModelProvider);
         getCardSelectionViewDataMock = Mock.ofInstance(getCardSelectionViewData);
@@ -144,7 +144,7 @@ describe('AutomatedChecksView', () => {
             .verifiable(Times.once());
     });
 
-    const createContentPagesInfoStub = (): ContentPagesInfo => {
+    const createContentPagesInfo = (): ContentPagesInfo => {
         const leftNavItemKeys: LeftNavItemKey[] = ['automated-checks', 'needs-review'];
         const contentPagesInfo = {} as ContentPagesInfo;
         leftNavItemKeys.forEach(

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -21,20 +21,25 @@ import {
     UnifiedScanResultStoreData,
 } from 'common/types/store-data/unified-data-interface';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { LeftNavStoreData } from 'electron/flux/types/left-nav-store-data';
 import { ScanStatus } from 'electron/flux/types/scan-status';
+import { ContentPagesInfo } from 'electron/types/content-page-info';
+import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 import {
     AutomatedChecksView,
     AutomatedChecksViewProps,
 } from 'electron/views/automated-checks/automated-checks-view';
+import { TitleBar } from 'electron/views/automated-checks/components/title-bar';
+import { TestView } from 'electron/views/automated-checks/test-view';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
 import { ScreenshotViewModel } from 'electron/views/screenshot/screenshot-view-model';
 import { screenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
-import { LeftNavStoreData } from 'electron/flux/types/left-nav-store-data';
 
 describe('AutomatedChecksView', () => {
+    const initialSelectedKey: LeftNavItemKey = 'automated-checks';
     let isResultHighlightUnavailableStub: IsResultHighlightUnavailable;
     let props: AutomatedChecksViewProps;
     let screenshotViewModelProviderMock = Mock.ofInstance(screenshotViewModelProvider);
@@ -74,7 +79,7 @@ describe('AutomatedChecksView', () => {
             } as PlatformData,
         };
         const leftNavStoreData: LeftNavStoreData = {
-            selectedKey: 'automated-checks',
+            selectedKey: initialSelectedKey,
         };
 
         const ruleResultsByStatusStub = {
@@ -89,6 +94,8 @@ describe('AutomatedChecksView', () => {
             },
         } as ScreenshotViewModel;
 
+        const contentPagesInfo = createContentPagesInfoStub();
+
         screenshotViewModelProviderMock = Mock.ofInstance(screenshotViewModelProvider);
         getCardSelectionViewDataMock = Mock.ofInstance(getCardSelectionViewData);
         getUnifiedRuleResultsMock = Mock.ofInstance(getCardViewData);
@@ -100,6 +107,7 @@ describe('AutomatedChecksView', () => {
                 getCardSelectionViewData: getCardSelectionViewDataMock.object,
                 screenshotViewModelProvider: screenshotViewModelProviderMock.object,
                 isResultHighlightUnavailable: isResultHighlightUnavailableStub,
+                contentPagesInfo: contentPagesInfo,
             },
             cardSelectionStoreData,
             androidSetupStoreData: {},
@@ -136,6 +144,20 @@ describe('AutomatedChecksView', () => {
             .verifiable(Times.once());
     });
 
+    const createContentPagesInfoStub = (): ContentPagesInfo => {
+        const leftNavItemKeys: LeftNavItemKey[] = ['automated-checks', 'needs-review'];
+        const contentPagesInfo = {} as ContentPagesInfo;
+        leftNavItemKeys.forEach(
+            key =>
+                (contentPagesInfo[key] = {
+                    title: `test-${key}-title`,
+                    description: <>test {key} description</>,
+                }),
+        );
+
+        return contentPagesInfo;
+    };
+
     const scanStatuses = [
         undefined,
         ScanStatus[ScanStatus.Scanning],
@@ -166,6 +188,29 @@ describe('AutomatedChecksView', () => {
         shallow(<AutomatedChecksView {...props} />);
 
         scanActionCreatorMock.verifyAll();
+    });
+
+    describe('right content panel info', () => {
+        it('renders with default/initial value', () => {
+            const expectedTitle = `test-${initialSelectedKey}-title`;
+
+            const wrapped = shallow(<AutomatedChecksView {...props} />);
+
+            expect(wrapped.find(TitleBar).props().pageTitle).toEqual(expectedTitle);
+            expect(wrapped.find(TestView).getElement()).toMatchSnapshot();
+        });
+
+        it('changes when left nav selected key changes', () => {
+            const changedSelectedKey = 'needs-review';
+            const expectedTitle = `test-${changedSelectedKey}-title`;
+
+            props.leftNavStoreData.selectedKey = changedSelectedKey;
+
+            const wrapped = shallow(<AutomatedChecksView {...props} />);
+
+            expect(wrapped.find(TitleBar).props().pageTitle).toEqual(expectedTitle);
+            expect(wrapped.find(TestView).getElement()).toMatchSnapshot();
+        });
     });
 
     describe('DeviceDisconnectedPopup event handlers', () => {

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/header-section.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/header-section.test.tsx.snap
@@ -7,12 +7,14 @@ exports[`HeaderSection renders 1`] = `
   <h1
     className="title"
   >
-    Automated checks
+    test-title
   </h1>
   <p
     className="subtitle"
   >
-    Automated checks can detect some common accessibility problems such as missing or invalid properties. But most accessibility problems can only be discovered through manual testing.
+    <React.Fragment>
+      test-description
+    </React.Fragment>
   </p>
 </div>
 `;

--- a/src/tests/unit/tests/electron/views/automated-checks/components/header-section.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/header-section.test.tsx
@@ -1,12 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { HeaderSection } from 'electron/views/automated-checks/components/header-section';
+import {
+    HeaderSection,
+    HeaderSectionProps,
+} from 'electron/views/automated-checks/components/header-section';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('HeaderSection', () => {
+    const props: HeaderSectionProps = {
+        title: 'test-title',
+        description: <>test-description</>,
+    };
     it('renders', () => {
-        const wrapper = shallow(<HeaderSection />);
+        const wrapper = shallow(<HeaderSection {...props} />);
 
         expect(wrapper.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/electron/views/automated-checks/components/header-section.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/header-section.test.tsx
@@ -9,9 +9,12 @@ import * as React from 'react';
 
 describe('HeaderSection', () => {
     const props: HeaderSectionProps = {
-        title: 'test-title',
-        description: <>test-description</>,
+        contentPageInfo: {
+            title: 'test-title',
+            description: <>test-description</>,
+        },
     };
+
     it('renders', () => {
         const wrapper = shallow(<HeaderSection {...props} />);
 

--- a/src/tests/unit/tests/electron/views/automated-checks/test-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/test-view.test.tsx
@@ -5,7 +5,7 @@ import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { ScanStatus } from 'electron/flux/types/scan-status';
-import { HeaderSectionProps } from 'electron/views/automated-checks/components/header-section';
+import { ContentPageInfo } from 'electron/types/content-page-info';
 import { TestView, TestViewDeps, TestViewProps } from 'electron/views/automated-checks/test-view';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -15,7 +15,7 @@ describe('TestView', () => {
     let scanMetadataStub: ScanMetadata;
     let cardsViewDataStub: CardsViewModel;
     let userConfigurationStoreDataStub: UserConfigurationStoreData;
-    let headerSectionProps: HeaderSectionProps;
+    let contentPageInfo: ContentPageInfo;
 
     beforeEach(() => {
         scanMetadataStub = {
@@ -27,9 +27,9 @@ describe('TestView', () => {
         userConfigurationStoreDataStub = {
             isFirstTime: false,
         } as UserConfigurationStoreData;
-        headerSectionProps = {
+        contentPageInfo = {
             title: 'some title',
-        } as HeaderSectionProps;
+        } as ContentPageInfo;
     });
 
     const scanStatuses = [
@@ -46,7 +46,7 @@ describe('TestView', () => {
             userConfigurationStoreData: userConfigurationStoreDataStub,
             cardsViewData: cardsViewDataStub,
             scanStatus: ScanStatus[scanStatusName],
-            ...headerSectionProps,
+            contentPageInfo: contentPageInfo,
         };
 
         const testSubject = shallow(<TestView {...props} />);

--- a/src/tests/unit/tests/electron/views/automated-checks/test-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/test-view.test.tsx
@@ -5,6 +5,7 @@ import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { ScanStatus } from 'electron/flux/types/scan-status';
+import { HeaderSectionProps } from 'electron/views/automated-checks/components/header-section';
 import { TestView, TestViewDeps, TestViewProps } from 'electron/views/automated-checks/test-view';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -14,6 +15,7 @@ describe('TestView', () => {
     let scanMetadataStub: ScanMetadata;
     let cardsViewDataStub: CardsViewModel;
     let userConfigurationStoreDataStub: UserConfigurationStoreData;
+    let headerSectionProps: HeaderSectionProps;
 
     beforeEach(() => {
         scanMetadataStub = {
@@ -25,6 +27,9 @@ describe('TestView', () => {
         userConfigurationStoreDataStub = {
             isFirstTime: false,
         } as UserConfigurationStoreData;
+        headerSectionProps = {
+            title: 'some title',
+        } as HeaderSectionProps;
     });
 
     const scanStatuses = [
@@ -41,6 +46,7 @@ describe('TestView', () => {
             userConfigurationStoreData: userConfigurationStoreDataStub,
             cardsViewData: cardsViewDataStub,
             scanStatus: ScanStatus[scanStatusName],
+            ...headerSectionProps,
         };
 
         const testSubject = shallow(<TestView {...props} />);


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

- `HeaderSection` refactored to use contentPageInfo from `HeaderSectionProps`
- `TestView` updated to include `ContentPageInfo` in props
- `AutomatedChecksView` updated to get contentPageInfo from `ContentPanelDeps` based on the selected `LeftNavItemKey`
- Created `needsReviewTestConfig` and added it to `androidTestConfigs`

Gif of TestView header section changing when 'Automated checks' or 'Needs review' is selected
![ai-unified-change-test-view-based-on-selected-left-nav-key](https://user-images.githubusercontent.com/48259897/95144046-85d1b280-072c-11eb-83b5-90a3ae841b30.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: # 1779568
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
