### PR TITLE
feat(android-nav-reflow): Use FluentLeftNav component instead of LeftNav

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -34,6 +34,7 @@ import { TitleBar, TitleBarDeps } from 'electron/views/automated-checks/componen
 import { TestView } from 'electron/views/automated-checks/test-view';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
 import { ContentPanelDeps } from 'electron/views/left-nav/content-panel-deps';
+import { FluentLeftNav } from 'electron/views/left-nav/fluent-left-nav';
 import { LeftNav, LeftNavDeps } from 'electron/views/left-nav/left-nav';
 import { ScreenshotView } from 'electron/views/screenshot/screenshot-view';
 import { ScreenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
@@ -164,9 +165,12 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                 featureFlag={UnifiedFeatureFlags.leftNavBar}
                 featureFlagStoreData={this.props.featureFlagStoreData}
                 enableJSXElement={
-                    <LeftNav
+                    <FluentLeftNav
                         deps={this.props.deps}
+                        isNavOpen={this.props.leftNavStoreData.leftNavVisible}
+                        narrowModeStatus={this.props.narrowModeStatus}
                         selectedKey={this.props.leftNavStoreData.selectedKey}
+                        setSideNavOpen={this.props.deps.leftNavActionCreator.setLeftNavVisible}
                     />
                 }
             />

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -250,7 +250,9 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
               },
             }
           }
+          isNavOpen={true}
           selectedKey="automated-checks"
+          setSideNavOpen={[Function]}
         />
       }
       featureFlag="leftNavBar"
@@ -690,7 +692,9 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
               },
             }
           }
+          isNavOpen={true}
           selectedKey="automated-checks"
+          setSideNavOpen={[Function]}
         />
       }
       featureFlag="leftNavBar"
@@ -1089,7 +1093,9 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
               },
             }
           }
+          isNavOpen={true}
           selectedKey="automated-checks"
+          setSideNavOpen={[Function]}
         />
       }
       featureFlag="leftNavBar"
@@ -1484,7 +1490,9 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
               },
             }
           }
+          isNavOpen={true}
           selectedKey="automated-checks"
+          setSideNavOpen={[Function]}
         />
       }
       featureFlag="leftNavBar"


### PR DESCRIPTION
#### Description of changes

This change inserts the use of the FluentLeftNav component where the LefNav component was previously used. This should allow the left nav bar to be hidden and made visible by the hamburger button when the app window shrinks sufficiently.
