### PR TITLE
feat(android-nav-reflow): left nav panel closed after test select

### DIFF
--- a/src/electron/flux/store/left-nav-store.ts
+++ b/src/electron/flux/store/left-nav-store.ts
@@ -27,6 +27,7 @@ export class LeftNavStore extends BaseStoreImpl<LeftNavStoreData> {
 
     private onItemSelected = (key: LeftNavItemKey): void => {
         this.state.selectedKey = key;
+        this.state.leftNavVisible = false;
         this.emitChanged();
     };
 

--- a/src/tests/unit/tests/electron/flux/store/left-nav-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/left-nav-store.test.ts
@@ -30,7 +30,7 @@ describe('LeftNavStore', () => {
         };
         const expectedState: LeftNavStoreData = {
             selectedKey: 'automated-checks',
-            leftNavVisible: true,
+            leftNavVisible: false,
         };
 
         CreateStoreTesterForLeftNavActions('itemSelected')


### PR DESCRIPTION
#### Description of changes

Gif of it closing:
![leftnavcloses](https://user-images.githubusercontent.com/32555133/97351023-72f35f00-184e-11eb-8d2d-89279ff1760c.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
