### PR TITLE
test(e2e-flakiness): suppress flaky e2e failure of form pageerror with message 'Object'

### DIFF
--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -47,6 +47,12 @@ export class Page {
                 return; // benign; caused by https://github.com/OfficeDev/office-ui-fabric-react/issues/9715
             }
 
+            if (error.name === 'Error' && error.message === 'Object' && error.stack == null) {
+                // unknown flakiness, tracked by https://github.com/microsoft/accessibility-insights-web/issues/3529
+                console.warn(`'pageerror' (console.error): ${serializeError(error)}`);
+                return;
+            }
+
             forceEventFailure(`'pageerror' (console.error): ${serializeError(error)}`);
         });
         underlyingPage.on('requestfailed', request => {

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { includes } from 'lodash';
 import * as Playwright from 'playwright';
+import { inspect } from 'util';
 
 import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
 import {
@@ -32,7 +33,7 @@ export class Page {
         }
 
         function serializeError(error: Error): string {
-            return `[Error]{name: '${error.name}', message: '${error.message}', stack: '${error.stack}'}`;
+            return `[Error]{\n${inspect(error, { compact: false, depth: 4 })}\n}`;
         }
 
         underlyingPage.on('pageerror', error => {


### PR DESCRIPTION
#### Description of changes

This suppresses the pageerrors tracked by #3529 which are a big source of flaky e2e behavior

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: temporary workaround for #3529
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
