### PR TITLE
feat(android-nav-reflow): Use ReflowCommandBar when narrow mode is enabled

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -20,6 +20,7 @@ import {
 } from 'DetailsView/components/details-view-overlay/settings-panel/settings-panel';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
+import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { AndroidSetupStoreData } from 'electron/flux/types/android-setup-store-data';
@@ -28,6 +29,7 @@ import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { ContentPageInfo } from 'electron/types/content-page-info';
+import { ReflowCommandBar } from 'electron/views/automated-checks/components/reflow-command-bar';
 import { TitleBar, TitleBarDeps } from 'electron/views/automated-checks/components/title-bar';
 import { TestView } from 'electron/views/automated-checks/test-view';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
@@ -48,6 +50,7 @@ export type AutomatedChecksViewDeps = CommandBarDeps &
     ContentPanelDeps &
     SettingsPanelDeps & {
         scanActionCreator: ScanActionCreator;
+        leftNavActionCreator: LeftNavActionCreator;
         windowStateActionCreator: WindowStateActionCreator;
         getCardsViewData: GetCardViewData;
         getCardSelectionViewData: GetCardSelectionViewData;
@@ -200,7 +203,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
               };
     }
 
-    private renderCommandBar(
+    private renderStandardCommandBar(
         cardsViewData: CardsViewModel,
         scanMetadata: ScanMetadata,
     ): JSX.Element {
@@ -214,6 +217,34 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                 scanMetadata={scanMetadata}
             />
         );
+    }
+
+    private renderReflowCommandBar(
+        cardsViewData: CardsViewModel,
+        scanMetadata: ScanMetadata,
+    ): JSX.Element {
+        return (
+            <ReflowCommandBar
+                cardsViewData={cardsViewData}
+                deps={this.props.deps}
+                featureFlagStoreData={this.props.featureFlagStoreData}
+                isSideNavOpen={this.props.leftNavStoreData.leftNavVisible}
+                narrowModeStatus={this.props.narrowModeStatus}
+                scanMetadata={scanMetadata}
+                scanPort={this.getScanPort()}
+                scanStoreData={this.props.scanStoreData}
+                setSideNavOpen={this.props.deps.leftNavActionCreator.setLeftNavVisible}
+            />
+        );
+    }
+
+    private renderCommandBar(
+        cardsViewData: CardsViewModel,
+        scanMetadata: ScanMetadata,
+    ): JSX.Element {
+        return this.props.narrowModeStatus.isCommandBarCollapsed
+            ? this.renderReflowCommandBar(cardsViewData, scanMetadata)
+            : this.renderStandardCommandBar(cardsViewData, scanMetadata);
     }
 
     private renderExpandedCommandBar(
@@ -239,7 +270,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                 featureFlag={UnifiedFeatureFlags.leftNavBar}
                 featureFlagStoreData={this.props.featureFlagStoreData}
                 enableJSXElement={null}
-                disableJSXElement={this.renderCommandBar(cardsViewData, scanMetadata)}
+                disableJSXElement={this.renderStandardCommandBar(cardsViewData, scanMetadata)}
             />
         );
     }

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -238,15 +238,6 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
         );
     }
 
-    private renderCommandBar(
-        cardsViewData: CardsViewModel,
-        scanMetadata: ScanMetadata,
-    ): JSX.Element {
-        return this.props.narrowModeStatus.isCommandBarCollapsed
-            ? this.renderReflowCommandBar(cardsViewData, scanMetadata)
-            : this.renderStandardCommandBar(cardsViewData, scanMetadata);
-    }
-
     private renderExpandedCommandBar(
         cardsViewData: CardsViewModel,
         scanMetadata: ScanMetadata,
@@ -255,7 +246,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
             <FlaggedComponent
                 featureFlag={UnifiedFeatureFlags.leftNavBar}
                 featureFlagStoreData={this.props.featureFlagStoreData}
-                enableJSXElement={this.renderCommandBar(cardsViewData, scanMetadata)}
+                enableJSXElement={this.renderReflowCommandBar(cardsViewData, scanMetadata)}
                 disableJSXElement={null}
             />
         );

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -549,6 +549,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             contentPagesInfo,
             navLinkRenderer: new NavLinkRenderer(),
             getNarrowModeThresholds: getNarrowModeThresholdsForUnified,
+            leftNavActionCreator,
         };
 
         window.insightsUserConfiguration = new UserConfigurationController(interpreter);

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -1,391 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AutomatedChecksView renders ReflowCommandBar when narrow mode status is collapsed 1`] = `
-<div
-  className="automatedChecksView"
-  data-automation-id="automated-checks-view"
->
-  <TitleBar
-    deps={
-      Object {
-        "contentPagesInfo": Object {
-          "automated-checks": Object {
-            "description": <React.Fragment>
-              test 
-              automated-checks
-               description
-            </React.Fragment>,
-            "title": "test-automated-checks-title",
-          },
-          "needs-review": Object {
-            "description": <React.Fragment>
-              test 
-              needs-review
-               description
-            </React.Fragment>,
-            "title": "test-needs-review-title",
-          },
-        },
-        "getCardSelectionViewData": [Function],
-        "getCardsViewData": [Function],
-        "isResultHighlightUnavailable": [Function],
-        "leftNavActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "actions": undefined,
-          "itemSelected": [Function],
-          "setLeftNavVisible": [Function],
-        },
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceActions": undefined,
-          "scanActions": undefined,
-        },
-        "screenshotViewModelProvider": [Function],
-        "toolData": Object {
-          "applicationProperties": Object {
-            "name": "some app",
-          },
-        },
-      }
-    }
-    pageTitle="test-automated-checks-title"
-  />
-  <div
-    className="applicationView"
-  >
-    <FlaggedComponent
-      enableJSXElement={
-        <LeftNav
-          deps={
-            Object {
-              "contentPagesInfo": Object {
-                "automated-checks": Object {
-                  "description": <React.Fragment>
-                    test 
-                    automated-checks
-                     description
-                  </React.Fragment>,
-                  "title": "test-automated-checks-title",
-                },
-                "needs-review": Object {
-                  "description": <React.Fragment>
-                    test 
-                    needs-review
-                     description
-                  </React.Fragment>,
-                  "title": "test-needs-review-title",
-                },
-              },
-              "getCardSelectionViewData": [Function],
-              "getCardsViewData": [Function],
-              "isResultHighlightUnavailable": [Function],
-              "leftNavActionCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "actions": undefined,
-                "itemSelected": [Function],
-                "setLeftNavVisible": [Function],
-              },
-              "scanActionCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "deviceActions": undefined,
-                "scanActions": undefined,
-              },
-              "screenshotViewModelProvider": [Function],
-              "toolData": Object {
-                "applicationProperties": Object {
-                  "name": "some app",
-                },
-              },
-            }
-          }
-          selectedKey="automated-checks"
-        />
-      }
-      featureFlag="leftNavBar"
-    />
-    <div
-      className="automatedChecksPanelContainer"
-    >
-      <FlaggedComponent
-        disableJSXElement={null}
-        enableJSXElement={
-          <ReflowCommandBar
-            cardsViewData={
-              Object {
-                "cards": Object {
-                  "fail": Array [
-                    Object {
-                      "id": "test-fail-id",
-                    },
-                  ],
-                },
-              }
-            }
-            deps={
-              Object {
-                "contentPagesInfo": Object {
-                  "automated-checks": Object {
-                    "description": <React.Fragment>
-                      test 
-                      automated-checks
-                       description
-                    </React.Fragment>,
-                    "title": "test-automated-checks-title",
-                  },
-                  "needs-review": Object {
-                    "description": <React.Fragment>
-                      test 
-                      needs-review
-                       description
-                    </React.Fragment>,
-                    "title": "test-needs-review-title",
-                  },
-                },
-                "getCardSelectionViewData": [Function],
-                "getCardsViewData": [Function],
-                "isResultHighlightUnavailable": [Function],
-                "leftNavActionCreator": proxy {
-                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                  "actions": undefined,
-                  "itemSelected": [Function],
-                  "setLeftNavVisible": [Function],
-                },
-                "scanActionCreator": proxy {
-                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                  "deviceActions": undefined,
-                  "scanActions": undefined,
-                },
-                "screenshotViewModelProvider": [Function],
-                "toolData": Object {
-                  "applicationProperties": Object {
-                    "name": "some app",
-                  },
-                },
-              }
-            }
-            isSideNavOpen={true}
-            narrowModeStatus={
-              Object {
-                "isCommandBarCollapsed": true,
-                "isHeaderAndNavCollapsed": false,
-              }
-            }
-            scanMetadata={null}
-            scanStoreData={Object {}}
-            setSideNavOpen={[Function]}
-          />
-        }
-        featureFlag="leftNavBar"
-      />
-      <div
-        className="automatedChecksPanelLayout"
-      >
-        <div
-          className="mainContentWrapper"
-        >
-          <FlaggedComponent
-            disableJSXElement={
-              <CommandBar
-                cardsViewData={
-                  Object {
-                    "cards": Object {
-                      "fail": Array [
-                        Object {
-                          "id": "test-fail-id",
-                        },
-                      ],
-                    },
-                  }
-                }
-                deps={
-                  Object {
-                    "contentPagesInfo": Object {
-                      "automated-checks": Object {
-                        "description": <React.Fragment>
-                          test 
-                          automated-checks
-                           description
-                        </React.Fragment>,
-                        "title": "test-automated-checks-title",
-                      },
-                      "needs-review": Object {
-                        "description": <React.Fragment>
-                          test 
-                          needs-review
-                           description
-                        </React.Fragment>,
-                        "title": "test-needs-review-title",
-                      },
-                    },
-                    "getCardSelectionViewData": [Function],
-                    "getCardsViewData": [Function],
-                    "isResultHighlightUnavailable": [Function],
-                    "leftNavActionCreator": proxy {
-                      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                      "actions": undefined,
-                      "itemSelected": [Function],
-                      "setLeftNavVisible": [Function],
-                    },
-                    "scanActionCreator": proxy {
-                      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                      "deviceActions": undefined,
-                      "scanActions": undefined,
-                    },
-                    "screenshotViewModelProvider": [Function],
-                    "toolData": Object {
-                      "applicationProperties": Object {
-                        "name": "some app",
-                      },
-                    },
-                  }
-                }
-                scanMetadata={null}
-                scanStoreData={Object {}}
-              />
-            }
-            enableJSXElement={null}
-            featureFlag="leftNavBar"
-          />
-          <main>
-            <TestView
-              cardsViewData={
-                Object {
-                  "cards": Object {
-                    "fail": Array [
-                      Object {
-                        "id": "test-fail-id",
-                      },
-                    ],
-                  },
-                }
-              }
-              contentPageInfo={
-                Object {
-                  "description": <React.Fragment>
-                    test 
-                    automated-checks
-                     description
-                  </React.Fragment>,
-                  "title": "test-automated-checks-title",
-                }
-              }
-              deps={
-                Object {
-                  "contentPagesInfo": Object {
-                    "automated-checks": Object {
-                      "description": <React.Fragment>
-                        test 
-                        automated-checks
-                         description
-                      </React.Fragment>,
-                      "title": "test-automated-checks-title",
-                    },
-                    "needs-review": Object {
-                      "description": <React.Fragment>
-                        test 
-                        needs-review
-                         description
-                      </React.Fragment>,
-                      "title": "test-needs-review-title",
-                    },
-                  },
-                  "getCardSelectionViewData": [Function],
-                  "getCardsViewData": [Function],
-                  "isResultHighlightUnavailable": [Function],
-                  "leftNavActionCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "actions": undefined,
-                    "itemSelected": [Function],
-                    "setLeftNavVisible": [Function],
-                  },
-                  "scanActionCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "deviceActions": undefined,
-                    "scanActions": undefined,
-                  },
-                  "screenshotViewModelProvider": [Function],
-                  "toolData": Object {
-                    "applicationProperties": Object {
-                      "name": "some app",
-                    },
-                  },
-                }
-              }
-              scanMetadata={null}
-              userConfigurationStoreData={
-                Object {
-                  "isFirstTime": false,
-                }
-              }
-            />
-          </main>
-        </div>
-        <ScreenshotView
-          viewModel={
-            Object {
-              "screenshotData": Object {
-                "base64PngData": "this should appear in snapshotted ScreenshotView props",
-              },
-            }
-          }
-        />
-      </div>
-    </div>
-  </div>
-  <SettingsPanel
-    deps={
-      Object {
-        "contentPagesInfo": Object {
-          "automated-checks": Object {
-            "description": <React.Fragment>
-              test 
-              automated-checks
-               description
-            </React.Fragment>,
-            "title": "test-automated-checks-title",
-          },
-          "needs-review": Object {
-            "description": <React.Fragment>
-              test 
-              needs-review
-               description
-            </React.Fragment>,
-            "title": "test-needs-review-title",
-          },
-        },
-        "getCardSelectionViewData": [Function],
-        "getCardsViewData": [Function],
-        "isResultHighlightUnavailable": [Function],
-        "leftNavActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "actions": undefined,
-          "itemSelected": [Function],
-          "setLeftNavVisible": [Function],
-        },
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceActions": undefined,
-          "scanActions": undefined,
-        },
-        "screenshotViewModelProvider": [Function],
-        "toolData": Object {
-          "applicationProperties": Object {
-            "name": "some app",
-          },
-        },
-      }
-    }
-    featureFlagData={Object {}}
-    layerClassName="settingsPanelLayerHost"
-    userConfigStoreState={
-      Object {
-        "isFirstTime": false,
-      }
-    }
-  />
-</div>
-`;
-
 exports[`AutomatedChecksView right content panel info changes when left nav selected key changes 1`] = `
 <TestView
   cardsViewData={
@@ -647,7 +261,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
       <FlaggedComponent
         disableJSXElement={null}
         enableJSXElement={
-          <CommandBar
+          <ReflowCommandBar
             cardsViewData={
               Object {
                 "cards": Object {
@@ -702,6 +316,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                 },
               }
             }
+            isSideNavOpen={true}
             scanMetadata={
               Object {
                 "deviceName": "TEST DEVICE",
@@ -723,6 +338,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                 "status": 2,
               }
             }
+            setSideNavOpen={[Function]}
           />
         }
         featureFlag="leftNavBar"
@@ -1085,7 +701,7 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
       <FlaggedComponent
         disableJSXElement={null}
         enableJSXElement={
-          <CommandBar
+          <ReflowCommandBar
             cardsViewData={
               Object {
                 "cards": Object {
@@ -1140,12 +756,14 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                 },
               }
             }
+            isSideNavOpen={true}
             scanMetadata={null}
             scanStoreData={
               Object {
                 "status": 3,
               }
             }
+            setSideNavOpen={[Function]}
           />
         }
         featureFlag="leftNavBar"
@@ -1482,7 +1100,7 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
       <FlaggedComponent
         disableJSXElement={null}
         enableJSXElement={
-          <CommandBar
+          <ReflowCommandBar
             cardsViewData={
               Object {
                 "cards": Object {
@@ -1537,12 +1155,14 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                 },
               }
             }
+            isSideNavOpen={true}
             scanMetadata={null}
             scanStoreData={
               Object {
                 "status": 1,
               }
             }
+            setSideNavOpen={[Function]}
           />
         }
         featureFlag="leftNavBar"
@@ -1875,7 +1495,7 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
       <FlaggedComponent
         disableJSXElement={null}
         enableJSXElement={
-          <CommandBar
+          <ReflowCommandBar
             cardsViewData={
               Object {
                 "cards": Object {
@@ -1930,12 +1550,14 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                 },
               }
             }
+            isSideNavOpen={true}
             scanMetadata={null}
             scanStoreData={
               Object {
                 "status": undefined,
               }
             }
+            setSideNavOpen={[Function]}
           />
         }
         featureFlag="leftNavBar"

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -1,5 +1,391 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AutomatedChecksView renders ReflowCommandBar when narrow mode status is collapsed 1`] = `
+<div
+  className="automatedChecksView"
+  data-automation-id="automated-checks-view"
+>
+  <TitleBar
+    deps={
+      Object {
+        "contentPagesInfo": Object {
+          "automated-checks": Object {
+            "description": <React.Fragment>
+              test 
+              automated-checks
+               description
+            </React.Fragment>,
+            "title": "test-automated-checks-title",
+          },
+          "needs-review": Object {
+            "description": <React.Fragment>
+              test 
+              needs-review
+               description
+            </React.Fragment>,
+            "title": "test-needs-review-title",
+          },
+        },
+        "getCardSelectionViewData": [Function],
+        "getCardsViewData": [Function],
+        "isResultHighlightUnavailable": [Function],
+        "leftNavActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "itemSelected": [Function],
+          "setLeftNavVisible": [Function],
+        },
+        "scanActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
+          "scanActions": undefined,
+        },
+        "screenshotViewModelProvider": [Function],
+        "toolData": Object {
+          "applicationProperties": Object {
+            "name": "some app",
+          },
+        },
+      }
+    }
+    pageTitle="test-automated-checks-title"
+  />
+  <div
+    className="applicationView"
+  >
+    <FlaggedComponent
+      enableJSXElement={
+        <LeftNav
+          deps={
+            Object {
+              "contentPagesInfo": Object {
+                "automated-checks": Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "title": "test-automated-checks-title",
+                },
+                "needs-review": Object {
+                  "description": <React.Fragment>
+                    test 
+                    needs-review
+                     description
+                  </React.Fragment>,
+                  "title": "test-needs-review-title",
+                },
+              },
+              "getCardSelectionViewData": [Function],
+              "getCardsViewData": [Function],
+              "isResultHighlightUnavailable": [Function],
+              "leftNavActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "actions": undefined,
+                "itemSelected": [Function],
+                "setLeftNavVisible": [Function],
+              },
+              "scanActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "deviceActions": undefined,
+                "scanActions": undefined,
+              },
+              "screenshotViewModelProvider": [Function],
+              "toolData": Object {
+                "applicationProperties": Object {
+                  "name": "some app",
+                },
+              },
+            }
+          }
+          selectedKey="automated-checks"
+        />
+      }
+      featureFlag="leftNavBar"
+    />
+    <div
+      className="automatedChecksPanelContainer"
+    >
+      <FlaggedComponent
+        disableJSXElement={null}
+        enableJSXElement={
+          <ReflowCommandBar
+            cardsViewData={
+              Object {
+                "cards": Object {
+                  "fail": Array [
+                    Object {
+                      "id": "test-fail-id",
+                    },
+                  ],
+                },
+              }
+            }
+            deps={
+              Object {
+                "contentPagesInfo": Object {
+                  "automated-checks": Object {
+                    "description": <React.Fragment>
+                      test 
+                      automated-checks
+                       description
+                    </React.Fragment>,
+                    "title": "test-automated-checks-title",
+                  },
+                  "needs-review": Object {
+                    "description": <React.Fragment>
+                      test 
+                      needs-review
+                       description
+                    </React.Fragment>,
+                    "title": "test-needs-review-title",
+                  },
+                },
+                "getCardSelectionViewData": [Function],
+                "getCardsViewData": [Function],
+                "isResultHighlightUnavailable": [Function],
+                "leftNavActionCreator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "actions": undefined,
+                  "itemSelected": [Function],
+                  "setLeftNavVisible": [Function],
+                },
+                "scanActionCreator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "deviceActions": undefined,
+                  "scanActions": undefined,
+                },
+                "screenshotViewModelProvider": [Function],
+                "toolData": Object {
+                  "applicationProperties": Object {
+                    "name": "some app",
+                  },
+                },
+              }
+            }
+            isSideNavOpen={true}
+            narrowModeStatus={
+              Object {
+                "isCommandBarCollapsed": true,
+                "isHeaderAndNavCollapsed": false,
+              }
+            }
+            scanMetadata={null}
+            scanStoreData={Object {}}
+            setSideNavOpen={[Function]}
+          />
+        }
+        featureFlag="leftNavBar"
+      />
+      <div
+        className="automatedChecksPanelLayout"
+      >
+        <div
+          className="mainContentWrapper"
+        >
+          <FlaggedComponent
+            disableJSXElement={
+              <CommandBar
+                cardsViewData={
+                  Object {
+                    "cards": Object {
+                      "fail": Array [
+                        Object {
+                          "id": "test-fail-id",
+                        },
+                      ],
+                    },
+                  }
+                }
+                deps={
+                  Object {
+                    "contentPagesInfo": Object {
+                      "automated-checks": Object {
+                        "description": <React.Fragment>
+                          test 
+                          automated-checks
+                           description
+                        </React.Fragment>,
+                        "title": "test-automated-checks-title",
+                      },
+                      "needs-review": Object {
+                        "description": <React.Fragment>
+                          test 
+                          needs-review
+                           description
+                        </React.Fragment>,
+                        "title": "test-needs-review-title",
+                      },
+                    },
+                    "getCardSelectionViewData": [Function],
+                    "getCardsViewData": [Function],
+                    "isResultHighlightUnavailable": [Function],
+                    "leftNavActionCreator": proxy {
+                      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                      "actions": undefined,
+                      "itemSelected": [Function],
+                      "setLeftNavVisible": [Function],
+                    },
+                    "scanActionCreator": proxy {
+                      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                      "deviceActions": undefined,
+                      "scanActions": undefined,
+                    },
+                    "screenshotViewModelProvider": [Function],
+                    "toolData": Object {
+                      "applicationProperties": Object {
+                        "name": "some app",
+                      },
+                    },
+                  }
+                }
+                scanMetadata={null}
+                scanStoreData={Object {}}
+              />
+            }
+            enableJSXElement={null}
+            featureFlag="leftNavBar"
+          />
+          <main>
+            <TestView
+              cardsViewData={
+                Object {
+                  "cards": Object {
+                    "fail": Array [
+                      Object {
+                        "id": "test-fail-id",
+                      },
+                    ],
+                  },
+                }
+              }
+              contentPageInfo={
+                Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "title": "test-automated-checks-title",
+                }
+              }
+              deps={
+                Object {
+                  "contentPagesInfo": Object {
+                    "automated-checks": Object {
+                      "description": <React.Fragment>
+                        test 
+                        automated-checks
+                         description
+                      </React.Fragment>,
+                      "title": "test-automated-checks-title",
+                    },
+                    "needs-review": Object {
+                      "description": <React.Fragment>
+                        test 
+                        needs-review
+                         description
+                      </React.Fragment>,
+                      "title": "test-needs-review-title",
+                    },
+                  },
+                  "getCardSelectionViewData": [Function],
+                  "getCardsViewData": [Function],
+                  "isResultHighlightUnavailable": [Function],
+                  "leftNavActionCreator": proxy {
+                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                    "actions": undefined,
+                    "itemSelected": [Function],
+                    "setLeftNavVisible": [Function],
+                  },
+                  "scanActionCreator": proxy {
+                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                    "deviceActions": undefined,
+                    "scanActions": undefined,
+                  },
+                  "screenshotViewModelProvider": [Function],
+                  "toolData": Object {
+                    "applicationProperties": Object {
+                      "name": "some app",
+                    },
+                  },
+                }
+              }
+              scanMetadata={null}
+              userConfigurationStoreData={
+                Object {
+                  "isFirstTime": false,
+                }
+              }
+            />
+          </main>
+        </div>
+        <ScreenshotView
+          viewModel={
+            Object {
+              "screenshotData": Object {
+                "base64PngData": "this should appear in snapshotted ScreenshotView props",
+              },
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+  <SettingsPanel
+    deps={
+      Object {
+        "contentPagesInfo": Object {
+          "automated-checks": Object {
+            "description": <React.Fragment>
+              test 
+              automated-checks
+               description
+            </React.Fragment>,
+            "title": "test-automated-checks-title",
+          },
+          "needs-review": Object {
+            "description": <React.Fragment>
+              test 
+              needs-review
+               description
+            </React.Fragment>,
+            "title": "test-needs-review-title",
+          },
+        },
+        "getCardSelectionViewData": [Function],
+        "getCardsViewData": [Function],
+        "isResultHighlightUnavailable": [Function],
+        "leftNavActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "itemSelected": [Function],
+          "setLeftNavVisible": [Function],
+        },
+        "scanActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
+          "scanActions": undefined,
+        },
+        "screenshotViewModelProvider": [Function],
+        "toolData": Object {
+          "applicationProperties": Object {
+            "name": "some app",
+          },
+        },
+      }
+    }
+    featureFlagData={Object {}}
+    layerClassName="settingsPanelLayerHost"
+    userConfigStoreState={
+      Object {
+        "isFirstTime": false,
+      }
+    }
+  />
+</div>
+`;
+
 exports[`AutomatedChecksView right content panel info changes when left nav selected key changes 1`] = `
 <TestView
   cardsViewData={
@@ -47,6 +433,12 @@ exports[`AutomatedChecksView right content panel info changes when left nav sele
       "getCardsViewData": [Function],
       "getDateFromTimestamp": [Function],
       "isResultHighlightUnavailable": [Function],
+      "leftNavActionCreator": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "actions": undefined,
+        "itemSelected": [Function],
+        "setLeftNavVisible": [Function],
+      },
       "scanActionCreator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
         "deviceActions": undefined,
@@ -116,6 +508,12 @@ exports[`AutomatedChecksView right content panel info renders with default/initi
       "getCardsViewData": [Function],
       "getDateFromTimestamp": [Function],
       "isResultHighlightUnavailable": [Function],
+      "leftNavActionCreator": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "actions": undefined,
+        "itemSelected": [Function],
+        "setLeftNavVisible": [Function],
+      },
       "scanActionCreator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
         "deviceActions": undefined,
@@ -168,6 +566,12 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
+        "leftNavActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "itemSelected": [Function],
+          "setLeftNavVisible": [Function],
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "deviceActions": undefined,
@@ -213,6 +617,12 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
               "getCardsViewData": [Function],
               "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
+              "leftNavActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "actions": undefined,
+                "itemSelected": [Function],
+                "setLeftNavVisible": [Function],
+              },
               "scanActionCreator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "deviceActions": undefined,
@@ -273,6 +683,12 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                 "getCardsViewData": [Function],
                 "getDateFromTimestamp": [Function],
                 "isResultHighlightUnavailable": [Function],
+                "leftNavActionCreator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "actions": undefined,
+                  "itemSelected": [Function],
+                  "setLeftNavVisible": [Function],
+                },
                 "scanActionCreator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "deviceActions": undefined,
@@ -355,6 +771,12 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                     "getCardsViewData": [Function],
                     "getDateFromTimestamp": [Function],
                     "isResultHighlightUnavailable": [Function],
+                    "leftNavActionCreator": proxy {
+                      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                      "actions": undefined,
+                      "itemSelected": [Function],
+                      "setLeftNavVisible": [Function],
+                    },
                     "scanActionCreator": proxy {
                       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                       "deviceActions": undefined,
@@ -441,6 +863,12 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                   "getCardsViewData": [Function],
                   "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
+                  "leftNavActionCreator": proxy {
+                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                    "actions": undefined,
+                    "itemSelected": [Function],
+                    "setLeftNavVisible": [Function],
+                  },
                   "scanActionCreator": proxy {
                     "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                     "deviceActions": undefined,
@@ -516,6 +944,12 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
+        "leftNavActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "itemSelected": [Function],
+          "setLeftNavVisible": [Function],
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "deviceActions": undefined,
@@ -570,6 +1004,12 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
+        "leftNavActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "itemSelected": [Function],
+          "setLeftNavVisible": [Function],
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "deviceActions": undefined,
@@ -615,6 +1055,12 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
               "getCardsViewData": [Function],
               "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
+              "leftNavActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "actions": undefined,
+                "itemSelected": [Function],
+                "setLeftNavVisible": [Function],
+              },
               "scanActionCreator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "deviceActions": undefined,
@@ -675,6 +1121,12 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                 "getCardsViewData": [Function],
                 "getDateFromTimestamp": [Function],
                 "isResultHighlightUnavailable": [Function],
+                "leftNavActionCreator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "actions": undefined,
+                  "itemSelected": [Function],
+                  "setLeftNavVisible": [Function],
+                },
                 "scanActionCreator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "deviceActions": undefined,
@@ -742,6 +1194,12 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                     "getCardsViewData": [Function],
                     "getDateFromTimestamp": [Function],
                     "isResultHighlightUnavailable": [Function],
+                    "leftNavActionCreator": proxy {
+                      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                      "actions": undefined,
+                      "itemSelected": [Function],
+                      "setLeftNavVisible": [Function],
+                    },
                     "scanActionCreator": proxy {
                       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                       "deviceActions": undefined,
@@ -813,6 +1271,12 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                   "getCardsViewData": [Function],
                   "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
+                  "leftNavActionCreator": proxy {
+                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                    "actions": undefined,
+                    "itemSelected": [Function],
+                    "setLeftNavVisible": [Function],
+                  },
                   "scanActionCreator": proxy {
                     "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                     "deviceActions": undefined,
@@ -877,6 +1341,12 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
+        "leftNavActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "itemSelected": [Function],
+          "setLeftNavVisible": [Function],
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "deviceActions": undefined,
@@ -931,6 +1401,12 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
+        "leftNavActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "itemSelected": [Function],
+          "setLeftNavVisible": [Function],
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "deviceActions": undefined,
@@ -976,6 +1452,12 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
               "getCardsViewData": [Function],
               "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
+              "leftNavActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "actions": undefined,
+                "itemSelected": [Function],
+                "setLeftNavVisible": [Function],
+              },
               "scanActionCreator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "deviceActions": undefined,
@@ -1036,6 +1518,12 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                 "getCardsViewData": [Function],
                 "getDateFromTimestamp": [Function],
                 "isResultHighlightUnavailable": [Function],
+                "leftNavActionCreator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "actions": undefined,
+                  "itemSelected": [Function],
+                  "setLeftNavVisible": [Function],
+                },
                 "scanActionCreator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "deviceActions": undefined,
@@ -1103,6 +1591,12 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                     "getCardsViewData": [Function],
                     "getDateFromTimestamp": [Function],
                     "isResultHighlightUnavailable": [Function],
+                    "leftNavActionCreator": proxy {
+                      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                      "actions": undefined,
+                      "itemSelected": [Function],
+                      "setLeftNavVisible": [Function],
+                    },
                     "scanActionCreator": proxy {
                       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                       "deviceActions": undefined,
@@ -1174,6 +1668,12 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                   "getCardsViewData": [Function],
                   "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
+                  "leftNavActionCreator": proxy {
+                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                    "actions": undefined,
+                    "itemSelected": [Function],
+                    "setLeftNavVisible": [Function],
+                  },
                   "scanActionCreator": proxy {
                     "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                     "deviceActions": undefined,
@@ -1234,6 +1734,12 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
+        "leftNavActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "itemSelected": [Function],
+          "setLeftNavVisible": [Function],
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "deviceActions": undefined,
@@ -1288,6 +1794,12 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
+        "leftNavActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "itemSelected": [Function],
+          "setLeftNavVisible": [Function],
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "deviceActions": undefined,
@@ -1333,6 +1845,12 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
               "getCardsViewData": [Function],
               "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
+              "leftNavActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "actions": undefined,
+                "itemSelected": [Function],
+                "setLeftNavVisible": [Function],
+              },
               "scanActionCreator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "deviceActions": undefined,
@@ -1393,6 +1911,12 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                 "getCardsViewData": [Function],
                 "getDateFromTimestamp": [Function],
                 "isResultHighlightUnavailable": [Function],
+                "leftNavActionCreator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "actions": undefined,
+                  "itemSelected": [Function],
+                  "setLeftNavVisible": [Function],
+                },
                 "scanActionCreator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "deviceActions": undefined,
@@ -1460,6 +1984,12 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                     "getCardsViewData": [Function],
                     "getDateFromTimestamp": [Function],
                     "isResultHighlightUnavailable": [Function],
+                    "leftNavActionCreator": proxy {
+                      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                      "actions": undefined,
+                      "itemSelected": [Function],
+                      "setLeftNavVisible": [Function],
+                    },
                     "scanActionCreator": proxy {
                       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                       "deviceActions": undefined,
@@ -1531,6 +2061,12 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                   "getCardsViewData": [Function],
                   "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
+                  "leftNavActionCreator": proxy {
+                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                    "actions": undefined,
+                    "itemSelected": [Function],
+                    "setLeftNavVisible": [Function],
+                  },
                   "scanActionCreator": proxy {
                     "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                     "deviceActions": undefined,
@@ -1590,6 +2126,12 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
+        "leftNavActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "itemSelected": [Function],
+          "setLeftNavVisible": [Function],
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "deviceActions": undefined,

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -21,6 +21,8 @@ import {
     UnifiedRule,
     UnifiedScanResultStoreData,
 } from 'common/types/store-data/unified-data-interface';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
+import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { LeftNavStoreData } from 'electron/flux/types/left-nav-store-data';
 import { ScanStatus } from 'electron/flux/types/scan-status';
@@ -55,6 +57,7 @@ describe('AutomatedChecksView', () => {
             'highlighted-uid-1': 'visible',
             'not-highlighted-uid-1': 'hidden',
         } as ResultsHighlightStatus;
+
         const timeStampStub = 'test timestamp';
         const scanDate = new Date(Date.UTC(0, 1, 2, 3));
         const toolDataStub: ToolData = {
@@ -64,11 +67,13 @@ describe('AutomatedChecksView', () => {
         const cardSelectionViewDataStub = {
             resultsHighlightStatus: resultsHighlightStatus,
         } as CardSelectionViewData;
+
         const rulesStub = [{ description: 'test-rule-description' } as UnifiedRule];
         const resultsStub = [
             { uid: 'highlighted-uid-1' },
             { uid: 'not-highlighted-uid-1' },
         ] as UnifiedResult[];
+
         const unifiedScanResultStoreData: UnifiedScanResultStoreData = {
             targetAppInfo: {
                 name: 'test-target-app-name',
@@ -81,6 +86,7 @@ describe('AutomatedChecksView', () => {
                 deviceName: 'TEST DEVICE',
             } as PlatformData,
         };
+
         const leftNavStoreData: LeftNavStoreData = {
             selectedKey: initialSelectedKey,
             leftNavVisible: true,
@@ -89,9 +95,11 @@ describe('AutomatedChecksView', () => {
         const ruleResultsByStatusStub = {
             fail: [{ id: 'test-fail-id' } as CardRuleResult],
         } as CardRuleResultsByStatus;
+
         const cardsViewData = {
             cards: ruleResultsByStatusStub,
         } as CardsViewModel;
+
         const screenshotViewModelStub = {
             screenshotData: {
                 base64PngData: 'this should appear in snapshotted ScreenshotView props',
@@ -105,9 +113,15 @@ describe('AutomatedChecksView', () => {
         getUnifiedRuleResultsMock = Mock.ofInstance(getCardViewData);
         getDateFromTimestampMock = Mock.ofInstance(DateProvider.getDateFromTimestamp);
 
+        const narrowModeStatus: NarrowModeStatus = {
+            isHeaderAndNavCollapsed: false,
+            isCommandBarCollapsed: false,
+        };
+
         props = {
             deps: {
                 scanActionCreator: Mock.ofType(ScanActionCreator).object,
+                leftNavActionCreator: Mock.ofType(LeftNavActionCreator).object,
                 getCardsViewData: getUnifiedRuleResultsMock.object,
                 getCardSelectionViewData: getCardSelectionViewDataMock.object,
                 screenshotViewModelProvider: screenshotViewModelProviderMock.object,
@@ -126,6 +140,7 @@ describe('AutomatedChecksView', () => {
             },
             unifiedScanResultStoreData,
             leftNavStoreData,
+            narrowModeStatus,
         } as AutomatedChecksViewProps;
 
         getCardSelectionViewDataMock
@@ -182,6 +197,14 @@ describe('AutomatedChecksView', () => {
         getCardSelectionViewDataMock.verifyAll();
         getUnifiedRuleResultsMock.verifyAll();
         screenshotViewModelProviderMock.verifyAll();
+    });
+
+    it('renders ReflowCommandBar when narrow mode status is collapsed', () => {
+        props.narrowModeStatus.isCommandBarCollapsed = true;
+
+        const wrapped = shallow(<AutomatedChecksView {...props} />);
+
+        expect(wrapped.getElement()).toMatchSnapshot();
     });
 
     it('triggers scan when first mounted', () => {

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -21,7 +21,6 @@ import {
     UnifiedRule,
     UnifiedScanResultStoreData,
 } from 'common/types/store-data/unified-data-interface';
-import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { LeftNavStoreData } from 'electron/flux/types/left-nav-store-data';
@@ -113,11 +112,6 @@ describe('AutomatedChecksView', () => {
         getUnifiedRuleResultsMock = Mock.ofInstance(getCardViewData);
         getDateFromTimestampMock = Mock.ofInstance(DateProvider.getDateFromTimestamp);
 
-        const narrowModeStatus: NarrowModeStatus = {
-            isHeaderAndNavCollapsed: false,
-            isCommandBarCollapsed: false,
-        };
-
         props = {
             deps: {
                 scanActionCreator: Mock.ofType(ScanActionCreator).object,
@@ -140,7 +134,6 @@ describe('AutomatedChecksView', () => {
             },
             unifiedScanResultStoreData,
             leftNavStoreData,
-            narrowModeStatus,
         } as AutomatedChecksViewProps;
 
         getCardSelectionViewDataMock
@@ -197,14 +190,6 @@ describe('AutomatedChecksView', () => {
         getCardSelectionViewDataMock.verifyAll();
         getUnifiedRuleResultsMock.verifyAll();
         screenshotViewModelProviderMock.verifyAll();
-    });
-
-    it('renders ReflowCommandBar when narrow mode status is collapsed', () => {
-        props.narrowModeStatus.isCommandBarCollapsed = true;
-
-        const wrapped = shallow(<AutomatedChecksView {...props} />);
-
-        expect(wrapped.getElement()).toMatchSnapshot();
     });
 
     it('triggers scan when first mounted', () => {


### PR DESCRIPTION
#### Description of changes

This change makes it so that when the window width is less than the narrow mode threshold for the command bar, the ReflowCommandBar component will be rendered instead of the standard CommandBar component.

The change only applies of course in the case where the feature flag is active.
