### PR TITLE
feat(android-nav-reflow): add hamburger button to fluent left nav

### DIFF
--- a/src/electron/views/left-nav/fluent-left-nav.scss
+++ b/src/electron/views/left-nav/fluent-left-nav.scss
@@ -13,6 +13,14 @@
             padding: 0px;
         }
     }
+    .nav-menu-container {
+        display: flex;
+        min-height: $detailsViewCommandBarHeight;
+        align-items: center;
+        .nav-menu {
+            color: $primary-text;
+        }
+    }
 }
 
 :global(.is-mac-os) {

--- a/src/electron/views/left-nav/fluent-left-nav.tsx
+++ b/src/electron/views/left-nav/fluent-left-nav.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { FastPassLeftNavHamburgerButton } from 'common/components/expand-collapse-left-nav-hamburger-button';
 import { NamedFC } from 'common/react/named-fc';
 import { GenericPanel } from 'DetailsView/components/generic-panel';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
@@ -17,10 +18,11 @@ export type FluentLeftNavProps = {
     narrowModeStatus: NarrowModeStatus;
     selectedKey: LeftNavItemKey;
     isNavOpen: boolean;
+    setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const FluentLeftNav = NamedFC<FluentLeftNavProps>('LeftNav', props => {
-    const { narrowModeStatus, selectedKey, isNavOpen, deps } = props;
+    const { narrowModeStatus, selectedKey, isNavOpen, deps, setSideNavOpen } = props;
     const leftNav = <LeftNav selectedKey={selectedKey} deps={deps} />;
 
     if (!narrowModeStatus.isHeaderAndNavCollapsed) {
@@ -38,6 +40,13 @@ export const FluentLeftNav = NamedFC<FluentLeftNavProps>('LeftNav', props => {
             onRenderNavigation={() => null}
             type={PanelType.customNear}
         >
+            <div className={styles.navMenuContainer}>
+                <FastPassLeftNavHamburgerButton
+                    isSideNavOpen={isNavOpen}
+                    setSideNavOpen={setSideNavOpen}
+                    className={styles.navMenu}
+                />
+            </div>
             {leftNav}
         </GenericPanel>
     );

--- a/src/electron/views/left-nav/left-nav.scss
+++ b/src/electron/views/left-nav/left-nav.scss
@@ -6,8 +6,8 @@
     display: flex;
     flex-direction: column;
     min-width: $reflowLeftNavWidth;
+    max-width: $reflowLeftNavWidth;
     border-right: $reflowLeftNavBorderWidth solid $neutral-alpha-8;
-    height: 100%;
     background-color: $neutral-0;
 
     .header-container {

--- a/src/tests/unit/tests/electron/views/left-nav/__snapshots__/fluent-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/left-nav/__snapshots__/fluent-left-nav.test.tsx.snap
@@ -22,6 +22,15 @@ exports[`FluentLeftNav render left nav inside panel 1`] = `
   onRenderNavigationContent={[Function]}
   type={8}
 >
+  <div
+    className="navMenuContainer"
+  >
+    <FastPassLeftNavHamburgerButton
+      className="navMenu"
+      isSideNavOpen={true}
+      setSideNavOpen={[Function]}
+    />
+  </div>
   <LeftNav
     deps={Object {}}
     selectedKey="automated-checks"

--- a/src/tests/unit/tests/electron/views/left-nav/fluent-left-nav.test.tsx
+++ b/src/tests/unit/tests/electron/views/left-nav/fluent-left-nav.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { FastPassLeftNavHamburgerButton } from 'common/components/expand-collapse-left-nav-hamburger-button';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import {
     FluentLeftNav,
@@ -13,23 +14,30 @@ import * as React from 'react';
 describe('FluentLeftNav', () => {
     let props: FluentLeftNavProps;
     let narrowModeStatusStub: NarrowModeStatus;
+    let setSideNavOpenStub: (value: boolean) => void;
 
     beforeEach(() => {
         narrowModeStatusStub = {
             isHeaderAndNavCollapsed: true,
         } as NarrowModeStatus;
 
+        setSideNavOpenStub = _ => null;
+
         props = {
             deps: {} as FluentLeftNavDeps,
             selectedKey: 'automated-checks',
             isNavOpen: true,
             narrowModeStatus: narrowModeStatusStub,
+            setSideNavOpen: setSideNavOpenStub,
         };
     });
 
     test('render left nav inside panel', () => {
         const testSubject = shallow(<FluentLeftNav {...props} />);
         expect(testSubject.getElement()).toMatchSnapshot();
+        expect(testSubject.find(FastPassLeftNavHamburgerButton).prop('setSideNavOpen')).toEqual(
+            setSideNavOpenStub,
+        );
     });
 
     test('render left nav by itself', () => {


### PR DESCRIPTION
#### Description of changes

Here's a screen grab:

![image](https://user-images.githubusercontent.com/32555133/96768872-337ecb80-1393-11eb-84a9-846e2041ce83.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
