### PR TITLE
fix: use distinguishable colors for test status choice groups in OS high-contrast modes

### DIFF
--- a/src/DetailsView/components/test-status-choice-group.scss
+++ b/src/DetailsView/components/test-status-choice-group.scss
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-@import '../../common/styles/colors.scss';
+@import '../../common/styles/common.scss';
 
 .radio-button-group {
     float: left;
@@ -18,8 +18,8 @@
             margin-top: 0px !important;
         }
         .ms-ChoiceField-wrapper.is-inFocus .ms-ChoiceField-field {
-            @media screen and (-ms-high-contrast: active) {
-                outline: 3px highlighttext solid !important;
+            @include ms-high-contrast-override {
+                outline: 3px HighlightText solid !important;
             }
         }
         .ms-ChoiceField:nth-of-type(1) {
@@ -33,6 +33,13 @@
                 .ms-ChoiceField-field::before,
                 .ms-ChoiceField-field::after {
                     border-color: $positive-outcome;
+
+                    // See #3435
+                    @include ms-high-contrast-override {
+                        forced-color-adjust: none;
+                        border-color: Highlight;
+                        background-color: HighlightText;
+                    }
                 }
             }
         }
@@ -41,6 +48,13 @@
                 .ms-ChoiceField-field::before,
                 .ms-ChoiceField-field::after {
                     border-color: $negative-outcome;
+
+                    // See #3435
+                    @include ms-high-contrast-override {
+                        forced-color-adjust: none;
+                        border-color: Highlight;
+                        background-color: HighlightText;
+                    }
                 }
             }
         }
@@ -55,7 +69,7 @@
         line-height: 24px;
         color: $neutral-100;
         @media screen and (-ms-high-contrast: active) {
-            color: highlighttext !important;
+            color: HighlightText !important;
         }
     }
 }
@@ -63,6 +77,6 @@
 .undo-button:focus,
 .undo-button-icon:focus {
     @media screen and (-ms-high-contrast: active) {
-        outline: 1px highlighttext solid !important;
+        outline: 1px HighlightText solid !important;
     }
 }

--- a/src/DetailsView/components/test-status-choice-group.scss
+++ b/src/DetailsView/components/test-status-choice-group.scss
@@ -68,7 +68,7 @@
         font-size: 16px;
         line-height: 24px;
         color: $neutral-100;
-        @media screen and (-ms-high-contrast: active) {
+        @include ms-high-contrast-override {
             color: HighlightText !important;
         }
     }
@@ -76,7 +76,7 @@
 
 .undo-button:focus,
 .undo-button-icon:focus {
-    @media screen and (-ms-high-contrast: active) {
+    @include ms-high-contrast-override {
         outline: 1px HighlightText solid !important;
     }
 }


### PR DESCRIPTION
#### Description of changes

This PR addresses #3435, where in Windows high contrast mode, pass/fail radio buttons that were selected vs not were indistinguishable.

Per discussion with @ferBonnin, this intentionally causes the buttons to use the system-provided colors for selected buttons, which means they do not use different colors for pass vs fail like they do in our app-specific HC mode and in the default theme. Respecting the system theme is more important.

This makes use of some relatively new Edge features around forced-color mode (specifically, the `forced-color-adjust: none;` property). See discussion in #3435 for references.

Screenshots showing before on left and after on right in assorted HC setting modes:

**App HC off, Windows HC off (intentionally no change):**
![image](https://user-images.githubusercontent.com/376284/96037229-8e647000-0e33-11eb-8b6e-35a96c0ae05f.png)

**App HC on, Windows HC off (intentionally no change):**
![image](https://user-images.githubusercontent.com/376284/96037273-9fad7c80-0e33-11eb-81ab-9ec6211945f9.png)

**App HC off, Windows HC theme 1:**
![image](https://user-images.githubusercontent.com/376284/96037375-c1a6ff00-0e33-11eb-93b8-3d764895d465.png)

**App HC off, Windows HC theme 2:**
![image](https://user-images.githubusercontent.com/376284/96037404-ca97d080-0e33-11eb-81cf-017a77c4df79.png)

**App HC off, Windows HC theme Black (motivating case):**
![image](https://user-images.githubusercontent.com/376284/96037431-d4b9cf00-0e33-11eb-80d5-4b44417a170a.png)

**App HC off, Windows HC theme White:**
![image](https://user-images.githubusercontent.com/376284/96037465-dedbcd80-0e33-11eb-911f-27cafdb9210c.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3435
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
