### PR TITLE
feat(android-nav-reflow): Add e2e tests

### DIFF
--- a/src/common/components/left-nav-hamburger-button.tsx
+++ b/src/common/components/left-nav-hamburger-button.tsx
@@ -13,6 +13,8 @@ export type LeftNavHamburgerButtonProps = {
     className?: string;
 };
 
+export const leftNavHamburgerButtonAutomationId = 'left-nav-hamburger-button';
+
 export const LeftNavHamburgerButton = NamedFC<LeftNavHamburgerButtonProps>(
     'LeftNavHamburgerButton',
     props => {
@@ -26,6 +28,7 @@ export const LeftNavHamburgerButton = NamedFC<LeftNavHamburgerButtonProps>(
                 iconProps={{ iconName: 'GlobalNavButton' }}
                 ariaLabel={props.ariaLabel}
                 aria-expanded={props.isSideNavOpen}
+                data-automation-id={leftNavHamburgerButtonAutomationId}
                 onClick={onClick}
             />
         );

--- a/src/electron/views/left-nav/fluent-left-nav.tsx
+++ b/src/electron/views/left-nav/fluent-left-nav.tsx
@@ -11,6 +11,8 @@ import { LeftNav, LeftNavDeps } from 'electron/views/left-nav/left-nav';
 import { PanelType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
+export const fluentLeftNavAutomationId = 'fluent-left-nav';
+
 export type FluentLeftNavDeps = LeftNavDeps;
 
 export type FluentLeftNavProps = {
@@ -31,6 +33,7 @@ export const FluentLeftNav = NamedFC<FluentLeftNavProps>('LeftNav', props => {
 
     return (
         <GenericPanel
+            innerPanelAutomationId={fluentLeftNavAutomationId}
             layerProps={{ className: styles.leftNavPanelHost }}
             className={styles.leftNavPanel}
             isOpen={isNavOpen}

--- a/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
@@ -4,9 +4,11 @@ import { collapsibleButtonAutomationId } from 'common/components/cards/collapsib
 import { instanceCardAutomationId } from 'common/components/cards/instance-details';
 import { ruleContentAutomationId } from 'common/components/cards/instance-details-group';
 import { ruleGroupAutomationId } from 'common/components/cards/rules-with-instances';
+import { leftNavHamburgerButtonAutomationId } from 'common/components/left-nav-hamburger-button';
 import { testViewLeftNavLinkAutomationId } from 'DetailsView/components/left-nav/test-view-left-nav-link';
 import { automatedChecksViewAutomationId } from 'electron/views/automated-checks/automated-checks-view';
 import { commandButtonSettingsId } from 'electron/views/automated-checks/components/command-bar';
+import { fluentLeftNavAutomationId } from 'electron/views/left-nav/fluent-left-nav';
 import { leftNavAutomationId } from 'electron/views/left-nav/left-nav';
 import { highlightBoxAutomationId } from 'electron/views/screenshot/highlight-box';
 import { screenshotImageAutomationId } from 'electron/views/screenshot/screenshot';
@@ -21,6 +23,8 @@ export const AutomatedChecksViewSelectors = {
     ruleGroup: getAutomationIdSelector(ruleGroupAutomationId),
     ruleContent: getAutomationIdSelector(ruleContentAutomationId),
     leftNav: getAutomationIdSelector(leftNavAutomationId),
+    fluentLeftNav: getAutomationIdSelector(fluentLeftNavAutomationId),
+    leftNavHamburgerButton: getAutomationIdSelector(leftNavHamburgerButtonAutomationId),
 
     nthRuleGroupCollapseExpandButton: (position: number) =>
         `${nthRuleGroup(position)} ${getAutomationIdSelector(collapsibleButtonAutomationId)}`,

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -234,41 +234,40 @@ describe('AutomatedChecksView', () => {
         expect(result.value).toBeNull();
     });
 
-    it('hamburger button click opens and closes left nav', async () => {
-        await setupWindowForCommandBarReflowTest(2);
+    const waitForFluentLeftNavToDisappear = async (): Promise<void> => {
+        return automatedChecksView.waitForSelectorToDisappear(
+            AutomatedChecksViewSelectors.fluentLeftNav,
+        );
+    };
 
+    const expectFluentLeftNavNotToBeRendered = async (): Promise<void> => {
         const result = await automatedChecksView.client.$(
             AutomatedChecksViewSelectors.fluentLeftNav,
         );
         expect(result.state).toBe('failure');
+    };
 
+    it('hamburger button click opens and closes left nav', async () => {
+        await setupWindowForCommandBarReflowTest(2);
+        await expectFluentLeftNavNotToBeRendered();
         await automatedChecksView.client.click(AutomatedChecksViewSelectors.leftNavHamburgerButton);
-
-        // if the nav bar doesn't appear, the timeout has expired and the test fails.
         await automatedChecksView.waitForSelector(AutomatedChecksViewSelectors.fluentLeftNav);
 
-        // The fluent left nav bar appears over the command bar
-        // so it requires a different selector
+        // Clicks the hamburger button inside the fluent left nav (there is one within the command bar as well)
         const selector = `${AutomatedChecksViewSelectors.fluentLeftNav} ${AutomatedChecksViewSelectors.leftNavHamburgerButton}`;
         await automatedChecksView.client.click(selector);
-
-        // if the nav bar doesn't disappear, the timeout has expired and the test fails.
-        await automatedChecksView.waitForSelectorToDisappear(
-            AutomatedChecksViewSelectors.fluentLeftNav,
-        );
+        await waitForFluentLeftNavToDisappear();
+        await expectFluentLeftNavNotToBeRendered();
     });
 
-    it.only('left nav closes when item is selected', async () => {
+    it('left nav closes when item is selected', async () => {
         await setupWindowForCommandBarReflowTest(2);
         await automatedChecksView.client.click(AutomatedChecksViewSelectors.leftNavHamburgerButton);
         await automatedChecksView.waitForSelector(AutomatedChecksViewSelectors.fluentLeftNav);
 
         const selector = `${AutomatedChecksViewSelectors.fluentLeftNav} a`;
         await automatedChecksView.client.click(selector);
-
-        // if the nav bar doesn't disappear, the timeout has expired and the test fails.
-        await automatedChecksView.waitForSelectorToDisappear(
-            AutomatedChecksViewSelectors.fluentLeftNav,
-        );
+        await waitForFluentLeftNavToDisappear();
+        await expectFluentLeftNavNotToBeRendered();
     });
 });

--- a/src/tests/unit/tests/common/components/__snapshots__/left-nav-hamburger-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/left-nav-hamburger-button.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`LeftNavHamburgerButton renders per snapshot 1`] = `
   aria-expanded={false}
   ariaLabel="test-aria-label"
   className="leftNavHamburgerButton some-class"
+  data-automation-id="left-nav-hamburger-button"
   iconProps={
     Object {
       "iconName": "GlobalNavButton",

--- a/src/tests/unit/tests/electron/views/left-nav/__snapshots__/fluent-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/left-nav/__snapshots__/fluent-left-nav.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`FluentLeftNav render left nav inside panel 1`] = `
 <GenericPanel
   className="leftNavPanel"
   hasCloseButton={false}
+  innerPanelAutomationId="fluent-left-nav"
   isLightDismiss={true}
   isOpen={true}
   layerProps={


### PR DESCRIPTION
#### Description of changes

Added tests to check the following scenarios

- When the window width is greater than the narrow mode threshold for unified, the hamburger button is not shown in the command bar
- When the window width is less than the narrow mode threshold for unified,
	- the hamburger button is shown in the command bar
	- the left nav bar is not initially visible
	- when the hamburger button is clicked, the left nav pane becomes visible
	- if the hamburger button is clicked again, the left nav pane disappears
	- if a link in the left nav pane is clicked, the left nav pane disappears
