### PR TITLE
feat(combined-report-ui): fit and finish for scan details

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -1317,7 +1317,6 @@
       }
       .crawl-details-section--1fOcG .crawl-details-section-list--jnYUU li {
         display: inline-block;
-        padding-top: 6px;
       }
       .crawl-details-section--1fOcG
         .crawl-details-section-list--jnYUU
@@ -1327,10 +1326,23 @@
         position: relative;
         top: 3px;
       }
+      .crawl-details-section--1fOcG
+        .crawl-details-section-list--jnYUU
+        li.targetSite--21S0a {
+        margin-bottom: 6px;
+      }
       .crawl-details-section--1fOcG .text--10LOi,
       .crawl-details-section--1fOcG .label--2A9-a {
         word-break: break-all;
         color: var(--neutral-55);
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: normal;
+        font-size: 14px;
+        line-height: 20px;
+      }
+      .crawl-details-section--1fOcG .label--2A9-a {
         font-weight: 600;
       }
       .crawl-details-section--1fOcG .label--2A9-a.no-icon--1hwhv {

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -1317,7 +1317,6 @@
       }
       .crawl-details-section--1fOcG .crawl-details-section-list--jnYUU li {
         display: inline-block;
-        padding-top: 6px;
       }
       .crawl-details-section--1fOcG
         .crawl-details-section-list--jnYUU
@@ -1327,10 +1326,23 @@
         position: relative;
         top: 3px;
       }
+      .crawl-details-section--1fOcG
+        .crawl-details-section-list--jnYUU
+        li.targetSite--21S0a {
+        margin-bottom: 6px;
+      }
       .crawl-details-section--1fOcG .text--10LOi,
       .crawl-details-section--1fOcG .label--2A9-a {
         word-break: break-all;
         color: var(--neutral-55);
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: normal;
+        font-size: 14px;
+        line-height: 20px;
+      }
+      .crawl-details-section--1fOcG .label--2A9-a {
         font-weight: 600;
       }
       .crawl-details-section--1fOcG .label--2A9-a.no-icon--1hwhv {

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -1317,7 +1317,6 @@
       }
       .crawl-details-section--1fOcG .crawl-details-section-list--jnYUU li {
         display: inline-block;
-        padding-top: 6px;
       }
       .crawl-details-section--1fOcG
         .crawl-details-section-list--jnYUU
@@ -1327,10 +1326,23 @@
         position: relative;
         top: 3px;
       }
+      .crawl-details-section--1fOcG
+        .crawl-details-section-list--jnYUU
+        li.targetSite--21S0a {
+        margin-bottom: 6px;
+      }
       .crawl-details-section--1fOcG .text--10LOi,
       .crawl-details-section--1fOcG .label--2A9-a {
         word-break: break-all;
         color: var(--neutral-55);
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: normal;
+        font-size: 14px;
+        line-height: 20px;
+      }
+      .crawl-details-section--1fOcG .label--2A9-a {
         font-weight: 600;
       }
       .crawl-details-section--1fOcG .label--2A9-a.no-icon--1hwhv {
@@ -1570,7 +1582,7 @@
         ><div class="crawl-details-section--1fOcG"
           ><h2>Scan details</h2
           ><ul class="crawl-details-section-list--jnYUU"
-            ><li
+            ><li class="targetSite--21S0a"
               ><span class="icon--2efHF" aria-hidden="true"
                 ><svg
                   width="17"

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -1317,7 +1317,6 @@
       }
       .crawl-details-section--1fOcG .crawl-details-section-list--jnYUU li {
         display: inline-block;
-        padding-top: 6px;
       }
       .crawl-details-section--1fOcG
         .crawl-details-section-list--jnYUU
@@ -1327,10 +1326,23 @@
         position: relative;
         top: 3px;
       }
+      .crawl-details-section--1fOcG
+        .crawl-details-section-list--jnYUU
+        li.targetSite--21S0a {
+        margin-bottom: 6px;
+      }
       .crawl-details-section--1fOcG .text--10LOi,
       .crawl-details-section--1fOcG .label--2A9-a {
         word-break: break-all;
         color: var(--neutral-55);
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: normal;
+        font-size: 14px;
+        line-height: 20px;
+      }
+      .crawl-details-section--1fOcG .label--2A9-a {
         font-weight: 600;
       }
       .crawl-details-section--1fOcG .label--2A9-a.no-icon--1hwhv {
@@ -1570,7 +1582,7 @@
         ><div class="crawl-details-section--1fOcG"
           ><h2>Scan details</h2
           ><ul class="crawl-details-section-list--jnYUU"
-            ><li
+            ><li class="targetSite--21S0a"
               ><span class="icon--2efHF" aria-hidden="true"
                 ><svg
                   width="17"

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -1317,7 +1317,6 @@
       }
       .crawl-details-section--1fOcG .crawl-details-section-list--jnYUU li {
         display: inline-block;
-        padding-top: 6px;
       }
       .crawl-details-section--1fOcG
         .crawl-details-section-list--jnYUU
@@ -1327,10 +1326,23 @@
         position: relative;
         top: 3px;
       }
+      .crawl-details-section--1fOcG
+        .crawl-details-section-list--jnYUU
+        li.targetSite--21S0a {
+        margin-bottom: 6px;
+      }
       .crawl-details-section--1fOcG .text--10LOi,
       .crawl-details-section--1fOcG .label--2A9-a {
         word-break: break-all;
         color: var(--neutral-55);
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: normal;
+        font-size: 14px;
+        line-height: 20px;
+      }
+      .crawl-details-section--1fOcG .label--2A9-a {
         font-weight: 600;
       }
       .crawl-details-section--1fOcG .label--2A9-a.no-icon--1hwhv {
@@ -1570,7 +1582,7 @@
         ><div class="crawl-details-section--1fOcG"
           ><h2>Scan details</h2
           ><ul class="crawl-details-section-list--jnYUU"
-            ><li
+            ><li class="targetSite--21S0a"
               ><span class="icon--2efHF" aria-hidden="true"
                 ><svg
                   width="17"

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -1317,7 +1317,6 @@
       }
       .crawl-details-section--1fOcG .crawl-details-section-list--jnYUU li {
         display: inline-block;
-        padding-top: 6px;
       }
       .crawl-details-section--1fOcG
         .crawl-details-section-list--jnYUU
@@ -1327,10 +1326,23 @@
         position: relative;
         top: 3px;
       }
+      .crawl-details-section--1fOcG
+        .crawl-details-section-list--jnYUU
+        li.targetSite--21S0a {
+        margin-bottom: 6px;
+      }
       .crawl-details-section--1fOcG .text--10LOi,
       .crawl-details-section--1fOcG .label--2A9-a {
         word-break: break-all;
         color: var(--neutral-55);
+        font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
+          BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
+          sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-weight: normal;
+        font-size: 14px;
+        line-height: 20px;
+      }
+      .crawl-details-section--1fOcG .label--2A9-a {
         font-weight: 600;
       }
       .crawl-details-section--1fOcG .label--2A9-a.no-icon--1hwhv {
@@ -1570,7 +1582,7 @@
         ><div class="crawl-details-section--1fOcG"
           ><h2>Scan details</h2
           ><ul class="crawl-details-section-list--jnYUU"
-            ><li
+            ><li class="targetSite--21S0a"
               ><span class="icon--2efHF" aria-hidden="true"
                 ><svg
                   width="17"

--- a/src/reports/components/report-sections/summary-report-details-section.scss
+++ b/src/reports/components/report-sections/summary-report-details-section.scss
@@ -24,12 +24,15 @@
 
         li {
             display: inline-block;
-            padding-top: 6px;
             .icon {
                 padding-right: 12px;
                 position: relative;
                 top: 3px;
             }
+        }
+
+        li.targetSite {
+            margin-bottom: 6px;
         }
     }
 
@@ -37,6 +40,9 @@
     .label {
         word-break: break-all;
         color: $neutral-55;
+        @include text-style-body-m;
+    }
+    .label {
         font-weight: $fontWeightSemiBold;
     }
     .label.no-icon {

--- a/src/reports/components/report-sections/summary-report-details-section.tsx
+++ b/src/reports/components/report-sections/summary-report-details-section.tsx
@@ -15,9 +15,14 @@ export const SummaryReportDetailsSection = NamedFC<BaseSummaryReportSectionProps
         const { scanMetadata, toUtcString, secondsToTimeString } = props;
         const scanTimespan = scanMetadata.timespan;
 
-        const createListItem = (label: string, content: string | JSX.Element, icon?: JSX.Element) =>
+        const createListItem = (
+            label: string,
+            content: string | JSX.Element,
+            icon?: JSX.Element,
+            className?: string,
+        ) =>
             icon ? (
-                <li>
+                <li className={className}>
                     <span className={styles.icon} aria-hidden="true">
                         {icon}
                     </span>
@@ -25,7 +30,7 @@ export const SummaryReportDetailsSection = NamedFC<BaseSummaryReportSectionProps
                     <span className={styles.text}>{content}</span>
                 </li>
             ) : (
-                <li>
+                <li className={className}>
                     <span className={css(styles.noIcon, styles.label)}>{`${label} `}</span>
                     <span className={styles.text}>{content}</span>
                 </li>
@@ -48,6 +53,7 @@ export const SummaryReportDetailsSection = NamedFC<BaseSummaryReportSectionProps
                             {scanMetadata.targetAppInfo.url}
                         </NewTabLinkWithConfirmationDialog>,
                         <UrlIcon />,
+                        styles.targetSite,
                     )}
                     {createListItem('Scans started', scanStartUTC, <DateIcon />)}
                     {createListItem('Scans completed', scanCompleteUTC)}

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-report-details-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-report-details-section.test.tsx.snap
@@ -10,7 +10,9 @@ exports[` renders 1`] = `
   <ul
     className="crawlDetailsSectionList"
   >
-    <li>
+    <li
+      className="targetSite"
+    >
       <span
         aria-hidden="true"
         className="icon"


### PR DESCRIPTION
#### Description of changes

Fixes font weight and spacing on scan details report section's content.

Out of scope: fixing the font weight on the `<h2>Scan details</h2>` (will look at this in concert with all the other similarly too-heavy `<h2>`s on the page)

Figma:
![image](https://user-images.githubusercontent.com/376284/97616550-13828400-19f3-11eb-8d13-9b25f0872718.png)

Before:
![image](https://user-images.githubusercontent.com/376284/97616517-09608580-19f3-11eb-889e-77a30b6e667d.png)

After:
![image](https://user-images.githubusercontent.com/376284/97616481-ffd71d80-19f2-11eb-89fe-c7f0179bb593.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: part of 1788861
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
