### PR TITLE
feat(android-nav-reflow): Add NarrowModeDetector into the react component hierarchy

### DIFF
--- a/src/DetailsView/components/narrow-mode-detector.tsx
+++ b/src/DetailsView/components/narrow-mode-detector.tsx
@@ -11,7 +11,9 @@ export type NarrowModeStatus = {
 
 export type NarrowModeDetectorProps<P = { narrowModeStatus: NarrowModeStatus }> = {
     isNarrowModeEnabled: boolean;
-    Component: ReactFCWithDisplayName<P & { narrowModeStatus: NarrowModeStatus }>;
+    Component:
+        | ReactFCWithDisplayName<P & { narrowModeStatus: NarrowModeStatus }>
+        | React.ComponentClass<P & { narrowModeStatus: NarrowModeStatus }>;
     childrenProps: P;
 };
 

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -18,6 +18,7 @@ import {
     SettingsPanel,
     SettingsPanelDeps,
 } from 'DetailsView/components/details-view-overlay/settings-panel/settings-panel';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
@@ -65,6 +66,7 @@ export type AutomatedChecksViewProps = {
     featureFlagStoreData: FeatureFlagStoreData;
     androidSetupStoreData: AndroidSetupStoreData;
     leftNavStoreData: LeftNavStoreData;
+    narrowModeStatus: NarrowModeStatus;
 };
 
 export class AutomatedChecksView extends React.Component<AutomatedChecksViewProps> {

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -18,6 +18,7 @@ import { WindowStateStoreData } from 'electron/flux/types/window-state-store-dat
 import {
     AutomatedChecksView,
     AutomatedChecksViewDeps,
+    AutomatedChecksViewProps,
 } from 'electron/views/automated-checks/automated-checks-view';
 import {
     DeviceConnectViewContainer,
@@ -25,6 +26,7 @@ import {
 } from 'electron/views/device-connect-view/components/device-connect-view-container';
 import * as React from 'react';
 import { LeftNavStoreData } from 'electron/flux/types/left-nav-store-data';
+import { NarrowModeDetector } from 'DetailsView/components/narrow-mode-detector';
 
 export type RootContainerDeps = WithStoreSubscriptionDeps<RootContainerState> &
     DeviceConnectViewContainerDeps &
@@ -50,8 +52,19 @@ export type RootContainerState = {
 export const RootContainerInternal = NamedFC<RootContainerProps>('RootContainerInternal', props => {
     const { storeState, ...rest } = props;
 
+    const childProps: Omit<AutomatedChecksViewProps, 'narrowModeStatus'> = {
+        ...storeState,
+        ...rest,
+    };
+
     if (storeState.windowStateStoreData.routeId === 'resultsView') {
-        return <AutomatedChecksView {...storeState} {...rest} />;
+        return (
+            <NarrowModeDetector
+                isNarrowModeEnabled={true}
+                Component={AutomatedChecksView}
+                childrenProps={childProps}
+            />
+        );
     }
 
     return <DeviceConnectViewContainer {...storeState} {...rest} />;

--- a/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
@@ -40,40 +40,34 @@ exports[`RootContainer renders with routeId = deviceConnectView 1`] = `
 `;
 
 exports[`RootContainer renders with routeId = resultsView 1`] = `
-<AutomatedChecksView
-  cardSelectionStoreData={
+<NarrowModeDetector
+  Component={[Function]}
+  childrenProps={
     Object {
-      "rules": Object {},
-    }
-  }
-  deps={
-    Object {
-      "storesHub": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "stores": undefined,
+      "cardSelectionStoreData": Object {
+        "rules": Object {},
+      },
+      "deps": Object {
+        "storesHub": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "stores": undefined,
+        },
+      },
+      "scanStoreData": Object {
+        "status": 2,
+      },
+      "unifiedScanResultStoreData": Object {
+        "rules": Array [],
+      },
+      "userConfigurationStoreData": Object {
+        "isFirstTime": false,
+      },
+      "windowStateStoreData": Object {
+        "currentWindowState": "customSize",
+        "routeId": "resultsView",
       },
     }
   }
-  scanStoreData={
-    Object {
-      "status": 2,
-    }
-  }
-  unifiedScanResultStoreData={
-    Object {
-      "rules": Array [],
-    }
-  }
-  userConfigurationStoreData={
-    Object {
-      "isFirstTime": false,
-    }
-  }
-  windowStateStoreData={
-    Object {
-      "currentWindowState": "customSize",
-      "routeId": "resultsView",
-    }
-  }
+  isNarrowModeEnabled={true}
 />
 `;


### PR DESCRIPTION
#### Description of changes

- Added this above AutomatedChecksView.
- Changed the NarrowModeDetectorProps.component property so that it would accomodate AutomatedChecksView.
