### PR TITLE
chore(null): fix all remaining null:find results

### DIFF
--- a/src/common/html-element-utils.ts
+++ b/src/common/html-element-utils.ts
@@ -9,8 +9,8 @@ export class HTMLElementUtils {
         this.clientWindow = clientWindow || window;
     }
 
-    public getContentWindow(frame: HTMLIFrameElement): Window | null {
-        return frame.contentWindow;
+    public getContentWindow(frame?: HTMLIFrameElement): Window | null {
+        return frame?.contentWindow ?? null;
     }
 
     public scrollInToView(element: Element): void {

--- a/src/injected/analyzers/rule-analyzer.ts
+++ b/src/injected/analyzers/rule-analyzer.ts
@@ -31,7 +31,7 @@ export class RuleAnalyzer extends BaseAnalyzer {
         protected dateGetter: () => Date,
         protected telemetryFactory: TelemetryDataFactory,
         protected readonly visualizationConfigFactory: VisualizationConfigurationFactory,
-        private postOnResolve: PostResolveCallback,
+        private postOnResolve: PostResolveCallback | null,
         scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
         logger: Logger,
     ) {
@@ -74,7 +74,9 @@ export class RuleAnalyzer extends BaseAnalyzer {
 
     protected onResolve = (analyzerResult: AxeAnalyzerResult): void => {
         this.sendScanCompleteResolveMessage(analyzerResult, this.config);
-        this.postOnResolve(analyzerResult);
+        if (this.postOnResolve != null) {
+            this.postOnResolve(analyzerResult);
+        }
     };
 
     protected sendScanCompleteResolveMessage(

--- a/src/injected/element-finder-by-path.ts
+++ b/src/injected/element-finder-by-path.ts
@@ -25,17 +25,17 @@ export class ElementFinderByPath {
     };
 
     protected onFindElementByPath = (
-        message: ElementFinderByPathMessage,
-        error: ErrorMessageContent,
-        sourceWin: Window,
+        result: any | undefined,
+        error: ErrorMessageContent | undefined,
+        messageSourceWindow: Window,
         responder?: FrameMessageResponseCallback,
     ): void => {
-        this.processRequest(message).then(
+        this.processRequest(result).then(
             result => {
-                responder(result, null, sourceWin);
+                responder != null && responder(result, undefined, messageSourceWindow);
             },
             err => {
-                responder(null, err, sourceWin);
+                responder != null && responder(undefined, err, messageSourceWindow);
             },
         );
     };

--- a/src/injected/frameCommunicators/frame-communicator.ts
+++ b/src/injected/frameCommunicators/frame-communicator.ts
@@ -40,25 +40,25 @@ export class FrameCommunicator {
             this.subscribe(
                 FrameCommunicator.PingCommand,
                 (
-                    data: any,
-                    error: ErrorMessageContent,
+                    result: any | undefined,
+                    error: ErrorMessageContent | undefined,
                     messageSourceWindow: Window,
-                    callback: Function,
+                    responder?: FrameMessageResponseCallback,
                 ) => {
-                    this.invokeMethodIfExists(callback, data);
+                    this.invokeMethodIfExists(responder, result);
                 },
             );
 
             this.subscribe(
                 FrameCommunicator.DisposeCommand,
                 (
-                    data: any,
-                    error: ErrorMessageContent,
+                    result: any | undefined,
+                    error: ErrorMessageContent | undefined,
                     messageSourceWindow: Window,
-                    callback: Function,
+                    responder?: FrameMessageResponseCallback,
                 ) => {
                     this.dispose().then(() => {
-                        this.invokeMethodIfExists(callback, data);
+                        this.invokeMethodIfExists(responder, result);
                     });
                 },
             );
@@ -150,7 +150,7 @@ export class FrameCommunicator {
     private doesFrameSupportScripting(frame: HTMLIFrameElement): boolean {
         return (
             !frame.hasAttribute('sandbox') ||
-            frame.getAttribute('sandbox').toLocaleLowerCase().lastIndexOf('allow-scripts') >= 0
+            frame.getAttribute('sandbox')!.toLocaleLowerCase().lastIndexOf('allow-scripts') >= 0
         );
     }
 
@@ -171,7 +171,7 @@ export class FrameCommunicator {
         return this.q.timeout(promise, timeOut);
     }
 
-    private invokeMethodIfExists(method: Function, data?: any): void {
+    private invokeMethodIfExists(method?: Function, data?: any): void {
         if (method) {
             method(data);
         }

--- a/src/injected/frameCommunicators/scrolling-controller.ts
+++ b/src/injected/frameCommunicators/scrolling-controller.ts
@@ -27,12 +27,12 @@ export class ScrollingController {
     }
 
     private onTriggerScrolling = (
-        message: ScrollingWindowMessage,
-        error: ErrorMessageContent,
-        sourceWin: Window,
+        result: any | undefined,
+        error: ErrorMessageContent | undefined,
+        messageSourceWindow: Window,
         responder?: FrameMessageResponseCallback,
     ): void => {
-        this.processRequest(message);
+        this.processRequest(result);
     };
 
     public processRequest(message: ScrollingWindowMessage): void {
@@ -48,8 +48,10 @@ export class ScrollingController {
     }
 
     private scrollElementInCurrentFrame(selector: string): void {
-        const targetElement: Element = this.htmlElementUtils.querySelector(selector);
-        this.htmlElementUtils.scrollInToView(targetElement);
+        const targetElement: Element | null = this.htmlElementUtils.querySelector(selector);
+        if (targetElement != null) {
+            this.htmlElementUtils.scrollInToView(targetElement);
+        }
     }
 
     private scrollElementInIFrames(focusedTarget: string[], frame: HTMLIFrameElement): void {

--- a/src/injected/frameCommunicators/window-message-handler.ts
+++ b/src/injected/frameCommunicators/window-message-handler.ts
@@ -7,8 +7,8 @@ import { WindowMessage } from './window-message';
 import { WindowMessageMarshaller } from './window-message-marshaller';
 
 export type FrameMessageResponseCallback = (
-    result: any,
-    error: ErrorMessageContent,
+    result: any | undefined,
+    error: ErrorMessageContent | undefined,
     messageSourceWindow: Window,
     responder?: FrameMessageResponseCallback,
 ) => void;
@@ -66,7 +66,7 @@ export class WindowMessageHandler {
 
     private windowMessageHandler = (e: MessageEvent): void => {
         const sourceWindow = e.source as Window;
-        const data: WindowMessage = this.windowMessageParser.parseMessage(e.data);
+        const data: WindowMessage | null = this.windowMessageParser.parseMessage(e.data);
         if (data == null) {
             return;
         }
@@ -80,11 +80,14 @@ export class WindowMessageHandler {
                 this.processNewMessage(sourceWindow, data);
             }
         } catch (err) {
-            this.post(sourceWindow, data.command, err, null, messageId);
+            this.post(sourceWindow, data.command, err, undefined, messageId);
         }
     };
 
-    private updateResponseCallbackMap(messageId, callback): void {
+    private updateResponseCallbackMap(
+        messageId: string,
+        callback?: FrameMessageResponseCallback,
+    ): void {
         if (callback) {
             this.callbacksForMessagesSentFromCurrentFrame[messageId] = callback;
         } else {

--- a/src/tests/unit/tests/common/html-element-utils.test.ts
+++ b/src/tests/unit/tests/common/html-element-utils.test.ts
@@ -5,17 +5,32 @@ import { It, Mock, Times } from 'typemoq';
 import { HTMLElementUtils } from '../../../../common/html-element-utils';
 import { HTMLCollectionOfBuilder } from '../../common/html-collection-of-builder';
 
-describe('HTMLElementUtilsTest', () => {
-    test('getContentWindow', () => {
-        const testObject = new HTMLElementUtils();
+describe('HTMLElementUtils', () => {
+    describe('getContentWindow', () => {
+        it('returns the frame.contentWindow property', () => {
+            const testObject = new HTMLElementUtils();
 
-        const frame = {
-            contentWindow: 'content-window',
-        } as any;
+            const frame = {
+                contentWindow: 'content-window',
+            } as any;
 
-        const result = testObject.getContentWindow(frame);
+            const result = testObject.getContentWindow(frame);
 
-        expect(result).toEqual(frame.contentWindow);
+            expect(result).toEqual(frame.contentWindow);
+        });
+
+        it.each([null, undefined])('returns null for %p frame', frame => {
+            const testObject = new HTMLElementUtils();
+            expect(testObject.getContentWindow(frame)).toBeNull();
+        });
+
+        it.each([null, undefined])('returns null for %p contentWindow', contentWindow => {
+            const testObject = new HTMLElementUtils();
+            const frame = {
+                contentWindow,
+            } as any;
+            expect(testObject.getContentWindow(frame)).toBeNull();
+        });
     });
 
     test('scrollIntoView', () => {

--- a/src/tests/unit/tests/injected/element-finder-by-path.test.ts
+++ b/src/tests/unit/tests/injected/element-finder-by-path.test.ts
@@ -80,9 +80,8 @@ describe('ElementFinderByPositionTest', () => {
                 errorCallback = error;
             });
 
-        responderMock.setup(rm => rm(resultsStub, null, windowStub)).verifiable();
-
-        responderMock.setup(rm => rm(null, errorStub, windowStub)).verifiable();
+        responderMock.setup(rm => rm(resultsStub, undefined, windowStub)).verifiable();
+        responderMock.setup(rm => rm(undefined, errorStub, windowStub)).verifiable();
 
         testSubject.initialize();
         testSubject.processRequest = processRequestMock.object;

--- a/src/tests/unit/tests/injected/scrolling-controller.test.ts
+++ b/src/tests/unit/tests/injected/scrolling-controller.test.ts
@@ -61,6 +61,40 @@ describe('ScrollingControllerTest', () => {
         HTMLElementUtilsMock.verifyAll();
     });
 
+    test('scroll to nonexistent element is a noop', () => {
+        let subscribeCallback: (result: any, error: any, responder?: any) => void;
+
+        frameCommunicatorMock
+            .setup(fcm =>
+                fcm.subscribe(It.isValue(ScrollingController.triggerScrollingCommand), It.isAny()),
+            )
+            .returns((cmd, func) => {
+                subscribeCallback = func;
+            })
+            .verifiable(Times.once());
+
+        const message: ScrollingWindowMessage = {
+            focusedTarget: ['a'],
+        };
+
+        HTMLElementUtilsMock.setup(dm => dm.querySelector(It.isValue('a')))
+            .returns(() => null)
+            .verifiable(Times.once());
+
+        HTMLElementUtilsMock.setup(h => h.scrollInToView(It.isAny())).verifiable(Times.never());
+
+        const testObject = new ScrollingController(
+            frameCommunicatorMock.object,
+            HTMLElementUtilsMock.object,
+        );
+
+        testObject.initialize();
+        subscribeCallback(message, null);
+
+        frameCommunicatorMock.verifyAll();
+        HTMLElementUtilsMock.verifyAll();
+    });
+
     test('scroll in other frames', () => {
         let subscribeCallback: (result: any, error: any, responder?: any) => void;
 

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -268,6 +268,8 @@
         "./src/injected/analyzers/filter-results.ts",
         "./src/injected/client-utils.ts",
         "./src/injected/constants.ts",
+        "./src/injected/frame-url-finder.ts",
+        "./src/injected/frame-url-search-initiator.ts",
         "./src/injected/frameCommunicators/error-message-content.ts",
         "./src/injected/frameCommunicators/frame-communicator.ts",
         "./src/injected/frameCommunicators/window-message-handler.ts",

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -269,6 +269,7 @@
         "./src/injected/client-utils.ts",
         "./src/injected/constants.ts",
         "./src/injected/frameCommunicators/error-message-content.ts",
+        "./src/injected/frameCommunicators/window-message-handler.ts",
         "./src/injected/frameCommunicators/window-message-marshaller.ts",
         "./src/injected/frameCommunicators/window-message.ts",
         "./src/injected/iframe-detector.ts",

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -268,6 +268,7 @@
         "./src/injected/analyzers/filter-results.ts",
         "./src/injected/client-utils.ts",
         "./src/injected/constants.ts",
+        "./src/injected/element-finder-by-path.ts",
         "./src/injected/frame-url-finder.ts",
         "./src/injected/frame-url-search-initiator.ts",
         "./src/injected/frameCommunicators/error-message-content.ts",

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -374,6 +374,7 @@
         "./src/tests/unit/common/axe-internals.ts",
         "./src/tests/unit/common/base-data-builder.ts",
         "./src/tests/unit/common/event-stub-factory.ts",
+        "./src/tests/unit/common/fail-test-on-error-logger.ts",
         "./src/tests/unit/common/html-collection-of-builder.ts",
         "./src/tests/unit/common/it-is-function.ts",
         "./src/tests/unit/common/node-list-builder.ts",

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -269,6 +269,7 @@
         "./src/injected/client-utils.ts",
         "./src/injected/constants.ts",
         "./src/injected/frameCommunicators/error-message-content.ts",
+        "./src/injected/frameCommunicators/frame-communicator.ts",
         "./src/injected/frameCommunicators/window-message-handler.ts",
         "./src/injected/frameCommunicators/window-message-marshaller.ts",
         "./src/injected/frameCommunicators/window-message.ts",

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -272,6 +272,7 @@
         "./src/injected/frame-url-search-initiator.ts",
         "./src/injected/frameCommunicators/error-message-content.ts",
         "./src/injected/frameCommunicators/frame-communicator.ts",
+        "./src/injected/frameCommunicators/scrolling-controller.ts",
         "./src/injected/frameCommunicators/window-message-handler.ts",
         "./src/injected/frameCommunicators/window-message-marshaller.ts",
         "./src/injected/frameCommunicators/window-message.ts",

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -278,6 +278,7 @@
         "./src/injected/frameCommunicators/window-message-marshaller.ts",
         "./src/injected/frameCommunicators/window-message.ts",
         "./src/injected/iframe-detector.ts",
+        "./src/injected/path-snippet-controller.ts",
         "./src/injected/scan-incomplete-warning-detector.ts",
         "./src/injected/scanner.d.ts",
         "./src/injected/shadow-initializer.ts",


### PR DESCRIPTION
#### Description of changes

This PR resolves all `yarn null:find` results. Unfortunately, that still leaves about half the non-test files in the repo outside of strictNullChecks, so it implies that there's still a bug happening somewhere in `yarn null:find` preventing it from listing all the files it should; fixing that is for a separate PR.

`yarn null:progress` as of this PR:

```markdown
## Web strict-null progress

**49%** complete (**682**/1382 non-test files)

*Contribute at [#2869](https://github.com/microsoft/accessibility-insights-web/issues/2869). Last update: Wed Nov 04 2020*
```

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2869
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
