### PR TITLE
fix(android-left-nav): change background to white for left nav/command bar

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -30,6 +30,7 @@ button.settings-gear-button {
     justify-content: space-between;
     align-items: center;
     align-content: stretch;
+    background-color: $neutral-0;
 
     .items {
         padding-left: 15px;

--- a/src/electron/views/left-nav/left-nav.scss
+++ b/src/electron/views/left-nav/left-nav.scss
@@ -8,6 +8,7 @@
     min-width: 249px;
     border-right: 1px solid $neutral-alpha-8;
     height: 100%;
+    background-color: $neutral-0;
 
     .header-container {
         display: flex;


### PR DESCRIPTION
#### Description of changes

![image](https://user-images.githubusercontent.com/32555133/95621822-325ead80-0a27-11eb-9062-a7ac68492b97.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
