### PR TITLE
test(combined-report-ui): use real axe rule ids in testing data

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -1602,7 +1602,7 @@
             href="https://markreay.github.io/AU/before.html"
             class="ms-Link insights-link root-49"
             title="Page Title for Axe Results With Issues"
-            id="new-tab-link-with-confirmation-dialog__1"
+            id="new-tab-link-with-confirmation-dialog__0"
             >Page Title for Axe Results With Issues</a
           ><script>
             (function (linkId, doc, confirmCallback) {
@@ -1617,7 +1617,7 @@
                   event.preventDefault();
                 }
               });
-            })("new-tab-link-with-confirmation-dialog__1", document, confirm);
+            })("new-tab-link-with-confirmation-dialog__0", document, confirm);
           </script></div
         ></div
       ></header
@@ -1647,7 +1647,7 @@
                   href="https://markreay.github.io/AU/before.html"
                   class="ms-Link insights-link root-49"
                   title="Page Title for Axe Results With Issues"
-                  id="new-tab-link-with-confirmation-dialog__2"
+                  id="new-tab-link-with-confirmation-dialog__1"
                   >https://markreay.github.io/AU/before.html</a
                 ><script>
                   (function (linkId, doc, confirmCallback) {
@@ -1663,7 +1663,7 @@
                       }
                     });
                   })(
-                    "new-tab-link-with-confirmation-dialog__2",
+                    "new-tab-link-with-confirmation-dialog__1",
                     document,
                     confirm
                   );

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -1602,7 +1602,7 @@
             href="https://markreay.github.io/AU/after.html"
             class="ms-Link insights-link root-49"
             title="Page Title for Axe Results Without Issues"
-            id="new-tab-link-with-confirmation-dialog__3"
+            id="new-tab-link-with-confirmation-dialog__0"
             >Page Title for Axe Results Without Issues</a
           ><script>
             (function (linkId, doc, confirmCallback) {
@@ -1617,7 +1617,7 @@
                   event.preventDefault();
                 }
               });
-            })("new-tab-link-with-confirmation-dialog__3", document, confirm);
+            })("new-tab-link-with-confirmation-dialog__0", document, confirm);
           </script></div
         ></div
       ></header
@@ -1647,7 +1647,7 @@
                   href="https://markreay.github.io/AU/after.html"
                   class="ms-Link insights-link root-49"
                   title="Page Title for Axe Results Without Issues"
-                  id="new-tab-link-with-confirmation-dialog__4"
+                  id="new-tab-link-with-confirmation-dialog__1"
                   >https://markreay.github.io/AU/after.html</a
                 ><script>
                   (function (linkId, doc, confirmCallback) {
@@ -1663,7 +1663,7 @@
                       }
                     });
                   })(
-                    "new-tab-link-with-confirmation-dialog__4",
+                    "new-tab-link-with-confirmation-dialog__1",
                     document,
                     confirm
                   );

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.input.ts
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.input.ts
@@ -29,21 +29,47 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                             elementSelector: '.rule-1-selector-1',
                             snippet: '<div>snippet 1</div>',
                             fix: {
-                                all: [
+                                all: [],
+                                any: [
                                     {
-                                        id: 'fix1',
-                                        message: 'fix failed-rule-1 failure 1',
                                         data: null,
+                                        id: 'internal-link-present',
+                                        impact: 'serious',
+                                        message: 'No valid skip link found',
+                                        relatedNodes: [],
+                                    },
+                                    {
+                                        data: null,
+                                        id: 'header-present',
+                                        impact: 'serious',
+                                        message: 'Page does not have a header',
+                                        relatedNodes: [],
+                                    },
+                                    {
+                                        data: null,
+                                        id: 'landmark',
+                                        impact: 'serious',
+                                        message: 'Page does not have a landmark region',
+                                        relatedNodes: [],
                                     },
                                 ],
-                                any: [],
+                                failureSummary:
+                                    'Fix any of the following:\n  No valid skip link found\n  Page does not have a header\n  Page does not have a landmark region',
                                 none: [],
                             },
                             rule: {
-                                description: 'failed-rule-1 description',
-                                ruleUrl: 'https://rules/failed-rule-1',
-                                ruleId: 'failed-rule-1',
-                                tags: ['rule-1-tag-1', 'rule-1-tag-2'],
+                                description:
+                                    'Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content',
+                                ruleUrl:
+                                    'https://dequeuniversity.com/rules/axe/3.3/bypass?application=webdriverjs',
+                                ruleId: 'bypass',
+                                tags: [
+                                    'cat.keyboard',
+                                    'wcag2a',
+                                    'wcag241',
+                                    'section508',
+                                    'section508.22.o',
+                                ],
                             },
                         },
                         {
@@ -51,21 +77,47 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                             elementSelector: '.rule-1-selector-2',
                             snippet: '<div>snippet 2</div>',
                             fix: {
-                                all: [
+                                all: [],
+                                any: [
                                     {
-                                        id: 'fix1',
-                                        message: 'fix failed-rule-1 failure 2',
                                         data: null,
+                                        id: 'internal-link-present',
+                                        impact: 'serious',
+                                        message: 'No valid skip link found',
+                                        relatedNodes: [],
+                                    },
+                                    {
+                                        data: null,
+                                        id: 'header-present',
+                                        impact: 'serious',
+                                        message: 'Page does not have a header',
+                                        relatedNodes: [],
+                                    },
+                                    {
+                                        data: null,
+                                        id: 'landmark',
+                                        impact: 'serious',
+                                        message: 'Page does not have a landmark region',
+                                        relatedNodes: [],
                                     },
                                 ],
-                                any: [],
+                                failureSummary:
+                                    'Fix any of the following:\n  No valid skip link found\n  Page does not have a header\n  Page does not have a landmark region',
                                 none: [],
                             },
                             rule: {
-                                description: 'failed-rule-1 description',
-                                ruleUrl: 'https://rules/failed-rule-1',
-                                ruleId: 'failed-rule-1',
-                                tags: ['rule-1-tag-1', 'rule-1-tag-2'],
+                                description:
+                                    'Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content',
+                                ruleUrl:
+                                    'https://dequeuniversity.com/rules/axe/3.3/bypass?application=webdriverjs',
+                                ruleId: 'bypass',
+                                tags: [
+                                    'cat.keyboard',
+                                    'wcag2a',
+                                    'wcag241',
+                                    'section508',
+                                    'section508.22.o',
+                                ],
                             },
                         },
                     ],
@@ -81,23 +133,38 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
                                 all: [],
                                 any: [
                                     {
-                                        id: 'fix1',
-                                        message: 'fix failed-rule-2 option 1',
-                                        data: null,
-                                    },
-                                    {
-                                        id: 'fix2',
-                                        message: 'fix failed-rule-2 option 2',
-                                        data: null,
+                                        data: {
+                                            bgColor: '#e7ecd8',
+                                            contrastRatio: 2.52,
+                                            expectedContrastRatio: '4.5:1',
+                                            fgColor: '#8a94a8',
+                                            fontSize: '12.0pt (16px)',
+                                            fontWeight: 'normal',
+                                            missingData: null,
+                                        },
+                                        id: 'color-contrast',
+                                        impact: 'serious',
+                                        message:
+                                            'Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1',
+                                        relatedNodes: [
+                                            {
+                                                html: '<li>',
+                                                target: ['#menu > li:nth-child(1)'],
+                                            },
+                                        ],
                                     },
                                 ],
                                 none: [],
+                                failureSummary:
+                                    'Fix any of the following:\n  Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1',
                             },
                             rule: {
-                                description: 'failed-rule-2 description',
-                                ruleUrl: 'https://rules/failed-rule-2',
-                                ruleId: 'failed-rule-2',
-                                tags: ['rule-2-tag'],
+                                description:
+                                    'Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds',
+                                ruleUrl:
+                                    'https://dequeuniversity.com/rules/axe/3.3/color-contrast?application=webdriverjs',
+                                ruleId: 'color-contrast',
+                                tags: ['cat.color', 'wcag2aa', 'wcag143'],
                             },
                         },
                     ],

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -1789,8 +1789,8 @@
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
-                        aria-controls="content-container-failed-rule-1"
-                        aria-label="failed-rule-1 2 Failed failed-rule-1 description"
+                        aria-controls="content-container-bypass"
+                        aria-label="bypass 2 Failed Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content"
                         ><span
                           data-automation-id="rule-detail"
                           class="rule-detail"
@@ -1833,16 +1833,18 @@
                             ><span
                               data-automation-id="cards-rule-id"
                               class="rule-details-id"
-                              >failed-rule-1</span
+                              >bypass</span
                             >:
                             <span class="rule-details-description"
-                              >failed-rule-1 description</span
+                              >Ensures each page has at least one mechanism for
+                              a user to bypass navigation and jump straight to
+                              the content</span
                             ></span
                           ></span
                         ></button
                       ></div
                     ><div
-                      id="content-container-failed-rule-1"
+                      id="content-container-bypass"
                       class="collapsible-content"
                       aria-hidden="true"
                       ><div class="rule-more-resources--3PCDe"
@@ -1851,10 +1853,10 @@
                         ><span class="rule-details-id--ie-v-"
                           ><a
                             target="_blank"
-                            href="https://rules/failed-rule-1"
+                            href="https://accessibilityinsights.io/info-examples/web/bypass"
                             class="ms-Link insights-link root-49"
                             id="new-tab-link-with-confirmation-dialog__2"
-                            >More information about failed-rule-1</a
+                            >More information about bypass</a
                           ><script>
                             (function (linkId, doc, confirmCallback) {
                               const targetPageLink = doc.getElementById(linkId);
@@ -1877,94 +1879,44 @@
                               confirm
                             );
                           </script></span
-                        ><span></span></div
+                        ><span
+                          ><span class="guidance-links"
+                            ><a
+                              target="_blank"
+                              href="https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks"
+                              class="ms-Link insights-link root-49"
+                              id="new-tab-link-with-confirmation-dialog__3"
+                              >WCAG 2.4.1</a
+                            ><script>
+                              (function (linkId, doc, confirmCallback) {
+                                const targetPageLink = doc.getElementById(
+                                  linkId
+                                );
+                                targetPageLink.addEventListener(
+                                  "click",
+                                  function (event) {
+                                    const result = confirmCallback(
+                                      "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                                        "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                                        "Cancel to stay on the current page."
+                                    );
+                                    if (result === false) {
+                                      event.preventDefault();
+                                    }
+                                  }
+                                );
+                              })(
+                                "new-tab-link-with-confirmation-dialog__3",
+                                document,
+                                confirm
+                              );
+                            </script></span
+                          ></span
+                        ></div
                       ><ul
                         data-automation-id="cards-rule-content"
                         class="instance-details-list--2Beza"
                         aria-label="instances with path, snippet and how to resolve information"
-                        ><li
-                          ><div
-                            data-automation-id="instance-card"
-                            class="instance-details-card-container--_ELdq"
-                            ><div class="instance-details-card--OrpLo"
-                              ><div
-                                ><table class="report-instance-table--ljlFi"
-                                  ><tbody
-                                    ><tr class="row--kaG63"
-                                      ><th class="row-label--1iEmL">URL</th
-                                      ><td class="row-content--usdIW"
-                                        ><ul class="urls-row-content--2TTTB"
-                                          ><li
-                                            ><a
-                                              target="_blank"
-                                              href="https://url/rule-1/failure-1"
-                                              class="ms-Link insights-link root-49"
-                                              id="new-tab-link-with-confirmation-dialog__3"
-                                              >https://url/rule-1/failure-1</a
-                                            ><script>
-                                              (function (
-                                                linkId,
-                                                doc,
-                                                confirmCallback
-                                              ) {
-                                                const targetPageLink = doc.getElementById(
-                                                  linkId
-                                                );
-                                                targetPageLink.addEventListener(
-                                                  "click",
-                                                  function (event) {
-                                                    const result = confirmCallback(
-                                                      "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                                        "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                                        "Cancel to stay on the current page."
-                                                    );
-                                                    if (result === false) {
-                                                      event.preventDefault();
-                                                    }
-                                                  }
-                                                );
-                                              })(
-                                                "new-tab-link-with-confirmation-dialog__3",
-                                                document,
-                                                confirm
-                                              );
-                                            </script></li
-                                          ></ul
-                                        ></td
-                                      ></tr
-                                    ><tr class="row--kaG63"
-                                      ><th class="row-label--1iEmL">Path</th
-                                      ><td class="row-content--usdIW"
-                                        >.rule-1-selector-1</td
-                                      ></tr
-                                    ><tr class="row--kaG63"
-                                      ><th class="row-label--1iEmL">Snippet</th
-                                      ><td
-                                        class="row-content--usdIW snippet--msVz-"
-                                        >&lt;div&gt;snippet 1&lt;/div&gt;</td
-                                      ></tr
-                                    ><tr class="row--kaG63"
-                                      ><th class="row-label--1iEmL"
-                                        >How to fix</th
-                                      ><td class="row-content--usdIW"
-                                        ><div class="how-to-fix-content--2-Pc1"
-                                          ><div
-                                            ><div>Fix the following:</div
-                                            ><ul
-                                              class="insights-fix-instruction-list--1vUZj"
-                                              ><li
-                                                >fix failed-rule-1 failure 1</li
-                                              ></ul
-                                            ></div
-                                          ></div
-                                        ></td
-                                      ></tr
-                                    ></tbody
-                                  ></table
-                                ></div
-                              ></div
-                            ></div
-                          ></li
                         ><li
                           ><div
                             data-automation-id="instance-card"
@@ -2012,13 +1964,65 @@
                                                 confirm
                                               );
                                             </script></li
+                                          ></ul
+                                        ></td
+                                      ></tr
+                                    ><tr class="row--kaG63"
+                                      ><th class="row-label--1iEmL">Path</th
+                                      ><td class="row-content--usdIW"
+                                        >.rule-1-selector-1</td
+                                      ></tr
+                                    ><tr class="row--kaG63"
+                                      ><th class="row-label--1iEmL">Snippet</th
+                                      ><td
+                                        class="row-content--usdIW snippet--msVz-"
+                                        >&lt;div&gt;snippet 1&lt;/div&gt;</td
+                                      ></tr
+                                    ><tr class="row--kaG63"
+                                      ><th class="row-label--1iEmL"
+                                        >How to fix</th
+                                      ><td class="row-content--usdIW"
+                                        ><div class="how-to-fix-content--2-Pc1"
+                                          ><div
+                                            ><div>Fix ONE of the following:</div
+                                            ><ul
+                                              class="insights-fix-instruction-list--1vUZj"
+                                              ><li>No valid skip link found</li
+                                              ><li
+                                                >Page does not have a header</li
+                                              ><li
+                                                >Page does not have a landmark
+                                                region</li
+                                              ></ul
+                                            ></div
+                                          ></div
+                                        ></td
+                                      ></tr
+                                    ></tbody
+                                  ></table
+                                ></div
+                              ></div
+                            ></div
+                          ></li
+                        ><li
+                          ><div
+                            data-automation-id="instance-card"
+                            class="instance-details-card-container--_ELdq"
+                            ><div class="instance-details-card--OrpLo"
+                              ><div
+                                ><table class="report-instance-table--ljlFi"
+                                  ><tbody
+                                    ><tr class="row--kaG63"
+                                      ><th class="row-label--1iEmL">URL</th
+                                      ><td class="row-content--usdIW"
+                                        ><ul class="urls-row-content--2TTTB"
                                           ><li
                                             ><a
                                               target="_blank"
-                                              href="https://url/rule1/failure-2"
+                                              href="https://url/rule-1/failure-1"
                                               class="ms-Link insights-link root-49"
                                               id="new-tab-link-with-confirmation-dialog__5"
-                                              >https://url/rule1/failure-2</a
+                                              >https://url/rule-1/failure-1</a
                                             ><script>
                                               (function (
                                                 linkId,
@@ -2047,6 +2051,41 @@
                                                 confirm
                                               );
                                             </script></li
+                                          ><li
+                                            ><a
+                                              target="_blank"
+                                              href="https://url/rule1/failure-2"
+                                              class="ms-Link insights-link root-49"
+                                              id="new-tab-link-with-confirmation-dialog__6"
+                                              >https://url/rule1/failure-2</a
+                                            ><script>
+                                              (function (
+                                                linkId,
+                                                doc,
+                                                confirmCallback
+                                              ) {
+                                                const targetPageLink = doc.getElementById(
+                                                  linkId
+                                                );
+                                                targetPageLink.addEventListener(
+                                                  "click",
+                                                  function (event) {
+                                                    const result = confirmCallback(
+                                                      "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                                                        "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                                                        "Cancel to stay on the current page."
+                                                    );
+                                                    if (result === false) {
+                                                      event.preventDefault();
+                                                    }
+                                                  }
+                                                );
+                                              })(
+                                                "new-tab-link-with-confirmation-dialog__6",
+                                                document,
+                                                confirm
+                                              );
+                                            </script></li
                                           ></ul
                                         ></td
                                       ></tr
@@ -2067,11 +2106,15 @@
                                       ><td class="row-content--usdIW"
                                         ><div class="how-to-fix-content--2-Pc1"
                                           ><div
-                                            ><div>Fix the following:</div
+                                            ><div>Fix ONE of the following:</div
                                             ><ul
                                               class="insights-fix-instruction-list--1vUZj"
+                                              ><li>No valid skip link found</li
                                               ><li
-                                                >fix failed-rule-1 failure 2</li
+                                                >Page does not have a header</li
+                                              ><li
+                                                >Page does not have a landmark
+                                                region</li
                                               ></ul
                                             ></div
                                           ></div
@@ -2092,8 +2135,8 @@
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
-                        aria-controls="content-container-failed-rule-2"
-                        aria-label="failed-rule-2 1 Failed failed-rule-2 description"
+                        aria-controls="content-container-color-contrast"
+                        aria-label="color-contrast 1 Failed Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds"
                         ><span
                           data-automation-id="rule-detail"
                           class="rule-detail"
@@ -2136,16 +2179,18 @@
                             ><span
                               data-automation-id="cards-rule-id"
                               class="rule-details-id"
-                              >failed-rule-2</span
+                              >color-contrast</span
                             >:
                             <span class="rule-details-description"
-                              >failed-rule-2 description</span
+                              >Ensures the contrast between foreground and
+                              background colors meets WCAG 2 AA contrast ratio
+                              thresholds</span
                             ></span
                           ></span
                         ></button
                       ></div
                     ><div
-                      id="content-container-failed-rule-2"
+                      id="content-container-color-contrast"
                       class="collapsible-content"
                       aria-hidden="true"
                       ><div class="rule-more-resources--3PCDe"
@@ -2154,10 +2199,10 @@
                         ><span class="rule-details-id--ie-v-"
                           ><a
                             target="_blank"
-                            href="https://rules/failed-rule-2"
+                            href="https://accessibilityinsights.io/info-examples/web/color-contrast"
                             class="ms-Link insights-link root-49"
-                            id="new-tab-link-with-confirmation-dialog__6"
-                            >More information about failed-rule-2</a
+                            id="new-tab-link-with-confirmation-dialog__7"
+                            >More information about color-contrast</a
                           ><script>
                             (function (linkId, doc, confirmCallback) {
                               const targetPageLink = doc.getElementById(linkId);
@@ -2175,12 +2220,45 @@
                                 }
                               );
                             })(
-                              "new-tab-link-with-confirmation-dialog__6",
+                              "new-tab-link-with-confirmation-dialog__7",
                               document,
                               confirm
                             );
                           </script></span
-                        ><span></span></div
+                        ><span
+                          ><span class="guidance-links"
+                            ><a
+                              target="_blank"
+                              href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html"
+                              class="ms-Link insights-link root-49"
+                              id="new-tab-link-with-confirmation-dialog__8"
+                              >WCAG 1.4.3</a
+                            ><script>
+                              (function (linkId, doc, confirmCallback) {
+                                const targetPageLink = doc.getElementById(
+                                  linkId
+                                );
+                                targetPageLink.addEventListener(
+                                  "click",
+                                  function (event) {
+                                    const result = confirmCallback(
+                                      "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                                        "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                                        "Cancel to stay on the current page."
+                                    );
+                                    if (result === false) {
+                                      event.preventDefault();
+                                    }
+                                  }
+                                );
+                              })(
+                                "new-tab-link-with-confirmation-dialog__8",
+                                document,
+                                confirm
+                              );
+                            </script></span
+                          ></span
+                        ></div
                       ><ul
                         data-automation-id="cards-rule-content"
                         class="instance-details-list--2Beza"
@@ -2202,7 +2280,7 @@
                                               target="_blank"
                                               href="https://url/rule2/failure1"
                                               class="ms-Link insights-link root-49"
-                                              id="new-tab-link-with-confirmation-dialog__7"
+                                              id="new-tab-link-with-confirmation-dialog__9"
                                               >https://url/rule2/failure1</a
                                             ><script>
                                               (function (
@@ -2227,7 +2305,7 @@
                                                   }
                                                 );
                                               })(
-                                                "new-tab-link-with-confirmation-dialog__7",
+                                                "new-tab-link-with-confirmation-dialog__9",
                                                 document,
                                                 confirm
                                               );
@@ -2252,13 +2330,45 @@
                                       ><td class="row-content--usdIW"
                                         ><div class="how-to-fix-content--2-Pc1"
                                           ><div
-                                            ><div>Fix ONE of the following:</div
+                                            ><div>Fix the following:</div
                                             ><ul
                                               class="insights-fix-instruction-list--1vUZj"
                                               ><li
-                                                >fix failed-rule-2 option 1</li
-                                              ><li
-                                                >fix failed-rule-2 option 2</li
+                                                ><span aria-hidden="true"
+                                                  ><span
+                                                    >Element has insufficient
+                                                    color contrast of 2.52
+                                                    (foreground color: </span
+                                                  ><span
+                                                    class="fix-instruction-color-box--HXJ1A"
+                                                    style="
+                                                      background-color: #8a94a8;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#8a94a8, background color: </span
+                                                  ><span
+                                                    class="fix-instruction-color-box--HXJ1A"
+                                                    style="
+                                                      background-color: #e7ecd8;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#e7ecd8, font size: 12.0pt
+                                                    (16px), font weight:
+                                                    normal). Expected contrast
+                                                    ratio of 4.5:1</span
+                                                  ></span
+                                                ><span
+                                                  class="screen-reader-only--1uWLQ"
+                                                  >Element has insufficient
+                                                  color contrast of 2.52
+                                                  (foreground color: #8a94a8,
+                                                  background color: #e7ecd8,
+                                                  font size: 12.0pt (16px), font
+                                                  weight: normal). Expected
+                                                  contrast ratio of 4.5:1</span
+                                                ></li
                                               ></ul
                                             ></div
                                           ></div
@@ -2318,7 +2428,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__8"
+                          id="new-tab-link-with-confirmation-dialog__10"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2336,7 +2446,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__8",
+                            "new-tab-link-with-confirmation-dialog__10",
                             document,
                             confirm
                           );
@@ -2365,7 +2475,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__9"
+                          id="new-tab-link-with-confirmation-dialog__11"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2383,7 +2493,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__9",
+                            "new-tab-link-with-confirmation-dialog__11",
                             document,
                             confirm
                           );
@@ -2412,7 +2522,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__10"
+                          id="new-tab-link-with-confirmation-dialog__12"
                           >WCAG 1.3.5</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2430,7 +2540,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__10",
+                            "new-tab-link-with-confirmation-dialog__12",
                             document,
                             confirm
                           );
@@ -2484,7 +2594,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__11"
+                          id="new-tab-link-with-confirmation-dialog__13"
                           >WCAG 1.1.1</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2502,7 +2612,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__11",
+                            "new-tab-link-with-confirmation-dialog__13",
                             document,
                             confirm
                           );</script
@@ -2511,7 +2621,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__12"
+                          id="new-tab-link-with-confirmation-dialog__14"
                           >WCAG 2.4.4</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2529,7 +2639,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__12",
+                            "new-tab-link-with-confirmation-dialog__14",
                             document,
                             confirm
                           );</script
@@ -2538,7 +2648,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__13"
+                          id="new-tab-link-with-confirmation-dialog__15"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2556,7 +2666,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__13",
+                            "new-tab-link-with-confirmation-dialog__15",
                             document,
                             confirm
                           );
@@ -2585,7 +2695,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__14"
+                          id="new-tab-link-with-confirmation-dialog__16"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2603,7 +2713,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__14",
+                            "new-tab-link-with-confirmation-dialog__16",
                             document,
                             confirm
                           );</script
@@ -2612,7 +2722,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__15"
+                          id="new-tab-link-with-confirmation-dialog__17"
                           >WCAG 1.3.1</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2630,7 +2740,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__15",
+                            "new-tab-link-with-confirmation-dialog__17",
                             document,
                             confirm
                           );

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -1622,7 +1622,7 @@
                   href="https://example.com/mock-base-url"
                   class="ms-Link insights-link root-49"
                   title="Mock base without failures or unscannables"
-                  id="new-tab-link-with-confirmation-dialog__1"
+                  id="new-tab-link-with-confirmation-dialog__0"
                   >https://example.com/mock-base-url</a
                 ><script>
                   (function (linkId, doc, confirmCallback) {
@@ -1638,7 +1638,7 @@
                       }
                     });
                   })(
-                    "new-tab-link-with-confirmation-dialog__1",
+                    "new-tab-link-with-confirmation-dialog__0",
                     document,
                     confirm
                   );
@@ -1855,7 +1855,7 @@
                             target="_blank"
                             href="https://accessibilityinsights.io/info-examples/web/bypass"
                             class="ms-Link insights-link root-49"
-                            id="new-tab-link-with-confirmation-dialog__2"
+                            id="new-tab-link-with-confirmation-dialog__1"
                             >More information about bypass</a
                           ><script>
                             (function (linkId, doc, confirmCallback) {
@@ -1874,7 +1874,7 @@
                                 }
                               );
                             })(
-                              "new-tab-link-with-confirmation-dialog__2",
+                              "new-tab-link-with-confirmation-dialog__1",
                               document,
                               confirm
                             );
@@ -1885,7 +1885,7 @@
                               target="_blank"
                               href="https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks"
                               class="ms-Link insights-link root-49"
-                              id="new-tab-link-with-confirmation-dialog__3"
+                              id="new-tab-link-with-confirmation-dialog__2"
                               >WCAG 2.4.1</a
                             ><script>
                               (function (linkId, doc, confirmCallback) {
@@ -1906,7 +1906,7 @@
                                   }
                                 );
                               })(
-                                "new-tab-link-with-confirmation-dialog__3",
+                                "new-tab-link-with-confirmation-dialog__2",
                                 document,
                                 confirm
                               );
@@ -1934,7 +1934,7 @@
                                               target="_blank"
                                               href="https://url/rule-1/failure-1"
                                               class="ms-Link insights-link root-49"
-                                              id="new-tab-link-with-confirmation-dialog__4"
+                                              id="new-tab-link-with-confirmation-dialog__3"
                                               >https://url/rule-1/failure-1</a
                                             ><script>
                                               (function (
@@ -1959,7 +1959,7 @@
                                                   }
                                                 );
                                               })(
-                                                "new-tab-link-with-confirmation-dialog__4",
+                                                "new-tab-link-with-confirmation-dialog__3",
                                                 document,
                                                 confirm
                                               );
@@ -2021,7 +2021,7 @@
                                               target="_blank"
                                               href="https://url/rule-1/failure-1"
                                               class="ms-Link insights-link root-49"
-                                              id="new-tab-link-with-confirmation-dialog__5"
+                                              id="new-tab-link-with-confirmation-dialog__4"
                                               >https://url/rule-1/failure-1</a
                                             ><script>
                                               (function (
@@ -2046,7 +2046,7 @@
                                                   }
                                                 );
                                               })(
-                                                "new-tab-link-with-confirmation-dialog__5",
+                                                "new-tab-link-with-confirmation-dialog__4",
                                                 document,
                                                 confirm
                                               );
@@ -2056,7 +2056,7 @@
                                               target="_blank"
                                               href="https://url/rule1/failure-2"
                                               class="ms-Link insights-link root-49"
-                                              id="new-tab-link-with-confirmation-dialog__6"
+                                              id="new-tab-link-with-confirmation-dialog__5"
                                               >https://url/rule1/failure-2</a
                                             ><script>
                                               (function (
@@ -2081,7 +2081,7 @@
                                                   }
                                                 );
                                               })(
-                                                "new-tab-link-with-confirmation-dialog__6",
+                                                "new-tab-link-with-confirmation-dialog__5",
                                                 document,
                                                 confirm
                                               );
@@ -2201,7 +2201,7 @@
                             target="_blank"
                             href="https://accessibilityinsights.io/info-examples/web/color-contrast"
                             class="ms-Link insights-link root-49"
-                            id="new-tab-link-with-confirmation-dialog__7"
+                            id="new-tab-link-with-confirmation-dialog__6"
                             >More information about color-contrast</a
                           ><script>
                             (function (linkId, doc, confirmCallback) {
@@ -2220,7 +2220,7 @@
                                 }
                               );
                             })(
-                              "new-tab-link-with-confirmation-dialog__7",
+                              "new-tab-link-with-confirmation-dialog__6",
                               document,
                               confirm
                             );
@@ -2231,7 +2231,7 @@
                               target="_blank"
                               href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html"
                               class="ms-Link insights-link root-49"
-                              id="new-tab-link-with-confirmation-dialog__8"
+                              id="new-tab-link-with-confirmation-dialog__7"
                               >WCAG 1.4.3</a
                             ><script>
                               (function (linkId, doc, confirmCallback) {
@@ -2252,7 +2252,7 @@
                                   }
                                 );
                               })(
-                                "new-tab-link-with-confirmation-dialog__8",
+                                "new-tab-link-with-confirmation-dialog__7",
                                 document,
                                 confirm
                               );
@@ -2280,7 +2280,7 @@
                                               target="_blank"
                                               href="https://url/rule2/failure1"
                                               class="ms-Link insights-link root-49"
-                                              id="new-tab-link-with-confirmation-dialog__9"
+                                              id="new-tab-link-with-confirmation-dialog__8"
                                               >https://url/rule2/failure1</a
                                             ><script>
                                               (function (
@@ -2305,7 +2305,7 @@
                                                   }
                                                 );
                                               })(
-                                                "new-tab-link-with-confirmation-dialog__9",
+                                                "new-tab-link-with-confirmation-dialog__8",
                                                 document,
                                                 confirm
                                               );
@@ -2428,6 +2428,53 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
+                          id="new-tab-link-with-confirmation-dialog__9"
+                          >WCAG 4.1.2</a
+                        ><script>
+                          (function (linkId, doc, confirmCallback) {
+                            const targetPageLink = doc.getElementById(linkId);
+                            targetPageLink.addEventListener("click", function (
+                              event
+                            ) {
+                              const result = confirmCallback(
+                                "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                                  "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                                  "Cancel to stay on the current page."
+                              );
+                              if (result === false) {
+                                event.preventDefault();
+                              }
+                            });
+                          })(
+                            "new-tab-link-with-confirmation-dialog__9",
+                            document,
+                            confirm
+                          );
+                        </script></span
+                      >)</div
+                    ></div
+                  ><div class="rule-detail"
+                    ><div>
+                      <span class="rule-details-id"
+                        ><a
+                          target="_blank"
+                          href="https://accessibilityinsights.io/info-examples/web/aria-toggle-field-name"
+                          class="ms-Link insights-link root-49"
+                          aria-label="rule aria-toggle-field-name"
+                          aria-describedby="not-applicable-rule-aria-toggle-field-name-description"
+                          >aria-toggle-field-name</a
+                        ></span
+                      >:
+                      <span
+                        class="rule-details-description"
+                        id="not-applicable-rule-aria-toggle-field-name-description"
+                        >Ensures every ARIA toggle field has an accessible
+                        name</span
+                      >(<span class="guidance-links"
+                        ><a
+                          target="_blank"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                          class="ms-Link insights-link root-49"
                           id="new-tab-link-with-confirmation-dialog__10"
                           >WCAG 4.1.2</a
                         ><script>
@@ -2458,53 +2505,6 @@
                       <span class="rule-details-id"
                         ><a
                           target="_blank"
-                          href="https://accessibilityinsights.io/info-examples/web/aria-toggle-field-name"
-                          class="ms-Link insights-link root-49"
-                          aria-label="rule aria-toggle-field-name"
-                          aria-describedby="not-applicable-rule-aria-toggle-field-name-description"
-                          >aria-toggle-field-name</a
-                        ></span
-                      >:
-                      <span
-                        class="rule-details-description"
-                        id="not-applicable-rule-aria-toggle-field-name-description"
-                        >Ensures every ARIA toggle field has an accessible
-                        name</span
-                      >(<span class="guidance-links"
-                        ><a
-                          target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
-                          class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__11"
-                          >WCAG 4.1.2</a
-                        ><script>
-                          (function (linkId, doc, confirmCallback) {
-                            const targetPageLink = doc.getElementById(linkId);
-                            targetPageLink.addEventListener("click", function (
-                              event
-                            ) {
-                              const result = confirmCallback(
-                                "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                  "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                  "Cancel to stay on the current page."
-                              );
-                              if (result === false) {
-                                event.preventDefault();
-                              }
-                            });
-                          })(
-                            "new-tab-link-with-confirmation-dialog__11",
-                            document,
-                            confirm
-                          );
-                        </script></span
-                      >)</div
-                    ></div
-                  ><div class="rule-detail"
-                    ><div>
-                      <span class="rule-details-id"
-                        ><a
-                          target="_blank"
                           href="https://accessibilityinsights.io/info-examples/web/autocomplete-valid"
                           class="ms-Link insights-link root-49"
                           aria-label="rule autocomplete-valid"
@@ -2522,7 +2522,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__12"
+                          id="new-tab-link-with-confirmation-dialog__11"
                           >WCAG 1.3.5</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2540,7 +2540,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__12",
+                            "new-tab-link-with-confirmation-dialog__11",
                             document,
                             confirm
                           );
@@ -2594,8 +2594,35 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__13"
+                          id="new-tab-link-with-confirmation-dialog__12"
                           >WCAG 1.1.1</a
+                        ><script>
+                          (function (linkId, doc, confirmCallback) {
+                            const targetPageLink = doc.getElementById(linkId);
+                            targetPageLink.addEventListener("click", function (
+                              event
+                            ) {
+                              const result = confirmCallback(
+                                "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                                  "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                                  "Cancel to stay on the current page."
+                              );
+                              if (result === false) {
+                                event.preventDefault();
+                              }
+                            });
+                          })(
+                            "new-tab-link-with-confirmation-dialog__12",
+                            document,
+                            confirm
+                          );</script
+                        ><span>, </span
+                        ><a
+                          target="_blank"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html"
+                          class="ms-Link insights-link root-49"
+                          id="new-tab-link-with-confirmation-dialog__13"
+                          >WCAG 2.4.4</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
                             const targetPageLink = doc.getElementById(linkId);
@@ -2619,36 +2646,9 @@
                         ><span>, </span
                         ><a
                           target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html"
-                          class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__14"
-                          >WCAG 2.4.4</a
-                        ><script>
-                          (function (linkId, doc, confirmCallback) {
-                            const targetPageLink = doc.getElementById(linkId);
-                            targetPageLink.addEventListener("click", function (
-                              event
-                            ) {
-                              const result = confirmCallback(
-                                "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                  "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                  "Cancel to stay on the current page."
-                              );
-                              if (result === false) {
-                                event.preventDefault();
-                              }
-                            });
-                          })(
-                            "new-tab-link-with-confirmation-dialog__14",
-                            document,
-                            confirm
-                          );</script
-                        ><span>, </span
-                        ><a
-                          target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__15"
+                          id="new-tab-link-with-confirmation-dialog__14"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2666,7 +2666,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__15",
+                            "new-tab-link-with-confirmation-dialog__14",
                             document,
                             confirm
                           );
@@ -2695,7 +2695,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__16"
+                          id="new-tab-link-with-confirmation-dialog__15"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2713,7 +2713,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__16",
+                            "new-tab-link-with-confirmation-dialog__15",
                             document,
                             confirm
                           );</script
@@ -2722,7 +2722,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__17"
+                          id="new-tab-link-with-confirmation-dialog__16"
                           >WCAG 1.3.1</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2740,7 +2740,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__17",
+                            "new-tab-link-with-confirmation-dialog__16",
                             document,
                             confirm
                           );

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -1622,7 +1622,7 @@
                   href="https://example.com/mock-base-url"
                   class="ms-Link insights-link root-49"
                   title="Mock base without failures or unscannables"
-                  id="new-tab-link-with-confirmation-dialog__18"
+                  id="new-tab-link-with-confirmation-dialog__0"
                   >https://example.com/mock-base-url</a
                 ><script>
                   (function (linkId, doc, confirmCallback) {
@@ -1638,7 +1638,7 @@
                       }
                     });
                   })(
-                    "new-tab-link-with-confirmation-dialog__18",
+                    "new-tab-link-with-confirmation-dialog__0",
                     document,
                     confirm
                   );
@@ -1833,7 +1833,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__19"
+                          id="new-tab-link-with-confirmation-dialog__1"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -1851,7 +1851,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__19",
+                            "new-tab-link-with-confirmation-dialog__1",
                             document,
                             confirm
                           );
@@ -1880,7 +1880,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__20"
+                          id="new-tab-link-with-confirmation-dialog__2"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -1898,7 +1898,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__20",
+                            "new-tab-link-with-confirmation-dialog__2",
                             document,
                             confirm
                           );
@@ -1927,7 +1927,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__21"
+                          id="new-tab-link-with-confirmation-dialog__3"
                           >WCAG 1.3.5</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -1945,7 +1945,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__21",
+                            "new-tab-link-with-confirmation-dialog__3",
                             document,
                             confirm
                           );
@@ -1999,7 +1999,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__22"
+                          id="new-tab-link-with-confirmation-dialog__4"
                           >WCAG 1.1.1</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2017,7 +2017,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__22",
+                            "new-tab-link-with-confirmation-dialog__4",
                             document,
                             confirm
                           );</script
@@ -2026,7 +2026,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__23"
+                          id="new-tab-link-with-confirmation-dialog__5"
                           >WCAG 2.4.4</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2044,7 +2044,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__23",
+                            "new-tab-link-with-confirmation-dialog__5",
                             document,
                             confirm
                           );</script
@@ -2053,7 +2053,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__24"
+                          id="new-tab-link-with-confirmation-dialog__6"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2071,7 +2071,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__24",
+                            "new-tab-link-with-confirmation-dialog__6",
                             document,
                             confirm
                           );
@@ -2100,7 +2100,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__25"
+                          id="new-tab-link-with-confirmation-dialog__7"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2118,7 +2118,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__25",
+                            "new-tab-link-with-confirmation-dialog__7",
                             document,
                             confirm
                           );</script
@@ -2127,7 +2127,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__26"
+                          id="new-tab-link-with-confirmation-dialog__8"
                           >WCAG 1.3.1</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2145,7 +2145,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__26",
+                            "new-tab-link-with-confirmation-dialog__8",
                             document,
                             confirm
                           );

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -1622,7 +1622,7 @@
                   href="https://example.com/mock-base-url"
                   class="ms-Link insights-link root-49"
                   title="Mock base without failures or unscannables"
-                  id="new-tab-link-with-confirmation-dialog__16"
+                  id="new-tab-link-with-confirmation-dialog__18"
                   >https://example.com/mock-base-url</a
                 ><script>
                   (function (linkId, doc, confirmCallback) {
@@ -1638,7 +1638,7 @@
                       }
                     });
                   })(
-                    "new-tab-link-with-confirmation-dialog__16",
+                    "new-tab-link-with-confirmation-dialog__18",
                     document,
                     confirm
                   );
@@ -1833,7 +1833,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__17"
+                          id="new-tab-link-with-confirmation-dialog__19"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -1851,7 +1851,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__17",
+                            "new-tab-link-with-confirmation-dialog__19",
                             document,
                             confirm
                           );
@@ -1880,7 +1880,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__18"
+                          id="new-tab-link-with-confirmation-dialog__20"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -1898,7 +1898,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__18",
+                            "new-tab-link-with-confirmation-dialog__20",
                             document,
                             confirm
                           );
@@ -1927,7 +1927,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__19"
+                          id="new-tab-link-with-confirmation-dialog__21"
                           >WCAG 1.3.5</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -1945,7 +1945,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__19",
+                            "new-tab-link-with-confirmation-dialog__21",
                             document,
                             confirm
                           );
@@ -1999,7 +1999,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__20"
+                          id="new-tab-link-with-confirmation-dialog__22"
                           >WCAG 1.1.1</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2017,7 +2017,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__20",
+                            "new-tab-link-with-confirmation-dialog__22",
                             document,
                             confirm
                           );</script
@@ -2026,7 +2026,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__21"
+                          id="new-tab-link-with-confirmation-dialog__23"
                           >WCAG 2.4.4</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2044,7 +2044,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__21",
+                            "new-tab-link-with-confirmation-dialog__23",
                             document,
                             confirm
                           );</script
@@ -2053,7 +2053,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__22"
+                          id="new-tab-link-with-confirmation-dialog__24"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2071,7 +2071,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__22",
+                            "new-tab-link-with-confirmation-dialog__24",
                             document,
                             confirm
                           );
@@ -2100,7 +2100,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__23"
+                          id="new-tab-link-with-confirmation-dialog__25"
                           >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2118,7 +2118,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__23",
+                            "new-tab-link-with-confirmation-dialog__25",
                             document,
                             confirm
                           );</script
@@ -2127,7 +2127,7 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__24"
+                          id="new-tab-link-with-confirmation-dialog__26"
                           >WCAG 1.3.1</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
@@ -2145,7 +2145,7 @@
                               }
                             });
                           })(
-                            "new-tab-link-with-confirmation-dialog__24",
+                            "new-tab-link-with-confirmation-dialog__26",
                             document,
                             confirm
                           );

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -1622,7 +1622,7 @@
                   href="https://example.com/mock-base-url"
                   class="ms-Link insights-link root-49"
                   title="Mock base with failures and unscannables"
-                  id="new-tab-link-with-confirmation-dialog__1"
+                  id="new-tab-link-with-confirmation-dialog__0"
                   >https://example.com/mock-base-url</a
                 ><script>
                   (function (linkId, doc, confirmCallback) {
@@ -1638,7 +1638,7 @@
                       }
                     });
                   })(
-                    "new-tab-link-with-confirmation-dialog__1",
+                    "new-tab-link-with-confirmation-dialog__0",
                     document,
                     confirm
                   );

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -1622,7 +1622,7 @@
                   href="https://example.com/mock-base-url"
                   class="ms-Link insights-link root-49"
                   title="Mock base without failures or unscannables"
-                  id="new-tab-link-with-confirmation-dialog__2"
+                  id="new-tab-link-with-confirmation-dialog__0"
                   >https://example.com/mock-base-url</a
                 ><script>
                   (function (linkId, doc, confirmCallback) {
@@ -1638,7 +1638,7 @@
                       }
                     });
                   })(
-                    "new-tab-link-with-confirmation-dialog__2",
+                    "new-tab-link-with-confirmation-dialog__0",
                     document,
                     confirm
                   );

--- a/packages/report-e2e-tests/src/from-axe-result.test.ts
+++ b/packages/report-e2e-tests/src/from-axe-result.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AxeReportParameters, reporterFactory } from 'accessibility-insights-report';
+import { resetIds } from 'office-ui-fabric-react';
 import * as path from 'path';
 import * as prettier from 'prettier';
 
@@ -15,6 +16,12 @@ describe('fromAxeResult', () => {
 
     describe.each(Object.keys(examples))('with example input "%s"', (exampleName: string) => {
         const input: AxeReportParameters = examples[exampleName];
+
+        beforeEach(() => {
+            // Reset office fabric's id counter so changes to
+            // the id counts in one test will not affect the others
+            resetIds();
+        });
 
         it('produces pinned HTML file', () => {
             const output = reporterFactory().fromAxeResult(input).asHTML();

--- a/packages/report-e2e-tests/src/from-combined-results.test.ts
+++ b/packages/report-e2e-tests/src/from-combined-results.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { reporterFactory, CombinedReportParameters } from 'accessibility-insights-report';
+import { resetIds } from 'office-ui-fabric-react';
 import * as path from 'path';
 import * as prettier from 'prettier';
 
@@ -15,6 +16,12 @@ describe('fromCombinedResults', () => {
 
     describe.each(Object.keys(examples))('with example input "%s"', (exampleName: string) => {
         const input: CombinedReportParameters = examples[exampleName];
+
+        beforeEach(() => {
+            // Reset office fabric's id counter so changes to
+            // the id counts in one test will not affect the others
+            resetIds();
+        });
 
         it('produces pinned HTML file', () => {
             const output = reporterFactory().fromCombinedResults(input).asHTML();

--- a/packages/report-e2e-tests/src/from-summary-results.test.ts
+++ b/packages/report-e2e-tests/src/from-summary-results.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { reporterFactory, SummaryReportParameters } from 'accessibility-insights-report';
+import { resetIds } from 'office-ui-fabric-react';
 import * as path from 'path';
 import * as prettier from 'prettier';
 
@@ -15,6 +16,12 @@ describe('fromSummaryResults', () => {
 
     describe.each(Object.keys(examples))('with example input "%s"', (exampleName: string) => {
         const input: SummaryReportParameters = examples[exampleName];
+
+        beforeEach(() => {
+            // Reset office fabric's id counter so changes to
+            // the id counts in one test will not affect the others
+            resetIds();
+        });
 
         it('produces pinned HTML file', () => {
             const output = reporterFactory().fromSummaryResults(input).asHTML();


### PR DESCRIPTION
#### Description of changes

In the current combined report snapshots, the WCAG links are missing for failed rules because the mock data uses fake rule names that we do not have a guidance link mapping for. This PR updates the data to use real axe rule data, which makes WCAG links appear in the snapshots:

<img width="731" alt="wcag links" src="https://user-images.githubusercontent.com/55459788/97607957-ef14b080-19ce-11eb-870e-ca1a5aa902e0.PNG">

Updating the combined-results-with-issues snapshot also caused the combined-results-without-issues snapshot to change, because the link component used for guidance links uses a getId function from Office Fabric to generate ids, and the id counter is not reset after every test. This PR also adds a resetId call before every report e2e test, so we don't have unexpected snapshot changes like this in the future. This is the reason for the id changes in the other report testing snapshots.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
