### PR TITLE
chore(deps-dev): pin @types/node to match engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
         "webextension-polyfill-ts": "^0.20.0"
     },
     "resolutions": {
+        "@types/node": "^12.16.1",
         "acorn": "^7.1.1",
         "dot-prop": "^5.2.0",
         "kind-of": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,15 +2092,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/node@*", "@types/node@^12.0.12":
-  version "12.12.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.11.tgz#bec2961975888d964196bf0016a2f984d793d3ce"
-  integrity sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ==
-
-"@types/node@>= 8":
-  version "14.11.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.10.tgz#8c102aba13bf5253f35146affbf8b26275069bef"
-  integrity sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==
+"@types/node@*", "@types/node@>= 8", "@types/node@^12.0.12", "@types/node@^12.16.1":
+  version "12.19.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.1.tgz#303f74c8a2b35644594139e948b2be470ae1186f"
+  integrity sha512-/xaVmBBjOGh55WCqumLAHXU9VhjGtmyTGqJzFBXRWZzByOXI5JAJNx9xPVGEsNizrNwcec92fQMj458MWfjN1A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
#### Description of changes

Web's dependency graph involves several transitive dependencies on weakly-specified `@types/node` versions (eg, `@types/node@*` and `@types/node@>= 8`. Practically speaking, these end up getting set to whatever `@types/node` version had the "latest" tag at the time of the last dependabot PR that updated one of the dependency chains including it.

Since our builds pin to using LTS node (12.x), what we actually should be doing is resolving these explictly to 12.x typings. Previously, we happened to gotten lucky and ended up with `12.x` versions for most past cases, but today, a few dependabot PRs (#3509, #3525) that involve relevant updates happen to be picking up a 14.x types resolution, which is causing build breaks that aren't particularly related to the actual dependency updates in those PRs.

This PR forcibly pins our node typings to match the node we actually build against (ie, the version our "engine" requirement in package.json suggests). I verified that applying this resolution to the two PRs linked above resolves the build errors in those PRs.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
