### PR TITLE
test(combined-report-ui): implement E2E pinning test for combined report

### DIFF
--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.input.ts
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.input.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CombinedReportParameters } from "reports/package/accessibilityInsightsReport";
+import { CombinedReportParameters } from 'accessibility-insights-report';
 
 export const combinedResultsWithIssues: CombinedReportParameters = {
     serviceName: 'Mock Service Name',
@@ -34,7 +34,7 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                                 ruleUrl: 'https://rules/failed-rule-1',
                                 ruleId: 'failed-rule-1',
                                 tags: ['rule-1-tag-1', 'rule-1-tag-2'],
-                            }
+                            },
                         },
                         {
                             urls: ['https://url/rule-1/failure-1', 'https://url/rule1/failure-2'],
@@ -46,9 +46,9 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                                 ruleUrl: 'https://rules/failed-rule-1',
                                 ruleId: 'failed-rule-1',
                                 tags: ['rule-1-tag-1', 'rule-1-tag-2'],
-                            }
-                        }
-                    ]
+                            },
+                        },
+                    ],
                 },
                 {
                     key: 'failed-rule-2',
@@ -63,21 +63,29 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                                 ruleUrl: 'https://rules/rule2/failed-rule-1',
                                 ruleId: 'failed-rule-2',
                                 tags: ['rule-2-tag'],
-                            }
+                            },
                         },
-                    ]
+                    ],
                 },
             ],
             passed: [
                 {
                     description: 'Ensures <area> elements of image maps have alternate text',
-                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/area-alt?application=webdriverjs',
+                    ruleUrl:
+                        'https://dequeuniversity.com/rules/axe/3.3/area-alt?application=webdriverjs',
                     ruleId: 'area-alt',
-                    tags: ['cat.text-alternatives', 'wcag2a', 'wcag111', 'section508', 'section508.22.a'],
+                    tags: [
+                        'cat.text-alternatives',
+                        'wcag2a',
+                        'wcag111',
+                        'section508',
+                        'section508.22.a',
+                    ],
                 },
                 {
                     description: 'Ensures aria-hidden elements do not contain focusable elements',
-                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=webdriverjs',
+                    ruleUrl:
+                        'https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=webdriverjs',
                     ruleId: 'aria-hidden-focus',
                     tags: ['cat.name-role-value', 'wcag2a', 'wcag412', 'wcag131'],
                 },
@@ -85,23 +93,27 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
             notApplicable: [
                 {
                     description: 'Ensures every ARIA input field has an accessible name',
-                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-input-field-name?application=webdriverjs',
+                    ruleUrl:
+                        'https://dequeuniversity.com/rules/axe/3.3/aria-input-field-name?application=webdriverjs',
                     ruleId: 'aria-input-field-name',
                     tags: ['wcag2a', 'wcag412'],
                 },
                 {
                     description: 'Ensures every ARIA toggle field has an accessible name',
-                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-toggle-field-name?application=webdriverjs',
+                    ruleUrl:
+                        'https://dequeuniversity.com/rules/axe/3.3/aria-toggle-field-name?application=webdriverjs',
                     ruleId: 'aria-toggle-field-name',
                     tags: ['wcag2a', 'wcag412'],
                 },
                 {
-                    description: 'Ensure the autocomplete attribute is correct and suitable for the form field',
-                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/autocomplete-valid?application=webdriverjs',
+                    description:
+                        'Ensure the autocomplete attribute is correct and suitable for the form field',
+                    ruleUrl:
+                        'https://dequeuniversity.com/rules/axe/3.3/autocomplete-valid?application=webdriverjs',
                     ruleId: 'autocomplete-valid',
                     tags: ['cat.forms', 'wcag21aa', 'wcag135'],
                 },
-            ]
-        }
-    }
+            ],
+        },
+    },
 };

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -1,0 +1,1644 @@
+<!DOCTYPE html>
+<html lang="en"
+  ><head
+    ><meta charset="UTF-8" /><title
+      >Accessibility Insights automated checks result</title
+    ><style>
+      :root {
+        --black: #000000;
+        --light-black: #161616;
+        --white: #ffffff;
+        --brand-blue: #004880;
+        --grey: #333333;
+        --ada-brand-color: var(--brand-blue);
+        --primary-text: rgba(0, 0, 0, 0.9);
+        --secondary-text: rgba(0, 0, 0, 0.7);
+        --disabled-text: rgba(0, 0, 0, 0.38);
+        --communication-primary: #106ebe;
+        --communication-tint-40: #eff6fc;
+        --communication-tint-30: #deecf9;
+        --communication-tint-20: #c7e0f4;
+        --communication-tint-10: #2b88d8;
+        --communication-shade-20: #004578;
+        --neutral-0: var(--white);
+        --neutral-2: #f8f8f8;
+        --neutral-3: #f6f6f6;
+        --neutral-4: #f4f4f4;
+        --neutral-6: #f2f2f2;
+        --neutral-6-5: #f1f1f1;
+        --neutral-8: #ebebeb;
+        --neutral-10: #dedede;
+        --neutral-20: #c8c8c8;
+        --neutral-30: #a6a6a6;
+        --neutral-55: #6e6e6e;
+        --neutral-60: #666666;
+        --neutral-70: #3c3c3c;
+        --neutral-80: var(--grey);
+        --neutral-100: var(--black);
+        --neutral-alpha-2: rgba(0, 0, 0, 0.02);
+        --neutral-alpha-4: rgba(0, 0, 0, 0.04);
+        --neutral-alpha-6: rgba(0, 0, 0, 0.06);
+        --neutral-alpha-8: rgba(0, 0, 0, 0.08);
+        --neutral-alpha-10: rgba(0, 0, 0, 0.1);
+        --neutral-alpha-20: rgba(0, 0, 0, 0.2);
+        --neutral-alpha-30: rgba(0, 0, 0, 0.3);
+        --neutral-alpha-60: rgba(0, 0, 0, 0.6);
+        --neutral-alpha-70: rgba(0, 0, 0, 0.7);
+        --neutral-alpha-80: rgba(0, 0, 0, 0.8);
+        --neutral-alpha-90: rgba(0, 0, 0, 0.9);
+        --positive-outcome: #228722;
+        --negative-outcome: #e81123;
+        --neutral-outcome: var(--neutral-60);
+        --box-shadow-108: rgba(0, 0, 0, 0.108);
+        --box-shadow-132: rgba(0, 0, 0, 0.132);
+        --box-shadow-27: rgba(0, 0, 0, 0.27);
+        --screenshot-image-outline: #8b8b8b;
+        --card-border: transparent;
+        --card-footer-border: var(--neutral-10);
+        --header-bar-title-color: var(--neutral-0);
+        --help-links-section-background: var(--neutral-4);
+        --help-links-section-border: var(--neutral-4);
+        --index-circle-background: var(--communication-primary);
+        --link-hover: var(--communication-shade-20);
+        --link: var(--communication-primary);
+        --menu-border: var(--neutral-3);
+        --menu-item-background-active: var(--neutral-alpha-8);
+        --menu-item-background-hover: var(--neutral-alpha-4);
+        --left-nav-icon: var(--neutral-55);
+        --pill-background: var(--neutral-alpha-8);
+        --pill: var(--primary-text);
+        --spinner-text: var(--communication-primary);
+        --nav-link-hover: var(--neutral-alpha-8);
+        --nav-link-selected: var(--communication-tint-20);
+        --nav-link-expanded: var(--communication-tint-40);
+        --insights-button-hover: #0179d4;
+        --landmark-contentinfo: #00a88c;
+        --landmark-main: #cb2e6d;
+        --landmark-complementary: #6b9d1a;
+        --landmark-banner: #d08311;
+        --landmark-region: #2560e0;
+        --landmark-navigation: #9b38e6;
+        --landmark-search: #d363d8;
+        --landmark-form: #0298c7;
+      }
+      :root .high-contrast-theme {
+        --ada-brand-color: var(--white);
+        --secondary-text: var(--white);
+        --primary-text: var(--white);
+        --disabled-text: #c285ff;
+        --communication-tint-40: #38a9ff;
+        --communication-tint-30: var(--communication-tint-10);
+        --neutral-0: var(--light-black);
+        --neutral-2: var(--light-black);
+        --neutral-3: var(--light-black);
+        --neutral-4: var(--light-black);
+        --neutral-6: var(--light-black);
+        --neutral-6-5: var(--light-black);
+        --neutral-8: var(--white);
+        --neutral-10: var(--light-black);
+        --neutral-20: var(--white);
+        --neutral-30: var(--white);
+        --neutral-55: var(--white);
+        --neutral-60: var(--white);
+        --neutral-70: var(--white);
+        --neutral-80: var(--white);
+        --neutral-100: var(--white);
+        --neutral-alpha-8: var(--white);
+        --neutral-alpha-90: var(--white);
+        --positive-outcome: #4ac94a;
+        --negative-outcome: #fc7ab1;
+        --neutral-outcome: var(--neutral-0);
+        --card-border: var(--white);
+        --card-footer-border: var(--white);
+        --header-bar-title-color: var(--brand-blue);
+        --help-links-section-background: transparent;
+        --help-links-section-border: var(--white);
+        --index-circle-background: var(--communication-tint-40);
+        --link-hover: #ffff00;
+        --link: #ffff00;
+        --menu-border: var(--grey);
+        --menu-item-background-active: var(--communication-tint-40);
+        --menu-item-background-hover: var(--grey);
+        --left-nav-icon: var(--black);
+        --pill-background: var(--white);
+        --pill: var(--black);
+        --screenshot-image-outline: var(--white);
+        --spinner-text: var(--communication-tint-40);
+        --nav-link-hover: #2a2a2a;
+        --nav-link-selected: var(--communication-tint-40);
+        --nav-link-expanded: transparent;
+      }
+      .ms-Fabric.is-focusVisible .ms-Nav-group .ms-nav-linkButton:focus::after {
+        border: 1px solid var(--neutral-100);
+      }
+      @media screen and (-ms-high-contrast: active) {
+        .ms-Fabric.is-focusVisible
+          .ms-Nav-group
+          .ms-nav-linkButton:focus::after {
+          border: 1px dashed windowtext !important;
+        }
+      }
+      button::after {
+        content: "";
+        position: absolute;
+      }
+      .ms-fontColor-neutralPrimary,
+      .ms-fontColor-neutralPrimary--hover:hover {
+        color: var(--neutral-100) !important;
+      }
+      .ms-Fabric {
+        color: var(--neutral-100);
+      }
+      .high-contrast-theme .insights-link:hover {
+        text-decoration: underline;
+      }
+      .high-contrast-theme .is-selected .status-icon {
+        color: var(--black) !important;
+      }
+      .insights-link {
+        color: var(--link) !important;
+        text-decoration: none;
+      }
+      .insights-link:hover {
+        color: var(--link-hover) !important;
+        text-decoration: underline;
+      }
+      .ms-Spinner .ms-Spinner-circle {
+        border-top-color: var(--spinner-text);
+      }
+      .ms-Spinner .ms-Spinner-label {
+        color: var(--spinner-text);
+      }
+      .guidance-tags span {
+        font-size: 12px;
+        font-weight: normal;
+        margin-left: 8px;
+        padding: 2px 12px;
+        color: var(--pill);
+        background-color: var(--pill-background);
+        border-radius: 120px;
+      }
+      .instance-details-card {
+        border-radius: 4px;
+        border: 1px solid var(--card-border);
+        outline-style: "border-style";
+        box-shadow: 0px 0.6px 1.8px var(--box-shadow-108),
+          0px 3.2px 7.2px var(--box-shadow-132);
+        margin-bottom: 16px;
+        cursor: pointer;
+        width: -moz-available; /* WebKit-based browsers will ignore this. */
+        width: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
+        width: fill-available;
+      }
+      .instance-details-card-container.selected {
+        outline: 5px solid var(--communication-tint-10);
+      }
+      .instance-details-card.selected {
+        border: 1px solid transparent;
+      }
+      .instance-details-card:focus {
+        outline: 2px solid var(--primary-text);
+        outline-offset: 2px;
+      }
+      .instance-details-card.selected:focus {
+        outline-offset: 8px;
+      }
+      .instance-details-card:hover {
+        box-shadow: 0px 8px 10px var(--box-shadow-108),
+          0px 8px 10px var(--box-shadow-132);
+      }
+      .report-instance-table {
+        background: var(--neutral-0);
+        display: table;
+        table-layout: fixed;
+        width: -moz-available; /* WebKit-based browsers will ignore this. */
+        width: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
+        width: fill-available;
+        border-radius: inherit;
+        border-collapse: collapse;
+        overflow-wrap: break-word;
+        word-break: break-word;
+      }
+      .report-instance-table .row {
+        display: flex;
+        flex-wrap: wrap;
+        padding-top: 2px;
+        padding-bottom: 14px;
+        padding-left: 0px;
+        padding-right: 20px;
+        border-bottom: 0.5px solid var(--neutral-10);
+      }
+      .report-instance-table .row > * {
+        margin-top: 12px;
+        margin-bottom: 0px;
+        margin-left: 20px;
+        margin-right: 0px;
+        padding: 0;
+      }
+      .report-instance-table .row:last-child {
+        border-bottom: none;
+      }
+      .report-instance-table .row-label {
+        flex-basis: 90px;
+        flex-shrink: 1;
+        flex-grow: 0;
+        font-size: 14px;
+        line-height: 20px;
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        color: var(--primary-text);
+        text-align: left;
+      }
+      .report-instance-table .row-content {
+        flex-basis: 200px;
+        flex-shrink: 1;
+        flex-grow: 1;
+        color: var(--secondary-text);
+        font-size: 14px;
+        line-height: 20px;
+        align-items: flex-end;
+        display: flex;
+      }
+      .outcome-summary-bar {
+        display: flex;
+        flex-grow: 0;
+        flex-shrink: 0;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: center;
+        margin-top: 16px;
+        margin-bottom: 0px;
+        line-height: 24px;
+        font-size: 17px;
+        font-weight: 600;
+        white-space: pre-wrap;
+      }
+      .outcome-summary-bar .block,
+      .outcome-summary-bar .fail,
+      .outcome-summary-bar .pass,
+      .outcome-summary-bar .inapplicable,
+      .outcome-summary-bar .unscannable,
+      .outcome-summary-bar .incomplete {
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        line-height: 20px;
+        font-size: 16px;
+        color: var(--neutral-0);
+        padding: 8px 8px 10px 10px;
+        height: 16px;
+        display: flex;
+        align-items: center;
+        margin-right: 4px;
+      }
+      .outcome-summary-bar .count {
+        font-weight: 600;
+      }
+      .outcome-summary-bar .fail {
+        background-color: var(--negative-outcome);
+      }
+      .outcome-summary-bar .fail .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-summary-bar .fail .check-container svg circle {
+        fill: var(--negative-outcome);
+      }
+      .outcome-summary-bar .fail .check-container {
+        bottom: -1px;
+        margin-right: 8px;
+      }
+      .outcome-summary-bar .pass {
+        background-color: var(--positive-outcome);
+      }
+      .outcome-summary-bar .pass .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-summary-bar .pass .check-container svg circle {
+        fill: var(--positive-outcome);
+      }
+      .outcome-summary-bar .pass .check-container {
+        bottom: -1px;
+        margin-right: 8px;
+        margin-left: 4px;
+      }
+      .outcome-summary-bar .inapplicable,
+      .outcome-summary-bar .unscannable {
+        background-color: var(--neutral-outcome);
+      }
+      .outcome-summary-bar .inapplicable .check-container,
+      .outcome-summary-bar .unscannable .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-summary-bar .inapplicable .check-container,
+      .outcome-summary-bar .unscannable .check-container {
+        bottom: -1px;
+        margin-right: 8px;
+        margin-left: 4px;
+      }
+      .outcome-summary-bar .incomplete {
+        background-color: var(--neutral-outcome);
+        color: var(--white);
+        border: 2px var(--neutral-60) solid;
+        height: 12px;
+      }
+      .outcome-summary-bar .incomplete .check-container {
+        position: relative;
+        width: 8px;
+        height: 8px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 3px solid var(--neutral-0);
+      }
+      .outcome-summary-bar .incomplete .check-container {
+        margin-right: 6px;
+        border-color: var(--white);
+      }
+      .outcome-summary-bar .summary-bar-left-edge {
+        border-top-left-radius: 2px;
+        border-bottom-left-radius: 2px;
+      }
+      .outcome-summary-bar .summary-bar-right-edge {
+        border-top-right-radius: 2px;
+        border-bottom-right-radius: 2px;
+        margin-right: 0px;
+      }
+      .outcome-summary-bar .label {
+        font-weight: normal;
+      }
+      .screen-reader-only {
+        position: absolute;
+        left: -10000px;
+        top: auto;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+      }
+      .check-container svg {
+        width: 100%;
+        height: 100%;
+      }
+      .outcome-chip {
+        height: 16px;
+        color: var(--primary-text);
+        border-radius: 0px 8px 8px 0px;
+        margin: 0 4px 0 4px;
+        display: inline-flex;
+        align-items: center;
+        margin-bottom: -3px;
+      }
+      .outcome-chip .icon {
+        border-radius: 50%;
+        width: 16px;
+        height: 16px;
+      }
+      .outcome-chip .count {
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        line-height: 13px;
+        font-size: 11px;
+        border-radius: 0 8px 8px 0;
+        padding: 0 6px 0 10px;
+        font-weight: 700;
+        margin-left: -8px;
+        height: 13px;
+      }
+      .outcome-chip.outcome-chip-pass .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-chip.outcome-chip-pass .check-container svg circle {
+        fill: var(--positive-outcome);
+      }
+      .outcome-chip.outcome-chip-pass .check-container {
+        background-color: var(--positive-outcome);
+      }
+      .outcome-chip.outcome-chip-pass .count {
+        background-color: transparent;
+        border: 1.5px solid var(--positive-outcome);
+      }
+      .outcome-chip.outcome-chip-incomplete .check-container,
+      .outcome-chip.outcome-chip-review .check-container {
+        position: relative;
+        width: 14px;
+        height: 14px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 1px solid var(--neutral-0);
+      }
+      .outcome-chip.outcome-chip-incomplete .check-container,
+      .outcome-chip.outcome-chip-review .check-container {
+        background-color: var(--neutral-60);
+      }
+      .outcome-chip.outcome-chip-incomplete .count,
+      .outcome-chip.outcome-chip-review .count {
+        background-color: transparent;
+        border: 1.5px solid var(--neutral-60);
+      }
+      .outcome-chip.outcome-chip-fail .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-chip.outcome-chip-fail .check-container svg circle {
+        fill: var(--negative-outcome);
+      }
+      .outcome-chip.outcome-chip-fail .check-container {
+        background-color: var(--negative-outcome);
+      }
+      .outcome-chip.outcome-chip-fail .count {
+        background-color: transparent;
+        border: 1.5px solid var(--negative-outcome);
+      }
+      .outcome-chip.outcome-chip-inapplicable .check-container,
+      .outcome-chip.outcome-chip-unscannable .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-chip.outcome-chip-inapplicable .check-container,
+      .outcome-chip.outcome-chip-unscannable .check-container {
+        background-color: var(--neutral-outcome);
+      }
+      .outcome-chip.outcome-chip-inapplicable .count,
+      .outcome-chip.outcome-chip-unscannable .count {
+        background-color: transparent;
+        border: 1.5px solid var(--neutral-outcome);
+      }
+      .outcome-icon-set .outcome-icon {
+        margin-left: 4px;
+        border-radius: 50%;
+      }
+      .outcome-icon-set .outcome-icon-pass .check-container {
+        position: relative;
+        width: 14px;
+        height: 14px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-icon-set .outcome-icon-pass .check-container svg circle {
+        fill: var(--positive-outcome);
+      }
+      .outcome-icon-set .outcome-icon-incomplete .check-container {
+        position: relative;
+        width: 12px;
+        height: 12px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 1px solid var(--neutral-0);
+      }
+      .outcome-icon-set .outcome-icon-incomplete .check-container {
+        border-color: var(--neutral-60);
+      }
+      .outcome-icon-set .outcome-icon-fail .check-container {
+        position: relative;
+        width: 14px;
+        height: 14px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-icon-set .outcome-icon-fail .check-container svg circle {
+        fill: var(--negative-outcome);
+      }
+      body {
+        font-size: 14px;
+        margin: auto;
+        background-color: var(--neutral-2);
+        color: black;
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      }
+      .outer-container {
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+      }
+      .outer-container .content-container {
+        max-width: 960px;
+        margin: 0 auto;
+        margin-top: 24px;
+      }
+      .outer-container .content-container h2 {
+        margin: 0px;
+        font-size: 17px;
+        line-height: 24px;
+      }
+      @media only screen and (max-width: 1000px) {
+        .outer-container .content-container {
+          margin: 24px 16px 0 16px;
+        }
+      }
+      .report-footer-container {
+        max-width: 960px;
+        margin: 0 auto;
+        margin-bottom: 68px;
+        margin-top: 24px;
+      }
+      .report-footer-container .report-footer {
+        line-height: 20px;
+        color: var(--secondary-text);
+      }
+      .report-footer-container .report-footer .tool-name-link {
+        color: var(--secondary-text) !important;
+      }
+      @media only screen and (max-width: 1000px) {
+        .report-footer-container {
+          margin: 0px 16px 68px 16px;
+        }
+      }
+      .report-header-command-bar {
+        height: 40px;
+        width: 100%;
+        display: flex;
+        justify-content: end;
+        min-height: fit-content;
+        align-items: center;
+        background-color: var(--neutral-0);
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+      }
+      .report-header-command-bar .target-page {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin: 0px 0px 0px 16px;
+        display: inherit;
+        color: var(--primary-text);
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-size: 14px;
+        line-height: 20px;
+        font-weight: normal;
+      }
+      .report-header-command-bar .target-page a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .title-section h1 {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        margin: 0px 0px 24px 0px;
+        font-size: 21px;
+        line-height: 32px;
+        letter-spacing: -0.02em;
+      }
+      .results-container {
+        margin-top: 56px;
+      }
+      .urls-summary-section {
+        box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108),
+          0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
+        border-radius: 4px;
+        background-color: var(--neutral-0);
+        padding: 20px;
+        margin-bottom: 24px;
+      }
+      .urls-summary-section h2 {
+        margin-bottom: 16px !important;
+      }
+      .urls-summary-section .failure-instances {
+        margin-top: 40px;
+      }
+      .crawl-details-section {
+        box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108),
+          0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
+        border-radius: 4px;
+        background-color: var(--neutral-0);
+        padding: 20px;
+        margin-bottom: 22px;
+      }
+      .crawl-details-section .crawl-details-section-list {
+        list-style: none;
+        font-size: 14px;
+        line-height: 16px;
+        padding-left: 0px;
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        flex-direction: column;
+      }
+      .crawl-details-section .crawl-details-section-list li {
+        display: inline-block;
+        padding-top: 6px;
+      }
+      .crawl-details-section .crawl-details-section-list li .icon {
+        padding-right: 12px;
+        position: relative;
+        top: 3px;
+      }
+      .crawl-details-section .text,
+      .crawl-details-section .label {
+        word-break: break-all;
+        color: var(--neutral-55);
+        font-weight: 600;
+      }
+      .crawl-details-section .label.no-icon {
+        padding-left: 29px;
+      }
+      .url-result-section {
+        padding-bottom: 31px;
+      }
+      .url-result-section
+        .title-container[aria-level="3"]
+        .collapsible-control::before {
+        position: relative;
+        bottom: 2px;
+        margin-right: 14px;
+      }
+      .url-result-section .collapsible-content {
+        margin-top: 19px;
+      }
+      .url-results-container {
+        margin-top: 56px;
+      }
+      .url-results-container .results-heading {
+        margin-top: 32px;
+        margin-bottom: 32px;
+      }
+      .summary-results-table {
+        width: 100%;
+        margin: 0px;
+        text-align: left;
+        border-spacing: 0px;
+        border-collapse: collapse;
+        font-size: 14px;
+        line-height: 20px;
+      }
+      .summary-results-table th,
+      .summary-results-table td {
+        border: 1px solid var(--neutral-20);
+        padding: 16px 8px 16px 8px;
+      }
+      .summary-results-table th {
+        font-weight: 600;
+        background-color: var(--neutral-6);
+      }
+      .summary-results-table thead tr :first-child {
+        width: 172px;
+      }
+      .summary-results-table td {
+        background-color: var(--neutral-0);
+      }
+      .summary-results-table td.text-cell {
+        overflow-wrap: break-word;
+      }
+      .summary-results-table td.url-cell {
+        overflow-wrap: anywhere;
+      }
+      @media screen and (max-width: 640px) {
+        .outcome-past-tense {
+          display: none;
+        }
+      }
+      .result-section {
+        padding-bottom: 58px;
+      }
+      .result-section
+        .title-container[aria-level="2"]
+        .collapsible-control::before {
+        position: relative;
+        bottom: 2px;
+        margin-right: 14px;
+      }
+      .collapsible-container:not(.collapsible-rule-details-group)
+        .collapsible-control {
+        padding-left: 2px;
+        padding-right: 16px;
+        position: relative;
+      }
+      .collapsible-container .collapsible-control[aria-expanded="false"]:before,
+      .collapsible-container .collapsible-control[aria-expanded="true"]:before {
+        display: inline-block;
+        border-right: 1px solid var(--secondary-text);
+        border-bottom: 1px solid var(--secondary-text);
+        min-width: 7px;
+        width: 7px;
+        height: 7px;
+        content: "";
+        transform-origin: 50% 50%;
+        transition: transform 0.1s linear 0s;
+      }
+      .collapsible-container .collapsible-control {
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        background-color: transparent;
+        cursor: pointer;
+        border: none;
+        display: flex;
+        align-items: baseline;
+        width: 100%;
+      }
+      .collapsible-container .collapsible-control:hover {
+        background-color: var(--neutral-alpha-4);
+      }
+      .collapsible-container
+        .collapsible-control[aria-expanded="false"]:before {
+        -webkit-transform: rotate(-45deg);
+        -ms-transform: rotate(-45deg);
+        transform: rotate(-45deg);
+      }
+      .collapsible-container .collapsible-control[aria-expanded="true"]:before {
+        -webkit-transform: rotate(45deg);
+        -ms-transform: rotate(45deg);
+        transform: rotate(45deg);
+      }
+      .collapsible-container .collapsible-content[aria-hidden="true"] {
+        display: none;
+      }</style
+    ><style>
+      .report-congrats-message--1O-Tl {
+        word-break: break-word;
+        overflow-wrap: break-word;
+      }
+      .report-congrats-head--6pvch {
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--primary-text);
+        padding: 10px 0 10px 0;
+      }
+      .report-congrats-info--pvbRt {
+        font-size: 14px;
+        color: var(--secondary-text);
+        padding: 10px 0 10px 0;
+      }
+      .sleeping-ada--3M6Q7 {
+        height: 100px;
+      }
+      .outcome-chip-container--3NUUD {
+        min-width: 50px;
+      }
+      .instance-details-card--OrpLo {
+        border-radius: 4px;
+        border: 1px solid var(--card-border);
+        outline-style: "border-style";
+        box-shadow: 0px 0.6px 1.8px var(--box-shadow-108),
+          0px 3.2px 7.2px var(--box-shadow-132);
+        margin-bottom: 16px;
+        cursor: pointer;
+        width: -moz-available; /* WebKit-based browsers will ignore this. */
+        width: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
+        width: fill-available;
+      }
+      .instance-details-card-container--_ELdq.selected--3O8dW {
+        outline: 5px solid var(--communication-tint-10);
+      }
+      .instance-details-card--OrpLo.selected--3O8dW {
+        border: 1px solid transparent;
+      }
+      .instance-details-card--OrpLo:focus {
+        outline: 2px solid var(--primary-text);
+        outline-offset: 2px;
+      }
+      .instance-details-card--OrpLo.selected--3O8dW:focus {
+        outline-offset: 8px;
+      }
+      .instance-details-card--OrpLo:hover {
+        box-shadow: 0px 8px 10px var(--box-shadow-108),
+          0px 8px 10px var(--box-shadow-132);
+      }
+      .report-instance-table--ljlFi {
+        background: var(--neutral-0);
+        display: table;
+        table-layout: fixed;
+        width: -moz-available; /* WebKit-based browsers will ignore this. */
+        width: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
+        width: fill-available;
+        border-radius: inherit;
+        border-collapse: collapse;
+        overflow-wrap: break-word;
+        word-break: break-word;
+      }
+      .report-instance-table--ljlFi .row--kaG63 {
+        display: flex;
+        flex-wrap: wrap;
+        padding-top: 2px;
+        padding-bottom: 14px;
+        padding-left: 0px;
+        padding-right: 20px;
+        border-bottom: 0.5px solid var(--neutral-10);
+      }
+      .report-instance-table--ljlFi .row--kaG63 > * {
+        margin-top: 12px;
+        margin-bottom: 0px;
+        margin-left: 20px;
+        margin-right: 0px;
+        padding: 0;
+      }
+      .report-instance-table--ljlFi .row--kaG63:last-child {
+        border-bottom: none;
+      }
+      .report-instance-table--ljlFi .row-label--1iEmL {
+        flex-basis: 90px;
+        flex-shrink: 1;
+        flex-grow: 0;
+        font-size: 14px;
+        line-height: 20px;
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        color: var(--primary-text);
+        text-align: left;
+      }
+      .report-instance-table--ljlFi .row-content--usdIW {
+        flex-basis: 200px;
+        flex-shrink: 1;
+        flex-grow: 1;
+        color: var(--secondary-text);
+        font-size: 14px;
+        line-height: 20px;
+        align-items: flex-end;
+        display: flex;
+      }
+      .multi-line-text-no-bullet--3igrU {
+        padding-left: 0;
+        list-style: none;
+      }
+      .multi-line-text-no-bullet--3igrU li:not(:last-child) {
+        margin-bottom: 4px;
+      }
+      .multi-line-text-yes-bullet--ebJpE {
+        padding-left: 16px;
+      }
+      .multi-line-text-yes-bullet--ebJpE li {
+        list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .combination-lists--2hRoK {
+        flex-direction: column;
+        display: flex;
+      }
+      .urls-row-content--2TTTB {
+        padding-left: 16px;
+      }
+      .urls-row-content--2TTTB li {
+        list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .insights-fix-instruction-list--1vUZj
+        li
+        span.fix-instruction-color-box--2DKsr {
+        width: 14px;
+        height: 14px;
+        display: inline-block;
+        vertical-align: -5%;
+        margin: 0px 2px;
+        border: 1px solid var(--light-black);
+      }
+      .insights-fix-instruction-list--1vUZj .screen-reader-only--QfHg0 {
+        position: absolute;
+        left: -10000px;
+        top: auto;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+      }
+      .toast-container--YaZxW {
+        display: inline-block;
+      }
+      .toast-content--Wt0Lj {
+        background: var(--neutral-70);
+        border-radius: 4px;
+        color: var(--neutral-0);
+        padding-left: 20px;
+        padding-top: 14px;
+        padding-bottom: 14px;
+        padding-right: 20px;
+        width: 316px;
+        margin-left: calc(316px / -2 - 20px);
+        left: 50%;
+        bottom: 20px;
+        z-index: 1000;
+        position: absolute;
+      }
+      .how-to-fix-content--2-Pc1 {
+        margin-bottom: 16px;
+      }
+      .how-to-fix-content--2-Pc1 ul {
+        padding-left: 16px;
+      }
+      .how-to-fix-content--2-Pc1 ul li {
+        list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .snippet--msVz- {
+        font-family: Menlo, Consolas, Courier New, monospace;
+        white-space: normal;
+      }
+      div.insights-dialog-main-override--12zq8 {
+        width: 75%;
+        max-width: 500px;
+        user-select: text;
+      }
+      @media screen and (max-width: 500px) {
+        div.insights-dialog-main-override--12zq8 {
+          min-width: 240px;
+          width: 75%;
+        }
+      }
+      div.insights-dialog-main-override--12zq8 .dialog-body--2gMoa {
+        font-size: 16px;
+      }
+      .issue-filing-dialog--2bt4g .ms-Dialog-title {
+        font-size: 21px;
+        line-height: 32px;
+        letter-spacing: -0.02em;
+        font-weight: 600;
+        padding-bottom: 0;
+      }
+      .issue-filing-dialog--2bt4g .ms-Dialog-subText {
+        font-weight: 400;
+        font-size: 15px;
+        color: var(--secondary-text);
+      }
+      .action-and-cancel-buttons-component--GI-yD {
+        display: flex;
+        justify-content: flex-end;
+      }
+      .action-and-cancel-buttons-component--GI-yD
+        .action-cancel-button-col--2EdOO
+        + .action-cancel-button-col--2EdOO {
+        margin-left: 8px;
+      }
+      div.kebab-menu-callout--14fgT {
+        box-shadow: 0px 6.4px 14.4px var(--box-shadow-132),
+          0px 1.2px 3.6px var(--box-shadow-108);
+        border-radius: 4px;
+        border-width: 0px;
+      }
+      div.kebab-menu-callout--14fgT > div {
+        border-radius: 4px;
+      }
+      .kebab-menu--z2Gzc {
+        background: var(--neutral-3);
+        border: 1px solid var(--menu-border);
+      }
+      .kebab-menu--z2Gzc li {
+        background-color: var(--neutral-3);
+      }
+      .kebab-menu--z2Gzc button i {
+        color: var(--primary-text);
+      }
+      .kebab-menu--z2Gzc button:hover {
+        background-color: var(--menu-item-background-hover);
+      }
+      .kebab-menu--z2Gzc button:active {
+        background-color: var(--menu-item-background-active);
+        color: var(--light-black);
+      }
+      .kebab-menu--z2Gzc button:active i {
+        color: var(--light-black);
+      }
+      button.kebab-menu-button--2aa2O {
+        width: 34px;
+        height: 32px;
+        margin: 8px;
+        border-radius: 2px;
+        background: transparent;
+      }
+      button.kebab-menu-button--2aa2O svg {
+        stroke: var(--primary-text);
+      }
+      @media screen and (-ms-high-contrast: active) {
+        button.kebab-menu-button--2aa2O svg {
+          fill: inherit !important;
+        }
+      }
+      button.kebab-menu-button--2aa2O:hover {
+        background-color: var(--menu-item-background-hover);
+      }
+      button.kebab-menu-button--2aa2O:active,
+      button.kebab-menu-button--2aa2O[aria-expanded="true"] {
+        background-color: var(--menu-item-background-active);
+        color: var(--light-black);
+      }
+      button.kebab-menu-button--2aa2O:active svg > circle,
+      button.kebab-menu-button--2aa2O[aria-expanded="true"] svg > circle {
+        stroke: var(--light-black);
+      }
+      button.kebab-menu-button--2aa2O > span {
+        justify-content: center;
+      }
+      .foot--1bb1r {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background-color: var(--neutral-2);
+        min-height: 48px;
+        padding-left: 12px;
+        border-top: 0.5px solid var(--card-footer-border);
+        border-bottom-left-radius: inherit;
+        border-bottom-right-radius: inherit;
+      }
+      .foot--1bb1r .highlight-status--1IQGd {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: transparent;
+      }
+      .foot--1bb1r .highlight-status--1IQGd svg {
+        fill: var(--secondary-text);
+      }
+      .foot--1bb1r .highlight-status--1IQGd label {
+        color: var(--secondary-text);
+        font-size: 14px;
+        overflow-wrap: break-word;
+        word-break: break-word;
+      }
+      ul.instance-details-list--2Beza {
+        list-style-type: none;
+        padding-inline-start: unset;
+        margin-block-start: unset;
+        margin-block-end: unset;
+      }
+      ul.instance-details-list--2Beza > li {
+        margin-bottom: 16px;
+      }
+      ul.instance-details-list--2Beza > li:last-child {
+        margin-bottom: unset;
+      }
+      .rule-more-resources--3PCDe {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 16px;
+        padding: 14px 20px;
+        background-color: var(--neutral-0);
+        box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108),
+          0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
+        border-radius: 4px;
+        border: 1px solid var(--card-border);
+        line-height: 20px;
+        overflow-wrap: break-word;
+        word-break: break-word;
+      }
+      .rule-more-resources--3PCDe .more-resources-title--17xOw {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      }
+      .rule-more-resources--3PCDe .rule-details-id--ie-v- {
+        padding: 12px 0;
+      }
+      .rule-details-group--39A1d .rule-detail {
+        font-size: 14px;
+        padding: 16px 8px;
+        display: flex;
+        align-items: baseline;
+        text-align: left;
+      }
+      .rule-details-group--39A1d .rule-detail .outcome-chip {
+        vertical-align: middle;
+        margin-bottom: 2px;
+      }
+      .rule-details-group--39A1d .rule-detail .rule-details-id {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        color: var(--primary-text);
+        word-break: break-all;
+      }
+      .rule-details-group--39A1d .rule-detail .rule-details-id a {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        color: var(--primary-text) !important;
+      }
+      .rule-details-group--39A1d .rule-detail .rule-detail-description {
+        color: var(--secondary-text) !important;
+        word-break: break-all;
+      }
+      .rule-details-group--39A1d .rule-detail .guidance-links a {
+        color: var(--secondary-text) !important;
+      }
+      .collapsible-rule-details-group--3aN3u {
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+      }
+      .collapsible-rule-details-group--3aN3u .rule-detail {
+        box-shadow: unset;
+      }
+      .collapsible-rule-details-group--3aN3u:not(.collapsed) {
+        box-shadow: unset;
+      }
+      .result-section-title--27ZOL {
+        display: flex;
+        flex-wrap: nowrap;
+        justify-content: flex-start;
+        align-items: center;
+        margin-top: 8px;
+        margin-bottom: 8px;
+      }
+      .result-section-title--27ZOL .outcome-chip.outcome-chip-fail .count {
+        line-height: 11px;
+      }
+      .result-section-title--27ZOL .outcome-chip.outcome-chip-fail svg {
+        margin-bottom: 3px;
+      }
+      .result-section-title--27ZOL .title--nA1u1 {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: 600;
+        font-size: 17px;
+        line-height: 24px;
+        margin-right: 6px;
+        color: var(--primary-text);
+      }
+      .result-section-title--27ZOL .heading--3ryVY {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: 600;
+        font-size: 15px;
+        line-height: 20px;
+        margin-right: 6px;
+        color: var(--primary-text);
+      }
+      .result-section-title--27ZOL .outcome-chip-container--1Vd7P {
+        display: flex;
+        height: 16px;
+      }
+      .result-section--1FLO5 {
+        padding-bottom: 58px;
+      }
+      .result-section--1FLO5
+        .title-container--1CFvU[aria-level="2"]
+        .collapsible-control--ey-Vd::before {
+        position: relative;
+        bottom: 2px;
+      }
+      .result-section--1FLO5 > h2 {
+        margin: 0px;
+        font-size: 17px;
+        line-height: 24px;
+      }
+      .report-header-bar--kg10M {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        flex-wrap: nowrap;
+        background-color: var(--ada-brand-color);
+        height: 40px;
+        width: 100%;
+      }
+      .report-header-bar--kg10M .header-icon {
+        flex-shrink: 0;
+        margin-left: 16px;
+        height: 22px;
+        width: 22px;
+      }
+      .report-header-bar--kg10M .header-text--2L-Jl {
+        margin-left: 8px;
+        color: var(--header-bar-title-color);
+        flex-shrink: 1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: normal;
+        font-size: 17px;
+        line-height: 24px;
+      }
+      .report-header-command-bar--CWe48 {
+        height: 40px;
+        width: 100%;
+        display: flex;
+        justify-content: end;
+        min-height: fit-content;
+        align-items: center;
+        background-color: var(--neutral-0);
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+      }
+      .report-header-command-bar--CWe48 .target-page--16UqC {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin: 0px 0px 0px 16px;
+        display: inherit;
+        color: var(--primary-text);
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-size: 14px;
+        line-height: 20px;
+        font-weight: normal;
+      }
+      .report-header-command-bar--CWe48 .target-page--16UqC a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .urls-summary-section--2D8aF {
+        box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108),
+          0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
+        border-radius: 4px;
+        background-color: var(--neutral-0);
+        padding: 20px;
+        margin-bottom: 24px;
+      }
+      .urls-summary-section--2D8aF h2 {
+        margin-bottom: 16px !important;
+      }
+      .urls-summary-section--2D8aF .failure-instances--2tbUx {
+        margin-top: 40px;
+      }
+      span.fix-instruction-color-box--HXJ1A {
+        width: 14px;
+        height: 14px;
+        display: inline-block;
+        vertical-align: -5%;
+        margin: 0px 2px;
+        border: 1px solid var(--light-black);
+      }
+      .screen-reader-only--1uWLQ {
+        position: absolute;
+        left: -10000px;
+        top: auto;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+      }
+    </style></head
+  ><body
+    ><header
+      ><div class="report-header-bar--kg10M"
+        ><svg
+          role="img"
+          aria-hidden="true"
+          class="header-icon"
+          viewBox="0 0 48 48"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <mask
+            id="mask0"
+            maskUnits="userSpaceOnUse"
+            x="0"
+            y="3"
+            width="48"
+            height="43"
+            style="mask-type: alpha"
+          >
+            <path
+              d="M43.8309 27.1383C49.3148 21.6544 49.3148 12.7633 43.8309 7.27934C38.347 1.79544 29.4558 1.79543 23.9719 7.27934C18.488 1.79544 9.59684 1.79544 4.11293 7.27934C-1.37098 12.7633 -1.37098 21.6544 4.11293 27.1383L21.986 45.0114C23.0828 46.1082 24.861 46.1082 25.9578 45.0114L43.8309 27.1383Z"
+              fill="white"
+            ></path>
+          </mask>
+          <g mask="url(#mask0)">
+            <path
+              d="M43.8309 27.1383C49.3148 21.6544 49.3148 12.7633 43.8309 7.27934C38.347 1.79544 29.4558 1.79543 23.9719 7.27934C18.488 1.79544 9.59684 1.79544 4.11293 7.27934C-1.37098 12.7633 -1.37098 21.6544 4.11293 27.1383L21.986 45.0114C23.0828 46.1082 24.861 46.1082 25.9578 45.0114L43.8309 27.1383Z"
+              fill="white"
+            ></path>
+            <rect
+              x="43.9494"
+              y="7.24556"
+              width="14.0948"
+              height="42.2726"
+              transform="rotate(45 43.9494 7.24556)"
+              fill="#D6E9F7"
+            ></rect>
+            <mask
+              id="mask1"
+              maskUnits="userSpaceOnUse"
+              x="-6"
+              y="-3"
+              width="30"
+              height="31"
+              style="mask-type: alpha"
+            >
+              <path
+                d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79472 18.4879 1.79472 23.9718 7.27863Z"
+                fill="#CFEBFF"
+              ></path>
+              <path
+                d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79472 18.4879 1.79472 23.9718 7.27863Z"
+                fill="url(#paint0_linear)"
+              ></path>
+            </mask>
+            <g mask="url(#mask1)">
+              <path
+                d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79472 18.4879 1.79472 23.9718 7.27863Z"
+                fill="white"
+              ></path>
+              <path
+                d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79472 18.4879 1.79472 23.9718 7.27863Z"
+                fill="url(#paint1_linear)"
+              ></path>
+              <rect
+                x="4.54834"
+                y="6.88206"
+                width="16.3577"
+                height="42.2726"
+                transform="rotate(-45 4.54834 6.88206)"
+                fill="#D6E9F7"
+              ></rect>
+              <rect
+                x="4.54834"
+                y="6.88206"
+                width="16.3577"
+                height="42.2726"
+                transform="rotate(-45 4.54834 6.88206)"
+                fill="url(#paint2_linear)"
+              ></rect>
+            </g>
+            <g filter="url(#filter0_d)">
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M34.0764 27.3564C39.8071 27.3483 44.4461 22.6961 44.438 16.9655C44.4299 11.2349 39.7778 6.59585 34.0472 6.60393C28.3165 6.61201 23.6775 11.2642 23.6856 16.9948C23.6888 19.2829 24.4324 21.397 25.6895 23.1108L23.4287 25.3788C22.8852 25.395 22.3466 25.6109 21.9324 26.0265L17.1218 30.8526C16.4185 31.5582 16.4203 32.7005 17.126 33.4038L17.6952 33.9713C18.4009 34.6746 19.5431 34.6728 20.2465 33.9671L25.057 29.141C25.4715 28.7252 25.6857 28.1855 25.6998 27.6415L27.9603 25.3737C29.6766 26.6235 31.7907 27.3596 34.0764 27.3564ZM34.0368 23.2439C37.4964 23.2579 40.3122 20.4647 40.3262 17.0051C40.3401 13.5456 37.5469 10.7298 34.0874 10.7158C30.6279 10.7018 27.812 13.495 27.7981 16.9545C27.7841 20.4141 30.5773 23.2299 34.0368 23.2439Z"
+                fill="#004880"
+              ></path>
+            </g>
+          </g>
+          <defs>
+            <filter
+              id="filter0_d"
+              x="15.748"
+              y="6.50654"
+              width="29.5246"
+              height="29.5269"
+              filterUnits="userSpaceOnUse"
+              color-interpolation-filters="sRGB"
+            >
+              <feFlood flood-opacity="0" result="BackgroundImageFix"></feFlood>
+              <feColorMatrix
+                in="SourceAlpha"
+                type="matrix"
+                values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+              ></feColorMatrix>
+              <feOffset dy="0.725705"></feOffset>
+              <feGaussianBlur stdDeviation="0.40317"></feGaussianBlur>
+              <feColorMatrix
+                type="matrix"
+                values="0 0 0 0 0.0447352 0 0 0 0 0.305769 0 0 0 0 0.492222 0 0 0 0.51 0"
+              ></feColorMatrix>
+              <feBlend
+                mode="normal"
+                in2="BackgroundImageFix"
+                result="effect1_dropShadow"
+              ></feBlend>
+              <feBlend
+                mode="normal"
+                in="SourceGraphic"
+                in2="effect1_dropShadow"
+                result="shape"
+              ></feBlend>
+            </filter>
+            <linearGradient
+              id="paint0_linear"
+              x1="14.3166"
+              y1="16.8744"
+              x2="5.92409"
+              y2="8.23504"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset="0" stop-color="#073A5F" stop-opacity="0.3"></stop>
+              <stop offset="1" stop-color="#CFEBFF" stop-opacity="0"></stop>
+            </linearGradient>
+            <linearGradient
+              id="paint1_linear"
+              x1="14.3166"
+              y1="16.8744"
+              x2="5.92409"
+              y2="8.23504"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset="0" stop-color="#165B8E" stop-opacity="0.29"></stop>
+              <stop offset="1" stop-color="white" stop-opacity="0"></stop>
+            </linearGradient>
+            <linearGradient
+              id="paint2_linear"
+              x1="11.3179"
+              y1="20.1024"
+              x2="11.0819"
+              y2="11.1606"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset="0" stop-color="#165B8E" stop-opacity="0.29"></stop>
+              <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
+            </linearGradient>
+          </defs></svg
+        ><div class="header-text--2L-Jl">Accessibility Insights</div></div
+      ></header
+    ><main class="outer-container"
+      ><div class="content-container"
+        ><div class="title-section"><h1>Automated checks results</h1></div
+        ><div class="crawl-details-section"
+          ><h2>Scan details</h2
+          ><ul class="crawl-details-section-list"
+            ><li
+              ><span class="icon" aria-hidden="true"
+                ><svg
+                  width="17"
+                  height="16"
+                  viewBox="0 0 17 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
+                    fill="#737373"
+                  ></path></svg></span
+              ><span class="label">Target site </span
+              ><span class="text"
+                ><a
+                  target="_blank"
+                  href="https://example.com/mock-base-url"
+                  class="ms-Link insights-link root-49"
+                  title="Mock base without failures or unscannables"
+                  id="new-tab-link-with-confirmation-dialog__1"
+                  >https://example.com/mock-base-url</a
+                ><script>
+                  (function (linkId, doc, confirmCallback) {
+                    const targetPageLink = doc.getElementById(linkId);
+                    targetPageLink.addEventListener("click", function (event) {
+                      const result = confirmCallback(
+                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                          "Cancel to stay on the current page."
+                      );
+                      if (result === false) {
+                        event.preventDefault();
+                      }
+                    });
+                  })(
+                    "new-tab-link-with-confirmation-dialog__1",
+                    document,
+                    confirm
+                  );
+                </script></span
+              ></li
+            ><li
+              ><span class="icon" aria-hidden="true"
+                ><svg
+                  width="17"
+                  height="16"
+                  viewBox="0 0 17 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
+                    fill="#737373"
+                  ></path></svg></span
+              ><span class="label">Scans started </span
+              ><span class="text">2020-02-02 3:04 AM UTC</span></li
+            ><li
+              ><span class="label no-icon">Scans completed </span
+              ><span class="text">2020-02-02 4:04 AM UTC</span></li
+            ><li
+              ><span class="label no-icon">Duration </span
+              ><span class="text">01:00:00</span></li
+            ></ul
+          ></div
+        ><div class="urls-summary-section--2D8aF"
+          ><h2>URLs</h2>6 total URLs discovered<div
+            class="outcome-summary-bar"
+            aria-label="3 Failed, 1 Not scanned, 2 Passed"
+            role="img"
+            ><div style="flex-grow: 3"
+              ><span class="fail summary-bar-left-edge"
+                ><span aria-hidden="true"
+                  ><span class="check-container"
+                    ><svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        clip-rule="evenodd"
+                        d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58173 12.4183 0 8 0C3.58172 0 0 3.58173 0 8C0 12.4183 3.58172 16 8 16ZM10.9947 4.99466C10.7018 4.70178 10.2269 4.70178 9.93401 4.99466L8 6.92868L6.06599 4.99466C5.77309 4.70178 5.29823 4.70178 5.00533 4.99466C4.71243 5.28757 4.71243 5.76242 5.00533 6.05533L6.93933 7.98932L4.99467 9.93399C4.70177 10.2269 4.70177 10.7018 4.99467 10.9947C5.28756 11.2876 5.76243 11.2876 6.05532 10.9947L8 9.04999L9.94467 10.9947C10.2376 11.2876 10.7124 11.2876 11.0053 10.9947C11.2982 10.7018 11.2982 10.2269 11.0053 9.93399L9.06066 7.98932L10.9947 6.05533C11.2876 5.76242 11.2876 5.28757 10.9947 4.99466Z"
+                        fill="var(--neutral-0)"
+                      ></path></svg></span></span
+                >3<div class="label"> Failed</div></span
+              ></div
+            ><div style="flex-grow: 1"
+              ><span class="unscannable"
+                ><span aria-hidden="true"
+                  ><span class="check-container"
+                    ><svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <circle cx="8" cy="8" r="8" fill="white"></circle>
+                      <line
+                        x1="5.66064"
+                        y1="5.625"
+                        x2="10.2568"
+                        y2="10.2212"
+                        stroke="#737373"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                      ></line></svg></span></span
+                >1<div class="label"> Not scanned</div></span
+              ></div
+            ><div style="flex-grow: 2"
+              ><span class="pass summary-bar-right-edge"
+                ><span aria-hidden="true"
+                  ><span class="check-container"
+                    ><svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        clip-rule="evenodd"
+                        d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16ZM6.0616 11.1442L6.05904 11.1417L4.27459 9.35718C3.90847 8.99104 3.90847 8.39747 4.27459 8.03134C4.64071 7.66524 5.2343 7.66524 5.60041 8.03134L6.72452 9.15545L10.6054 5.27457C10.9715 4.90848 11.5651 4.90848 11.9312 5.27457C12.2974 5.64071 12.2974 6.23427 11.9312 6.60041L7.391 11.1406L7.38742 11.1442C7.06707 11.4646 6.57256 11.5046 6.20867 11.2643C6.15668 11.23 6.10737 11.19 6.0616 11.1442Z"
+                        fill="white"
+                      ></path></svg></span></span
+                >2<div class="label"> Passed</div></span
+              ></div
+            ></div
+          ><div class="failure-instances--2tbUx"
+            ><h2>Failure Instances</h2
+            ><span class="outcome-chip outcome-chip-fail" title="4 Failed"
+              ><span class="icon"
+                ><span class="check-container"
+                  ><svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle cx="8" cy="8" r="8" fill="#E81123"></circle>
+                    <path
+                      d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                      fill="var(--neutral-0)"
+                    ></path></svg></span></span
+              ><span
+                data-automation-id="count"
+                class="count"
+                aria-hidden="true"
+              >
+                4</span
+              ><span class="screen-reader-only">4 Failed</span></span
+            >
+            Failure instances were detected</div
+          ></div
+        ></div
+      ></main
+    ><div class="report-footer-container"
+      ><div class="report-footer" role="contentinfo"
+        >This automated checks result was generated using the Mock Service Name
+        that helps find some of the most common accessibility issues. The scan
+        was performed using axe-core mock.axe.version and Mock user agent. For a
+        complete WCAG 2.1 compliance assessment please visit
+        <a
+          target="_blank"
+          href="http://aka.ms/AccessibilityInsights"
+          class="ms-Link insights-link tool-name-link root-49"
+          title="Get more information and download Accessibility Insights for Web"
+          >http://aka.ms/AccessibilityInsights</a
+        >.</div
+      ></div
+    ></body
+  ></html
+>

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.input.ts
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.input.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CombinedReportParameters } from "reports/package/accessibilityInsightsReport";
+import { CombinedReportParameters } from 'accessibility-insights-report';
 
 export const combinedResultsWithoutIssues: CombinedReportParameters = {
     serviceName: 'Mock Service Name',
@@ -24,13 +24,21 @@ export const combinedResultsWithoutIssues: CombinedReportParameters = {
             passed: [
                 {
                     description: 'Ensures <area> elements of image maps have alternate text',
-                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/area-alt?application=webdriverjs',
+                    ruleUrl:
+                        'https://dequeuniversity.com/rules/axe/3.3/area-alt?application=webdriverjs',
                     ruleId: 'area-alt',
-                    tags: ['cat.text-alternatives', 'wcag2a', 'wcag111', 'section508', 'section508.22.a'],
+                    tags: [
+                        'cat.text-alternatives',
+                        'wcag2a',
+                        'wcag111',
+                        'section508',
+                        'section508.22.a',
+                    ],
                 },
                 {
                     description: 'Ensures aria-hidden elements do not contain focusable elements',
-                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=webdriverjs',
+                    ruleUrl:
+                        'https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=webdriverjs',
                     ruleId: 'aria-hidden-focus',
                     tags: ['cat.name-role-value', 'wcag2a', 'wcag412', 'wcag131'],
                 },
@@ -38,23 +46,27 @@ export const combinedResultsWithoutIssues: CombinedReportParameters = {
             notApplicable: [
                 {
                     description: 'Ensures every ARIA input field has an accessible name',
-                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-input-field-name?application=webdriverjs',
+                    ruleUrl:
+                        'https://dequeuniversity.com/rules/axe/3.3/aria-input-field-name?application=webdriverjs',
                     ruleId: 'aria-input-field-name',
                     tags: ['wcag2a', 'wcag412'],
                 },
                 {
                     description: 'Ensures every ARIA toggle field has an accessible name',
-                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/aria-toggle-field-name?application=webdriverjs',
+                    ruleUrl:
+                        'https://dequeuniversity.com/rules/axe/3.3/aria-toggle-field-name?application=webdriverjs',
                     ruleId: 'aria-toggle-field-name',
                     tags: ['wcag2a', 'wcag412'],
                 },
                 {
-                    description: 'Ensure the autocomplete attribute is correct and suitable for the form field',
-                    ruleUrl: 'https://dequeuniversity.com/rules/axe/3.3/autocomplete-valid?application=webdriverjs',
+                    description:
+                        'Ensure the autocomplete attribute is correct and suitable for the form field',
+                    ruleUrl:
+                        'https://dequeuniversity.com/rules/axe/3.3/autocomplete-valid?application=webdriverjs',
                     ruleId: 'autocomplete-valid',
                     tags: ['cat.forms', 'wcag21aa', 'wcag135'],
                 },
-            ]
-        }
-    }
+            ],
+        },
+    },
 };

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -1,0 +1,1644 @@
+<!DOCTYPE html>
+<html lang="en"
+  ><head
+    ><meta charset="UTF-8" /><title
+      >Accessibility Insights automated checks result</title
+    ><style>
+      :root {
+        --black: #000000;
+        --light-black: #161616;
+        --white: #ffffff;
+        --brand-blue: #004880;
+        --grey: #333333;
+        --ada-brand-color: var(--brand-blue);
+        --primary-text: rgba(0, 0, 0, 0.9);
+        --secondary-text: rgba(0, 0, 0, 0.7);
+        --disabled-text: rgba(0, 0, 0, 0.38);
+        --communication-primary: #106ebe;
+        --communication-tint-40: #eff6fc;
+        --communication-tint-30: #deecf9;
+        --communication-tint-20: #c7e0f4;
+        --communication-tint-10: #2b88d8;
+        --communication-shade-20: #004578;
+        --neutral-0: var(--white);
+        --neutral-2: #f8f8f8;
+        --neutral-3: #f6f6f6;
+        --neutral-4: #f4f4f4;
+        --neutral-6: #f2f2f2;
+        --neutral-6-5: #f1f1f1;
+        --neutral-8: #ebebeb;
+        --neutral-10: #dedede;
+        --neutral-20: #c8c8c8;
+        --neutral-30: #a6a6a6;
+        --neutral-55: #6e6e6e;
+        --neutral-60: #666666;
+        --neutral-70: #3c3c3c;
+        --neutral-80: var(--grey);
+        --neutral-100: var(--black);
+        --neutral-alpha-2: rgba(0, 0, 0, 0.02);
+        --neutral-alpha-4: rgba(0, 0, 0, 0.04);
+        --neutral-alpha-6: rgba(0, 0, 0, 0.06);
+        --neutral-alpha-8: rgba(0, 0, 0, 0.08);
+        --neutral-alpha-10: rgba(0, 0, 0, 0.1);
+        --neutral-alpha-20: rgba(0, 0, 0, 0.2);
+        --neutral-alpha-30: rgba(0, 0, 0, 0.3);
+        --neutral-alpha-60: rgba(0, 0, 0, 0.6);
+        --neutral-alpha-70: rgba(0, 0, 0, 0.7);
+        --neutral-alpha-80: rgba(0, 0, 0, 0.8);
+        --neutral-alpha-90: rgba(0, 0, 0, 0.9);
+        --positive-outcome: #228722;
+        --negative-outcome: #e81123;
+        --neutral-outcome: var(--neutral-60);
+        --box-shadow-108: rgba(0, 0, 0, 0.108);
+        --box-shadow-132: rgba(0, 0, 0, 0.132);
+        --box-shadow-27: rgba(0, 0, 0, 0.27);
+        --screenshot-image-outline: #8b8b8b;
+        --card-border: transparent;
+        --card-footer-border: var(--neutral-10);
+        --header-bar-title-color: var(--neutral-0);
+        --help-links-section-background: var(--neutral-4);
+        --help-links-section-border: var(--neutral-4);
+        --index-circle-background: var(--communication-primary);
+        --link-hover: var(--communication-shade-20);
+        --link: var(--communication-primary);
+        --menu-border: var(--neutral-3);
+        --menu-item-background-active: var(--neutral-alpha-8);
+        --menu-item-background-hover: var(--neutral-alpha-4);
+        --left-nav-icon: var(--neutral-55);
+        --pill-background: var(--neutral-alpha-8);
+        --pill: var(--primary-text);
+        --spinner-text: var(--communication-primary);
+        --nav-link-hover: var(--neutral-alpha-8);
+        --nav-link-selected: var(--communication-tint-20);
+        --nav-link-expanded: var(--communication-tint-40);
+        --insights-button-hover: #0179d4;
+        --landmark-contentinfo: #00a88c;
+        --landmark-main: #cb2e6d;
+        --landmark-complementary: #6b9d1a;
+        --landmark-banner: #d08311;
+        --landmark-region: #2560e0;
+        --landmark-navigation: #9b38e6;
+        --landmark-search: #d363d8;
+        --landmark-form: #0298c7;
+      }
+      :root .high-contrast-theme {
+        --ada-brand-color: var(--white);
+        --secondary-text: var(--white);
+        --primary-text: var(--white);
+        --disabled-text: #c285ff;
+        --communication-tint-40: #38a9ff;
+        --communication-tint-30: var(--communication-tint-10);
+        --neutral-0: var(--light-black);
+        --neutral-2: var(--light-black);
+        --neutral-3: var(--light-black);
+        --neutral-4: var(--light-black);
+        --neutral-6: var(--light-black);
+        --neutral-6-5: var(--light-black);
+        --neutral-8: var(--white);
+        --neutral-10: var(--light-black);
+        --neutral-20: var(--white);
+        --neutral-30: var(--white);
+        --neutral-55: var(--white);
+        --neutral-60: var(--white);
+        --neutral-70: var(--white);
+        --neutral-80: var(--white);
+        --neutral-100: var(--white);
+        --neutral-alpha-8: var(--white);
+        --neutral-alpha-90: var(--white);
+        --positive-outcome: #4ac94a;
+        --negative-outcome: #fc7ab1;
+        --neutral-outcome: var(--neutral-0);
+        --card-border: var(--white);
+        --card-footer-border: var(--white);
+        --header-bar-title-color: var(--brand-blue);
+        --help-links-section-background: transparent;
+        --help-links-section-border: var(--white);
+        --index-circle-background: var(--communication-tint-40);
+        --link-hover: #ffff00;
+        --link: #ffff00;
+        --menu-border: var(--grey);
+        --menu-item-background-active: var(--communication-tint-40);
+        --menu-item-background-hover: var(--grey);
+        --left-nav-icon: var(--black);
+        --pill-background: var(--white);
+        --pill: var(--black);
+        --screenshot-image-outline: var(--white);
+        --spinner-text: var(--communication-tint-40);
+        --nav-link-hover: #2a2a2a;
+        --nav-link-selected: var(--communication-tint-40);
+        --nav-link-expanded: transparent;
+      }
+      .ms-Fabric.is-focusVisible .ms-Nav-group .ms-nav-linkButton:focus::after {
+        border: 1px solid var(--neutral-100);
+      }
+      @media screen and (-ms-high-contrast: active) {
+        .ms-Fabric.is-focusVisible
+          .ms-Nav-group
+          .ms-nav-linkButton:focus::after {
+          border: 1px dashed windowtext !important;
+        }
+      }
+      button::after {
+        content: "";
+        position: absolute;
+      }
+      .ms-fontColor-neutralPrimary,
+      .ms-fontColor-neutralPrimary--hover:hover {
+        color: var(--neutral-100) !important;
+      }
+      .ms-Fabric {
+        color: var(--neutral-100);
+      }
+      .high-contrast-theme .insights-link:hover {
+        text-decoration: underline;
+      }
+      .high-contrast-theme .is-selected .status-icon {
+        color: var(--black) !important;
+      }
+      .insights-link {
+        color: var(--link) !important;
+        text-decoration: none;
+      }
+      .insights-link:hover {
+        color: var(--link-hover) !important;
+        text-decoration: underline;
+      }
+      .ms-Spinner .ms-Spinner-circle {
+        border-top-color: var(--spinner-text);
+      }
+      .ms-Spinner .ms-Spinner-label {
+        color: var(--spinner-text);
+      }
+      .guidance-tags span {
+        font-size: 12px;
+        font-weight: normal;
+        margin-left: 8px;
+        padding: 2px 12px;
+        color: var(--pill);
+        background-color: var(--pill-background);
+        border-radius: 120px;
+      }
+      .instance-details-card {
+        border-radius: 4px;
+        border: 1px solid var(--card-border);
+        outline-style: "border-style";
+        box-shadow: 0px 0.6px 1.8px var(--box-shadow-108),
+          0px 3.2px 7.2px var(--box-shadow-132);
+        margin-bottom: 16px;
+        cursor: pointer;
+        width: -moz-available; /* WebKit-based browsers will ignore this. */
+        width: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
+        width: fill-available;
+      }
+      .instance-details-card-container.selected {
+        outline: 5px solid var(--communication-tint-10);
+      }
+      .instance-details-card.selected {
+        border: 1px solid transparent;
+      }
+      .instance-details-card:focus {
+        outline: 2px solid var(--primary-text);
+        outline-offset: 2px;
+      }
+      .instance-details-card.selected:focus {
+        outline-offset: 8px;
+      }
+      .instance-details-card:hover {
+        box-shadow: 0px 8px 10px var(--box-shadow-108),
+          0px 8px 10px var(--box-shadow-132);
+      }
+      .report-instance-table {
+        background: var(--neutral-0);
+        display: table;
+        table-layout: fixed;
+        width: -moz-available; /* WebKit-based browsers will ignore this. */
+        width: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
+        width: fill-available;
+        border-radius: inherit;
+        border-collapse: collapse;
+        overflow-wrap: break-word;
+        word-break: break-word;
+      }
+      .report-instance-table .row {
+        display: flex;
+        flex-wrap: wrap;
+        padding-top: 2px;
+        padding-bottom: 14px;
+        padding-left: 0px;
+        padding-right: 20px;
+        border-bottom: 0.5px solid var(--neutral-10);
+      }
+      .report-instance-table .row > * {
+        margin-top: 12px;
+        margin-bottom: 0px;
+        margin-left: 20px;
+        margin-right: 0px;
+        padding: 0;
+      }
+      .report-instance-table .row:last-child {
+        border-bottom: none;
+      }
+      .report-instance-table .row-label {
+        flex-basis: 90px;
+        flex-shrink: 1;
+        flex-grow: 0;
+        font-size: 14px;
+        line-height: 20px;
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        color: var(--primary-text);
+        text-align: left;
+      }
+      .report-instance-table .row-content {
+        flex-basis: 200px;
+        flex-shrink: 1;
+        flex-grow: 1;
+        color: var(--secondary-text);
+        font-size: 14px;
+        line-height: 20px;
+        align-items: flex-end;
+        display: flex;
+      }
+      .outcome-summary-bar {
+        display: flex;
+        flex-grow: 0;
+        flex-shrink: 0;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: center;
+        margin-top: 16px;
+        margin-bottom: 0px;
+        line-height: 24px;
+        font-size: 17px;
+        font-weight: 600;
+        white-space: pre-wrap;
+      }
+      .outcome-summary-bar .block,
+      .outcome-summary-bar .fail,
+      .outcome-summary-bar .pass,
+      .outcome-summary-bar .inapplicable,
+      .outcome-summary-bar .unscannable,
+      .outcome-summary-bar .incomplete {
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        line-height: 20px;
+        font-size: 16px;
+        color: var(--neutral-0);
+        padding: 8px 8px 10px 10px;
+        height: 16px;
+        display: flex;
+        align-items: center;
+        margin-right: 4px;
+      }
+      .outcome-summary-bar .count {
+        font-weight: 600;
+      }
+      .outcome-summary-bar .fail {
+        background-color: var(--negative-outcome);
+      }
+      .outcome-summary-bar .fail .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-summary-bar .fail .check-container svg circle {
+        fill: var(--negative-outcome);
+      }
+      .outcome-summary-bar .fail .check-container {
+        bottom: -1px;
+        margin-right: 8px;
+      }
+      .outcome-summary-bar .pass {
+        background-color: var(--positive-outcome);
+      }
+      .outcome-summary-bar .pass .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-summary-bar .pass .check-container svg circle {
+        fill: var(--positive-outcome);
+      }
+      .outcome-summary-bar .pass .check-container {
+        bottom: -1px;
+        margin-right: 8px;
+        margin-left: 4px;
+      }
+      .outcome-summary-bar .inapplicable,
+      .outcome-summary-bar .unscannable {
+        background-color: var(--neutral-outcome);
+      }
+      .outcome-summary-bar .inapplicable .check-container,
+      .outcome-summary-bar .unscannable .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-summary-bar .inapplicable .check-container,
+      .outcome-summary-bar .unscannable .check-container {
+        bottom: -1px;
+        margin-right: 8px;
+        margin-left: 4px;
+      }
+      .outcome-summary-bar .incomplete {
+        background-color: var(--neutral-outcome);
+        color: var(--white);
+        border: 2px var(--neutral-60) solid;
+        height: 12px;
+      }
+      .outcome-summary-bar .incomplete .check-container {
+        position: relative;
+        width: 8px;
+        height: 8px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 3px solid var(--neutral-0);
+      }
+      .outcome-summary-bar .incomplete .check-container {
+        margin-right: 6px;
+        border-color: var(--white);
+      }
+      .outcome-summary-bar .summary-bar-left-edge {
+        border-top-left-radius: 2px;
+        border-bottom-left-radius: 2px;
+      }
+      .outcome-summary-bar .summary-bar-right-edge {
+        border-top-right-radius: 2px;
+        border-bottom-right-radius: 2px;
+        margin-right: 0px;
+      }
+      .outcome-summary-bar .label {
+        font-weight: normal;
+      }
+      .screen-reader-only {
+        position: absolute;
+        left: -10000px;
+        top: auto;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+      }
+      .check-container svg {
+        width: 100%;
+        height: 100%;
+      }
+      .outcome-chip {
+        height: 16px;
+        color: var(--primary-text);
+        border-radius: 0px 8px 8px 0px;
+        margin: 0 4px 0 4px;
+        display: inline-flex;
+        align-items: center;
+        margin-bottom: -3px;
+      }
+      .outcome-chip .icon {
+        border-radius: 50%;
+        width: 16px;
+        height: 16px;
+      }
+      .outcome-chip .count {
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        line-height: 13px;
+        font-size: 11px;
+        border-radius: 0 8px 8px 0;
+        padding: 0 6px 0 10px;
+        font-weight: 700;
+        margin-left: -8px;
+        height: 13px;
+      }
+      .outcome-chip.outcome-chip-pass .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-chip.outcome-chip-pass .check-container svg circle {
+        fill: var(--positive-outcome);
+      }
+      .outcome-chip.outcome-chip-pass .check-container {
+        background-color: var(--positive-outcome);
+      }
+      .outcome-chip.outcome-chip-pass .count {
+        background-color: transparent;
+        border: 1.5px solid var(--positive-outcome);
+      }
+      .outcome-chip.outcome-chip-incomplete .check-container,
+      .outcome-chip.outcome-chip-review .check-container {
+        position: relative;
+        width: 14px;
+        height: 14px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 1px solid var(--neutral-0);
+      }
+      .outcome-chip.outcome-chip-incomplete .check-container,
+      .outcome-chip.outcome-chip-review .check-container {
+        background-color: var(--neutral-60);
+      }
+      .outcome-chip.outcome-chip-incomplete .count,
+      .outcome-chip.outcome-chip-review .count {
+        background-color: transparent;
+        border: 1.5px solid var(--neutral-60);
+      }
+      .outcome-chip.outcome-chip-fail .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-chip.outcome-chip-fail .check-container svg circle {
+        fill: var(--negative-outcome);
+      }
+      .outcome-chip.outcome-chip-fail .check-container {
+        background-color: var(--negative-outcome);
+      }
+      .outcome-chip.outcome-chip-fail .count {
+        background-color: transparent;
+        border: 1.5px solid var(--negative-outcome);
+      }
+      .outcome-chip.outcome-chip-inapplicable .check-container,
+      .outcome-chip.outcome-chip-unscannable .check-container {
+        position: relative;
+        width: 16px;
+        height: 16px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-chip.outcome-chip-inapplicable .check-container,
+      .outcome-chip.outcome-chip-unscannable .check-container {
+        background-color: var(--neutral-outcome);
+      }
+      .outcome-chip.outcome-chip-inapplicable .count,
+      .outcome-chip.outcome-chip-unscannable .count {
+        background-color: transparent;
+        border: 1.5px solid var(--neutral-outcome);
+      }
+      .outcome-icon-set .outcome-icon {
+        margin-left: 4px;
+        border-radius: 50%;
+      }
+      .outcome-icon-set .outcome-icon-pass .check-container {
+        position: relative;
+        width: 14px;
+        height: 14px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-icon-set .outcome-icon-pass .check-container svg circle {
+        fill: var(--positive-outcome);
+      }
+      .outcome-icon-set .outcome-icon-incomplete .check-container {
+        position: relative;
+        width: 12px;
+        height: 12px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 1px solid var(--neutral-0);
+      }
+      .outcome-icon-set .outcome-icon-incomplete .check-container {
+        border-color: var(--neutral-60);
+      }
+      .outcome-icon-set .outcome-icon-fail .check-container {
+        position: relative;
+        width: 14px;
+        height: 14px;
+        display: inline-block;
+        border-radius: 50%;
+        border: 0px solid var(--neutral-0);
+      }
+      .outcome-icon-set .outcome-icon-fail .check-container svg circle {
+        fill: var(--negative-outcome);
+      }
+      body {
+        font-size: 14px;
+        margin: auto;
+        background-color: var(--neutral-2);
+        color: black;
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      }
+      .outer-container {
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+      }
+      .outer-container .content-container {
+        max-width: 960px;
+        margin: 0 auto;
+        margin-top: 24px;
+      }
+      .outer-container .content-container h2 {
+        margin: 0px;
+        font-size: 17px;
+        line-height: 24px;
+      }
+      @media only screen and (max-width: 1000px) {
+        .outer-container .content-container {
+          margin: 24px 16px 0 16px;
+        }
+      }
+      .report-footer-container {
+        max-width: 960px;
+        margin: 0 auto;
+        margin-bottom: 68px;
+        margin-top: 24px;
+      }
+      .report-footer-container .report-footer {
+        line-height: 20px;
+        color: var(--secondary-text);
+      }
+      .report-footer-container .report-footer .tool-name-link {
+        color: var(--secondary-text) !important;
+      }
+      @media only screen and (max-width: 1000px) {
+        .report-footer-container {
+          margin: 0px 16px 68px 16px;
+        }
+      }
+      .report-header-command-bar {
+        height: 40px;
+        width: 100%;
+        display: flex;
+        justify-content: end;
+        min-height: fit-content;
+        align-items: center;
+        background-color: var(--neutral-0);
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+      }
+      .report-header-command-bar .target-page {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin: 0px 0px 0px 16px;
+        display: inherit;
+        color: var(--primary-text);
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-size: 14px;
+        line-height: 20px;
+        font-weight: normal;
+      }
+      .report-header-command-bar .target-page a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .title-section h1 {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        margin: 0px 0px 24px 0px;
+        font-size: 21px;
+        line-height: 32px;
+        letter-spacing: -0.02em;
+      }
+      .results-container {
+        margin-top: 56px;
+      }
+      .urls-summary-section {
+        box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108),
+          0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
+        border-radius: 4px;
+        background-color: var(--neutral-0);
+        padding: 20px;
+        margin-bottom: 24px;
+      }
+      .urls-summary-section h2 {
+        margin-bottom: 16px !important;
+      }
+      .urls-summary-section .failure-instances {
+        margin-top: 40px;
+      }
+      .crawl-details-section {
+        box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108),
+          0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
+        border-radius: 4px;
+        background-color: var(--neutral-0);
+        padding: 20px;
+        margin-bottom: 22px;
+      }
+      .crawl-details-section .crawl-details-section-list {
+        list-style: none;
+        font-size: 14px;
+        line-height: 16px;
+        padding-left: 0px;
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        flex-direction: column;
+      }
+      .crawl-details-section .crawl-details-section-list li {
+        display: inline-block;
+        padding-top: 6px;
+      }
+      .crawl-details-section .crawl-details-section-list li .icon {
+        padding-right: 12px;
+        position: relative;
+        top: 3px;
+      }
+      .crawl-details-section .text,
+      .crawl-details-section .label {
+        word-break: break-all;
+        color: var(--neutral-55);
+        font-weight: 600;
+      }
+      .crawl-details-section .label.no-icon {
+        padding-left: 29px;
+      }
+      .url-result-section {
+        padding-bottom: 31px;
+      }
+      .url-result-section
+        .title-container[aria-level="3"]
+        .collapsible-control::before {
+        position: relative;
+        bottom: 2px;
+        margin-right: 14px;
+      }
+      .url-result-section .collapsible-content {
+        margin-top: 19px;
+      }
+      .url-results-container {
+        margin-top: 56px;
+      }
+      .url-results-container .results-heading {
+        margin-top: 32px;
+        margin-bottom: 32px;
+      }
+      .summary-results-table {
+        width: 100%;
+        margin: 0px;
+        text-align: left;
+        border-spacing: 0px;
+        border-collapse: collapse;
+        font-size: 14px;
+        line-height: 20px;
+      }
+      .summary-results-table th,
+      .summary-results-table td {
+        border: 1px solid var(--neutral-20);
+        padding: 16px 8px 16px 8px;
+      }
+      .summary-results-table th {
+        font-weight: 600;
+        background-color: var(--neutral-6);
+      }
+      .summary-results-table thead tr :first-child {
+        width: 172px;
+      }
+      .summary-results-table td {
+        background-color: var(--neutral-0);
+      }
+      .summary-results-table td.text-cell {
+        overflow-wrap: break-word;
+      }
+      .summary-results-table td.url-cell {
+        overflow-wrap: anywhere;
+      }
+      @media screen and (max-width: 640px) {
+        .outcome-past-tense {
+          display: none;
+        }
+      }
+      .result-section {
+        padding-bottom: 58px;
+      }
+      .result-section
+        .title-container[aria-level="2"]
+        .collapsible-control::before {
+        position: relative;
+        bottom: 2px;
+        margin-right: 14px;
+      }
+      .collapsible-container:not(.collapsible-rule-details-group)
+        .collapsible-control {
+        padding-left: 2px;
+        padding-right: 16px;
+        position: relative;
+      }
+      .collapsible-container .collapsible-control[aria-expanded="false"]:before,
+      .collapsible-container .collapsible-control[aria-expanded="true"]:before {
+        display: inline-block;
+        border-right: 1px solid var(--secondary-text);
+        border-bottom: 1px solid var(--secondary-text);
+        min-width: 7px;
+        width: 7px;
+        height: 7px;
+        content: "";
+        transform-origin: 50% 50%;
+        transition: transform 0.1s linear 0s;
+      }
+      .collapsible-container .collapsible-control {
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        background-color: transparent;
+        cursor: pointer;
+        border: none;
+        display: flex;
+        align-items: baseline;
+        width: 100%;
+      }
+      .collapsible-container .collapsible-control:hover {
+        background-color: var(--neutral-alpha-4);
+      }
+      .collapsible-container
+        .collapsible-control[aria-expanded="false"]:before {
+        -webkit-transform: rotate(-45deg);
+        -ms-transform: rotate(-45deg);
+        transform: rotate(-45deg);
+      }
+      .collapsible-container .collapsible-control[aria-expanded="true"]:before {
+        -webkit-transform: rotate(45deg);
+        -ms-transform: rotate(45deg);
+        transform: rotate(45deg);
+      }
+      .collapsible-container .collapsible-content[aria-hidden="true"] {
+        display: none;
+      }</style
+    ><style>
+      .report-congrats-message--1O-Tl {
+        word-break: break-word;
+        overflow-wrap: break-word;
+      }
+      .report-congrats-head--6pvch {
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--primary-text);
+        padding: 10px 0 10px 0;
+      }
+      .report-congrats-info--pvbRt {
+        font-size: 14px;
+        color: var(--secondary-text);
+        padding: 10px 0 10px 0;
+      }
+      .sleeping-ada--3M6Q7 {
+        height: 100px;
+      }
+      .outcome-chip-container--3NUUD {
+        min-width: 50px;
+      }
+      .instance-details-card--OrpLo {
+        border-radius: 4px;
+        border: 1px solid var(--card-border);
+        outline-style: "border-style";
+        box-shadow: 0px 0.6px 1.8px var(--box-shadow-108),
+          0px 3.2px 7.2px var(--box-shadow-132);
+        margin-bottom: 16px;
+        cursor: pointer;
+        width: -moz-available; /* WebKit-based browsers will ignore this. */
+        width: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
+        width: fill-available;
+      }
+      .instance-details-card-container--_ELdq.selected--3O8dW {
+        outline: 5px solid var(--communication-tint-10);
+      }
+      .instance-details-card--OrpLo.selected--3O8dW {
+        border: 1px solid transparent;
+      }
+      .instance-details-card--OrpLo:focus {
+        outline: 2px solid var(--primary-text);
+        outline-offset: 2px;
+      }
+      .instance-details-card--OrpLo.selected--3O8dW:focus {
+        outline-offset: 8px;
+      }
+      .instance-details-card--OrpLo:hover {
+        box-shadow: 0px 8px 10px var(--box-shadow-108),
+          0px 8px 10px var(--box-shadow-132);
+      }
+      .report-instance-table--ljlFi {
+        background: var(--neutral-0);
+        display: table;
+        table-layout: fixed;
+        width: -moz-available; /* WebKit-based browsers will ignore this. */
+        width: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
+        width: fill-available;
+        border-radius: inherit;
+        border-collapse: collapse;
+        overflow-wrap: break-word;
+        word-break: break-word;
+      }
+      .report-instance-table--ljlFi .row--kaG63 {
+        display: flex;
+        flex-wrap: wrap;
+        padding-top: 2px;
+        padding-bottom: 14px;
+        padding-left: 0px;
+        padding-right: 20px;
+        border-bottom: 0.5px solid var(--neutral-10);
+      }
+      .report-instance-table--ljlFi .row--kaG63 > * {
+        margin-top: 12px;
+        margin-bottom: 0px;
+        margin-left: 20px;
+        margin-right: 0px;
+        padding: 0;
+      }
+      .report-instance-table--ljlFi .row--kaG63:last-child {
+        border-bottom: none;
+      }
+      .report-instance-table--ljlFi .row-label--1iEmL {
+        flex-basis: 90px;
+        flex-shrink: 1;
+        flex-grow: 0;
+        font-size: 14px;
+        line-height: 20px;
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        color: var(--primary-text);
+        text-align: left;
+      }
+      .report-instance-table--ljlFi .row-content--usdIW {
+        flex-basis: 200px;
+        flex-shrink: 1;
+        flex-grow: 1;
+        color: var(--secondary-text);
+        font-size: 14px;
+        line-height: 20px;
+        align-items: flex-end;
+        display: flex;
+      }
+      .multi-line-text-no-bullet--3igrU {
+        padding-left: 0;
+        list-style: none;
+      }
+      .multi-line-text-no-bullet--3igrU li:not(:last-child) {
+        margin-bottom: 4px;
+      }
+      .multi-line-text-yes-bullet--ebJpE {
+        padding-left: 16px;
+      }
+      .multi-line-text-yes-bullet--ebJpE li {
+        list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .combination-lists--2hRoK {
+        flex-direction: column;
+        display: flex;
+      }
+      .urls-row-content--2TTTB {
+        padding-left: 16px;
+      }
+      .urls-row-content--2TTTB li {
+        list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .insights-fix-instruction-list--1vUZj
+        li
+        span.fix-instruction-color-box--2DKsr {
+        width: 14px;
+        height: 14px;
+        display: inline-block;
+        vertical-align: -5%;
+        margin: 0px 2px;
+        border: 1px solid var(--light-black);
+      }
+      .insights-fix-instruction-list--1vUZj .screen-reader-only--QfHg0 {
+        position: absolute;
+        left: -10000px;
+        top: auto;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+      }
+      .toast-container--YaZxW {
+        display: inline-block;
+      }
+      .toast-content--Wt0Lj {
+        background: var(--neutral-70);
+        border-radius: 4px;
+        color: var(--neutral-0);
+        padding-left: 20px;
+        padding-top: 14px;
+        padding-bottom: 14px;
+        padding-right: 20px;
+        width: 316px;
+        margin-left: calc(316px / -2 - 20px);
+        left: 50%;
+        bottom: 20px;
+        z-index: 1000;
+        position: absolute;
+      }
+      .how-to-fix-content--2-Pc1 {
+        margin-bottom: 16px;
+      }
+      .how-to-fix-content--2-Pc1 ul {
+        padding-left: 16px;
+      }
+      .how-to-fix-content--2-Pc1 ul li {
+        list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .snippet--msVz- {
+        font-family: Menlo, Consolas, Courier New, monospace;
+        white-space: normal;
+      }
+      div.insights-dialog-main-override--12zq8 {
+        width: 75%;
+        max-width: 500px;
+        user-select: text;
+      }
+      @media screen and (max-width: 500px) {
+        div.insights-dialog-main-override--12zq8 {
+          min-width: 240px;
+          width: 75%;
+        }
+      }
+      div.insights-dialog-main-override--12zq8 .dialog-body--2gMoa {
+        font-size: 16px;
+      }
+      .issue-filing-dialog--2bt4g .ms-Dialog-title {
+        font-size: 21px;
+        line-height: 32px;
+        letter-spacing: -0.02em;
+        font-weight: 600;
+        padding-bottom: 0;
+      }
+      .issue-filing-dialog--2bt4g .ms-Dialog-subText {
+        font-weight: 400;
+        font-size: 15px;
+        color: var(--secondary-text);
+      }
+      .action-and-cancel-buttons-component--GI-yD {
+        display: flex;
+        justify-content: flex-end;
+      }
+      .action-and-cancel-buttons-component--GI-yD
+        .action-cancel-button-col--2EdOO
+        + .action-cancel-button-col--2EdOO {
+        margin-left: 8px;
+      }
+      div.kebab-menu-callout--14fgT {
+        box-shadow: 0px 6.4px 14.4px var(--box-shadow-132),
+          0px 1.2px 3.6px var(--box-shadow-108);
+        border-radius: 4px;
+        border-width: 0px;
+      }
+      div.kebab-menu-callout--14fgT > div {
+        border-radius: 4px;
+      }
+      .kebab-menu--z2Gzc {
+        background: var(--neutral-3);
+        border: 1px solid var(--menu-border);
+      }
+      .kebab-menu--z2Gzc li {
+        background-color: var(--neutral-3);
+      }
+      .kebab-menu--z2Gzc button i {
+        color: var(--primary-text);
+      }
+      .kebab-menu--z2Gzc button:hover {
+        background-color: var(--menu-item-background-hover);
+      }
+      .kebab-menu--z2Gzc button:active {
+        background-color: var(--menu-item-background-active);
+        color: var(--light-black);
+      }
+      .kebab-menu--z2Gzc button:active i {
+        color: var(--light-black);
+      }
+      button.kebab-menu-button--2aa2O {
+        width: 34px;
+        height: 32px;
+        margin: 8px;
+        border-radius: 2px;
+        background: transparent;
+      }
+      button.kebab-menu-button--2aa2O svg {
+        stroke: var(--primary-text);
+      }
+      @media screen and (-ms-high-contrast: active) {
+        button.kebab-menu-button--2aa2O svg {
+          fill: inherit !important;
+        }
+      }
+      button.kebab-menu-button--2aa2O:hover {
+        background-color: var(--menu-item-background-hover);
+      }
+      button.kebab-menu-button--2aa2O:active,
+      button.kebab-menu-button--2aa2O[aria-expanded="true"] {
+        background-color: var(--menu-item-background-active);
+        color: var(--light-black);
+      }
+      button.kebab-menu-button--2aa2O:active svg > circle,
+      button.kebab-menu-button--2aa2O[aria-expanded="true"] svg > circle {
+        stroke: var(--light-black);
+      }
+      button.kebab-menu-button--2aa2O > span {
+        justify-content: center;
+      }
+      .foot--1bb1r {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background-color: var(--neutral-2);
+        min-height: 48px;
+        padding-left: 12px;
+        border-top: 0.5px solid var(--card-footer-border);
+        border-bottom-left-radius: inherit;
+        border-bottom-right-radius: inherit;
+      }
+      .foot--1bb1r .highlight-status--1IQGd {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: transparent;
+      }
+      .foot--1bb1r .highlight-status--1IQGd svg {
+        fill: var(--secondary-text);
+      }
+      .foot--1bb1r .highlight-status--1IQGd label {
+        color: var(--secondary-text);
+        font-size: 14px;
+        overflow-wrap: break-word;
+        word-break: break-word;
+      }
+      ul.instance-details-list--2Beza {
+        list-style-type: none;
+        padding-inline-start: unset;
+        margin-block-start: unset;
+        margin-block-end: unset;
+      }
+      ul.instance-details-list--2Beza > li {
+        margin-bottom: 16px;
+      }
+      ul.instance-details-list--2Beza > li:last-child {
+        margin-bottom: unset;
+      }
+      .rule-more-resources--3PCDe {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 16px;
+        padding: 14px 20px;
+        background-color: var(--neutral-0);
+        box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108),
+          0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
+        border-radius: 4px;
+        border: 1px solid var(--card-border);
+        line-height: 20px;
+        overflow-wrap: break-word;
+        word-break: break-word;
+      }
+      .rule-more-resources--3PCDe .more-resources-title--17xOw {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      }
+      .rule-more-resources--3PCDe .rule-details-id--ie-v- {
+        padding: 12px 0;
+      }
+      .rule-details-group--39A1d .rule-detail {
+        font-size: 14px;
+        padding: 16px 8px;
+        display: flex;
+        align-items: baseline;
+        text-align: left;
+      }
+      .rule-details-group--39A1d .rule-detail .outcome-chip {
+        vertical-align: middle;
+        margin-bottom: 2px;
+      }
+      .rule-details-group--39A1d .rule-detail .rule-details-id {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        color: var(--primary-text);
+        word-break: break-all;
+      }
+      .rule-details-group--39A1d .rule-detail .rule-details-id a {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        color: var(--primary-text) !important;
+      }
+      .rule-details-group--39A1d .rule-detail .rule-detail-description {
+        color: var(--secondary-text) !important;
+        word-break: break-all;
+      }
+      .rule-details-group--39A1d .rule-detail .guidance-links a {
+        color: var(--secondary-text) !important;
+      }
+      .collapsible-rule-details-group--3aN3u {
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+      }
+      .collapsible-rule-details-group--3aN3u .rule-detail {
+        box-shadow: unset;
+      }
+      .collapsible-rule-details-group--3aN3u:not(.collapsed) {
+        box-shadow: unset;
+      }
+      .result-section-title--27ZOL {
+        display: flex;
+        flex-wrap: nowrap;
+        justify-content: flex-start;
+        align-items: center;
+        margin-top: 8px;
+        margin-bottom: 8px;
+      }
+      .result-section-title--27ZOL .outcome-chip.outcome-chip-fail .count {
+        line-height: 11px;
+      }
+      .result-section-title--27ZOL .outcome-chip.outcome-chip-fail svg {
+        margin-bottom: 3px;
+      }
+      .result-section-title--27ZOL .title--nA1u1 {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: 600;
+        font-size: 17px;
+        line-height: 24px;
+        margin-right: 6px;
+        color: var(--primary-text);
+      }
+      .result-section-title--27ZOL .heading--3ryVY {
+        font-family: "Segoe UI Semibold", "Segoe UI Web (West European)",
+          "Segoe UI", "-apple-system", BlinkMacSystemFont, Roboto,
+          "Helvetica Neue", Helvetica, Ubuntu, Arial, sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: 600;
+        font-size: 15px;
+        line-height: 20px;
+        margin-right: 6px;
+        color: var(--primary-text);
+      }
+      .result-section-title--27ZOL .outcome-chip-container--1Vd7P {
+        display: flex;
+        height: 16px;
+      }
+      .result-section--1FLO5 {
+        padding-bottom: 58px;
+      }
+      .result-section--1FLO5
+        .title-container--1CFvU[aria-level="2"]
+        .collapsible-control--ey-Vd::before {
+        position: relative;
+        bottom: 2px;
+      }
+      .result-section--1FLO5 > h2 {
+        margin: 0px;
+        font-size: 17px;
+        line-height: 24px;
+      }
+      .report-header-bar--kg10M {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        flex-wrap: nowrap;
+        background-color: var(--ada-brand-color);
+        height: 40px;
+        width: 100%;
+      }
+      .report-header-bar--kg10M .header-icon {
+        flex-shrink: 0;
+        margin-left: 16px;
+        height: 22px;
+        width: 22px;
+      }
+      .report-header-bar--kg10M .header-text--2L-Jl {
+        margin-left: 8px;
+        color: var(--header-bar-title-color);
+        flex-shrink: 1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: normal;
+        font-size: 17px;
+        line-height: 24px;
+      }
+      .report-header-command-bar--CWe48 {
+        height: 40px;
+        width: 100%;
+        display: flex;
+        justify-content: end;
+        min-height: fit-content;
+        align-items: center;
+        background-color: var(--neutral-0);
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+      }
+      .report-header-command-bar--CWe48 .target-page--16UqC {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin: 0px 0px 0px 16px;
+        display: inherit;
+        color: var(--primary-text);
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-size: 14px;
+        line-height: 20px;
+        font-weight: normal;
+      }
+      .report-header-command-bar--CWe48 .target-page--16UqC a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .urls-summary-section--2D8aF {
+        box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108),
+          0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
+        border-radius: 4px;
+        background-color: var(--neutral-0);
+        padding: 20px;
+        margin-bottom: 24px;
+      }
+      .urls-summary-section--2D8aF h2 {
+        margin-bottom: 16px !important;
+      }
+      .urls-summary-section--2D8aF .failure-instances--2tbUx {
+        margin-top: 40px;
+      }
+      span.fix-instruction-color-box--HXJ1A {
+        width: 14px;
+        height: 14px;
+        display: inline-block;
+        vertical-align: -5%;
+        margin: 0px 2px;
+        border: 1px solid var(--light-black);
+      }
+      .screen-reader-only--1uWLQ {
+        position: absolute;
+        left: -10000px;
+        top: auto;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+      }
+    </style></head
+  ><body
+    ><header
+      ><div class="report-header-bar--kg10M"
+        ><svg
+          role="img"
+          aria-hidden="true"
+          class="header-icon"
+          viewBox="0 0 48 48"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <mask
+            id="mask0"
+            maskUnits="userSpaceOnUse"
+            x="0"
+            y="3"
+            width="48"
+            height="43"
+            style="mask-type: alpha"
+          >
+            <path
+              d="M43.8309 27.1383C49.3148 21.6544 49.3148 12.7633 43.8309 7.27934C38.347 1.79544 29.4558 1.79543 23.9719 7.27934C18.488 1.79544 9.59684 1.79544 4.11293 7.27934C-1.37098 12.7633 -1.37098 21.6544 4.11293 27.1383L21.986 45.0114C23.0828 46.1082 24.861 46.1082 25.9578 45.0114L43.8309 27.1383Z"
+              fill="white"
+            ></path>
+          </mask>
+          <g mask="url(#mask0)">
+            <path
+              d="M43.8309 27.1383C49.3148 21.6544 49.3148 12.7633 43.8309 7.27934C38.347 1.79544 29.4558 1.79543 23.9719 7.27934C18.488 1.79544 9.59684 1.79544 4.11293 7.27934C-1.37098 12.7633 -1.37098 21.6544 4.11293 27.1383L21.986 45.0114C23.0828 46.1082 24.861 46.1082 25.9578 45.0114L43.8309 27.1383Z"
+              fill="white"
+            ></path>
+            <rect
+              x="43.9494"
+              y="7.24556"
+              width="14.0948"
+              height="42.2726"
+              transform="rotate(45 43.9494 7.24556)"
+              fill="#D6E9F7"
+            ></rect>
+            <mask
+              id="mask1"
+              maskUnits="userSpaceOnUse"
+              x="-6"
+              y="-3"
+              width="30"
+              height="31"
+              style="mask-type: alpha"
+            >
+              <path
+                d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79472 18.4879 1.79472 23.9718 7.27863Z"
+                fill="#CFEBFF"
+              ></path>
+              <path
+                d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79472 18.4879 1.79472 23.9718 7.27863Z"
+                fill="url(#paint0_linear)"
+              ></path>
+            </mask>
+            <g mask="url(#mask1)">
+              <path
+                d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79472 18.4879 1.79472 23.9718 7.27863Z"
+                fill="white"
+              ></path>
+              <path
+                d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79472 18.4879 1.79472 23.9718 7.27863Z"
+                fill="url(#paint1_linear)"
+              ></path>
+              <rect
+                x="4.54834"
+                y="6.88206"
+                width="16.3577"
+                height="42.2726"
+                transform="rotate(-45 4.54834 6.88206)"
+                fill="#D6E9F7"
+              ></rect>
+              <rect
+                x="4.54834"
+                y="6.88206"
+                width="16.3577"
+                height="42.2726"
+                transform="rotate(-45 4.54834 6.88206)"
+                fill="url(#paint2_linear)"
+              ></rect>
+            </g>
+            <g filter="url(#filter0_d)">
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M34.0764 27.3564C39.8071 27.3483 44.4461 22.6961 44.438 16.9655C44.4299 11.2349 39.7778 6.59585 34.0472 6.60393C28.3165 6.61201 23.6775 11.2642 23.6856 16.9948C23.6888 19.2829 24.4324 21.397 25.6895 23.1108L23.4287 25.3788C22.8852 25.395 22.3466 25.6109 21.9324 26.0265L17.1218 30.8526C16.4185 31.5582 16.4203 32.7005 17.126 33.4038L17.6952 33.9713C18.4009 34.6746 19.5431 34.6728 20.2465 33.9671L25.057 29.141C25.4715 28.7252 25.6857 28.1855 25.6998 27.6415L27.9603 25.3737C29.6766 26.6235 31.7907 27.3596 34.0764 27.3564ZM34.0368 23.2439C37.4964 23.2579 40.3122 20.4647 40.3262 17.0051C40.3401 13.5456 37.5469 10.7298 34.0874 10.7158C30.6279 10.7018 27.812 13.495 27.7981 16.9545C27.7841 20.4141 30.5773 23.2299 34.0368 23.2439Z"
+                fill="#004880"
+              ></path>
+            </g>
+          </g>
+          <defs>
+            <filter
+              id="filter0_d"
+              x="15.748"
+              y="6.50654"
+              width="29.5246"
+              height="29.5269"
+              filterUnits="userSpaceOnUse"
+              color-interpolation-filters="sRGB"
+            >
+              <feFlood flood-opacity="0" result="BackgroundImageFix"></feFlood>
+              <feColorMatrix
+                in="SourceAlpha"
+                type="matrix"
+                values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+              ></feColorMatrix>
+              <feOffset dy="0.725705"></feOffset>
+              <feGaussianBlur stdDeviation="0.40317"></feGaussianBlur>
+              <feColorMatrix
+                type="matrix"
+                values="0 0 0 0 0.0447352 0 0 0 0 0.305769 0 0 0 0 0.492222 0 0 0 0.51 0"
+              ></feColorMatrix>
+              <feBlend
+                mode="normal"
+                in2="BackgroundImageFix"
+                result="effect1_dropShadow"
+              ></feBlend>
+              <feBlend
+                mode="normal"
+                in="SourceGraphic"
+                in2="effect1_dropShadow"
+                result="shape"
+              ></feBlend>
+            </filter>
+            <linearGradient
+              id="paint0_linear"
+              x1="14.3166"
+              y1="16.8744"
+              x2="5.92409"
+              y2="8.23504"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset="0" stop-color="#073A5F" stop-opacity="0.3"></stop>
+              <stop offset="1" stop-color="#CFEBFF" stop-opacity="0"></stop>
+            </linearGradient>
+            <linearGradient
+              id="paint1_linear"
+              x1="14.3166"
+              y1="16.8744"
+              x2="5.92409"
+              y2="8.23504"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset="0" stop-color="#165B8E" stop-opacity="0.29"></stop>
+              <stop offset="1" stop-color="white" stop-opacity="0"></stop>
+            </linearGradient>
+            <linearGradient
+              id="paint2_linear"
+              x1="11.3179"
+              y1="20.1024"
+              x2="11.0819"
+              y2="11.1606"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset="0" stop-color="#165B8E" stop-opacity="0.29"></stop>
+              <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
+            </linearGradient>
+          </defs></svg
+        ><div class="header-text--2L-Jl">Accessibility Insights</div></div
+      ></header
+    ><main class="outer-container"
+      ><div class="content-container"
+        ><div class="title-section"><h1>Automated checks results</h1></div
+        ><div class="crawl-details-section"
+          ><h2>Scan details</h2
+          ><ul class="crawl-details-section-list"
+            ><li
+              ><span class="icon" aria-hidden="true"
+                ><svg
+                  width="17"
+                  height="16"
+                  viewBox="0 0 17 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
+                    fill="#737373"
+                  ></path></svg></span
+              ><span class="label">Target site </span
+              ><span class="text"
+                ><a
+                  target="_blank"
+                  href="https://example.com/mock-base-url"
+                  class="ms-Link insights-link root-49"
+                  title="Mock base without failures or unscannables"
+                  id="new-tab-link-with-confirmation-dialog__2"
+                  >https://example.com/mock-base-url</a
+                ><script>
+                  (function (linkId, doc, confirmCallback) {
+                    const targetPageLink = doc.getElementById(linkId);
+                    targetPageLink.addEventListener("click", function (event) {
+                      const result = confirmCallback(
+                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                          "Cancel to stay on the current page."
+                      );
+                      if (result === false) {
+                        event.preventDefault();
+                      }
+                    });
+                  })(
+                    "new-tab-link-with-confirmation-dialog__2",
+                    document,
+                    confirm
+                  );
+                </script></span
+              ></li
+            ><li
+              ><span class="icon" aria-hidden="true"
+                ><svg
+                  width="17"
+                  height="16"
+                  viewBox="0 0 17 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
+                    fill="#737373"
+                  ></path></svg></span
+              ><span class="label">Scans started </span
+              ><span class="text">2020-02-02 3:04 AM UTC</span></li
+            ><li
+              ><span class="label no-icon">Scans completed </span
+              ><span class="text">2020-02-02 4:04 AM UTC</span></li
+            ><li
+              ><span class="label no-icon">Duration </span
+              ><span class="text">01:00:00</span></li
+            ></ul
+          ></div
+        ><div class="urls-summary-section--2D8aF"
+          ><h2>URLs</h2>3 total URLs discovered<div
+            class="outcome-summary-bar"
+            aria-label="0 Failed, 1 Not scanned, 2 Passed"
+            role="img"
+            ><div style="flex-grow: 0"
+              ><span class="fail summary-bar-left-edge"
+                ><span aria-hidden="true"
+                  ><span class="check-container"
+                    ><svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        clip-rule="evenodd"
+                        d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58173 12.4183 0 8 0C3.58172 0 0 3.58173 0 8C0 12.4183 3.58172 16 8 16ZM10.9947 4.99466C10.7018 4.70178 10.2269 4.70178 9.93401 4.99466L8 6.92868L6.06599 4.99466C5.77309 4.70178 5.29823 4.70178 5.00533 4.99466C4.71243 5.28757 4.71243 5.76242 5.00533 6.05533L6.93933 7.98932L4.99467 9.93399C4.70177 10.2269 4.70177 10.7018 4.99467 10.9947C5.28756 11.2876 5.76243 11.2876 6.05532 10.9947L8 9.04999L9.94467 10.9947C10.2376 11.2876 10.7124 11.2876 11.0053 10.9947C11.2982 10.7018 11.2982 10.2269 11.0053 9.93399L9.06066 7.98932L10.9947 6.05533C11.2876 5.76242 11.2876 5.28757 10.9947 4.99466Z"
+                        fill="var(--neutral-0)"
+                      ></path></svg></span></span
+                >0<div class="label"> Failed</div></span
+              ></div
+            ><div style="flex-grow: 1"
+              ><span class="unscannable"
+                ><span aria-hidden="true"
+                  ><span class="check-container"
+                    ><svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <circle cx="8" cy="8" r="8" fill="white"></circle>
+                      <line
+                        x1="5.66064"
+                        y1="5.625"
+                        x2="10.2568"
+                        y2="10.2212"
+                        stroke="#737373"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                      ></line></svg></span></span
+                >1<div class="label"> Not scanned</div></span
+              ></div
+            ><div style="flex-grow: 2"
+              ><span class="pass summary-bar-right-edge"
+                ><span aria-hidden="true"
+                  ><span class="check-container"
+                    ><svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        clip-rule="evenodd"
+                        d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16ZM6.0616 11.1442L6.05904 11.1417L4.27459 9.35718C3.90847 8.99104 3.90847 8.39747 4.27459 8.03134C4.64071 7.66524 5.2343 7.66524 5.60041 8.03134L6.72452 9.15545L10.6054 5.27457C10.9715 4.90848 11.5651 4.90848 11.9312 5.27457C12.2974 5.64071 12.2974 6.23427 11.9312 6.60041L7.391 11.1406L7.38742 11.1442C7.06707 11.4646 6.57256 11.5046 6.20867 11.2643C6.15668 11.23 6.10737 11.19 6.0616 11.1442Z"
+                        fill="white"
+                      ></path></svg></span></span
+                >2<div class="label"> Passed</div></span
+              ></div
+            ></div
+          ><div class="failure-instances--2tbUx"
+            ><h2>Failure Instances</h2
+            ><span class="outcome-chip outcome-chip-fail" title="0 Failed"
+              ><span class="icon"
+                ><span class="check-container"
+                  ><svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle cx="8" cy="8" r="8" fill="#E81123"></circle>
+                    <path
+                      d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                      fill="var(--neutral-0)"
+                    ></path></svg></span></span
+              ><span
+                data-automation-id="count"
+                class="count"
+                aria-hidden="true"
+              >
+                0</span
+              ><span class="screen-reader-only">0 Failed</span></span
+            >
+            Failure instances were detected</div
+          ></div
+        ></div
+      ></main
+    ><div class="report-footer-container"
+      ><div class="report-footer" role="contentinfo"
+        >This automated checks result was generated using the Mock Service Name
+        that helps find some of the most common accessibility issues. The scan
+        was performed using axe-core mock.axe.version and Mock user agent. For a
+        complete WCAG 2.1 compliance assessment please visit
+        <a
+          target="_blank"
+          href="http://aka.ms/AccessibilityInsights"
+          class="ms-Link insights-link tool-name-link root-49"
+          title="Get more information and download Accessibility Insights for Web"
+          >http://aka.ms/AccessibilityInsights</a
+        >.</div
+      ></div
+    ></body
+  ></html
+>

--- a/packages/report-e2e-tests/src/from-combined-results.test.ts
+++ b/packages/report-e2e-tests/src/from-combined-results.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { reporterFactory, CombinedReportParameters } from 'accessibility-insights-report';
+import * as path from 'path';
+import * as prettier from 'prettier';
+
+import { combinedResultsWithIssues } from './examples/combined-results-with-issues.input';
+import { combinedResultsWithoutIssues } from './examples/combined-results-without-issues.input';
+
+describe('fromCombinedResults', () => {
+    const examples = {
+        'combined-results-with-issues': combinedResultsWithIssues,
+        'combined-results-without-issues': combinedResultsWithoutIssues,
+    };
+
+    describe.each(Object.keys(examples))('with example input "%s"', (exampleName: string) => {
+        const input: CombinedReportParameters = examples[exampleName];
+
+        it('produces pinned HTML file', () => {
+            const output = reporterFactory().fromCombinedResults(input).asHTML();
+            const formattedOutput = prettier.format(output, {
+                parser: 'html',
+                htmlWhitespaceSensitivity: 'strict',
+            });
+
+            const snapshotFile = path.join(__dirname, 'examples', `${exampleName}.snap.html`);
+            expect(formattedOutput).toMatchFile(snapshotFile);
+        });
+    });
+});

--- a/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
@@ -22,18 +22,18 @@ Object {
             },
             "highlightStatus": "unavailable",
             "identifiers": Object {
-              "conciseName": ".rule-1-selector-1",
-              "css-selector": ".rule-1-selector-1",
-              "identifier": ".rule-1-selector-1",
+              "conciseName": ".failed-rule-1-selector-1",
+              "css-selector": ".failed-rule-1-selector-1",
+              "identifier": ".failed-rule-1-selector-1",
               "urls": Object {
                 "urls": Array [
-                  "https://url/rule-1/failure-1",
+                  "https://example.com/failed-rule-1/only-violation",
                 ],
               },
             },
             "isSelected": false,
             "resolution": Object {
-              "howToFixSummary": "fix failed-rule-1",
+              "howToFixSummary": "Fix the failed-rule-1 violation",
             },
             "ruleId": "failed-rule-1",
             "status": "fail",
@@ -45,26 +45,27 @@ Object {
             },
             "highlightStatus": "unavailable",
             "identifiers": Object {
-              "conciseName": ".rule-1-selector-2",
-              "css-selector": ".rule-1-selector-2",
-              "identifier": ".rule-1-selector-2",
+              "conciseName": ".failed-rule-1-selector-2",
+              "css-selector": ".failed-rule-1-selector-2",
+              "identifier": ".failed-rule-1-selector-2",
               "urls": Object {
                 "urls": Array [
-                  "https://url/rule-1/failure-1",
-                  "https://url/rule1/failure-2",
+                  "https://example.com/failed-rule-1/violations/1",
+                  "https://example.com/failed-rule-1/violations/2",
+                  "https://example.com/failed-rule-1/violations/3",
                 ],
               },
             },
             "isSelected": false,
             "resolution": Object {
-              "howToFixSummary": "fix failed-rule-1",
+              "howToFixSummary": "Fix the failed-rule-1 violation",
             },
             "ruleId": "failed-rule-1",
             "status": "fail",
             "uid": "test uid",
           },
         ],
-        "url": "https://rules/failed-rule-1",
+        "url": "https://example.com/rules/failed-rule-1",
       },
       Object {
         "description": "failed-rule-2 description",
@@ -79,98 +80,84 @@ Object {
         "nodes": Array [
           Object {
             "descriptors": Object {
-              "snippet": "<div>snippet</div>",
+              "snippet": "<div>snippet 1</div>",
             },
             "highlightStatus": "unavailable",
             "identifiers": Object {
-              "conciseName": ".rule-2-selector-1",
-              "css-selector": ".rule-2-selector-1",
-              "identifier": ".rule-2-selector-1",
+              "conciseName": ".failed-rule-2-selector-1",
+              "css-selector": ".failed-rule-2-selector-1",
+              "identifier": ".failed-rule-2-selector-1",
               "urls": Object {
                 "urls": Array [
-                  "https://url/rule2/failure1",
+                  "https://example.com/failed-rule-2/only-violation",
                 ],
               },
             },
             "isSelected": false,
             "resolution": Object {
-              "howToFixSummary": "fix failed-rule-2",
+              "howToFixSummary": "Fix the failed-rule-2 violation",
+            },
+            "ruleId": "failed-rule-2",
+            "status": "fail",
+            "uid": "test uid",
+          },
+          Object {
+            "descriptors": Object {
+              "snippet": "<div>snippet 2</div>",
+            },
+            "highlightStatus": "unavailable",
+            "identifiers": Object {
+              "conciseName": ".failed-rule-2-selector-2",
+              "css-selector": ".failed-rule-2-selector-2",
+              "identifier": ".failed-rule-2-selector-2",
+              "urls": Object {
+                "urls": Array [
+                  "https://example.com/failed-rule-2/violations/1",
+                  "https://example.com/failed-rule-2/violations/2",
+                  "https://example.com/failed-rule-2/violations/3",
+                ],
+              },
+            },
+            "isSelected": false,
+            "resolution": Object {
+              "howToFixSummary": "Fix the failed-rule-2 violation",
             },
             "ruleId": "failed-rule-2",
             "status": "fail",
             "uid": "test uid",
           },
         ],
-        "url": "https://rules/rule2/failed-rule-1",
+        "url": "https://example.com/rules/failed-rule-2",
       },
     ],
     "inapplicable": Array [
       Object {
-        "description": "Ensures every ARIA input field has an accessible name",
+        "description": "inapplicable-rule-1 description",
         "guidance": Array [
           Object {
-            "href": "https://guidance-link-stub/aria-input-field-name",
-            "text": "guidance for aria-input-field-name",
+            "href": "https://guidance-link-stub/inapplicable-rule-1",
+            "text": "guidance for inapplicable-rule-1",
           },
         ],
-        "id": "aria-input-field-name",
+        "id": "inapplicable-rule-1",
         "isExpanded": false,
         "nodes": Array [],
-        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-input-field-name?application=webdriverjs",
-      },
-      Object {
-        "description": "Ensures every ARIA toggle field has an accessible name",
-        "guidance": Array [
-          Object {
-            "href": "https://guidance-link-stub/aria-toggle-field-name",
-            "text": "guidance for aria-toggle-field-name",
-          },
-        ],
-        "id": "aria-toggle-field-name",
-        "isExpanded": false,
-        "nodes": Array [],
-        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-toggle-field-name?application=webdriverjs",
-      },
-      Object {
-        "description": "Ensure the autocomplete attribute is correct and suitable for the form field",
-        "guidance": Array [
-          Object {
-            "href": "https://guidance-link-stub/autocomplete-valid",
-            "text": "guidance for autocomplete-valid",
-          },
-        ],
-        "id": "autocomplete-valid",
-        "isExpanded": false,
-        "nodes": Array [],
-        "url": "https://dequeuniversity.com/rules/axe/3.3/autocomplete-valid?application=webdriverjs",
+        "url": "https://example.com/rules/inapplicable-rule-1",
       },
     ],
     "pass": Array [
       Object {
-        "description": "Ensures <area> elements of image maps have alternate text",
+        "description": "passed-rule-1 description",
         "guidance": Array [
           Object {
-            "href": "https://guidance-link-stub/area-alt",
-            "text": "guidance for area-alt",
+            "href": "https://guidance-link-stub/passed-rule-1",
+            "text": "guidance for passed-rule-1",
           },
         ],
-        "id": "area-alt",
+        "id": "passed-rule-1",
         "isExpanded": false,
         "nodes": Array [],
-        "url": "https://dequeuniversity.com/rules/axe/3.3/area-alt?application=webdriverjs",
-      },
-      Object {
-        "description": "Ensures aria-hidden elements do not contain focusable elements",
-        "guidance": Array [
-          Object {
-            "href": "https://guidance-link-stub/aria-hidden-focus",
-            "text": "guidance for aria-hidden-focus",
-          },
-        ],
-        "id": "aria-hidden-focus",
-        "isExpanded": false,
-        "nodes": Array [],
-        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=webdriverjs",
+        "url": "https://example.com/rules/passed-rule-1",
       },
     ],
     "unknown": Array [],
@@ -186,71 +173,58 @@ Object {
     "fail": Array [],
     "inapplicable": Array [
       Object {
-        "description": "Ensures every ARIA input field has an accessible name",
+        "description": "inapplicable-rule-1 description",
         "guidance": Array [
           Object {
-            "href": "https://guidance-link-stub/aria-input-field-name",
-            "text": "guidance for aria-input-field-name",
+            "href": "https://guidance-link-stub/inapplicable-rule-1",
+            "text": "guidance for inapplicable-rule-1",
           },
         ],
-        "id": "aria-input-field-name",
+        "id": "inapplicable-rule-1",
         "isExpanded": false,
         "nodes": Array [],
-        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-input-field-name?application=webdriverjs",
+        "url": "https://example.com/rules/inapplicable-rule-1",
       },
       Object {
-        "description": "Ensures every ARIA toggle field has an accessible name",
+        "description": "inapplicable-rule-2 description",
         "guidance": Array [
           Object {
-            "href": "https://guidance-link-stub/aria-toggle-field-name",
-            "text": "guidance for aria-toggle-field-name",
+            "href": "https://guidance-link-stub/inapplicable-rule-2",
+            "text": "guidance for inapplicable-rule-2",
           },
         ],
-        "id": "aria-toggle-field-name",
+        "id": "inapplicable-rule-2",
         "isExpanded": false,
         "nodes": Array [],
-        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-toggle-field-name?application=webdriverjs",
-      },
-      Object {
-        "description": "Ensure the autocomplete attribute is correct and suitable for the form field",
-        "guidance": Array [
-          Object {
-            "href": "https://guidance-link-stub/autocomplete-valid",
-            "text": "guidance for autocomplete-valid",
-          },
-        ],
-        "id": "autocomplete-valid",
-        "isExpanded": false,
-        "nodes": Array [],
-        "url": "https://dequeuniversity.com/rules/axe/3.3/autocomplete-valid?application=webdriverjs",
+        "url": "https://example.com/rules/inapplicable-rule-2",
       },
     ],
     "pass": Array [
       Object {
-        "description": "Ensures <area> elements of image maps have alternate text",
+        "description": "passed-rule-1 description",
         "guidance": Array [
           Object {
-            "href": "https://guidance-link-stub/area-alt",
-            "text": "guidance for area-alt",
+            "href": "https://guidance-link-stub/passed-rule-1",
+            "text": "guidance for passed-rule-1",
           },
         ],
-        "id": "area-alt",
+        "id": "passed-rule-1",
         "isExpanded": false,
         "nodes": Array [],
-        "url": "https://dequeuniversity.com/rules/axe/3.3/area-alt?application=webdriverjs",
+        "url": "https://example.com/rules/passed-rule-1",
       },
       Object {
-        "description": "Ensures aria-hidden elements do not contain focusable elements",
+        "description": "passed-rule-2 description",
         "guidance": Array [
           Object {
-            "href": "https://guidance-link-stub/aria-hidden-focus",
-            "text": "guidance for aria-hidden-focus",
+            "href": "https://guidance-link-stub/passed-rule-2",
+            "text": "guidance for passed-rule-2",
           },
         ],
-        "id": "aria-hidden-focus",
+        "id": "passed-rule-2",
         "isExpanded": false,
         "nodes": Array [],
-        "url": "https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=webdriverjs",
+        "url": "https://example.com/rules/passed-rule-2",
       },
     ],
     "unknown": Array [],
@@ -281,18 +255,18 @@ Object {
             },
             "highlightStatus": "unavailable",
             "identifiers": Object {
-              "conciseName": ".rule-1-selector-1",
-              "css-selector": ".rule-1-selector-1",
-              "identifier": ".rule-1-selector-1",
+              "conciseName": ".failed-rule-1-selector-1",
+              "css-selector": ".failed-rule-1-selector-1",
+              "identifier": ".failed-rule-1-selector-1",
               "urls": Object {
                 "urls": Array [
-                  "https://url/rule-1/failure-1",
+                  "https://example.com/failed-rule-1/only-violation",
                 ],
               },
             },
             "isSelected": false,
             "resolution": Object {
-              "howToFixSummary": "fix failed-rule-1",
+              "howToFixSummary": "Fix the failed-rule-1 violation",
             },
             "ruleId": "failed-rule-1",
             "status": "fail",
@@ -304,63 +278,27 @@ Object {
             },
             "highlightStatus": "unavailable",
             "identifiers": Object {
-              "conciseName": ".rule-1-selector-2",
-              "css-selector": ".rule-1-selector-2",
-              "identifier": ".rule-1-selector-2",
+              "conciseName": ".failed-rule-1-selector-2",
+              "css-selector": ".failed-rule-1-selector-2",
+              "identifier": ".failed-rule-1-selector-2",
               "urls": Object {
                 "urls": Array [
-                  "https://url/rule-1/failure-1",
-                  "https://url/rule1/failure-2",
+                  "https://example.com/failed-rule-1/violations/1",
+                  "https://example.com/failed-rule-1/violations/2",
+                  "https://example.com/failed-rule-1/violations/3",
                 ],
               },
             },
             "isSelected": false,
             "resolution": Object {
-              "howToFixSummary": "fix failed-rule-1",
+              "howToFixSummary": "Fix the failed-rule-1 violation",
             },
             "ruleId": "failed-rule-1",
             "status": "fail",
             "uid": "test uid",
           },
         ],
-        "url": "https://rules/failed-rule-1",
-      },
-      Object {
-        "description": "failed-rule-2 description",
-        "guidance": Array [
-          Object {
-            "href": "https://guidance-link-stub/failed-rule-2",
-            "text": "guidance for failed-rule-2",
-          },
-        ],
-        "id": "failed-rule-2",
-        "isExpanded": false,
-        "nodes": Array [
-          Object {
-            "descriptors": Object {
-              "snippet": "<div>snippet</div>",
-            },
-            "highlightStatus": "unavailable",
-            "identifiers": Object {
-              "conciseName": ".rule-2-selector-1",
-              "css-selector": ".rule-2-selector-1",
-              "identifier": ".rule-2-selector-1",
-              "urls": Object {
-                "urls": Array [
-                  "https://url/rule2/failure1",
-                ],
-              },
-            },
-            "isSelected": false,
-            "resolution": Object {
-              "howToFixSummary": "fix failed-rule-2",
-            },
-            "ruleId": "failed-rule-2",
-            "status": "fail",
-            "uid": "test uid",
-          },
-        ],
-        "url": "https://rules/rule2/failed-rule-1",
+        "url": "https://example.com/rules/failed-rule-1",
       },
     ],
     "inapplicable": Array [],


### PR DESCRIPTION
#### Description of changes

Adds a pinning E2E test for the combined report (currently pinning its existing unfinished behavior).

I reused the full inputs @pownkel already made for the unit tests by moving them to the E2Es and updating the unit tests to use more test-specific input data

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1783607
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
