### PR TITLE
test(e2e-flakiness): attempt 2 at suppressing Error: Object e2e issue

### DIFF
--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -48,13 +48,19 @@ export class Page {
                 return; // benign; caused by https://github.com/OfficeDev/office-ui-fabric-react/issues/9715
             }
 
-            if (error.name === 'Error' && error.message === 'Object' && error.stack == null) {
+            const serializedError = serializeError(error);
+            if (serializedError === '[Error: Object]') {
                 // unknown flakiness, tracked by https://github.com/microsoft/accessibility-insights-web/issues/3529
-                console.warn(`'pageerror' (console.error): ${serializeError(error)}`);
+                console.warn(
+                    `'pageerror' (console.error):\n` +
+                        `    name='${error.name}',\n` +
+                        `    message='${error.message}',\n` +
+                        `    serializeError='${serializeError(error)}`,
+                );
                 return;
             }
 
-            forceEventFailure(`'pageerror' (console.error): ${serializeError(error)}`);
+            forceEventFailure(`'pageerror' (console.error): ${serializedError}`);
         });
         underlyingPage.on('requestfailed', request => {
             const failure = request.failure()!;

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -48,19 +48,13 @@ export class Page {
                 return; // benign; caused by https://github.com/OfficeDev/office-ui-fabric-react/issues/9715
             }
 
-            const serializedError = serializeError(error);
-            if (serializedError === '[Error: Object]') {
+            if (`${error.message}` === 'Object') {
                 // unknown flakiness, tracked by https://github.com/microsoft/accessibility-insights-web/issues/3529
-                console.warn(
-                    `'pageerror' (console.error):\n` +
-                        `    name='${error.name}',\n` +
-                        `    message='${error.message}',\n` +
-                        `    serializeError='${serializeError(error)}`,
-                );
+                console.warn(`'pageerror' (console.error): ${serializeError(error)}`);
                 return;
             }
 
-            forceEventFailure(`'pageerror' (console.error): ${serializedError}`);
+            forceEventFailure(`'pageerror' (console.error): ${serializeError(error)}`);
         });
         underlyingPage.on('requestfailed', request => {
             const failure = request.failure()!;


### PR DESCRIPTION
#### Description of changes

It looks like #3530 wasn't actually effective in practice; we're still seeing [build failures](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=15339&view=logs&j=68a299b9-62d0-5a30-ce8c-dfe0a5cc8669&t=a830d86d-93e7-5957-11a0-b663859dbe26&l=34) of the form:

```
    Received: "Playwright.Page 'chrome-extension://eheeiipehjcbehnicfejeidgbhffnikc/background/background.html' emitted 'pageerror' (console.error): [Error]{
    [Error: Object]
    }"

```

I haven't been able to reproduce this locally, so it's not clear to me exactly why the current filtering isn't working; this attempts to filter based on the serialized error based on its real properties, since presumably the real message property is some actual object that won't serialize well rather than the string 'Object'

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: temporary workaround for #3529
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
