### PR TITLE
test(e2e-flakiness): update automated checks title test to wait

### DIFF
--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -21,10 +21,16 @@ export class AppController {
         }
     }
 
-    public async getTitle(): Promise<string> {
-        // getTitle() is normally synchronous in Electron, but Spectron overrides this and makes it async, confusing Typescript
-        // tslint:disable-next-line: await-promise
-        return await this.app.webContents.getTitle();
+    public async waitForTitle(expectedTitle: string): Promise<void> {
+        const timeout = DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS;
+        await this.client.waitUntil(
+            async () => {
+                const title = await this.app.webContents.getTitle();
+                return title === expectedTitle;
+            },
+            timeout,
+            `was expecting window title to transition to ${expectedTitle} within ${timeout}ms`,
+        );
     }
 
     public async openDeviceConnectionDialog(): Promise<DeviceConnectionDialogController> {

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -41,7 +41,7 @@ describe('AutomatedChecksView', () => {
     });
 
     it('should use the expected window title', async () => {
-        expect(await app.getTitle()).toBe('Accessibility Insights for Android - Automated checks');
+        await app.waitForTitle('Accessibility Insights for Android - Automated checks');
     });
 
     it('displays automated checks results collapsed by default', async () => {


### PR DESCRIPTION
#### Description of changes

Swaps out `getTitle()` based test for a `waitForTitle()` instead

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
