### PR TITLE
chore(dev-deps): revert playwright from 1.5.1 to 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
         "node-sass": "^4.14.1",
         "npm-run-all": "^4.1.5",
         "pkg": "^4.4.9",
-        "playwright": "^1.5.1",
+        "playwright": "^1.4.2",
         "preprocess": "^3.2.0",
         "prettier": "^2.1.2",
         "react-devtools": "^4.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9174,7 +9174,7 @@ pkg@^4.4.9:
     resolve "^1.15.1"
     stream-meter "^1.0.4"
 
-playwright@^1.5.1:
+playwright@^1.4.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.5.1.tgz#f5333cbfefaf9cb7213b0c9ca8bc9f3f18efcf16"
   integrity sha512-FYxrQ2TAmvp5ZnBnc6EJHc1Vt3DmXx8xVDq6rxVVG4YVoNKHYMarHI92zGyDlueN2kKCavrhk4Et9w6jJ5XWaA==


### PR DESCRIPTION
#### Description of changes

@waabid and I are seeing more flakiness than usual in web E2Es today and we're suspicious that this morning's playwright update might be related. Trying out reverting it to see if that improves reliability.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
