### PR TITLE
chore(lint): part 1 of reenabling no-floating-promises

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -122,6 +122,7 @@ import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-t
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
 import { MasterCheckBoxConfigProvider } from './handlers/master-checkbox-config-provider';
 import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-handler';
+import { Logger } from 'common/logging/logger';
 
 declare const window: AutoChecker & Window;
 
@@ -486,7 +487,11 @@ if (tabId != null) {
             window.A11YSelfValidator = a11ySelfValidator;
         },
         () => {
-            const renderer = createNullifiedRenderer(document, ReactDOM.render);
+            const renderer = createNullifiedRenderer(
+                document,
+                ReactDOM.render,
+                createDefaultLogger(),
+            );
             renderer.render();
         },
     );
@@ -495,9 +500,10 @@ if (tabId != null) {
 function createNullifiedRenderer(
     doc: Document,
     render: typeof ReactDOM.render,
+    logger: Logger,
 ): NoContentAvailableViewRenderer {
     // using an instance of an actual store (instead of a StoreProxy) so we can get the default state.
-    const store = new UserConfigurationStore(null, new UserConfigurationActions(), null);
+    const store = new UserConfigurationStore(null, new UserConfigurationActions(), null, logger);
     const storesHub = new BaseClientStoresHub<ThemeInnerState>([store]);
 
     const deps: NoContentAvailableViewDeps = {

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -6,6 +6,7 @@ import { ConsoleTelemetryClient } from 'background/telemetry/console-telemetry-c
 import { DebugToolsTelemetryClient } from 'background/telemetry/debug-tools-telemetry-client';
 import { createToolData } from 'common/application-properties-provider';
 import { BrowserAdapterFactory } from 'common/browser-adapters/browser-adapter-factory';
+import { WindowUtils } from 'common/window-utils';
 import { UAParser } from 'ua-parser-js';
 import { AxeInfo } from '../common/axe-info';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -56,6 +57,8 @@ async function initialize(): Promise<void> {
         browserAdapter,
         deprecatedStorageDataKeys,
     );
+
+    const windowUtils = new WindowUtils();
 
     const urlValidator = new UrlValidator(browserAdapter);
     const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(getIndexedDBStore());
@@ -186,6 +189,7 @@ async function initialize(): Promise<void> {
         promiseFactory,
         logger,
         usageLogger,
+        windowUtils,
     );
 
     const targetPageController = new TargetPageController(

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -61,6 +61,7 @@ export class GlobalContextFactory {
             indexedDBInstance,
             persistedData,
             storageAdapter,
+            logger,
         );
 
         const featureFlagsController = new FeatureFlagsController(

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -3,6 +3,7 @@
 import { PermissionsStateStore } from 'background/stores/global/permissions-state-store';
 import { FeatureFlagDefaultsHelper } from 'common/feature-flag-defaults-helper';
 import { getAllFeatureFlagDetails } from 'common/feature-flags';
+import { Logger } from 'common/logging/logger';
 import { BaseStore } from '../../../common/base-store';
 import { BrowserAdapter } from '../../../common/browser-adapters/browser-adapter';
 import { StorageAdapter } from '../../../common/browser-adapters/storage-adapter';
@@ -43,6 +44,7 @@ export class GlobalStoreHub implements StoreHub {
         indexedDbInstance: IndexedDBAPI,
         persistedData: PersistedData,
         storageAdapter: StorageAdapter,
+        logger: Logger,
     ) {
         this.commandStore = new CommandStore(globalActionHub.commandActions, telemetryEventHandler);
         this.featureFlagStore = new FeatureFlagStore(
@@ -66,11 +68,13 @@ export class GlobalStoreHub implements StoreHub {
             indexedDbInstance,
             persistedData.assessmentStoreData,
             new InitialAssessmentStoreDataGenerator(assessmentsProvider.all()),
+            logger,
         );
         this.userConfigurationStore = new UserConfigurationStore(
             persistedData.userConfigurationData,
             globalActionHub.userConfigurationActions,
             indexedDbInstance,
+            logger,
         );
         this.permissionsStateStore = new PermissionsStateStore(
             globalActionHub.permissionsStateActions,

--- a/src/background/stores/global/user-configuration-store.ts
+++ b/src/background/stores/global/user-configuration-store.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Logger } from 'common/logging/logger';
 import { cloneDeep, isPlainObject } from 'lodash';
 import { IndexedDBAPI } from '../../../common/indexedDB/indexedDB';
 import { StoreNames } from '../../../common/stores/store-names';
@@ -33,6 +34,7 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
         private readonly persistedState: UserConfigurationStoreData,
         private readonly userConfigActions: UserConfigurationActions,
         private readonly indexDbApi: IndexedDBAPI,
+        private readonly logger: Logger,
     ) {
         super(StoreNames.UserConfigurationStore);
     }
@@ -133,8 +135,10 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
     };
 
     private saveAndEmitChanged(): void {
-        // tslint:disable-next-line:no-floating-promises - grandfathered-in pre-existing violation
-        this.indexDbApi.setItem(IndexedDBDataKeys.userConfiguration, this.state);
+        this.indexDbApi
+            .setItem(IndexedDBDataKeys.userConfiguration, this.state)
+            .catch(this.logger.error);
+
         this.emitChanged();
     }
 }

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -6,6 +6,7 @@ import { Logger } from 'common/logging/logger';
 import { NotificationCreator } from 'common/notification-creator';
 import { PromiseFactory } from 'common/promises/promise-factory';
 import { StateDispatcher } from 'common/state-dispatcher';
+import { WindowUtils } from 'common/window-utils';
 import { ActionCreator } from './actions/action-creator';
 import { ActionHub } from './actions/action-hub';
 import { CardSelectionActionCreator } from './actions/card-selection-action-creator';
@@ -39,6 +40,7 @@ export class TabContextFactory {
         private readonly promiseFactory: PromiseFactory,
         private readonly logger: Logger,
         private readonly usageLogger: UsageLogger,
+        private readonly windowUtils: WindowUtils,
     ) {}
 
     public createTabContext(
@@ -139,6 +141,8 @@ export class TabContextFactory {
             interpreter,
             storeHub.tabStore,
             storeHub.inspectStore,
+            this.windowUtils,
+            this.logger,
         );
 
         shortcutsPageActionCreator.registerCallbacks();

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -183,12 +183,11 @@ const indexedDBDataKeysToFetch = [
     IndexedDBDataKeys.unifiedFeatureFlags,
 ];
 
-// tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
-getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
-    (persistedData: Partial<PersistedData>) => {
-        const installationData: InstallationData = persistedData.installationData;
+const logger = createDefaultLogger();
 
-        const logger = createDefaultLogger();
+getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
+    .then((persistedData: Partial<PersistedData>) => {
+        const installationData: InstallationData = persistedData.installationData;
 
         const applicationTelemetryDataFactory = getApplicationTelemetryDataFactory(
             installationData,
@@ -203,6 +202,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             persistedData.userConfigurationData,
             userConfigActions,
             indexedDBInstance,
+            logger,
         );
         userConfigurationStore.initialize();
 
@@ -561,5 +561,5 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
         sendAppInitializedTelemetryEvent(telemetryEventHandler, platformInfo);
 
         ipcRendererShim.initializeWindow();
-    },
-);
+    })
+    .catch(logger.error);

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Logger } from 'common/logging/logger';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 
 import { BaseStore } from '../../common/base-store';
@@ -21,25 +22,19 @@ import { PostResolveCallback, RuleAnalyzer } from './rule-analyzer';
 import { TabStopsAnalyzer } from './tab-stops-analyzer';
 
 export class AnalyzerProvider {
-    private tabStopsListener: TabStopsListener;
-    private scopingStore: BaseStore<ScopingStoreData>;
-    private sendMessageDelegate: (message) => void;
-    private scanner: ScannerUtils;
-    private telemetryDataFactory: TelemetryDataFactory;
-    private dateGetter: () => Date;
-
     constructor(
-        tabStopsListener: TabStopsListener,
-        scopingStore: BaseStore<ScopingStoreData>,
-        sendMessageDelegate: (message) => void,
-        scanner: ScannerUtils,
-        telemetryDataFactory: TelemetryDataFactory,
-        dateGetter: () => Date,
+        private readonly tabStopsListener: TabStopsListener,
+        private readonly scopingStore: BaseStore<ScopingStoreData>,
+        private readonly sendMessageDelegate: (message) => void,
+        private readonly scanner: ScannerUtils,
+        private readonly telemetryDataFactory: TelemetryDataFactory,
+        private readonly dateGetter: () => Date,
         private readonly visualizationConfigFactory: VisualizationConfigurationFactory,
-        private filterResultsByRules: IResultRuleFilter,
-        private sendConvertedResults: PostResolveCallback,
-        private sendNeedsReviewResults: PostResolveCallback,
-        private scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
+        private readonly filterResultsByRules: IResultRuleFilter,
+        private readonly sendConvertedResults: PostResolveCallback,
+        private readonly sendNeedsReviewResults: PostResolveCallback,
+        private readonly scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
+        private readonly logger: Logger,
     ) {
         this.tabStopsListener = tabStopsListener;
         this.scopingStore = scopingStore;
@@ -116,6 +111,7 @@ export class AnalyzerProvider {
             new WindowUtils(),
             this.sendMessageDelegate,
             this.scanIncompleteWarningDetector,
+            this.logger,
         );
     }
 
@@ -124,6 +120,7 @@ export class AnalyzerProvider {
             config,
             this.sendMessageDelegate,
             this.scanIncompleteWarningDetector,
+            this.logger,
         );
     }
 }

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -55,6 +55,7 @@ export class AnalyzerProvider {
             this.visualizationConfigFactory,
             null,
             this.scanIncompleteWarningDetector,
+            this.logger,
         );
     }
 
@@ -71,6 +72,7 @@ export class AnalyzerProvider {
             this.visualizationConfigFactory,
             this.sendConvertedResults,
             this.scanIncompleteWarningDetector,
+            this.logger,
         );
     }
 
@@ -87,6 +89,7 @@ export class AnalyzerProvider {
             this.visualizationConfigFactory,
             this.sendNeedsReviewResults,
             this.scanIncompleteWarningDetector,
+            this.logger,
         );
     }
 

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -104,6 +104,7 @@ export class AnalyzerProvider {
             this.visualizationConfigFactory,
             this.filterResultsByRules,
             this.scanIncompleteWarningDetector,
+            this.logger,
         );
     }
 

--- a/src/injected/analyzers/base-analyzer.ts
+++ b/src/injected/analyzers/base-analyzer.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Logger } from 'common/logging/logger';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import * as Q from 'q';
 
@@ -20,21 +21,17 @@ export class BaseAnalyzer implements Analyzer {
     };
 
     constructor(
-        protected config: AnalyzerConfiguration,
-        protected sendMessage: (message) => void,
-        private scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
+        protected readonly config: AnalyzerConfiguration,
+        protected readonly sendMessage: (message) => void,
+        private readonly scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
+        protected readonly logger: Logger,
     ) {
         this.visualizationType = config.testType;
     }
 
     public analyze(): void {
         const results = this.getResults();
-
-        // We intentionally float this promise; the current analyzer API is that analyze starts the
-        // analysis and it's allowed to continue running for arbitrarily long until teardown() is called.
-        //
-        // tslint:disable-next-line:no-floating-promises
-        results.then(this.onResolve);
+        results.then(this.onResolve).catch(this.logger.error);
     }
 
     public teardown(): void {}

--- a/src/injected/analyzers/batched-rule-analyzer.ts
+++ b/src/injected/analyzers/batched-rule-analyzer.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Logger } from 'common/logging/logger';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 
 import { BaseStore } from '../../common/base-store';
@@ -26,6 +27,7 @@ export class BatchedRuleAnalyzer extends RuleAnalyzer {
         protected readonly visualizationConfigFactory: VisualizationConfigurationFactory,
         private postScanFilter: IResultRuleFilter,
         scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
+        logger: Logger,
     ) {
         super(
             config,
@@ -37,6 +39,7 @@ export class BatchedRuleAnalyzer extends RuleAnalyzer {
             visualizationConfigFactory,
             null,
             scanIncompleteWarningDetector,
+            logger,
         );
         BatchedRuleAnalyzer.batchConfigs.push(config);
     }

--- a/src/injected/analyzers/rule-analyzer.ts
+++ b/src/injected/analyzers/rule-analyzer.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScopingInputTypes } from 'background/scoping-input-types';
+import { Logger } from 'common/logging/logger';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import * as Q from 'q';
 
@@ -32,8 +33,9 @@ export class RuleAnalyzer extends BaseAnalyzer {
         protected readonly visualizationConfigFactory: VisualizationConfigurationFactory,
         private postOnResolve: PostResolveCallback,
         scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
+        logger: Logger,
     ) {
-        super(config, sendMessageDelegate, scanIncompleteWarningDetector);
+        super(config, sendMessageDelegate, scanIncompleteWarningDetector, logger);
     }
 
     protected getResults = (): Q.Promise<AxeAnalyzerResult> => {

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Logger } from 'common/logging/logger';
+import { WindowUtils } from 'common/window-utils';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import * as Q from 'q';
 
-import { WindowUtils } from '../../common/window-utils';
 import { TabStopEvent, TabStopsListener } from '../tab-stops-listener';
 import {
     AxeAnalyzerResult,
@@ -32,8 +33,9 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         windowUtils: WindowUtils,
         sendMessageDelegate: (message) => void,
         scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
+        logger: Logger,
     ) {
-        super(config, sendMessageDelegate, scanIncompleteWarningDetector);
+        super(config, sendMessageDelegate, scanIncompleteWarningDetector, logger);
         this.tabStopsListener = tabStopsListener;
         this.windowUtils = windowUtils;
     }
@@ -42,9 +44,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         // We intentionally float this promise; the current analyzer API is that analyze starts the
         // analysis and it's allowed to continue running for arbitrarily long until teardown() is called.
         // We use a Promise for this internally only so we can reuse Q's "onprogress" behavior.
-        //
-        // tslint:disable-next-line:no-floating-promises
-        this.getResults().progress(this.onProgress);
+        this.getResults().progress(this.onProgress).catch(this.logger.error);
     }
 
     protected getResults = (): Q.Promise<AxeAnalyzerResult> => {

--- a/src/injected/client-init.ts
+++ b/src/injected/client-init.ts
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { createDefaultLogger } from 'common/logging/default-logger';
 import { initializeFabricIcons } from '../common/fabric-icons';
 import { MainWindowInitializer } from './main-window-initializer';
 import { WindowInitializer } from './window-initializer';
 
 if (!window.windowInitializer) {
+    const logger = createDefaultLogger();
     initializeFabricIcons();
 
     if (window.top === window) {
@@ -13,6 +15,5 @@ if (!window.windowInitializer) {
         window.windowInitializer = new WindowInitializer();
     }
 
-    // tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
-    window.windowInitializer.initialize();
+    window.windowInitializer.initialize().catch(logger.error);
 }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -321,6 +321,7 @@ export class MainWindowInitializer extends WindowInitializer {
             unifiedResultSender.sendAutomatedChecksResults,
             unifiedResultSender.sendNeedsReviewResults,
             scanIncompleteWarningDetector,
+            logger,
         );
 
         const analyzerStateUpdateHandler = new AnalyzerStateUpdateHandler(

--- a/src/popup/popup-init.ts
+++ b/src/popup/popup-init.ts
@@ -16,14 +16,14 @@ const browserAdapterFactory = new BrowserAdapterFactory(userAgentParser);
 const browserAdapter = browserAdapterFactory.makeFromUserAgent();
 const urlValidator = new UrlValidator(browserAdapter);
 const targetTabFinder = new TargetTabFinder(window, browserAdapter, urlValidator, new UrlParser());
+const logger = createDefaultLogger();
 
 const isSupportedBrowser = createSupportedBrowserChecker(userAgentParser);
 const popupInitializer: PopupInitializer = new PopupInitializer(
     browserAdapter,
     targetTabFinder,
     isSupportedBrowser,
-    createDefaultLogger(),
+    logger,
 );
 
-// tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
-popupInitializer.initialize();
+popupInitializer.initialize().catch(logger.error);

--- a/src/tests/unit/common/assessment-store-data-builder.ts
+++ b/src/tests/unit/common/assessment-store-data-builder.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../common/types/store-data/assessment-result-data';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { BaseDataBuilder } from './base-data-builder';
+import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 
 export class AssessmentsStoreDataBuilder extends BaseDataBuilder<AssessmentStoreData> {
     private storeDataGeneratorMock: IMock<InitialAssessmentStoreDataGenerator>;
@@ -31,6 +32,7 @@ export class AssessmentsStoreDataBuilder extends BaseDataBuilder<AssessmentStore
             null,
             null,
             initialAssessmentStoreDataGenerator || this.getPreparedMock(),
+            failTestOnErrorLogger,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/common/fail-test-on-error-logger.ts
+++ b/src/tests/unit/common/fail-test-on-error-logger.ts
@@ -8,6 +8,8 @@ export const failTestOnErrorLogger: Logger = {
         // intentionally ignored
     },
     error: (message?: string, ...optionalParams: any[]) => {
-        fail(`FailTestOnErrorLogger.error invoked with "${message}" ${inspect(optionalParams)}`);
+        expect(
+            `FailTestOnErrorLogger.error invoked with "${message}" ${inspect(optionalParams)}`,
+        ).toBe('FailTestOnErrorLogger.error never invoked');
     },
 };

--- a/src/tests/unit/common/fail-test-on-error-logger.ts
+++ b/src/tests/unit/common/fail-test-on-error-logger.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { inspect } from 'util';
+import { Logger } from 'common/logging/logger';
+
+export const failTestOnErrorLogger: Logger = {
+    log: () => {
+        // intentionally ignored
+    },
+    error: (message?: string, ...optionalParams: any[]) => {
+        fail(`FailTestOnErrorLogger.error invoked with "${message}" ${inspect(optionalParams)}`);
+    },
+};

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -76,6 +76,7 @@ export class StoreMocks {
         null,
         null,
         null,
+        null,
     ).getDefaultState();
     public scopingStoreData = new ScopingStore(null).getDefaultState();
     public inspectStoreData = new InspectStore(null, null).getDefaultState();

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -10,11 +10,12 @@ import { Interpreter } from 'background/interpreter';
 import { InspectStore } from 'background/stores/inspect-store';
 import { TabStore } from 'background/stores/tab-store';
 import { VisualizationStore } from 'background/stores/visualization-store';
-import { Messages } from '../../../../common/messages';
-import { VisualizationStoreData } from '../../../../common/types/store-data/visualization-store-data';
-import { WindowUtils } from '../../../../common/window-utils';
-import { itIsFunction } from '../../common/it-is-function';
-import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
+import { Messages } from 'common/messages';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { WindowUtils } from 'common/window-utils';
+import { itIsFunction } from 'tests/unit/common/it-is-function';
+import { VisualizationStoreDataBuilder } from 'tests/unit/common/visualization-store-data-builder';
+import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 
 describe('InjectorControllerTest', () => {
     let validator: InjectorControllerValidator;
@@ -176,6 +177,7 @@ class InjectorControllerValidator {
             this.mockTabStore.object,
             this.mockInspectStore.object,
             this.mockWindowUtils.object,
+            failTestOnErrorLogger,
         );
     }
 

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -50,6 +50,7 @@ import {
 import { TabStopEvent } from 'injected/tab-stops-listener';
 import { cloneDeep, isFunction } from 'lodash';
 import { ScanResults } from 'scanner/iruleresults';
+import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DictionaryStringTo } from 'types/common-types';
 import { AssessmentDataBuilder } from '../../../common/assessment-data-builder';
@@ -130,6 +131,7 @@ describe('AssessmentStore', () => {
             null,
             null,
             initialAssessmentStoreDataGeneratorMock.object,
+            failTestOnErrorLogger,
         );
 
         const actualState = testObject.getDefaultState();
@@ -224,6 +226,7 @@ describe('AssessmentStore', () => {
             null,
             persisted,
             initialAssessmentStoreDataGeneratorMock.object,
+            failTestOnErrorLogger,
         );
         const actualState = testObject.getDefaultState();
 
@@ -1981,6 +1984,7 @@ describe('AssessmentStore', () => {
                 indexDBInstanceMock.object,
                 null,
                 initialAssessmentStoreDataGeneratorMock.object,
+                failTestOnErrorLogger,
             );
         return new AssessmentStoreTester(
             AssessmentActions,

--- a/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
@@ -12,6 +12,7 @@ import { PermissionsStateStore } from 'background/stores/global/permissions-stat
 import { ScopingStore } from 'background/stores/global/scoping-store';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
 import { cloneDeep } from 'lodash';
+import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, Mock, Times } from 'typemoq';
 import { BaseStore } from '../../../../../../common/base-store';
 import { IndexedDBAPI } from '../../../../../../common/indexedDB/indexedDB';
@@ -60,6 +61,7 @@ describe('GlobalStoreHubTest', () => {
             idbInstance,
             cloneDeep(persistedDataStub),
             null,
+            failTestOnErrorLogger,
         );
         const allStores = testSubject.getAllStores();
 
@@ -84,6 +86,7 @@ describe('GlobalStoreHubTest', () => {
             idbInstance,
             cloneDeep(persistedDataStub),
             null,
+            failTestOnErrorLogger,
         );
         const allStores = testSubject.getAllStores() as BaseStoreImpl<any>[];
         const initializeMocks: Array<IMock<Function>> = [];

--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -224,6 +224,7 @@ describe('UserConfigurationStoreTest', () => {
                     .setup(i =>
                         i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
                     )
+                    .returns(() => Promise.resolve(true))
                     .verifiable(Times.once());
 
                 storeTester
@@ -279,6 +280,7 @@ describe('UserConfigurationStoreTest', () => {
                     .setup(i =>
                         i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
                     )
+                    .returns(() => Promise.resolve(true))
                     .verifiable(Times.once());
 
                 storeTester
@@ -334,6 +336,7 @@ describe('UserConfigurationStoreTest', () => {
                     .setup(i =>
                         i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
                     )
+                    .returns(() => Promise.resolve(true))
                     .verifiable(Times.once());
 
                 storeTester
@@ -373,6 +376,7 @@ describe('UserConfigurationStoreTest', () => {
                 .setup(i =>
                     i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
                 )
+                .returns(() => Promise.resolve(true))
                 .verifiable(Times.once());
 
             storeTester
@@ -419,6 +423,7 @@ describe('UserConfigurationStoreTest', () => {
                 .setup(indexDb =>
                     indexDb.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
                 )
+                .returns(() => Promise.resolve(true))
                 .verifiable(Times.once());
 
             storeTester
@@ -448,6 +453,7 @@ describe('UserConfigurationStoreTest', () => {
             .setup(indexDb =>
                 indexDb.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
             )
+            .returns(() => Promise.resolve(true))
             .verifiable(Times.once());
 
         storeTester
@@ -468,6 +474,7 @@ describe('UserConfigurationStoreTest', () => {
             .setup(indexDb =>
                 indexDb.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
             )
+            .returns(() => Promise.resolve(true))
             .verifiable(Times.once());
 
         storeTester
@@ -508,6 +515,7 @@ describe('UserConfigurationStoreTest', () => {
                 .setup(i =>
                     i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
                 )
+                .returns(() => Promise.resolve(true))
                 .verifiable(Times.once());
 
             storeTester

--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -23,6 +23,7 @@ import {
     UserConfigurationStoreData,
 } from '../../../../../../common/types/store-data/user-configuration-store';
 import { StoreTester } from '../../../../common/store-tester';
+import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 
 describe('UserConfigurationStoreTest', () => {
     let initialStoreData: UserConfigurationStoreData;
@@ -60,6 +61,7 @@ describe('UserConfigurationStoreTest', () => {
             initialStoreData,
             new UserConfigurationActions(),
             indexDbStrictMock.object,
+            failTestOnErrorLogger,
         );
 
         expect(testSubject.getState()).toBeUndefined();
@@ -70,6 +72,7 @@ describe('UserConfigurationStoreTest', () => {
             null,
             new UserConfigurationActions(),
             indexDbStrictMock.object,
+            failTestOnErrorLogger,
         );
 
         testSubject.initialize();
@@ -82,6 +85,7 @@ describe('UserConfigurationStoreTest', () => {
             cloneDeep(initialStoreData),
             new UserConfigurationActions(),
             indexDbStrictMock.object,
+            failTestOnErrorLogger,
         );
 
         testSubject.initialize();
@@ -108,6 +112,7 @@ describe('UserConfigurationStoreTest', () => {
             persisted as UserConfigurationStoreData,
             new UserConfigurationActions(),
             indexDbStrictMock.object,
+            failTestOnErrorLogger,
         );
 
         testSubject.initialize();
@@ -120,6 +125,7 @@ describe('UserConfigurationStoreTest', () => {
             null,
             new UserConfigurationActions(),
             indexDbStrictMock.object,
+            failTestOnErrorLogger,
         );
         testSubject.initialize();
 
@@ -135,6 +141,7 @@ describe('UserConfigurationStoreTest', () => {
             cloneDeep(initialStoreData),
             new UserConfigurationActions(),
             indexDbStrictMock.object,
+            failTestOnErrorLogger,
         );
 
         const firstCallDefaultState = testSubject.getDefaultState();
@@ -150,6 +157,7 @@ describe('UserConfigurationStoreTest', () => {
             null,
             new UserConfigurationActions(),
             indexDbStrictMock.object,
+            failTestOnErrorLogger,
         );
 
         const firstCallDefaultState = testSubject.getDefaultState();
@@ -165,6 +173,7 @@ describe('UserConfigurationStoreTest', () => {
             initialStoreData,
             new UserConfigurationActions(),
             indexDbStrictMock.object,
+            failTestOnErrorLogger,
         );
 
         expect(testSubject.getId()).toBe(StoreNames[StoreNames.UserConfigurationStore]);
@@ -512,7 +521,12 @@ describe('UserConfigurationStoreTest', () => {
         actionName: keyof UserConfigurationActions,
     ): StoreTester<UserConfigurationStoreData, UserConfigurationActions> {
         const factory = (actions: UserConfigurationActions) =>
-            new UserConfigurationStore(initialStoreData, actions, indexDbStrictMock.object);
+            new UserConfigurationStore(
+                initialStoreData,
+                actions,
+                indexDbStrictMock.object,
+                failTestOnErrorLogger,
+            );
 
         return new StoreTester(UserConfigurationActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -15,6 +15,7 @@ import { TargetTabController } from 'background/target-tab-controller';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { Logger } from 'common/logging/logger';
 import { NotificationCreator } from 'common/notification-creator';
+import { WindowUtils } from 'common/window-utils';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { UnifiedScanResultStore } from '../../../../background/stores/unified-scan-result-store';
 import { UsageLogger } from '../../../../background/usage-logger';
@@ -37,6 +38,7 @@ describe('TabContextFactoryTest', () => {
     let mockLogger: IMock<Logger>;
     let mockUsageLogger: IMock<UsageLogger>;
     let mockNotificationCreator: IMock<NotificationCreator>;
+    let mockWindowUtils: IMock<WindowUtils>;
 
     beforeEach(() => {
         mockBrowserAdapter = Mock.ofType<BrowserAdapter>();
@@ -44,6 +46,7 @@ describe('TabContextFactoryTest', () => {
         mockUsageLogger = Mock.ofType<UsageLogger>();
         mockDetailsViewController = Mock.ofType<ExtensionDetailsViewController>();
         mockNotificationCreator = Mock.ofType<NotificationCreator>();
+        mockWindowUtils = Mock.ofType<WindowUtils>();
     });
 
     it('createInterpreter', () => {
@@ -98,6 +101,7 @@ describe('TabContextFactoryTest', () => {
             promiseFactoryMock.object,
             mockLogger.object,
             mockUsageLogger.object,
+            mockWindowUtils.object,
         );
 
         const tabContext = testObject.createTabContext(

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { ScopingStore } from 'background/stores/global/scoping-store';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, Mock } from 'typemoq';
 
 import { VisualizationConfigurationFactory } from '../../../../../common/configs/visualization-configuration-factory';
@@ -69,6 +70,7 @@ describe('AnalyzerProviderTests', () => {
             sendConvertedResultsMock.object,
             sendNeedsReviewResultsMock.object,
             scanIncompleteWarningDetectorMock.object,
+            failTestOnErrorLogger,
         );
     });
 

--- a/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
@@ -8,6 +8,7 @@ import { VisualizationType } from 'common/types/visualization-type';
 import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { BaseAnalyzer } from 'injected/analyzers/base-analyzer';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 
 describe('BaseAnalyzer', () => {
     let testSubject: BaseAnalyzer;
@@ -29,6 +30,7 @@ describe('BaseAnalyzer', () => {
             configStub,
             sendMessageMock.object,
             scanIncompleteWarningDetectorMock.object,
+            failTestOnErrorLogger,
         );
     });
 

--- a/src/tests/unit/tests/injected/analyzers/batched-rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/batched-rule-analyzer.test.ts
@@ -4,6 +4,7 @@ import { ScopingInputTypes } from 'background/scoping-input-types';
 import { ScopingStore } from 'background/stores/global/scoping-store';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { clone, isFunction } from 'lodash';
+import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { VisualizationConfiguration } from '../../../../../common/configs/visualization-configuration';
@@ -292,6 +293,7 @@ describe('BatchedRuleAnalyzer', () => {
             visualizationConfigurationFactoryMock.object,
             resultConfigFilterMock.object,
             scanIncompleteWarningDetectorMock.object,
+            failTestOnErrorLogger,
         );
     }
 });

--- a/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
@@ -4,6 +4,7 @@ import { ScopingInputTypes } from 'background/scoping-input-types';
 import { ScopingStore } from 'background/stores/global/scoping-store';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { isFunction } from 'lodash';
+import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { VisualizationConfiguration } from '../../../../../common/configs/visualization-configuration';
@@ -136,6 +137,7 @@ describe('RuleAnalyzer', () => {
             visualizationConfigurationFactoryMock.object,
             postResolveCallbackMock.object,
             scanIncompleteWarningDetectorMock.object,
+            failTestOnErrorLogger,
         );
 
         const scanResults = createTestResults();

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -1,18 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
-import { Message } from '../../../../../common/message';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { WindowUtils } from '../../../../../common/window-utils';
-import {
-    FocusAnalyzerConfiguration,
-    ScanBasePayload,
-} from '../../../../../injected/analyzers/analyzer';
-import { TabStopsAnalyzer } from '../../../../../injected/analyzers/tab-stops-analyzer';
-import { TabStopEvent, TabStopsListener } from '../../../../../injected/tab-stops-listener';
-import { itIsFunction } from '../../../common/it-is-function';
+import { Message } from 'common/message';
+import { VisualizationType } from 'common/types/visualization-type';
+import { WindowUtils } from 'common/window-utils';
+import { FocusAnalyzerConfiguration, ScanBasePayload } from 'injected/analyzers/analyzer';
+import { TabStopsAnalyzer } from 'injected/analyzers/tab-stops-analyzer';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { TabStopEvent, TabStopsListener } from 'injected/tab-stops-listener';
+import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
+import { itIsFunction } from 'tests/unit/common/it-is-function';
 
 describe('TabStopsAnalyzer', () => {
     let windowUtilsMock: IMock<WindowUtils>;
@@ -50,6 +48,7 @@ describe('TabStopsAnalyzer', () => {
             windowUtilsMock.object,
             sendMessageMock.object,
             scanIncompleteWarningDetectorMock.object,
+            failTestOnErrorLogger,
         );
         typeStub = -1 as VisualizationType;
     });

--- a/src/tests/unit/tests/injected/frameCommunicators/frame-communicator.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/frame-communicator.test.ts
@@ -19,7 +19,7 @@ import { QStub } from '../../../stubs/q-stub';
 
 // These tests were written before we started enforcing no-floating-promises, and we've grandfathered in
 // their warnings because they pervasively use a Q-mocking strategy that consistently trips the check.
-// tslint:disable:no-floating-promises
+/* eslint-disable @typescript-eslint/no-floating-promises */
 
 interface FrameInfo {
     frameElement: HTMLIFrameElement;


### PR DESCRIPTION
#### Description of changes

When we transitioned from tslint to eslint, we disabled the no-floating-promises rule due to high false positives. This PR is part 1 of working towards re-enabling it; it fixes about half the issues it catches.

It mostly does this by adding `.catch(logger.error)` behavior to floating cases; that essentially matches the behavior in most browsers from leaving them floating, so it shouldn't have a behavioral impact.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
