### PR TITLE
refactor(android-nav-reflow): refactor hamburger button to take css from parent

### DIFF
--- a/src/DetailsView/components/interactive-header.scss
+++ b/src/DetailsView/components/interactive-header.scss
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+
+.nav-menu {
+    color: $neutral-0;
+}

--- a/src/DetailsView/components/interactive-header.tsx
+++ b/src/DetailsView/components/interactive-header.tsx
@@ -6,7 +6,7 @@ import { Header, HeaderDeps } from 'common/components/header';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { navMenu } from 'DetailsView/components/interactive-header.scss';
+import * as styles from 'DetailsView/components/interactive-header.scss';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import * as React from 'react';
 import { SwitcherDeps } from './switcher';
@@ -41,7 +41,7 @@ export const InteractiveHeader = NamedFC<InteractiveHeaderProps>('InteractiveHea
             <props.navMenu
                 setSideNavOpen={props.setSideNavOpen}
                 isSideNavOpen={props.isSideNavOpen}
-                className={navMenu}
+                className={styles.navMenu}
             />
         );
     };

--- a/src/DetailsView/components/interactive-header.tsx
+++ b/src/DetailsView/components/interactive-header.tsx
@@ -6,6 +6,7 @@ import { Header, HeaderDeps } from 'common/components/header';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { navMenu } from 'DetailsView/components/interactive-header.scss';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import * as React from 'react';
 import { SwitcherDeps } from './switcher';
@@ -40,6 +41,7 @@ export const InteractiveHeader = NamedFC<InteractiveHeaderProps>('InteractiveHea
             <props.navMenu
                 setSideNavOpen={props.setSideNavOpen}
                 isSideNavOpen={props.isSideNavOpen}
+                className={navMenu}
             />
         );
     };

--- a/src/common/components/expand-collapse-left-nav-hamburger-button.tsx
+++ b/src/common/components/expand-collapse-left-nav-hamburger-button.tsx
@@ -8,6 +8,7 @@ import * as React from 'react';
 export type ExpandCollpaseLeftNavButtonProps = {
     isSideNavOpen: boolean;
     setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    className?: string;
 };
 
 export const AssessmentLeftNavHamburgerButton = NamedFC<ExpandCollpaseLeftNavButtonProps>(
@@ -19,6 +20,7 @@ export const AssessmentLeftNavHamburgerButton = NamedFC<ExpandCollpaseLeftNavBut
                 ariaLabel={ariaLabel}
                 isSideNavOpen={props.isSideNavOpen}
                 setSideNavOpen={props.setSideNavOpen}
+                className={props.className}
             />
         );
     },
@@ -33,6 +35,7 @@ export const FastPassLeftNavHamburgerButton = NamedFC<ExpandCollpaseLeftNavButto
                 ariaLabel={ariaLabel}
                 isSideNavOpen={props.isSideNavOpen}
                 setSideNavOpen={props.setSideNavOpen}
+                className={props.className}
             />
         );
     },

--- a/src/common/components/left-nav-hamburger-button.scss
+++ b/src/common/components/left-nav-hamburger-button.scss
@@ -3,7 +3,6 @@
 @import '../../common/styles/colors.scss';
 
 .left-nav-hamburger-button {
-    color: $neutral-0;
     margin-left: 11px;
 }
 

--- a/src/common/components/left-nav-hamburger-button.tsx
+++ b/src/common/components/left-nav-hamburger-button.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { IconButton } from 'office-ui-fabric-react';
+import { IconButton, css } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import * as styles from './left-nav-hamburger-button.scss';
@@ -10,6 +10,7 @@ export type LeftNavHamburgerButtonProps = {
     ariaLabel: string;
     isSideNavOpen: boolean;
     setSideNavOpen: (isOpen: boolean, event?: React.MouseEvent<any>) => void;
+    className?: string;
 };
 
 export const LeftNavHamburgerButton = NamedFC<LeftNavHamburgerButtonProps>(
@@ -21,7 +22,7 @@ export const LeftNavHamburgerButton = NamedFC<LeftNavHamburgerButtonProps>(
 
         return (
             <IconButton
-                className={styles.leftNavHamburgerButton}
+                className={css(styles.leftNavHamburgerButton, props.className)}
                 iconProps={{ iconName: 'GlobalNavButton' }}
                 ariaLabel={props.ariaLabel}
                 aria-expanded={props.isSideNavOpen}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/interactive-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/interactive-header.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`InteractiveHeader render: isNavCollapsed equals true 1`] = `
   }
   navMenu={
     <test-nav-menu
+      className="navMenu"
       isSideNavOpen={false}
       setSideNavOpen={null}
     />

--- a/src/tests/unit/tests/common/components/__snapshots__/expand-collapse-left-nav-hamburger-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/expand-collapse-left-nav-hamburger-button.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`AssessmentLeftNavHamburgerButton renders per snapshot 1`] = `
 <LeftNavHamburgerButton
   ariaLabel="Assessment - all tests and requirements list"
+  className="some-class"
   isSideNavOpen={false}
   setSideNavOpen={null}
 />
@@ -11,6 +12,7 @@ exports[`AssessmentLeftNavHamburgerButton renders per snapshot 1`] = `
 exports[`FastPassLeftNavHamburgerButton renders per snapshot 1`] = `
 <LeftNavHamburgerButton
   ariaLabel="FastPass - all tests list"
+  className="some-class"
   isSideNavOpen={false}
   setSideNavOpen={null}
 />

--- a/src/tests/unit/tests/common/components/__snapshots__/left-nav-hamburger-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/left-nav-hamburger-button.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`LeftNavHamburgerButton renders per snapshot 1`] = `
 <CustomizedIconButton
   aria-expanded={false}
   ariaLabel="test-aria-label"
-  className="leftNavHamburgerButton"
+  className="leftNavHamburgerButton some-class"
   iconProps={
     Object {
       "iconName": "GlobalNavButton",

--- a/src/tests/unit/tests/common/components/expand-collapse-left-nav-hamburger-button.test.tsx
+++ b/src/tests/unit/tests/common/components/expand-collapse-left-nav-hamburger-button.test.tsx
@@ -10,7 +10,11 @@ import * as React from 'react';
 describe('AssessmentLeftNavHamburgerButton', () => {
     it('renders per snapshot', () => {
         const wrapper = shallow(
-            <AssessmentLeftNavHamburgerButton isSideNavOpen={false} setSideNavOpen={null} />,
+            <AssessmentLeftNavHamburgerButton
+                isSideNavOpen={false}
+                setSideNavOpen={null}
+                className={'some-class'}
+            />,
         );
 
         expect(wrapper.getElement()).toMatchSnapshot();
@@ -20,7 +24,11 @@ describe('AssessmentLeftNavHamburgerButton', () => {
 describe('FastPassLeftNavHamburgerButton', () => {
     it('renders per snapshot', () => {
         const wrapper = shallow(
-            <FastPassLeftNavHamburgerButton isSideNavOpen={false} setSideNavOpen={null} />,
+            <FastPassLeftNavHamburgerButton
+                isSideNavOpen={false}
+                setSideNavOpen={null}
+                className={'some-class'}
+            />,
         );
 
         expect(wrapper.getElement()).toMatchSnapshot();

--- a/src/tests/unit/tests/common/components/left-nav-hamburger-button.test.tsx
+++ b/src/tests/unit/tests/common/components/left-nav-hamburger-button.test.tsx
@@ -17,6 +17,7 @@ describe('LeftNavHamburgerButton', () => {
                 isSideNavOpen={false}
                 setSideNavOpen={null}
                 ariaLabel={ariaLabel}
+                className={'some-class'}
             />,
         );
 


### PR DESCRIPTION
#### Description of changes

There are no visible changes. We will use this component in the android app and at that time it will have a white background (meaning the color should be different). Since the color of the hamburger menu changes based on the context, it made sense to give that power to the parent rather than the component.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
