### PR TITLE
feat(combined-report-ui): fix failure count in rule header aria-label

### DIFF
--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -1807,7 +1807,7 @@
                         class="collapsible-control"
                         aria-expanded="false"
                         aria-controls="content-container-bypass"
-                        aria-label="bypass 2 Failed Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content"
+                        aria-label="bypass 3 Failed Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content"
                         ><span
                           data-automation-id="rule-detail"
                           class="rule-detail"

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -91,7 +91,8 @@ export const RulesWithInstances = NamedFC<RulesWithInstancesProps>(
             >
                 {rules.map((rule, idx) => {
                     const { pastTense } = outcomeTypeSemantics[outcomeType];
-                    const buttonAriaLabel = `${rule.id} ${rule.nodes.length} ${pastTense} ${rule.description}`;
+                    const count = outcomeCounter(rule.nodes);
+                    const buttonAriaLabel = `${rule.id} ${count} ${pastTense} ${rule.description}`;
                     const CollapsibleComponent = deps.collapsibleControl(
                         getCollapsibleComponentProps(rule, idx, buttonAriaLabel),
                     );

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`RulesWithInstances renders 1`] = `
   data-automation-id="rule-details-group"
 >
   <CollapsibleControlStub
-    buttonAriaLabel="some-rule 1 Passed sample-description"
+    buttonAriaLabel="some-rule 5 Passed sample-description"
     containerAutomationId="cards-rule-group"
     containerClassName="collapsibleRuleDetailsGroup"
     content={

--- a/src/tests/unit/tests/common/components/cards/rules-with-instances.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/rules-with-instances.test.tsx
@@ -28,6 +28,7 @@ describe('RulesWithInstances', () => {
                 <CollapsibleControlStub {...props} />
             ),
         } as RulesWithInstancesDeps;
+        const outcomeCounterStub = () => 5;
 
         const wrapped = shallow(
             <RulesWithInstances
@@ -37,7 +38,7 @@ describe('RulesWithInstances', () => {
                 rules={rules}
                 userConfigurationStoreData={null}
                 targetAppInfo={{ name: 'app' }}
-                outcomeCounter={() => null}
+                outcomeCounter={outcomeCounterStub}
                 headingLevel={5}
             />,
         );


### PR DESCRIPTION
#### Description of changes

Currently, the accessible label for the rules header still reports the count of cards, not the value on the chip, which takes the number of URLs into account in the combined report:

![url-failure-counts](https://user-images.githubusercontent.com/55459788/97760840-60349080-1ac1-11eb-94f1-2cdf6a9c49ef.png)

This PR will use the outcomeCounter in the accessible label, like it is already being used to calculate the number on the chip, so that the two counts match. This will not affect the automated checks or summary reports.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
