### PR TITLE
fix(android-needs-review): make left nav panel dismiss on escape and on click out of menu

### DIFF
--- a/src/electron/views/left-nav/fluent-left-nav.tsx
+++ b/src/electron/views/left-nav/fluent-left-nav.tsx
@@ -37,11 +37,11 @@ export const FluentLeftNav = NamedFC<FluentLeftNavProps>('LeftNav', props => {
             layerProps={{ className: styles.leftNavPanelHost }}
             className={styles.leftNavPanel}
             isOpen={isNavOpen}
-            isLightDismiss
             hasCloseButton={false}
             onRenderNavigationContent={() => null}
             onRenderNavigation={() => null}
             type={PanelType.customNear}
+            onDismiss={() => setSideNavOpen(false)}
         >
             <div className={styles.navMenuContainer}>
                 <FastPassLeftNavHamburgerButton

--- a/src/tests/unit/tests/electron/views/left-nav/__snapshots__/fluent-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/left-nav/__snapshots__/fluent-left-nav.test.tsx.snap
@@ -12,13 +12,13 @@ exports[`FluentLeftNav render left nav inside panel 1`] = `
   className="leftNavPanel"
   hasCloseButton={false}
   innerPanelAutomationId="fluent-left-nav"
-  isLightDismiss={true}
   isOpen={true}
   layerProps={
     Object {
       "className": "leftNavPanelHost",
     }
   }
+  onDismiss={[Function]}
   onRenderNavigation={[Function]}
   onRenderNavigationContent={[Function]}
   type={8}

--- a/src/tests/unit/tests/electron/views/left-nav/fluent-left-nav.test.tsx
+++ b/src/tests/unit/tests/electron/views/left-nav/fluent-left-nav.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { FastPassLeftNavHamburgerButton } from 'common/components/expand-collapse-left-nav-hamburger-button';
+import { GenericPanel } from 'DetailsView/components/generic-panel';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import {
     FluentLeftNav,
@@ -10,6 +11,7 @@ import {
 } from 'electron/views/left-nav/fluent-left-nav';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { Mock, MockBehavior } from 'typemoq';
 
 describe('FluentLeftNav', () => {
     let props: FluentLeftNavProps;
@@ -44,5 +46,17 @@ describe('FluentLeftNav', () => {
         props.narrowModeStatus.isHeaderAndNavCollapsed = false;
         const testSubject = shallow(<FluentLeftNav {...props} />);
         expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    test('dismissing the panel uses setSideNavOpen(false)', () => {
+        const setSideNavOpenMock = Mock.ofInstance((state: boolean) => {}, MockBehavior.Strict);
+        props.setSideNavOpen = setSideNavOpenMock.object;
+        const testSubject = shallow(<FluentLeftNav {...props} />);
+
+        setSideNavOpenMock.setup(m => m(false)).verifiable();
+
+        testSubject.find(GenericPanel).prop('onDismiss')();
+
+        setSideNavOpenMock.verifyAll();
     });
 });


### PR DESCRIPTION
#### Description of changes

Addresses #3692.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3692.
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
