### PR TITLE
chore(build): fix ts-jest warning

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -23,7 +23,7 @@ module.exports = {
     displayName: '<should be overriden by individual jest.configs>',
     globals: {
         'ts-jest': {
-            tsConfig: '<rootDir>/tsconfig.json',
+            tsconfig: '<rootDir>/tsconfig.json',
         },
     },
     moduleDirectories: ['node_modules'],


### PR DESCRIPTION
#### Description of changes

A recent ts-jest update started showing this warning when running web unit tests:

```
ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead
```

This resolves the warning.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
