### PR TITLE
refactor: clarify naming/usage of visualization store injectionInProgress

### DIFF
--- a/src/background/injector-controller.ts
+++ b/src/background/injector-controller.ts
@@ -32,15 +32,17 @@ export class InjectorController {
 
     private inject = (): void => {
         const tabId: number = this.tabStore.getState().id;
-        const visualizationStoreState = this.visualizationStore.getState();
         const inspectStoreState = this.inspectStore.getState();
+        const visualizationStoreState = this.visualizationStore.getState();
 
-        if (
-            ((this.oldInspectType !== inspectStoreState.inspectMode &&
-                inspectStoreState.inspectMode !== InspectMode.off) ||
-                visualizationStoreState.injectingInProgress === true) &&
-            !visualizationStoreState.injectingStarted
-        ) {
+        const inspectStoreInjectingRequested =
+            this.oldInspectType !== inspectStoreState.inspectMode &&
+            inspectStoreState.inspectMode !== InspectMode.off;
+
+        const isInjectingRequested =
+            inspectStoreInjectingRequested || visualizationStoreState.injectingRequested;
+
+        if (isInjectingRequested && !visualizationStoreState.injectingStarted) {
             this.windowUtils.setTimeout(() => {
                 this.interpreter.interpret({
                     messageType: Messages.Visualizations.State.InjectionStarted,

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -97,7 +97,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
             selectedAdhocDetailsView: VisualizationType.Issues,
             selectedDetailsViewPivot: DetailsViewPivotType.fastPass,
             injectingStarted: false,
-            injectingInProgress: null,
+            injectingRequested: false,
             focusedTarget: null,
         };
 
@@ -190,7 +190,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
                 this.state.scanning = configuration.getIdentifier(step);
             }
 
-            this.state.injectingInProgress = true;
+            this.state.injectingRequested = true;
             configuration.enableTest(this.state.tests, payload);
         }
         this.emitChanged();
@@ -242,7 +242,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
     };
 
     private onInjectionCompleted = (): void => {
-        this.state.injectingInProgress = false;
+        this.state.injectingRequested = false;
         this.state.injectingStarted = false;
         this.emitChanged();
     };
@@ -252,7 +252,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
             return;
         }
 
-        this.state.injectingInProgress = true;
+        this.state.injectingRequested = true;
         this.state.injectingStarted = true;
         this.emitChanged();
     };

--- a/src/common/types/store-data/visualization-store-data.ts
+++ b/src/common/types/store-data/visualization-store-data.ts
@@ -18,7 +18,7 @@ export interface VisualizationStoreData {
     selectedFastPassDetailsView: VisualizationType;
     selectedAdhocDetailsView: VisualizationType;
     selectedDetailsViewPivot: DetailsViewPivotType;
-    injectingInProgress: boolean;
+    injectingRequested: boolean;
     injectingStarted: boolean;
     focusedTarget: string[];
 }

--- a/src/injected/analyzer-state-update-handler.ts
+++ b/src/injected/analyzer-state-update-handler.ts
@@ -61,11 +61,11 @@ export class AnalyzerStateUpdateHandler {
         prevState: VisualizationStoreData,
         currState: VisualizationStoreData,
     ): void {
-        if (currState.scanning != null && currState.injectingInProgress !== true) {
+        if (currState.scanning != null && currState.injectingRequested !== true) {
             if (
                 prevState == null ||
                 prevState.scanning !== currState.scanning ||
-                prevState.injectingInProgress !== currState.injectingInProgress
+                prevState.injectingRequested !== currState.injectingRequested
             ) {
                 this.startScan(currState.scanning);
             }

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -181,7 +181,7 @@ exports[`DetailsViewBody render render 1`] = `
       visualizationStoreData={
         Object {
           "focusedTarget": null,
-          "injectingInProgress": null,
+          "injectingRequested": false,
           "injectingStarted": false,
           "scanning": null,
           "selectedAdhocDetailsView": 1,
@@ -485,7 +485,7 @@ exports[`DetailsViewBody render render 1`] = `
         visualizationStoreData={
           Object {
             "focusedTarget": null,
-            "injectingInProgress": null,
+            "injectingRequested": false,
             "injectingStarted": false,
             "scanning": null,
             "selectedAdhocDetailsView": 1,
@@ -796,7 +796,7 @@ exports[`DetailsViewBody render render 1`] = `
             visualizationStoreData={
               Object {
                 "focusedTarget": null,
-                "injectingInProgress": null,
+                "injectingRequested": false,
                 "injectingStarted": false,
                 "scanning": null,
                 "selectedAdhocDetailsView": 1,

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -296,7 +296,7 @@ exports[` render renders normally 1`] = `
     visualizationStoreData={
       Object {
         "focusedTarget": null,
-        "injectingInProgress": null,
+        "injectingRequested": false,
         "injectingStarted": false,
         "scanning": null,
         "selectedAdhocDetailsView": -1,

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -27,7 +27,7 @@ describe('InjectorControllerTest', () => {
 
     test('initialize: inject occurs', async () => {
         const visualizationData = new VisualizationStoreDataBuilder()
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .build();
 
         validator
@@ -78,7 +78,7 @@ describe('InjectorControllerTest', () => {
 
     test("inject doesn't occur when inspect mode changed to off", async () => {
         const visualizationData = new VisualizationStoreDataBuilder()
-            .with('injectingInProgress', false)
+            .with('injectingRequested', false)
             .build();
 
         validator
@@ -102,7 +102,7 @@ describe('InjectorControllerTest', () => {
 
     test('initialize: already injecting => no inject', () => {
         const visualizationData = new VisualizationStoreDataBuilder()
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .with('injectingStarted', true)
             .build();
 
@@ -118,7 +118,7 @@ describe('InjectorControllerTest', () => {
 
     test('initialize: injectingInProgress is false => no inject', () => {
         const visualizationData = new VisualizationStoreDataBuilder()
-            .with('injectingInProgress', false)
+            .with('injectingRequested', false)
             .with('injectingStarted', true)
             .build();
 

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -257,7 +257,7 @@ describe('VisualizationStoreTest ', () => {
             .with('scanning', 'headings')
             .with('selectedAdhocDetailsView', VisualizationType.Issues)
             .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .build();
 
         createStoreTesterForVisualizationActions(actionName)
@@ -277,7 +277,7 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = dataBuilder
             .withHeadingsAssessment(true, payload.requirement)
             .with('selectedAdhocDetailsView', VisualizationType.Issues)
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .build();
 
         createStoreTesterForVisualizationActions(actionName)
@@ -313,7 +313,7 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = new VisualizationStoreDataBuilder()
             .withHeadingsEnable()
             .withHeadingsAssessment(false, HeadingsTestStep.missingHeadings)
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .with('scanning', 'headings')
             .build();
 
@@ -334,7 +334,7 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = new VisualizationStoreDataBuilder()
             .withHeadingsAssessment(true, payload.requirement)
             .withHeadingsEnable()
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .with('scanning', HeadingsTestStep.missingHeadings)
             .build();
 
@@ -357,7 +357,7 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = new VisualizationStoreDataBuilder()
             .withLandmarksAssessment(false, LandmarkTestStep.landmarkRoles)
             .withHeadingsAssessment(true, payload.requirement)
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .with('scanning', HeadingsTestStep.missingHeadings)
             .build();
 
@@ -380,7 +380,7 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = new VisualizationStoreDataBuilder()
             .withHeadingsAssessment(false, HeadingsTestStep.headingFunction)
             .withHeadingsAssessment(true, payload.requirement)
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .with('scanning', HeadingsTestStep.missingHeadings)
             .build();
 
@@ -424,7 +424,7 @@ describe('VisualizationStoreTest ', () => {
         const initialState = dataBuilder.build();
         const expectedState = dataBuilder
             .withTabStopsEnable()
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .with('scanning', 'tabStops')
             .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
             .build();
@@ -506,7 +506,7 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = new VisualizationStoreDataBuilder()
             .withLandmarksEnable()
             .with('scanning', 'landmarks')
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
             .build();
 
@@ -569,7 +569,7 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = new VisualizationStoreDataBuilder()
             .withIssuesEnable()
             .with('scanning', 'issues')
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .with('selectedAdhocDetailsView', VisualizationType.Issues)
             .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
             .build();
@@ -634,7 +634,7 @@ describe('VisualizationStoreTest ', () => {
             .withColorEnable()
             .with('scanning', 'color')
             .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .build();
 
         createStoreTesterForVisualizationActions(actionName)
@@ -691,7 +691,7 @@ describe('VisualizationStoreTest ', () => {
         const initialState = new VisualizationStoreDataBuilder().build();
 
         const expectedState = new VisualizationStoreDataBuilder()
-            .with('injectingInProgress', false)
+            .with('injectingRequested', false)
             .with('injectingStarted', false)
             .build();
 
@@ -709,7 +709,7 @@ describe('VisualizationStoreTest ', () => {
             .build();
 
         const expectedState = new VisualizationStoreDataBuilder()
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .with('injectingStarted', true)
             .build();
 
@@ -727,7 +727,7 @@ describe('VisualizationStoreTest ', () => {
             .build();
 
         const expectedState = new VisualizationStoreDataBuilder()
-            .with('injectingInProgress', null)
+            .with('injectingRequested', null)
             .with('injectingStarted', true)
             .build();
 

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -727,7 +727,7 @@ describe('VisualizationStoreTest ', () => {
             .build();
 
         const expectedState = new VisualizationStoreDataBuilder()
-            .with('injectingRequested', null)
+            .with('injectingRequested', false)
             .with('injectingStarted', true)
             .build();
 

--- a/src/tests/unit/tests/injected/analyzer-state-update-handler.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-state-update-handler.test.ts
@@ -53,7 +53,7 @@ describe('AnalyzerStateUpdateHandlerTest', () => {
     test('do not start scan if inject in progress', () => {
         const state = new VisualizationStoreDataBuilder()
             .with('scanning', 'landmarks')
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .withLandmarksEnable()
             .build();
 
@@ -98,7 +98,7 @@ describe('AnalyzerStateUpdateHandlerTest', () => {
     test('start scan: inject just completed', () => {
         const enabledStep = HeadingsTestStep.headingFunction;
         const prevState = new VisualizationStoreDataBuilder()
-            .with('injectingInProgress', true)
+            .with('injectingRequested', true)
             .with('scanning', enabledStep)
             .withHeadingsAssessment(true, enabledStep)
             .build();


### PR DESCRIPTION
#### Description of changes

I was doing some work in the InjectionController and got confused trying to remember the difference between the VisualizationStoreData properties `injectionStarted` and `injectionInProgress`. This PR:

* Renames `injectionInProgress` to `injectionRequested`, to better reflect its usage
* Extracts the complex if clause in `InjectionController` to give names to individual subparts

No behavior change.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
