### PR TITLE
feat(save-and-load-assessment): add save assessment factory

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -531,17 +531,6 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
-    public getAssessment = (event: React.MouseEvent<any>): void => {
-        const telemetry = this.telemetryFactory.fromDetailsView(event);
-        const payload: BaseActionPayload = {
-            telemetry: telemetry,
-        };
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ContinuePreviousAssessment,
-            payload,
-        });
-    };
-
     public startOverAllAssessments = (event: React.MouseEvent<any>): void => {
         const telemetry = this.telemetryFactory.fromDetailsView(event);
         const setDetailsViewRightContentPanelPayload: DetailsViewRightContentPanelType = 'Overview';

--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -531,6 +531,17 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
+    public getAssessment = (event: React.MouseEvent<any>): void => {
+        const telemetry = this.telemetryFactory.fromDetailsView(event);
+        const payload: BaseActionPayload = {
+            telemetry: telemetry,
+        };
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.ContinuePreviousAssessment,
+            payload,
+        });
+    };
+
     public startOverAllAssessments = (event: React.MouseEvent<any>): void => {
         const telemetry = this.telemetryFactory.fromDetailsView(event);
         const setDetailsViewRightContentPanelPayload: DetailsViewRightContentPanelType = 'Overview';

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -22,7 +22,10 @@ import { ExportDialogDeps } from 'DetailsView/components/export-dialog';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { ReportExportButton } from 'DetailsView/components/report-export-button';
 import { ReportExportDialogFactoryProps } from 'DetailsView/components/report-export-dialog-factory';
-import {  SaveAssessmentFactoryDeps, SaveAssessmentFactoryProps } from 'DetailsView/components/save-assessment-factory';
+import {
+    SaveAssessmentFactoryDeps,
+    SaveAssessmentFactoryProps,
+} from 'DetailsView/components/save-assessment-factory';
 import { ShouldShowReportExportButtonProps } from 'DetailsView/components/should-show-report-export-button';
 import { StartOverFactoryDeps } from 'DetailsView/components/start-over-component-factory';
 import {
@@ -45,8 +48,9 @@ export type DetailsViewCommandBarDeps = {
     reportGenerator: ReportGenerator;
     getDateFromTimestamp: (timestamp: string) => Date;
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-} & ExportDialogDeps & SaveAssessmentFactoryDeps &
-    StartOverFactoryDeps
+} & ExportDialogDeps &
+    SaveAssessmentFactoryDeps &
+    StartOverFactoryDeps;
 
 export type CommandBarProps = DetailsViewCommandBarProps;
 
@@ -210,11 +214,9 @@ export class DetailsViewCommandBar extends React.Component<
 
     private renderSaveAssessmentButton = (): JSX.Element | null => {
         if (this.props.featureFlagStoreData.saveAndLoadAssessment) {
-            return (
-                this.props.switcherNavConfiguration.SaveAssessmentFactory({
-                    ...this.props,
-                })
-            );
+            return this.props.switcherNavConfiguration.SaveAssessmentFactory({
+                ...this.props,
+            });
         }
         return null;
     };

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -23,6 +23,7 @@ import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { ReportExportButton } from 'DetailsView/components/report-export-button';
 import { ReportExportDialogFactoryProps } from 'DetailsView/components/report-export-dialog-factory';
 import { SaveAssessmentButton } from 'DetailsView/components/save-assessment-button';
+import { SaveAssessmentFactoryProps, SaveAssessmentFactoryDeps } from 'DetailsView/components/save-assessment-factory';
 import { ShouldShowReportExportButtonProps } from 'DetailsView/components/should-show-report-export-button';
 import { StartOverFactoryDeps } from 'DetailsView/components/start-over-component-factory';
 import {
@@ -45,8 +46,8 @@ export type DetailsViewCommandBarDeps = {
     reportGenerator: ReportGenerator;
     getDateFromTimestamp: (timestamp: string) => Date;
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-} & ExportDialogDeps &
-    StartOverFactoryDeps;
+} & ExportDialogDeps & SaveAssessmentFactoryDeps &
+    StartOverFactoryDeps
 
 export type CommandBarProps = DetailsViewCommandBarProps;
 
@@ -210,11 +211,7 @@ export class DetailsViewCommandBar extends React.Component<
         if (this.props.featureFlagStoreData.saveAndLoadAssessment) {
             return (
             <SaveAssessmentButton
-                getAssessment={
-                    this.props.deps
-                    .detailsViewActionMessageCreator
-                    .getAssessment
-                }
+                getAssessment={}
             />);
         }
         return null;

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -22,8 +22,7 @@ import { ExportDialogDeps } from 'DetailsView/components/export-dialog';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { ReportExportButton } from 'DetailsView/components/report-export-button';
 import { ReportExportDialogFactoryProps } from 'DetailsView/components/report-export-dialog-factory';
-import { SaveAssessmentButton } from 'DetailsView/components/save-assessment-button';
-import { SaveAssessmentFactoryProps, SaveAssessmentFactoryDeps } from 'DetailsView/components/save-assessment-factory';
+import {  SaveAssessmentFactoryDeps, SaveAssessmentFactoryProps } from 'DetailsView/components/save-assessment-factory';
 import { ShouldShowReportExportButtonProps } from 'DetailsView/components/should-show-report-export-button';
 import { StartOverFactoryDeps } from 'DetailsView/components/start-over-component-factory';
 import {
@@ -57,6 +56,8 @@ export type DetailsViewCommandBarState = {
 };
 
 export type ReportExportDialogFactory = (props: ReportExportDialogFactoryProps) => JSX.Element;
+
+export type SaveAssessmentFactory = (props: SaveAssessmentFactoryProps) => JSX.Element;
 
 export interface DetailsViewCommandBarProps {
     deps: DetailsViewCommandBarDeps;
@@ -210,9 +211,10 @@ export class DetailsViewCommandBar extends React.Component<
     private renderSaveAssessmentButton = (): JSX.Element | null => {
         if (this.props.featureFlagStoreData.saveAndLoadAssessment) {
             return (
-            <SaveAssessmentButton
-                getAssessment={}
-            />);
+                this.props.switcherNavConfiguration.SaveAssessmentFactory({
+                    ...this.props,
+                })
+            );
         }
         return null;
     };

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -37,8 +37,6 @@ import {
 } from 'DetailsView/components/start-over-dialog';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { FeatureFlags } from 'common/feature-flags';
-import { FlaggedComponent } from 'common/components/flagged-component';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
 import * as styles from './details-view-command-bar.scss';
 import { DetailsRightPanelConfiguration } from './details-view-right-panel';

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -208,7 +208,14 @@ export class DetailsViewCommandBar extends React.Component<
 
     private renderSaveAssessmentButton = (): JSX.Element | null => {
         if (this.props.featureFlagStoreData.saveAndLoadAssessment) {
-            return <SaveAssessmentButton />;
+            return (
+            <SaveAssessmentButton
+                getAssessment={
+                    this.props.deps
+                    .detailsViewActionMessageCreator
+                    .getAssessment
+                }
+            />);
         }
         return null;
     };

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -10,6 +10,7 @@ import { AutomatedChecksCommandBar } from 'DetailsView/components/automated-chec
 import {
     CommandBarProps,
     ReportExportDialogFactory,
+    SaveAssessmentFactory,
 } from 'DetailsView/components/details-view-command-bar';
 import {
     getReportExportDialogForAssessment,
@@ -18,7 +19,6 @@ import {
 import {
     getReportForAssessment,
     getReportForFastPass,
-    SaveAssessmentFactory,
 } from 'DetailsView/components/save-assessment-factory';
 import {
     ShouldShowReportExportButton,

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -16,6 +16,11 @@ import {
     getReportExportDialogForFastPass,
 } from 'DetailsView/components/report-export-dialog-factory';
 import {
+    getReportForAssessment,
+    getReportForFastPass,
+    SaveAssessmentFactory,
+} from 'DetailsView/components/save-assessment-factory';
+import {
     ShouldShowReportExportButton,
     shouldShowReportExportButtonForAssessment,
     shouldShowReportExportButtonForFastpass,
@@ -64,6 +69,7 @@ export type DetailsViewSwitcherNavConfiguration = Readonly<{
     CommandBar: ReactFCWithDisplayName<CommandBarProps>;
     ReportExportDialogFactory: ReportExportDialogFactory;
     shouldShowReportExportButton: ShouldShowReportExportButton;
+    SaveAssessmentFactory: SaveAssessmentFactory;
     StartOverComponentFactory: StartOverComponentFactory;
     LeftNav: ReactFCWithDisplayName<LeftNavProps>;
     getSelectedDetailsView: (props: GetSelectedDetailsViewProps) => VisualizationType;
@@ -75,6 +81,7 @@ type InternalDetailsViewSwitcherNavConfiguration = Readonly<{
     CommandBar: ReactFCWithDisplayName<CommandBarProps>;
     ReportExportDialogFactory: ReportExportDialogFactory;
     shouldShowReportExportButton: ShouldShowReportExportButton;
+    SaveAssessmentFactory: SaveAssessmentFactory;
     StartOverComponentFactory: StartOverComponentFactory;
     LeftNav: ReactFCWithDisplayName<InternalLeftNavProps>;
     getSelectedDetailsView: (props: GetSelectedDetailsViewProps) => VisualizationType;
@@ -93,6 +100,7 @@ const detailsViewSwitcherNavs: {
         CommandBar: AssessmentCommandBar,
         ReportExportDialogFactory: getReportExportDialogForAssessment,
         shouldShowReportExportButton: shouldShowReportExportButtonForAssessment,
+        SaveAssessmentFactory: getReportForAssessment,
         StartOverComponentFactory: AssessmentStartOverFactory,
         LeftNav: AssessmentLeftNav,
         getSelectedDetailsView: getAssessmentSelectedDetailsView,
@@ -103,6 +111,7 @@ const detailsViewSwitcherNavs: {
         CommandBar: AutomatedChecksCommandBar,
         ReportExportDialogFactory: getReportExportDialogForFastPass,
         shouldShowReportExportButton: shouldShowReportExportButtonForFastpass,
+        SaveAssessmentFactory: getReportForFastPass,
         StartOverComponentFactory: FastpassStartOverFactory,
         LeftNav: FastPassLeftNav,
         getSelectedDetailsView: getFastPassSelectedDetailsView,

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -17,8 +17,8 @@ import {
     getReportExportDialogForFastPass,
 } from 'DetailsView/components/report-export-dialog-factory';
 import {
-    getReportForAssessment,
-    getReportForFastPass,
+    getSaveButtonForAssessment,
+    getSaveButtonForFastPass,
 } from 'DetailsView/components/save-assessment-factory';
 import {
     ShouldShowReportExportButton,
@@ -100,7 +100,7 @@ const detailsViewSwitcherNavs: {
         CommandBar: AssessmentCommandBar,
         ReportExportDialogFactory: getReportExportDialogForAssessment,
         shouldShowReportExportButton: shouldShowReportExportButtonForAssessment,
-        SaveAssessmentFactory: getReportForAssessment,
+        SaveAssessmentFactory: getSaveButtonForAssessment,
         StartOverComponentFactory: AssessmentStartOverFactory,
         LeftNav: AssessmentLeftNav,
         getSelectedDetailsView: getAssessmentSelectedDetailsView,
@@ -111,7 +111,7 @@ const detailsViewSwitcherNavs: {
         CommandBar: AutomatedChecksCommandBar,
         ReportExportDialogFactory: getReportExportDialogForFastPass,
         shouldShowReportExportButton: shouldShowReportExportButtonForFastpass,
-        SaveAssessmentFactory: getReportForFastPass,
+        SaveAssessmentFactory: getSaveButtonForFastPass,
         StartOverComponentFactory: FastpassStartOverFactory,
         LeftNav: FastPassLeftNav,
         getSelectedDetailsView: getFastPassSelectedDetailsView,

--- a/src/DetailsView/components/save-assessment-button.tsx
+++ b/src/DetailsView/components/save-assessment-button.tsx
@@ -2,17 +2,12 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
-export interface SaveAssessmentButtonProps {
-    // getAssessment: (e) => void;
-}
+export interface SaveAssessmentButtonProps {}
 
 export class SaveAssessmentButton extends React.Component<SaveAssessmentButtonProps> {
     public render(): JSX.Element {
         return (
-            <InsightsCommandButton
-                iconProps={{ iconName: 'Save' }}
-                // onClick={this.props.getAssessment}
-            >
+            <InsightsCommandButton iconProps={{ iconName: 'Save' }}>
                 Save assessment
             </InsightsCommandButton>
         );

--- a/src/DetailsView/components/save-assessment-button.tsx
+++ b/src/DetailsView/components/save-assessment-button.tsx
@@ -2,13 +2,17 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
-
-export interface SaveAssessmentButtonProps {}
+export interface SaveAssessmentButtonProps {
+    getAssessment: (e) => void;
+}
 
 export class SaveAssessmentButton extends React.Component<SaveAssessmentButtonProps> {
     public render(): JSX.Element {
         return (
-            <InsightsCommandButton iconProps={{ iconName: 'Save' }}>
+            <InsightsCommandButton
+                iconProps={{ iconName: 'Save' }}
+                onClick={this.props.getAssessment}
+            >
                 Save assessment
             </InsightsCommandButton>
         );

--- a/src/DetailsView/components/save-assessment-button.tsx
+++ b/src/DetailsView/components/save-assessment-button.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 export interface SaveAssessmentButtonProps {
-    getAssessment: (e) => void;
+    // getAssessment: (e) => void;
 }
 
 export class SaveAssessmentButton extends React.Component<SaveAssessmentButtonProps> {
@@ -11,7 +11,7 @@ export class SaveAssessmentButton extends React.Component<SaveAssessmentButtonPr
         return (
             <InsightsCommandButton
                 iconProps={{ iconName: 'Save' }}
-                onClick={this.props.getAssessment}
+                // onClick={this.props.getAssessment}
             >
                 Save assessment
             </InsightsCommandButton>

--- a/src/DetailsView/components/save-assessment-factory.tsx
+++ b/src/DetailsView/components/save-assessment-factory.tsx
@@ -2,22 +2,21 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
-import { FileURLProvider } from '../../common/file-url-provider';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { SaveAssessmentButton } from 'DetailsView/components/save-assessment-button';
 
 export type SaveAssessmentFactoryDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-}
+};
 
 export type SaveAssessmentFactoryProps = CommandBarProps & {
     deps: SaveAssessmentFactoryDeps;
-}
+};
 
 export function getReportForAssessment(props: SaveAssessmentFactoryProps): JSX.Element {
-    return <SaveAssessmentButton />
+    return <SaveAssessmentButton />;
 }
 
 export function getReportForFastPass(props: SaveAssessmentFactoryProps): JSX.Element | null {
-    return null
+    return null;
 }

--- a/src/DetailsView/components/save-assessment-factory.tsx
+++ b/src/DetailsView/components/save-assessment-factory.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { FileURLProvider } from '../../common/file-url-provider';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
+import { SaveAssessmentButton } from 'DetailsView/components/save-assessment-button';
 
 export type SaveAssessmentFactoryDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
@@ -15,11 +16,13 @@ export type SaveAssessmentFactoryProps = CommandBarProps & {
 }
 
 export interface SaveAssessmentFactory {
-    getAssessment: (props: SaveAssessmentFactoryProps) => void;
+    // getAssessment: (props: SaveAssessmentFactoryProps) => void;
 }
 
-export function getReportForAssessment(props: SaveAssessmentFactoryProps) :void {
+export function getReportForAssessment(props: SaveAssessmentFactoryProps): JSX.Element {
     const selectedTest = props.assessmentStoreData.assessmentNavState.selectedTestType
+
+    return <SaveAssessmentButton />
 }
 
 export function getReportForFastPass(props: SaveAssessmentFactoryProps) :void {

--- a/src/DetailsView/components/save-assessment-factory.tsx
+++ b/src/DetailsView/components/save-assessment-factory.tsx
@@ -8,23 +8,16 @@ import { SaveAssessmentButton } from 'DetailsView/components/save-assessment-but
 
 export type SaveAssessmentFactoryDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-    fileURLProvider: FileURLProvider;
 }
 
 export type SaveAssessmentFactoryProps = CommandBarProps & {
     deps: SaveAssessmentFactoryDeps;
 }
 
-export interface SaveAssessmentFactory {
-    // getAssessment: (props: SaveAssessmentFactoryProps) => void;
-}
-
 export function getReportForAssessment(props: SaveAssessmentFactoryProps): JSX.Element {
-    const selectedTest = props.assessmentStoreData.assessmentNavState.selectedTestType
-
     return <SaveAssessmentButton />
 }
 
-export function getReportForFastPass(props: SaveAssessmentFactoryProps) :void {
-    const selectedTest = props.assessmentStoreData.assessmentNavState.selectedTestType
+export function getReportForFastPass(props: SaveAssessmentFactoryProps): JSX.Element | null {
+    return null
 }

--- a/src/DetailsView/components/save-assessment-factory.tsx
+++ b/src/DetailsView/components/save-assessment-factory.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
+import { FileURLProvider } from '../../common/file-url-provider';
+import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
+
+export type SaveAssessmentFactoryDeps = {
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+    fileURLProvider: FileURLProvider;
+}
+
+export type SaveAssessmentFactoryProps = CommandBarProps & {
+    deps: SaveAssessmentFactoryDeps;
+}
+
+export interface SaveAssessmentFactory {
+    getAssessment: (props: SaveAssessmentFactoryProps) => void;
+}
+
+export function getReportForAssessment(props: SaveAssessmentFactoryProps) :void {
+    const selectedTest = props.assessmentStoreData.assessmentNavState.selectedTestType
+}
+
+export function getReportForFastPass(props: SaveAssessmentFactoryProps) :void {
+    const selectedTest = props.assessmentStoreData.assessmentNavState.selectedTestType
+}

--- a/src/DetailsView/components/save-assessment-factory.tsx
+++ b/src/DetailsView/components/save-assessment-factory.tsx
@@ -2,21 +2,18 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
-import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { SaveAssessmentButton } from 'DetailsView/components/save-assessment-button';
 
-export type SaveAssessmentFactoryDeps = {
-    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-};
+export type SaveAssessmentFactoryDeps = {};
 
 export type SaveAssessmentFactoryProps = CommandBarProps & {
     deps: SaveAssessmentFactoryDeps;
 };
 
-export function getReportForAssessment(props: SaveAssessmentFactoryProps): JSX.Element {
+export function getSaveButtonForAssessment(props: SaveAssessmentFactoryProps): JSX.Element {
     return <SaveAssessmentButton />;
 }
 
-export function getReportForFastPass(props: SaveAssessmentFactoryProps): JSX.Element | null {
+export function getSaveButtonForFastPass(props: SaveAssessmentFactoryProps): JSX.Element | null {
     return null;
 }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -66,7 +66,9 @@ exports[`DetailsViewCommandBar renders with export button, with save assessment,
       buttonRef={[Function]}
       showReportExportDialog={[Function]}
     />
-    <SaveAssessmentButton />
+    <div>
+      Save assessment
+    </div>
     <CustomizedActionButton>
       Start Over Component
     </CustomizedActionButton>
@@ -131,6 +133,7 @@ exports[`DetailsViewCommandBar renders with export button, with save assessment,
         "CommandBar": [Function],
         "LeftNav": [Function],
         "ReportExportDialogFactory": [Function],
+        "SaveAssessmentFactory": [Function],
         "StartOverComponentFactory": Object {
           "getStartOverComponent": [Function],
         },
@@ -255,6 +258,7 @@ exports[`DetailsViewCommandBar renders with export button, without save assessme
         "CommandBar": [Function],
         "LeftNav": [Function],
         "ReportExportDialogFactory": [Function],
+        "SaveAssessmentFactory": [Function],
         "StartOverComponentFactory": Object {
           "getStartOverComponent": [Function],
         },
@@ -375,6 +379,7 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
         "CommandBar": [Function],
         "LeftNav": [Function],
         "ReportExportDialogFactory": [Function],
+        "SaveAssessmentFactory": [Function],
         "StartOverComponentFactory": Object {
           "getStartOverComponent": [Function],
         },
@@ -488,7 +493,9 @@ exports[`DetailsViewCommandBar renders without export button, with save assessme
   <div
     className="detailsViewCommandButtons"
   >
-    <SaveAssessmentButton />
+    <div>
+      Save assessment
+    </div>
   </div>
   <div>
     Export dialog
@@ -550,6 +557,7 @@ exports[`DetailsViewCommandBar renders without export button, with save assessme
         "CommandBar": [Function],
         "LeftNav": [Function],
         "ReportExportDialogFactory": [Function],
+        "SaveAssessmentFactory": [Function],
         "StartOverComponentFactory": Object {
           "getStartOverComponent": [Function],
         },
@@ -673,6 +681,7 @@ exports[`DetailsViewCommandBar renders without export button, without save asses
         "CommandBar": [Function],
         "LeftNav": [Function],
         "ReportExportDialogFactory": [Function],
+        "SaveAssessmentFactory": [Function],
         "StartOverComponentFactory": Object {
           "getStartOverComponent": [Function],
         },
@@ -789,6 +798,7 @@ exports[`DetailsViewCommandBar renders without export button, without save asses
         "CommandBar": [Function],
         "LeftNav": [Function],
         "ReportExportDialogFactory": [Function],
+        "SaveAssessmentFactory": [Function],
         "StartOverComponentFactory": Object {
           "getStartOverComponent": [Function],
         },

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-factory.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SaveAssessmentFactory getReportForAssessment renders save assessment button 1`] = `<SaveAssessmentButton />`;
+exports[`SaveAssessmentFactory getSaveButtonForAssessment renders save assessment button 1`] = `<SaveAssessmentButton />`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-factory.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SaveAssessmentFactory getReportForAssessment renders save assessment button 1`] = `<SaveAssessmentButton />`;

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -28,12 +28,15 @@ import {
     DetailsViewCommandBar,
     DetailsViewCommandBarProps,
     ReportExportDialogFactory,
+    SaveAssessmentFactory,
 } from '../../../../../DetailsView/components/details-view-command-bar';
+import { SaveAssessmentFactoryProps } from 'DetailsView/components/save-assessment-factory';
 
 describe('DetailsViewCommandBar', () => {
     const thePageTitle = 'command-bar-test-tab-title';
     const thePageUrl = 'command-bar-test-url';
     const reportExportDialogStub = <div>Export dialog</div>;
+    const saveAssessmentStub = <div>Save assessment</div>;
 
     let tabStoreData: TabStoreData;
     let startOverComponent: JSX.Element;
@@ -42,7 +45,7 @@ describe('DetailsViewCommandBar', () => {
     let isCommandBarCollapsed: boolean;
     let showReportExportButton: boolean;
     let reportExportDialogFactory: IMock<ReportExportDialogFactory>;
-    let saveAssessmentButtonMock: IMock<(Props: SaveAssessmentButtonProps) => JSX.Element>;
+    let saveAssessmentFactory: IMock<SaveAssessmentFactory>;
     let getStartOverComponentMock: IMock<(Props: StartOverFactoryProps) => JSX.Element>;
 
     beforeEach(() => {
@@ -51,7 +54,7 @@ describe('DetailsViewCommandBar', () => {
             MockBehavior.Loose,
         );
         reportExportDialogFactory = Mock.ofInstance(props => null);
-        saveAssessmentButtonMock = Mock.ofInstance(props => null);
+        saveAssessmentFactory = Mock.ofInstance(props => null);
         getStartOverComponentMock = Mock.ofInstance(props => null);
         tabStoreData = {
             title: thePageTitle,
@@ -74,6 +77,7 @@ describe('DetailsViewCommandBar', () => {
         const switcherNavConfiguration: DetailsViewSwitcherNavConfiguration = {
             CommandBar: CommandBarStub,
             ReportExportDialogFactory: reportExportDialogFactory.object,
+            SaveAssessmentFactory: saveAssessmentFactory.object,
             shouldShowReportExportButton: p => showReportExportButton,
             StartOverComponentFactory: {
                 getStartOverComponent: getStartOverComponentMock.object,
@@ -290,6 +294,7 @@ describe('DetailsViewCommandBar', () => {
 
         props.featureFlagStoreData = { saveAndLoadAssessment: renderSaveAssessment };
 
+        setupSaveAssessmentFactory(props);
         setupStartOverButtonFactory(props);
         setupReportExportDialogFactory({ isOpen: false });
 
@@ -313,6 +318,11 @@ describe('DetailsViewCommandBar', () => {
     ): void {
         const argMatcher = isNil(expectedProps) ? It.isAny() : It.isObjectWith(expectedProps);
         reportExportDialogFactory.setup(r => r(argMatcher)).returns(() => reportExportDialogStub);
+    }
+
+    function setupSaveAssessmentFactory(expectedProps?: Partial<SaveAssessmentFactoryProps>): void {
+        const argMatcher = isNil(expectedProps) ? It.isAny() : It.isObjectWith(expectedProps);
+        saveAssessmentFactory.setup(r => r(argMatcher)).returns(() => saveAssessmentStub);
     }
 
     function setupStartOverButtonFactory(props: CommandBarProps): void {

--- a/src/tests/unit/tests/DetailsView/components/save-assessment-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/save-assessment-factory.test.tsx
@@ -1,24 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import {
-    getReportForAssessment,
-    getReportForFastPass,
+    getSaveButtonForAssessment,
+    getSaveButtonForFastPass,
     SaveAssessmentFactoryProps,
 } from 'DetailsView/components/save-assessment-factory';
 
 describe('SaveAssessmentFactory', () => {
     let props: SaveAssessmentFactoryProps;
 
-    describe('getReportForAssessment', () => {
+    describe('getSaveButtonForAssessment', () => {
         test('renders save assessment button', () => {
-            const rendered = getReportForAssessment(props);
+            const rendered = getSaveButtonForAssessment(props);
             expect(rendered).toMatchSnapshot();
         });
     });
 
-    describe('getReportForFastPass', () => {
+    describe('getSaveButtonForFastPass', () => {
         test('renders save assessment button as null', () => {
-            const rendered = getReportForFastPass(props);
+            const rendered = getSaveButtonForFastPass(props);
             expect(rendered).toBeNull();
         });
     });

--- a/src/tests/unit/tests/DetailsView/components/save-assessment-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/save-assessment-factory.test.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    getReportForAssessment,
+    getReportForFastPass,
+    SaveAssessmentFactoryProps,
+} from 'DetailsView/components/save-assessment-factory';
+
+describe('SaveAssessmentFactory', () => {
+    let props: SaveAssessmentFactoryProps;
+
+    describe('getReportForAssessment', () => {
+        test('renders save assessment button', () => {
+            const rendered = getReportForAssessment(props);
+            expect(rendered).toMatchSnapshot();
+        });
+    });
+
+    describe('getReportForFastPass', () => {
+        test('renders save assessment button as null', () => {
+            const rendered = getReportForFastPass(props);
+            expect(rendered).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
#### Description of changes
This PR adds the save assessment factory and removes the save assessment button from rendering in FastPass. 


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Feature request #653
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS

FastPass:
![image](https://user-images.githubusercontent.com/18401275/98182473-b129f780-1eba-11eb-9639-1da8532756a3.png)

Assessments:
![image](https://user-images.githubusercontent.com/18401275/98182506-cc950280-1eba-11eb-84e2-c8568589e708.png)

