### PR TITLE
fix: Improve user messages when connecting Android device

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
@@ -33,6 +33,10 @@ export const PromptConnectToDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
 
         return (
             <AndroidSetupStepLayout {...layoutProps}>
+                <p>
+                    Connect a hardware device to your computer via USB, or run a virtual device in
+                    Android Studio or the Android Virtual Device Manager.
+                </p>
                 <PrimaryButton
                     data-automation-id={detectDeviceAutomationId}
                     text="Detect my device"

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
@@ -44,7 +44,8 @@ export const PromptGrantPermissionsStep = NamedFC<CommonAndroidSetupStepProps>(
             <AndroidSetupStepLayout {...layoutProps}>
                 <p>
                     Be sure the Accessibility Insights for Android Service on your device is turned
-                    on and has permission to access your device and capture screenshots.
+                    on and has permission to access your device and capture screenshots. Then select{' '}
+                    <i>Try again</i> to connect.
                 </p>
                 <DeviceDescription {...descriptionProps}></DeviceDescription>
                 <PrimaryButton

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connect-to-device-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connect-to-device-step.test.tsx.snap
@@ -24,6 +24,9 @@ exports[`PromptConnectToDeviceStep renders per snapshot 1`] = `
     }
   }
 >
+  <p>
+    Connect a hardware device to your computer via USB, or run a virtual device in Android Studio or the Android Virtual Device Manager.
+  </p>
   <CustomizedPrimaryButton
     className="detectButton"
     data-automation-id="detect-device"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
@@ -25,7 +25,12 @@ exports[`PromptGrantPermissionsStep renders with device 1`] = `
   }
 >
   <p>
-    Be sure the Accessibility Insights for Android Service on your device is turned on and has permission to access your device and capture screenshots.
+    Be sure the Accessibility Insights for Android Service on your device is turned on and has permission to access your device and capture screenshots. Then select
+     
+    <i>
+      Try again
+    </i>
+     to connect.
   </p>
   <DeviceDescription
     className="deviceDescription"
@@ -66,7 +71,12 @@ exports[`PromptGrantPermissionsStep renders with emulator 1`] = `
   }
 >
   <p>
-    Be sure the Accessibility Insights for Android Service on your device is turned on and has permission to access your device and capture screenshots.
+    Be sure the Accessibility Insights for Android Service on your device is turned on and has permission to access your device and capture screenshots. Then select
+     
+    <i>
+      Try again
+    </i>
+     to connect.
   </p>
   <DeviceDescription
     className="deviceDescription"


### PR DESCRIPTION
#### Description of changes

This makes the text changes called out in #3542. Here are the before and after images:

Screen | Before | After
--- | --- | ---
Connect Device | ![image](https://user-images.githubusercontent.com/45672944/99452738-d2d2a800-28d8-11eb-9a3d-c5f28d5c4a90.png) | ![image](https://user-images.githubusercontent.com/45672944/99452795-e3831e00-28d8-11eb-9a62-680a24f4cb03.png)
Grant Permissions | ![image](https://user-images.githubusercontent.com/45672944/99452880-fbf33880-28d8-11eb-91ff-ac2a76b44115.png) | ![image](https://user-images.githubusercontent.com/45672944/99452904-07466400-28d9-11eb-9bdf-b5026032d0d6.png)

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3542 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
