### PR TITLE
feat(combined-report-ui): convert combined results to cards data

### DIFF
--- a/src/common/types/store-data/card-view-model.ts
+++ b/src/common/types/store-data/card-view-model.ts
@@ -13,7 +13,6 @@ export interface CardRuleResult {
     url: string;
     guidance: GuidanceLink[];
     isExpanded: boolean;
-    instanceUrls?: string[];
 }
 export type CardRuleResultsByStatus = {
     [key in CardRuleResultStatus]: CardRuleResult[];
@@ -28,6 +27,7 @@ export type CardsViewModel = {
 export interface CardResult extends UnifiedResult {
     isSelected: boolean;
     highlightStatus: HighlightState;
+    instanceUrls?: string[];
 }
 export const AllRuleResultStatuses: CardRuleResultStatus[] = [
     'pass',

--- a/src/common/types/store-data/card-view-model.ts
+++ b/src/common/types/store-data/card-view-model.ts
@@ -13,6 +13,7 @@ export interface CardRuleResult {
     url: string;
     guidance: GuidanceLink[];
     isExpanded: boolean;
+    instanceUrls?: string[];
 }
 export type CardRuleResultsByStatus = {
     [key in CardRuleResultStatus]: CardRuleResult[];

--- a/src/reports/combined-report-html-generator.tsx
+++ b/src/reports/combined-report-html-generator.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';
@@ -17,12 +18,13 @@ export class CombinedReportHtmlGenerator {
         private readonly secondsToTimeStringConverter: (seconds: number) => string,
     ) {}
 
-    public generateHtml(scanMetadata: ScanMetadata): string {
+    public generateHtml(scanMetadata: ScanMetadata, cardsByRule: CardsViewModel): string {
         const HeadSection = this.sectionFactory.HeadSection;
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(<HeadSection />);
 
         const detailsProps: CombinedReportSectionProps = {
             scanMetadata,
+            cardsByRule,
             toUtcString: this.utcDateConverter,
             secondsToTimeString: this.secondsToTimeStringConverter,
             getCollapsibleScript: this.getCollapsibleScript,

--- a/src/reports/components/report-sections/combined-report-section-factory.ts
+++ b/src/reports/components/report-sections/combined-report-section-factory.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NullComponent } from 'common/components/null-component';
+import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { BaseSummaryReportSectionProps } from 'reports/components/report-sections/base-summary-report-section-props';
 import { SummaryReportDetailsSection } from 'reports/components/report-sections/summary-report-details-section';
 import { SummaryReportHeaderSection } from 'reports/components/report-sections/summary-report-header-section';
@@ -12,7 +13,9 @@ import { ReportFooter } from './report-footer';
 import { ReportSectionFactory } from './report-section-factory';
 import { TitleSection } from './title-section';
 
-export type CombinedReportSectionProps = BaseSummaryReportSectionProps;
+export type CombinedReportSectionProps = BaseSummaryReportSectionProps & {
+    cardsByRule: CardsViewModel;
+};
 
 export const CombinedReportSectionFactory: ReportSectionFactory<CombinedReportSectionProps> = {
     HeadSection: SummaryReportHead,

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -69,15 +69,19 @@ declare namespace AccessibilityInsightsReport {
         rule: AxeRuleData
     };
 
-    export interface ResultsGroup {
+    export interface FailuresGroup {
         key: string,
         failed: FailureData[],
-        passed?: AxeRuleData,
-        notApplicable?: AxeRuleData,
+    }
+
+    export type GroupedResults = {
+        failed: FailuresGroup[],
+        passed?: AxeRuleData[],
+        notApplicable?: AxeRuleData[],
     }
 
     export type CombinedReportResults = {
-        resultsByRule: ResultsGroup[],
+        resultsByRule: GroupedResults,
     }
 
     export type CombinedReportParameters = {

--- a/src/reports/package/combined-results-report.ts
+++ b/src/reports/package/combined-results-report.ts
@@ -3,6 +3,7 @@
 import AccessibilityInsightsReport from './accessibilityInsightsReport';
 import { CombinedReportHtmlGenerator } from 'reports/combined-report-html-generator';
 import { ScanMetadata, ScanTimespan, ToolData } from 'common/types/store-data/unified-data-interface';
+import { CombinedResultsToCardsModelConverter } from 'reports/package/combined-results-to-cards-model-converter';
 
 export type CombinedResultsReportDeps = {
     reportHtmlGenerator: CombinedReportHtmlGenerator;
@@ -13,6 +14,7 @@ export class CombinedResultsReport implements AccessibilityInsightsReport.Report
         private readonly deps: CombinedResultsReportDeps,
         private readonly parameters: AccessibilityInsightsReport.CombinedReportParameters,
         private readonly toolInfo: ToolData,
+        private readonly resultsToCardsConverter: CombinedResultsToCardsModelConverter
     ) {}
 
     public asHTML(): string {
@@ -35,6 +37,10 @@ export class CombinedResultsReport implements AccessibilityInsightsReport.Report
             timespan,
         };
 
-        return this.deps.reportHtmlGenerator.generateHtml(scanMetadata);
+        const cardsByRule = this.resultsToCardsConverter.convertResults(
+            this.parameters.results.resultsByRule
+        );
+
+        return this.deps.reportHtmlGenerator.generateHtml(scanMetadata, cardsByRule);
     }
 }

--- a/src/reports/package/combined-results-to-cards-model-converter.ts
+++ b/src/reports/package/combined-results-to-cards-model-converter.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { CardSelectionViewData } from "common/get-card-selection-view-data";
+import { CardRuleResultsByStatus, CardsViewModel } from "common/types/store-data/card-view-model";
+import { GroupedResults } from "reports/package/accessibilityInsightsReport";
+import { GuidanceLink } from "scanner/rule-to-links-mappings";
+
+export class CombinedResultsToCardsModelConverter {
+    constructor(
+        private readonly getGuidanceLinks: (ruleId: string) => GuidanceLink[],
+        private readonly cardSelectionViewData: CardSelectionViewData
+    ) {}
+
+    public convertResults = (
+        results: GroupedResults,
+    ): CardsViewModel => {
+        const statusResults: CardRuleResultsByStatus = {
+            fail: [],
+            pass: [],
+            inapplicable: [],
+            unknown: [],
+        };
+    
+        return {
+            cards: statusResults,
+            visualHelperEnabled: this.cardSelectionViewData.visualHelperEnabled,
+            allCardsCollapsed: this.cardSelectionViewData.expandedRuleIds.length === 0,
+        };
+    }
+}

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { createToolData } from 'common/application-properties-provider';
+import { CardSelectionViewData } from 'common/get-card-selection-view-data';
 import { getCardViewData } from 'common/rule-based-view-model-provider';
 import { generateUID } from 'common/uid-generator';
 import { getCheckResolution, getFixResolution } from 'injected/adapters/resolution-creator';
@@ -16,6 +17,7 @@ import { SummaryReportSectionFactory } from 'reports/components/report-sections/
 import { ReporterHead } from 'reports/components/reporter-automated-check-head';
 import { AxeResultsReport, AxeResultsReportDeps } from 'reports/package/axe-results-report';
 import { CombinedResultsReport } from 'reports/package/combined-results-report';
+import { CombinedResultsToCardsModelConverter } from 'reports/package/combined-results-to-cards-model-converter';
 import { FooterTextForService } from 'reports/package/footer-text-for-service';
 import { SummaryResultsReport } from 'reports/package/summary-results-report';
 import { ReactStaticRenderer } from 'reports/react-static-renderer';
@@ -151,7 +153,23 @@ const combinedResultsReportGenerator = (parameters: CombinedReportParameters) =>
         reportHtmlGenerator,
     }
 
-    return new CombinedResultsReport(deps, parameters, toolData);
+    const getGuidanceLinks = (ruleId: string) => {
+        return ruleToLinkConfiguration[ruleId];
+    };
+    const cardSelectionViewData: CardSelectionViewData = {
+        selectedResultUids: [],
+        expandedRuleIds: [],
+        visualHelperEnabled: false,
+        resultsHighlightStatus: {},
+    };
+
+    const resultsToCardsConverter = new CombinedResultsToCardsModelConverter(
+        getGuidanceLinks,
+        cardSelectionViewData,
+        generateUID,
+    );
+
+    return new CombinedResultsReport(deps, parameters, toolData, resultsToCardsConverter);
 }
 
 initializeFabricIcons();

--- a/src/scanner/rule-to-links-mappings.ts
+++ b/src/scanner/rule-to-links-mappings.ts
@@ -16,7 +16,9 @@ export const BestPractice: HyperlinkDefinition = {
     href: '',
 };
 
-export const ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]> = {
+export type RuleToLinksMapping = DictionaryStringTo<HyperlinkDefinition[]>;
+
+export const ruleToLinkConfiguration: RuleToLinksMapping = {
     'aria-input-field-name': [link.WCAG_4_1_2],
     'aria-toggle-field-name': [link.WCAG_4_1_2],
     'avoid-inline-spacing': [link.WCAG_1_4_12],

--- a/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
@@ -14,6 +14,7 @@ import { CombinedReportSectionProps } from 'reports/components/report-sections/c
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';
 import { ReportSectionFactory } from 'reports/components/report-sections/report-section-factory';
 import { ReactStaticRenderer } from 'reports/react-static-renderer';
+import { exampleUnifiedStatusResults } from 'tests/unit/tests/common/components/cards/sample-view-model-data';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('CombinedReportHtmlGenerator', () => {
@@ -54,6 +55,12 @@ describe('CombinedReportHtmlGenerator', () => {
         timespan: scanTimespan,
     } as ScanMetadata;
 
+    const cardsViewData = {
+        cards: exampleUnifiedStatusResults,
+        visualHelperEnabled: true,
+        allCardsCollapsed: true,
+    };
+
     let getScriptMock: IMock<() => string>;
     let sectionFactoryMock: IMock<ReportSectionFactory<CombinedReportSectionProps>>;
     let rendererMock: IMock<ReactStaticRenderer>;
@@ -79,6 +86,7 @@ describe('CombinedReportHtmlGenerator', () => {
             secondsToTimeString: getTimeStringFromSecondsStub,
             getCollapsibleScript: getScriptMock.object,
             scanMetadata,
+            cardsByRule: cardsViewData,
         };
 
         const headElement: JSX.Element = <NullComponent />;
@@ -94,7 +102,7 @@ describe('CombinedReportHtmlGenerator', () => {
             .returns(() => '<body-markup />')
             .verifiable(Times.once());
 
-        const html = testSubject.generateHtml(scanMetadata);
+        const html = testSubject.generateHtml(scanMetadata, cardsViewData);
 
         expect(html).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CombinedResultsToCardsModelConverter converts results without issues to cards view data 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [],
+    "inapplicable": Array [
+      Object {
+        "description": "Ensures every ARIA input field has an accessible name",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/aria-input-field-name",
+            "text": "guidance for aria-input-field-name",
+          },
+        ],
+        "id": "aria-input-field-name",
+        "isExpanded": false,
+        "nodes": Array [],
+        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-input-field-name?application=webdriverjs",
+      },
+      Object {
+        "description": "Ensures every ARIA toggle field has an accessible name",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/aria-toggle-field-name",
+            "text": "guidance for aria-toggle-field-name",
+          },
+        ],
+        "id": "aria-toggle-field-name",
+        "isExpanded": false,
+        "nodes": Array [],
+        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-toggle-field-name?application=webdriverjs",
+      },
+      Object {
+        "description": "Ensure the autocomplete attribute is correct and suitable for the form field",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/autocomplete-valid",
+            "text": "guidance for autocomplete-valid",
+          },
+        ],
+        "id": "autocomplete-valid",
+        "isExpanded": false,
+        "nodes": Array [],
+        "url": "https://dequeuniversity.com/rules/axe/3.3/autocomplete-valid?application=webdriverjs",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "Ensures <area> elements of image maps have alternate text",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/area-alt",
+            "text": "guidance for area-alt",
+          },
+        ],
+        "id": "area-alt",
+        "isExpanded": false,
+        "nodes": Array [],
+        "url": "https://dequeuniversity.com/rules/axe/3.3/area-alt?application=webdriverjs",
+      },
+      Object {
+        "description": "Ensures aria-hidden elements do not contain focusable elements",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/aria-hidden-focus",
+            "text": "guidance for aria-hidden-focus",
+          },
+        ],
+        "id": "aria-hidden-focus",
+        "isExpanded": false,
+        "nodes": Array [],
+        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=webdriverjs",
+      },
+    ],
+    "unknown": Array [],
+  },
+  "visualHelperEnabled": false,
+}
+`;

--- a/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CombinedResultsToCardsModelConverter converts results to cards view data 1`] = `
+exports[`CombinedResultsToCardsModelConverter with issues 1`] = `
 Object {
   "allCardsCollapsed": true,
   "cards": Object {
@@ -167,6 +167,192 @@ Object {
         "url": "https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=webdriverjs",
       },
     ],
+    "unknown": Array [],
+  },
+  "visualHelperEnabled": false,
+}
+`;
+
+exports[`CombinedResultsToCardsModelConverter without issues 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [],
+    "inapplicable": Array [
+      Object {
+        "description": "Ensures every ARIA input field has an accessible name",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/aria-input-field-name",
+            "text": "guidance for aria-input-field-name",
+          },
+        ],
+        "id": "aria-input-field-name",
+        "isExpanded": false,
+        "nodes": Array [],
+        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-input-field-name?application=webdriverjs",
+      },
+      Object {
+        "description": "Ensures every ARIA toggle field has an accessible name",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/aria-toggle-field-name",
+            "text": "guidance for aria-toggle-field-name",
+          },
+        ],
+        "id": "aria-toggle-field-name",
+        "isExpanded": false,
+        "nodes": Array [],
+        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-toggle-field-name?application=webdriverjs",
+      },
+      Object {
+        "description": "Ensure the autocomplete attribute is correct and suitable for the form field",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/autocomplete-valid",
+            "text": "guidance for autocomplete-valid",
+          },
+        ],
+        "id": "autocomplete-valid",
+        "isExpanded": false,
+        "nodes": Array [],
+        "url": "https://dequeuniversity.com/rules/axe/3.3/autocomplete-valid?application=webdriverjs",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "Ensures <area> elements of image maps have alternate text",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/area-alt",
+            "text": "guidance for area-alt",
+          },
+        ],
+        "id": "area-alt",
+        "isExpanded": false,
+        "nodes": Array [],
+        "url": "https://dequeuniversity.com/rules/axe/3.3/area-alt?application=webdriverjs",
+      },
+      Object {
+        "description": "Ensures aria-hidden elements do not contain focusable elements",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/aria-hidden-focus",
+            "text": "guidance for aria-hidden-focus",
+          },
+        ],
+        "id": "aria-hidden-focus",
+        "isExpanded": false,
+        "nodes": Array [],
+        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=webdriverjs",
+      },
+    ],
+    "unknown": Array [],
+  },
+  "visualHelperEnabled": false,
+}
+`;
+
+exports[`CombinedResultsToCardsModelConverter without passed or inapplicable rules 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "failed-rule-1 description",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/failed-rule-1",
+            "text": "guidance for failed-rule-1",
+          },
+        ],
+        "id": "failed-rule-1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": Object {
+              "snippet": "<div>snippet 1</div>",
+            },
+            "highlightStatus": "unavailable",
+            "identifiers": Object {
+              "conciseName": ".rule-1-selector-1",
+              "css-selector": ".rule-1-selector-1",
+              "identifier": ".rule-1-selector-1",
+            },
+            "instanceUrls": Array [
+              "https://url/rule-1/failure1",
+            ],
+            "isSelected": false,
+            "resolution": Object {
+              "howToFixSummary": "fix failed-rule-1",
+            },
+            "ruleId": "failed-rule-1",
+            "status": "fail",
+            "uid": "test uid",
+          },
+          Object {
+            "descriptors": Object {
+              "snippet": "<div>snippet 2</div>",
+            },
+            "highlightStatus": "unavailable",
+            "identifiers": Object {
+              "conciseName": ".rule-1-selector-2",
+              "css-selector": ".rule-1-selector-2",
+              "identifier": ".rule-1-selector-2",
+            },
+            "instanceUrls": Array [
+              "https://url/rule1/failure2",
+              "https://url/rule1/failure3",
+            ],
+            "isSelected": false,
+            "resolution": Object {
+              "howToFixSummary": "fix failed-rule-1",
+            },
+            "ruleId": "failed-rule-1",
+            "status": "fail",
+            "uid": "test uid",
+          },
+        ],
+        "url": "https://rules/failed-rule-1",
+      },
+      Object {
+        "description": "failed-rule-2 description",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/failed-rule-2",
+            "text": "guidance for failed-rule-2",
+          },
+        ],
+        "id": "failed-rule-2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": Object {
+              "snippet": "<div>snippet</div>",
+            },
+            "highlightStatus": "unavailable",
+            "identifiers": Object {
+              "conciseName": ".rule-2-selector-1",
+              "css-selector": ".rule-2-selector-1",
+              "identifier": ".rule-2-selector-1",
+            },
+            "instanceUrls": Array [
+              "https://url/rule2/failure1",
+            ],
+            "isSelected": false,
+            "resolution": Object {
+              "howToFixSummary": "fix failed-rule-2",
+            },
+            "ruleId": "failed-rule-2",
+            "status": "fail",
+            "uid": "test uid",
+          },
+        ],
+        "url": "https://rules/rule2/failed-rule-1",
+      },
+    ],
+    "inapplicable": Array [],
+    "pass": Array [],
     "unknown": Array [],
   },
   "visualHelperEnabled": false,

--- a/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
@@ -1,10 +1,103 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CombinedResultsToCardsModelConverter converts results without issues to cards view data 1`] = `
+exports[`CombinedResultsToCardsModelConverter converts results to cards view data 1`] = `
 Object {
   "allCardsCollapsed": true,
   "cards": Object {
-    "fail": Array [],
+    "fail": Array [
+      Object {
+        "description": "failed-rule-1 description",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/failed-rule-1",
+            "text": "guidance for failed-rule-1",
+          },
+        ],
+        "id": "failed-rule-1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": Object {
+              "snippet": "<div>snippet 1</div>",
+            },
+            "highlightStatus": "unavailable",
+            "identifiers": Object {
+              "conciseName": ".rule-1-selector-1",
+              "css-selector": ".rule-1-selector-1",
+              "identifier": ".rule-1-selector-1",
+            },
+            "instanceUrls": Array [
+              "https://url/rule-1/failure1",
+            ],
+            "isSelected": false,
+            "resolution": Object {
+              "howToFixSummary": "fix failed-rule-1",
+            },
+            "ruleId": "failed-rule-1",
+            "status": "fail",
+            "uid": "test uid",
+          },
+          Object {
+            "descriptors": Object {
+              "snippet": "<div>snippet 2</div>",
+            },
+            "highlightStatus": "unavailable",
+            "identifiers": Object {
+              "conciseName": ".rule-1-selector-2",
+              "css-selector": ".rule-1-selector-2",
+              "identifier": ".rule-1-selector-2",
+            },
+            "instanceUrls": Array [
+              "https://url/rule1/failure2",
+              "https://url/rule1/failure3",
+            ],
+            "isSelected": false,
+            "resolution": Object {
+              "howToFixSummary": "fix failed-rule-1",
+            },
+            "ruleId": "failed-rule-1",
+            "status": "fail",
+            "uid": "test uid",
+          },
+        ],
+        "url": "https://rules/failed-rule-1",
+      },
+      Object {
+        "description": "failed-rule-2 description",
+        "guidance": Array [
+          Object {
+            "href": "https://guidance-link-stub/failed-rule-2",
+            "text": "guidance for failed-rule-2",
+          },
+        ],
+        "id": "failed-rule-2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": Object {
+              "snippet": "<div>snippet</div>",
+            },
+            "highlightStatus": "unavailable",
+            "identifiers": Object {
+              "conciseName": ".rule-2-selector-1",
+              "css-selector": ".rule-2-selector-1",
+              "identifier": ".rule-2-selector-1",
+            },
+            "instanceUrls": Array [
+              "https://url/rule2/failure1",
+            ],
+            "isSelected": false,
+            "resolution": Object {
+              "howToFixSummary": "fix failed-rule-2",
+            },
+            "ruleId": "failed-rule-2",
+            "status": "fail",
+            "uid": "test uid",
+          },
+        ],
+        "url": "https://rules/rule2/failed-rule-1",
+      },
+    ],
     "inapplicable": Array [
       Object {
         "description": "Ensures every ARIA input field has an accessible name",

--- a/src/tests/unit/tests/reports/package/combined-results-to-cards-model-converter.test.ts
+++ b/src/tests/unit/tests/reports/package/combined-results-to-cards-model-converter.test.ts
@@ -33,13 +33,32 @@ describe(CombinedResultsToCardsModelConverter, () => {
         );
     })
 
-    it('converts results to cards view data', () => {
+    it('with issues', () => {
         setupGuidanceLinks();
 
         const cardsViewModel = testSubject.convertResults(combinedResultsWithIssues.results.resultsByRule);
 
         expect(cardsViewModel).toMatchSnapshot();
-    })
+    });
+
+    it('without issues', () => {
+        setupGuidanceLinks();
+
+        const cardsViewModel = testSubject.convertResults(combinedResultsWithoutIssues.results.resultsByRule);
+
+        expect(cardsViewModel).toMatchSnapshot();
+    });
+
+    it('without passed or inapplicable rules', () => {
+        setupGuidanceLinks();
+        const onlyFailedResults = {
+            failed: combinedResultsWithIssues.results.resultsByRule.failed,
+        };
+
+        const cardsViewModel = testSubject.convertResults(onlyFailedResults);
+
+        expect(cardsViewModel).toMatchSnapshot();
+    });
 
     function setupGuidanceLinks() {
         getGuidanceLinksMock.setup(gl => gl(It.isAny())).returns((ruleId) => {

--- a/src/tests/unit/tests/reports/package/combined-results-to-cards-model-converter.test.ts
+++ b/src/tests/unit/tests/reports/package/combined-results-to-cards-model-converter.test.ts
@@ -5,7 +5,7 @@ import { CardSelectionViewData } from "common/get-card-selection-view-data";
 import { CardsViewModel } from "common/types/store-data/card-view-model";
 import { CombinedResultsToCardsModelConverter } from "reports/package/combined-results-to-cards-model-converter";
 import { GuidanceLink } from "scanner/rule-to-links-mappings";
-import { IMock, Mock } from "typemoq";
+import { IMock, It, Mock } from "typemoq";
 import { combinedResultsWithoutIssues } from "./example-input/combined-results-without-issues";
 
 describe(CombinedResultsToCardsModelConverter, () => {
@@ -21,23 +21,24 @@ describe(CombinedResultsToCardsModelConverter, () => {
 
     beforeEach(() => {
         getGuidanceLinksMock = Mock.ofInstance(() => null);
+        
         testSubject = new CombinedResultsToCardsModelConverter(getGuidanceLinksMock.object, viewDataStub);
     })
 
     it('converts results without issues to cards view data', () => {
-        const expected: CardsViewModel = {
-            cards: {
-                fail: [],
-                pass: [],
-                inapplicable: [],
-                unknown: [],
-            },
-            visualHelperEnabled: viewDataStub.visualHelperEnabled,
-            allCardsCollapsed: true,
-        };
+        setupGuidanceLinks();
 
         const cardsViewModel = testSubject.convertResults(combinedResultsWithoutIssues.results.resultsByRule);
 
-        expect(cardsViewModel).toEqual(expected);
+        expect(cardsViewModel).toMatchSnapshot();
     })
+
+    function setupGuidanceLinks() {
+        getGuidanceLinksMock.setup(gl => gl(It.isAny())).returns((ruleId) => {
+            return [{
+                href: `https://guidance-link-stub/${ruleId}`,
+                text: `guidance for ${ruleId}`,
+            }];
+        });
+    }
 });

--- a/src/tests/unit/tests/reports/package/combined-results-to-cards-model-converter.test.ts
+++ b/src/tests/unit/tests/reports/package/combined-results-to-cards-model-converter.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { CardSelectionViewData } from "common/get-card-selection-view-data";
+import { CardsViewModel } from "common/types/store-data/card-view-model";
+import { CombinedResultsToCardsModelConverter } from "reports/package/combined-results-to-cards-model-converter";
+import { GuidanceLink } from "scanner/rule-to-links-mappings";
+import { IMock, Mock } from "typemoq";
+import { combinedResultsWithoutIssues } from "./example-input/combined-results-without-issues";
+
+describe(CombinedResultsToCardsModelConverter, () => {
+    let getGuidanceLinksMock: IMock<(ruleId: string) => GuidanceLink[]>;
+    const viewDataStub: CardSelectionViewData = {
+        selectedResultUids: [],
+        expandedRuleIds: [],
+        visualHelperEnabled: false,
+        resultsHighlightStatus: {},
+    };
+
+    let testSubject: CombinedResultsToCardsModelConverter;
+
+    beforeEach(() => {
+        getGuidanceLinksMock = Mock.ofInstance(() => null);
+        testSubject = new CombinedResultsToCardsModelConverter(getGuidanceLinksMock.object, viewDataStub);
+    })
+
+    it('converts results without issues to cards view data', () => {
+        const expected: CardsViewModel = {
+            cards: {
+                fail: [],
+                pass: [],
+                inapplicable: [],
+                unknown: [],
+            },
+            visualHelperEnabled: viewDataStub.visualHelperEnabled,
+            allCardsCollapsed: true,
+        };
+
+        const cardsViewModel = testSubject.convertResults(combinedResultsWithoutIssues.results.resultsByRule);
+
+        expect(cardsViewModel).toEqual(expected);
+    })
+});

--- a/src/tests/unit/tests/reports/package/combined-results-to-cards-model-converter.test.ts
+++ b/src/tests/unit/tests/reports/package/combined-results-to-cards-model-converter.test.ts
@@ -2,33 +2,41 @@
 // Licensed under the MIT License.
 
 import { CardSelectionViewData } from "common/get-card-selection-view-data";
-import { CardsViewModel } from "common/types/store-data/card-view-model";
+import { UUIDGenerator } from "common/uid-generator";
 import { CombinedResultsToCardsModelConverter } from "reports/package/combined-results-to-cards-model-converter";
 import { GuidanceLink } from "scanner/rule-to-links-mappings";
+import { combinedResultsWithIssues } from "tests/unit/tests/reports/package/example-input/combined-results-with-issues";
 import { IMock, It, Mock } from "typemoq";
 import { combinedResultsWithoutIssues } from "./example-input/combined-results-without-issues";
 
 describe(CombinedResultsToCardsModelConverter, () => {
-    let getGuidanceLinksMock: IMock<(ruleId: string) => GuidanceLink[]>;
     const viewDataStub: CardSelectionViewData = {
         selectedResultUids: [],
         expandedRuleIds: [],
         visualHelperEnabled: false,
         resultsHighlightStatus: {},
     };
+    let getGuidanceLinksMock: IMock<(ruleId: string) => GuidanceLink[]>;
+    let uuidGeneratorMock: IMock<UUIDGenerator>;
 
     let testSubject: CombinedResultsToCardsModelConverter;
 
     beforeEach(() => {
         getGuidanceLinksMock = Mock.ofInstance(() => null);
+        uuidGeneratorMock = Mock.ofType<UUIDGenerator>();
+        uuidGeneratorMock.setup(ug => ug()).returns(() => 'test uid');
         
-        testSubject = new CombinedResultsToCardsModelConverter(getGuidanceLinksMock.object, viewDataStub);
+        testSubject = new CombinedResultsToCardsModelConverter(
+            getGuidanceLinksMock.object,
+            viewDataStub,
+            uuidGeneratorMock.object
+        );
     })
 
-    it('converts results without issues to cards view data', () => {
+    it('converts results to cards view data', () => {
         setupGuidanceLinks();
 
-        const cardsViewModel = testSubject.convertResults(combinedResultsWithoutIssues.results.resultsByRule);
+        const cardsViewModel = testSubject.convertResults(combinedResultsWithIssues.results.resultsByRule);
 
         expect(cardsViewModel).toMatchSnapshot();
     })

--- a/src/tests/unit/tests/reports/package/example-input/combined-results-with-issues.ts
+++ b/src/tests/unit/tests/reports/package/example-input/combined-results-with-issues.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { CombinedReportParameters } from "reports/package/accessibilityInsightsReport";
+
+export const combinedResultsWithoutIssues: CombinedReportParameters = {
+    serviceName: 'Mock Service Name',
+    axeVersion: 'mock.axe.version',
+    scanDetails: {
+        basePageTitle: 'Mock base without failures or unscannables',
+        baseUrl: 'https://example.com/mock-base-url',
+        scanStart: new Date(Date.UTC(2020, 1, 2, 3, 4, 5)), // Jan 2 2020, 03:04:05am
+        scanComplete: new Date(Date.UTC(2020, 1, 2, 4, 4, 5)), // Jan 2 2020, 04:04:05am
+        durationSeconds: 1 * 60 * 60,
+    },
+    userAgent: 'Mock user agent',
+    results: {
+        resultsByRule: {
+            failed: [
+                {
+                    key: 'failed-rule-1',
+                    failed: [
+                        {
+                            urls: ['https://url/rule-1/failure1'],
+                            elementSelector: '.rule-1-selector-1',
+                            snippet: '<div>snippet 1</div>',
+                            fix: 'fix failed-rule-1',
+                            rule: {
+                                description: 'failed-rule-1 description',
+                                ruleUrl: 'https://rules/failed-rule-1',
+                                ruleId: 'failed-rule-1',
+                                tags: ['rule-1-tag-1', 'rule-1-tag-2'],
+                            }
+                        },
+                        {
+                            urls: ['https://url/rule1/failure2', 'https://url/rule1/failure3'],
+                            elementSelector: '.rule-1-selector-2',
+                            snippet: '<div>snippet 2</div>',
+                            fix: 'fix failed-rule-1',
+                            rule: {
+                                description: 'failed-rule-1 description',
+                                ruleUrl: 'https://rules/failed-rule-1',
+                                ruleId: 'failed-rule-1',
+                                tags: ['rule-1-tag-1', 'rule-1-tag-2'],
+                            }
+                        }
+                    ]
+                },
+                {
+                    key: 'failed-rule-2',
+                    failed: [
+                        {
+                            urls: ['https://url/rule2/failure1'],
+                            elementSelector: '.rule-2-selector-1',
+                            snippet: '<div>snippet</div>',
+                            fix: 'fix failed-rule-2',
+                            rule: {
+                                description: 'failed-rule-2 description',
+                                ruleUrl: 'https://rules/rule2/failed-rule-1',
+                                ruleId: 'failed-rule-2',
+                                tags: ['rule-2-tag'],
+                            }
+                        },
+                    ]
+                },
+            ],
+            passed: [
+                {
+                    description: 'Ensures <area> elements of image maps have alternate text',
+                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/area-alt?application=webdriverjs',
+                    ruleId: 'area-alt',
+                    tags: ['cat.text-alternatives', 'wcag2a', 'wcag111', 'section508', 'section508.22.a'],
+                },
+                {
+                    description: 'Ensures aria-hidden elements do not contain focusable elements',
+                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=webdriverjs',
+                    ruleId: 'aria-hidden-focus',
+                    tags: ['cat.name-role-value', 'wcag2a', 'wcag412', 'wcag131'],
+                },
+            ],
+            notApplicable: [
+                {
+                    description: 'Ensures every ARIA input field has an accessible name',
+                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-input-field-name?application=webdriverjs',
+                    ruleId: 'aria-input-field-name',
+                    tags: ['wcag2a', 'wcag412'],
+                },
+                {
+                    description: 'Ensures every ARIA toggle field has an accessible name',
+                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-toggle-field-name?application=webdriverjs',
+                    ruleId: 'aria-toggle-field-name',
+                    tags: ['wcag2a', 'wcag412'],
+                },
+                {
+                    description: 'Ensure the autocomplete attribute is correct and suitable for the form field',
+                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/autocomplete-valid?application=webdriverjs',
+                    ruleId: 'autocomplete-valid',
+                    tags: ['cat.forms', 'wcag21aa', 'wcag135'],
+                },
+            ]
+        }
+    }
+};

--- a/src/tests/unit/tests/reports/package/example-input/combined-results-with-issues.ts
+++ b/src/tests/unit/tests/reports/package/example-input/combined-results-with-issues.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { CombinedReportParameters } from "reports/package/accessibilityInsightsReport";
 
-export const combinedResultsWithoutIssues: CombinedReportParameters = {
+export const combinedResultsWithIssues: CombinedReportParameters = {
     serviceName: 'Mock Service Name',
     axeVersion: 'mock.axe.version',
     scanDetails: {

--- a/src/tests/unit/tests/reports/package/example-input/combined-results-without-issues.ts
+++ b/src/tests/unit/tests/reports/package/example-input/combined-results-without-issues.ts
@@ -16,8 +16,40 @@ export const combinedResultsWithoutIssues: CombinedReportParameters = {
     results: {
         resultsByRule: {
             failed: [],
-            passed: [],
-            notApplicable: []
+            passed: [
+                {
+                    description: 'Ensures <area> elements of image maps have alternate text',
+                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/area-alt?application=webdriverjs',
+                    ruleId: 'area-alt',
+                    tags: ['cat.text-alternatives', 'wcag2a', 'wcag111', 'section508', 'section508.22.a'],
+                },
+                {
+                    description: 'Ensures aria-hidden elements do not contain focusable elements',
+                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=webdriverjs',
+                    ruleId: 'aria-hidden-focus',
+                    tags: ['cat.name-role-value', 'wcag2a', 'wcag412', 'wcag131'],
+                },
+            ],
+            notApplicable: [
+                {
+                    description: 'Ensures every ARIA input field has an accessible name',
+                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-input-field-name?application=webdriverjs',
+                    ruleId: 'aria-input-field-name',
+                    tags: ['wcag2a', 'wcag412'],
+                },
+                {
+                    description: 'Ensures every ARIA toggle field has an accessible name',
+                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-toggle-field-name?application=webdriverjs',
+                    ruleId: 'aria-toggle-field-name',
+                    tags: ['wcag2a', 'wcag412'],
+                },
+                {
+                    description: 'Ensure the autocomplete attribute is correct and suitable for the form field',
+                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/autocomplete-valid?application=webdriverjs',
+                    ruleId: 'autocomplete-valid',
+                    tags: ['cat.forms', 'wcag21aa', 'wcag135'],
+                },
+            ]
         }
     }
 };

--- a/src/tests/unit/tests/reports/package/example-input/combined-results-without-issues.ts
+++ b/src/tests/unit/tests/reports/package/example-input/combined-results-without-issues.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { CombinedReportParameters } from "reports/package/accessibilityInsightsReport";
+
+export const combinedResultsWithoutIssues: CombinedReportParameters = {
+    serviceName: 'Mock Service Name',
+    axeVersion: 'mock.axe.version',
+    scanDetails: {
+        basePageTitle: 'Mock base without failures or unscannables',
+        baseUrl: 'https://example.com/mock-base-url',
+        scanStart: new Date(Date.UTC(2020, 1, 2, 3, 4, 5)), // Jan 2 2020, 03:04:05am
+        scanComplete: new Date(Date.UTC(2020, 1, 2, 4, 4, 5)), // Jan 2 2020, 04:04:05am
+        durationSeconds: 1 * 60 * 60,
+    },
+    userAgent: 'Mock user agent',
+    results: {
+        resultsByRule: {
+            failed: [],
+            passed: [],
+            notApplicable: []
+        }
+    }
+};


### PR DESCRIPTION
#### Description of changes

- Convert the combined/deduplicated results we take as input into CardsViewModel and add cards data to CombinedReportSectionProps
- Small change to report package interface to fix structuring of passed and inapplicable rules
- Add instance failure urls to CardResult
- Add mock testing data for combined report

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1772544
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
