### PR TITLE
feat(android-needs-review): Rename AutomatedChecks* to Results* in e2e tests

### DIFF
--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -90,7 +90,7 @@ export enum TelemetryEventSource {
     TargetPage,
     ContentPage,
     ElectronDeviceConnect,
-    ElectronAutomatedChecksView,
+    ElectronResultsView,
 }
 
 export type BaseTelemetryData = {

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -380,7 +380,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         const cardSelectionMessageCreator = new CardSelectionMessageCreator(
             dispatcher,
             telemetryDataFactory,
-            TelemetryEventSource.ElectronAutomatedChecksView,
+            TelemetryEventSource.ElectronResultsView,
         );
 
         const windowFrameListener = new WindowFrameListener(
@@ -417,7 +417,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
 
         const dropdownClickHandler = new DropdownClickHandler(
             dropdownActionMessageCreator,
-            TelemetryEventSource.ElectronAutomatedChecksView,
+            TelemetryEventSource.ElectronResultsView,
         );
 
         const detailsViewActionMessageCreator = new DetailsViewActionMessageCreator(
@@ -448,7 +448,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         const issueFilingActionMessageCreator = new IssueFilingActionMessageCreator(
             dispatcher,
             telemetryDataFactory,
-            TelemetryEventSource.ElectronAutomatedChecksView,
+            TelemetryEventSource.ElectronResultsView,
         );
 
         const androidSetupStartListener = new AndroidSetupStartListener(

--- a/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
@@ -4,29 +4,14 @@ import { collapsibleButtonAutomationId } from 'common/components/cards/collapsib
 import { instanceCardAutomationId } from 'common/components/cards/instance-details';
 import { ruleContentAutomationId } from 'common/components/cards/instance-details-group';
 import { ruleGroupAutomationId } from 'common/components/cards/rules-with-instances';
-import { leftNavHamburgerButtonAutomationId } from 'common/components/left-nav-hamburger-button';
-import { testViewLeftNavLinkAutomationId } from 'DetailsView/components/left-nav/test-view-left-nav-link';
-import { exportReportCommandBarButtonId } from 'DetailsView/components/report-export-component';
-import { resultsViewAutomationId } from 'electron/views/results/results-view';
-import { commandButtonSettingsId } from 'electron/views/results/components/command-bar';
-import { fluentLeftNavAutomationId } from 'electron/views/left-nav/fluent-left-nav';
-import { leftNavAutomationId } from 'electron/views/left-nav/left-nav';
-import { highlightBoxAutomationId } from 'electron/views/screenshot/highlight-box';
-import { screenshotImageAutomationId } from 'electron/views/screenshot/screenshot';
-import { screenshotViewAutomationId } from 'electron/views/screenshot/screenshot-view';
 import { cardsRuleIdAutomationId } from 'reports/components/report-sections/minimal-rule-header';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 
 const nthRuleGroup = (n: number) => `${AutomatedChecksViewSelectors.ruleGroup}:nth-of-type(${n})`;
 
 export const AutomatedChecksViewSelectors = {
-    mainContainer: getAutomationIdSelector(resultsViewAutomationId),
     ruleGroup: getAutomationIdSelector(ruleGroupAutomationId),
     ruleContent: getAutomationIdSelector(ruleContentAutomationId),
-    leftNav: getAutomationIdSelector(leftNavAutomationId),
-    fluentLeftNav: getAutomationIdSelector(fluentLeftNavAutomationId),
-    leftNavHamburgerButton: getAutomationIdSelector(leftNavHamburgerButtonAutomationId),
-    exportReportButton: getAutomationIdSelector(exportReportCommandBarButtonId),
 
     nthRuleGroupCollapseExpandButton: (position: number) =>
         `${nthRuleGroup(position)} ${getAutomationIdSelector(collapsibleButtonAutomationId)}`,
@@ -34,19 +19,4 @@ export const AutomatedChecksViewSelectors = {
         `${nthRuleGroup(position)} ${getAutomationIdSelector(cardsRuleIdAutomationId)}`,
     nthRuleGroupInstances: (position: number) =>
         `${nthRuleGroup(position)} ${getAutomationIdSelector(instanceCardAutomationId)}`,
-
-    nthTestInLeftNav: (position: number) =>
-        `${getAutomationIdSelector(
-            leftNavAutomationId,
-        )} li:nth-of-type(${position}) ${getAutomationIdSelector(testViewLeftNavLinkAutomationId)}`,
-
-    settingsButton: getAutomationIdSelector(commandButtonSettingsId),
-};
-
-export const ScreenshotViewSelectors = {
-    screenshotView: getAutomationIdSelector(screenshotViewAutomationId),
-    screenshotImage: getAutomationIdSelector(screenshotImageAutomationId),
-    highlightBox: getAutomationIdSelector(highlightBoxAutomationId),
-    getHighlightBoxByIndex: (index: number) =>
-        `${ScreenshotViewSelectors.highlightBox}:nth-of-type(${index})`,
 };

--- a/src/tests/electron/common/element-identifiers/results-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/results-view-selectors.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { leftNavHamburgerButtonAutomationId } from 'common/components/left-nav-hamburger-button';
+import { testViewLeftNavLinkAutomationId } from 'DetailsView/components/left-nav/test-view-left-nav-link';
+import { exportReportCommandBarButtonId } from 'DetailsView/components/report-export-component';
+import { resultsViewAutomationId } from 'electron/views/results/results-view';
+import { commandButtonSettingsId } from 'electron/views/results/components/command-bar';
+import { fluentLeftNavAutomationId } from 'electron/views/left-nav/fluent-left-nav';
+import { leftNavAutomationId } from 'electron/views/left-nav/left-nav';
+import { highlightBoxAutomationId } from 'electron/views/screenshot/highlight-box';
+import { screenshotImageAutomationId } from 'electron/views/screenshot/screenshot';
+import { screenshotViewAutomationId } from 'electron/views/screenshot/screenshot-view';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
+
+export const ResultsViewSelectors = {
+    mainContainer: getAutomationIdSelector(resultsViewAutomationId),
+    leftNav: getAutomationIdSelector(leftNavAutomationId),
+    fluentLeftNav: getAutomationIdSelector(fluentLeftNavAutomationId),
+    leftNavHamburgerButton: getAutomationIdSelector(leftNavHamburgerButtonAutomationId),
+    exportReportButton: getAutomationIdSelector(exportReportCommandBarButtonId),
+
+    nthTestInLeftNav: (position: number) =>
+        `${getAutomationIdSelector(
+            leftNavAutomationId,
+        )} li:nth-of-type(${position}) ${getAutomationIdSelector(testViewLeftNavLinkAutomationId)}`,
+
+    settingsButton: getAutomationIdSelector(commandButtonSettingsId),
+};

--- a/src/tests/electron/common/element-identifiers/screenshot-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/screenshot-view-selectors.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { highlightBoxAutomationId } from 'electron/views/screenshot/highlight-box';
+import { screenshotImageAutomationId } from 'electron/views/screenshot/screenshot';
+import { screenshotViewAutomationId } from 'electron/views/screenshot/screenshot-view';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
+
+export const ScreenshotViewSelectors = {
+    screenshotView: getAutomationIdSelector(screenshotViewAutomationId),
+    screenshotImage: getAutomationIdSelector(screenshotImageAutomationId),
+    highlightBox: getAutomationIdSelector(highlightBoxAutomationId),
+    getHighlightBoxByIndex: (index: number) =>
+        `${ScreenshotViewSelectors.highlightBox}:nth-of-type(${index})`,
+};

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -4,12 +4,12 @@ import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setu
 import { Application } from 'spectron';
 import { AndroidSetupViewController } from 'tests/electron/common/view-controllers/android-setup-view-controller';
 import { DeviceConnectionDialogController } from 'tests/electron/common/view-controllers/device-connection-dialog-controller';
+import { ResultsViewController } from 'tests/electron/common/view-controllers/results-view-controller';
 import {
     getSpectronAsyncClient,
     SpectronAsyncClient,
 } from 'tests/electron/common/view-controllers/spectron-async-client';
 import { DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS } from 'tests/electron/setup/timeouts';
-import { AutomatedChecksViewController } from './automated-checks-view-controller';
 
 export class AppController {
     public client: SpectronAsyncClient;
@@ -53,20 +53,20 @@ export class AppController {
         return androidSetupController;
     }
 
-    public async openAutomatedChecksView(): Promise<AutomatedChecksViewController> {
+    public async openResultsView(): Promise<ResultsViewController> {
         const androidSetupViewController = await this.openAndroidSetupView(
             'prompt-connected-start-testing',
         );
         await androidSetupViewController.startTesting();
 
-        return this.waitForAutomatedChecksView();
+        return this.waitForResultsView();
     }
 
-    public async waitForAutomatedChecksView(): Promise<AutomatedChecksViewController> {
-        const automatedChecksView = new AutomatedChecksViewController(this.client);
-        await automatedChecksView.waitForViewVisible();
+    public async waitForResultsView(): Promise<ResultsViewController> {
+        const resultsView = new ResultsViewController(this.client);
+        await resultsView.waitForViewVisible();
 
-        return automatedChecksView;
+        return resultsView;
     }
 
     public async setHighContrastMode(enableHighContrast: boolean): Promise<void> {

--- a/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
+import { ScreenshotViewSelectors } from 'tests/electron/common/element-identifiers/screenshot-view-selectors';
 import { SpectronAsyncClient } from 'tests/electron/common/view-controllers/spectron-async-client';
 import { settingsPanelSelectors } from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
-import {
-    AutomatedChecksViewSelectors,
-    ScreenshotViewSelectors,
-} from '../element-identifiers/automated-checks-view-selectors';
+import { AutomatedChecksViewSelectors } from '../element-identifiers/automated-checks-view-selectors';
 import { ViewController } from './view-controller';
 
 export class AutomatedChecksViewController extends ViewController {
@@ -32,21 +29,6 @@ export class AutomatedChecksViewController extends ViewController {
         await this.client.click(selector);
     }
 
-    public async waitForViewVisible(): Promise<void> {
-        await this.waitForSelector(AutomatedChecksViewSelectors.mainContainer);
-    }
-
-    public async waitForScreenshotViewVisible(): Promise<void> {
-        await this.waitForSelector(ScreenshotViewSelectors.screenshotView);
-    }
-
-    public async openSettingsPanel(): Promise<void> {
-        await this.waitForSelector(AutomatedChecksViewSelectors.settingsButton);
-        await this.click(AutomatedChecksViewSelectors.settingsButton);
-        await this.waitForSelector(settingsPanelSelectors.settingsPanel);
-        await this.waitForMilliseconds(750); // Allow for fabric's panel animation to settle
-    }
-
     public async setToggleState(toggleSelector: string, newState: boolean): Promise<void> {
         await this.waitForSelector(toggleSelector);
         const oldState = await this.client.getAttribute(toggleSelector, 'aria-checked');
@@ -64,15 +46,5 @@ export class AutomatedChecksViewController extends ViewController {
             : settingsPanelSelectors.disabledToggle(toggleSelector);
 
         await this.waitForSelector(toggleInStateSelector);
-    }
-
-    public async clickLeftNavItem(key: LeftNavItemKey): Promise<void> {
-        const selector = this.getSelectorForLeftNavItemLink(key);
-        await this.waitForSelector(selector);
-        await this.click(selector);
-    }
-
-    private getSelectorForLeftNavItemLink(key: LeftNavItemKey): string {
-        return `${AutomatedChecksViewSelectors.leftNav} a[data-automation-id="${key}"]`;
     }
 }

--- a/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
@@ -28,23 +28,4 @@ export class AutomatedChecksViewController extends ViewController {
         await this.waitForSelector(selector);
         await this.client.click(selector);
     }
-
-    public async setToggleState(toggleSelector: string, newState: boolean): Promise<void> {
-        await this.waitForSelector(toggleSelector);
-        const oldState = await this.client.getAttribute(toggleSelector, 'aria-checked');
-
-        const oldStateBool = oldState.toLowerCase() === 'true';
-        if (oldStateBool !== newState) {
-            await this.click(toggleSelector);
-            await this.expectToggleState(toggleSelector, newState);
-        }
-    }
-
-    public async expectToggleState(toggleSelector: string, expectedState: boolean): Promise<void> {
-        const toggleInStateSelector = expectedState
-            ? settingsPanelSelectors.enabledToggle(toggleSelector)
-            : settingsPanelSelectors.disabledToggle(toggleSelector);
-
-        await this.waitForSelector(toggleInStateSelector);
-    }
 }

--- a/src/tests/electron/common/view-controllers/results-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/results-view-controller.ts
@@ -41,4 +41,23 @@ export class ResultsViewController extends ViewController {
     public createAutomatedChecksViewController(): AutomatedChecksViewController {
         return new AutomatedChecksViewController(this.client);
     }
+
+    public async setToggleState(toggleSelector: string, newState: boolean): Promise<void> {
+        await this.waitForSelector(toggleSelector);
+        const oldState = await this.client.getAttribute(toggleSelector, 'aria-checked');
+
+        const oldStateBool = oldState.toLowerCase() === 'true';
+        if (oldStateBool !== newState) {
+            await this.click(toggleSelector);
+            await this.expectToggleState(toggleSelector, newState);
+        }
+    }
+
+    public async expectToggleState(toggleSelector: string, expectedState: boolean): Promise<void> {
+        const toggleInStateSelector = expectedState
+            ? settingsPanelSelectors.enabledToggle(toggleSelector)
+            : settingsPanelSelectors.disabledToggle(toggleSelector);
+
+        await this.waitForSelector(toggleInStateSelector);
+    }
 }

--- a/src/tests/electron/common/view-controllers/results-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/results-view-controller.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
+import { ResultsViewSelectors } from 'tests/electron/common/element-identifiers/results-view-selectors';
+import { ScreenshotViewSelectors } from 'tests/electron/common/element-identifiers/screenshot-view-selectors';
+import { AutomatedChecksViewController } from 'tests/electron/common/view-controllers/automated-checks-view-controller';
+import { SpectronAsyncClient } from 'tests/electron/common/view-controllers/spectron-async-client';
+import { settingsPanelSelectors } from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
+import { ViewController } from './view-controller';
+
+export class ResultsViewController extends ViewController {
+    constructor(client: SpectronAsyncClient) {
+        super(client);
+    }
+
+    public async waitForViewVisible(): Promise<void> {
+        await this.waitForSelector(ResultsViewSelectors.mainContainer);
+    }
+
+    public async waitForScreenshotViewVisible(): Promise<void> {
+        await this.waitForSelector(ScreenshotViewSelectors.screenshotView);
+    }
+
+    public async openSettingsPanel(): Promise<void> {
+        await this.waitForSelector(ResultsViewSelectors.settingsButton);
+        await this.click(ResultsViewSelectors.settingsButton);
+        await this.waitForSelector(settingsPanelSelectors.settingsPanel);
+        await this.waitForMilliseconds(750); // Allow for fabric's panel animation to settle
+    }
+
+    public async clickLeftNavItem(key: LeftNavItemKey): Promise<void> {
+        const selector = this.getSelectorForLeftNavItemLink(key);
+        await this.waitForSelector(selector);
+        await this.click(selector);
+    }
+
+    private getSelectorForLeftNavItemLink(key: LeftNavItemKey): string {
+        return `${ResultsViewSelectors.leftNav} a[data-automation-id="${key}"]`;
+    }
+
+    public createAutomatedChecksViewController(): AutomatedChecksViewController {
+        return new AutomatedChecksViewController(this.client);
+    }
+}

--- a/src/tests/electron/tests/android-setup-prompt-connected-start-testing.test.ts
+++ b/src/tests/electron/tests/android-setup-prompt-connected-start-testing.test.ts
@@ -87,7 +87,7 @@ describe('Android setup - prompt-connected-start-testing', () => {
 
     it('goes to automated checks upon start testing', async () => {
         await dialog.click(getAutomationIdSelector(startTestingId));
-        await app.waitForAutomatedChecksView();
+        await app.waitForResultsView();
     });
 
     it('should pass accessibility validation in all contrast modes', async () => {

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -1,26 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getNarrowModeThresholdsForUnified } from 'electron/common/narrow-mode-thresholds';
-import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
-import * as fs from 'fs';
 import * as path from 'path';
 import { createApplication } from 'tests/electron/common/create-application';
-import {
-    AutomatedChecksViewSelectors,
-    ScreenshotViewSelectors,
-} from 'tests/electron/common/element-identifiers/automated-checks-view-selectors';
+import { AutomatedChecksViewSelectors } from 'tests/electron/common/element-identifiers/automated-checks-view-selectors';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
 import { AutomatedChecksViewController } from 'tests/electron/common/view-controllers/automated-checks-view-controller';
 import { commonAdbConfigs, setupMockAdb } from 'tests/miscellaneous/mock-adb/setup-mock-adb';
-import { testResourceServerConfig } from '../setup/test-resource-server-config';
-import { androidTestConfigs } from 'electron/platform/android/test-configs/android-test-configs';
 
 describe('AutomatedChecksView', () => {
     let app: AppController;
     let automatedChecksView: AutomatedChecksViewController;
-    const narrowModeThresholds = getNarrowModeThresholdsForUnified();
-    const height = 400;
 
     beforeEach(async () => {
         await setupMockAdb(
@@ -29,8 +19,9 @@ describe('AutomatedChecksView', () => {
             'beforeEach',
         );
         app = await createApplication({ suppressFirstTimeDialog: true });
-        automatedChecksView = await app.openAutomatedChecksView();
-        await automatedChecksView.waitForScreenshotViewVisible();
+        const resultsView = await app.openResultsView();
+        await resultsView.waitForScreenshotViewVisible();
+        automatedChecksView = resultsView.createAutomatedChecksViewController();
     });
 
     afterEach(async () => {
@@ -77,32 +68,6 @@ describe('AutomatedChecksView', () => {
         await assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
     });
 
-    it('should pass accessibility validation when left nav is showing', async () => {
-        await app.client.browserWindow.setSize(
-            narrowModeThresholds.collapseCommandBarThreshold + 1,
-            height,
-        );
-        await app.setFeatureFlag(UnifiedFeatureFlags.leftNavBar, true);
-        await automatedChecksView.waitForSelector(AutomatedChecksViewSelectors.leftNav);
-        await scanForAccessibilityIssuesInAllModes(app);
-    });
-
-    it('left nav allows to change between tests', async () => {
-        const testIndex = 1;
-        const expectedTestTitle = androidTestConfigs[testIndex].contentPageInfo.title;
-        await app.client.browserWindow.setSize(
-            narrowModeThresholds.collapseCommandBarThreshold + 1,
-            height,
-        );
-        await app.setFeatureFlag(UnifiedFeatureFlags.leftNavBar, true);
-        await automatedChecksView.waitForSelector(AutomatedChecksViewSelectors.leftNav);
-        await automatedChecksView.client.click(
-            AutomatedChecksViewSelectors.nthTestInLeftNav(testIndex + 1),
-        );
-        const title = await automatedChecksView.client.getText('h1');
-        expect(title).toEqual(expectedTestTitle);
-    });
-
     it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });
@@ -137,129 +102,4 @@ describe('AutomatedChecksView', () => {
         );
         expect(failures).toHaveLength(0);
     }
-
-    it('ScreenshotView renders screenshot image from specified source', async () => {
-        const resultExamplePath = path.join(
-            testResourceServerConfig.absolutePath,
-            'AccessibilityInsights/result.json',
-        );
-        const axeRuleResultExample = JSON.parse(
-            fs.readFileSync(resultExamplePath, { encoding: 'utf-8' }),
-        );
-        const expectedScreenshotImage =
-            'data:image/png;base64,' + axeRuleResultExample.axeContext.screenshot;
-
-        await automatedChecksView.waitForSelector(ScreenshotViewSelectors.screenshotImage);
-        const actualScreenshotImage = await automatedChecksView.client.getAttribute(
-            ScreenshotViewSelectors.screenshotImage,
-            'src',
-        );
-
-        expect(actualScreenshotImage).toEqual(expectedScreenshotImage);
-    });
-
-    it('ScreenshotView renders expected number/size of highlight boxes in expected positions', async () => {
-        await automatedChecksView.waitForSelector(ScreenshotViewSelectors.highlightBox);
-
-        const boxes = await automatedChecksView.client.$$(ScreenshotViewSelectors.highlightBox);
-        const styles = await Promise.all(boxes.map(async b => await b.getAttribute('style')));
-        const actualHighlightBoxStyles = styles.map(extractPositionStyles);
-        verifyHighlightBoxStyles(actualHighlightBoxStyles, [
-            { width: 10.7407, height: 6.04167, top: 3.28125, left: 89.2593 },
-            { width: 10.7407, height: 6.04167, top: 3.28125, left: 89.2593 },
-            { width: 10.7407, height: 6.04167, top: 10.4167, left: 13.4259 },
-            { width: 48.6111, height: 4.94792, top: 23.5417, left: 25.6481 },
-        ]);
-    });
-
-    type PositionStyles = {
-        width: number;
-        height: number;
-        top: number;
-        left: number;
-    };
-
-    function extractPositionStyles(styleValue: string): PositionStyles {
-        return {
-            width: extractStyleProperty(styleValue, 'width'),
-            height: extractStyleProperty(styleValue, 'height'),
-            top: extractStyleProperty(styleValue, 'top'),
-            left: extractStyleProperty(styleValue, 'left'),
-        };
-    }
-
-    function extractStyleProperty(styleValue: string, propertyName: string): number {
-        return parseFloat(RegExp(`${propertyName}: (-?\\d+(\\.\\d+)?)%`).exec(styleValue)[1]);
-    }
-
-    function verifyHighlightBoxStyles(
-        actualHighlightBoxStyles: PositionStyles[],
-        expectedHighlightBoxStyles: PositionStyles[],
-    ): void {
-        expect(actualHighlightBoxStyles).toHaveLength(expectedHighlightBoxStyles.length);
-
-        actualHighlightBoxStyles.forEach((boxStyle, index) => {
-            expect(boxStyle.top).toBeCloseTo(expectedHighlightBoxStyles[index].top);
-            expect(boxStyle.left).toBeCloseTo(expectedHighlightBoxStyles[index].left);
-            expect(boxStyle.width).toBeCloseTo(expectedHighlightBoxStyles[index].width);
-            expect(boxStyle.height).toBeCloseTo(expectedHighlightBoxStyles[index].height);
-        });
-    }
-
-    const setupWindowForCommandBarReflowTest = async (mode: 'narrow' | 'wide'): Promise<void> => {
-        await app.setFeatureFlag(UnifiedFeatureFlags.leftNavBar, true);
-
-        const width =
-            mode === 'narrow'
-                ? narrowModeThresholds.collapseCommandBarThreshold - 2
-                : narrowModeThresholds.collapseCommandBarThreshold;
-
-        await app.client.browserWindow.restore();
-        await app.client.browserWindow.setSize(width, height);
-    };
-
-    it('command bar reflows when narrow mode threshold is crossed', async () => {
-        await setupWindowForCommandBarReflowTest('narrow');
-        await automatedChecksView.waitForSelector(
-            AutomatedChecksViewSelectors.leftNavHamburgerButton,
-        );
-
-        await setupWindowForCommandBarReflowTest('wide');
-        await automatedChecksView.waitForSelectorToDisappear(
-            AutomatedChecksViewSelectors.leftNavHamburgerButton,
-        );
-    });
-
-    const waitForFluentLeftNavToDisappear = async (): Promise<void> => {
-        await automatedChecksView.waitForSelectorToDisappear(
-            AutomatedChecksViewSelectors.fluentLeftNav,
-        );
-    };
-
-    it('hamburger button click opens and closes left nav', async () => {
-        await setupWindowForCommandBarReflowTest('narrow');
-        await waitForFluentLeftNavToDisappear();
-        await automatedChecksView.client.click(AutomatedChecksViewSelectors.leftNavHamburgerButton);
-        await automatedChecksView.waitForSelector(AutomatedChecksViewSelectors.fluentLeftNav);
-
-        // Clicks the hamburger button inside the fluent left nav (there is one within the command bar as well)
-        const selector = `${AutomatedChecksViewSelectors.fluentLeftNav} ${AutomatedChecksViewSelectors.leftNavHamburgerButton}`;
-        await automatedChecksView.client.click(selector);
-        await waitForFluentLeftNavToDisappear();
-    });
-
-    it('left nav closes when item is selected', async () => {
-        await setupWindowForCommandBarReflowTest('narrow');
-        await automatedChecksView.client.click(AutomatedChecksViewSelectors.leftNavHamburgerButton);
-        await automatedChecksView.waitForSelector(AutomatedChecksViewSelectors.fluentLeftNav);
-
-        const selector = `${AutomatedChecksViewSelectors.fluentLeftNav} a`;
-        await automatedChecksView.client.click(selector);
-        await waitForFluentLeftNavToDisappear();
-    });
-
-    it('export report button exists', async () => {
-        await setupWindowForCommandBarReflowTest('wide');
-        await automatedChecksView.waitForSelector(AutomatedChecksViewSelectors.exportReportButton);
-    });
 });

--- a/src/tests/electron/tests/needs-review-view.test.ts
+++ b/src/tests/electron/tests/needs-review-view.test.ts
@@ -26,7 +26,7 @@ describe('NeedsReviewView', () => {
         app = await createApplication({ suppressFirstTimeDialog: true });
         app.client.browserWindow.setSize(windowWidth, windowHeight);
         await app.setFeatureFlag(UnifiedFeatureFlags.leftNavBar, true);
-        automatedChecksViewController = await app.openAutomatedChecksView();
+        automatedChecksViewController = await app.openResultsView();
         await automatedChecksViewController.clickLeftNavItem('needs-review');
     });
 

--- a/src/tests/electron/tests/needs-review-view.test.ts
+++ b/src/tests/electron/tests/needs-review-view.test.ts
@@ -4,15 +4,15 @@ import { getNarrowModeThresholdsForUnified } from 'electron/common/narrow-mode-t
 import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import * as path from 'path';
 import { createApplication } from 'tests/electron/common/create-application';
-import { AutomatedChecksViewSelectors } from 'tests/electron/common/element-identifiers/automated-checks-view-selectors';
+import { ResultsViewSelectors } from 'tests/electron/common/element-identifiers/results-view-selectors';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
-import { AutomatedChecksViewController } from 'tests/electron/common/view-controllers/automated-checks-view-controller';
+import { ResultsViewController } from 'tests/electron/common/view-controllers/results-view-controller';
 import { commonAdbConfigs, setupMockAdb } from 'tests/miscellaneous/mock-adb/setup-mock-adb';
 
 describe('NeedsReviewView', () => {
     let app: AppController;
-    let automatedChecksViewController: AutomatedChecksViewController;
+    let resultsViewController: ResultsViewController;
     const windowWidth = getNarrowModeThresholdsForUnified().collapseHeaderAndNavThreshold + 5;
     const windowHeight = 1000;
 
@@ -26,8 +26,8 @@ describe('NeedsReviewView', () => {
         app = await createApplication({ suppressFirstTimeDialog: true });
         app.client.browserWindow.setSize(windowWidth, windowHeight);
         await app.setFeatureFlag(UnifiedFeatureFlags.leftNavBar, true);
-        automatedChecksViewController = await app.openResultsView();
-        await automatedChecksViewController.clickLeftNavItem('needs-review');
+        resultsViewController = await app.openResultsView();
+        await resultsViewController.clickLeftNavItem('needs-review');
     });
 
     afterEach(async () => {
@@ -45,8 +45,8 @@ describe('NeedsReviewView', () => {
     });
 
     it('export report button does not exist', async () => {
-        await automatedChecksViewController.waitForSelectorToDisappear(
-            AutomatedChecksViewSelectors.exportReportButton,
+        await resultsViewController.waitForSelectorToDisappear(
+            ResultsViewSelectors.exportReportButton,
         );
     });
 });

--- a/src/tests/electron/tests/results-view.test.ts
+++ b/src/tests/electron/tests/results-view.test.ts
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { getNarrowModeThresholdsForUnified } from 'electron/common/narrow-mode-thresholds';
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
+import { androidTestConfigs } from 'electron/platform/android/test-configs/android-test-configs';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createApplication } from 'tests/electron/common/create-application';
+import { ResultsViewSelectors } from 'tests/electron/common/element-identifiers/results-view-selectors';
+import { ScreenshotViewSelectors } from 'tests/electron/common/element-identifiers/screenshot-view-selectors';
+import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
+import { AppController } from 'tests/electron/common/view-controllers/app-controller';
+import { ResultsViewController } from 'tests/electron/common/view-controllers/results-view-controller';
+import { commonAdbConfigs, setupMockAdb } from 'tests/miscellaneous/mock-adb/setup-mock-adb';
+import { testResourceServerConfig } from '../setup/test-resource-server-config';
+
+describe('ResultsView', () => {
+    let app: AppController;
+    let resultsView: ResultsViewController;
+    const narrowModeThresholds = getNarrowModeThresholdsForUnified();
+    const height = 400;
+
+    beforeEach(async () => {
+        await setupMockAdb(
+            commonAdbConfigs['single-device'],
+            path.basename(__filename),
+            'beforeEach',
+        );
+        app = await createApplication({ suppressFirstTimeDialog: true });
+        resultsView = await app.openResultsView();
+        await resultsView.waitForScreenshotViewVisible();
+    });
+
+    afterEach(async () => {
+        if (app != null) {
+            await app.stop();
+        }
+    });
+
+    it('should pass accessibility validation when left nav is showing', async () => {
+        await app.client.browserWindow.setSize(
+            narrowModeThresholds.collapseCommandBarThreshold + 1,
+            height,
+        );
+        await app.setFeatureFlag(UnifiedFeatureFlags.leftNavBar, true);
+        await resultsView.waitForSelector(ResultsViewSelectors.leftNav);
+        await scanForAccessibilityIssuesInAllModes(app);
+    });
+
+    it('left nav allows to change between tests', async () => {
+        const testIndex = 1;
+        const expectedTestTitle = androidTestConfigs[testIndex].contentPageInfo.title;
+        await app.client.browserWindow.setSize(
+            narrowModeThresholds.collapseCommandBarThreshold + 1,
+            height,
+        );
+        await app.setFeatureFlag(UnifiedFeatureFlags.leftNavBar, true);
+        await resultsView.waitForSelector(ResultsViewSelectors.leftNav);
+        await resultsView.client.click(ResultsViewSelectors.nthTestInLeftNav(testIndex + 1));
+        const title = await resultsView.client.getText('h1');
+        expect(title).toEqual(expectedTestTitle);
+    });
+
+    it('should pass accessibility validation in all contrast modes', async () => {
+        await scanForAccessibilityIssuesInAllModes(app);
+    });
+
+    it('ScreenshotView renders screenshot image from specified source', async () => {
+        const resultExamplePath = path.join(
+            testResourceServerConfig.absolutePath,
+            'AccessibilityInsights/result.json',
+        );
+        const axeRuleResultExample = JSON.parse(
+            fs.readFileSync(resultExamplePath, { encoding: 'utf-8' }),
+        );
+        const expectedScreenshotImage =
+            'data:image/png;base64,' + axeRuleResultExample.axeContext.screenshot;
+
+        await resultsView.waitForSelector(ScreenshotViewSelectors.screenshotImage);
+        const actualScreenshotImage = await resultsView.client.getAttribute(
+            ScreenshotViewSelectors.screenshotImage,
+            'src',
+        );
+
+        expect(actualScreenshotImage).toEqual(expectedScreenshotImage);
+    });
+
+    it('ScreenshotView renders expected number/size of highlight boxes in expected positions', async () => {
+        await resultsView.waitForSelector(ScreenshotViewSelectors.highlightBox);
+
+        const boxes = await resultsView.client.$$(ScreenshotViewSelectors.highlightBox);
+        const styles = await Promise.all(boxes.map(async b => await b.getAttribute('style')));
+        const actualHighlightBoxStyles = styles.map(extractPositionStyles);
+        verifyHighlightBoxStyles(actualHighlightBoxStyles, [
+            { width: 10.7407, height: 6.04167, top: 3.28125, left: 89.2593 },
+            { width: 10.7407, height: 6.04167, top: 3.28125, left: 89.2593 },
+            { width: 10.7407, height: 6.04167, top: 10.4167, left: 13.4259 },
+            { width: 48.6111, height: 4.94792, top: 23.5417, left: 25.6481 },
+        ]);
+    });
+
+    type PositionStyles = {
+        width: number;
+        height: number;
+        top: number;
+        left: number;
+    };
+
+    function extractPositionStyles(styleValue: string): PositionStyles {
+        return {
+            width: extractStyleProperty(styleValue, 'width'),
+            height: extractStyleProperty(styleValue, 'height'),
+            top: extractStyleProperty(styleValue, 'top'),
+            left: extractStyleProperty(styleValue, 'left'),
+        };
+    }
+
+    function extractStyleProperty(styleValue: string, propertyName: string): number {
+        return parseFloat(RegExp(`${propertyName}: (-?\\d+(\\.\\d+)?)%`).exec(styleValue)[1]);
+    }
+
+    function verifyHighlightBoxStyles(
+        actualHighlightBoxStyles: PositionStyles[],
+        expectedHighlightBoxStyles: PositionStyles[],
+    ): void {
+        expect(actualHighlightBoxStyles).toHaveLength(expectedHighlightBoxStyles.length);
+
+        actualHighlightBoxStyles.forEach((boxStyle, index) => {
+            expect(boxStyle.top).toBeCloseTo(expectedHighlightBoxStyles[index].top);
+            expect(boxStyle.left).toBeCloseTo(expectedHighlightBoxStyles[index].left);
+            expect(boxStyle.width).toBeCloseTo(expectedHighlightBoxStyles[index].width);
+            expect(boxStyle.height).toBeCloseTo(expectedHighlightBoxStyles[index].height);
+        });
+    }
+
+    const setupWindowForCommandBarReflowTest = async (mode: 'narrow' | 'wide'): Promise<void> => {
+        await app.setFeatureFlag(UnifiedFeatureFlags.leftNavBar, true);
+
+        const width =
+            mode === 'narrow'
+                ? narrowModeThresholds.collapseCommandBarThreshold - 2
+                : narrowModeThresholds.collapseCommandBarThreshold;
+
+        await app.client.browserWindow.restore();
+        await app.client.browserWindow.setSize(width, height);
+    };
+
+    it('command bar reflows when narrow mode threshold is crossed', async () => {
+        await setupWindowForCommandBarReflowTest('narrow');
+        await resultsView.waitForSelector(ResultsViewSelectors.leftNavHamburgerButton);
+
+        await setupWindowForCommandBarReflowTest('wide');
+        await resultsView.waitForSelectorToDisappear(ResultsViewSelectors.leftNavHamburgerButton);
+    });
+
+    const waitForFluentLeftNavToDisappear = async (): Promise<void> => {
+        await resultsView.waitForSelectorToDisappear(ResultsViewSelectors.fluentLeftNav);
+    };
+
+    it('hamburger button click opens and closes left nav', async () => {
+        await setupWindowForCommandBarReflowTest('narrow');
+        await waitForFluentLeftNavToDisappear();
+        await resultsView.client.click(ResultsViewSelectors.leftNavHamburgerButton);
+        await resultsView.waitForSelector(ResultsViewSelectors.fluentLeftNav);
+
+        // Clicks the hamburger button inside the fluent left nav (there is one within the command bar as well)
+        const selector = `${ResultsViewSelectors.fluentLeftNav} ${ResultsViewSelectors.leftNavHamburgerButton}`;
+        await resultsView.client.click(selector);
+        await waitForFluentLeftNavToDisappear();
+    });
+
+    it('left nav closes when item is selected', async () => {
+        await setupWindowForCommandBarReflowTest('narrow');
+        await resultsView.client.click(ResultsViewSelectors.leftNavHamburgerButton);
+        await resultsView.waitForSelector(ResultsViewSelectors.fluentLeftNav);
+
+        const selector = `${ResultsViewSelectors.fluentLeftNav} a`;
+        await resultsView.client.click(selector);
+        await waitForFluentLeftNavToDisappear();
+    });
+
+    it('export report button exists', async () => {
+        await setupWindowForCommandBarReflowTest('wide');
+        await resultsView.waitForSelector(ResultsViewSelectors.exportReportButton);
+    });
+});

--- a/src/tests/electron/tests/unified-settings-panel.test.ts
+++ b/src/tests/electron/tests/unified-settings-panel.test.ts
@@ -4,13 +4,13 @@ import * as path from 'path';
 import { createApplication } from 'tests/electron/common/create-application';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
-import { AutomatedChecksViewController } from 'tests/electron/common/view-controllers/automated-checks-view-controller';
+import { ResultsViewController } from 'tests/electron/common/view-controllers/results-view-controller';
 import { CommonSelectors } from 'tests/end-to-end/common/element-identifiers/common-selectors';
 import { settingsPanelSelectors } from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
 import { commonAdbConfigs, setupMockAdb } from 'tests/miscellaneous/mock-adb/setup-mock-adb';
 describe('AutomatedChecksView -> Settings Panel', () => {
     let app: AppController;
-    let automatedChecksView: AutomatedChecksViewController;
+    let resultsView: ResultsViewController;
 
     beforeEach(async () => {
         await setupMockAdb(
@@ -19,9 +19,9 @@ describe('AutomatedChecksView -> Settings Panel', () => {
             'beforeEach',
         );
         app = await createApplication({ suppressFirstTimeDialog: true });
-        automatedChecksView = await app.openResultsView();
-        await automatedChecksView.waitForViewVisible();
-        await automatedChecksView.openSettingsPanel();
+        resultsView = await app.openResultsView();
+        await resultsView.waitForViewVisible();
+        await resultsView.openSettingsPanel();
     });
 
     afterEach(async () => {
@@ -32,24 +32,15 @@ describe('AutomatedChecksView -> Settings Panel', () => {
 
     describe('Telemetry toggle', () => {
         it('should be "off" as per our suppressFirstTimeDialog implementation of the initial state', async () => {
-            await automatedChecksView.expectToggleState(
-                settingsPanelSelectors.telemetryStateToggle,
-                false,
-            );
+            await resultsView.expectToggleState(settingsPanelSelectors.telemetryStateToggle, false);
         });
 
         it('should reflect the state applied via the insightsUserConfiguration controller', async () => {
             await app.setTelemetryState(true);
-            await automatedChecksView.expectToggleState(
-                settingsPanelSelectors.telemetryStateToggle,
-                true,
-            );
+            await resultsView.expectToggleState(settingsPanelSelectors.telemetryStateToggle, true);
 
             await app.setTelemetryState(false);
-            await automatedChecksView.expectToggleState(
-                settingsPanelSelectors.telemetryStateToggle,
-                false,
-            );
+            await resultsView.expectToggleState(settingsPanelSelectors.telemetryStateToggle, false);
         });
     });
 
@@ -59,39 +50,31 @@ describe('AutomatedChecksView -> Settings Panel', () => {
         it.skip('should default to system setting or non-high-contrast mode', async () => {
             const highContrastModeEnabled = false;
 
-            await automatedChecksView.expectToggleState(
+            await resultsView.expectToggleState(
                 settingsPanelSelectors.highContrastModeToggle,
                 highContrastModeEnabled,
             );
         });
 
         it('should apply the appropriate CSS style when High Contrast Mode setting is toggled', async () => {
-            await automatedChecksView.setToggleState(
-                settingsPanelSelectors.highContrastModeToggle,
-                true,
-            );
+            await resultsView.setToggleState(settingsPanelSelectors.highContrastModeToggle, true);
 
-            await automatedChecksView.waitForSelector(CommonSelectors.highContrastThemeSelector);
+            await resultsView.waitForSelector(CommonSelectors.highContrastThemeSelector);
 
-            await automatedChecksView.setToggleState(
-                settingsPanelSelectors.highContrastModeToggle,
-                false,
-            );
+            await resultsView.setToggleState(settingsPanelSelectors.highContrastModeToggle, false);
 
-            await automatedChecksView.waitForSelectorToDisappear(
-                CommonSelectors.highContrastThemeSelector,
-            );
+            await resultsView.waitForSelectorToDisappear(CommonSelectors.highContrastThemeSelector);
         });
 
         it('should reflect the state applied via the insightsUserConfiguration controller', async () => {
             await app.setHighContrastMode(true);
-            await automatedChecksView.expectToggleState(
+            await resultsView.expectToggleState(
                 settingsPanelSelectors.highContrastModeToggle,
                 true,
             );
 
             await app.setHighContrastMode(false);
-            await automatedChecksView.expectToggleState(
+            await resultsView.expectToggleState(
                 settingsPanelSelectors.highContrastModeToggle,
                 false,
             );

--- a/src/tests/electron/tests/unified-settings-panel.test.ts
+++ b/src/tests/electron/tests/unified-settings-panel.test.ts
@@ -19,7 +19,7 @@ describe('AutomatedChecksView -> Settings Panel', () => {
             'beforeEach',
         );
         app = await createApplication({ suppressFirstTimeDialog: true });
-        automatedChecksView = await app.openAutomatedChecksView();
+        automatedChecksView = await app.openResultsView();
         await automatedChecksView.waitForViewVisible();
         await automatedChecksView.openSettingsPanel();
     });


### PR DESCRIPTION
#### Description of changes

The idea is to separate test code for the results view -- which covers the overall content of the app such as the command bar, left nav bar, and page content -- into its own file, while keeping the test code for the automated checks view -- the automated test results -- in its own file.

- Rename `ElectronAutomatedChecksView` to `ElectronResultsView` in `TelemetryEventSource`
- Extract code having to do with results view from `AutomatedChecksViewController` into `ResultsViewController` (likewise with selectors)
- Extract tests having to do with results view into a separate e2e test file
- Both sets of tests should still test for accessibility
