### PR TITLE
chore: fix format-on-save by setting default vscode formatter to prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,7 @@
             ]
         }
     ],
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.tabSize": 4,
     "html.format.endWithNewline": true,
     "files.eol": "\n",


### PR DESCRIPTION
#### Description of changes

A few of us were noting that VS Code's "format-on-save" seemed to not be working recently. I suspect this is because VS Code added a new non-prettier js/ts formatter, so when we weren't explicitly setting a default formatter to use, VS Code didn't know which one to use and chose to give up rather than guessing.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
