### PR TITLE
chore: add /packages/README.md describing planned monorepo layout

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,37 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# accessibility-insights-web packages
+
+As of writing, this repository is an ad-hoc monorepo; `/src` contains code for multiple projects,
+and does not separate them as cleanly as we would like.
+
+We plan to gradually convert the repository into a Lerna/Yarn Workspaces based monorepo, similar to
+how [accessibility-insights-service](https://github.com/microsoft/accessibility-insights-service) is
+structured.
+
+## Planned package layout
+
+At minimum, we plan to use individual packages for each individually released project:
+
+* `/packages/report`: `accessibility-insights-report` (NPM package, primarily for consumption by [accessibility-insights-service](https://github.com/microsoft/accessibility-insights-service))
+* `/packages/ui`: `accessibility-insights-ui` (NPM package, primarily for consumption by [accessibilityinsights.io](https://accessibilityinsights.io))
+* `/packages/unified`: Accessibility Insights for Android (Electron application)
+* `/packages/web`: Accessibility Insights for Web (browser extension)
+
+We also plan to move end-to-end tests of packages into separate packages, to better test "true"
+package API boundaries. For example:
+
+* `/packages/report-e2e-tests`: End-to-end tests of the `report` package APIs
+
+Beyond these, some functionality of web/unified may gradually get extracted to separate packages
+for the purposes of improving build time/encapsulation; for example, some of the subdirectories
+currently under `/src` might turn into separate packages one day.
+
+## Current package layout
+
+* `/src/packages/accessibility-insights-ui/root`: current home of future `/packages/ui`
+* `/src/reports/package/root`: current home of future `/packages/report`
+* `/package.json`/`/src`: current home of web, unified, and most of the build rules for ui/report

--- a/packages/README.md
+++ b/packages/README.md
@@ -12,7 +12,7 @@ We plan to gradually convert the repository into a Lerna/Yarn Workspaces based m
 how [accessibility-insights-service](https://github.com/microsoft/accessibility-insights-service) is
 structured.
 
-## Short-term (~3 months) planned package layout
+## Short-term (~Dec 2020) planned package layout
 
 At minimum, we plan to use individual packages for each individually released project:
 
@@ -29,7 +29,7 @@ package API boundaries. For example:
 
 * `/packages/report-e2e-tests`: End-to-end tests of the `report` package APIs
 
-## Longer term plans
+## Longer term (2021+) plans
 
 Some functionality of web/unified may gradually get extracted to separate packages
 for the purposes of improving build time/encapsulation; for example, some of the subdirectories
@@ -41,7 +41,7 @@ this or not, but in the interest of keeping it easy, we want to lean towards usi
 decisions between the two of them for "directory layout", "which tools run repo-wide vs
 per-package", etc.
 
-## Current package layout
+## Current (Oct 2020) package layout
 
 * `/src/packages/accessibility-insights-ui/root`: current home of future `/packages/ui`
 * `/src/reports/package/root`: current home of future `/packages/report`

--- a/packages/README.md
+++ b/packages/README.md
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 # accessibility-insights-web packages
 
-As of writing, this repository is an ad-hoc monorepo; `/src` contains code for multiple projects,
+As of Oct 2020, this repository is an ad-hoc monorepo; `/src` contains code for multiple projects,
 and does not separate them as cleanly as we would like.
 
 We plan to gradually convert the repository into a Lerna/Yarn Workspaces based monorepo, similar to

--- a/packages/README.md
+++ b/packages/README.md
@@ -12,7 +12,7 @@ We plan to gradually convert the repository into a Lerna/Yarn Workspaces based m
 how [accessibility-insights-service](https://github.com/microsoft/accessibility-insights-service) is
 structured.
 
-## Planned package layout
+## Short-term (~3 months) planned package layout
 
 At minimum, we plan to use individual packages for each individually released project:
 
@@ -21,14 +21,25 @@ At minimum, we plan to use individual packages for each individually released pr
 * `/packages/unified`: Accessibility Insights for Android (Electron application)
 * `/packages/web`: Accessibility Insights for Web (browser extension)
 
+We will start out with having unified and web still combined under `/packages/web`; they will
+require some work to split out.
+
 We also plan to move end-to-end tests of packages into separate packages, to better test "true"
 package API boundaries. For example:
 
 * `/packages/report-e2e-tests`: End-to-end tests of the `report` package APIs
 
-Beyond these, some functionality of web/unified may gradually get extracted to separate packages
+## Longer term plans
+
+Some functionality of web/unified may gradually get extracted to separate packages
 for the purposes of improving build time/encapsulation; for example, some of the subdirectories
 currently under `/src` might turn into separate packages one day.
+
+Eventually, we could imagine wanting to combine `accessibility-insights-service` and
+`accessibility-insights-web` into one monorepo; we aren't sure whether we necessarily want to do
+this or not, but in the interest of keeping it easy, we want to lean towards using consistent
+decisions between the two of them for "directory layout", "which tools run repo-wide vs
+per-package", etc.
 
 ## Current package layout
 


### PR DESCRIPTION
#### Description of changes

This adds a `/packages/` directory containing a README documenting monorepoization discussion from the last engineering discussion. I thought this would be more durable (and easier to ask clarifying review comments on) than just leaving it in notes from the meeting.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
