### PR TITLE
chore: break circular dependency between markup and content-page

### DIFF
--- a/src/tests/unit/tests/views/content/markup.test.tsx
+++ b/src/tests/unit/tests/views/content/markup.test.tsx
@@ -4,9 +4,9 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { It, Mock, Times } from 'typemoq';
 
+import { ContentActionMessageCreator } from 'common/message-creators/content-action-message-creator';
+import { create } from 'content/common';
 import { createMarkup } from 'views/content/markup';
-import { create } from '../../../../../../src/content/common';
-import { ContentActionMessageCreator } from '../../../../../common/message-creators/content-action-message-creator';
 
 describe('ContentPage', () => {
     const contentActionMessageCreatorMock = Mock.ofType<ContentActionMessageCreator>();

--- a/src/views/content/content-page.tsx
+++ b/src/views/content/content-page.tsx
@@ -5,20 +5,19 @@ import * as React from 'react';
 
 import { NamedFC } from 'common/react/named-fc';
 import { HyperlinkDefinition } from 'common/types/hyperlink-definition';
-import { createMarkup, Markup, MarkupDeps } from './markup';
+import { MarkupBasedComponentProps, createMarkup, Markup, MarkupDeps } from './markup';
 
 type HyperlinkDefinitionMap = { [KEY in string]: { href: string; text: string } };
 type HyperlinkComponentMap<M extends HyperlinkDefinitionMap> = { [KEY in keyof M]: React.FC };
 
 export type ContentPageDeps = MarkupDeps;
-export interface ContentPageOptions {
-    setPageTitle?: boolean;
-}
-export type ContentPageProps = { deps: ContentPageDeps; options?: ContentPageOptions };
+export type ContentPageProps = MarkupBasedComponentProps;
+
 export type ContentPageComponent = React.FC<ContentPageProps> & {
     displayName: 'ContentPageComponent';
     pageTitle?: string;
 };
+
 export type ContentReference = string | ContentPageComponent;
 type CreateProps<M extends HyperlinkDefinitionMap> = {
     Markup: Markup;

--- a/src/views/content/markup.tsx
+++ b/src/views/content/markup.tsx
@@ -4,12 +4,11 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 
 import { Code, Emphasis, Tag, Term } from 'assessments/markup';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { CheckIcon } from 'common/icons/check-icon';
+import { CrossIcon } from 'common/icons/cross-icon';
+import { ContentActionMessageCreator } from 'common/message-creators/content-action-message-creator';
 import { TextContent } from 'content/strings/text-content';
-import { NewTabLink } from '../../common/components/new-tab-link';
-import { CheckIcon } from '../../common/icons/check-icon';
-import { CrossIcon } from '../../common/icons/cross-icon';
-import { ContentActionMessageCreator } from '../../common/message-creators/content-action-message-creator';
-import { ContentPageComponent, ContentPageOptions } from './content-page';
 import { CodeExample, CodeExampleProps } from './markup/code-example';
 
 type PassFailProps = {
@@ -40,7 +39,7 @@ export type Markup = {
     Table: React.FC;
     LandmarkLegend: React.FC<{ role: string }>;
     ProblemList: React.FC;
-    Include: React.FC<{ content: ContentPageComponent }>;
+    Include: React.FC<{ content: MarkupBasedComponent }>;
 };
 
 export type MarkupDeps = {
@@ -48,8 +47,19 @@ export type MarkupDeps = {
     contentActionMessageCreator: Pick<ContentActionMessageCreator, 'openContentHyperLink'>;
 };
 
-export const createMarkup = (deps: MarkupDeps, options: ContentPageOptions) => {
-    function Include(props: { content: ContentPageComponent }): JSX.Element {
+export interface MarkupOptions {
+    setPageTitle?: boolean;
+}
+
+export type MarkupBasedComponentProps = {
+    deps: MarkupDeps;
+    options?: MarkupOptions;
+};
+
+export type MarkupBasedComponent = React.FC<MarkupBasedComponentProps>;
+
+export const createMarkup = (deps: MarkupDeps, options: MarkupOptions) => {
+    function Include(props: { content: MarkupBasedComponent }): JSX.Element {
         const Content = props.content;
         return <Content deps={deps} options={options} />;
     }


### PR DESCRIPTION
#### Description of changes

This PR breaks a cyclic dependency between `src/views/content/content-page.tsx` and `src/views/content/markup.tsx` by updating `Markup.Include` to work in terms of props types that `markup.tsx` defines rather than the types `content-page.tsx` defines, then updating the related `content-page` types to be defined in terms of `markup`'s definitions.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
