### PR TITLE
feat(android-needs-review): Add e2e test to validate expected cards in needs review view

### DIFF
--- a/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
@@ -28,4 +28,36 @@ export class AutomatedChecksViewController extends ViewController {
         await this.waitForSelector(selector);
         await this.client.click(selector);
     }
+
+    public async assertExpandedRuleGroup(
+        position: number,
+        expectedTitle: string,
+        expectedFailures: number,
+    ): Promise<void> {
+        const title = await this.client.getText(
+            AutomatedChecksViewSelectors.nthRuleGroupTitle(position),
+        );
+
+        expect(title).toEqual(expectedTitle);
+
+        const failures = await this.client.$$(
+            AutomatedChecksViewSelectors.nthRuleGroupInstances(position),
+        );
+
+        expect(failures).toHaveLength(expectedFailures);
+    }
+
+    public async assertCollapsedRuleGroup(position: number, expectedTitle: string): Promise<void> {
+        const title = await this.client.getText(
+            AutomatedChecksViewSelectors.nthRuleGroupTitle(position),
+        );
+
+        expect(title).toEqual(expectedTitle);
+
+        const failures = await this.client.$$(
+            AutomatedChecksViewSelectors.nthRuleGroupInstances(position),
+        );
+
+        expect(failures).toHaveLength(0);
+    }
 }

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -46,60 +46,29 @@ describe('AutomatedChecksView', () => {
         expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(0);
 
         await automatedChecksView.toggleRuleGroupAtPosition(1);
-        await assertExpandedRuleGroup(1, 'ImageViewName', 1);
+        await automatedChecksView.assertExpandedRuleGroup(1, 'ImageViewName', 1);
 
         await automatedChecksView.toggleRuleGroupAtPosition(2);
-        await assertExpandedRuleGroup(2, 'ActiveViewName', 2);
+        await automatedChecksView.assertExpandedRuleGroup(2, 'ActiveViewName', 2);
 
         await automatedChecksView.toggleRuleGroupAtPosition(3);
-        await assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
+        await automatedChecksView.assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
 
         await automatedChecksView.waitForHighlightBoxCount(4);
         expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(3);
 
         await automatedChecksView.toggleRuleGroupAtPosition(1);
-        await assertCollapsedRuleGroup(1, 'ImageViewName');
+        await automatedChecksView.assertCollapsedRuleGroup(1, 'ImageViewName');
 
         await automatedChecksView.toggleRuleGroupAtPosition(2);
-        await assertCollapsedRuleGroup(2, 'ActiveViewName');
+        await automatedChecksView.assertCollapsedRuleGroup(2, 'ActiveViewName');
 
         await automatedChecksView.waitForHighlightBoxCount(1);
         expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(1);
-        await assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
+        await automatedChecksView.assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
     });
 
-    it('should pass accessibility validation in all contrast modes', async () => {
+    it('should pass accessibility rvalidation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });
-
-    async function assertExpandedRuleGroup(
-        position: number,
-        expectedTitle: string,
-        expectedFailures: number,
-    ): Promise<void> {
-        const title = await automatedChecksView.client.getText(
-            AutomatedChecksViewSelectors.nthRuleGroupTitle(position),
-        );
-        expect(title).toEqual(expectedTitle);
-
-        const failures = await automatedChecksView.client.$$(
-            AutomatedChecksViewSelectors.nthRuleGroupInstances(position),
-        );
-        expect(failures).toHaveLength(expectedFailures);
-    }
-
-    async function assertCollapsedRuleGroup(
-        position: number,
-        expectedTitle: string,
-    ): Promise<void> {
-        const title = await automatedChecksView.client.getText(
-            AutomatedChecksViewSelectors.nthRuleGroupTitle(position),
-        );
-        expect(title).toEqual(expectedTitle);
-
-        const failures = await automatedChecksView.client.$$(
-            AutomatedChecksViewSelectors.nthRuleGroupInstances(position),
-        );
-        expect(failures).toHaveLength(0);
-    }
 });

--- a/src/tests/electron/tests/needs-review-view.test.ts
+++ b/src/tests/electron/tests/needs-review-view.test.ts
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 import { getNarrowModeThresholdsForUnified } from 'electron/common/narrow-mode-thresholds';
 import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
+import { resultsView } from 'electron/views/results/results-view.scss';
 import * as path from 'path';
 import { createApplication } from 'tests/electron/common/create-application';
+import { AutomatedChecksViewSelectors } from 'tests/electron/common/element-identifiers/automated-checks-view-selectors';
 import { ResultsViewSelectors } from 'tests/electron/common/element-identifiers/results-view-selectors';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
@@ -38,6 +40,18 @@ describe('NeedsReviewView', () => {
 
     it('should use the expected window title', async () => {
         await app.waitForTitle('Accessibility Insights for Android - Needs review');
+    });
+
+    it('displays needs review results with one failing result', async () => {
+        const automatedChecksView = resultsViewController.createAutomatedChecksViewController();
+        await automatedChecksView.waitForRuleGroupCount(1);
+        expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(0);
+        await automatedChecksView.waitForHighlightBoxCount(1);
+
+        await automatedChecksView.toggleRuleGroupAtPosition(1);
+        await automatedChecksView.assertExpandedRuleGroup(1, 'ColorContrast', 1);
+
+        expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(1);
     });
 
     it('should pass accessibility validation in all contrast modes', async () => {


### PR DESCRIPTION
#### Description of changes

Validate there should be one rule and one failure instance for color contrast in needs review.

The next step will be to rename `AutomatedChecksViewController` to `CardsViewController` because the latter is more descriptive of the classes current purpose. The rename will be done separately to keep the diff in this change targeted.


<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
