### PR TITLE
feat(android-nav-reflow): Add left nav visible state to LeftNavStore

### DIFF
--- a/src/electron/flux/action-creator/left-nav-action-creator.ts
+++ b/src/electron/flux/action-creator/left-nav-action-creator.ts
@@ -8,4 +8,5 @@ export class LeftNavActionCreator {
     constructor(private readonly actions: LeftNavActions) {}
 
     public itemSelected = (itemKey: LeftNavItemKey) => this.actions.itemSelected.invoke(itemKey);
+    public setLeftNavVisible = (value: boolean) => this.actions.setLeftNavVisible.invoke(value);
 }

--- a/src/electron/flux/action/left-nav-actions.ts
+++ b/src/electron/flux/action/left-nav-actions.ts
@@ -5,4 +5,5 @@ import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 
 export class LeftNavActions {
     public readonly itemSelected = new Action<LeftNavItemKey>();
+    public readonly setLeftNavVisible = new Action<boolean>();
 }

--- a/src/electron/flux/store/left-nav-store.ts
+++ b/src/electron/flux/store/left-nav-store.ts
@@ -16,15 +16,22 @@ export class LeftNavStore extends BaseStoreImpl<LeftNavStoreData> {
     public getDefaultState(): LeftNavStoreData {
         return {
             selectedKey: 'automated-checks',
+            leftNavVisible: true,
         };
     }
 
     protected addActionListeners(): void {
         this.actions.itemSelected.addListener(this.onItemSelected);
+        this.actions.setLeftNavVisible.addListener(this.onSetLeftNavVisible);
     }
 
     private onItemSelected = (key: LeftNavItemKey): void => {
         this.state.selectedKey = key;
+        this.emitChanged();
+    };
+
+    private onSetLeftNavVisible = (value: boolean): void => {
+        this.state.leftNavVisible = value;
         this.emitChanged();
     };
 }

--- a/src/electron/flux/types/left-nav-store-data.ts
+++ b/src/electron/flux/types/left-nav-store-data.ts
@@ -5,4 +5,5 @@ import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 
 export type LeftNavStoreData = {
     selectedKey: LeftNavItemKey;
+    leftNavVisible: boolean;
 };

--- a/src/tests/unit/tests/electron/flux/action-creator/left-nav-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/left-nav-action-creator.test.ts
@@ -5,23 +5,24 @@ import { Action } from 'common/flux/action';
 import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { LeftNavActions } from 'electron/flux/action/left-nav-actions';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, MockBehavior } from 'typemoq';
 
 describe('LeftNavActionCreator', () => {
     let actionsMock: IMock<LeftNavActions>;
-    let itemSelectedMock: IMock<Action<LeftNavItemKey>>;
-
     let actionCreator: LeftNavActionCreator;
 
     beforeEach(() => {
-        actionsMock = Mock.ofType<LeftNavActions>();
-        itemSelectedMock = Mock.ofType<Action<LeftNavItemKey>>();
-
-        actionsMock.setup(actions => actions.itemSelected).returns(() => itemSelectedMock.object);
+        actionsMock = Mock.ofType<LeftNavActions>(undefined, MockBehavior.Strict);
         actionCreator = new LeftNavActionCreator(actionsMock.object);
     });
 
     it('itemSelected', () => {
+        const itemSelectedMock = Mock.ofType<Action<LeftNavItemKey>>();
+        actionsMock
+            .setup(actions => actions.itemSelected)
+            .returns(() => itemSelectedMock.object)
+            .verifiable();
+
         const expectedKey: LeftNavItemKey = 'needs-review';
 
         itemSelectedMock.setup(m => m.invoke(expectedKey)).verifiable();
@@ -29,5 +30,21 @@ describe('LeftNavActionCreator', () => {
         actionCreator.itemSelected(expectedKey);
 
         itemSelectedMock.verifyAll();
+        actionsMock.verifyAll();
+    });
+
+    it.each([[true], [false]])('setLeftNavVisible', testValue => {
+        const setLeftNavVisibleMock = Mock.ofType<Action<boolean>>();
+        actionsMock
+            .setup(actions => actions.setLeftNavVisible)
+            .returns(() => setLeftNavVisibleMock.object)
+            .verifiable();
+
+        setLeftNavVisibleMock.setup(m => m.invoke(testValue)).verifiable();
+
+        actionCreator.setLeftNavVisible(testValue);
+
+        setLeftNavVisibleMock.verifyAll();
+        actionsMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/flux/store/__snapshots__/left-nav-store.test.ts.snap
+++ b/src/tests/unit/tests/electron/flux/store/__snapshots__/left-nav-store.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`LeftNavStore returns default state 1`] = `
 Object {
+  "leftNavVisible": true,
   "selectedKey": "automated-checks",
 }
 `;

--- a/src/tests/unit/tests/electron/flux/store/left-nav-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/left-nav-store.test.ts
@@ -1,10 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import { LeftNavActions } from 'electron/flux/action/left-nav-actions';
 import { LeftNavStore } from 'electron/flux/store/left-nav-store';
 import { LeftNavStoreData } from 'electron/flux/types/left-nav-store-data';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
 import { createStoreWithNullParams, StoreTester } from 'tests/unit/common/store-tester';
 
 describe('LeftNavStore', () => {
@@ -26,13 +26,35 @@ describe('LeftNavStore', () => {
     it('item selection causes state change', () => {
         const initialState: LeftNavStoreData = {
             selectedKey: 'needs-review',
+            leftNavVisible: true,
         };
         const expectedState: LeftNavStoreData = {
             selectedKey: 'automated-checks',
+            leftNavVisible: true,
         };
 
         CreateStoreTesterForLeftNavActions('itemSelected')
             .withActionParam(expectedState.selectedKey)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    it.each([
+        [true, false],
+        [false, true],
+        [false, false],
+        [true, true],
+    ])('setLeftNavVisible causes state change', (initialValue, expectedValue) => {
+        const initialState: LeftNavStoreData = {
+            selectedKey: 'needs-review',
+            leftNavVisible: initialValue,
+        };
+        const expectedState: LeftNavStoreData = {
+            selectedKey: 'needs-review',
+            leftNavVisible: expectedValue,
+        };
+
+        CreateStoreTesterForLeftNavActions('setLeftNavVisible')
+            .withActionParam(expectedValue)
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
 

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -80,6 +80,7 @@ describe('AutomatedChecksView', () => {
         };
         const leftNavStoreData: LeftNavStoreData = {
             selectedKey: initialSelectedKey,
+            leftNavVisible: true,
         };
 
         const ruleResultsByStatusStub = {


### PR DESCRIPTION
#### Description of changes

This is the state which will be set when narrow mode is enabled and the hamburger button has shown or hidden the left nav pane.
