### PR TITLE
fix: change text color for report WCAG links and footer text

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -72,6 +72,7 @@
         --nav-link-selected: var(--communication-tint-20);
         --nav-link-expanded: var(--communication-tint-40);
         --insights-button-hover: #0179d4;
+        --report-footer-text: #222222;
         --landmark-contentinfo: #00a88c;
         --landmark-main: #cb2e6d;
         --landmark-complementary: #6b9d1a;
@@ -623,10 +624,7 @@
       }
       .report-footer-container .report-footer {
         line-height: 20px;
-        color: var(--secondary-text);
-      }
-      .report-footer-container .report-footer .tool-name-link {
-        color: var(--secondary-text) !important;
+        color: var(--report-footer-text);
       }
       @media only screen and (max-width: 1000px) {
         .report-footer-container {
@@ -1147,9 +1145,6 @@
       .rule-details-group--39A1d .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
-      }
-      .rule-details-group--39A1d .rule-detail .guidance-links a {
-        color: var(--secondary-text) !important;
       }
       .collapsible-rule-details-group--3aN3u {
         box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -72,6 +72,7 @@
         --nav-link-selected: var(--communication-tint-20);
         --nav-link-expanded: var(--communication-tint-40);
         --insights-button-hover: #0179d4;
+        --report-footer-text: #222222;
         --landmark-contentinfo: #00a88c;
         --landmark-main: #cb2e6d;
         --landmark-complementary: #6b9d1a;
@@ -623,10 +624,7 @@
       }
       .report-footer-container .report-footer {
         line-height: 20px;
-        color: var(--secondary-text);
-      }
-      .report-footer-container .report-footer .tool-name-link {
-        color: var(--secondary-text) !important;
+        color: var(--report-footer-text);
       }
       @media only screen and (max-width: 1000px) {
         .report-footer-container {
@@ -1147,9 +1145,6 @@
       .rule-details-group--39A1d .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
-      }
-      .rule-details-group--39A1d .rule-detail .guidance-links a {
-        color: var(--secondary-text) !important;
       }
       .collapsible-rule-details-group--3aN3u {
         box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -72,6 +72,7 @@
         --nav-link-selected: var(--communication-tint-20);
         --nav-link-expanded: var(--communication-tint-40);
         --insights-button-hover: #0179d4;
+        --report-footer-text: #222222;
         --landmark-contentinfo: #00a88c;
         --landmark-main: #cb2e6d;
         --landmark-complementary: #6b9d1a;
@@ -623,10 +624,7 @@
       }
       .report-footer-container .report-footer {
         line-height: 20px;
-        color: var(--secondary-text);
-      }
-      .report-footer-container .report-footer .tool-name-link {
-        color: var(--secondary-text) !important;
+        color: var(--report-footer-text);
       }
       @media only screen and (max-width: 1000px) {
         .report-footer-container {
@@ -1147,9 +1145,6 @@
       .rule-details-group--39A1d .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
-      }
-      .rule-details-group--39A1d .rule-detail .guidance-links a {
-        color: var(--secondary-text) !important;
       }
       .collapsible-rule-details-group--3aN3u {
         box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -72,6 +72,7 @@
         --nav-link-selected: var(--communication-tint-20);
         --nav-link-expanded: var(--communication-tint-40);
         --insights-button-hover: #0179d4;
+        --report-footer-text: #222222;
         --landmark-contentinfo: #00a88c;
         --landmark-main: #cb2e6d;
         --landmark-complementary: #6b9d1a;
@@ -623,10 +624,7 @@
       }
       .report-footer-container .report-footer {
         line-height: 20px;
-        color: var(--secondary-text);
-      }
-      .report-footer-container .report-footer .tool-name-link {
-        color: var(--secondary-text) !important;
+        color: var(--report-footer-text);
       }
       @media only screen and (max-width: 1000px) {
         .report-footer-container {
@@ -1147,9 +1145,6 @@
       .rule-details-group--39A1d .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
-      }
-      .rule-details-group--39A1d .rule-detail .guidance-links a {
-        color: var(--secondary-text) !important;
       }
       .collapsible-rule-details-group--3aN3u {
         box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -72,6 +72,7 @@
         --nav-link-selected: var(--communication-tint-20);
         --nav-link-expanded: var(--communication-tint-40);
         --insights-button-hover: #0179d4;
+        --report-footer-text: #222222;
         --landmark-contentinfo: #00a88c;
         --landmark-main: #cb2e6d;
         --landmark-complementary: #6b9d1a;
@@ -623,10 +624,7 @@
       }
       .report-footer-container .report-footer {
         line-height: 20px;
-        color: var(--secondary-text);
-      }
-      .report-footer-container .report-footer .tool-name-link {
-        color: var(--secondary-text) !important;
+        color: var(--report-footer-text);
       }
       @media only screen and (max-width: 1000px) {
         .report-footer-container {
@@ -1147,9 +1145,6 @@
       .rule-details-group--39A1d .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
-      }
-      .rule-details-group--39A1d .rule-detail .guidance-links a {
-        color: var(--secondary-text) !important;
       }
       .collapsible-rule-details-group--3aN3u {
         box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -72,6 +72,7 @@
         --nav-link-selected: var(--communication-tint-20);
         --nav-link-expanded: var(--communication-tint-40);
         --insights-button-hover: #0179d4;
+        --report-footer-text: #222222;
         --landmark-contentinfo: #00a88c;
         --landmark-main: #cb2e6d;
         --landmark-complementary: #6b9d1a;
@@ -623,10 +624,7 @@
       }
       .report-footer-container .report-footer {
         line-height: 20px;
-        color: var(--secondary-text);
-      }
-      .report-footer-container .report-footer .tool-name-link {
-        color: var(--secondary-text) !important;
+        color: var(--report-footer-text);
       }
       @media only screen and (max-width: 1000px) {
         .report-footer-container {
@@ -1147,9 +1145,6 @@
       .rule-details-group--39A1d .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
-      }
-      .rule-details-group--39A1d .rule-detail .guidance-links a {
-        color: var(--secondary-text) !important;
       }
       .collapsible-rule-details-group--3aN3u {
         box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);

--- a/src/common/components/cards/rules-with-instances.scss
+++ b/src/common/components/cards/rules-with-instances.scss
@@ -33,12 +33,6 @@
             color: $secondary-text !important;
             word-break: break-all;
         }
-
-        :global(.guidance-links) {
-            a {
-                color: $secondary-text !important;
-            }
-        }
     }
 }
 

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -90,6 +90,7 @@ $nav-link-hover: var(--nav-link-hover);
 $nav-link-selected: var(--nav-link-selected);
 $nav-link-expanded: var(--nav-link-expanded);
 $insights-button-hover: var(--insights-button-hover);
+$report-footer-text: var(--report-footer-text);
 
 // Consistent colors that don't vary with high contrast mode. Use sparingly.
 $always-white: var(--white);

--- a/src/common/styles/root-level-only/color-definitions.scss
+++ b/src/common/styles/root-level-only/color-definitions.scss
@@ -89,6 +89,7 @@
     --nav-link-selected: var(--communication-tint-20);
     --nav-link-expanded: var(--communication-tint-40);
     --insights-button-hover: #0179d4;
+    --report-footer-text: #222222;
 
     // Landmark colors
     --landmark-contentinfo: #00a88c;

--- a/src/reports/components/report-sections/footer-section.scss
+++ b/src/reports/components/report-sections/footer-section.scss
@@ -11,11 +11,7 @@
     .report-footer {
         line-height: 20px;
 
-        color: $secondary-text;
-
-        .tool-name-link {
-            color: $secondary-text !important;
-        }
+        color: $report-footer-text;
     }
 
     @media only screen and (max-width: 1000px) {


### PR DESCRIPTION
#### Description of changes

Change WCAG links and tool link in the report to our usual blue link color so the links are distinguishable from the rest of the text. Also make the footer text darker to have 3:1 contrast with the link color.

Before:
<img width="730" alt="wcag links before" src="https://user-images.githubusercontent.com/55459788/98171059-f5f66400-1ea3-11eb-8c07-7bd1c5f5c5ed.PNG">
<img width="721" alt="footer text before" src="https://user-images.githubusercontent.com/55459788/98171077-fb53ae80-1ea3-11eb-8dd2-76b3948a1964.PNG">

After:
<img width="738" alt="wcag links after" src="https://user-images.githubusercontent.com/55459788/98171111-0c9cbb00-1ea4-11eb-9767-fcd75c1e77dc.PNG">
<img width="730" alt="footer text after" src="https://user-images.githubusercontent.com/55459788/98171127-10c8d880-1ea4-11eb-8f47-988dcf5420f0.PNG">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3448
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
