### PR TITLE
feat(android-needs-review): use android Continue Investigating text in needs review congrats message

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -455,7 +455,7 @@ if (tabId != null) {
                 isResultHighlightUnavailable: isResultHighlightUnavailableWeb,
                 setFocusVisibility,
                 documentManipulator,
-                customCongratsMessage: null, // uses default message
+                customCongratsContinueInvestigatingMessage: null, // uses default message
                 scopingActionMessageCreator,
                 inspectActionMessageCreator,
                 issuesSelection,

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -487,8 +487,8 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
             unifiedResultToIssueFilingDataConverter: new UnifiedResultToIssueFilingDataConverter(),
             windowUtils: windowUtils,
             setFocusVisibility,
-            customCongratsMessage:
-                "No failed automated checks were found. Continue investigating your app's accessibility compliance through manual testing.",
+            customCongratsContinueInvestigatingMessage:
+                "Continue investigating your app's accessibility compliance through manual testing.",
         };
 
         const documentManipulator = new DocumentManipulator(document);

--- a/src/reports/components/report-sections/no-failed-instances-congrats.tsx
+++ b/src/reports/components/report-sections/no-failed-instances-congrats.tsx
@@ -7,7 +7,7 @@ import { InstanceOutcomeType } from 'reports/components/instance-outcome-type';
 import * as styles from './no-failed-instances-congrats.scss';
 
 export type NoFailedInstancesCongratsDeps = {
-    customCongratsMessage: String;
+    customCongratsContinueInvestigatingMessage?: string;
 };
 
 export type NoFailedInstancesCongratsProps = {
@@ -20,9 +20,10 @@ export const NoFailedInstancesCongrats = NamedFC<NoFailedInstancesCongratsProps>
     props => {
         const messageSubject =
             props.outcomeType === 'review' ? 'instances to review' : 'failed automated checks';
-        const message =
-            props.deps.customCongratsMessage ??
-            `No ${messageSubject} were found. Continue investigating your website's accessibility compliance through manual testing using Tab stops and Assessment in Accessibility Insights for Web.`;
+        const continueInvestigatingMessage =
+            props.deps.customCongratsContinueInvestigatingMessage ??
+            "Continue investigating your website's accessibility compliance through manual testing using Tab stops and Assessment in Accessibility Insights for Web.";
+        const message = `No ${messageSubject} were found. ${continueInvestigatingMessage}`;
         return (
             <div className={styles.reportCongratsMessage}>
                 <div className={styles.reportCongratsHead}>Congratulations!</div>

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/no-failed-instances-congrats.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/no-failed-instances-congrats.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`NoFailedInstancesCongrats with outcomeType fail renders per snapshot wi
   <div
     className="reportCongratsInfo"
   >
-    Look, ma! No bugs!
+    No failed automated checks were found. Continue investigating!
   </div>
   <InlineImage
     alt=""
@@ -56,7 +56,7 @@ exports[`NoFailedInstancesCongrats with outcomeType inapplicable renders per sna
   <div
     className="reportCongratsInfo"
   >
-    Look, ma! No bugs!
+    No failed automated checks were found. Continue investigating!
   </div>
   <InlineImage
     alt=""
@@ -100,7 +100,7 @@ exports[`NoFailedInstancesCongrats with outcomeType pass renders per snapshot wi
   <div
     className="reportCongratsInfo"
   >
-    Look, ma! No bugs!
+    No failed automated checks were found. Continue investigating!
   </div>
   <InlineImage
     alt=""
@@ -144,7 +144,7 @@ exports[`NoFailedInstancesCongrats with outcomeType review renders per snapshot 
   <div
     className="reportCongratsInfo"
   >
-    Look, ma! No bugs!
+    No instances to review were found. Continue investigating!
   </div>
   <InlineImage
     alt=""

--- a/src/tests/unit/tests/reports/components/report-sections/no-failed-instances-congrats.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/no-failed-instances-congrats.test.tsx
@@ -14,7 +14,7 @@ describe.each(allInstanceOutcomeTypes)(
     outcomeType => {
         it('renders per snapshot with default message', () => {
             const deps: NoFailedInstancesCongratsDeps = {
-                customCongratsMessage: null,
+                customCongratsContinueInvestigatingMessage: null,
                 outcomeType: outcomeType,
             };
             const wrapper = shallow(
@@ -26,7 +26,7 @@ describe.each(allInstanceOutcomeTypes)(
 
         it('renders per snapshot with custom message', () => {
             const deps: NoFailedInstancesCongratsDeps = {
-                customCongratsMessage: 'Look, ma! No bugs!',
+                customCongratsContinueInvestigatingMessage: 'Continue investigating!',
                 outcomeType: outcomeType,
             };
             const wrapper = shallow(


### PR DESCRIPTION
#### Description of changes

Updates the unified path for forming the "congrats!" message when no instances are found to be cognizant of the automated checks vs needs review difference.

![screenshot showing updated text](https://user-images.githubusercontent.com/376284/98595312-d4321e00-22a3-11eb-83f1-8f21d1b1fcca.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1790679
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
