### PR TITLE
test(e2e-flakiness): add retries around unified e2e app.start

### DIFF
--- a/src/tests/common/retry.ts
+++ b/src/tests/common/retry.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { serializeError } from 'tests/common/serialize-error';
+
+export type RetryOptions = {
+    operationLabel?: string;
+    retryOnlyIfMatches?: (e: any) => boolean;
+    maxRetries?: number;
+    warnOnRetry?: boolean;
+};
+export async function retry<T>(operation: () => Promise<T>, options?: RetryOptions): Promise<T> {
+    options = {
+        retryOnlyIfMatches: () => true,
+        maxRetries: 3,
+        warnOnRetry: false,
+        operationLabel: 'operation',
+        ...options,
+    };
+    const maxTries = options.maxRetries + 1;
+    for (let currentTry = 1; currentTry <= maxTries; currentTry += 1) {
+        try {
+            return await operation();
+        } catch (e: any) {
+            if (currentTry === maxTries || !options.retryOnlyIfMatches(e)) {
+                throw e;
+            } else if (options.warnOnRetry) {
+                console.warn(
+                    `${options.operationLabel} attempt ${currentTry} failed with ${serializeError(
+                        e,
+                    )}, retrying...`,
+                );
+            }
+        }
+    }
+    throw new Error('unreachable');
+}

--- a/src/tests/common/retry.ts
+++ b/src/tests/common/retry.ts
@@ -16,12 +16,12 @@ export async function retry<T>(operation: () => Promise<T>, options?: RetryOptio
         operationLabel: 'operation',
         ...options,
     };
-    const maxTries = options.maxRetries + 1;
+    const maxTries = options.maxRetries! + 1;
     for (let currentTry = 1; currentTry <= maxTries; currentTry += 1) {
         try {
             return await operation();
         } catch (e: any) {
-            if (currentTry === maxTries || !options.retryOnlyIfMatches(e)) {
+            if (currentTry === maxTries || !options.retryOnlyIfMatches!(e)) {
                 throw e;
             } else if (options.warnOnRetry) {
                 console.warn(

--- a/src/tests/common/serialize-error.ts
+++ b/src/tests/common/serialize-error.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { inspect } from 'util';
+
+export function serializeError(error: any): string {
+    return `[Error]{\n${inspect(error, { compact: false, depth: 4 })}\n}`;
+}

--- a/src/tests/electron/common/create-application.ts
+++ b/src/tests/electron/common/create-application.ts
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 import * as Electron from 'electron';
 import { AppConstructorOptions, Application } from 'spectron';
+import { retry } from 'tests/common/retry';
 
 import {
     DEFAULT_APP_CONNECT_RETRIES,
     DEFAULT_APP_CONNECT_TIMEOUT_MS,
+    DEFAULT_CHROMEDRIVER_START_RETRIES,
     DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS,
 } from 'tests/electron/setup/timeouts';
 import { AppController } from './view-controllers/app-controller';
@@ -38,14 +40,26 @@ export async function createAppController(
     targetApp: string,
     overrideSpectronOptions?: Partial<AppConstructorOptions>,
 ): Promise<AppController> {
-    const app = new Application({
-        path: Electron as any,
-        args: [targetApp],
-        connectionRetryCount: DEFAULT_APP_CONNECT_RETRIES,
-        connectionRetryTimeout: DEFAULT_APP_CONNECT_TIMEOUT_MS,
-        startTimeout: DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS,
-        ...overrideSpectronOptions,
-    });
-    await app.start();
+    const app = await retry(
+        async () => {
+            const app = new Application({
+                path: Electron as any,
+                args: [targetApp],
+                connectionRetryCount: DEFAULT_APP_CONNECT_RETRIES,
+                connectionRetryTimeout: DEFAULT_APP_CONNECT_TIMEOUT_MS,
+                startTimeout: DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS,
+                ...overrideSpectronOptions,
+            });
+            await app.start();
+            return app;
+        },
+        {
+            operationLabel: 'app.start',
+            warnOnRetry: true,
+            maxRetries: DEFAULT_CHROMEDRIVER_START_RETRIES,
+            retryOnlyIfMatches: err => err?.message?.includes('ChromeDriver did not start within'),
+        },
+    );
+
     return new AppController(app);
 }

--- a/src/tests/electron/common/create-application.ts
+++ b/src/tests/electron/common/create-application.ts
@@ -6,6 +6,7 @@ import { AppConstructorOptions, Application } from 'spectron';
 import {
     DEFAULT_APP_CONNECT_RETRIES,
     DEFAULT_APP_CONNECT_TIMEOUT_MS,
+    DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS,
 } from 'tests/electron/setup/timeouts';
 import { AppController } from './view-controllers/app-controller';
 
@@ -42,6 +43,7 @@ export async function createAppController(
         args: [targetApp],
         connectionRetryCount: DEFAULT_APP_CONNECT_RETRIES,
         connectionRetryTimeout: DEFAULT_APP_CONNECT_TIMEOUT_MS,
+        startTimeout: DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS,
         ...overrideSpectronOptions,
     });
     await app.start();

--- a/src/tests/electron/setup/timeouts.ts
+++ b/src/tests/electron/setup/timeouts.ts
@@ -9,8 +9,10 @@ export const DEFAULT_ELECTRON_TEST_TIMEOUT_MS = 60000;
 export const DEFAULT_APP_CONNECT_TIMEOUT_MS = 10000;
 export const DEFAULT_APP_CONNECT_RETRIES = 3;
 
-// This governs how long Spectron should allow for ChromeDriver to start
-export const DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS = 10000;
+// These govern how long Spectron should allow for ChromeDriver to start
+// The product of these should be significantly less than the test timeout
+export const DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS = 5000;
+export const DEFAULT_CHROMEDRIVER_START_RETRIES = 3;
 
 // How long to wait for an element to be visible
 export const DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS = 5000;

--- a/src/tests/electron/setup/timeouts.ts
+++ b/src/tests/electron/setup/timeouts.ts
@@ -9,6 +9,9 @@ export const DEFAULT_ELECTRON_TEST_TIMEOUT_MS = 60000;
 export const DEFAULT_APP_CONNECT_TIMEOUT_MS = 10000;
 export const DEFAULT_APP_CONNECT_RETRIES = 3;
 
+// This governs how long Spectron should allow for ChromeDriver to start
+export const DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS = 10000;
+
 // How long to wait for an element to be visible
 export const DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS = 5000;
 

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -16,6 +16,7 @@ import {
     DEFAULT_NEW_PAGE_WAIT_TIMEOUT_MS,
     DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS,
 } from '../timeouts';
+import { serializeError } from 'tests/common/serialize-error';
 
 const promiseFactory = createDefaultPromiseFactory();
 
@@ -29,10 +30,6 @@ export class Page {
             forceTestFailure(
                 `Playwright.Page '${underlyingPage.url()}' emitted ${eventDescription}`,
             );
-        }
-
-        function serializeError(error: Error): string {
-            return `[Error]{name: '${error.name}', message: '${error.message}', stack: '${error.stack}'}`;
         }
 
         underlyingPage.on('pageerror', error => {


### PR DESCRIPTION
#### Description of changes

This is an attempt to improve one of the more common forms of unified e2e flakiness, where arbitrary tests will fail with an error like ([example](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=15160&view=logs&j=d8690f4f-0e2c-53bd-8425-d38de88bbdbc&t=9af9e376-ae64-51a0-7cc0-a01a37a7a200)):

```
    ChromeDriver did not start within 5000ms

      at node_modules/spectron/lib/chrome-driver.js:63:25
      at Request._callback (node_modules/spectron/lib/chrome-driver.js:121:23)
      at self.callback (node_modules/request/request.js:185:22)
      at Request.Object.<anonymous>.Request.onRequestError (node_modules/request/request.js:881:8)
```

I initially tried just increasing the timeout from 5s to 10s, but was still seeing the same class of failure. This PR now attempts to add retry logic around app.start (where the issue occurs).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
