### PR TITLE
feat(android-needs-review): remove ! label from needs review screenshot highlights

### DIFF
--- a/src/electron/views/screenshot/highlight-box.tsx
+++ b/src/electron/views/screenshot/highlight-box.tsx
@@ -21,6 +21,10 @@ export const HighlightBox = NamedFC<HighlightBoxProps>('HighlightBox', props => 
         top: viewModel.top,
         left: viewModel.left,
     };
+    const renderedLabel =
+        viewModel.label == null ? null : (
+            <div className={highlightBoxLabel}>${viewModel.label}</div>
+        );
 
     return (
         <div
@@ -29,7 +33,7 @@ export const HighlightBox = NamedFC<HighlightBoxProps>('HighlightBox', props => 
             aria-hidden="true"
             data-automation-id={highlightBoxAutomationId}
         >
-            <div className={highlightBoxLabel}>!</div>
+            {renderedLabel}
         </div>
     );
 });

--- a/src/electron/views/screenshot/highlight-box.tsx
+++ b/src/electron/views/screenshot/highlight-box.tsx
@@ -22,9 +22,7 @@ export const HighlightBox = NamedFC<HighlightBoxProps>('HighlightBox', props => 
         left: viewModel.left,
     };
     const renderedLabel =
-        viewModel.label == null ? null : (
-            <div className={highlightBoxLabel}>${viewModel.label}</div>
-        );
+        viewModel.label == null ? null : <div className={highlightBoxLabel}>{viewModel.label}</div>;
 
     return (
         <div

--- a/src/electron/views/screenshot/screenshot-view-model-provider.ts
+++ b/src/electron/views/screenshot/screenshot-view-model-provider.ts
@@ -58,6 +58,7 @@ function getHighlightBoxViewModelFromResult(
     const heightInPx = rectInPx.bottom - rectInPx.top;
     return {
         resultUid: result.uid,
+        label: result.status === 'fail' ? '!' : null,
         left: pxAsPercentRelativeTo(rectInPx.left, viewPort.width),
         top: pxAsPercentRelativeTo(rectInPx.top, viewPort.height),
         width: pxAsPercentRelativeTo(widthInPx, viewPort.width),

--- a/src/electron/views/screenshot/screenshot-view-model.ts
+++ b/src/electron/views/screenshot/screenshot-view-model.ts
@@ -8,6 +8,7 @@ export type HighlightBoxViewModel = {
     top: string;
     width: string;
     height: string;
+    label: string | null;
 };
 
 export type ScreenshotViewModel = {

--- a/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
+++ b/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
@@ -32,6 +32,19 @@ export const exampleUnifiedResult: UnifiedResult = {
     },
 };
 
+export const exampleUnifiedResultWithBoundingRectangle = {
+    ...exampleUnifiedResult,
+    descriptors: {
+        ...exampleUnifiedResult.descriptors,
+        boundingRectangle: {
+            left: 1,
+            top: 2,
+            right: 3,
+            bottom: 4,
+        },
+    },
+};
+
 export const exampleUnifiedRuleResult: CardRuleResult = {
     id: 'some-rule',
     nodes: [exampleUnifiedResult as UnifiedResult],

--- a/src/tests/unit/tests/electron/views/screenshot/__snapshots__/highlight-box.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/screenshot/__snapshots__/highlight-box.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`HighlightBox renders for label="!" with appropriate position and dimens
   <div
     className="highlightBoxLabel"
   >
-    $
     !
   </div>
 </div>

--- a/src/tests/unit/tests/electron/views/screenshot/__snapshots__/highlight-box.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/screenshot/__snapshots__/highlight-box.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HighlightBox renders with appropriate position and dimensions 1`] = `
+exports[`HighlightBox renders for label="!" with appropriate position and dimensions 1`] = `
 <div
   aria-hidden="true"
   className="highlightBox"
@@ -17,7 +17,24 @@ exports[`HighlightBox renders with appropriate position and dimensions 1`] = `
   <div
     className="highlightBoxLabel"
   >
+    $
     !
   </div>
 </div>
+`;
+
+exports[`HighlightBox renders for label=null with appropriate position and dimensions 1`] = `
+<div
+  aria-hidden="true"
+  className="highlightBox"
+  data-automation-id="screenshot-highlight-box"
+  style={
+    Object {
+      "height": "50px",
+      "left": "50%",
+      "top": "50%",
+      "width": "100px",
+    }
+  }
+/>
 `;

--- a/src/tests/unit/tests/electron/views/screenshot/__snapshots__/screenshot-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/screenshot/__snapshots__/screenshot-container.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`ScreenshotContainer renders per snapshot with highlight boxes 1`] = `
     viewModel={
       Object {
         "height": "height-1",
+        "label": null,
         "left": "left-1",
         "resultUid": "result-1",
         "top": "top-1",
@@ -22,6 +23,7 @@ exports[`ScreenshotContainer renders per snapshot with highlight boxes 1`] = `
     viewModel={
       Object {
         "height": "height-2",
+        "label": "!",
         "left": "left-2",
         "resultUid": "result-2",
         "top": "top-2",

--- a/src/tests/unit/tests/electron/views/screenshot/highlight-box.test.tsx
+++ b/src/tests/unit/tests/electron/views/screenshot/highlight-box.test.tsx
@@ -8,7 +8,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('HighlightBox', () => {
-    const viewModel: HighlightBoxViewModel = {
+    const baseViewModel: Partial<HighlightBoxViewModel> = {
         resultUid: 'test-uid',
         top: '50%',
         left: '50%',
@@ -16,7 +16,11 @@ describe('HighlightBox', () => {
         height: '50px',
     };
 
-    it('renders with appropriate position and dimensions', () => {
+    it.each([null, '!'])('renders for label=%p with appropriate position and dimensions', label => {
+        const viewModel = {
+            ...baseViewModel,
+            label,
+        } as HighlightBoxViewModel;
         const testObject = shallow(<HighlightBox viewModel={viewModel} />);
         expect(testObject.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/electron/views/screenshot/screenshot-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/screenshot/screenshot-container.test.tsx
@@ -27,6 +27,7 @@ describe('ScreenshotContainer', () => {
         const highlightBoxViewModels: HighlightBoxViewModel[] = [
             {
                 resultUid: 'result-1',
+                label: null,
                 top: 'top-1',
                 left: 'left-1',
                 width: 'width-1',
@@ -34,6 +35,7 @@ describe('ScreenshotContainer', () => {
             },
             {
                 resultUid: 'result-2',
+                label: '!',
                 top: 'top-2',
                 left: 'left-2',
                 width: 'width-2',


### PR DESCRIPTION
#### Description of changes

This removes the ! labels from needs review highlight boxes by making the view model provider determine the label according to result status.

Needs review omitting "!" labels:
![image](https://user-images.githubusercontent.com/376284/99126386-10cb8580-25d4-11eb-8c89-912cd4246ab7.png)

Automated checks still showing same "!" labels:
![image](https://user-images.githubusercontent.com/376284/99126366-090be100-25d4-11eb-9078-b47253bba2ce.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1792948
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
