### PR TITLE
test(e2e-flakiness): simplify browser.close calls in test fixtures

### DIFF
--- a/src/tests/end-to-end/common/browser.ts
+++ b/src/tests/end-to-end/common/browser.ts
@@ -14,22 +14,29 @@ import { TargetPage, targetPageUrl, TargetPageUrlOptions } from './page-controll
 export class Browser {
     private memoizedBackgroundPage: BackgroundPage;
     private pages: Array<Page> = [];
+    private underlyingBrowserContext: Playwright.BrowserContext | null;
 
     constructor(
         private readonly browserInstanceId: string,
-        private readonly underlyingBrowserContext: Playwright.BrowserContext,
+        underlyingBrowserContext: Playwright.BrowserContext,
         private readonly onClose?: () => Promise<void>,
     ) {
+        this.underlyingBrowserContext = underlyingBrowserContext;
         underlyingBrowserContext.on('close', onBrowserDisconnected);
     }
 
     public async close(): Promise<void> {
+        if (null == this.underlyingBrowserContext) {
+            return;
+        }
+
         if (this.onClose) {
             await this.onClose();
         }
 
         this.underlyingBrowserContext.removeListener('close', onBrowserDisconnected);
         await this.underlyingBrowserContext.close();
+        this.underlyingBrowserContext = null;
     }
 
     public async backgroundPage(): Promise<BackgroundPage> {

--- a/src/tests/end-to-end/tests/common/settings-drop-down.test.ts
+++ b/src/tests/end-to-end/tests/common/settings-drop-down.test.ts
@@ -21,16 +21,11 @@ describe('Settings Dropdown', () => {
     });
 
     afterEach(async () => {
-        if (browser) {
-            await browser.closeAllPages();
-        }
+        await browser?.closeAllPages();
     });
 
     afterAll(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     it('content should match snapshot', async () => {

--- a/src/tests/end-to-end/tests/content/guidance-content.test.ts
+++ b/src/tests/end-to-end/tests/content/guidance-content.test.ts
@@ -20,10 +20,7 @@ describe('Guidance Content pages', () => {
     });
 
     afterAll(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     describe.each(contentPaths)('%s', path => {

--- a/src/tests/end-to-end/tests/details-view/cross-origin-iframe.test.ts
+++ b/src/tests/end-to-end/tests/details-view/cross-origin-iframe.test.ts
@@ -39,10 +39,7 @@ describe('scanning', () => {
         });
 
         afterAll(async () => {
-            if (browser) {
-                await browser.close();
-                browser = undefined;
-            }
+            await browser?.close();
         });
 
         it('does not get results from inside cross-origin iframes', async () => {
@@ -75,10 +72,7 @@ describe('scanning', () => {
         });
 
         afterAll(async () => {
-            if (browser) {
-                await browser.close();
-                browser = undefined;
-            }
+            await browser?.close();
         });
 
         it('does find results from inside cross-origin iframes', async () => {

--- a/src/tests/end-to-end/tests/details-view/headings.test.ts
+++ b/src/tests/end-to-end/tests/details-view/headings.test.ts
@@ -21,10 +21,7 @@ describe('Details View -> Assessment -> Headings', () => {
     });
 
     afterAll(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     describe('Requirement page', () => {

--- a/src/tests/end-to-end/tests/details-view/landmarks.test.ts
+++ b/src/tests/end-to-end/tests/details-view/landmarks.test.ts
@@ -15,10 +15,7 @@ describe('Details View -> Assessment -> Landmarks', () => {
     });
 
     afterEach(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     describe('Primary content', () => {

--- a/src/tests/end-to-end/tests/details-view/overview.test.ts
+++ b/src/tests/end-to-end/tests/details-view/overview.test.ts
@@ -20,10 +20,7 @@ describe('Details View -> Overview Page', () => {
     });
 
     afterAll(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     it.each([true, false])(

--- a/src/tests/end-to-end/tests/details-view/preview-features.test.ts
+++ b/src/tests/end-to-end/tests/details-view/preview-features.test.ts
@@ -24,10 +24,7 @@ describe('Details View -> Preview Features Panel', () => {
     });
 
     afterAll(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     it('should match content in snapshot', async () => {

--- a/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
+++ b/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
@@ -26,10 +26,7 @@ describe('Details View -> Assessment -> Reflow', () => {
     });
 
     afterAll(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     const { commandBarMenuButtonSelectors, hamburgerMenuButtonSelectors } = navMenuSelectors;

--- a/src/tests/end-to-end/tests/details-view/settings-panel.test.ts
+++ b/src/tests/end-to-end/tests/details-view/settings-panel.test.ts
@@ -25,10 +25,7 @@ describe('Details View -> Settings Panel', () => {
     });
 
     afterAll(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     describe('Telemetry toggle', () => {

--- a/src/tests/end-to-end/tests/popup/adhoc-panel.test.ts
+++ b/src/tests/end-to-end/tests/popup/adhoc-panel.test.ts
@@ -22,10 +22,7 @@ describe('Popup -> Ad-hoc tools', () => {
     });
 
     afterEach(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     it('should have launchpad link that takes us to adhoc panel & is sticky', async () => {

--- a/src/tests/end-to-end/tests/popup/first-time-dialog.test.ts
+++ b/src/tests/end-to-end/tests/popup/first-time-dialog.test.ts
@@ -18,10 +18,7 @@ describe('First time Dialog', () => {
     });
 
     afterEach(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     async function newPopupPage(): Promise<PopupPage> {

--- a/src/tests/end-to-end/tests/popup/hamburger-menu.test.ts
+++ b/src/tests/end-to-end/tests/popup/hamburger-menu.test.ts
@@ -21,10 +21,7 @@ describe('Popup -> Hamburger menu', () => {
     });
 
     afterAll(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     it('should have content matching snapshot', async () => {

--- a/src/tests/end-to-end/tests/popup/launchpad.test.ts
+++ b/src/tests/end-to-end/tests/popup/launchpad.test.ts
@@ -21,10 +21,7 @@ describe('Popup -> Launch Pad', () => {
     });
 
     afterAll(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     it('content should match snapshot', async () => {

--- a/src/tests/end-to-end/tests/target-page/issue-dialog.test.ts
+++ b/src/tests/end-to-end/tests/target-page/issue-dialog.test.ts
@@ -22,10 +22,7 @@ describe('Target Page issue dialog', () => {
     });
 
     afterAll(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     it('should pass accessibility validation', async () => {

--- a/src/tests/end-to-end/tests/target-page/tabstop.test.ts
+++ b/src/tests/end-to-end/tests/target-page/tabstop.test.ts
@@ -22,9 +22,7 @@ describe('Tab stops visualization', () => {
     });
 
     afterEach(async () => {
-        if (browser) {
-            await browser.close();
-        }
+        await browser?.close();
     });
 
     it('should show the expected visuals in the target page after enabling from popup and tabbing through target page', async () => {

--- a/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
+++ b/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
@@ -23,10 +23,7 @@ describe('Target Page visualization boxes', () => {
     });
 
     afterEach(async () => {
-        if (browser) {
-            await browser.close();
-            browser = undefined;
-        }
+        await browser?.close();
     });
 
     const adhocTools = ['Landmarks', 'Headings', 'Automated checks'];


### PR DESCRIPTION
#### Description of changes

This was originally motivated by wanting to audit all the `browser.close` instances to see if we were ever closing a browser while there might still be an unawaited page.close in progress, which per [this puppeteer issue](https://github.com/puppeteer/puppeteer/issues/1947) might explain [failures like what we're seeing in the e2e windows jobs here](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=15197&view=results).

I didn't find anything to suggest that that's an accurate root cause for our issue, but I thought this update made stuff more readable regardless.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
