### PR TITLE
chore: move yarn build:package:* output to match future monorepo layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,10 @@
 /extension/
 /test-results/
 /package/
-/drop/
+bundle/
+drop/
 *.scss.d.ts
+
 # Dependency directories
 node_modules/
 .DS_STORE

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,6 +21,7 @@
 .vs/
 AppXManifest.xml
 copyright-header.txt
+bundle/
 dist/
 docs/art/ada-cat.ansi256.txt
 docs/LICENSE.txt

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,11 +14,11 @@ module.exports = function (grunt) {
 
     const extensionPath = 'extension';
 
-    const packageReportPath = path.join('package', 'report');
+    const packageReportPath = path.join('packages', 'report');
     const packageReportBundlePath = path.join(packageReportPath, 'bundle');
     const packageReportDropPath = path.join(packageReportPath, 'drop');
 
-    const packageUIPath = path.join('package', 'ui');
+    const packageUIPath = path.join('packages', 'ui');
     const packageUIBundlePath = path.join(packageUIPath, 'bundle');
     const packageUIDropPath = path.join(packageUIPath, 'drop');
 

--- a/copyright-header.config.json
+++ b/copyright-header.config.json
@@ -15,6 +15,8 @@
         "./extension",
         "./node_modules",
         "./package",
+        "./packages/*/bundle",
+        "./packages/*/drop",
         "./src/assessments/color/test-steps/flashing-text-example.html",
         "./src/tests/miscellaneous/mock-adb/bin",
         "./test-results",

--- a/pipeline/build-package.template.yaml
+++ b/pipeline/build-package.template.yaml
@@ -60,4 +60,4 @@ jobs:
             inputs:
                 command: 'publish'
                 publishEndpoint: 'npmjs.com (accessibility-insights-team)'
-                workingDir: '$(System.DefaultWorkingDirectory)/package/${{ parameters.suffix }}/drop'
+                workingDir: '$(System.DefaultWorkingDirectory)/packages/${{ parameters.suffix }}/drop'

--- a/src/reports/bundled-reporter-styles.ts
+++ b/src/reports/bundled-reporter-styles.ts
@@ -1,3 +1,3 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-export const styleSheet = `<<CSS:../../package/report/bundle/report.css>>`;
+export const styleSheet = `<<CSS:../../packages/report/bundle/report.css>>`;

--- a/src/tests/unit/tests/reports/components/__snapshots__/report-head.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/report-head.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`ReporterHead renders 1`] = `
 <Head
   bundledStyles={
     Object {
-      "styleSheet": "<<CSS:../../package/report/bundle/report.css>>",
+      "styleSheet": "<<CSS:../../packages/report/bundle/report.css>>",
     }
   }
   titlePreface="Accessibility Insights"

--- a/src/tests/unit/tests/reports/components/__snapshots__/summary-report-head.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/summary-report-head.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`SummaryReportHead renders 1`] = `
   <style
     dangerouslySetInnerHTML={
       Object {
-        "__html": "<<CSS:../../package/report/bundle/report.css>>",
+        "__html": "<<CSS:../../packages/report/bundle/report.css>>",
       }
     }
   />

--- a/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
@@ -12,7 +12,7 @@ exports[`report package API fromAxeResult matches snapshot for scan input with i
     &lt;&lt;CSS:../reports/automated-checks-report.css&gt;&gt;
   </style>
   <style>
-    &lt;&lt;CSS:../../package/report/bundle/report.css&gt;&gt;
+    &lt;&lt;CSS:../../packages/report/bundle/report.css&gt;&gt;
   </style>
   <header>
     <div
@@ -7031,7 +7031,7 @@ exports[`report package API fromAxeResult matches snapshot for scan input withou
     &lt;&lt;CSS:../reports/automated-checks-report.css&gt;&gt;
   </style>
   <style>
-    &lt;&lt;CSS:../../package/report/bundle/report.css&gt;&gt;
+    &lt;&lt;CSS:../../packages/report/bundle/report.css&gt;&gt;
   </style>
   <header>
     <div
@@ -10768,7 +10768,7 @@ exports[`report package API fromSummaryResults matches snapshot for scan input w
     &lt;&lt;CSS:../reports/summary-report.css&gt;&gt;
   </style>
   <style>
-    &lt;&lt;CSS:../../package/report/bundle/report.css&gt;&gt;
+    &lt;&lt;CSS:../../packages/report/bundle/report.css&gt;&gt;
   </style>
   <header>
     <div
@@ -11814,7 +11814,7 @@ exports[`report package API fromSummaryResults matches snapshot for scan input w
     &lt;&lt;CSS:../reports/summary-report.css&gt;&gt;
   </style>
   <style>
-    &lt;&lt;CSS:../../package/report/bundle/report.css&gt;&gt;
+    &lt;&lt;CSS:../../packages/report/bundle/report.css&gt;&gt;
   </style>
   <header>
     <div

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -188,7 +188,7 @@ const packageReportConfig = {
     mode: 'development',
     devtool: false,
     output: {
-        path: path.join(__dirname, 'package/report/bundle'),
+        path: path.join(__dirname, 'packages/report/bundle'),
         filename: '[name].bundle.js',
         pathinfo: false,
         library: '[name]',
@@ -209,7 +209,7 @@ const packageUIConfig = {
     mode: 'development',
     devtool: false,
     output: {
-        path: path.join(__dirname, 'package/ui/bundle'),
+        path: path.join(__dirname, 'packages/ui/bundle'),
         filename: '[name].bundle.js',
         pathinfo: false,
         library: '[name]',


### PR DESCRIPTION
#### Description of changes

This migrates the webpack/grunt output for the 2 npm packages in the repo from `/package/package-name/*` to `/packages/package-name/*` (package -> packages) to match where the output will start living with the future migration to a monorepo layout.

I verified with a directory diff that `/package/report/drop` before this change and `/packages/report/drop` after this change have identical contents after `yarn build:package:report`.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
