### PR TITLE
fix: added WCAG link to the links list and requirement

### DIFF
--- a/src/assessments/prerecorded-multimedia/test-steps/audio-description.tsx
+++ b/src/assessments/prerecorded-multimedia/test-steps/audio-description.tsx
@@ -43,5 +43,5 @@ export const AudioDescription: Requirement = {
     howToTest: audioHowToTest,
     isManual: true,
     ...content,
-    guidanceLinks: [link.WCAG_1_2_5],
+    guidanceLinks: [link.WCAG_1_2_3, link.WCAG_1_2_5],
 };

--- a/src/content/link.tsx
+++ b/src/content/link.tsx
@@ -7,6 +7,10 @@ export const link = {
     WCAG_1_1_1: guidanceLinkTo('WCAG 1.1.1', 'https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html'),
     WCAG_1_2_1: guidanceLinkTo('WCAG 1.2.1', 'https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded'),
     WCAG_1_2_2: guidanceLinkTo('WCAG 1.2.2', 'https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html'),
+    WCAG_1_2_3: guidanceLinkTo(
+        'WCAG 1.2.3',
+        'https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded',
+    ),
     WCAG_1_2_4: guidanceLinkTo('WCAG 1.2.4', 'https://www.w3.org/WAI/WCAG21/Understanding/captions-live.html'),
     WCAG_1_2_5: guidanceLinkTo('WCAG 1.2.5', 'https://www.w3.org/WAI/WCAG21/Understanding/audio-description-prerecorded'),
     WCAG_1_3_1: guidanceLinkTo('WCAG 1.3.1', 'https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships'),


### PR DESCRIPTION
#### Description of changes

added WCAG link to the links list and requirement for WCAG 1.2.3 that was missing in the report.
![multimedia test, Audio description requirement now has WCAG 1.2.3 and WCAG 1.2.5](https://user-images.githubusercontent.com/9062104/100029268-c43b3380-2da5-11eb-888c-ecb404c98d84.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3414 
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
