### PR TITLE
fix: inline start over button

### DIFF
--- a/src/DetailsView/components/adhoc-issues-test-view.tsx
+++ b/src/DetailsView/components/adhoc-issues-test-view.tsx
@@ -65,6 +65,7 @@ function createTargetPageChangedView(props: AdhocIssuesTestViewProps): JSX.Eleme
             visualizationType={selectedTest}
             toggleClickHandler={clickHandler}
             featureFlagStoreData={props.featureFlagStoreData}
+            detailsViewActionMessageCreator={props.deps.detailsViewActionMessageCreator}
         />
     );
 }

--- a/src/DetailsView/components/adhoc-static-test-view.tsx
+++ b/src/DetailsView/components/adhoc-static-test-view.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import * as React from 'react';
 import { ContentReference } from 'views/content/content-page';
 
@@ -17,7 +18,9 @@ import {
 } from './static-content-details-view';
 import { TargetPageChangedView } from './target-page-changed-view';
 
-export type AdhocStaticTestViewDeps = StaticContentDetailsViewDeps;
+export type AdhocStaticTestViewDeps = {
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+} & StaticContentDetailsViewDeps;
 
 export interface AdhocStaticTestViewProps {
     deps: AdhocStaticTestViewDeps;
@@ -49,6 +52,7 @@ export const AdhocStaticTestView = NamedFC<AdhocStaticTestViewProps>(
                     visualizationType={selectedTest}
                     toggleClickHandler={clickHandler}
                     featureFlagStoreData={props.featureFlagStoreData}
+                    detailsViewActionMessageCreator={props.deps.detailsViewActionMessageCreator}
                 />
             );
         }

--- a/src/DetailsView/components/details-list-issues-view.tsx
+++ b/src/DetailsView/components/details-list-issues-view.tsx
@@ -44,6 +44,7 @@ export const DetailsListIssuesView = NamedFC<DetailsListIssuesViewProps>(
                 scanMetadata={props.scanMetadata}
                 cardsViewData={props.cardsViewData}
                 instancesSection={props.instancesSection}
+                visualizationStoreData={props.visualizationStoreData}
             />
         );
     },

--- a/src/DetailsView/components/inline-start-over-button.scss
+++ b/src/DetailsView/components/inline-start-over-button.scss
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+
+.inline-start-over-button {
+    height: fit-content;
+    padding: 4px;
+    margin-bottom: -4px;
+    vertical-align: text-bottom;
+    border-color: $secondary-text;
+    background-color: $neutral-0;
+}

--- a/src/DetailsView/components/inline-start-over-button.tsx
+++ b/src/DetailsView/components/inline-start-over-button.tsx
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
+import { NamedFC } from 'common/react/named-fc';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import * as React from 'react';
+import * as styles from './inline-start-over-button.scss';
+
+export type InlineStartOverButtonProps = {
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+    selectedTest: VisualizationType;
+};
+
+export const InlineStartOverButton = NamedFC<InlineStartOverButtonProps>(
+    'InlineStartOverButton',
+    props => {
+        const rescan = event =>
+            props.detailsViewActionMessageCreator.rescanVisualization(props.selectedTest, event);
+        return (
+            <InsightsCommandButton
+                onClick={rescan}
+                text="Start over"
+                iconProps={{ iconName: 'Refresh' }}
+                className={styles.inlineStartOverButton}
+            />
+        );
+    },
+);

--- a/src/DetailsView/components/issues-table.scss
+++ b/src/DetailsView/components/issues-table.scss
@@ -30,5 +30,14 @@
         display: flex;
         flex-direction: column;
         min-height: 0;
+
+        .inline-start-over-button {
+            height: fit-content;
+            padding: 4px;
+            margin-bottom: -4px;
+            vertical-align: text-bottom;
+            border-color: $secondary-text;
+            background-color: $neutral-0;
+        }
     }
 }

--- a/src/DetailsView/components/issues-table.scss
+++ b/src/DetailsView/components/issues-table.scss
@@ -30,14 +30,5 @@
         display: flex;
         flex-direction: column;
         min-height: 0;
-
-        .inline-start-over-button {
-            height: fit-content;
-            padding: 4px;
-            margin-bottom: -4px;
-            vertical-align: text-bottom;
-            border-color: $secondary-text;
-            background-color: $neutral-0;
-        }
     }
 }

--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -1,16 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as Markup from 'assessments/markup';
 import {
     CommonInstancesSectionDeps,
     CommonInstancesSectionProps,
 } from 'common/components/cards/common-instances-section-props';
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { ScanningSpinner } from 'common/components/scanning-spinner/scanning-spinner';
 import { ReactFCWithDisplayName } from 'common/react/named-fc';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import * as styles from 'DetailsView/components/issues-table.scss';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
@@ -33,6 +34,7 @@ export interface IssuesTableProps {
     scanMetadata: ScanMetadata;
     cardsViewData: CardsViewModel;
     instancesSection: ReactFCWithDisplayName<CommonInstancesSectionProps>;
+    visualizationStoreData: VisualizationStoreData;
 }
 
 export class IssuesTable extends React.Component<IssuesTableProps> {
@@ -95,11 +97,27 @@ export class IssuesTable extends React.Component<IssuesTableProps> {
         return <ScanningSpinner isSpinning={true} label={label} />;
     }
 
+    private renderInlineStartOverButton(): JSX.Element {
+        const selectedTest = this.props.visualizationStoreData.selectedFastPassDetailsView;
+        const rescan = event =>
+            this.props.deps.detailsViewActionMessageCreator.rescanVisualization(
+                selectedTest,
+                event,
+            );
+        return (
+            <InsightsCommandButton
+                onClick={rescan}
+                text="Start over"
+                iconProps={{ iconName: 'Refresh' }}
+                className={styles.inlineStartOverButton}
+            />
+        );
+    }
+
     private renderDisabledMessage(): JSX.Element {
+        const startOverButton = this.renderInlineStartOverButton();
         const disabledMessage = (
-            <span>
-                Use the <Markup.Term>Start over button</Markup.Term> to scan the target page.
-            </span>
+            <span>Use the {startOverButton} button to scan the target page.</span>
         );
 
         return (

--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -12,6 +12,7 @@ import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { InlineStartOverButton } from 'DetailsView/components/inline-start-over-button';
 import * as styles from 'DetailsView/components/issues-table.scss';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
@@ -97,25 +98,14 @@ export class IssuesTable extends React.Component<IssuesTableProps> {
         return <ScanningSpinner isSpinning={true} label={label} />;
     }
 
-    private renderInlineStartOverButton(): JSX.Element {
+    private renderDisabledMessage(): JSX.Element {
         const selectedTest = this.props.visualizationStoreData.selectedFastPassDetailsView;
-        const rescan = event =>
-            this.props.deps.detailsViewActionMessageCreator.rescanVisualization(
-                selectedTest,
-                event,
-            );
-        return (
-            <InsightsCommandButton
-                onClick={rescan}
-                text="Start over"
-                iconProps={{ iconName: 'Refresh' }}
-                className={styles.inlineStartOverButton}
+        const startOverButton = (
+            <InlineStartOverButton
+                selectedTest={selectedTest}
+                detailsViewActionMessageCreator={this.props.deps.detailsViewActionMessageCreator}
             />
         );
-    }
-
-    private renderDisabledMessage(): JSX.Element {
-        const startOverButton = this.renderInlineStartOverButton();
         const disabledMessage = (
             <span>Use the {startOverButton} button to scan the target page.</span>
         );

--- a/src/DetailsView/components/target-page-changed-view.tsx
+++ b/src/DetailsView/components/target-page-changed-view.tsx
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { InlineStartOverButton } from 'DetailsView/components/inline-start-over-button';
 import * as commonStaticStyles from 'DetailsView/components/static-content-common.scss';
 import * as styles from 'DetailsView/components/target-page-changed-view.scss';
 import * as React from 'react';
@@ -12,6 +14,7 @@ export interface TargetPageChangedViewProps {
     visualizationType: VisualizationType;
     displayableData: DisplayableVisualizationTypeData;
     toggleClickHandler: (event) => void;
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
 }
 
 export const TargetPageChangedView = NamedFC<TargetPageChangedViewProps>(
@@ -19,8 +22,18 @@ export const TargetPageChangedView = NamedFC<TargetPageChangedViewProps>(
     props => {
         const { title = '', subtitle } = props.displayableData;
 
-        const startOverText =
-            'The target page has changed. Use the start over button to scan the new target page.';
+        const startOverButton = (
+            <InlineStartOverButton
+                selectedTest={props.visualizationType}
+                detailsViewActionMessageCreator={props.detailsViewActionMessageCreator}
+            />
+        );
+        const startOverText = (
+            <>
+                'The target page has changed. Use the {startOverButton} button to scan the new
+                target page.'
+            </>
+        );
 
         return (
             <div className={commonStaticStyles.staticContentInDetailsView}>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-issues-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-issues-test-view.test.tsx.snap
@@ -6,6 +6,11 @@ exports[`AdhocIssuesTestView should return DetailsListIssuesView 1`] = `
 >
   <React.Fragment>
     <ScanIncompleteWarning
+      deps={
+        Object {
+          "detailsViewActionMessageCreator": Object {},
+        }
+      }
       test={-1}
       warningConfiguration={Object {}}
       warnings={Array []}
@@ -24,6 +29,11 @@ exports[`AdhocIssuesTestView should return DetailsListIssuesView 1`] = `
             "title": "test title",
           },
           "getStoreData": [Function],
+        }
+      }
+      deps={
+        Object {
+          "detailsViewActionMessageCreator": Object {},
         }
       }
       instancesSection={[Function]}
@@ -55,6 +65,7 @@ exports[`AdhocIssuesTestView should return target page changed view as tab is ch
   className="issuesTestView"
 >
   <TargetPageChangedView
+    detailsViewActionMessageCreator={Object {}}
     displayableData={
       Object {
         "title": "test title",

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-static-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-static-test-view.test.tsx.snap
@@ -96,4 +96,4 @@ exports[`AdhocStaticTestView render handles no content & no guidance 1`] = `
                 }]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[undefined]} guidance={[undefined]} />"
 `;
 
-exports[`AdhocStaticTestView should return target page changed view as tab is changed 1`] = `"<TargetPageChangedView displayableData={{...}} visualizationType={-1} toggleClickHandler={[Function: clickHandlerStub]} featureFlagStoreData={[undefined]} />"`;
+exports[`AdhocStaticTestView should return target page changed view as tab is changed 1`] = `"<TargetPageChangedView displayableData={{...}} visualizationType={-1} toggleClickHandler={[Function: clickHandlerStub]} featureFlagStoreData={[undefined]} detailsViewActionMessageCreator={[Function]} />"`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-list-issues-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-list-issues-view.test.tsx.snap
@@ -67,5 +67,11 @@ exports[`DetailsListIssuesView should return issues table with scanning to false
     </React.Fragment>
   }
   title="test title"
+  visualizationStoreData={
+    Object {
+      "scanning": null,
+      "tests": Object {},
+    }
+  }
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/inline-start-over-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/inline-start-over-button.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` renders 1`] = `
+<InsightsCommandButton
+  className="inlineStartOverButton"
+  iconProps={
+    Object {
+      "iconName": "Refresh",
+    }
+  }
+  onClick={[Function]}
+  text="Start over"
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
@@ -17,15 +17,37 @@ exports[`IssuesTableTest automated checks disabled 1`] = `
       >
         <span>
           Use the 
-          <InsightsCommandButton
-            className="inlineStartOverButton"
-            iconProps={
-              Object {
-                "iconName": "Refresh",
+          <InlineStartOverButton
+            detailsViewActionMessageCreator={
+              proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "addPathForValidation": [Function],
+                "cancelStartOver": [Function],
+                "cancelStartOverAllAssessments": [Function],
+                "changeAssessmentVisualizationState": [Function],
+                "changeManualRequirementStatus": [Function],
+                "changeManualTestStatus": [Function],
+                "clearPathSnippetData": [Function],
+                "closePreviewFeaturesPanel": [Function],
+                "closeScopingPanel": [Function],
+                "closeSettingsPanel": [Function],
+                "continuePreviousAssessment": [Function],
+                "copyIssueDetailsClicked": [Function],
+                "dispatcher": undefined,
+                "editFailureInstance": [Function],
+                "leftNavPanelExpanded": [Function],
+                "removeFailureInstance": [Function],
+                "rescanVisualization": [Function],
+                "setAllUrlsPermissionState": [Function],
+                "setFeatureFlag": [Function],
+                "startOverAllAssessments": [Function],
+                "switchToTargetTab": [Function],
+                "telemetryFactory": undefined,
+                "undoManualRequirementStatusChange": [Function],
+                "undoManualTestStatusChange": [Function],
               }
             }
-            onClick={[Function]}
-            text="Start over"
+            selectedTest={-1}
           />
            button to scan the target page.
         </span>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
@@ -17,10 +17,17 @@ exports[`IssuesTableTest automated checks disabled 1`] = `
       >
         <span>
           Use the 
-          <Term>
-            Start over button
-          </Term>
-           to scan the target page.
+          <InsightsCommandButton
+            className="inlineStartOverButton"
+            iconProps={
+              Object {
+                "iconName": "Refresh",
+              }
+            }
+            onClick={[Function]}
+            text="Start over"
+          />
+           button to scan the target page.
         </span>
       </div>
     </React.Fragment>
@@ -113,6 +120,33 @@ exports[`IssuesTableTest not scanning, issuesEnabled is true 1`] = `
       }
       deps={
         Object {
+          "detailsViewActionMessageCreator": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "addPathForValidation": [Function],
+            "cancelStartOver": [Function],
+            "cancelStartOverAllAssessments": [Function],
+            "changeAssessmentVisualizationState": [Function],
+            "changeManualRequirementStatus": [Function],
+            "changeManualTestStatus": [Function],
+            "clearPathSnippetData": [Function],
+            "closePreviewFeaturesPanel": [Function],
+            "closeScopingPanel": [Function],
+            "closeSettingsPanel": [Function],
+            "continuePreviousAssessment": [Function],
+            "copyIssueDetailsClicked": [Function],
+            "dispatcher": undefined,
+            "editFailureInstance": [Function],
+            "leftNavPanelExpanded": [Function],
+            "removeFailureInstance": [Function],
+            "rescanVisualization": [Function],
+            "setAllUrlsPermissionState": [Function],
+            "setFeatureFlag": [Function],
+            "startOverAllAssessments": [Function],
+            "switchToTargetTab": [Function],
+            "telemetryFactory": undefined,
+            "undoManualRequirementStatusChange": [Function],
+            "undoManualTestStatusChange": [Function],
+          },
           "getDateFromTimestamp": [Function],
           "reportGenerator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
@@ -13,7 +13,14 @@ exports[`TargetPageChangedView renders with subtitle=test subtitle content and f
     test subtitle content
   </div>
   <p>
-    The target page has changed. Use the start over button to scan the new target page.
+    <React.Fragment>
+      'The target page has changed. Use the 
+      <InlineStartOverButton
+        detailsViewActionMessageCreator={Object {}}
+        selectedTest={2}
+      />
+       button to scan the new target page.'
+    </React.Fragment>
   </p>
 </div>
 `;
@@ -29,7 +36,14 @@ exports[`TargetPageChangedView renders with subtitle=undefined and feature flag=
     className="targetPageChangedSubtitle"
   />
   <p>
-    The target page has changed. Use the start over button to scan the new target page.
+    <React.Fragment>
+      'The target page has changed. Use the 
+      <InlineStartOverButton
+        detailsViewActionMessageCreator={Object {}}
+        selectedTest={2}
+      />
+       button to scan the new target page.'
+    </React.Fragment>
   </p>
 </div>
 `;
@@ -45,7 +59,14 @@ exports[`TargetPageChangedView renders with subtitle=undefined and feature flag=
     className="targetPageChangedSubtitle"
   />
   <p>
-    The target page has changed. Use the start over button to scan the new target page.
+    <React.Fragment>
+      'The target page has changed. Use the 
+      <InlineStartOverButton
+        detailsViewActionMessageCreator={Object {}}
+        selectedTest={2}
+      />
+       button to scan the new target page.'
+    </React.Fragment>
   </p>
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/adhoc-issues-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/adhoc-issues-test-view.test.tsx
@@ -11,6 +11,7 @@ import {
     VisualizationStoreData,
 } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import {
     AdhocIssuesTestView,
     AdhocIssuesTestViewProps,
@@ -52,6 +53,9 @@ describe('AdhocIssuesTestView', () => {
         selectedTest: selectedTest,
         scanIncompleteWarnings: [],
         instancesSection: NamedFC<CommonInstancesSectionProps>('test', _ => null),
+        deps: {
+            detailsViewActionMessageCreator: {} as DetailsViewActionMessageCreator,
+        },
     } as AdhocIssuesTestViewProps;
 
     const scanDataStub: ScanData = {

--- a/src/tests/unit/tests/DetailsView/components/inline-start-over-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/inline-start-over-button.test.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { VisualizationType } from 'common/types/visualization-type';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import {
+    InlineStartOverButton,
+    InlineStartOverButtonProps,
+} from 'DetailsView/components/inline-start-over-button';
+import { shallow } from 'enzyme';
+import { IMock, Mock } from 'typemoq';
+import * as React from 'react';
+
+describe(InlineStartOverButton, () => {
+    const testType: VisualizationType = 1;
+    let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
+    let props: InlineStartOverButtonProps;
+
+    beforeEach(() => {
+        detailsViewActionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator);
+        props = {
+            selectedTest: testType,
+            detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
+        };
+    });
+
+    it('renders', () => {
+        const button = shallow(<InlineStartOverButton {...props} />);
+
+        expect(button.getElement()).toMatchSnapshot();
+    });
+
+    it('rescans on click', () => {
+        const event = {} as MouseEvent;
+        detailsViewActionMessageCreatorMock
+            .setup(acm => acm.rescanVisualization(testType, event))
+            .verifiable();
+
+        const button = shallow(<InlineStartOverButton {...props} />);
+        button.simulate('click', event);
+
+        detailsViewActionMessageCreatorMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CommonInstancesSectionProps } from 'common/components/cards/common-instances-section-props';
-import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { DateProvider } from 'common/date-provider';
 import { NamedFC } from 'common/react/named-fc';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
@@ -61,29 +60,6 @@ describe('IssuesTableTest', () => {
         expect(wrapped.getElement()).toMatchSnapshot();
     });
 
-    test('inline start over button', () => {
-        const issuesEnabled = false;
-        const testType = VisualizationType.ColorSensoryAssessment;
-        const clickEvent = {} as MouseEvent;
-
-        const props = new TestPropsBuilder()
-            .setDeps(deps)
-            .setIssuesEnabled(issuesEnabled)
-            .setTestType(testType)
-            .build();
-
-        detailsViewActionMessageCreatorMock
-            .setup(amc => amc.rescanVisualization(testType, clickEvent))
-            .verifiable();
-
-        const wrapped = shallow(<IssuesTable {...props} />);
-
-        const button = wrapped.find(InsightsCommandButton);
-        button.simulate('click', clickEvent);
-
-        detailsViewActionMessageCreatorMock.verifyAll();
-    });
-
     it('spinner for scanning state', () => {
         const issuesEnabled = true;
 
@@ -133,11 +109,6 @@ class TestPropsBuilder {
 
     public setSubtitle(subtitle?: JSX.Element): TestPropsBuilder {
         this.subtitle = subtitle;
-        return this;
-    }
-
-    public setTestType(testType: VisualizationType): TestPropsBuilder {
-        this.testType = testType;
         return this;
     }
 

--- a/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { DisplayableVisualizationTypeData } from 'common/configs/visualization-configuration-factory';
 import { VisualizationType } from 'common/types/visualization-type';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import {
     TargetPageChangedView,
     TargetPageChangedViewProps,
@@ -25,11 +26,13 @@ describe('TargetPageChangedView', () => {
                 toggleLabel: 'test toggle label',
                 subtitle,
             } as DisplayableVisualizationTypeData;
+            const detailsViewActionMessageCreator = {} as DetailsViewActionMessageCreator;
 
             const props: TargetPageChangedViewProps = {
                 visualizationType,
                 displayableData,
                 toggleClickHandler: clickHandlerStub,
+                detailsViewActionMessageCreator,
             };
 
             const wrapped = shallow(<TargetPageChangedView {...props} />);


### PR DESCRIPTION
#### Description of changes

Replace the "Start over" text in "use the start over button to scan the target page" with an inline button, as described in #3229:

<img width="286" alt="screenshot of inline start over button" src="https://user-images.githubusercontent.com/55459788/100681396-7637aa00-3328-11eb-9240-e000314374f1.PNG">
<img width="280" alt="screenshot of inline start over button in high contract mode-hicontrast" src="https://user-images.githubusercontent.com/55459788/100681401-79329a80-3328-11eb-9b8e-6c3fd1e86139.PNG">

This affects the "target changed" view in all fastpass pages, and the view before scanning for "automated checks" and "needs review."

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3229 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
