### PR TITLE
refactor: report input data

### DIFF
--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -9,7 +9,12 @@ import { DetailsViewBody } from 'DetailsView/details-view-body';
 import { DetailsViewContainerProps } from 'DetailsView/details-view-container';
 import * as React from 'react';
 
+export type DetailsViewContentDeps = {
+    getDateFromTimestamp: (timestamp: string) => Date;
+};
+
 export type DetailsViewContentProps = DetailsViewContainerProps & {
+    deps: DetailsViewContentDeps;
     isSideNavOpen: boolean;
     setSideNavOpen: (isOpen: boolean, event?: React.MouseEvent<any>) => void;
     narrowModeStatus: NarrowModeStatus;
@@ -87,8 +92,14 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
             url: props.storeState.tabStoreData.url,
         };
 
+        const scanDate = props.deps.getDateFromTimestamp(
+            props.storeState.unifiedScanResultStoreData.timestamp,
+        );
+
         const scanMetadata: ScanMetadata = {
-            timestamp: props.storeState.unifiedScanResultStoreData.timestamp,
+            timespan: {
+                scanComplete: scanDate,
+            },
             targetAppInfo: targetAppInfo,
             toolData: props.storeState.unifiedScanResultStoreData.toolInfo,
         };

--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -32,7 +32,7 @@ export function getReportExportDialogForAssessment(
         deps: deps,
         reportExportFormat: 'Assessment',
         pageTitle: scanMetadata.targetAppInfo.name,
-        scanDate: deps.getCurrentDate(),
+        scanDate: scanMetadata.timespan.scanComplete,
         htmlGenerator: description =>
             reportGenerator.generateAssessmentReport(
                 assessmentStoreData,
@@ -71,17 +71,15 @@ export function getReportExportDialogForFastPass(
     }
 
     const { deps, isOpen, dismissExportDialog, afterDialogDismissed } = props;
-    const scanDate = deps.getDateFromTimestamp(props.scanMetadata.timestamp);
     const reportGenerator = deps.reportGenerator;
 
     const dialogProps: ExportDialogWithLocalStateProps = {
         deps: deps,
-        scanDate: scanDate,
         pageTitle: props.scanMetadata.targetAppInfo.name,
+        scanDate: props.scanMetadata.timespan.scanComplete,
         reportExportFormat: 'AutomatedChecks',
         htmlGenerator: description =>
             reportGenerator.generateFastPassAutomatedChecksReport(
-                scanDate,
                 props.cardsViewData,
                 description,
                 props.scanMetadata,

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -36,6 +36,7 @@ import { DetailsViewCommandBarDeps } from './components/details-view-command-bar
 import { DetailsViewOverlayDeps } from './components/details-view-overlay/details-view-overlay';
 import {
     DetailsRightPanelConfiguration,
+    DetailsViewContentDeps,
     GetDetailsRightPanelConfiguration,
 } from './components/details-view-right-panel';
 import { GetDetailsSwitcherNavConfiguration } from './components/details-view-switcher-nav';
@@ -69,7 +70,8 @@ export type DetailsViewContainerDeps = {
     WithStoreSubscriptionDeps<DetailsViewContainerState> &
     ThemeDeps &
     TargetChangeDialogDeps &
-    NarrowModeDetectorDeps;
+    NarrowModeDetectorDeps &
+    DetailsViewContentDeps;
 
 export interface DetailsViewContainerProps {
     deps: DetailsViewContainerDeps;

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -302,10 +302,10 @@ if (tabId != null) {
             const browserSpec = navigatorUtils.getBrowserSpec();
 
             const toolData = createToolData(
-                toolName,
-                browserAdapter.getVersion(),
                 'axe-core',
                 AxeInfo.Default.version,
+                toolName,
+                browserAdapter.getVersion(),
                 browserSpec,
             );
 

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -108,10 +108,10 @@ async function initialize(): Promise<void> {
     const browserSpec = new NavigatorUtils(window.navigator, logger).getBrowserSpec();
 
     const toolData = createToolData(
-        toolName,
-        browserAdapter.getVersion(),
         'axe-core',
         AxeInfo.Default.version,
+        toolName,
+        browserAdapter.getVersion(),
         browserSpec,
     );
 

--- a/src/common/application-properties-provider.ts
+++ b/src/common/application-properties-provider.ts
@@ -3,10 +3,10 @@
 import { ToolData } from './types/store-data/unified-data-interface';
 
 export const createToolData = (
-    toolName: string,
-    toolVersion: string,
     scanEngineName: string,
     scanEngineVersion: string,
+    toolName: string,
+    toolVersion?: string,
     environmentName?: string,
 ): ToolData => {
     return {

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -44,8 +44,15 @@ export interface ToolData {
     applicationProperties: ApplicationProperties;
 }
 
+export type ScanTimespan = {
+    scanComplete: Date;
+    scanStart?: Date;
+    durationSeconds?: number;
+};
+
 export type ScanMetadata = {
-    timestamp: string;
+    timespan?: ScanTimespan;
+    timestamp?: string;
     toolData: ToolData;
     targetAppInfo: TargetAppData;
     deviceName?: string;

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -12,7 +12,7 @@ export interface ScanEngineProperties {
 
 export interface ApplicationProperties {
     name: string;
-    version: string;
+    version?: string;
     environmentName?: string;
 }
 

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -51,8 +51,7 @@ export type ScanTimespan = {
 };
 
 export type ScanMetadata = {
-    timespan?: ScanTimespan;
-    timestamp?: string;
+    timespan: ScanTimespan;
     toolData: ToolData;
     targetAppInfo: TargetAppData;
     deviceName?: string;

--- a/src/electron/common/application-properties-provider.ts
+++ b/src/electron/common/application-properties-provider.ts
@@ -12,6 +12,6 @@ export const createGetToolDataDelegate = (
     scanEngineName: string,
 ): ToolDataDelegate => {
     return scanResults => {
-        return createToolData(toolName, toolVersion, scanEngineName, scanResults.axeVersion);
+        return createToolData(scanEngineName, scanResults.axeVersion, toolName, toolVersion);
     };
 };

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -53,6 +53,7 @@ export type AutomatedChecksViewDeps = CommandBarDeps &
         getCardSelectionViewData: GetCardSelectionViewData;
         screenshotViewModelProvider: ScreenshotViewModelProvider;
         isResultHighlightUnavailable: IsResultHighlightUnavailable;
+        getDateFromTimestamp: (timestamp: string) => Date;
     };
 
 export type AutomatedChecksViewProps = {
@@ -102,7 +103,11 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
             highlightedResultUids,
         );
 
-        const scanMetadata: ScanMetadata = this.getScanMetadata(status, unifiedScanResultStoreData);
+        const scanMetadata: ScanMetadata = this.getScanMetadata(
+            status,
+            unifiedScanResultStoreData,
+            deps.getDateFromTimestamp,
+        );
 
         const contentPageInfo: ContentPageInfo = this.getContentPageInfo();
 
@@ -181,11 +186,14 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
     private getScanMetadata(
         status: ScanStatus,
         unifiedScanResultStoreData: UnifiedScanResultStoreData,
+        getDateFromTimestamp: (timestamp: string) => Date,
     ): ScanMetadata {
         return status !== ScanStatus.Completed
             ? null
             : {
-                  timestamp: unifiedScanResultStoreData.timestamp,
+                  timespan: {
+                      scanComplete: getDateFromTimestamp(unifiedScanResultStoreData.timestamp),
+                  },
                   toolData: unifiedScanResultStoreData.toolInfo,
                   targetAppInfo: unifiedScanResultStoreData.targetAppInfo,
                   deviceName: unifiedScanResultStoreData.platformInfo.deviceName,

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -23,7 +23,6 @@ import * as styles from './command-bar.scss';
 export type CommandBarDeps = {
     scanActionCreator: ScanActionCreator;
     dropdownClickHandler: DropdownClickHandler;
-    getDateFromTimestamp: (timestamp: string) => Date;
     reportGenerator: ReportGenerator;
 } & ReportExportComponentDeps;
 
@@ -49,10 +48,9 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
                 deps={deps}
                 reportExportFormat={'AutomatedChecks'}
                 pageTitle={scanMetadata.targetAppInfo.name}
-                scanDate={deps.getDateFromTimestamp(scanMetadata.timestamp)}
+                scanDate={scanMetadata.timespan.scanComplete}
                 htmlGenerator={description =>
                     deps.reportGenerator.generateFastPassAutomatedChecksReport(
-                        deps.getDateFromTimestamp(scanMetadata.timestamp),
                         cardsViewData,
                         description,
                         scanMetadata,

--- a/src/electron/views/automated-checks/components/reflow-command-bar.tsx
+++ b/src/electron/views/automated-checks/components/reflow-command-bar.tsx
@@ -25,7 +25,6 @@ import { CommandBarButtonsMenu } from 'DetailsView/components/command-bar-button
 export type ReflowCommandBarDeps = {
     scanActionCreator: ScanActionCreator;
     dropdownClickHandler: DropdownClickHandler;
-    getDateFromTimestamp: (timestamp: string) => Date;
     reportGenerator: ReportGenerator;
 } & ReportExportComponentDeps;
 
@@ -63,10 +62,9 @@ export const ReflowCommandBar = NamedFC<ReflowCommandBarProps>('ReflowCommandBar
                 deps={deps}
                 reportExportFormat={'AutomatedChecks'}
                 pageTitle={scanMetadata.targetAppInfo.name}
-                scanDate={deps.getDateFromTimestamp(scanMetadata.timestamp)}
+                scanDate={scanMetadata.timespan.scanComplete}
                 htmlGenerator={description =>
                     deps.reportGenerator.generateFastPassAutomatedChecksReport(
-                        deps.getDateFromTimestamp(scanMetadata.timestamp),
                         cardsViewData,
                         description,
                         scanMetadata,

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -204,10 +204,10 @@ export class MainWindowInitializer extends WindowInitializer {
         const browserSpec = new NavigatorUtils(window.navigator, logger).getBrowserSpec();
 
         const toolData = createToolData(
-            toolName,
-            this.appDataAdapter.getVersion(),
             'axe-core',
             AxeInfo.Default.version,
+            toolName,
+            this.appDataAdapter.getVersion(),
             browserSpec,
         );
 

--- a/src/reports/combined-report-html-generator.tsx
+++ b/src/reports/combined-report-html-generator.tsx
@@ -3,7 +3,6 @@
 
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
-import { ScanTimespan } from 'reports/components/report-sections/base-summary-report-section-props';
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';
 import { CombinedReportSectionProps } from './components/report-sections/combined-report-section-factory';
 import { ReportSectionFactory } from './components/report-sections/report-section-factory';
@@ -18,12 +17,11 @@ export class CombinedReportHtmlGenerator {
         private readonly secondsToTimeStringConverter: (seconds: number) => string,
     ) {}
 
-    public generateHtml(scanTimespan: ScanTimespan, scanMetadata: ScanMetadata): string {
+    public generateHtml(scanMetadata: ScanMetadata): string {
         const HeadSection = this.sectionFactory.HeadSection;
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(<HeadSection />);
 
         const detailsProps: CombinedReportSectionProps = {
-            scanTimespan,
             scanMetadata,
             toUtcString: this.utcDateConverter,
             secondsToTimeString: this.secondsToTimeStringConverter,

--- a/src/reports/components/report-sections/base-summary-report-section-props.ts
+++ b/src/reports/components/report-sections/base-summary-report-section-props.ts
@@ -3,14 +3,7 @@
 
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 
-export type ScanTimespan = {
-    scanStart: Date;
-    scanComplete: Date;
-    durationSeconds: number;
-};
-
 export type BaseSummaryReportSectionProps = {
-    scanTimespan: ScanTimespan;
     toUtcString: (date: Date) => string;
     secondsToTimeString: (seconds: number) => string;
     getCollapsibleScript: () => string;

--- a/src/reports/components/report-sections/make-details-section-fc.tsx
+++ b/src/reports/components/report-sections/make-details-section-fc.tsx
@@ -12,7 +12,7 @@ import { SectionProps } from './report-section-factory';
 
 export type DetailsSectionProps = Pick<
     SectionProps,
-    'scanMetadata' | 'description' | 'scanDate' | 'toUtcString'
+    'scanMetadata' | 'description' | 'toUtcString'
 >;
 
 export type ScanDetailInfo = {
@@ -24,7 +24,7 @@ export function makeDetailsSectionFC(
     getDisplayedScanTargetInfo: (scanMetadata: ScanMetadata) => ScanDetailInfo,
 ): ReactFCWithDisplayName<DetailsSectionProps> {
     return NamedFC<DetailsSectionProps>('DetailsSection', props => {
-        const { scanMetadata, description, scanDate, toUtcString } = props;
+        const { scanMetadata, description, toUtcString } = props;
 
         const createListItem = (
             icon: JSX.Element,
@@ -41,7 +41,7 @@ export function makeDetailsSectionFC(
             </li>
         );
 
-        const scanDateUTC: string = toUtcString(scanDate);
+        const scanDateUTC: string = toUtcString(scanMetadata.timespan.scanComplete);
         const showCommentRow = !isEmpty(description);
         const displayedScanTargetInfo: ScanDetailInfo = getDisplayedScanTargetInfo(scanMetadata);
 

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -19,7 +19,6 @@ export type SectionProps = {
     deps: SectionDeps;
     fixInstructionProcessor: FixInstructionProcessor;
     description: string;
-    scanDate: Date;
     toUtcString: (date: Date) => string;
     getCollapsibleScript: () => string;
     getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks;

--- a/src/reports/components/report-sections/summary-report-details-section.tsx
+++ b/src/reports/components/report-sections/summary-report-details-section.tsx
@@ -9,7 +9,8 @@ import { BaseSummaryReportSectionProps } from 'reports/components/report-section
 export const SummaryReportDetailsSection = NamedFC<BaseSummaryReportSectionProps>(
     'SummaryReportDetailsSection',
     props => {
-        const { scanMetadata, scanTimespan, toUtcString, secondsToTimeString } = props;
+        const { scanMetadata, toUtcString, secondsToTimeString } = props;
+        const scanTimespan = scanMetadata.timespan;
 
         const createListItem = (label: string, content: string | JSX.Element) => (
             <li>

--- a/src/reports/package/axe-results-report.ts
+++ b/src/reports/package/axe-results-report.ts
@@ -16,6 +16,7 @@ export type AxeResultsReportDeps = {
     getUnifiedRules: typeof convertScanResultsToUnifiedRules;
     getUnifiedResults: ConvertScanResultsToUnifiedResultsDelegate;
     getCards: typeof getCardViewData;
+    getDateFromTimestamp: (timestamp: string) => Date;
 };
 
 export class AxeResultsReport implements AccessibilityInsightsReport.Report {
@@ -26,10 +27,17 @@ export class AxeResultsReport implements AccessibilityInsightsReport.Report {
     ) { }
 
     public asHTML(): string {
-        const { resultDecorator, getUnifiedRules, getUnifiedResults, getCards, reportHtmlGenerator } = this.deps;
+        const {
+            resultDecorator,
+            getUnifiedRules,
+            getUnifiedResults,
+            getCards,
+            reportHtmlGenerator,
+            getDateFromTimestamp
+        } = this.deps;
         const { results, description, scanContext: { pageTitle } } = this.parameters;
 
-        const scanDate = new Date(results.timestamp);
+        const scanDate = getDateFromTimestamp(results.timestamp);
 
         const scanResults = resultDecorator.decorateResults(results);
 
@@ -54,11 +62,12 @@ export class AxeResultsReport implements AccessibilityInsightsReport.Report {
         const scanMetadata: ScanMetadata = {
             targetAppInfo: targetAppInfo,
             toolData: this.toolInfo,
-            timestamp: null,
+            timespan: {
+                scanComplete: scanDate,
+            },
         };
 
         const html = reportHtmlGenerator.generateHtml(
-            scanDate,
             description,
             cardsViewModel,
             scanMetadata,

--- a/src/reports/package/combined-results-report.ts
+++ b/src/reports/package/combined-results-report.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import AccessibilityInsightsReport from './accessibilityInsightsReport';
 import { CombinedReportHtmlGenerator } from 'reports/combined-report-html-generator';
-import { ScanTimespan } from 'reports/components/report-sections/base-summary-report-section-props';
-import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-interface';
+import { ScanMetadata, ScanTimespan, ToolData } from 'common/types/store-data/unified-data-interface';
 
 export type CombinedResultsReportDeps = {
     reportHtmlGenerator: CombinedReportHtmlGenerator;
@@ -24,18 +23,18 @@ export class CombinedResultsReport implements AccessibilityInsightsReport.Report
             url: scanDetails.baseUrl,
         };
 
-        const scanMetadata: ScanMetadata = {
-            targetAppInfo: targetAppInfo,
-            toolData: this.toolInfo,
-            timestamp: null,
-        };
-
         const timespan: ScanTimespan = {
             scanStart: scanDetails.scanStart,
             scanComplete: scanDetails.scanComplete,
             durationSeconds: scanDetails.durationSeconds,
         }
 
-        return this.deps.reportHtmlGenerator.generateHtml(timespan, scanMetadata);
+        const scanMetadata: ScanMetadata = {
+            targetAppInfo: targetAppInfo,
+            toolData: this.toolInfo,
+            timespan,
+        };
+
+        return this.deps.reportHtmlGenerator.generateHtml(scanMetadata);
     }
 }

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -97,6 +97,7 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
         getUnifiedRules: convertScanResultsToUnifiedRules,
         getUnifiedResults: getUnifiedResults,
         getCards: getCardViewData,
+        getDateFromTimestamp: DateProvider.getDateFromTimestamp,
     };
 
     return new AxeResultsReport(deps, parameters, toolData);

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -56,10 +56,10 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
     const fixInstructionProcessor = new FixInstructionProcessor();
 
     const toolData = createToolData(
-        serviceName,
-        '',
         'axe-core',
         axeVersion,
+        serviceName,
+        null,
         userAgent,
     );
 
@@ -106,10 +106,10 @@ const summaryResultsReportGenerator = (parameters: SummaryReportParameters) => {
     const { serviceName, axeVersion, userAgent } = parameters;
 
     const toolData = createToolData(
-        serviceName,
-        '',
         'axe-core',
         axeVersion,
+        serviceName,
+        null,
         userAgent,
     );
 
@@ -132,10 +132,10 @@ const combinedResultsReportGenerator = (parameters: CombinedReportParameters) =>
     const { serviceName, axeVersion, userAgent } = parameters;
 
     const toolData = createToolData(
-        serviceName,
-        '',
         'axe-core',
         axeVersion,
+        serviceName,
+        null,
         userAgent,
     );
 

--- a/src/reports/package/summary-results-report.ts
+++ b/src/reports/package/summary-results-report.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import {  ToolData, ScanMetadata } from 'common/types/store-data/unified-data-interface';
+import {  ToolData, ScanMetadata, ScanTimespan } from 'common/types/store-data/unified-data-interface';
 import AccessibilityInsightsReport from './accessibilityInsightsReport';
 import { SummaryReportHtmlGenerator } from 'reports/summary-report-html-generator';
-import { ScanTimespan } from 'reports/components/report-sections/base-summary-report-section-props';
 
 export type SummaryResultsReportDeps = {
     reportHtmlGenerator: SummaryReportHtmlGenerator;
@@ -25,20 +24,19 @@ export class SummaryResultsReport implements AccessibilityInsightsReport.Report 
             url: scanDetails.baseUrl,
         };
 
-        const scanMetadata: ScanMetadata = {
-            targetAppInfo: targetAppInfo,
-            toolData: this.toolInfo,
-            timestamp: null,
-        };
-
         const timespan: ScanTimespan = {
             scanStart: scanDetails.scanStart,
             scanComplete: scanDetails.scanComplete,
             durationSeconds: scanDetails.durationSeconds,
         }
 
+        const scanMetadata: ScanMetadata = {
+            targetAppInfo: targetAppInfo,
+            toolData: this.toolInfo,
+            timespan: timespan,
+        };
+
         const html = reportHtmlGenerator.generateHtml(
-            timespan,
             scanMetadata,
             results,
         );

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -21,17 +21,11 @@ export class ReportGenerator {
     }
 
     public generateFastPassAutomatedChecksReport(
-        scanDate: Date,
         cardsViewData: CardsViewModel,
         description: string,
         scanMetadata: ScanMetadata,
     ): string {
-        return this.reportHtmlGenerator.generateHtml(
-            scanDate,
-            description,
-            cardsViewData,
-            scanMetadata,
-        );
+        return this.reportHtmlGenerator.generateHtml(description, cardsViewData, scanMetadata);
     }
 
     public generateAssessmentReport(

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -31,7 +31,6 @@ export class ReportHtmlGenerator {
     ) {}
 
     public generateHtml(
-        scanDate: Date,
         description: string,
         cardsViewData: CardsViewModel,
         scanMetadata: ScanMetadata,
@@ -41,7 +40,6 @@ export class ReportHtmlGenerator {
 
         const detailsProps: SectionProps = {
             description,
-            scanDate,
             deps: {
                 fixInstructionProcessor: this.fixInstructionProcessor,
                 collapsibleControl: ReportCollapsibleContainerControl,

--- a/src/reports/summary-report-html-generator.tsx
+++ b/src/reports/summary-report-html-generator.tsx
@@ -19,10 +19,7 @@ export class SummaryReportHtmlGenerator {
         private readonly secondsToTimeStringConverter: (seconds: number) => string,
     ) {}
 
-    public generateHtml(
-        scanMetadata: ScanMetadata,
-        results: SummaryScanResults,
-    ): string {
+    public generateHtml(scanMetadata: ScanMetadata, results: SummaryScanResults): string {
         const HeadSection = this.sectionFactory.HeadSection;
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(<HeadSection />);
 

--- a/src/reports/summary-report-html-generator.tsx
+++ b/src/reports/summary-report-html-generator.tsx
@@ -9,7 +9,6 @@ import { ReportSectionFactory } from './components/report-sections/report-sectio
 import { ReactStaticRenderer } from './react-static-renderer';
 import { SummaryReportSectionProps } from 'reports/components/report-sections/summary-report-section-factory';
 import { SummaryScanResults } from 'reports/package/accessibilityInsightsReport';
-import { ScanTimespan } from 'reports/components/report-sections/base-summary-report-section-props';
 
 export class SummaryReportHtmlGenerator {
     constructor(
@@ -21,7 +20,6 @@ export class SummaryReportHtmlGenerator {
     ) {}
 
     public generateHtml(
-        scanTimespan: ScanTimespan,
         scanMetadata: ScanMetadata,
         results: SummaryScanResults,
     ): string {
@@ -32,7 +30,6 @@ export class SummaryReportHtmlGenerator {
             deps: {
                 collapsibleControl: ReportCollapsibleContainerControl,
             },
-            scanTimespan,
             scanMetadata,
             results,
             toUtcString: this.utcDateConverter,

--- a/src/tests/unit/common/application-properties-provider.test.ts
+++ b/src/tests/unit/common/application-properties-provider.test.ts
@@ -5,10 +5,10 @@ import { createToolData } from 'common/application-properties-provider';
 describe('createToolData', () => {
     it('returns proper tool data', () => {
         const result = createToolData(
-            'test-tool-name',
-            'test-tool-version',
             'test-engine-name',
             'test-engine-version',
+            'test-tool-name',
+            'test-tool-version',
             'test-environment-name',
         );
 

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -43,6 +43,7 @@ exports[` render renders normally 1`] = `
         },
         "getCardSelectionViewData": [Function],
         "getCardViewData": [Function],
+        "getDateFromTimestamp": [Function],
         "getDetailsRightPanelConfiguration": [Function],
         "getDetailsSwitcherNavConfiguration": [Function],
         "isResultHighlightUnavailable": [Function],
@@ -129,6 +130,7 @@ exports[` render renders normally 1`] = `
         },
         "getCardSelectionViewData": [Function],
         "getCardViewData": [Function],
+        "getDateFromTimestamp": [Function],
         "getDetailsRightPanelConfiguration": [Function],
         "getDetailsSwitcherNavConfiguration": [Function],
         "isResultHighlightUnavailable": [Function],
@@ -188,7 +190,9 @@ exports[` render renders normally 1`] = `
           "name": "DetailsViewContainerTest title",
           "url": "http://detailsViewContainerTest/url/",
         },
-        "timestamp": "timestamp",
+        "timespan": Object {
+          "scanComplete": 1900-02-02T11:00:00.000Z,
+        },
         "toolData": Object {
           "applicationProperties": Object {
             "name": "some app",
@@ -462,6 +466,7 @@ exports[` render renders normally 1`] = `
         },
         "getCardSelectionViewData": [Function],
         "getCardViewData": [Function],
+        "getDateFromTimestamp": [Function],
         "getDetailsRightPanelConfiguration": [Function],
         "getDetailsSwitcherNavConfiguration": [Function],
         "isResultHighlightUnavailable": [Function],

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -191,7 +191,7 @@ exports[` render renders normally 1`] = `
           "url": "http://detailsViewContainerTest/url/",
         },
         "timespan": Object {
-          "scanComplete": 1900-02-02T11:00:00.000Z,
+          "scanComplete": 1900-02-02T03:00:00.000Z,
         },
         "toolData": Object {
           "applicationProperties": Object {

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -60,7 +60,7 @@ describe('ReportExportDialogFactory', () => {
             url: thePageUrl,
         };
         scanMetadata = {
-            timestamp: theTimestamp,
+            timespan: { scanComplete: theDate },
             toolData: theToolData,
             targetAppInfo: targetAppInfo,
         } as ScanMetadata;

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -61,6 +61,7 @@ describe(DetailsViewContent, () => {
     let isResultHighlightUnavailableStub: IsResultHighlightUnavailable;
     let timestamp: string;
     let toolData: ToolData;
+    let getDateFromTimestampMock: IMock<(timestamp: string) => Date>;
 
     beforeEach(() => {
         detailsViewActionMessageCreator = Mock.ofType(DetailsViewActionMessageCreator);
@@ -86,6 +87,8 @@ describe(DetailsViewContent, () => {
         );
         isResultHighlightUnavailableStub = () => null;
         timestamp = 'timestamp';
+        getDateFromTimestampMock = Mock.ofInstance(() => null);
+        getDateFromTimestampMock.setup(gd => gd(timestamp)).returns(() => new Date(0, 1, 2, 3));
         targetAppInfo = {
             name: pageTitle,
             url: pageUrl,
@@ -100,6 +103,7 @@ describe(DetailsViewContent, () => {
             getCardViewData: getCardViewDataMock.object,
             getCardSelectionViewData: getCardSelectionViewDataMock.object,
             isResultHighlightUnavailable: isResultHighlightUnavailableStub,
+            getDateFromTimestamp: getDateFromTimestampMock.object,
         } as DetailsViewContainerDeps;
     });
 

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -60,6 +60,7 @@ describe(DetailsViewContent, () => {
     let targetAppInfo: TargetAppData;
     let isResultHighlightUnavailableStub: IsResultHighlightUnavailable;
     let timestamp: string;
+    let scanDate: Date;
     let toolData: ToolData;
     let getDateFromTimestampMock: IMock<(timestamp: string) => Date>;
 
@@ -87,8 +88,9 @@ describe(DetailsViewContent, () => {
         );
         isResultHighlightUnavailableStub = () => null;
         timestamp = 'timestamp';
+        scanDate = new Date(Date.UTC(0, 1, 2, 3));
         getDateFromTimestampMock = Mock.ofInstance(() => null);
-        getDateFromTimestampMock.setup(gd => gd(timestamp)).returns(() => new Date(0, 1, 2, 3));
+        getDateFromTimestampMock.setup(gd => gd(timestamp)).returns(() => scanDate);
         targetAppInfo = {
             name: pageTitle,
             url: pageUrl,

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`AutomatedChecksView right content panel info changes when left nav sele
       },
       "getCardSelectionViewData": [Function],
       "getCardsViewData": [Function],
+      "getDateFromTimestamp": [Function],
       "isResultHighlightUnavailable": [Function],
       "scanActionCreator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -113,6 +114,7 @@ exports[`AutomatedChecksView right content panel info renders with default/initi
       },
       "getCardSelectionViewData": [Function],
       "getCardsViewData": [Function],
+      "getDateFromTimestamp": [Function],
       "isResultHighlightUnavailable": [Function],
       "scanActionCreator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -164,6 +166,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
         },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
+        "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -208,6 +211,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
               },
               "getCardSelectionViewData": [Function],
               "getCardsViewData": [Function],
+              "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
               "scanActionCreator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -267,6 +271,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                 },
                 "getCardSelectionViewData": [Function],
                 "getCardsViewData": [Function],
+                "getDateFromTimestamp": [Function],
                 "isResultHighlightUnavailable": [Function],
                 "scanActionCreator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -287,7 +292,9 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                 "targetAppInfo": Object {
                   "name": "test-target-app-name",
                 },
-                "timestamp": "test timestamp",
+                "timespan": Object {
+                  "scanComplete": 1900-02-02T11:00:00.000Z,
+                },
                 "toolData": Object {
                   "applicationProperties": Object {
                     "name": "some app",
@@ -346,6 +353,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                     },
                     "getCardSelectionViewData": [Function],
                     "getCardsViewData": [Function],
+                    "getDateFromTimestamp": [Function],
                     "isResultHighlightUnavailable": [Function],
                     "scanActionCreator": proxy {
                       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -366,7 +374,9 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                     "targetAppInfo": Object {
                       "name": "test-target-app-name",
                     },
-                    "timestamp": "test timestamp",
+                    "timespan": Object {
+                      "scanComplete": 1900-02-02T11:00:00.000Z,
+                    },
                     "toolData": Object {
                       "applicationProperties": Object {
                         "name": "some app",
@@ -429,6 +439,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                   },
                   "getCardSelectionViewData": [Function],
                   "getCardsViewData": [Function],
+                  "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
                   "scanActionCreator": proxy {
                     "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -449,7 +460,9 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                   "targetAppInfo": Object {
                     "name": "test-target-app-name",
                   },
-                  "timestamp": "test timestamp",
+                  "timespan": Object {
+                    "scanComplete": 1900-02-02T11:00:00.000Z,
+                  },
                   "toolData": Object {
                     "applicationProperties": Object {
                       "name": "some app",
@@ -501,6 +514,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
         },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
+        "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -554,6 +568,7 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
         },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
+        "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -598,6 +613,7 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
               },
               "getCardSelectionViewData": [Function],
               "getCardsViewData": [Function],
+              "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
               "scanActionCreator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -657,6 +673,7 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                 },
                 "getCardSelectionViewData": [Function],
                 "getCardsViewData": [Function],
+                "getDateFromTimestamp": [Function],
                 "isResultHighlightUnavailable": [Function],
                 "scanActionCreator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -723,6 +740,7 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                     },
                     "getCardSelectionViewData": [Function],
                     "getCardsViewData": [Function],
+                    "getDateFromTimestamp": [Function],
                     "isResultHighlightUnavailable": [Function],
                     "scanActionCreator": proxy {
                       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -793,6 +811,7 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                   },
                   "getCardSelectionViewData": [Function],
                   "getCardsViewData": [Function],
+                  "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
                   "scanActionCreator": proxy {
                     "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -856,6 +875,7 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
         },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
+        "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -909,6 +929,7 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
         },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
+        "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -953,6 +974,7 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
               },
               "getCardSelectionViewData": [Function],
               "getCardsViewData": [Function],
+              "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
               "scanActionCreator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -1012,6 +1034,7 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                 },
                 "getCardSelectionViewData": [Function],
                 "getCardsViewData": [Function],
+                "getDateFromTimestamp": [Function],
                 "isResultHighlightUnavailable": [Function],
                 "scanActionCreator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -1078,6 +1101,7 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                     },
                     "getCardSelectionViewData": [Function],
                     "getCardsViewData": [Function],
+                    "getDateFromTimestamp": [Function],
                     "isResultHighlightUnavailable": [Function],
                     "scanActionCreator": proxy {
                       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -1148,6 +1172,7 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                   },
                   "getCardSelectionViewData": [Function],
                   "getCardsViewData": [Function],
+                  "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
                   "scanActionCreator": proxy {
                     "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -1207,6 +1232,7 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
         },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
+        "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -1260,6 +1286,7 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
         },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
+        "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -1304,6 +1331,7 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
               },
               "getCardSelectionViewData": [Function],
               "getCardsViewData": [Function],
+              "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
               "scanActionCreator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -1363,6 +1391,7 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                 },
                 "getCardSelectionViewData": [Function],
                 "getCardsViewData": [Function],
+                "getDateFromTimestamp": [Function],
                 "isResultHighlightUnavailable": [Function],
                 "scanActionCreator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -1429,6 +1458,7 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                     },
                     "getCardSelectionViewData": [Function],
                     "getCardsViewData": [Function],
+                    "getDateFromTimestamp": [Function],
                     "isResultHighlightUnavailable": [Function],
                     "scanActionCreator": proxy {
                       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -1499,6 +1529,7 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                   },
                   "getCardSelectionViewData": [Function],
                   "getCardsViewData": [Function],
+                  "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
                   "scanActionCreator": proxy {
                     "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -1557,6 +1588,7 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
         },
         "getCardSelectionViewData": [Function],
         "getCardsViewData": [Function],
+        "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -293,7 +293,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                   "name": "test-target-app-name",
                 },
                 "timespan": Object {
-                  "scanComplete": 1900-02-02T11:00:00.000Z,
+                  "scanComplete": 1900-02-02T03:00:00.000Z,
                 },
                 "toolData": Object {
                   "applicationProperties": Object {
@@ -375,7 +375,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                       "name": "test-target-app-name",
                     },
                     "timespan": Object {
-                      "scanComplete": 1900-02-02T11:00:00.000Z,
+                      "scanComplete": 1900-02-02T03:00:00.000Z,
                     },
                     "toolData": Object {
                       "applicationProperties": Object {
@@ -461,7 +461,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                     "name": "test-target-app-name",
                   },
                   "timespan": Object {
-                    "scanComplete": 1900-02-02T11:00:00.000Z,
+                    "scanComplete": 1900-02-02T03:00:00.000Z,
                   },
                   "toolData": Object {
                     "applicationProperties": Object {

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/test-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/test-view.test.tsx.snap
@@ -18,7 +18,9 @@ exports[`TestView when status scan <Completed> 1`] = `
     deps={Object {}}
     scanMetadata={
       Object {
-        "timestamp": "some time",
+        "timespan": Object {
+          "scanComplete": 1900-02-02T11:04:00.000Z,
+        },
       }
     }
     userConfigurationStoreData={

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/test-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/test-view.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`TestView when status scan <Completed> 1`] = `
     scanMetadata={
       Object {
         "timespan": Object {
-          "scanComplete": 1900-02-02T11:04:00.000Z,
+          "scanComplete": 1900-02-02T03:04:00.000Z,
         },
       }
     }

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -56,7 +56,7 @@ describe('AutomatedChecksView', () => {
             'not-highlighted-uid-1': 'hidden',
         } as ResultsHighlightStatus;
         const timeStampStub = 'test timestamp';
-        const scanDate = new Date(0, 1, 2, 3);
+        const scanDate = new Date(Date.UTC(0, 1, 2, 3));
         const toolDataStub: ToolData = {
             applicationProperties: { name: 'some app' },
         } as ToolData;

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DateProvider } from 'common/date-provider';
 import {
     CardSelectionViewData,
     getCardSelectionViewData,
@@ -36,7 +37,7 @@ import { ScreenshotViewModel } from 'electron/views/screenshot/screenshot-view-m
 import { screenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Mock, Times } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 
 describe('AutomatedChecksView', () => {
     const initialSelectedKey: LeftNavItemKey = 'automated-checks';
@@ -45,6 +46,7 @@ describe('AutomatedChecksView', () => {
     let screenshotViewModelProviderMock = Mock.ofInstance(screenshotViewModelProvider);
     let getCardSelectionViewDataMock = Mock.ofInstance(getCardSelectionViewData);
     let getUnifiedRuleResultsMock = Mock.ofInstance(getCardViewData);
+    let getDateFromTimestampMock: IMock<(timestamp: string) => Date>;
 
     beforeEach(() => {
         isResultHighlightUnavailableStub = () => null;
@@ -54,6 +56,7 @@ describe('AutomatedChecksView', () => {
             'not-highlighted-uid-1': 'hidden',
         } as ResultsHighlightStatus;
         const timeStampStub = 'test timestamp';
+        const scanDate = new Date(0, 1, 2, 3);
         const toolDataStub: ToolData = {
             applicationProperties: { name: 'some app' },
         } as ToolData;
@@ -99,6 +102,7 @@ describe('AutomatedChecksView', () => {
         screenshotViewModelProviderMock = Mock.ofInstance(screenshotViewModelProvider);
         getCardSelectionViewDataMock = Mock.ofInstance(getCardSelectionViewData);
         getUnifiedRuleResultsMock = Mock.ofInstance(getCardViewData);
+        getDateFromTimestampMock = Mock.ofInstance(DateProvider.getDateFromTimestamp);
 
         props = {
             deps: {
@@ -108,6 +112,7 @@ describe('AutomatedChecksView', () => {
                 screenshotViewModelProvider: screenshotViewModelProviderMock.object,
                 isResultHighlightUnavailable: isResultHighlightUnavailableStub,
                 contentPagesInfo: contentPagesInfo,
+                getDateFromTimestamp: getDateFromTimestampMock.object,
             },
             cardSelectionStoreData,
             androidSetupStoreData: {},
@@ -142,6 +147,7 @@ describe('AutomatedChecksView', () => {
             .setup(provider => provider(unifiedScanResultStoreData, ['highlighted-uid-1']))
             .returns(() => screenshotViewModelStub)
             .verifiable(Times.once());
+        getDateFromTimestampMock.setup(gd => gd(timeStampStub)).returns(() => scanDate);
     });
 
     const createContentPagesInfo = (): ContentPagesInfo => {

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -120,7 +120,6 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
         <ReportExportComponent
           deps={
             Object {
-              "getDateFromTimestamp": [Function],
               "reportGenerator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "assessmentReportHtmlGenerator": undefined,
@@ -227,7 +226,6 @@ exports[`CommandBar renders while status is <Default> 1`] = `
         <ReportExportComponent
           deps={
             Object {
-              "getDateFromTimestamp": [Function],
               "reportGenerator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "assessmentReportHtmlGenerator": undefined,
@@ -334,7 +332,6 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
         <ReportExportComponent
           deps={
             Object {
-              "getDateFromTimestamp": [Function],
               "reportGenerator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "assessmentReportHtmlGenerator": undefined,
@@ -441,7 +438,6 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
         <ReportExportComponent
           deps={
             Object {
-              "getDateFromTimestamp": [Function],
               "reportGenerator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "assessmentReportHtmlGenerator": undefined,

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/reflow-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/reflow-command-bar.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`ReflowCommandBar reflow behavior isHeaderAndNavCollapsed is true 1`] = 
           <ReportExportComponent
             deps={
               Object {
-                "getDateFromTimestamp": [Function],
                 "reportGenerator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "assessmentReportHtmlGenerator": undefined,
@@ -166,7 +165,6 @@ exports[`ReflowCommandBar renders while status is <Completed> 1`] = `
           <ReportExportComponent
             deps={
               Object {
-                "getDateFromTimestamp": [Function],
                 "reportGenerator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "assessmentReportHtmlGenerator": undefined,
@@ -238,7 +236,6 @@ exports[`ReflowCommandBar renders while status is <Default> 1`] = `
           <ReportExportComponent
             deps={
               Object {
-                "getDateFromTimestamp": [Function],
                 "reportGenerator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "assessmentReportHtmlGenerator": undefined,
@@ -310,7 +307,6 @@ exports[`ReflowCommandBar renders while status is <Failed> 1`] = `
           <ReportExportComponent
             deps={
               Object {
-                "getDateFromTimestamp": [Function],
                 "reportGenerator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "assessmentReportHtmlGenerator": undefined,
@@ -382,7 +378,6 @@ exports[`ReflowCommandBar renders while status is <Scanning> 1`] = `
           <ReportExportComponent
             deps={
               Object {
-                "getDateFromTimestamp": [Function],
                 "reportGenerator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "assessmentReportHtmlGenerator": undefined,
@@ -401,7 +396,6 @@ exports[`ReflowCommandBar renders while status is <Scanning> 1`] = `
             htmlGenerator={[Function]}
             pageTitle="scan target name"
             reportExportFormat="AutomatedChecks"
-            scanDate={1970-01-01T00:00:00.000Z}
             updatePersistedDescription={[Function]}
           />
         }

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -22,7 +22,6 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('CommandBar', () => {
     let featureFlagStoreDataStub: FeatureFlagStoreData;
-    let getDateFromTimestampMock: IMock<(timestamp: string) => Date>;
     let cardsViewDataStub: CardsViewModel;
     let reportGeneratorMock: IMock<ReportGenerator>;
     let scanMetadataStub: ScanMetadata;
@@ -32,21 +31,18 @@ describe('CommandBar', () => {
         featureFlagStoreDataStub = {
             somefeatureflag: true,
         };
-        getDateFromTimestampMock = Mock.ofInstance((_: string) => null as Date);
         cardsViewDataStub = {} as CardsViewModel;
+        scanDateStub = new Date(0);
         scanMetadataStub = {
-            timestamp: '1234',
+            timespan: {
+                scanComplete: scanDateStub,
+            },
             toolData: {} as ToolData,
             targetAppInfo: {
                 name: 'scan target name',
             },
         };
-        scanDateStub = new Date(0);
         reportGeneratorMock = Mock.ofType(ReportGenerator);
-
-        getDateFromTimestampMock
-            .setup(mock => mock(scanMetadataStub.timestamp))
-            .returns(() => scanDateStub);
     });
 
     describe('renders', () => {
@@ -54,7 +50,6 @@ describe('CommandBar', () => {
             const props = {
                 deps: {
                     scanActionCreator: null,
-                    getDateFromTimestamp: getDateFromTimestampMock.object,
                     reportGenerator: reportGeneratorMock.object,
                 } as CommandBarDeps,
                 scanStoreData: {
@@ -74,7 +69,6 @@ describe('CommandBar', () => {
             const props = {
                 deps: {
                     scanActionCreator: null,
-                    getDateFromTimestamp: getDateFromTimestampMock.object,
                     reportGenerator: reportGeneratorMock.object,
                 } as CommandBarDeps,
                 scanStoreData: {
@@ -97,7 +91,6 @@ describe('CommandBar', () => {
             const props = {
                 deps: {
                     scanActionCreator: null,
-                    getDateFromTimestamp: getDateFromTimestampMock.object,
                     reportGenerator: reportGeneratorMock.object,
                 },
                 scanStoreData: {
@@ -129,7 +122,6 @@ describe('CommandBar', () => {
             const props = {
                 deps: {
                     scanActionCreator: scanActionCreatorMock.object,
-                    getDateFromTimestamp: getDateFromTimestampMock.object,
                     reportGenerator: reportGeneratorMock.object,
                 },
                 scanPort: port,
@@ -157,7 +149,6 @@ describe('CommandBar', () => {
             const props = {
                 deps: {
                     dropdownClickHandler: dropdownClickHandlerMock.object,
-                    getDateFromTimestamp: getDateFromTimestampMock.object,
                     reportGenerator: reportGeneratorMock.object,
                 },
                 scanStoreData: {

--- a/src/tests/unit/tests/electron/views/automated-checks/components/reflow-command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/reflow-command-bar.test.tsx
@@ -23,7 +23,6 @@ import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 
 describe('ReflowCommandBar', () => {
     let featureFlagStoreDataStub: FeatureFlagStoreData;
-    let getDateFromTimestampMock: IMock<(timestamp: string) => Date>;
     let cardsViewDataStub: CardsViewModel;
     let reportGeneratorMock: IMock<ReportGenerator>;
     let scanMetadataStub: ScanMetadata;
@@ -36,10 +35,11 @@ describe('ReflowCommandBar', () => {
         featureFlagStoreDataStub = {
             somefeatureflag: true,
         };
-        getDateFromTimestampMock = Mock.ofInstance((_: string) => null as Date);
         cardsViewDataStub = {} as CardsViewModel;
         scanMetadataStub = {
-            timestamp: '1234',
+            timespan: {
+                scanComplete: scanDateStub,
+            },
             toolData: {} as ToolData,
             targetAppInfo: {
                 name: 'scan target name',
@@ -53,14 +53,9 @@ describe('ReflowCommandBar', () => {
         reportGeneratorMock = Mock.ofType(ReportGenerator);
         scanPortStub = 1111;
 
-        getDateFromTimestampMock
-            .setup(mock => mock(scanMetadataStub.timestamp))
-            .returns(() => scanDateStub);
-
         props = {
             deps: {
                 scanActionCreator: null,
-                getDateFromTimestamp: getDateFromTimestampMock.object,
                 reportGenerator: reportGeneratorMock.object,
             } as ReflowCommandBarDeps,
             scanStoreData: {

--- a/src/tests/unit/tests/electron/views/automated-checks/test-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/test-view.test.tsx
@@ -19,7 +19,9 @@ describe('TestView', () => {
 
     beforeEach(() => {
         scanMetadataStub = {
-            timestamp: 'some time',
+            timespan: {
+                scanComplete: new Date(0, 1, 2, 3, 4),
+            },
         } as ScanMetadata;
         cardsViewDataStub = {
             visualHelperEnabled: true,

--- a/src/tests/unit/tests/electron/views/automated-checks/test-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/test-view.test.tsx
@@ -20,7 +20,7 @@ describe('TestView', () => {
     beforeEach(() => {
         scanMetadataStub = {
             timespan: {
-                scanComplete: new Date(0, 1, 2, 3, 4),
+                scanComplete: new Date(Date.UTC(0, 1, 2, 3, 4)),
             },
         } as ScanMetadata;
         cardsViewDataStub = {

--- a/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
@@ -3,7 +3,11 @@
 
 import { NullComponent } from 'common/components/null-component';
 import { DateProvider } from 'common/date-provider';
-import { ScanMetadata, ScanTimespan, ToolData } from 'common/types/store-data/unified-data-interface';
+import {
+    ScanMetadata,
+    ScanTimespan,
+    ToolData,
+} from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import { CombinedReportHtmlGenerator } from 'reports/combined-report-html-generator';
 import { CombinedReportSectionProps } from 'reports/components/report-sections/combined-report-section-factory';

--- a/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
@@ -3,10 +3,9 @@
 
 import { NullComponent } from 'common/components/null-component';
 import { DateProvider } from 'common/date-provider';
-import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-interface';
+import { ScanMetadata, ScanTimespan, ToolData } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import { CombinedReportHtmlGenerator } from 'reports/combined-report-html-generator';
-import { ScanTimespan } from 'reports/components/report-sections/base-summary-report-section-props';
 import { CombinedReportSectionProps } from 'reports/components/report-sections/combined-report-section-factory';
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';
 import { ReportSectionFactory } from 'reports/components/report-sections/report-section-factory';
@@ -39,16 +38,17 @@ describe('CombinedReportHtmlGenerator', () => {
         url: baseUrl,
     };
 
-    const scanMetadata = {
-        toolData: toolData,
-        targetAppInfo: targetAppInfo,
-    } as ScanMetadata;
-
     const scanTimespan: ScanTimespan = {
         scanStart: new Date(2020, 1, 2, 3),
         scanComplete: new Date(2020, 4, 5, 6),
         durationSeconds: 42,
     };
+
+    const scanMetadata = {
+        toolData: toolData,
+        targetAppInfo: targetAppInfo,
+        timespan: scanTimespan,
+    } as ScanMetadata;
 
     let getScriptMock: IMock<() => string>;
     let sectionFactoryMock: IMock<ReportSectionFactory<CombinedReportSectionProps>>;
@@ -75,7 +75,6 @@ describe('CombinedReportHtmlGenerator', () => {
             secondsToTimeString: getTimeStringFromSecondsStub,
             getCollapsibleScript: getScriptMock.object,
             scanMetadata,
-            scanTimespan,
         };
 
         const headElement: JSX.Element = <NullComponent />;
@@ -91,7 +90,7 @@ describe('CombinedReportHtmlGenerator', () => {
             .returns(() => '<body-markup />')
             .verifiable(Times.once());
 
-        const html = testSubject.generateHtml(scanTimespan, scanMetadata);
+        const html = testSubject.generateHtml(scanMetadata);
 
         expect(html).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
@@ -70,13 +70,14 @@ exports[`ReportBody renders 1`] = `
     getGuidanceTagsFromGuidanceLinks={[Function]}
     pageTitle="page-title"
     pageUrl="url:target-page"
-    scanDate={2019-05-29T19:12:16.804Z}
     scanMetadata={
       Object {
         "targetAppInfo": Object {
           "name": "app",
         },
-        "timestamp": "today",
+        "timespan": Object {
+          "scanComplete": 1900-02-02T11:00:00.000Z,
+        },
         "toolData": Object {
           "applicationProperties": Object {
             "environmentName": "environmentName",
@@ -214,13 +215,14 @@ exports[`ReportBody renders 1`] = `
       getGuidanceTagsFromGuidanceLinks={[Function]}
       pageTitle="page-title"
       pageUrl="url:target-page"
-      scanDate={2019-05-29T19:12:16.804Z}
       scanMetadata={
         Object {
           "targetAppInfo": Object {
             "name": "app",
           },
-          "timestamp": "today",
+          "timespan": Object {
+            "scanComplete": 1900-02-02T11:00:00.000Z,
+          },
           "toolData": Object {
             "applicationProperties": Object {
               "environmentName": "environmentName",
@@ -356,13 +358,14 @@ exports[`ReportBody renders 1`] = `
       getGuidanceTagsFromGuidanceLinks={[Function]}
       pageTitle="page-title"
       pageUrl="url:target-page"
-      scanDate={2019-05-29T19:12:16.804Z}
       scanMetadata={
         Object {
           "targetAppInfo": Object {
             "name": "app",
           },
-          "timestamp": "today",
+          "timespan": Object {
+            "scanComplete": 1900-02-02T11:00:00.000Z,
+          },
           "toolData": Object {
             "applicationProperties": Object {
               "environmentName": "environmentName",
@@ -498,13 +501,14 @@ exports[`ReportBody renders 1`] = `
       getGuidanceTagsFromGuidanceLinks={[Function]}
       pageTitle="page-title"
       pageUrl="url:target-page"
-      scanDate={2019-05-29T19:12:16.804Z}
       scanMetadata={
         Object {
           "targetAppInfo": Object {
             "name": "app",
           },
-          "timestamp": "today",
+          "timespan": Object {
+            "scanComplete": 1900-02-02T11:00:00.000Z,
+          },
           "toolData": Object {
             "applicationProperties": Object {
               "environmentName": "environmentName",
@@ -640,13 +644,14 @@ exports[`ReportBody renders 1`] = `
         getGuidanceTagsFromGuidanceLinks={[Function]}
         pageTitle="page-title"
         pageUrl="url:target-page"
-        scanDate={2019-05-29T19:12:16.804Z}
         scanMetadata={
           Object {
             "targetAppInfo": Object {
               "name": "app",
             },
-            "timestamp": "today",
+            "timespan": Object {
+              "scanComplete": 1900-02-02T11:00:00.000Z,
+            },
             "toolData": Object {
               "applicationProperties": Object {
                 "environmentName": "environmentName",
@@ -782,13 +787,14 @@ exports[`ReportBody renders 1`] = `
         getGuidanceTagsFromGuidanceLinks={[Function]}
         pageTitle="page-title"
         pageUrl="url:target-page"
-        scanDate={2019-05-29T19:12:16.804Z}
         scanMetadata={
           Object {
             "targetAppInfo": Object {
               "name": "app",
             },
-            "timestamp": "today",
+            "timespan": Object {
+              "scanComplete": 1900-02-02T11:00:00.000Z,
+            },
             "toolData": Object {
               "applicationProperties": Object {
                 "environmentName": "environmentName",
@@ -924,13 +930,14 @@ exports[`ReportBody renders 1`] = `
         getGuidanceTagsFromGuidanceLinks={[Function]}
         pageTitle="page-title"
         pageUrl="url:target-page"
-        scanDate={2019-05-29T19:12:16.804Z}
         scanMetadata={
           Object {
             "targetAppInfo": Object {
               "name": "app",
             },
-            "timestamp": "today",
+            "timespan": Object {
+              "scanComplete": 1900-02-02T11:00:00.000Z,
+            },
             "toolData": Object {
               "applicationProperties": Object {
                 "environmentName": "environmentName",
@@ -1069,13 +1076,14 @@ exports[`ReportBody renders 1`] = `
       getGuidanceTagsFromGuidanceLinks={[Function]}
       pageTitle="page-title"
       pageUrl="url:target-page"
-      scanDate={2019-05-29T19:12:16.804Z}
       scanMetadata={
         Object {
           "targetAppInfo": Object {
             "name": "app",
           },
-          "timestamp": "today",
+          "timespan": Object {
+            "scanComplete": 1900-02-02T11:00:00.000Z,
+          },
           "toolData": Object {
             "applicationProperties": Object {
               "environmentName": "environmentName",

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`ReportBody renders 1`] = `
           "name": "app",
         },
         "timespan": Object {
-          "scanComplete": 1900-02-02T11:00:00.000Z,
+          "scanComplete": 1900-02-02T03:00:00.000Z,
         },
         "toolData": Object {
           "applicationProperties": Object {
@@ -221,7 +221,7 @@ exports[`ReportBody renders 1`] = `
             "name": "app",
           },
           "timespan": Object {
-            "scanComplete": 1900-02-02T11:00:00.000Z,
+            "scanComplete": 1900-02-02T03:00:00.000Z,
           },
           "toolData": Object {
             "applicationProperties": Object {
@@ -364,7 +364,7 @@ exports[`ReportBody renders 1`] = `
             "name": "app",
           },
           "timespan": Object {
-            "scanComplete": 1900-02-02T11:00:00.000Z,
+            "scanComplete": 1900-02-02T03:00:00.000Z,
           },
           "toolData": Object {
             "applicationProperties": Object {
@@ -507,7 +507,7 @@ exports[`ReportBody renders 1`] = `
             "name": "app",
           },
           "timespan": Object {
-            "scanComplete": 1900-02-02T11:00:00.000Z,
+            "scanComplete": 1900-02-02T03:00:00.000Z,
           },
           "toolData": Object {
             "applicationProperties": Object {
@@ -650,7 +650,7 @@ exports[`ReportBody renders 1`] = `
               "name": "app",
             },
             "timespan": Object {
-              "scanComplete": 1900-02-02T11:00:00.000Z,
+              "scanComplete": 1900-02-02T03:00:00.000Z,
             },
             "toolData": Object {
               "applicationProperties": Object {
@@ -793,7 +793,7 @@ exports[`ReportBody renders 1`] = `
               "name": "app",
             },
             "timespan": Object {
-              "scanComplete": 1900-02-02T11:00:00.000Z,
+              "scanComplete": 1900-02-02T03:00:00.000Z,
             },
             "toolData": Object {
               "applicationProperties": Object {
@@ -936,7 +936,7 @@ exports[`ReportBody renders 1`] = `
               "name": "app",
             },
             "timespan": Object {
-              "scanComplete": 1900-02-02T11:00:00.000Z,
+              "scanComplete": 1900-02-02T03:00:00.000Z,
             },
             "toolData": Object {
               "applicationProperties": Object {
@@ -1082,7 +1082,7 @@ exports[`ReportBody renders 1`] = `
             "name": "app",
           },
           "timespan": Object {
-            "scanComplete": 1900-02-02T11:00:00.000Z,
+            "scanComplete": 1900-02-02T03:00:00.000Z,
           },
           "toolData": Object {
             "applicationProperties": Object {

--- a/src/tests/unit/tests/reports/components/report-sections/make-details-section-fc.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/make-details-section-fc.test.tsx
@@ -24,6 +24,9 @@ describe('makeDetailsSection', () => {
     const scanMetadata = {
         targetAppInfo,
         deviceName,
+        timespan: {
+            scanComplete: scanDate,
+        },
     } as ScanMetadata;
     const displayedScanTargetInfo: ScanDetailInfo = {
         label: 'item label',
@@ -47,7 +50,6 @@ describe('makeDetailsSection', () => {
 
     test.each(descriptionValues)('renders with description: %s', description => {
         const props: DetailsSectionProps = {
-            scanDate,
             targetAppInfo,
             description,
             environmentInfo: {

--- a/src/tests/unit/tests/reports/components/report-sections/report-body.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/report-body.test.tsx
@@ -18,6 +18,7 @@ describe('ReportBody', () => {
     it('renders', () => {
         const pageTitle = 'page-title';
         const pageUrl = 'url:target-page';
+        const scanDate = new Date(Date.UTC(0, 1, 2, 3));
         const getScriptStub = () => '';
         const getGuidanceTagsStub = () => [];
         const fixInstructionProcessorMock = Mock.ofType(FixInstructionProcessor);
@@ -65,7 +66,7 @@ describe('ReportBody', () => {
                 toolData,
                 targetAppInfo,
                 timespan: {
-                    scanComplete: new Date(0, 1, 2, 3),
+                    scanComplete: scanDate,
                 },
             },
         };

--- a/src/tests/unit/tests/reports/components/report-sections/report-body.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/report-body.test.tsx
@@ -40,7 +40,6 @@ describe('ReportBody', () => {
             pageTitle,
             pageUrl,
             description: 'test description',
-            scanDate: new Date('2019-05-29T19:12:16.804Z'),
             toolData,
             scanResult: {
                 passes: [],
@@ -65,7 +64,9 @@ describe('ReportBody', () => {
             scanMetadata: {
                 toolData,
                 targetAppInfo,
-                timestamp: 'today',
+                timespan: {
+                    scanComplete: new Date(0, 1, 2, 3),
+                },
             },
         };
 

--- a/src/tests/unit/tests/reports/components/report-sections/summary-report-details-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/summary-report-details-section.test.tsx
@@ -3,10 +3,9 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { SummaryReportDetailsSection } from 'reports/components/report-sections/summary-report-details-section';
-import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
+import { ScanMetadata, ScanTimespan } from 'common/types/store-data/unified-data-interface';
 import { IMock, Mock } from 'typemoq';
 import { SummaryReportSectionProps } from 'reports/components/report-sections/summary-report-section-factory';
-import { ScanTimespan } from 'reports/components/report-sections/base-summary-report-section-props';
 
 describe(SummaryReportDetailsSection, () => {
     const scanStart = new Date(0, 1, 2, 3);
@@ -42,9 +41,9 @@ describe(SummaryReportDetailsSection, () => {
                 name: 'page name',
                 url: 'page url',
             },
+            timespan: scanTimespan,
         } as ScanMetadata;
         const props = {
-            scanTimespan,
             scanMetadata,
             toUtcString: toUtcStringMock.object,
             secondsToTimeString: secondsToTimeStringMock.object,

--- a/src/tests/unit/tests/reports/package/axe-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/axe-results-report.test.ts
@@ -15,6 +15,7 @@ import { ResultDecorator } from 'scanner/result-decorator';
 import { Mock, MockBehavior } from 'typemoq';
 
 describe('AxeResultReport', () => {
+    const scanTimestamp = 'timestamp';
     const reportDateTime = new Date(2019, 10, 23, 15, 35, 0);
     const url = 'https://the.page';
     const pageTitle = 'PAGE_TITLE';
@@ -29,11 +30,13 @@ describe('AxeResultReport', () => {
     const scanMetadataStub = {
         toolData: toolDataStub,
         targetAppInfo: targetAppInfoStub,
-        timestamp: null,
+        timespan: {
+            scanComplete: reportDateTime,
+        }
     };
 
     const results = {
-        timestamp: reportDateTime.toISOString(),
+        timestamp: scanTimestamp,
         url,
     } as AxeResults;
 
@@ -73,8 +76,11 @@ describe('AxeResultReport', () => {
     const expectedHTML = '<div>The Report!</div>';
     const mockReportHtmlGenerator = Mock.ofType<ReportHtmlGenerator>(null, MockBehavior.Strict);
     mockReportHtmlGenerator
-        .setup(gen => gen.generateHtml(reportDateTime, description, mockCardsViewModel.object, scanMetadataStub))
+        .setup(gen => gen.generateHtml(description, mockCardsViewModel.object, scanMetadataStub))
         .returns(() => expectedHTML);
+
+    const mockGetDateFromTimestamp = Mock.ofType<(timestamp: string) => Date>();
+    mockGetDateFromTimestamp.setup(md => md(scanTimestamp)).returns(() => reportDateTime);
 
     const deps: AxeResultsReportDeps = {
         reportHtmlGenerator: mockReportHtmlGenerator.object,
@@ -82,6 +88,7 @@ describe('AxeResultReport', () => {
         getUnifiedRules: mockGetRules.object,
         getUnifiedResults: mockGetResults.object,
         getCards: mockGetCards.object,
+        getDateFromTimestamp: mockGetDateFromTimestamp.object,
     };
 
     it('returns HTML', () => {

--- a/src/tests/unit/tests/reports/package/combined-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/combined-results-report.test.ts
@@ -21,22 +21,22 @@ describe('CombinedResultsReport', () => {
         name: basePageTitle,
         url: baseUrl,
     };
-    const scanMetadataStub = {
-        toolData: toolDataStub,
-        targetAppInfo: targetAppInfoStub,
-        timestamp: null,
-    };
-    
-    const scanTimespan = {
+    const scanTimespanStub = {
         scanStart: new Date(2019, 1, 2, 3),
         scanComplete: new Date(2019, 4, 5, 6),
         durationSeconds: 42,
     };
+    const scanMetadataStub = {
+        toolData: toolDataStub,
+        targetAppInfo: targetAppInfoStub,
+        timespan: scanTimespanStub,
+    };
+    
 
     const scanDetails: ScanSummaryDetails = {
         baseUrl: baseUrl,
         basePageTitle: basePageTitle,
-        ...scanTimespan
+        ...scanTimespanStub
     };
 
     const results = {} as CombinedReportResults;
@@ -61,7 +61,7 @@ describe('CombinedResultsReport', () => {
     });
 
     it('returns HTML', () => {
-        reportHtmlGeneratorMock.setup(rhg => rhg.generateHtml(scanTimespan, scanMetadataStub)).returns(() => expectedHtml);
+        reportHtmlGeneratorMock.setup(rhg => rhg.generateHtml(scanMetadataStub)).returns(() => expectedHtml);
 
         const html = combinedResultsReport.asHTML();
 

--- a/src/tests/unit/tests/reports/package/summary-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/summary-results-report.test.ts
@@ -16,17 +16,15 @@ describe('SummaryResultsReport', () => {
         name: basePageTitle,
         url: baseUrl,
     };
-    const scanMetadataStub = {
-        toolData: toolDataStub,
-        targetAppInfo: targetAppInfoStub,
-        timestamp: null,
-    };
-
-    
     const scanTimespan = {
         scanStart: new Date(2019, 1, 2, 3),
         scanComplete: new Date(2019, 4, 5, 6),
         durationSeconds: 42,
+    };
+    const scanMetadataStub = {
+        toolData: toolDataStub,
+        targetAppInfo: targetAppInfoStub,
+        timespan: scanTimespan,
     };
 
     const scanDetails: ScanSummaryDetails = {
@@ -72,7 +70,7 @@ describe('SummaryResultsReport', () => {
 
     const mockHtmlGenerator = Mock.ofType<SummaryReportHtmlGenerator>();
     mockHtmlGenerator
-        .setup(hg => hg.generateHtml(scanTimespan, scanMetadataStub, results))
+        .setup(hg => hg.generateHtml(scanMetadataStub, results))
         .returns(() => expectedHTML);
 
     const deps = {

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -50,7 +50,7 @@ describe('ReportGenerator', () => {
     test('generateHtml', () => {
         dataBuilderMock
             .setup(builder =>
-                builder.generateHtml(date, description, cardsViewDataStub, scanMetadataStub),
+                builder.generateHtml(description, cardsViewDataStub, scanMetadataStub),
             )
             .returns(() => 'returned-data');
 
@@ -60,7 +60,6 @@ describe('ReportGenerator', () => {
             assessmentReportHtmlGeneratorMock.object,
         );
         const actual = testObject.generateFastPassAutomatedChecksReport(
-            date,
             cardsViewDataStub,
             description,
             scanMetadataStub,

--- a/src/tests/unit/tests/reports/report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/report-html-generator.test.tsx
@@ -61,6 +61,9 @@ describe('ReportHtmlGenerator', () => {
         const scanMetadata = {
             toolData: toolData,
             targetAppInfo: targetAppInfo,
+            timespan: {
+                scanComplete: scanDate,
+            },
         } as ScanMetadata;
 
         const sectionProps: ReportBodyProps = {
@@ -76,7 +79,6 @@ describe('ReportHtmlGenerator', () => {
             fixInstructionProcessor: fixInstructionProcessorMock.object,
             sectionFactory: sectionFactoryMock.object as ReportBodySectionFactory,
             description,
-            scanDate,
             toUtcString: getUTCStringFromDateStub,
             getCollapsibleScript: getScriptMock.object,
             getGuidanceTagsFromGuidanceLinks: getGuidanceTagsStub,
@@ -113,7 +115,6 @@ describe('ReportHtmlGenerator', () => {
         );
 
         const actual = testObject.generateHtml(
-            scanDate,
             description,
             {
                 cards: exampleUnifiedStatusResults,

--- a/src/tests/unit/tests/reports/summary-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/summary-report-html-generator.test.tsx
@@ -2,7 +2,11 @@
 // Licensed under the MIT License.
 import { NullComponent } from 'common/components/null-component';
 import { DateProvider } from 'common/date-provider';
-import { ScanMetadata, ScanTimespan, ToolData } from 'common/types/store-data/unified-data-interface';
+import {
+    ScanMetadata,
+    ScanTimespan,
+    ToolData,
+} from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';
 import { ReportSectionFactory } from 'reports/components/report-sections/report-section-factory';

--- a/src/tests/unit/tests/reports/summary-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/summary-report-html-generator.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { NullComponent } from 'common/components/null-component';
 import { DateProvider } from 'common/date-provider';
-import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-interface';
+import { ScanMetadata, ScanTimespan, ToolData } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';
 import { ReportSectionFactory } from 'reports/components/report-sections/report-section-factory';
@@ -12,7 +12,6 @@ import { SummaryReportSectionProps } from 'reports/components/report-sections/su
 import { SummaryScanResults } from 'reports/package/accessibilityInsightsReport';
 import { SummaryReportHtmlGenerator } from 'reports/summary-report-html-generator';
 import { ReportCollapsibleContainerControl } from 'reports/components/report-sections/report-collapsible-container';
-import { ScanTimespan } from 'reports/components/report-sections/base-summary-report-section-props';
 
 describe('ReportHtmlGenerator', () => {
     test('generateHtml', () => {
@@ -43,16 +42,18 @@ describe('ReportHtmlGenerator', () => {
             url: baseUrl,
         };
 
-        const scanMetadata = {
-            toolData: toolData,
-            targetAppInfo: targetAppInfo,
-        } as ScanMetadata;
-
         const scanTimespan: ScanTimespan = {
             scanStart: new Date(2020, 1, 2, 3),
             scanComplete: new Date(2020, 4, 5, 6),
             durationSeconds: 42,
         };
+
+        const scanMetadata = {
+            toolData: toolData,
+            targetAppInfo: targetAppInfo,
+            timespan: scanTimespan,
+        } as ScanMetadata;
+
         const deps = {
             collapsibleControl: ReportCollapsibleContainerControl,
         };
@@ -90,7 +91,6 @@ describe('ReportHtmlGenerator', () => {
             secondsToTimeString: getTimeStringFromSecondsStub,
             getCollapsibleScript: getScriptMock.object,
             scanMetadata,
-            scanTimespan,
             results,
         };
 
@@ -116,7 +116,7 @@ describe('ReportHtmlGenerator', () => {
             getTimeStringFromSecondsStub,
         );
 
-        const actual = testObject.generateHtml(scanTimespan, scanMetadata, results);
+        const actual = testObject.generateHtml(scanMetadata, results);
 
         expect(actual).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

- Make toolVersion optional in ToolData, since we don't have a version for reports generated by the service
- Move scanTimespan object into ScanMetadata and replace uses of timestamp with timespan.scanComplete
- Convert timestamp into Date object earlier instead of waiting until report generation time
- Remove redundant scanDate parameters and use the scanComplete timestamp from scanMetadata instead

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
