### PR TITLE
feat(combined-report-ui): Combined report summary section

### DIFF
--- a/src/common/types/store-data/card-view-model.ts
+++ b/src/common/types/store-data/card-view-model.ts
@@ -27,7 +27,6 @@ export type CardsViewModel = {
 export interface CardResult extends UnifiedResult {
     isSelected: boolean;
     highlightStatus: HighlightState;
-    instanceUrls?: string[];
 }
 export const AllRuleResultStatuses: CardRuleResultStatus[] = [
     'pass',

--- a/src/reports/combined-report-html-generator.tsx
+++ b/src/reports/combined-report-html-generator.tsx
@@ -5,6 +5,7 @@ import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';
+import { UrlResultCounts } from 'reports/package/accessibilityInsightsReport';
 import { CombinedReportSectionProps } from './components/report-sections/combined-report-section-factory';
 import { ReportSectionFactory } from './components/report-sections/report-section-factory';
 import { ReactStaticRenderer } from './react-static-renderer';
@@ -18,13 +19,18 @@ export class CombinedReportHtmlGenerator {
         private readonly secondsToTimeStringConverter: (seconds: number) => string,
     ) {}
 
-    public generateHtml(scanMetadata: ScanMetadata, cardsByRule: CardsViewModel): string {
+    public generateHtml(
+        scanMetadata: ScanMetadata,
+        cardsByRule: CardsViewModel,
+        urlResultCounts: UrlResultCounts,
+    ): string {
         const HeadSection = this.sectionFactory.HeadSection;
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(<HeadSection />);
 
         const detailsProps: CombinedReportSectionProps = {
             scanMetadata,
             cardsByRule,
+            urlResultCounts,
             toUtcString: this.utcDateConverter,
             secondsToTimeString: this.secondsToTimeStringConverter,
             getCollapsibleScript: this.getCollapsibleScript,

--- a/src/reports/components/report-sections/combined-report-section-factory.ts
+++ b/src/reports/components/report-sections/combined-report-section-factory.ts
@@ -3,6 +3,7 @@
 import { NullComponent } from 'common/components/null-component';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { BaseSummaryReportSectionProps } from 'reports/components/report-sections/base-summary-report-section-props';
+import { CombinedReportSummarySection } from 'reports/components/report-sections/combined-report-summary-section';
 import { SummaryReportDetailsSection } from 'reports/components/report-sections/summary-report-details-section';
 import { SummaryReportHeaderSection } from 'reports/components/report-sections/summary-report-header-section';
 import { SummaryReportHead } from 'reports/components/summary-report-head';
@@ -25,7 +26,7 @@ export const CombinedReportSectionFactory: ReportSectionFactory<CombinedReportSe
     ContentContainer,
     HeaderSection: SummaryReportHeaderSection,
     TitleSection,
-    SummarySection: NullComponent,
+    SummarySection: CombinedReportSummarySection,
     DetailsSection: SummaryReportDetailsSection,
     ResultsContainer: NullComponent,
     FailedInstancesSection: NullComponent,

--- a/src/reports/components/report-sections/combined-report-section-factory.ts
+++ b/src/reports/components/report-sections/combined-report-section-factory.ts
@@ -6,6 +6,7 @@ import { BaseSummaryReportSectionProps } from 'reports/components/report-section
 import { SummaryReportDetailsSection } from 'reports/components/report-sections/summary-report-details-section';
 import { SummaryReportHeaderSection } from 'reports/components/report-sections/summary-report-header-section';
 import { SummaryReportHead } from 'reports/components/summary-report-head';
+import { UrlResultCounts } from 'reports/package/accessibilityInsightsReport';
 import { FooterTextForService } from 'reports/package/footer-text-for-service';
 import { BodySection } from './body-section';
 import { ContentContainer } from './content-container';
@@ -15,6 +16,7 @@ import { TitleSection } from './title-section';
 
 export type CombinedReportSectionProps = BaseSummaryReportSectionProps & {
     cardsByRule: CardsViewModel;
+    urlResultCounts: UrlResultCounts;
 };
 
 export const CombinedReportSectionFactory: ReportSectionFactory<CombinedReportSectionProps> = {

--- a/src/reports/components/report-sections/combined-report-summary-section.tsx
+++ b/src/reports/components/report-sections/combined-report-summary-section.tsx
@@ -15,7 +15,7 @@ export const CombinedReportSummarySection = NamedFC<CombinedReportSectionProps>(
         let failedInstances = 0;
         cards.fail.forEach(failedScanResult => {
             failedScanResult.nodes.forEach(failureNode => {
-                failedInstances += failureNode.instanceUrls.length;
+                failedInstances += failureNode.identifiers.urls.urls.length;
             });
         });
 

--- a/src/reports/components/report-sections/combined-report-summary-section.tsx
+++ b/src/reports/components/report-sections/combined-report-summary-section.tsx
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+import { NamedFC } from 'common/react/named-fc';
+import { UrlsSummarySection } from 'reports/components/report-sections/urls-summary-section';
+import { CombinedReportSectionProps } from 'reports/components/report-sections/combined-report-section-factory';
+
+export const CombinedReportSummarySection = NamedFC<CombinedReportSectionProps>(
+    'CombinedReportSummarySection',
+    props => {
+        const { cardsByRule, urlResultCounts } = props;
+        const cards = cardsByRule.cards;
+
+        let failedInstances = 0;
+        cards.fail.forEach(failedScanResult => {
+            failedScanResult.nodes.forEach(failureNode => {
+                failedInstances += failureNode.instanceUrls.length;
+            });
+        });
+
+        const urlsSummarySectionProps = {
+            passedUrlsCount: urlResultCounts.passedUrls,
+            failedUrlsCount: urlResultCounts.failedUrls,
+            notScannedUrlsCount: urlResultCounts.unscannableUrls,
+            failureInstancesCount: failedInstances,
+        };
+
+        return <UrlsSummarySection {...urlsSummarySectionProps} />;
+    },
+);

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -80,8 +80,15 @@ declare namespace AccessibilityInsightsReport {
         notApplicable?: AxeRuleData[],
     }
 
+    export type UrlResultCounts = {
+        passedUrls: number,
+        failedUrls: number,
+        unscannableUrls: number,
+    }
+
     export type CombinedReportResults = {
         resultsByRule: GroupedResults,
+        urlResults: UrlResultCounts,
     }
 
     export type CombinedReportParameters = {

--- a/src/reports/package/combined-results-report.ts
+++ b/src/reports/package/combined-results-report.ts
@@ -18,7 +18,7 @@ export class CombinedResultsReport implements AccessibilityInsightsReport.Report
     ) {}
 
     public asHTML(): string {
-        const { scanDetails } = this.parameters;
+        const { scanDetails, results } = this.parameters;
 
         const targetAppInfo = {
             name: scanDetails.basePageTitle,
@@ -38,9 +38,13 @@ export class CombinedResultsReport implements AccessibilityInsightsReport.Report
         };
 
         const cardsByRule = this.resultsToCardsConverter.convertResults(
-            this.parameters.results.resultsByRule
+            results.resultsByRule
         );
 
-        return this.deps.reportHtmlGenerator.generateHtml(scanMetadata, cardsByRule);
+        return this.deps.reportHtmlGenerator.generateHtml(
+            scanMetadata,
+            cardsByRule,
+            results.urlResults
+        );
     }
 }

--- a/src/reports/package/combined-results-to-cards-model-converter.ts
+++ b/src/reports/package/combined-results-to-cards-model-converter.ts
@@ -80,6 +80,7 @@ export class CombinedResultsToCardsModelConverter {
                 identifier: cssSelector,
                 conciseName: IssueFilingUrlStringUtils.getSelectorLastPart(cssSelector),
                 'css-selector': cssSelector,
+                urls: { urls: failureData.urls },
             },
             descriptors: {
                 snippet: failureData.snippet,
@@ -89,7 +90,6 @@ export class CombinedResultsToCardsModelConverter {
             },
             isSelected: false,
             highlightStatus: 'unavailable',
-            instanceUrls: failureData.urls,
         }
     }
 }

--- a/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
@@ -55,6 +55,12 @@ describe('CombinedReportHtmlGenerator', () => {
         timespan: scanTimespan,
     } as ScanMetadata;
 
+    const urlResultCounts = {
+        passedUrls: 1,
+        failedUrls: 2,
+        unscannableUrls: 3,
+    };
+
     const cardsViewData = {
         cards: exampleUnifiedStatusResults,
         visualHelperEnabled: true,
@@ -87,6 +93,7 @@ describe('CombinedReportHtmlGenerator', () => {
             getCollapsibleScript: getScriptMock.object,
             scanMetadata,
             cardsByRule: cardsViewData,
+            urlResultCounts,
         };
 
         const headElement: JSX.Element = <NullComponent />;
@@ -102,7 +109,7 @@ describe('CombinedReportHtmlGenerator', () => {
             .returns(() => '<body-markup />')
             .verifiable(Times.once());
 
-        const html = testSubject.generateHtml(scanMetadata, cardsViewData);
+        const html = testSubject.generateHtml(scanMetadata, cardsViewData, urlResultCounts);
 
         expect(html).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/combined-report-summary-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/combined-report-summary-section.test.tsx.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` renders 1`] = `
+<UrlsSummarySection
+  failedUrlsCount={2}
+  failureInstancesCount={4}
+  notScannedUrlsCount={3}
+  passedUrlsCount={1}
+/>
+`;

--- a/src/tests/unit/tests/reports/components/report-sections/combined-report-summary-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/combined-report-summary-section.test.tsx
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { CardRuleResultsByStatus } from 'common/types/store-data/card-view-model';
+import {
+    CardResult,
+    CardRuleResult,
+    CardRuleResultsByStatus,
+} from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { CombinedReportSectionProps } from 'reports/components/report-sections/combined-report-section-factory';
@@ -19,16 +23,24 @@ describe(CombinedReportSummarySection, () => {
             {
                 id: 'some-rule',
                 nodes: [
-                    {
-                        instanceUrls: [
-                            'http://url-fail/1',
-                            'http://url-fail/2',
-                            'http://url-fail/3',
-                        ],
-                    },
-                    {
-                        instanceUrls: ['http://url-fail/1'],
-                    },
+                    ({
+                        identifiers: {
+                            urls: {
+                                urls: [
+                                    'http://url-fail/1',
+                                    'http://url-fail/2',
+                                    'http://url-fail/3',
+                                ],
+                            },
+                        },
+                    } as unknown) as CardResult,
+                    ({
+                        identifiers: {
+                            urls: {
+                                urls: ['http://url-fail/1'],
+                            },
+                        },
+                    } as unknown) as CardResult,
                 ],
             },
         ],

--- a/src/tests/unit/tests/reports/components/report-sections/combined-report-summary-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/combined-report-summary-section.test.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { CardRuleResultsByStatus } from 'common/types/store-data/card-view-model';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { CombinedReportSectionProps } from 'reports/components/report-sections/combined-report-section-factory';
+import { CombinedReportSummarySection } from 'reports/components/report-sections/combined-report-summary-section';
+
+describe(CombinedReportSummarySection, () => {
+    const urlResultCounts = {
+        passedUrls: 1,
+        failedUrls: 2,
+        unscannableUrls: 3,
+    };
+
+    const cards = {
+        fail: [
+            {
+                id: 'some-rule',
+                nodes: [
+                    {
+                        instanceUrls: [
+                            'http://url-fail/1',
+                            'http://url-fail/2',
+                            'http://url-fail/3',
+                        ],
+                    },
+                    {
+                        instanceUrls: ['http://url-fail/1'],
+                    },
+                ],
+            },
+        ],
+        pass: [],
+        unknown: [],
+        inapplicable: [],
+    } as CardRuleResultsByStatus;
+
+    it('renders', () => {
+        const props = ({
+            urlResultCounts,
+            cardsByRule: {
+                cards,
+            },
+        } as unknown) as CombinedReportSectionProps;
+        const wrapper = shallow(<CombinedReportSummarySection {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
@@ -27,7 +27,7 @@ Object {
               "identifier": ".rule-1-selector-1",
             },
             "instanceUrls": Array [
-              "https://url/rule-1/failure1",
+              "https://url/rule-1/failure-1",
             ],
             "isSelected": false,
             "resolution": Object {
@@ -48,8 +48,8 @@ Object {
               "identifier": ".rule-1-selector-2",
             },
             "instanceUrls": Array [
-              "https://url/rule1/failure2",
-              "https://url/rule1/failure3",
+              "https://url/rule-1/failure-1",
+              "https://url/rule1/failure-2",
             ],
             "isSelected": false,
             "resolution": Object {
@@ -280,7 +280,7 @@ Object {
               "identifier": ".rule-1-selector-1",
             },
             "instanceUrls": Array [
-              "https://url/rule-1/failure1",
+              "https://url/rule-1/failure-1",
             ],
             "isSelected": false,
             "resolution": Object {
@@ -301,8 +301,8 @@ Object {
               "identifier": ".rule-1-selector-2",
             },
             "instanceUrls": Array [
-              "https://url/rule1/failure2",
-              "https://url/rule1/failure3",
+              "https://url/rule-1/failure-1",
+              "https://url/rule1/failure-2",
             ],
             "isSelected": false,
             "resolution": Object {

--- a/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
@@ -25,10 +25,12 @@ Object {
               "conciseName": ".rule-1-selector-1",
               "css-selector": ".rule-1-selector-1",
               "identifier": ".rule-1-selector-1",
+              "urls": Object {
+                "urls": Array [
+                  "https://url/rule-1/failure-1",
+                ],
+              },
             },
-            "instanceUrls": Array [
-              "https://url/rule-1/failure-1",
-            ],
             "isSelected": false,
             "resolution": Object {
               "howToFixSummary": "fix failed-rule-1",
@@ -46,11 +48,13 @@ Object {
               "conciseName": ".rule-1-selector-2",
               "css-selector": ".rule-1-selector-2",
               "identifier": ".rule-1-selector-2",
+              "urls": Object {
+                "urls": Array [
+                  "https://url/rule-1/failure-1",
+                  "https://url/rule1/failure-2",
+                ],
+              },
             },
-            "instanceUrls": Array [
-              "https://url/rule-1/failure-1",
-              "https://url/rule1/failure-2",
-            ],
             "isSelected": false,
             "resolution": Object {
               "howToFixSummary": "fix failed-rule-1",
@@ -82,10 +86,12 @@ Object {
               "conciseName": ".rule-2-selector-1",
               "css-selector": ".rule-2-selector-1",
               "identifier": ".rule-2-selector-1",
+              "urls": Object {
+                "urls": Array [
+                  "https://url/rule2/failure1",
+                ],
+              },
             },
-            "instanceUrls": Array [
-              "https://url/rule2/failure1",
-            ],
             "isSelected": false,
             "resolution": Object {
               "howToFixSummary": "fix failed-rule-2",
@@ -278,10 +284,12 @@ Object {
               "conciseName": ".rule-1-selector-1",
               "css-selector": ".rule-1-selector-1",
               "identifier": ".rule-1-selector-1",
+              "urls": Object {
+                "urls": Array [
+                  "https://url/rule-1/failure-1",
+                ],
+              },
             },
-            "instanceUrls": Array [
-              "https://url/rule-1/failure-1",
-            ],
             "isSelected": false,
             "resolution": Object {
               "howToFixSummary": "fix failed-rule-1",
@@ -299,11 +307,13 @@ Object {
               "conciseName": ".rule-1-selector-2",
               "css-selector": ".rule-1-selector-2",
               "identifier": ".rule-1-selector-2",
+              "urls": Object {
+                "urls": Array [
+                  "https://url/rule-1/failure-1",
+                  "https://url/rule1/failure-2",
+                ],
+              },
             },
-            "instanceUrls": Array [
-              "https://url/rule-1/failure-1",
-              "https://url/rule1/failure-2",
-            ],
             "isSelected": false,
             "resolution": Object {
               "howToFixSummary": "fix failed-rule-1",
@@ -335,10 +345,12 @@ Object {
               "conciseName": ".rule-2-selector-1",
               "css-selector": ".rule-2-selector-1",
               "identifier": ".rule-2-selector-1",
+              "urls": Object {
+                "urls": Array [
+                  "https://url/rule2/failure1",
+                ],
+              },
             },
-            "instanceUrls": Array [
-              "https://url/rule2/failure1",
-            ],
             "isSelected": false,
             "resolution": Object {
               "howToFixSummary": "fix failed-rule-2",

--- a/src/tests/unit/tests/reports/package/combined-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/combined-results-report.test.ts
@@ -42,10 +42,17 @@ describe('CombinedResultsReport', () => {
         ...scanTimespanStub
     };
 
+    const urlResultsCount = {
+        passedUrls: 1,
+        failedUrls: 2,
+        unscannableUrls: 3,
+    };
+
     const results = {
         resultsByRule: {
             failed: [],
         },
+        urlResults: urlResultsCount,
     } as CombinedReportResults;
 
     const parameters: CombinedReportParameters = {
@@ -90,7 +97,7 @@ describe('CombinedResultsReport', () => {
             .returns(() => cardsViewDataStub);
 
         reportHtmlGeneratorMock
-            .setup(rhg => rhg.generateHtml(scanMetadataStub, cardsViewDataStub))
+            .setup(rhg => rhg.generateHtml(scanMetadataStub, cardsViewDataStub, urlResultsCount))
             .returns(() => expectedHtml);
 
         const html = combinedResultsReport.asHTML();

--- a/src/tests/unit/tests/reports/package/example-input/combined-results-with-issues.ts
+++ b/src/tests/unit/tests/reports/package/example-input/combined-results-with-issues.ts
@@ -14,13 +14,18 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
     },
     userAgent: 'Mock user agent',
     results: {
+        urlResults: {
+            failedUrls: 3,
+            passedUrls: 2,
+            unscannableUrls: 1,
+        },
         resultsByRule: {
             failed: [
                 {
                     key: 'failed-rule-1',
                     failed: [
                         {
-                            urls: ['https://url/rule-1/failure1'],
+                            urls: ['https://url/rule-1/failure-1'],
                             elementSelector: '.rule-1-selector-1',
                             snippet: '<div>snippet 1</div>',
                             fix: 'fix failed-rule-1',
@@ -32,7 +37,7 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                             }
                         },
                         {
-                            urls: ['https://url/rule1/failure2', 'https://url/rule1/failure3'],
+                            urls: ['https://url/rule-1/failure-1', 'https://url/rule1/failure-2'],
                             elementSelector: '.rule-1-selector-2',
                             snippet: '<div>snippet 2</div>',
                             fix: 'fix failed-rule-1',

--- a/src/tests/unit/tests/reports/package/example-input/combined-results-without-issues.ts
+++ b/src/tests/unit/tests/reports/package/example-input/combined-results-without-issues.ts
@@ -14,6 +14,11 @@ export const combinedResultsWithoutIssues: CombinedReportParameters = {
     },
     userAgent: 'Mock user agent',
     results: {
+        urlResults: {
+            failedUrls: 0,
+            passedUrls: 2,
+            unscannableUrls: 1,
+        },
         resultsByRule: {
             failed: [],
             passed: [


### PR DESCRIPTION
#### Description of changes

Created combined report summary section, which is visually identical to the summary section of the summary report, but accepts combined results as props:

<img width="755" alt="combined report summary section" src="https://user-images.githubusercontent.com/55459788/97063420-7c31b280-1554-11eb-9ab8-230b5d27ed03.PNG">

Also added a field to the report package interface to accept counts of passed/failed/unscannable URLs

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1772544
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
