### PR TITLE
feat(combined-report-ui): add "How to fix" card row

### DIFF
--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.input.ts
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.input.ts
@@ -32,7 +32,7 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                                 all: [
                                     {
                                         id: 'fix1',
-                                        message: 'fix failed-rule-1',
+                                        message: 'fix failed-rule-1 failure 1',
                                         data: null,
                                     },
                                 ],
@@ -51,14 +51,14 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                             elementSelector: '.rule-1-selector-2',
                             snippet: '<div>snippet 2</div>',
                             fix: {
-                                all: [],
-                                any: [
+                                all: [
                                     {
                                         id: 'fix1',
-                                        message: 'fix failed-rule-1',
+                                        message: 'fix failed-rule-1 failure 2',
                                         data: null,
                                     },
                                 ],
+                                any: [],
                                 none: [],
                             },
                             rule: {

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.input.ts
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.input.ts
@@ -28,7 +28,17 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                             urls: ['https://url/rule-1/failure-1'],
                             elementSelector: '.rule-1-selector-1',
                             snippet: '<div>snippet 1</div>',
-                            fix: 'fix failed-rule-1',
+                            fix: {
+                                all: [
+                                    {
+                                        id: 'fix1',
+                                        message: 'fix failed-rule-1',
+                                        data: null,
+                                    },
+                                ],
+                                any: [],
+                                none: [],
+                            },
                             rule: {
                                 description: 'failed-rule-1 description',
                                 ruleUrl: 'https://rules/failed-rule-1',
@@ -40,7 +50,17 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                             urls: ['https://url/rule-1/failure-1', 'https://url/rule1/failure-2'],
                             elementSelector: '.rule-1-selector-2',
                             snippet: '<div>snippet 2</div>',
-                            fix: 'fix failed-rule-1',
+                            fix: {
+                                all: [],
+                                any: [
+                                    {
+                                        id: 'fix1',
+                                        message: 'fix failed-rule-1',
+                                        data: null,
+                                    },
+                                ],
+                                none: [],
+                            },
                             rule: {
                                 description: 'failed-rule-1 description',
                                 ruleUrl: 'https://rules/failed-rule-1',
@@ -57,7 +77,22 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                             urls: ['https://url/rule2/failure1'],
                             elementSelector: '.rule-2-selector-1',
                             snippet: '<div>snippet</div>',
-                            fix: 'fix failed-rule-2',
+                            fix: {
+                                all: [],
+                                any: [
+                                    {
+                                        id: 'fix1',
+                                        message: 'fix failed-rule-2 option 1',
+                                        data: null,
+                                    },
+                                    {
+                                        id: 'fix2',
+                                        message: 'fix failed-rule-2 option 2',
+                                        data: null,
+                                    },
+                                ],
+                                none: [],
+                            },
                             rule: {
                                 description: 'failed-rule-2 description',
                                 ruleUrl: 'https://rules/failed-rule-2',

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -1843,6 +1843,22 @@
                                         class="row-content--usdIW snippet--msVz-"
                                         >&lt;div&gt;snippet 1&lt;/div&gt;</td
                                       ></tr
+                                    ><tr class="row--kaG63"
+                                      ><th class="row-label--1iEmL"
+                                        >How to fix</th
+                                      ><td class="row-content--usdIW"
+                                        ><div class="how-to-fix-content--2-Pc1"
+                                          ><div
+                                            ><div>Fix the following:</div
+                                            ><ul
+                                              class="insights-fix-instruction-list--1vUZj"
+                                              ><li
+                                                >fix failed-rule-1 failure 1</li
+                                              ></ul
+                                            ></div
+                                          ></div
+                                        ></td
+                                      ></tr
                                     ></tbody
                                   ></table
                                 ></div
@@ -1951,6 +1967,22 @@
                                         class="row-content--usdIW snippet--msVz-"
                                         >&lt;div&gt;snippet 2&lt;/div&gt;</td
                                       ></tr
+                                    ><tr class="row--kaG63"
+                                      ><th class="row-label--1iEmL"
+                                        >How to fix</th
+                                      ><td class="row-content--usdIW"
+                                        ><div class="how-to-fix-content--2-Pc1"
+                                          ><div
+                                            ><div>Fix the following:</div
+                                            ><ul
+                                              class="insights-fix-instruction-list--1vUZj"
+                                              ><li
+                                                >fix failed-rule-1 failure 2</li
+                                              ></ul
+                                            ></div
+                                          ></div
+                                        ></td
+                                      ></tr
                                     ></tbody
                                   ></table
                                 ></div
@@ -2028,7 +2060,7 @@
                         ><span class="rule-details-id--ie-v-"
                           ><a
                             target="_blank"
-                            href="https://rules/rule2/failed-rule-1"
+                            href="https://rules/failed-rule-2"
                             class="ms-Link insights-link root-49"
                             id="new-tab-link-with-confirmation-dialog__6"
                             >More information about failed-rule-2</a
@@ -2125,6 +2157,24 @@
                                       ><td
                                         class="row-content--usdIW snippet--msVz-"
                                         >&lt;div&gt;snippet&lt;/div&gt;</td
+                                      ></tr
+                                    ><tr class="row--kaG63"
+                                      ><th class="row-label--1iEmL"
+                                        >How to fix</th
+                                      ><td class="row-content--usdIW"
+                                        ><div class="how-to-fix-content--2-Pc1"
+                                          ><div
+                                            ><div>Fix ONE of the following:</div
+                                            ><ul
+                                              class="insights-fix-instruction-list--1vUZj"
+                                              ><li
+                                                >fix failed-rule-2 option 1</li
+                                              ><li
+                                                >fix failed-rule-2 option 2</li
+                                              ></ul
+                                            ></div
+                                          ></div
+                                        ></td
                                       ></tr
                                     ></tbody
                                   ></table

--- a/src/common/components/cards/urls-card-row.tsx
+++ b/src/common/components/cards/urls-card-row.tsx
@@ -18,7 +18,7 @@ export interface UrlsCardRowProps extends CardRowProps {
 export const UrlsCardRow = NamedFC<UrlsCardRowProps>('UrlsCardRow', ({ deps, ...props }) => {
     const renderUrlContent = () => {
         return (
-            <ul class={styles.urlsRowContent}>
+            <ul className={styles.urlsRowContent}>
                 {props.propertyData.urls.map((url, index) => (
                     <li key={`urls-${index}`}>
                         <deps.LinkComponent href={url}>{url}</deps.LinkComponent>

--- a/src/injected/adapters/resolution-creator.ts
+++ b/src/injected/adapters/resolution-creator.ts
@@ -6,9 +6,15 @@ import { AxeNodeResult } from '../../scanner/iruleresults';
 
 export type ResolutionCreator = (data: ResolutionCreatorData) => DictionaryStringTo<any>;
 
+export interface NodeResolutionData {
+    any: FormattedCheckResult[];
+    none: FormattedCheckResult[];
+    all: FormattedCheckResult[];
+}
+
 export interface ResolutionCreatorData {
     id: string;
-    nodeResult: AxeNodeResult;
+    nodeResult: NodeResolutionData;
 }
 
 export const getFixResolution: ResolutionCreator = (data: ResolutionCreatorData) => {

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -61,10 +61,16 @@ declare namespace AccessibilityInsightsReport {
         ruleUrl: string
     }
 
+    export interface FormattedCheckResult {
+        id: string;
+        message: string;
+        data: any;
+    }
+
     export type HowToFixData = {
-        any: axe.CheckResult[],
-        all: axe.CheckResult[],
-        none: axe.CheckResult[],
+        any: FormattedCheckResult[],
+        all: FormattedCheckResult[],
+        none: FormattedCheckResult[],
         failureSummary?: string,
     }
 

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -62,9 +62,9 @@ declare namespace AccessibilityInsightsReport {
     }
 
     export type HowToFixData = {
-        any: FormattedCheckResult[],
-        all: FormattedCheckResult[],
-        none: FormattedCheckResult[],
+        any: axe.CheckResult[],
+        all: axe.CheckResult[],
+        none: axe.CheckResult[],
         failureSummary?: string,
     }
 

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -61,11 +61,18 @@ declare namespace AccessibilityInsightsReport {
         ruleUrl: string
     }
 
+    export type HowToFixData = {
+        any: FormattedCheckResult[],
+        all: FormattedCheckResult[],
+        none: FormattedCheckResult[],
+        failureSummary?: string,
+    }
+
     export type FailureData = {
         urls: string[],
         elementSelector: string,
         snippet: string,
-        fix: string,
+        fix: HowToFixData,
         rule: AxeRuleData
     };
 

--- a/src/reports/package/combined-results-to-cards-model-converter.ts
+++ b/src/reports/package/combined-results-to-cards-model-converter.ts
@@ -4,6 +4,7 @@
 import { CardSelectionViewData } from "common/get-card-selection-view-data";
 import { CardResult, CardRuleResult, CardRuleResultsByStatus, CardsViewModel } from "common/types/store-data/card-view-model";
 import { UUIDGenerator } from "common/uid-generator";
+import { ResolutionCreator } from "injected/adapters/resolution-creator";
 import { IssueFilingUrlStringUtils } from "issue-filing/common/issue-filing-url-string-utils";
 import { isNil } from "lodash";
 import { AxeRuleData, FailureData, FailuresGroup, GroupedResults } from "reports/package/accessibilityInsightsReport";
@@ -16,6 +17,7 @@ export class CombinedResultsToCardsModelConverter {
         private readonly cardSelectionViewData: CardSelectionViewData,
         private readonly uuidGenerator: UUIDGenerator,
         private readonly helpUrlGetter: HelpUrlGetter,
+        private readonly getFixResolution: ResolutionCreator,
     ) {}
 
     public convertResults = (
@@ -87,7 +89,8 @@ export class CombinedResultsToCardsModelConverter {
                 snippet: failureData.snippet,
             },
             resolution: {
-                howToFixSummary: failureData.fix,
+                howToFixSummary: failureData.fix.failureSummary,
+                ...this.getFixResolution({ id: rule.ruleId, nodeResult: failureData.fix}),
             },
             isSelected: false,
             highlightStatus: 'unavailable',

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -175,6 +175,7 @@ const combinedResultsReportGenerator = (parameters: CombinedReportParameters) =>
         cardSelectionViewData,
         generateUID,
         helpUrlGetter,
+        getFixResolution,
     );
 
     return new CombinedResultsReport(deps, parameters, toolData, resultsToCardsConverter);

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/urls-card-row.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/urls-card-row.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`UrlsCardRow renders 1`] = `
 <SimpleCardRow
   content={
     <ul
-      class="urlsRowContent"
+      className="urlsRowContent"
     >
       <li>
         <NewTabLinkWithConfirmationDialog

--- a/src/tests/unit/tests/injected/adapters/resolution-creator.test.ts
+++ b/src/tests/unit/tests/injected/adapters/resolution-creator.test.ts
@@ -15,8 +15,6 @@ describe('ResolutionCreator', () => {
                 any: [],
                 all: [],
                 none: [],
-                html: 'test html',
-                target: ['test target'],
             },
         };
 
@@ -67,8 +65,6 @@ describe('ResolutionCreator', () => {
                 any: [],
                 all: [],
                 none: [],
-                html: 'test html',
-                target: ['test target'],
             },
         };
 

--- a/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
@@ -33,7 +33,8 @@ Object {
             },
             "isSelected": false,
             "resolution": Object {
-              "howToFixSummary": "Fix the failed-rule-1 violation",
+              "how-to-fix": "fix Violation 1 of rule failed-rule-1",
+              "howToFixSummary": "Violation 1 of rule failed-rule-1",
             },
             "ruleId": "failed-rule-1",
             "status": "fail",
@@ -58,7 +59,8 @@ Object {
             },
             "isSelected": false,
             "resolution": Object {
-              "howToFixSummary": "Fix the failed-rule-1 violation",
+              "how-to-fix": "fix Violation 2 of rule failed-rule-1",
+              "howToFixSummary": "Violation 2 of rule failed-rule-1",
             },
             "ruleId": "failed-rule-1",
             "status": "fail",
@@ -95,7 +97,8 @@ Object {
             },
             "isSelected": false,
             "resolution": Object {
-              "howToFixSummary": "Fix the failed-rule-2 violation",
+              "how-to-fix": "fix Violation 1 of rule failed-rule-2",
+              "howToFixSummary": "Violation 1 of rule failed-rule-2",
             },
             "ruleId": "failed-rule-2",
             "status": "fail",
@@ -120,7 +123,8 @@ Object {
             },
             "isSelected": false,
             "resolution": Object {
-              "howToFixSummary": "Fix the failed-rule-2 violation",
+              "how-to-fix": "fix Violation 2 of rule failed-rule-2",
+              "howToFixSummary": "Violation 2 of rule failed-rule-2",
             },
             "ruleId": "failed-rule-2",
             "status": "fail",
@@ -266,7 +270,8 @@ Object {
             },
             "isSelected": false,
             "resolution": Object {
-              "howToFixSummary": "Fix the failed-rule-1 violation",
+              "how-to-fix": "fix Violation 1 of rule failed-rule-1",
+              "howToFixSummary": "Violation 1 of rule failed-rule-1",
             },
             "ruleId": "failed-rule-1",
             "status": "fail",
@@ -291,7 +296,8 @@ Object {
             },
             "isSelected": false,
             "resolution": Object {
-              "howToFixSummary": "Fix the failed-rule-1 violation",
+              "how-to-fix": "fix Violation 2 of rule failed-rule-1",
+              "howToFixSummary": "Violation 2 of rule failed-rule-1",
             },
             "ruleId": "failed-rule-1",
             "status": "fail",


### PR DESCRIPTION
#### Description of changes

Add missing "how to fix" card row to combined report. This involves changing the input interface to accept the resolution data that we get from axe-core.

<img width="738" alt="howToFixCard" src="https://user-images.githubusercontent.com/55459788/97484889-97b30980-1916-11eb-96ce-fe405bb4fbf0.PNG">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1772544
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
