### PR TITLE
chore: Add missing parenthesis to report package readme example

### DIFF
--- a/src/reports/package/root/README.md
+++ b/src/reports/package/root/README.md
@@ -54,7 +54,7 @@ test('my accessibility test', async () => {
         JSON.stringify(html),
         { encoding: 'utf8' });
     await browser.close();
-}
+});
 ```
 
 ## Contributing


### PR DESCRIPTION
#### Description of changes
The usage example in the accessibility-insights-report package readme was missing a closing parenthesis and semicolon. This PR adds them. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
