### PR TITLE
fix(android-needs-review): make links in unified cards not also select the cards when clicked

### DIFF
--- a/src/electron/views/device-connect-view/components/electron-external-link.tsx
+++ b/src/electron/views/device-connect-view/components/electron-external-link.tsx
@@ -14,7 +14,11 @@ export interface ElectronExternalLinkProps {
 export const ElectronExternalLink = NamedFC<ElectronExternalLinkProps>(
     'ElectronExternalLink',
     (props: ElectronExternalLinkProps) => {
-        const onClick = () => props.shell.openExternal(props.href);
+        const onClick = (event: React.MouseEvent<any>) => {
+            props.shell.openExternal(props.href);
+            event.preventDefault();
+            event.stopPropagation();
+        };
         return (
             <Link role="link" onClick={onClick}>
                 {props.children}

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/electron-external-link.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/electron-external-link.test.tsx
@@ -6,9 +6,7 @@ import {
     ElectronExternalLinkProps,
 } from 'electron/views/device-connect-view/components/electron-external-link';
 import { shallow } from 'enzyme';
-import { Button } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { Mock, Times } from 'typemoq';
 
 describe('ElectronExternalLink', () => {
@@ -28,21 +26,29 @@ describe('ElectronExternalLink', () => {
     });
 
     test('click', () => {
-        const shellMock = Mock.ofType<Shell>();
-        const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<
-            Button
-        >;
-        shellMock.setup(shell => shell.openExternal(testHref)).verifiable(Times.once());
+        const mockShell = Mock.ofType<Shell>();
+        const mockPreventDefault = Mock.ofInstance(() => {});
+        const mockStopPropagation = Mock.ofInstance(() => {});
+        const mockEvent = {
+            preventDefault: mockPreventDefault.object,
+            stopPropagation: mockStopPropagation.object,
+        } as React.MouseEvent<unknown>;
+
+        mockShell.setup(shell => shell.openExternal(testHref)).verifiable(Times.once());
+        mockPreventDefault.setup(m => m()).verifiable(Times.once());
+        mockStopPropagation.setup(m => m()).verifiable(Times.once());
 
         const props: ElectronExternalLinkProps = {
             href: testHref,
             children: testText,
-            shell: shellMock.object,
+            shell: mockShell.object,
         };
 
         const rendered = shallow(<ElectronExternalLink {...props} />);
-        rendered.simulate('click', eventStub);
+        rendered.simulate('click', mockEvent);
 
-        shellMock.verifyAll();
+        mockShell.verifyAll();
+        mockPreventDefault.verifyAll();
+        mockStopPropagation.verifyAll();
     });
 });


### PR DESCRIPTION
#### Description of changes

Before this PR, when you click on a link that appears in the body of a card in unified's results view (eg, Color Contrast results as of the needs review feature), the click event bubbles up out of the link component, so in addition to opening the link, it also select/deselects the card. This PR prevents the event from propagating.

Note that the same basic issue affects web and this PR does *not* fix that case; the link components are product specific so they need separate fixes.

Before:
![animation showing clicks on the link selecting the card](https://user-images.githubusercontent.com/376284/99856131-4d5c2b80-2b56-11eb-9e6e-542d1563af8a.gif)

After:
![animation showing clicks on the link not selecting the card](https://user-images.githubusercontent.com/376284/99856228-8399ab00-2b56-11eb-86da-e8380a5d4816.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
