### PR TITLE
feat(android-nav-reflow): fix command bar '...' dropdown menu behavior

### DIFF
--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -21,6 +21,7 @@ export interface ReportExportComponentProps {
     updatePersistedDescription: (value: string) => void;
     getExportDescription: () => string;
     featureFlagStoreData: FeatureFlagStoreData;
+    onDialogDismiss?: () => void;
 }
 
 export interface ReportExportComponentState {
@@ -92,6 +93,7 @@ export class ReportExportComponent extends React.Component<
                     reportExportFormat={reportExportFormat}
                     onExportClick={this.generateHtml}
                     featureFlagStoreData={this.props.featureFlagStoreData}
+                    afterDismissed={this.props.onDialogDismiss}
                 />
             </>
         );

--- a/src/electron/views/automated-checks/components/reflow-command-bar.tsx
+++ b/src/electron/views/automated-checks/components/reflow-command-bar.tsx
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
+import { FastPassLeftNavHamburgerButton } from 'common/components/expand-collapse-left-nav-hamburger-button';
 import { FlaggedComponent } from 'common/components/flagged-component';
 import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { NamedFC } from 'common/react/named-fc';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
+import { CommandBarButtonsMenu } from 'DetailsView/components/command-bar-buttons-menu';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import {
     ReportExportComponent,
@@ -16,11 +18,10 @@ import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
+import { IButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import * as styles from './command-bar.scss';
-import { FastPassLeftNavHamburgerButton } from 'common/components/expand-collapse-left-nav-hamburger-button';
-import { CommandBarButtonsMenu } from 'DetailsView/components/command-bar-buttons-menu';
 
 export type ReflowCommandBarDeps = {
     scanActionCreator: ScanActionCreator;
@@ -55,6 +56,7 @@ export const ReflowCommandBar = NamedFC<ReflowCommandBarProps>('ReflowCommandBar
         setSideNavOpen,
     } = props;
     let exportReport: JSX.Element = null;
+    let dropdownMenuButtonRef: IButton = null;
 
     if (scanMetadata != null) {
         exportReport = (
@@ -73,6 +75,10 @@ export const ReflowCommandBar = NamedFC<ReflowCommandBarProps>('ReflowCommandBar
                 updatePersistedDescription={() => null}
                 getExportDescription={() => ''}
                 featureFlagStoreData={featureFlagStoreData}
+                onDialogDismiss={() => {
+                    dropdownMenuButtonRef.dismissMenu();
+                    dropdownMenuButtonRef.focus();
+                }}
             />
         );
     }
@@ -99,7 +105,9 @@ export const ReflowCommandBar = NamedFC<ReflowCommandBarProps>('ReflowCommandBar
                 <CommandBarButtonsMenu
                     renderExportReportButton={() => exportReport}
                     getStartOverMenuItem={() => startOverButtonProps}
-                    buttonRef={null}
+                    buttonRef={ref => {
+                        dropdownMenuButtonRef = ref;
+                    }}
                 />
             );
         }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`ReportExportComponentTest render 1`] = `
     Export result
   </InsightsCommandButton>
   <ExportDialog
+    afterDismissed={[Function]}
     deps={
       Object {
         "reportGenerator": proxy {
@@ -53,6 +54,7 @@ exports[`ReportExportComponentTest user interactions click export button: dialog
     Export result
   </InsightsCommandButton>
   <ExportDialog
+    afterDismissed={[Function]}
     deps={
       Object {
         "reportGenerator": proxy {
@@ -92,6 +94,7 @@ exports[`ReportExportComponentTest user interactions dismiss dialog: dialog shou
     Export result
   </InsightsCommandButton>
   <ExportDialog
+    afterDismissed={[Function]}
     deps={
       Object {
         "reportGenerator": proxy {
@@ -131,6 +134,7 @@ exports[`ReportExportComponentTest user interactions edit text field: test conte
     Export result
   </InsightsCommandButton>
   <ExportDialog
+    afterDismissed={[Function]}
     deps={
       Object {
         "reportGenerator": proxy {

--- a/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
@@ -40,12 +40,14 @@ describe('ReportExportComponentTest', () => {
             featureFlagStoreData: {
                 'test-feature-flag': true,
             },
+            onDialogDismiss: () => null,
         };
     });
 
     test('render', () => {
         const wrapper = shallow(<ReportExportComponent {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
+        expect(wrapper.find(ExportDialog).prop('afterDismissed')).toEqual(props.onDialogDismiss);
     });
 
     describe('user interactions', () => {

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/reflow-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/reflow-command-bar.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ReflowCommandBar reflow behavior isCommandBarCollapsed is true 1`] = `
     className="farItems"
   >
     <CommandBarButtonsMenu
-      buttonRef={null}
+      buttonRef={[Function]}
       getStartOverMenuItem={[Function]}
       renderExportReportButton={[Function]}
     />
@@ -27,6 +27,34 @@ exports[`ReflowCommandBar reflow behavior isCommandBarCollapsed is true 1`] = `
     />
   </div>
 </section>
+`;
+
+exports[`ReflowCommandBar reflow behavior isCommandBarCollapsed is true: export report 1`] = `
+<ReportExportComponent
+  deps={
+    Object {
+      "reportGenerator": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "assessmentReportHtmlGenerator": undefined,
+        "reportHtmlGenerator": undefined,
+        "reportNameGenerator": undefined,
+      },
+      "scanActionCreator": null,
+    }
+  }
+  featureFlagStoreData={
+    Object {
+      "somefeatureflag": true,
+    }
+  }
+  getExportDescription={[Function]}
+  htmlGenerator={[Function]}
+  onDialogDismiss={[Function]}
+  pageTitle="scan target name"
+  reportExportFormat="AutomatedChecks"
+  scanDate={1970-01-01T00:00:00.000Z}
+  updatePersistedDescription={[Function]}
+/>
 `;
 
 exports[`ReflowCommandBar reflow behavior isHeaderAndNavCollapsed is true 1`] = `
@@ -64,6 +92,7 @@ exports[`ReflowCommandBar reflow behavior isHeaderAndNavCollapsed is true 1`] = 
             }
             getExportDescription={[Function]}
             htmlGenerator={[Function]}
+            onDialogDismiss={[Function]}
             pageTitle="scan target name"
             reportExportFormat="AutomatedChecks"
             scanDate={1970-01-01T00:00:00.000Z}
@@ -181,6 +210,7 @@ exports[`ReflowCommandBar renders while status is <Completed> 1`] = `
             }
             getExportDescription={[Function]}
             htmlGenerator={[Function]}
+            onDialogDismiss={[Function]}
             pageTitle="scan target name"
             reportExportFormat="AutomatedChecks"
             scanDate={1970-01-01T00:00:00.000Z}
@@ -252,6 +282,7 @@ exports[`ReflowCommandBar renders while status is <Default> 1`] = `
             }
             getExportDescription={[Function]}
             htmlGenerator={[Function]}
+            onDialogDismiss={[Function]}
             pageTitle="scan target name"
             reportExportFormat="AutomatedChecks"
             scanDate={1970-01-01T00:00:00.000Z}
@@ -323,6 +354,7 @@ exports[`ReflowCommandBar renders while status is <Failed> 1`] = `
             }
             getExportDescription={[Function]}
             htmlGenerator={[Function]}
+            onDialogDismiss={[Function]}
             pageTitle="scan target name"
             reportExportFormat="AutomatedChecks"
             scanDate={1970-01-01T00:00:00.000Z}
@@ -394,6 +426,7 @@ exports[`ReflowCommandBar renders while status is <Scanning> 1`] = `
             }
             getExportDescription={[Function]}
             htmlGenerator={[Function]}
+            onDialogDismiss={[Function]}
             pageTitle="scan target name"
             reportExportFormat="AutomatedChecks"
             updatePersistedDescription={[Function]}

--- a/src/tests/unit/tests/electron/views/automated-checks/components/reflow-command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/reflow-command-bar.test.tsx
@@ -5,6 +5,8 @@ import { EnumHelper } from 'common/enum-helper';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-interface';
+import { CommandBarButtonsMenu } from 'DetailsView/components/command-bar-buttons-menu';
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import {
@@ -14,12 +16,12 @@ import {
     ReflowCommandBarProps,
 } from 'electron/views/automated-checks/components/reflow-command-bar';
 import { mount, shallow } from 'enzyme';
+import { IButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 
 describe('ReflowCommandBar', () => {
     let featureFlagStoreDataStub: FeatureFlagStoreData;
@@ -144,8 +146,10 @@ describe('ReflowCommandBar', () => {
             props.narrowModeStatus.isCommandBarCollapsed = true;
 
             const rendered = shallow(<ReflowCommandBar {...props} />);
+            const commandBar = rendered.find(CommandBarButtonsMenu);
 
             expect(rendered.getElement()).toMatchSnapshot();
+            expect(commandBar.prop('renderExportReportButton')()).toMatchSnapshot('export report');
         });
 
         test('isHeaderAndNavCollapsed is true', () => {
@@ -154,6 +158,25 @@ describe('ReflowCommandBar', () => {
             const rendered = shallow(<ReflowCommandBar {...props} />);
 
             expect(rendered.getElement()).toMatchSnapshot();
+        });
+
+        test('dropdown menu is dismissed and button focused when dialog is dismissed', () => {
+            props.narrowModeStatus.isCommandBarCollapsed = true;
+            const rendered = shallow(<ReflowCommandBar {...props} />);
+            const buttonMock = Mock.ofType<IButton>();
+            const commandBar = rendered.find(CommandBarButtonsMenu);
+            const buttonRefCallback = commandBar.prop('buttonRef') as any;
+            const onDialogDismissCallback = commandBar.prop('renderExportReportButton')().props[
+                'onDialogDismiss'
+            ];
+
+            buttonMock.setup(bm => bm.dismissMenu()).verifiable();
+            buttonMock.setup(bm => bm.focus()).verifiable();
+
+            buttonRefCallback(buttonMock.object);
+            onDialogDismissCallback();
+
+            buttonMock.verifyAll();
         });
     });
 });


### PR DESCRIPTION
#### Description of changes

Currently:

The dropdown menu does not disappear when the user leaves the export report dialog.

![dropdownmenu_before](https://user-images.githubusercontent.com/32555133/97062074-2c4fed00-154e-11eb-949e-ed4d4d282db0.gif)

Now:

The dropdown menu disappears and the dropdown button is focused.

![dropdownmenu_after](https://user-images.githubusercontent.com/32555133/97062080-307c0a80-154e-11eb-93c2-80a732fb0caa.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
