### PR TITLE
feat(android-needs-review): Rename AutomatedChecksViewController to CardsViewController

### DIFF
--- a/src/tests/electron/common/view-controllers/cards-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/cards-view-controller.ts
@@ -6,7 +6,7 @@ import { settingsPanelSelectors } from 'tests/end-to-end/common/element-identifi
 import { AutomatedChecksViewSelectors } from '../element-identifiers/automated-checks-view-selectors';
 import { ViewController } from './view-controller';
 
-export class AutomatedChecksViewController extends ViewController {
+export class CardsViewController extends ViewController {
     constructor(client: SpectronAsyncClient) {
         super(client);
     }

--- a/src/tests/electron/common/view-controllers/results-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/results-view-controller.ts
@@ -3,7 +3,7 @@
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 import { ResultsViewSelectors } from 'tests/electron/common/element-identifiers/results-view-selectors';
 import { ScreenshotViewSelectors } from 'tests/electron/common/element-identifiers/screenshot-view-selectors';
-import { AutomatedChecksViewController } from 'tests/electron/common/view-controllers/automated-checks-view-controller';
+import { CardsViewController } from 'tests/electron/common/view-controllers/cards-view-controller';
 import { SpectronAsyncClient } from 'tests/electron/common/view-controllers/spectron-async-client';
 import { settingsPanelSelectors } from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
 import { ViewController } from './view-controller';
@@ -38,8 +38,8 @@ export class ResultsViewController extends ViewController {
         return `${ResultsViewSelectors.leftNav} a[data-automation-id="${key}"]`;
     }
 
-    public createAutomatedChecksViewController(): AutomatedChecksViewController {
-        return new AutomatedChecksViewController(this.client);
+    public createCardsViewController(): CardsViewController {
+        return new CardsViewController(this.client);
     }
 
     public async setToggleState(toggleSelector: string, newState: boolean): Promise<void> {

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -5,12 +5,12 @@ import { createApplication } from 'tests/electron/common/create-application';
 import { AutomatedChecksViewSelectors } from 'tests/electron/common/element-identifiers/automated-checks-view-selectors';
 import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
 import { AppController } from 'tests/electron/common/view-controllers/app-controller';
-import { AutomatedChecksViewController } from 'tests/electron/common/view-controllers/automated-checks-view-controller';
+import { CardsViewController } from 'tests/electron/common/view-controllers/cards-view-controller';
 import { commonAdbConfigs, setupMockAdb } from 'tests/miscellaneous/mock-adb/setup-mock-adb';
 
 describe('AutomatedChecksView', () => {
     let app: AppController;
-    let automatedChecksView: AutomatedChecksViewController;
+    let cardsView: CardsViewController;
 
     beforeEach(async () => {
         await setupMockAdb(
@@ -21,7 +21,7 @@ describe('AutomatedChecksView', () => {
         app = await createApplication({ suppressFirstTimeDialog: true });
         const resultsView = await app.openResultsView();
         await resultsView.waitForScreenshotViewVisible();
-        automatedChecksView = resultsView.createAutomatedChecksViewController();
+        cardsView = resultsView.createCardsViewController();
     });
 
     afterEach(async () => {
@@ -35,37 +35,37 @@ describe('AutomatedChecksView', () => {
     });
 
     it('displays automated checks results collapsed by default', async () => {
-        await automatedChecksView.waitForRuleGroupCount(3);
+        await cardsView.waitForRuleGroupCount(3);
 
-        const collapsibleContentElements = await automatedChecksView.queryRuleGroupContents();
+        const collapsibleContentElements = await cardsView.queryRuleGroupContents();
         expect(collapsibleContentElements).toHaveLength(0);
     });
 
     it('supports expanding and collapsing rule groups', async () => {
-        await automatedChecksView.waitForHighlightBoxCount(4);
-        expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(0);
+        await cardsView.waitForHighlightBoxCount(4);
+        expect(await cardsView.queryRuleGroupContents()).toHaveLength(0);
 
-        await automatedChecksView.toggleRuleGroupAtPosition(1);
-        await automatedChecksView.assertExpandedRuleGroup(1, 'ImageViewName', 1);
+        await cardsView.toggleRuleGroupAtPosition(1);
+        await cardsView.assertExpandedRuleGroup(1, 'ImageViewName', 1);
 
-        await automatedChecksView.toggleRuleGroupAtPosition(2);
-        await automatedChecksView.assertExpandedRuleGroup(2, 'ActiveViewName', 2);
+        await cardsView.toggleRuleGroupAtPosition(2);
+        await cardsView.assertExpandedRuleGroup(2, 'ActiveViewName', 2);
 
-        await automatedChecksView.toggleRuleGroupAtPosition(3);
-        await automatedChecksView.assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
+        await cardsView.toggleRuleGroupAtPosition(3);
+        await cardsView.assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
 
-        await automatedChecksView.waitForHighlightBoxCount(4);
-        expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(3);
+        await cardsView.waitForHighlightBoxCount(4);
+        expect(await cardsView.queryRuleGroupContents()).toHaveLength(3);
 
-        await automatedChecksView.toggleRuleGroupAtPosition(1);
-        await automatedChecksView.assertCollapsedRuleGroup(1, 'ImageViewName');
+        await cardsView.toggleRuleGroupAtPosition(1);
+        await cardsView.assertCollapsedRuleGroup(1, 'ImageViewName');
 
-        await automatedChecksView.toggleRuleGroupAtPosition(2);
-        await automatedChecksView.assertCollapsedRuleGroup(2, 'ActiveViewName');
+        await cardsView.toggleRuleGroupAtPosition(2);
+        await cardsView.assertCollapsedRuleGroup(2, 'ActiveViewName');
 
-        await automatedChecksView.waitForHighlightBoxCount(1);
-        expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(1);
-        await automatedChecksView.assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
+        await cardsView.waitForHighlightBoxCount(1);
+        expect(await cardsView.queryRuleGroupContents()).toHaveLength(1);
+        await cardsView.assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
     });
 
     it('should pass accessibility rvalidation in all contrast modes', async () => {

--- a/src/tests/electron/tests/needs-review-view.test.ts
+++ b/src/tests/electron/tests/needs-review-view.test.ts
@@ -43,15 +43,15 @@ describe('NeedsReviewView', () => {
     });
 
     it('displays needs review results with one failing result', async () => {
-        const automatedChecksView = resultsViewController.createAutomatedChecksViewController();
-        await automatedChecksView.waitForRuleGroupCount(1);
-        expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(0);
-        await automatedChecksView.waitForHighlightBoxCount(1);
+        const cardsView = resultsViewController.createCardsViewController();
+        await cardsView.waitForRuleGroupCount(1);
+        expect(await cardsView.queryRuleGroupContents()).toHaveLength(0);
+        await cardsView.waitForHighlightBoxCount(1);
 
-        await automatedChecksView.toggleRuleGroupAtPosition(1);
-        await automatedChecksView.assertExpandedRuleGroup(1, 'ColorContrast', 1);
+        await cardsView.toggleRuleGroupAtPosition(1);
+        await cardsView.assertExpandedRuleGroup(1, 'ColorContrast', 1);
 
-        expect(await automatedChecksView.queryRuleGroupContents()).toHaveLength(1);
+        expect(await cardsView.queryRuleGroupContents()).toHaveLength(1);
     });
 
     it('should pass accessibility validation in all contrast modes', async () => {


### PR DESCRIPTION
#### Description of changes

The rename represents that testing cards is not exclusive to the automated checks page of the results view.
