### PR TITLE
feat(android-left-nav): added e2e test for android left nav

### DIFF
--- a/src/DetailsView/components/left-nav/test-view-left-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/test-view-left-nav-link.tsx
@@ -6,11 +6,17 @@ import * as React from 'react';
 import { NamedFC } from '../../../common/react/named-fc';
 import { BaseLeftNavLinkProps } from '../base-left-nav';
 
+export const testViewLeftNavLinkAutomationId = 'test-view-left-nav-link';
+
 export const TestViewLeftNavLink = NamedFC<BaseLeftNavLinkProps>(
     'TestViewLeftNavLink',
     ({ link, renderIcon }) => {
         return (
-            <span className={commonStyles.leftNavLinkContainer} aria-hidden="true">
+            <span
+                data-automation-id={testViewLeftNavLinkAutomationId}
+                className={commonStyles.leftNavLinkContainer}
+                aria-hidden="true"
+            >
                 {renderIcon(link)}
                 <span className={styles.testName}>{link.name}</span>
             </span>

--- a/src/electron/views/left-nav/left-nav.tsx
+++ b/src/electron/views/left-nav/left-nav.tsx
@@ -20,6 +20,8 @@ export type LeftNavProps = {
     selectedKey: LeftNavItemKey;
 };
 
+export const leftNavAutomationId = 'left-nav';
+
 export const LeftNav = NamedFC<LeftNavProps>('LeftNav', props => {
     const { deps } = props;
     const leftLinkItems: BaseLeftNavLink[] = deps.leftNavItems.map((item, index) => ({
@@ -36,7 +38,7 @@ export const LeftNav = NamedFC<LeftNavProps>('LeftNav', props => {
     }));
 
     return (
-        <div className={styles.leftNav}>
+        <div data-automation-id={leftNavAutomationId} className={styles.leftNav}>
             <div className={styles.headerContainer}>
                 <Icon iconName={'Rocket'} className={styles.rocketIcon} />
                 <h3>FastPass</h3>

--- a/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
@@ -4,8 +4,10 @@ import { collapsibleButtonAutomationId } from 'common/components/cards/collapsib
 import { instanceCardAutomationId } from 'common/components/cards/instance-details';
 import { ruleContentAutomationId } from 'common/components/cards/instance-details-group';
 import { ruleGroupAutomationId } from 'common/components/cards/rules-with-instances';
+import { testViewLeftNavLinkAutomationId } from 'DetailsView/components/left-nav/test-view-left-nav-link';
 import { automatedChecksViewAutomationId } from 'electron/views/automated-checks/automated-checks-view';
 import { commandButtonSettingsId } from 'electron/views/automated-checks/components/command-bar';
+import { leftNavAutomationId } from 'electron/views/left-nav/left-nav';
 import { highlightBoxAutomationId } from 'electron/views/screenshot/highlight-box';
 import { screenshotImageAutomationId } from 'electron/views/screenshot/screenshot';
 import { screenshotViewAutomationId } from 'electron/views/screenshot/screenshot-view';
@@ -18,6 +20,7 @@ export const AutomatedChecksViewSelectors = {
     mainContainer: getAutomationIdSelector(automatedChecksViewAutomationId),
     ruleGroup: getAutomationIdSelector(ruleGroupAutomationId),
     ruleContent: getAutomationIdSelector(ruleContentAutomationId),
+    leftNav: getAutomationIdSelector(leftNavAutomationId),
 
     nthRuleGroupCollapseExpandButton: (position: number) =>
         `${nthRuleGroup(position)} ${getAutomationIdSelector(collapsibleButtonAutomationId)}`,
@@ -25,6 +28,11 @@ export const AutomatedChecksViewSelectors = {
         `${nthRuleGroup(position)} ${getAutomationIdSelector(cardsRuleIdAutomationId)}`,
     nthRuleGroupInstances: (position: number) =>
         `${nthRuleGroup(position)} ${getAutomationIdSelector(instanceCardAutomationId)}`,
+
+    nthTestInLeftNav: (position: number) =>
+        `${getAutomationIdSelector(
+            leftNavAutomationId,
+        )} li:nth-of-type(${position}) ${getAutomationIdSelector(testViewLeftNavLinkAutomationId)}`,
 
     settingsButton: getAutomationIdSelector(commandButtonSettingsId),
 };

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import * as fs from 'fs';
 import * as path from 'path';
 import { createApplication } from 'tests/electron/common/create-application';
@@ -12,6 +13,8 @@ import { AppController } from 'tests/electron/common/view-controllers/app-contro
 import { AutomatedChecksViewController } from 'tests/electron/common/view-controllers/automated-checks-view-controller';
 import { commonAdbConfigs, setupMockAdb } from 'tests/miscellaneous/mock-adb/setup-mock-adb';
 import { testResourceServerConfig } from '../setup/test-resource-server-config';
+import { androidTestConfigs } from 'electron/platform/android/test-configs/android-test-configs';
+
 describe('AutomatedChecksView', () => {
     let app: AppController;
     let automatedChecksView: AutomatedChecksViewController;
@@ -75,6 +78,24 @@ describe('AutomatedChecksView', () => {
         expect(await countHighlightBoxes()).toBe(1);
         expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(1);
         await assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
+    });
+
+    it('left nav allows to change between tests', async () => {
+        await app.setFeatureFlag(UnifiedFeatureFlags.leftNavBar, true);
+        await automatedChecksView.waitForSelector(AutomatedChecksViewSelectors.leftNav);
+        await scanForAccessibilityIssuesInAllModes(app);
+    });
+
+    it('left nav allows to change between tests', async () => {
+        const testIndex = 1;
+        const expectedTestTitle = androidTestConfigs[testIndex].title;
+        await app.setFeatureFlag(UnifiedFeatureFlags.leftNavBar, true);
+        await automatedChecksView.waitForSelector(AutomatedChecksViewSelectors.leftNav);
+        await automatedChecksView.client.click(
+            AutomatedChecksViewSelectors.nthTestInLeftNav(testIndex + 1),
+        );
+        const title = await automatedChecksView.client.getText('h1');
+        expect(title).toEqual(expectedTestTitle);
     });
 
     it('should pass accessibility validation in all contrast modes', async () => {

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -80,7 +80,7 @@ describe('AutomatedChecksView', () => {
         await assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
     });
 
-    it('left nav allows to change between tests', async () => {
+    it('should pass accessibility validation when left nav is showing', async () => {
         await app.setFeatureFlag(UnifiedFeatureFlags.leftNavBar, true);
         await automatedChecksView.waitForSelector(AutomatedChecksViewSelectors.leftNav);
         await scanForAccessibilityIssuesInAllModes(app);

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/test-view-left-nav-link.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/test-view-left-nav-link.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`TestViewLeftNavLink renders 1`] = `
 <span
   aria-hidden="true"
   className="leftNavLinkContainer"
+  data-automation-id="test-view-left-nav-link"
 >
   <i>
     test-props-renderIcon

--- a/src/tests/unit/tests/electron/views/left-nav/__snapshots__/left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/left-nav/__snapshots__/left-nav.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`LeftNav render 1`] = `
 <div
   className="leftNav"
+  data-automation-id="left-nav"
 >
   <div
     className="headerContainer"


### PR DESCRIPTION
#### Description of changes

Adds two kinds of e2e tests:
- Scan for a11y issues with left nav showing
- Change selected test using left nav.

Not in this PR but should be done: re-naming automated checks view to a more generic name and resulting tests/e2e tests as well.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
