### PR TITLE
feat(android-nav-reflow): add a reflow command bar for android

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -46,4 +46,8 @@ button.settings-gear-button {
         color: $primary-text;
         line-height: 16px;
     }
+
+    .nav-menu {
+        color: $primary-text;
+    }
 }

--- a/src/electron/views/automated-checks/components/reflow-command-bar.tsx
+++ b/src/electron/views/automated-checks/components/reflow-command-bar.tsx
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
+import { FlaggedComponent } from 'common/components/flagged-component';
+import { DropdownClickHandler } from 'common/dropdown-click-handler';
+import { NamedFC } from 'common/react/named-fc';
+import { CardsViewModel } from 'common/types/store-data/card-view-model';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
+import {
+    ReportExportComponent,
+    ReportExportComponentDeps,
+} from 'DetailsView/components/report-export-component';
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
+import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { ScanStatus } from 'electron/flux/types/scan-status';
+import { ScanStoreData } from 'electron/flux/types/scan-store-data';
+import * as React from 'react';
+import { ReportGenerator } from 'reports/report-generator';
+import * as styles from './command-bar.scss';
+import { FastPassLeftNavHamburgerButton } from 'common/components/expand-collapse-left-nav-hamburger-button';
+import { CommandBarButtonsMenu } from 'DetailsView/components/command-bar-buttons-menu';
+
+export type ReflowCommandBarDeps = {
+    scanActionCreator: ScanActionCreator;
+    dropdownClickHandler: DropdownClickHandler;
+    getDateFromTimestamp: (timestamp: string) => Date;
+    reportGenerator: ReportGenerator;
+} & ReportExportComponentDeps;
+
+export interface ReflowCommandBarProps {
+    deps: ReflowCommandBarDeps;
+    scanPort: number;
+    scanStoreData: ScanStoreData;
+    featureFlagStoreData: FeatureFlagStoreData;
+    cardsViewData: CardsViewModel;
+    scanMetadata: ScanMetadata;
+    narrowModeStatus: NarrowModeStatus;
+    isSideNavOpen: boolean;
+    setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const commandButtonRefreshId = 'command-button-refresh';
+export const commandButtonSettingsId = 'command-button-settings';
+
+export const ReflowCommandBar = NamedFC<ReflowCommandBarProps>('ReflowCommandBar', props => {
+    const {
+        deps,
+        scanPort,
+        featureFlagStoreData,
+        cardsViewData,
+        scanMetadata,
+        narrowModeStatus,
+        isSideNavOpen,
+        setSideNavOpen,
+    } = props;
+    let exportReport: JSX.Element = null;
+
+    if (scanMetadata != null) {
+        exportReport = (
+            <ReportExportComponent
+                deps={deps}
+                reportExportFormat={'AutomatedChecks'}
+                pageTitle={scanMetadata.targetAppInfo.name}
+                scanDate={deps.getDateFromTimestamp(scanMetadata.timestamp)}
+                htmlGenerator={description =>
+                    deps.reportGenerator.generateFastPassAutomatedChecksReport(
+                        deps.getDateFromTimestamp(scanMetadata.timestamp),
+                        cardsViewData,
+                        description,
+                        scanMetadata,
+                    )
+                }
+                updatePersistedDescription={() => null}
+                getExportDescription={() => ''}
+                featureFlagStoreData={featureFlagStoreData}
+            />
+        );
+    }
+
+    const startOverButtonProps = {
+        'data-automation-id': commandButtonRefreshId,
+        text: 'Start over',
+        iconProps: { iconName: 'Refresh' },
+        onClick: () => deps.scanActionCreator.scan(scanPort),
+        disabled: props.scanStoreData.status === ScanStatus.Scanning,
+    };
+
+    const hamburgerMenuButton = !narrowModeStatus.isHeaderAndNavCollapsed ? null : (
+        <FastPassLeftNavHamburgerButton
+            isSideNavOpen={isSideNavOpen}
+            setSideNavOpen={setSideNavOpen}
+            className={styles.navMenu}
+        />
+    );
+
+    const getFarButtons = () => {
+        if (narrowModeStatus.isCommandBarCollapsed) {
+            return (
+                <CommandBarButtonsMenu
+                    renderExportReportButton={() => exportReport}
+                    getStartOverMenuItem={() => startOverButtonProps}
+                    buttonRef={null}
+                />
+            );
+        }
+
+        return (
+            <>
+                <FlaggedComponent
+                    enableJSXElement={exportReport}
+                    featureFlagStoreData={featureFlagStoreData}
+                    featureFlag={UnifiedFeatureFlags.exportReport}
+                />
+                <InsightsCommandButton {...startOverButtonProps} />
+            </>
+        );
+    };
+
+    return (
+        <section className={styles.commandBar} aria-label="command bar">
+            {hamburgerMenuButton}
+            <div className={styles.farItems}>
+                {getFarButtons()}
+                <InsightsCommandButton
+                    data-automation-id={commandButtonSettingsId}
+                    ariaLabel="settings"
+                    iconProps={{ iconName: 'Gear', className: styles.settingsGearButtonIcon }}
+                    onClick={event =>
+                        deps.dropdownClickHandler.openSettingsPanelHandler(event as any)
+                    }
+                    className={styles.settingsGearButton}
+                />
+            </div>
+        </section>
+    );
+});

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/reflow-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/reflow-command-bar.test.tsx.snap
@@ -1,0 +1,441 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReflowCommandBar reflow behavior isCommandBarCollapsed is true 1`] = `
+<section
+  aria-label="command bar"
+  className="commandBar"
+>
+  <div
+    className="farItems"
+  >
+    <CommandBarButtonsMenu
+      buttonRef={null}
+      getStartOverMenuItem={[Function]}
+      renderExportReportButton={[Function]}
+    />
+    <InsightsCommandButton
+      ariaLabel="settings"
+      className="settingsGearButton"
+      data-automation-id="command-button-settings"
+      iconProps={
+        Object {
+          "className": "settingsGearButtonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</section>
+`;
+
+exports[`ReflowCommandBar reflow behavior isHeaderAndNavCollapsed is true 1`] = `
+<section
+  aria-label="command bar"
+  className="commandBar"
+>
+  <FastPassLeftNavHamburgerButton
+    className="navMenu"
+    isSideNavOpen={true}
+    setSideNavOpen={[Function]}
+  />
+  <div
+    className="farItems"
+  >
+    <React.Fragment>
+      <FlaggedComponent
+        enableJSXElement={
+          <ReportExportComponent
+            deps={
+              Object {
+                "getDateFromTimestamp": [Function],
+                "reportGenerator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "assessmentReportHtmlGenerator": undefined,
+                  "reportHtmlGenerator": undefined,
+                  "reportNameGenerator": undefined,
+                },
+                "scanActionCreator": null,
+              }
+            }
+            featureFlagStoreData={
+              Object {
+                "somefeatureflag": true,
+              }
+            }
+            getExportDescription={[Function]}
+            htmlGenerator={[Function]}
+            pageTitle="scan target name"
+            reportExportFormat="AutomatedChecks"
+            scanDate={1970-01-01T00:00:00.000Z}
+            updatePersistedDescription={[Function]}
+          />
+        }
+        featureFlag="exportReport"
+        featureFlagStoreData={
+          Object {
+            "somefeatureflag": true,
+          }
+        }
+      />
+      <InsightsCommandButton
+        data-automation-id="command-button-refresh"
+        disabled={true}
+        iconProps={
+          Object {
+            "iconName": "Refresh",
+          }
+        }
+        onClick={[Function]}
+        text="Start over"
+      />
+    </React.Fragment>
+    <InsightsCommandButton
+      ariaLabel="settings"
+      className="settingsGearButton"
+      data-automation-id="command-button-settings"
+      iconProps={
+        Object {
+          "className": "settingsGearButtonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</section>
+`;
+
+exports[`ReflowCommandBar renders does not create report export when scan metadata is null 1`] = `
+<section
+  aria-label="command bar"
+  className="commandBar"
+>
+  <div
+    className="farItems"
+  >
+    <React.Fragment>
+      <FlaggedComponent
+        enableJSXElement={null}
+        featureFlag="exportReport"
+        featureFlagStoreData={
+          Object {
+            "somefeatureflag": true,
+          }
+        }
+      />
+      <InsightsCommandButton
+        data-automation-id="command-button-refresh"
+        disabled={true}
+        iconProps={
+          Object {
+            "iconName": "Refresh",
+          }
+        }
+        onClick={[Function]}
+        text="Start over"
+      />
+    </React.Fragment>
+    <InsightsCommandButton
+      ariaLabel="settings"
+      className="settingsGearButton"
+      data-automation-id="command-button-settings"
+      iconProps={
+        Object {
+          "className": "settingsGearButtonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</section>
+`;
+
+exports[`ReflowCommandBar renders while status is <Completed> 1`] = `
+<section
+  aria-label="command bar"
+  className="commandBar"
+>
+  <div
+    className="farItems"
+  >
+    <React.Fragment>
+      <FlaggedComponent
+        enableJSXElement={
+          <ReportExportComponent
+            deps={
+              Object {
+                "getDateFromTimestamp": [Function],
+                "reportGenerator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "assessmentReportHtmlGenerator": undefined,
+                  "reportHtmlGenerator": undefined,
+                  "reportNameGenerator": undefined,
+                },
+                "scanActionCreator": null,
+              }
+            }
+            featureFlagStoreData={
+              Object {
+                "somefeatureflag": true,
+              }
+            }
+            getExportDescription={[Function]}
+            htmlGenerator={[Function]}
+            pageTitle="scan target name"
+            reportExportFormat="AutomatedChecks"
+            scanDate={1970-01-01T00:00:00.000Z}
+            updatePersistedDescription={[Function]}
+          />
+        }
+        featureFlag="exportReport"
+        featureFlagStoreData={
+          Object {
+            "somefeatureflag": true,
+          }
+        }
+      />
+      <InsightsCommandButton
+        data-automation-id="command-button-refresh"
+        disabled={false}
+        iconProps={
+          Object {
+            "iconName": "Refresh",
+          }
+        }
+        onClick={[Function]}
+        text="Start over"
+      />
+    </React.Fragment>
+    <InsightsCommandButton
+      ariaLabel="settings"
+      className="settingsGearButton"
+      data-automation-id="command-button-settings"
+      iconProps={
+        Object {
+          "className": "settingsGearButtonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</section>
+`;
+
+exports[`ReflowCommandBar renders while status is <Default> 1`] = `
+<section
+  aria-label="command bar"
+  className="commandBar"
+>
+  <div
+    className="farItems"
+  >
+    <React.Fragment>
+      <FlaggedComponent
+        enableJSXElement={
+          <ReportExportComponent
+            deps={
+              Object {
+                "getDateFromTimestamp": [Function],
+                "reportGenerator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "assessmentReportHtmlGenerator": undefined,
+                  "reportHtmlGenerator": undefined,
+                  "reportNameGenerator": undefined,
+                },
+                "scanActionCreator": null,
+              }
+            }
+            featureFlagStoreData={
+              Object {
+                "somefeatureflag": true,
+              }
+            }
+            getExportDescription={[Function]}
+            htmlGenerator={[Function]}
+            pageTitle="scan target name"
+            reportExportFormat="AutomatedChecks"
+            scanDate={1970-01-01T00:00:00.000Z}
+            updatePersistedDescription={[Function]}
+          />
+        }
+        featureFlag="exportReport"
+        featureFlagStoreData={
+          Object {
+            "somefeatureflag": true,
+          }
+        }
+      />
+      <InsightsCommandButton
+        data-automation-id="command-button-refresh"
+        disabled={false}
+        iconProps={
+          Object {
+            "iconName": "Refresh",
+          }
+        }
+        onClick={[Function]}
+        text="Start over"
+      />
+    </React.Fragment>
+    <InsightsCommandButton
+      ariaLabel="settings"
+      className="settingsGearButton"
+      data-automation-id="command-button-settings"
+      iconProps={
+        Object {
+          "className": "settingsGearButtonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</section>
+`;
+
+exports[`ReflowCommandBar renders while status is <Failed> 1`] = `
+<section
+  aria-label="command bar"
+  className="commandBar"
+>
+  <div
+    className="farItems"
+  >
+    <React.Fragment>
+      <FlaggedComponent
+        enableJSXElement={
+          <ReportExportComponent
+            deps={
+              Object {
+                "getDateFromTimestamp": [Function],
+                "reportGenerator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "assessmentReportHtmlGenerator": undefined,
+                  "reportHtmlGenerator": undefined,
+                  "reportNameGenerator": undefined,
+                },
+                "scanActionCreator": null,
+              }
+            }
+            featureFlagStoreData={
+              Object {
+                "somefeatureflag": true,
+              }
+            }
+            getExportDescription={[Function]}
+            htmlGenerator={[Function]}
+            pageTitle="scan target name"
+            reportExportFormat="AutomatedChecks"
+            scanDate={1970-01-01T00:00:00.000Z}
+            updatePersistedDescription={[Function]}
+          />
+        }
+        featureFlag="exportReport"
+        featureFlagStoreData={
+          Object {
+            "somefeatureflag": true,
+          }
+        }
+      />
+      <InsightsCommandButton
+        data-automation-id="command-button-refresh"
+        disabled={false}
+        iconProps={
+          Object {
+            "iconName": "Refresh",
+          }
+        }
+        onClick={[Function]}
+        text="Start over"
+      />
+    </React.Fragment>
+    <InsightsCommandButton
+      ariaLabel="settings"
+      className="settingsGearButton"
+      data-automation-id="command-button-settings"
+      iconProps={
+        Object {
+          "className": "settingsGearButtonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</section>
+`;
+
+exports[`ReflowCommandBar renders while status is <Scanning> 1`] = `
+<section
+  aria-label="command bar"
+  className="commandBar"
+>
+  <div
+    className="farItems"
+  >
+    <React.Fragment>
+      <FlaggedComponent
+        enableJSXElement={
+          <ReportExportComponent
+            deps={
+              Object {
+                "getDateFromTimestamp": [Function],
+                "reportGenerator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "assessmentReportHtmlGenerator": undefined,
+                  "reportHtmlGenerator": undefined,
+                  "reportNameGenerator": undefined,
+                },
+                "scanActionCreator": null,
+              }
+            }
+            featureFlagStoreData={
+              Object {
+                "somefeatureflag": true,
+              }
+            }
+            getExportDescription={[Function]}
+            htmlGenerator={[Function]}
+            pageTitle="scan target name"
+            reportExportFormat="AutomatedChecks"
+            scanDate={1970-01-01T00:00:00.000Z}
+            updatePersistedDescription={[Function]}
+          />
+        }
+        featureFlag="exportReport"
+        featureFlagStoreData={
+          Object {
+            "somefeatureflag": true,
+          }
+        }
+      />
+      <InsightsCommandButton
+        data-automation-id="command-button-refresh"
+        disabled={true}
+        iconProps={
+          Object {
+            "iconName": "Refresh",
+          }
+        }
+        onClick={[Function]}
+        text="Start over"
+      />
+    </React.Fragment>
+    <InsightsCommandButton
+      ariaLabel="settings"
+      className="settingsGearButton"
+      data-automation-id="command-button-settings"
+      iconProps={
+        Object {
+          "className": "settingsGearButtonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</section>
+`;

--- a/src/tests/unit/tests/electron/views/automated-checks/components/reflow-command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/reflow-command-bar.test.tsx
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DropdownClickHandler } from 'common/dropdown-click-handler';
+import { EnumHelper } from 'common/enum-helper';
+import { CardsViewModel } from 'common/types/store-data/card-view-model';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-interface';
+import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { ScanStatus } from 'electron/flux/types/scan-status';
+import {
+    commandButtonRefreshId,
+    ReflowCommandBar,
+    ReflowCommandBarDeps,
+    ReflowCommandBarProps,
+} from 'electron/views/automated-checks/components/reflow-command-bar';
+import { mount, shallow } from 'enzyme';
+import * as React from 'react';
+import { ReportGenerator } from 'reports/report-generator';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
+import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
+
+describe('ReflowCommandBar', () => {
+    let featureFlagStoreDataStub: FeatureFlagStoreData;
+    let getDateFromTimestampMock: IMock<(timestamp: string) => Date>;
+    let cardsViewDataStub: CardsViewModel;
+    let reportGeneratorMock: IMock<ReportGenerator>;
+    let scanMetadataStub: ScanMetadata;
+    let scanDateStub: Date;
+    let narrowModeStatusStub: NarrowModeStatus;
+    let props: ReflowCommandBarProps;
+    let scanPortStub: number;
+
+    beforeEach(() => {
+        featureFlagStoreDataStub = {
+            somefeatureflag: true,
+        };
+        getDateFromTimestampMock = Mock.ofInstance((_: string) => null as Date);
+        cardsViewDataStub = {} as CardsViewModel;
+        scanMetadataStub = {
+            timestamp: '1234',
+            toolData: {} as ToolData,
+            targetAppInfo: {
+                name: 'scan target name',
+            },
+        };
+        narrowModeStatusStub = {
+            isHeaderAndNavCollapsed: false,
+            isCommandBarCollapsed: false,
+        };
+        scanDateStub = new Date(0);
+        reportGeneratorMock = Mock.ofType(ReportGenerator);
+        scanPortStub = 1111;
+
+        getDateFromTimestampMock
+            .setup(mock => mock(scanMetadataStub.timestamp))
+            .returns(() => scanDateStub);
+
+        props = {
+            deps: {
+                scanActionCreator: null,
+                getDateFromTimestamp: getDateFromTimestampMock.object,
+                reportGenerator: reportGeneratorMock.object,
+            } as ReflowCommandBarDeps,
+            scanStoreData: {
+                status: ScanStatus.Scanning,
+            },
+            cardsViewData: cardsViewDataStub,
+            featureFlagStoreData: featureFlagStoreDataStub,
+            scanMetadata: scanMetadataStub,
+            scanPort: scanPortStub,
+            narrowModeStatus: narrowModeStatusStub,
+            isSideNavOpen: true,
+            setSideNavOpen: () => null,
+        };
+    });
+
+    describe('renders', () => {
+        it('while status is <Scanning>', () => {
+            const rendered = shallow(<ReflowCommandBar {...props} />);
+
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
+
+        it('does not create report export when scan metadata is null', () => {
+            props.scanMetadata = null;
+            const rendered = shallow(<ReflowCommandBar {...props} />);
+
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
+
+        const notScanningStatuses = EnumHelper.getNumericValues<ScanStatus>(ScanStatus)
+            .filter(status => status !== ScanStatus.Scanning)
+            .map(status => ScanStatus[status]);
+
+        it.each(notScanningStatuses)('while status is <%s>', status => {
+            props.scanStoreData.status = ScanStatus[status];
+
+            const rendered = shallow(<ReflowCommandBar {...props} />);
+
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
+    });
+
+    describe('user interaction', () => {
+        const eventStub = new EventStubFactory().createMouseClickEvent();
+
+        it('handles start over click', () => {
+            const scanActionCreatorMock = Mock.ofType<ScanActionCreator>(
+                undefined,
+                MockBehavior.Strict,
+            );
+            props.deps.scanActionCreator = scanActionCreatorMock.object;
+            props.scanStoreData.status = ScanStatus.Default;
+
+            scanActionCreatorMock
+                .setup(creator => creator.scan(scanPortStub))
+                .verifiable(Times.once());
+
+            const rendered = mount(<ReflowCommandBar {...props} />);
+
+            const buttonSelector = `button${getAutomationIdSelector(commandButtonRefreshId)}`;
+            const button = rendered.find(buttonSelector);
+
+            button.simulate('click', eventStub);
+
+            scanActionCreatorMock.verifyAll();
+        });
+
+        it('handles settings click', () => {
+            const dropdownClickHandlerMock = Mock.ofType<DropdownClickHandler>();
+            props.deps.dropdownClickHandler = dropdownClickHandlerMock.object;
+
+            const rendered = mount(<ReflowCommandBar {...props} />);
+            const button = rendered.find('button[aria-label="settings"]');
+
+            button.simulate('click', eventStub);
+
+            dropdownClickHandlerMock.verify(
+                handler => handler.openSettingsPanelHandler(It.isAny()),
+                Times.once(),
+            );
+        });
+    });
+
+    describe('reflow behavior', () => {
+        test('isCommandBarCollapsed is true', () => {
+            props.narrowModeStatus.isCommandBarCollapsed = true;
+
+            const rendered = shallow(<ReflowCommandBar {...props} />);
+
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
+
+        test('isHeaderAndNavCollapsed is true', () => {
+            props.narrowModeStatus.isHeaderAndNavCollapsed = true;
+
+            const rendered = shallow(<ReflowCommandBar {...props} />);
+
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
+    });
+});


### PR DESCRIPTION
#### Description of changes

This creates a new command bar component which is a copy of the existing command bar component but with significant changes. It made sense to create a duplicate component that will be specified once in automated-checks-view instead of having multiple flagged component changes in combination with the narrow mode status detector conditional changes.

Note: since the command bar still uses the ReportExportComponent, it has an issue where the dropdown menu does not disappear after you select export report. This was an issue in web as well but has been resolved. I will look into getting the same result in a future PR (will likely need some further refactoring work).

Screenshot of how it looks:
![image](https://user-images.githubusercontent.com/32555133/96636974-dde2ea00-12d2-11eb-8793-6f5670957315.png)
Dropdown screenshot:
![image](https://user-images.githubusercontent.com/32555133/96637850-2058f680-12d4-11eb-84e3-959c7a9193b5.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
