### PR TITLE
feat(android-needs-review): Fix Android Needs Review screenshot highlighting behavior

### DIFF
--- a/src/common/get-card-selection-view-data.ts
+++ b/src/common/get-card-selection-view-data.ts
@@ -4,6 +4,7 @@ import { HighlightState } from 'common/components/cards/instance-details-footer'
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { ResultsFilter } from 'common/types/results-filter';
 import {
+    PlatformData,
     UnifiedResult,
     UnifiedScanResultStoreData,
 } from 'common/types/store-data/unified-data-interface';
@@ -46,18 +47,19 @@ export const getCardSelectionViewData: GetCardSelectionViewData = (
     viewData.visualHelperEnabled = cardSelectionStoreData.visualHelperEnabled || false;
     viewData.expandedRuleIds = getRuleIdsOfExpandedRules(cardSelectionStoreData.rules);
 
-    const filteredResults = unifiedScanResultStoreData.results.filter(resultsFilter);
-    const filteredResultUids = filteredResults.map(res => res.uid);
-    const allResultUids = getAllResultUids(filteredResultUids, cardSelectionStoreData.rules);
+    const candidateResults = unifiedScanResultStoreData.results.filter(resultsFilter);
+    const candidateResultUids = candidateResults.map(res => res.uid);
+    const allFilteredUids = getAllFilteredUids(candidateResultUids, cardSelectionStoreData.rules);
 
     const unavailableResultUids = getResultsWithUnavailableHighlightStatus(
-        unifiedScanResultStoreData,
+        candidateResults,
+        unifiedScanResultStoreData.platformInfo,
         isResultHighlightUnavailable,
     );
     let selectedResultUids = getOnlyResultUidsFromSelectedCards(
         cardSelectionStoreData.rules,
         viewData.expandedRuleIds,
-        filteredResultUids,
+        candidateResultUids,
     );
     let visibleResultUids: string[];
 
@@ -65,20 +67,20 @@ export const getCardSelectionViewData: GetCardSelectionViewData = (
         visibleResultUids = [];
         selectedResultUids = [];
     } else if (viewData.expandedRuleIds.length === 0) {
-        visibleResultUids = allResultUids;
+        visibleResultUids = allFilteredUids;
     } else if (selectedResultUids.length > 0) {
         visibleResultUids = selectedResultUids;
     } else {
         visibleResultUids = getFilteredResultUidsFromRuleIdArray(
             cardSelectionStoreData.rules,
             viewData.expandedRuleIds,
-            filteredResultUids,
+            candidateResultUids,
         );
     }
 
     viewData.selectedResultUids = selectedResultUids;
     viewData.resultsHighlightStatus = getHighlightStatusByResultUid(
-        allResultUids,
+        allFilteredUids,
         visibleResultUids,
         unavailableResultUids,
     );
@@ -96,14 +98,14 @@ function getEmptyViewData(): CardSelectionViewData {
 }
 
 function getResultsWithUnavailableHighlightStatus(
-    unifiedScanResultStoreData: UnifiedScanResultStoreData,
+    candidateResults: UnifiedResult[],
+    platformInfo: PlatformData,
     isResultHighlightUnavailable: IsResultHighlightUnavailable,
 ): string[] {
-    return unifiedScanResultStoreData.results
+    return candidateResults
         .filter(
             result =>
-                result.status === 'fail' &&
-                isResultHighlightUnavailable(result, unifiedScanResultStoreData.platformInfo),
+                result.status === 'fail' && isResultHighlightUnavailable(result, platformInfo),
         )
         .map(result => result.uid);
 }
@@ -120,25 +122,25 @@ function getRuleIdsOfExpandedRules(ruleDictionary: RuleExpandCollapseDataDiction
     return expandedRuleIds;
 }
 
-function getAllResultUids(
-    filteredResultUids: string[],
+function getAllFilteredUids(
+    candidateResultUids: string[],
     ruleDictionary: RuleExpandCollapseDataDictionary,
 ): string[] {
     return getFilteredResultUidsFromRuleIdArray(
         ruleDictionary,
         keys(ruleDictionary),
-        filteredResultUids,
+        candidateResultUids,
     );
 }
 
 function getFilteredResultUidsFromRuleIdArray(
     ruleDictionary: RuleExpandCollapseDataDictionary,
     ruleIds: string[],
-    filteredResultUids: string[],
+    candidateResultUids: string[],
 ): string[] {
     const allResultUids = flatMap(ruleIds, key => getAllResultUidsFromRule(ruleDictionary[key]));
 
-    return intersection(filteredResultUids, allResultUids);
+    return intersection(candidateResultUids, allResultUids);
 }
 
 function getAllResultUidsFromRule(rule: RuleExpandCollapseData): string[] {
@@ -148,13 +150,13 @@ function getAllResultUidsFromRule(rule: RuleExpandCollapseData): string[] {
 function getOnlyResultUidsFromSelectedCards(
     ruleDictionary: RuleExpandCollapseDataDictionary,
     ruleIds: string[],
-    filteredResultUids: string[],
+    candidateResultUids: string[],
 ): string[] {
     const selectedResultUids = flatMap(ruleIds, key =>
         getResultUidsFromSelectedCards(ruleDictionary[key]),
     );
 
-    return intersection(filteredResultUids, selectedResultUids);
+    return intersection(candidateResultUids, selectedResultUids);
 }
 
 function getResultUidsFromSelectedCards(rule: RuleExpandCollapseData): string[] {

--- a/src/tests/unit/tests/common/get-card-selection-view-data.test.ts
+++ b/src/tests/unit/tests/common/get-card-selection-view-data.test.ts
@@ -16,6 +16,7 @@ describe('getCardSelectionStoreviewData', () => {
     let initialCardSelectionState: CardSelectionStoreData;
     let initialUnifiedScanResultState: UnifiedScanResultStoreData;
     let isResultHighlightUnavailable: IMock<IsResultHighlightUnavailable>;
+    let resultsFilter: ResultsFilter;
 
     beforeEach(() => {
         const defaultCardSelectionState: CardSelectionStoreData = {
@@ -89,7 +90,7 @@ describe('getCardSelectionStoreviewData', () => {
     });
 
     test('all rules collapsed, visual helper enabled, resultsFilter passed, expect only filtered highlights', () => {
-        const resultsFilter: ResultsFilter = res => res.uid == 'sampleUid3';
+        resultsFilter = res => res.uid == 'sampleUid3';
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
@@ -242,6 +243,25 @@ describe('getCardSelectionStoreviewData', () => {
         expect(viewData.visualHelperEnabled).toEqual(true);
     });
 
+    test('one rule expanded, visual helper enabled, resultsFilter passed, expect some highlights', () => {
+        resultsFilter = res => res.uid == 'sampleUid2';
+        initialCardSelectionState.rules['sampleRuleId1'].isExpanded = true;
+
+        const viewData = getCardSelectionViewData(
+            initialCardSelectionState,
+            initialUnifiedScanResultState,
+            isResultHighlightUnavailable.object,
+            resultsFilter,
+        );
+
+        expect(viewData.resultsHighlightStatus).toEqual({
+            sampleUid2: 'visible',
+        });
+        expect(viewData.expandedRuleIds).toEqual(['sampleRuleId1']);
+        expect(viewData.selectedResultUids).toEqual([]);
+        expect(viewData.visualHelperEnabled).toEqual(true);
+    });
+
     test('all rules expanded, visual helper enabled, one card selected, expect one highlight', () => {
         initialCardSelectionState.rules['sampleRuleId1'].isExpanded = true;
         initialCardSelectionState.rules['sampleRuleId2'].isExpanded = true;
@@ -261,6 +281,27 @@ describe('getCardSelectionStoreviewData', () => {
         });
         expect(viewData.expandedRuleIds).toEqual(['sampleRuleId1', 'sampleRuleId2']);
         expect(viewData.selectedResultUids).toEqual(['sampleUid3']);
+        expect(viewData.visualHelperEnabled).toEqual(true);
+    });
+
+    test('all rules expanded, visual helper enabled, one card selected, resultsFilter passed, expect only filtered highlights', () => {
+        initialCardSelectionState.rules['sampleRuleId1'].isExpanded = true;
+        initialCardSelectionState.rules['sampleRuleId2'].isExpanded = true;
+        initialCardSelectionState.rules['sampleRuleId2'].cards['sampleUid3'] = true;
+        resultsFilter = res => res.uid == 'sampleUid2';
+
+        const viewData = getCardSelectionViewData(
+            initialCardSelectionState,
+            initialUnifiedScanResultState,
+            isResultHighlightUnavailable.object,
+            resultsFilter,
+        );
+
+        expect(viewData.resultsHighlightStatus).toEqual({
+            sampleUid2: 'visible',
+        });
+        expect(viewData.expandedRuleIds).toEqual(['sampleRuleId1', 'sampleRuleId2']);
+        expect(viewData.selectedResultUids).toEqual([]);
         expect(viewData.visualHelperEnabled).toEqual(true);
     });
 


### PR DESCRIPTION
#### Description of changes
PR #3633 introduced the concept of a `ResultsFilter` and used it to ensure that the proper elements are highlighted in Automated Checks and Needs Review when all cards are collapsed. Unfortunately, it failed to address the scenario where some cards are expanded or selected. This PR addresses those scenarios by ensuring that we always limit our `resultsHighlightStatus` data to reflect the currently selected tab's results.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
