### PR TITLE
feat:(android-needs-review): Don't show the export report button when needs review is selected

### DIFF
--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -31,6 +31,8 @@ export interface ReportExportComponentState {
     exportData: string;
 }
 
+export const exportReportCommandBarButtonId = 'export-report-command-bar-button';
+
 export class ReportExportComponent extends React.Component<
     ReportExportComponentProps,
     ReportExportComponentState
@@ -77,6 +79,7 @@ export class ReportExportComponent extends React.Component<
         return (
             <>
                 <InsightsCommandButton
+                    data-automation-id={exportReportCommandBarButtonId}
                     iconProps={{ iconName: 'Export' }}
                     onClick={this.onExportButtonClick}
                 >

--- a/src/electron/platform/android/test-configs/automated-checks/test-config.tsx
+++ b/src/electron/platform/android/test-configs/automated-checks/test-config.tsx
@@ -19,5 +19,6 @@ export const automatedChecksTestConfig: TestConfig = {
         ),
         instancesSectionComponent: FailedInstancesSection,
         resultsFilter: automatedChecksResultsFilter,
+        allowsExportReport: true,
     },
 };

--- a/src/electron/platform/android/test-configs/needs-review/test-config.tsx
+++ b/src/electron/platform/android/test-configs/needs-review/test-config.tsx
@@ -18,5 +18,6 @@ export const needsReviewTestConfig: TestConfig = {
         ),
         instancesSectionComponent: NeedsReviewInstancesSection,
         resultsFilter: needsReviewResultsFilter,
+        allowsExportReport: false,
     },
 };

--- a/src/electron/types/content-page-info.ts
+++ b/src/electron/types/content-page-info.ts
@@ -7,6 +7,7 @@ import { LeftNavItemKey } from './left-nav-item-key';
 
 export type ContentPageInfo = {
     title: string;
+    allowsExportReport: boolean;
     description: JSX.Element;
     instancesSectionComponent: ReactFCWithDisplayName<CommonInstancesSectionProps>;
     resultsFilter: ResultsFilter;

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -238,6 +238,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                 scanPort={this.getScanPort()}
                 scanStoreData={this.props.scanStoreData}
                 setSideNavOpen={this.props.deps.leftNavActionCreator.setLeftNavVisible}
+                currentContentPageInfo={this.getContentPageInfo()}
             />
         );
     }

--- a/src/electron/views/automated-checks/components/reflow-command-bar.tsx
+++ b/src/electron/views/automated-checks/components/reflow-command-bar.tsx
@@ -18,6 +18,7 @@ import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
+import { ContentPageInfo } from 'electron/types/content-page-info';
 import { css, IButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
@@ -39,6 +40,7 @@ export interface ReflowCommandBarProps {
     narrowModeStatus: NarrowModeStatus;
     isSideNavOpen: boolean;
     setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    currentContentPageInfo: ContentPageInfo;
 }
 
 export const commandButtonRefreshId = 'command-button-refresh';
@@ -54,11 +56,12 @@ export const ReflowCommandBar = NamedFC<ReflowCommandBarProps>('ReflowCommandBar
         narrowModeStatus,
         isSideNavOpen,
         setSideNavOpen,
+        currentContentPageInfo,
     } = props;
     let exportReport: JSX.Element = null;
     let dropdownMenuButtonRef: IButton = null;
 
-    if (scanMetadata != null) {
+    if (currentContentPageInfo.allowsExportReport && scanMetadata != null) {
         exportReport = (
             <ReportExportComponent
                 deps={deps}

--- a/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
@@ -6,6 +6,7 @@ import { ruleContentAutomationId } from 'common/components/cards/instance-detail
 import { ruleGroupAutomationId } from 'common/components/cards/rules-with-instances';
 import { leftNavHamburgerButtonAutomationId } from 'common/components/left-nav-hamburger-button';
 import { testViewLeftNavLinkAutomationId } from 'DetailsView/components/left-nav/test-view-left-nav-link';
+import { exportReportCommandBarButtonId } from 'DetailsView/components/report-export-component';
 import { automatedChecksViewAutomationId } from 'electron/views/automated-checks/automated-checks-view';
 import { commandButtonSettingsId } from 'electron/views/automated-checks/components/command-bar';
 import { fluentLeftNavAutomationId } from 'electron/views/left-nav/fluent-left-nav';
@@ -25,6 +26,7 @@ export const AutomatedChecksViewSelectors = {
     leftNav: getAutomationIdSelector(leftNavAutomationId),
     fluentLeftNav: getAutomationIdSelector(fluentLeftNavAutomationId),
     leftNavHamburgerButton: getAutomationIdSelector(leftNavHamburgerButtonAutomationId),
+    exportReportButton: getAutomationIdSelector(exportReportCommandBarButtonId),
 
     nthRuleGroupCollapseExpandButton: (position: number) =>
         `${nthRuleGroup(position)} ${getAutomationIdSelector(collapsibleButtonAutomationId)}`,

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -257,4 +257,9 @@ describe('AutomatedChecksView', () => {
         await automatedChecksView.client.click(selector);
         await waitForFluentLeftNavToDisappear();
     });
+
+    it('export report button exists', async () => {
+        await setupWindowForCommandBarReflowTest('wide');
+        await automatedChecksView.waitForSelector(AutomatedChecksViewSelectors.exportReportButton);
+    });
 });

--- a/src/tests/electron/tests/needs-review-view.test.ts
+++ b/src/tests/electron/tests/needs-review-view.test.ts
@@ -4,6 +4,7 @@ import { getNarrowModeThresholdsForUnified } from 'electron/common/narrow-mode-t
 import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import * as path from 'path';
 import { createApplication } from 'tests/electron/common/create-application';
+import { AutomatedChecksViewSelectors } from 'tests/electron/common/element-identifiers/automated-checks-view-selectors';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
 import { AutomatedChecksViewController } from 'tests/electron/common/view-controllers/automated-checks-view-controller';
@@ -41,5 +42,11 @@ describe('NeedsReviewView', () => {
 
     it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
+    });
+
+    it('export report button does not exist', async () => {
+        await automatedChecksViewController.waitForSelectorToDisappear(
+            AutomatedChecksViewSelectors.exportReportButton,
+        );
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`ReportExportComponentTest render 1`] = `
 <React.Fragment>
   <InsightsCommandButton
+    data-automation-id="export-report-command-bar-button"
     iconProps={
       Object {
         "iconName": "Export",
@@ -44,6 +45,7 @@ exports[`ReportExportComponentTest render 1`] = `
 exports[`ReportExportComponentTest user interactions click export button: dialog should show 1`] = `
 <React.Fragment>
   <InsightsCommandButton
+    data-automation-id="export-report-command-bar-button"
     iconProps={
       Object {
         "iconName": "Export",
@@ -84,6 +86,7 @@ exports[`ReportExportComponentTest user interactions click export button: dialog
 exports[`ReportExportComponentTest user interactions dismiss dialog: dialog should be dismissed 1`] = `
 <React.Fragment>
   <InsightsCommandButton
+    data-automation-id="export-report-command-bar-button"
     iconProps={
       Object {
         "iconName": "Export",
@@ -124,6 +127,7 @@ exports[`ReportExportComponentTest user interactions dismiss dialog: dialog shou
 exports[`ReportExportComponentTest user interactions edit text field: test content with special characters: <> $ " \` ' 1`] = `
 <React.Fragment>
   <InsightsCommandButton
+    data-automation-id="export-report-command-bar-button"
     iconProps={
       Object {
         "iconName": "Export",

--- a/src/tests/unit/tests/electron/common/content-page-info-factory.test.tsx
+++ b/src/tests/unit/tests/electron/common/content-page-info-factory.test.tsx
@@ -41,6 +41,7 @@ describe('createContentPagesInfo', () => {
                 () => null,
             ),
             resultsFilter: _ => true,
+            allowsExportReport: true,
         };
     }
 });

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -285,6 +285,16 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                 },
               }
             }
+            currentContentPageInfo={
+              Object {
+                "description": <React.Fragment>
+                  test 
+                  automated-checks
+                   description
+                </React.Fragment>,
+                "title": "test-automated-checks-title",
+              }
+            }
             deps={
               Object {
                 "contentPagesInfo": Object {
@@ -740,6 +750,16 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                 },
               }
             }
+            currentContentPageInfo={
+              Object {
+                "description": <React.Fragment>
+                  test 
+                  automated-checks
+                   description
+                </React.Fragment>,
+                "title": "test-automated-checks-title",
+              }
+            }
             deps={
               Object {
                 "contentPagesInfo": Object {
@@ -1154,6 +1174,16 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                 },
               }
             }
+            currentContentPageInfo={
+              Object {
+                "description": <React.Fragment>
+                  test 
+                  automated-checks
+                   description
+                </React.Fragment>,
+                "title": "test-automated-checks-title",
+              }
+            }
             deps={
               Object {
                 "contentPagesInfo": Object {
@@ -1562,6 +1592,16 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                     },
                   ],
                 },
+              }
+            }
+            currentContentPageInfo={
+              Object {
+                "description": <React.Fragment>
+                  test 
+                  automated-checks
+                   description
+                </React.Fragment>,
+                "title": "test-automated-checks-title",
               }
             }
             deps={

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -292,6 +292,7 @@ exports[`AutomatedChecksView when status scan <Completed> 1`] = `
                   automated-checks
                    description
                 </React.Fragment>,
+                "resultsFilter": [Function],
                 "title": "test-automated-checks-title",
               }
             }
@@ -757,6 +758,7 @@ exports[`AutomatedChecksView when status scan <Failed> 1`] = `
                   automated-checks
                    description
                 </React.Fragment>,
+                "resultsFilter": [Function],
                 "title": "test-automated-checks-title",
               }
             }
@@ -1181,6 +1183,7 @@ exports[`AutomatedChecksView when status scan <Scanning> 1`] = `
                   automated-checks
                    description
                 </React.Fragment>,
+                "resultsFilter": [Function],
                 "title": "test-automated-checks-title",
               }
             }
@@ -1601,6 +1604,7 @@ exports[`AutomatedChecksView when status scan <undefined> 1`] = `
                   automated-checks
                    description
                 </React.Fragment>,
+                "resultsFilter": [Function],
                 "title": "test-automated-checks-title",
               }
             }

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/reflow-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/reflow-command-bar.test.tsx.snap
@@ -134,6 +134,52 @@ exports[`ReflowCommandBar reflow behavior isHeaderAndNavCollapsed is true 1`] = 
 </section>
 `;
 
+exports[`ReflowCommandBar renders does not create report export when allowsExportReport is false 1`] = `
+<section
+  aria-label="command bar"
+  className="commandBar"
+>
+  <div
+    className="farItems reflow"
+  >
+    <React.Fragment>
+      <FlaggedComponent
+        enableJSXElement={null}
+        featureFlag="exportReport"
+        featureFlagStoreData={
+          Object {
+            "somefeatureflag": true,
+          }
+        }
+      />
+      <InsightsCommandButton
+        data-automation-id="command-button-refresh"
+        disabled={true}
+        iconProps={
+          Object {
+            "iconName": "Refresh",
+          }
+        }
+        onClick={[Function]}
+        text="Start over"
+      />
+    </React.Fragment>
+    <InsightsCommandButton
+      ariaLabel="settings"
+      className="settingsGearButton"
+      data-automation-id="command-button-settings"
+      iconProps={
+        Object {
+          "className": "settingsGearButtonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</section>
+`;
+
 exports[`ReflowCommandBar renders does not create report export when scan metadata is null 1`] = `
 <section
   aria-label="command bar"

--- a/src/tests/unit/tests/electron/views/automated-checks/components/reflow-command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/reflow-command-bar.test.tsx
@@ -9,6 +9,7 @@ import { CommandBarButtonsMenu } from 'DetailsView/components/command-bar-button
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
+import { ContentPageInfo } from 'electron/types/content-page-info';
 import {
     commandButtonRefreshId,
     ReflowCommandBar,
@@ -70,6 +71,9 @@ describe('ReflowCommandBar', () => {
             narrowModeStatus: narrowModeStatusStub,
             isSideNavOpen: true,
             setSideNavOpen: () => null,
+            currentContentPageInfo: {
+                allowsExportReport: true,
+            } as ContentPageInfo,
         };
     });
 
@@ -82,6 +86,13 @@ describe('ReflowCommandBar', () => {
 
         it('does not create report export when scan metadata is null', () => {
             props.scanMetadata = null;
+            const rendered = shallow(<ReflowCommandBar {...props} />);
+
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
+
+        it('does not create report export when allowsExportReport is false', () => {
+            props.currentContentPageInfo.allowsExportReport = false;
             const rendered = shallow(<ReflowCommandBar {...props} />);
 
             expect(rendered.getElement()).toMatchSnapshot();


### PR DESCRIPTION
#### Description of changes

- Add `allowsExportReport` property to `ContentPageInfo` so whether or not the export report button is shown can be specified as part of a test config
- Modify `ReflowCommandBar` to respect the `allowsExportReport`  setting
- Add e2e tests to confirm the export report button is shown for automated checks, but not for needs review

