### PR TITLE
fix: avoid background color tearing in fast pass automated checks

### DIFF
--- a/src/DetailsView/components/issues-table.scss
+++ b/src/DetailsView/components/issues-table.scss
@@ -11,7 +11,6 @@
 
 .issues-table {
     background-color: $neutral-2;
-    height: 100%;
     width: calc(100% - #{$fastPassRightPanelMarginRight} - #{$fastPassRightPanelMarginLeft});
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
#### Description of changes

Fixes #3446, where the background color previously tore halfway down the automated checks content panel from gray to white.

Screenshot showing prod on left and local build with fix on right:
![image](https://user-images.githubusercontent.com/376284/95356827-19be8e00-0895-11eb-8078-ede0eb1266dd.png)

Verified locally no impact on fastpass report or unified.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3446
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
