### PR TITLE
feat(save-and-load-assessment): get assessment data for save button

### DIFF
--- a/src/DetailsView/components/save-assessment-button.tsx
+++ b/src/DetailsView/components/save-assessment-button.tsx
@@ -2,12 +2,19 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
-export interface SaveAssessmentButtonProps {}
+export interface SaveAssessmentButtonProps {
+    download: string;
+    href: string;
+}
 
 export class SaveAssessmentButton extends React.Component<SaveAssessmentButtonProps> {
     public render(): JSX.Element {
         return (
-            <InsightsCommandButton iconProps={{ iconName: 'Save' }}>
+            <InsightsCommandButton
+                iconProps={{ iconName: 'Save' }}
+                download={this.props.download}
+                href={this.props.href}
+            >
                 Save assessment
             </InsightsCommandButton>
         );

--- a/src/DetailsView/components/save-assessment-factory.tsx
+++ b/src/DetailsView/components/save-assessment-factory.tsx
@@ -1,17 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
+import { FileURLProvider } from '../../common/file-url-provider';
 import { SaveAssessmentButton } from 'DetailsView/components/save-assessment-button';
+import { AssessmentDataFormatter } from 'common/assessment-data-formatter';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 
-export type SaveAssessmentFactoryDeps = {};
+export type SaveAssessmentFactoryDeps = {
+    fileURLProvider: FileURLProvider;
+    assessmentDataFormatter: AssessmentDataFormatter;
+};
 
-export type SaveAssessmentFactoryProps = CommandBarProps & {
+export type SaveAssessmentFactoryProps = {
     deps: SaveAssessmentFactoryDeps;
+    assessmentStoreData: AssessmentStoreData;
 };
 
 export function getSaveButtonForAssessment(props: SaveAssessmentFactoryProps): JSX.Element {
-    return <SaveAssessmentButton />;
+    const assessmentData = props.deps.assessmentDataFormatter.formatAssessmentData(
+        props.assessmentStoreData.assessments,
+    );
+    const fileURL = props.deps.fileURLProvider.provideURL([assessmentData], 'application/json');
+
+    return <SaveAssessmentButton download={'filename'} href={fileURL} />;
 }
 
 export function getSaveButtonForFastPass(props: SaveAssessmentFactoryProps): JSX.Element | null {

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -64,6 +64,7 @@ import { TelemetryEventSource } from '../common/extension-telemetry-events';
 import { initializeFabricIcons } from '../common/fabric-icons';
 import { getAllFeatureFlagDetails } from '../common/feature-flags';
 import { FileURLProvider } from '../common/file-url-provider';
+import { AssessmentDataFormatter } from 'common/assessment-data-formatter';
 import { GetGuidanceTagsFromGuidanceLinks } from '../common/get-guidance-tags-from-guidance-links';
 import { getInnerTextFromJsxElement } from '../common/get-inner-text-from-jsx-element';
 import { HTMLElementUtils } from '../common/html-element-utils';
@@ -385,6 +386,8 @@ if (tabId != null) {
                 assessmentReportHtmlGenerator,
             );
 
+            const assessmentDataFormatter = new AssessmentDataFormatter();
+
             const axeResultToIssueFilingDataConverter = new AxeResultToIssueFilingDataConverter(
                 IssueFilingUrlStringUtils.getSelectorLastPart,
             );
@@ -413,6 +416,7 @@ if (tabId != null) {
                 issueDetailsTextGenerator,
                 windowUtils,
                 fileURLProvider,
+                assessmentDataFormatter,
                 getAssessmentSummaryModelFromProviderAndStoreData: getAssessmentSummaryModelFromProviderAndStoreData,
                 getAssessmentSummaryModelFromProviderAndStatusData: getAssessmentSummaryModelFromProviderAndStatusData,
                 visualizationConfigurationFactory,

--- a/src/common/assessment-data-formatter.ts
+++ b/src/common/assessment-data-formatter.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export class AssessmentDataFormatter {
+    public formatAssessmentData = (assessmentData: {}): string => {
+        const assessmentReportData = JSON.stringify(assessmentData);
+        return assessmentReportData;
+    };
+}

--- a/src/tests/unit/common/__snapshots__/assessment-data-formatter.test.tsx.snap
+++ b/src/tests/unit/common/__snapshots__/assessment-data-formatter.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AssessmentDataFormatter returns the formatted assessment data object as a string 1`] = `"{\\"mock\\":\\"data\\"}"`;

--- a/src/tests/unit/common/assessment-data-formatter.test.tsx
+++ b/src/tests/unit/common/assessment-data-formatter.test.tsx
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AssessmentDataFormatter } from 'common/assessment-data-formatter';
+
+describe('AssessmentDataFormatter', () => {
+    it('returns the formatted assessment data object as a string', () => {
+        const testDataFormatter = new AssessmentDataFormatter();
+        const testAssessmentData = {
+            mock: 'data',
+        };
+        const formattedAssessmentData = testDataFormatter.formatAssessmentData(testAssessmentData);
+        expect(formattedAssessmentData).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-button.test.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`SaveAssessmentButton should render per the snapshot 1`] = `
 <InsightsCommandButton
+  download="download"
+  href="url"
   iconProps={
     Object {
       "iconName": "Save",

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-factory.test.tsx.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SaveAssessmentFactory getSaveButtonForAssessment renders save assessment button 1`] = `<SaveAssessmentButton />`;
+exports[`SaveAssessmentFactory getSaveButtonForAssessment renders save assessment button 1`] = `
+<SaveAssessmentButton
+  download="filename"
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-factory.test.tsx.snap
@@ -3,5 +3,6 @@
 exports[`SaveAssessmentFactory getSaveButtonForAssessment renders save assessment button 1`] = `
 <SaveAssessmentButton
   download="filename"
+  href="fileURL"
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -40,7 +40,7 @@ describe('DetailsViewCommandBar', () => {
 
     let tabStoreData: TabStoreData;
     let startOverComponent: JSX.Element;
-    let saveAssessmentButton: JSX.Element;
+    let SaveAssessmentButtonProps: SaveAssessmentButtonProps;
     let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
     let isCommandBarCollapsed: boolean;
     let showReportExportButton: boolean;
@@ -61,7 +61,6 @@ describe('DetailsViewCommandBar', () => {
             isClosed: false,
         } as TabStoreData;
         startOverComponent = null;
-        saveAssessmentButton = null;
         isCommandBarCollapsed = false;
         showReportExportButton = true;
     });
@@ -151,7 +150,7 @@ describe('DetailsViewCommandBar', () => {
     });
 
     test('renders with save assessment button', () => {
-        const rendered = shallow(<SaveAssessmentButton />);
+        const rendered = shallow(<SaveAssessmentButton {...SaveAssessmentButtonProps} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
 

--- a/src/tests/unit/tests/DetailsView/components/save-assessment-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/save-assessment-button.test.tsx
@@ -12,7 +12,9 @@ describe('SaveAssessmentButton', () => {
     let props: SaveAssessmentButtonProps;
 
     it('should render per the snapshot', () => {
-        const rendered = shallow(<SaveAssessmentButton {...props} />);
+        const rendered = shallow(
+            <SaveAssessmentButton {...props} download={'download'} href={'url'} />,
+        );
 
         expect(rendered.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/DetailsView/components/save-assessment-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/save-assessment-button.test.tsx
@@ -3,11 +3,16 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
-import { SaveAssessmentButton } from 'DetailsView/components/save-assessment-button';
+import {
+    SaveAssessmentButton,
+    SaveAssessmentButtonProps,
+} from 'DetailsView/components/save-assessment-button';
 
 describe('SaveAssessmentButton', () => {
+    let props: SaveAssessmentButtonProps;
+
     it('should render per the snapshot', () => {
-        const rendered = shallow(<SaveAssessmentButton />);
+        const rendered = shallow(<SaveAssessmentButton {...props} />);
 
         expect(rendered.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/DetailsView/components/save-assessment-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/save-assessment-factory.test.tsx
@@ -1,13 +1,39 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { IMock, Mock } from 'typemoq';
+import { AssessmentDataFormatter } from 'common/assessment-data-formatter';
+import { FileURLProvider } from 'common/file-url-provider';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import {
     getSaveButtonForAssessment,
     getSaveButtonForFastPass,
+    SaveAssessmentFactoryDeps,
     SaveAssessmentFactoryProps,
 } from 'DetailsView/components/save-assessment-factory';
 
 describe('SaveAssessmentFactory', () => {
+    let deps: SaveAssessmentFactoryDeps;
     let props: SaveAssessmentFactoryProps;
+
+    beforeEach(() => {
+        const fileURLProviderMock: IMock<FileURLProvider> = Mock.ofType(FileURLProvider);
+        const assessmentDataFormatterMock: IMock<AssessmentDataFormatter> = Mock.ofType(
+            AssessmentDataFormatter,
+        );
+
+        const assessmentStoreData = {
+            assessments: null,
+        } as AssessmentStoreData;
+
+        deps = {
+            assessmentDataFormatter: assessmentDataFormatterMock.object,
+            fileURLProvider: fileURLProviderMock.object,
+        } as SaveAssessmentFactoryDeps;
+        props = {
+            deps,
+            assessmentStoreData,
+        } as SaveAssessmentFactoryProps;
+    });
 
     describe('getSaveButtonForAssessment', () => {
         test('renders save assessment button', () => {

--- a/src/tests/unit/tests/DetailsView/components/save-assessment-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/save-assessment-factory.test.tsx
@@ -65,7 +65,8 @@ describe('SaveAssessmentFactory', () => {
 
             fileURLProviderMock
                 .setup(f => f.provideURL([formattedAssessmentData], 'application/json'))
-                .returns(() => 'fileURL');
+                .returns(() => 'fileURL')
+                .verifiable(Times.once());
 
             const rendered = getSaveButtonForAssessment(props);
             expect(rendered).toMatchSnapshot();


### PR DESCRIPTION
#### Description of changes
This PR adds the download functionality to the save assessment button and updates relevant tests. 


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Feature request #653
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a ] (UI changes only) Added screenshots/GIFs to description above
- [ n/a] (UI changes only) Verified usability with NVDA/JAWS
