### PR TITLE
fix: Make "Expand all" button more screen-reader friendly

### DIFF
--- a/src/common/components/cards/expand-collapse-all-button.tsx
+++ b/src/common/components/cards/expand-collapse-all-button.tsx
@@ -23,7 +23,7 @@ export const ExpandCollapseAllButton = NamedFC<ExpandCollapseAllButtonProps>(
         let expandCollapseAllButtonHandler = deps.cardSelectionMessageCreator.collapseAllRules;
         let buttonText = 'Collapse all';
         let iconName = 'ChevronDown';
-        let ariaLabel = buttonText;
+        let ariaLabel = null;
 
         if (allCardsCollapsed) {
             expandCollapseAllButtonHandler = deps.cardSelectionMessageCreator.expandAllRules;

--- a/src/common/components/cards/expand-collapse-all-button.tsx
+++ b/src/common/components/cards/expand-collapse-all-button.tsx
@@ -23,11 +23,13 @@ export const ExpandCollapseAllButton = NamedFC<ExpandCollapseAllButtonProps>(
         let expandCollapseAllButtonHandler = deps.cardSelectionMessageCreator.collapseAllRules;
         let buttonText = 'Collapse all';
         let iconName = 'ChevronDown';
+        let ariaLabel = buttonText;
 
         if (allCardsCollapsed) {
             expandCollapseAllButtonHandler = deps.cardSelectionMessageCreator.expandAllRules;
             buttonText = 'Expand all';
             iconName = 'ChevronRight';
+            ariaLabel = 'Expand all rules to show failed instances.';
         }
 
         return (
@@ -35,6 +37,7 @@ export const ExpandCollapseAllButton = NamedFC<ExpandCollapseAllButtonProps>(
                 iconProps={{ iconName }}
                 onClick={expandCollapseAllButtonHandler}
                 aria-expanded={!allCardsCollapsed}
+                aria-label={ariaLabel}
                 className={styles.expandCollapseAllButton}
             >
                 {buttonText}

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/expand-collapse-all-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/expand-collapse-all-button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ExpandCollapseAllButton renders per snapshot with allCardsCollapsed false 1`] = `
 <CustomizedActionButton
   aria-expanded={true}
-  aria-label="Collapse all"
+  aria-label={null}
   className="expandCollapseAllButton"
   iconProps={
     Object {

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/expand-collapse-all-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/expand-collapse-all-button.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`ExpandCollapseAllButton renders per snapshot with allCardsCollapsed false 1`] = `
 <CustomizedActionButton
   aria-expanded={true}
+  aria-label="Collapse all"
   className="expandCollapseAllButton"
   iconProps={
     Object {
@@ -18,6 +19,7 @@ exports[`ExpandCollapseAllButton renders per snapshot with allCardsCollapsed fal
 exports[`ExpandCollapseAllButton renders per snapshot with allCardsCollapsed true 1`] = `
 <CustomizedActionButton
   aria-expanded={false}
+  aria-label="Expand all rules to show failed instances."
   className="expandCollapseAllButton"
   iconProps={
     Object {


### PR DESCRIPTION
#### Description of changes
Issue #3539 suggests an improvement to the Expand all/Collapse all button when read via a screen reader. Specifically, set the aria-label property to a more descriptive value when the button is in the collapsed state. The issue says nothing about modifying the aria-label property in the expanded state. Change has been validated with NVDA in both Web and Unified clients.

HTML of the button in the collapsed state (aria-label property is new)

```
<button type="button" aria-expanded="false" aria-label="Expand all rules to show failed instances." class="ms-Button ms-Button--action ms-Button--command expand-collapse-all-button--3fwBF root-113" data-is-focusable="true"><span class="ms-Button-flexContainer flexContainer-108" data-automationid="splitbuttonprimary"><i data-icon-name="ChevronRight" role="presentation" aria-hidden="true" class="ms-Icon root-37 css-60 ms-Button-icon icon-114" style="font-family: FabricMDL2Icons;"></i><span class="ms-Button-textContainer textContainer-109"><span class="ms-Button-label label-57" id="id__18">Expand all</span></span></span></button>
```

HTML of the button in the expanded state (no aria-label is added, and button is unchanged from before):
```
<button type="button" aria-expanded="true" class="ms-Button ms-Button--action ms-Button--command expand-collapse-all-button--3fwBF root-113" data-is-focusable="true"><span class="ms-Button-flexContainer flexContainer-108" data-automationid="splitbuttonprimary"><i data-icon-name="ChevronDown" role="presentation" aria-hidden="true" class="ms-Icon root-37 css-60 ms-Button-icon icon-114" style="font-family: FabricMDL2Icons;"></i><span class="ms-Button-textContainer textContainer-109"><span class="ms-Button-label label-57" id="id__18">Collapse all</span></span></span></button>
```


<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3539 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
