### PR TITLE
fix: fastpass background css and refactor details view css

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -26,32 +26,12 @@ body {
     display: none !important;
 }
 
-.issue-filing-dialog {
-    .ms-Dialog-title {
-        font-size: 21px;
-        line-height: 32px;
-        letter-spacing: -0.02em;
-        font-weight: 600;
-        padding-bottom: 0;
-    }
-
-    .ms-Dialog-subText {
-        font-weight: 400;
-        font-size: 15px;
-        color: $secondary-text;
-    }
-}
-
 .insights-code {
     font-family: $codeFontFamily;
 }
 
 .column-header span:first-of-type {
     padding-left: 5px !important;
-}
-
-.details-view-dropdown-callout {
-    right: 0 !important;
 }
 
 .details-view-spinner {
@@ -63,22 +43,6 @@ body {
     flex-direction: column;
     height: 100%;
 
-    .ms-Nav-compositeLink a {
-        border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle $neutral-0;
-        border-top: 0px;
-        border-bottom: 0px;
-    }
-    .ms-Nav-compositeLink.is-selected a {
-        background-color: $communication-tint-40;
-        border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle $communication-primary;
-        .ms-Button-label,
-        .overview-percent {
-            color: $highlighted-text;
-        }
-        .left-nav-icon {
-            color: $left-nav-icon;
-        }
-    }
     .ms-DetailsRow,
     .ms-GroupHeader {
         user-select: text;

--- a/src/DetailsView/components/adhoc-issues-test-view.scss
+++ b/src/DetailsView/components/adhoc-issues-test-view.scss
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/common.scss';
+
+.issues-test-view {
+    background-color: $neutral-2;
+    height: 100%;
+}

--- a/src/DetailsView/components/adhoc-issues-test-view.tsx
+++ b/src/DetailsView/components/adhoc-issues-test-view.tsx
@@ -11,6 +11,7 @@ import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
+import * as styles from 'DetailsView/components/adhoc-issues-test-view.scss';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import {
     ScanIncompleteWarning,
@@ -45,21 +46,11 @@ export type AdhocIssuesTestViewProps = {
 export const AdhocIssuesTestView = NamedFC<AdhocIssuesTestViewProps>(
     'AdhocIssuesTestView',
     props => {
-        if (props.tabStoreData.isChanged) {
-            return createTargetPageChangedView(props);
-        }
+        const view = props.tabStoreData.isChanged
+            ? createTargetPageChangedView(props)
+            : createTestView(props);
 
-        return (
-            <>
-                <ScanIncompleteWarning
-                    deps={props.deps}
-                    warnings={props.scanIncompleteWarnings}
-                    warningConfiguration={props.switcherNavConfiguration.warningConfiguration}
-                    test={props.selectedTest}
-                />
-                <DetailsListIssuesView {...props} />
-            </>
-        );
+        return <div className={styles.issuesTestView}>{view}</div>;
     },
 );
 
@@ -78,5 +69,19 @@ function createTargetPageChangedView(props: AdhocIssuesTestViewProps): JSX.Eleme
             toggleClickHandler={clickHandler}
             featureFlagStoreData={props.featureFlagStoreData}
         />
+    );
+}
+
+function createTestView(props: AdhocIssuesTestViewProps): JSX.Element {
+    return (
+        <>
+            <ScanIncompleteWarning
+                deps={props.deps}
+                warnings={props.scanIncompleteWarnings}
+                warningConfiguration={props.switcherNavConfiguration.warningConfiguration}
+                test={props.selectedTest}
+            />
+            <DetailsListIssuesView {...props} />
+        </>
     );
 }

--- a/src/DetailsView/components/issue-filing-dialog.scss
+++ b/src/DetailsView/components/issue-filing-dialog.scss
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/common.scss';
+
+.issue-filing-dialog {
+    :global {
+        .ms-Dialog-title {
+            font-size: 21px;
+            line-height: 32px;
+            letter-spacing: -0.02em;
+            font-weight: 600;
+            padding-bottom: 0;
+        }
+
+        .ms-Dialog-subText {
+            font-weight: 400;
+            font-size: 15px;
+            color: $secondary-text;
+        }
+    }
+}

--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import * as styles from 'DetailsView/components/common-dialog-styles.scss';
+import * as issueFilingDialogStyles from 'DetailsView/components/issue-filing-dialog.scss';
 import { cloneDeep, isEqual } from 'lodash';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -80,7 +81,7 @@ export class IssueFilingDialog extends React.Component<
                 modalProps={{
                     isBlocking: false,
                     containerClassName: styles.insightsDialogMainOverride,
-                    className: 'issue-filing-dialog',
+                    className: issueFilingDialogStyles.issueFilingDialog,
                 }}
                 onDismiss={onClose}
             >

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-issues-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-issues-test-view.test.tsx.snap
@@ -1,59 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AdhocIssuesTestView should return DetailsListIssuesView 1`] = `
-<React.Fragment>
-  <ScanIncompleteWarning
-    test={-1}
-    warningConfiguration={Object {}}
-    warnings={Array []}
-  />
-  <DetailsListIssuesView
-    clickHandlerFactory={
-      proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "actionCreator": undefined,
-        "telemetryFactory": undefined,
+<div
+  className="issuesTestView"
+>
+  <React.Fragment>
+    <ScanIncompleteWarning
+      test={-1}
+      warningConfiguration={Object {}}
+      warnings={Array []}
+    />
+    <DetailsListIssuesView
+      clickHandlerFactory={
+        proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actionCreator": undefined,
+          "telemetryFactory": undefined,
+        }
       }
-    }
-    configuration={
-      Object {
-        "displayableData": Object {
-          "title": "test title",
-        },
-        "getStoreData": [Function],
+      configuration={
+        Object {
+          "displayableData": Object {
+            "title": "test title",
+          },
+          "getStoreData": [Function],
+        }
       }
-    }
-    instancesSection={[Function]}
-    scanIncompleteWarnings={Array []}
-    selectedTest={-1}
-    switcherNavConfiguration={
-      Object {
-        "warningConfiguration": Object {},
+      instancesSection={[Function]}
+      scanIncompleteWarnings={Array []}
+      selectedTest={-1}
+      switcherNavConfiguration={
+        Object {
+          "warningConfiguration": Object {},
+        }
       }
-    }
-    tabStoreData={
-      Object {
-        "isChanged": false,
+      tabStoreData={
+        Object {
+          "isChanged": false,
+        }
       }
-    }
-    visualizationStoreData={
-      Object {
-        "scanning": "test-scanning",
-        "tests": Object {},
+      visualizationStoreData={
+        Object {
+          "scanning": "test-scanning",
+          "tests": Object {},
+        }
       }
-    }
-  />
-</React.Fragment>
+    />
+  </React.Fragment>
+</div>
 `;
 
 exports[`AdhocIssuesTestView should return target page changed view as tab is changed 1`] = `
-<TargetPageChangedView
-  displayableData={
-    Object {
-      "title": "test title",
+<div
+  className="issuesTestView"
+>
+  <TargetPageChangedView
+    displayableData={
+      Object {
+        "title": "test title",
+      }
     }
-  }
-  toggleClickHandler={[Function]}
-  visualizationType={-1}
-/>
+    toggleClickHandler={[Function]}
+    visualizationType={-1}
+  />
+</div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have ch
   hidden={true}
   modalProps={
     Object {
-      "className": "issue-filing-dialog",
+      "className": "issueFilingDialog",
       "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
@@ -94,7 +94,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have no
   hidden={true}
   modalProps={
     Object {
-      "className": "issue-filing-dialog",
+      "className": "issueFilingDialog",
       "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
@@ -175,7 +175,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have change
   hidden={false}
   modalProps={
     Object {
-      "className": "issue-filing-dialog",
+      "className": "issueFilingDialog",
       "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
@@ -256,7 +256,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have not ch
   hidden={false}
   modalProps={
     Object {
-      "className": "issue-filing-dialog",
+      "className": "issueFilingDialog",
       "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
@@ -337,7 +337,7 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
   hidden={false}
   modalProps={
     Object {
-      "className": "issue-filing-dialog",
+      "className": "issueFilingDialog",
       "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
@@ -418,7 +418,7 @@ exports[`IssueFilingDialog render with isSettingsValid: true 1`] = `
   hidden={false}
   modalProps={
     Object {
-      "className": "issue-filing-dialog",
+      "className": "issueFilingDialog",
       "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
@@ -499,7 +499,7 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
   hidden={false}
   modalProps={
     Object {
-      "className": "issue-filing-dialog",
+      "className": "issueFilingDialog",
       "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
@@ -581,7 +581,7 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
   hidden={false}
   modalProps={
     Object {
-      "className": "issue-filing-dialog",
+      "className": "issueFilingDialog",
       "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }
@@ -662,7 +662,7 @@ exports[`IssueFilingDialog render: validate callback (onSelectedServiceChange) s
   hidden={false}
   modalProps={
     Object {
-      "className": "issue-filing-dialog",
+      "className": "issueFilingDialog",
       "containerClassName": "insightsDialogMainOverride",
       "isBlocking": false,
     }


### PR DESCRIPTION
#### Description of changes

This cleans up css in details view (removing dead unused css and refactors to use css-modules) while also fixing a couple css issues in our fastpass details views.

The issues:
- In a recent change, the gray background behind the cards view was fixed such that it extended through the entire cards view. However, this introduces the problem when the cards view takes up less space than the full details view, we get another issue of mismatching backgrounds. The changes here fix that.
- The background for when the target page was changed was white instead of grey.

Before:
![image](https://user-images.githubusercontent.com/32555133/95906807-76b3bb80-0d4f-11eb-8c69-208efd2c6e7d.png)
After:
![image](https://user-images.githubusercontent.com/32555133/95906852-8af7b880-0d4f-11eb-9c2b-7085a38082ef.png)

Before:
![image](https://user-images.githubusercontent.com/32555133/95906917-9fd44c00-0d4f-11eb-937a-8eafdef4b657.png)
After:
![image](https://user-images.githubusercontent.com/32555133/95906934-a8c51d80-0d4f-11eb-9d45-ab9299c5888a.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
