### PR TITLE
feat(combined-report-ui): Update InstanceDetailsGroup aria-label for combined report

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -1919,7 +1919,7 @@
                   ><ul
                     data-automation-id="cards-rule-content"
                     class="instance-details-list--2Beza"
-                    aria-label="instances with path, snippet and how to resolve information"
+                    aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
@@ -2049,7 +2049,7 @@
                   ><ul
                     data-automation-id="cards-rule-content"
                     class="instance-details-list--2Beza"
-                    aria-label="instances with path, snippet and how to resolve information"
+                    aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
@@ -2433,7 +2433,7 @@
                   ><ul
                     data-automation-id="cards-rule-content"
                     class="instance-details-list--2Beza"
-                    aria-label="instances with path, snippet and how to resolve information"
+                    aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
@@ -2560,7 +2560,7 @@
                   ><ul
                     data-automation-id="cards-rule-content"
                     class="instance-details-list--2Beza"
-                    aria-label="instances with path, snippet and how to resolve information"
+                    aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
@@ -2893,7 +2893,7 @@
                   ><ul
                     data-automation-id="cards-rule-content"
                     class="instance-details-list--2Beza"
-                    aria-label="instances with path, snippet and how to resolve information"
+                    aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
@@ -3696,7 +3696,7 @@
                   ><ul
                     data-automation-id="cards-rule-content"
                     class="instance-details-list--2Beza"
-                    aria-label="instances with path, snippet and how to resolve information"
+                    aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
@@ -3822,7 +3822,7 @@
                   ><ul
                     data-automation-id="cards-rule-content"
                     class="instance-details-list--2Beza"
-                    aria-label="instances with path, snippet and how to resolve information"
+                    aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
@@ -3948,7 +3948,7 @@
                   ><ul
                     data-automation-id="cards-rule-content"
                     class="instance-details-list--2Beza"
-                    aria-label="instances with path, snippet and how to resolve information"
+                    aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -1939,7 +1939,7 @@
                       ><ul
                         data-automation-id="cards-rule-content"
                         class="instance-details-list--2Beza"
-                        aria-label="instances with path, snippet and how to resolve information"
+                        aria-label="instances with additional information like path, snippet and how to fix"
                         ><li
                           ><div
                             data-automation-id="instance-card"
@@ -2285,7 +2285,7 @@
                       ><ul
                         data-automation-id="cards-rule-content"
                         class="instance-details-list--2Beza"
-                        aria-label="instances with path, snippet and how to resolve information"
+                        aria-label="instances with additional information like path, snippet and how to fix"
                         ><li
                           ><div
                             data-automation-id="instance-card"

--- a/src/common/components/cards/instance-details-group.tsx
+++ b/src/common/components/cards/instance-details-group.tsx
@@ -43,7 +43,7 @@ export const InstanceDetailsGroup = NamedFC<InstanceDetailsGroupProps>(
             <ul
                 data-automation-id={ruleContentAutomationId}
                 className={styles.instanceDetailsList}
-                aria-label="instances with path, snippet and how to resolve information"
+                aria-label="instances with additional information like path, snippet and how to fix"
             >
                 {nodes.map((node, index) => (
                     <li key={`instance-details-${index}`}>

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details-group.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details-group.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InstanceDetailsGroup renders 1`] = `
 <ul
-  aria-label="instances with path, snippet and how to resolve information"
+  aria-label="instances with additional information like path, snippet and how to fix"
   className="instanceDetailsList"
   data-automation-id="cards-rule-content"
 >


### PR DESCRIPTION
#### Description of changes
The existing aria label for the instance details group refers specifically to the path, snippet, and how to fix rows. The combined report has added a potential URL row. This PR updates the label to be accurate for both the combined report and existing scenarios.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
