### PR TITLE
chore(build): extend unit test timeout

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -46,7 +46,7 @@ jobs:
 
           - script: yarn test --ci
             displayName: run unit tests
-            timeoutInMinutes: 15
+            timeoutInMinutes: 25
 
           - task: PublishTestResults@2
             inputs:


### PR DESCRIPTION
#### Description of changes

Recently, about 30-40% of PR builds have started failing in unit test timeouts. These cases don't appear to be getting stuck; they seem to make progress and generally time out when they are about 80-95% done.

I picked the new timeout value by extrapolating from the worst-case in these timeouts (`15min * (80%)^(-1) ~= 19min`), adding 25% for future tests' fudge factor (~23.4min), and rounding to the nearest roundish number (25min).

I looked back over history and wasn't able to find any particular change that seemed related to causing the regression (there wasn't a specific suspicious jest update that I saw, in particular). I would like to try to work on improving the perf of these tests (15min is excessive), but I want to get PR builds unblocked in the meantime.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
