### PR TITLE
test(e2e-flakiness): improve reliability of automated-checks-view tests

### DIFF
--- a/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
@@ -13,8 +13,12 @@ export class AutomatedChecksViewController extends ViewController {
         super(client);
     }
 
-    public async queryRuleGroups(): Promise<any[]> {
-        return this.client.$$(AutomatedChecksViewSelectors.ruleGroup);
+    public async waitForRuleGroupCount(count: number): Promise<void> {
+        await this.waitForNumberOfSelectorMatches(AutomatedChecksViewSelectors.ruleGroup, count);
+    }
+
+    public async waitForHighlightBoxCount(count: number): Promise<void> {
+        await this.waitForNumberOfSelectorMatches(ScreenshotViewSelectors.highlightBox, count);
     }
 
     public async queryRuleGroupContents(): Promise<any[]> {

--- a/src/tests/electron/common/view-controllers/view-controller.ts
+++ b/src/tests/electron/common/view-controllers/view-controller.ts
@@ -16,7 +16,23 @@ export abstract class ViewController {
         // semantics than Puppeteer; in particular, it requires the element be in the viewport
         // but doesn't scroll the page to the element, so it's easy for it to fail in ways that
         // are dependent on the test environment.
-        await this.screenshotOnError(async () => this.client.waitForExist(selector, timeout));
+        await this.screenshotOnError(async () => await this.client.waitForExist(selector, timeout));
+    }
+
+    public async waitForNumberOfSelectorMatches(
+        selector: string,
+        expectedNumber: number,
+        timeout: number = DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS,
+    ): Promise<void> {
+        await this.screenshotOnError(async () => {
+            await this.client.waitUntil(
+                async () => {
+                    return (await this.client.$$(selector)).length === expectedNumber;
+                },
+                timeout,
+                `expected to find ${expectedNumber} matches for selector ${selector} within ${timeout}ms`,
+            );
+        });
     }
 
     public async waitForSelectorToDisappear(

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -41,20 +41,14 @@ describe('AutomatedChecksView', () => {
     });
 
     it('displays automated checks results collapsed by default', async () => {
-        const ruleGroups = await automatedChecksView.queryRuleGroups();
-        expect(ruleGroups).toHaveLength(3);
+        automatedChecksView.waitForRuleGroupCount(3);
 
         const collapsibleContentElements = await automatedChecksView.queryRuleGroupContents();
         expect(collapsibleContentElements).toHaveLength(0);
     });
 
-    async function countHighlightBoxes(): Promise<number> {
-        const boxes = await automatedChecksView.client.$$(ScreenshotViewSelectors.highlightBox);
-        return boxes.length;
-    }
-
     it('supports expanding and collapsing rule groups', async () => {
-        expect(await countHighlightBoxes()).toBe(4);
+        await automatedChecksView.waitForHighlightBoxCount(4);
         expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(0);
 
         await automatedChecksView.toggleRuleGroupAtPosition(1);
@@ -66,7 +60,7 @@ describe('AutomatedChecksView', () => {
         await automatedChecksView.toggleRuleGroupAtPosition(3);
         await assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
 
-        expect(await countHighlightBoxes()).toBe(4);
+        await automatedChecksView.waitForHighlightBoxCount(4);
         expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(3);
 
         await automatedChecksView.toggleRuleGroupAtPosition(1);
@@ -75,7 +69,7 @@ describe('AutomatedChecksView', () => {
         await automatedChecksView.toggleRuleGroupAtPosition(2);
         await assertCollapsedRuleGroup(2, 'ActiveViewName');
 
-        expect(await countHighlightBoxes()).toBe(1);
+        await automatedChecksView.waitForHighlightBoxCount(1);
         expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(1);
         await assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
     });


### PR DESCRIPTION
#### Description of changes

Some of the unified automated-checks-view tests had cases where they were starting out by **querying** for an expected UI state rather than **waiting** for an expected UI state. This updates them to work consistently with other tests by allowing for a timeout to get to the expected state.

Examples of motivating failures:

* [for "highlight box count" case](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=15135&view=logs&j=b652ef49-bd3c-5349-02df-b4a91dc35ba0&t=271e4398-bdf4-5bea-5b16-6aa3306d6007)
* [for "rule groups count" case](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=15136&view=logs&j=c5567cdb-c930-534d-6489-7c2dcf7ac8ee&t=fe6db478-348c-54d0-bafe-001288e28283)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
