### PR TITLE
chore: enable eslint rule enforcing === except for null checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,8 @@ module.exports = {
         },
     },
     rules: {
+        eqeqeq: ['error', 'always', { null: 'ignore' }],
+        // Disabled due to high existing-positive count during initial tslint -> eslint migration
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/no-unused-vars': 'off',

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -42,7 +42,7 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     },
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: data => data.results != undefined,
+    shouldShowExportReport: data => data.results != null,
     displayableData: {
         title: 'Automated checks',
         subtitle: (

--- a/src/background/completed-test-step-telemetry-creator.ts
+++ b/src/background/completed-test-step-telemetry-creator.ts
@@ -52,7 +52,7 @@ export class CompletedTestStepTelemetryCreator {
             this.isNewCompletedTestStep(assessment, step),
         );
         const targetTab = this.store.getState().persistedTabInfo;
-        if (completedStep != undefined && targetTab !== null) {
+        if (completedStep != null && targetTab !== null) {
             const payload: PayloadWithEventName = {
                 eventName: TelemetryEvents.CHANGE_OVERALL_REQUIREMENT_STATUS,
                 telemetry: this.createTelemetryInfo(assessment, completedStep),
@@ -64,7 +64,7 @@ export class CompletedTestStepTelemetryCreator {
                 payload,
             });
         }
-        return completedStep != undefined;
+        return completedStep != null;
     }
 
     private isNewCompletedTestStep(assessment: Assessment, step: Requirement): boolean {

--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -112,7 +112,7 @@ export class RuleInformationProvider {
         ruleResultsData: RuleResultsData,
     ): InstanceResultStatus => {
         if (
-            ruleResultsData.status == 'FAIL' &&
+            ruleResultsData.status === 'FAIL' &&
             ruleResultsData.props['Confidence in Color Detection'] === 'High'
         )
             return 'unknown';

--- a/src/injected/frameCommunicators/html-element-axe-results-helper.ts
+++ b/src/injected/frameCommunicators/html-element-axe-results-helper.ts
@@ -99,7 +99,7 @@ export class HtmlElementAxeResultsHelper {
             const elementResult = elementResults[i];
             const targetLength = elementResult.target.length;
 
-            if (elementResult.targetIndex == undefined) {
+            if (elementResult.targetIndex == null) {
                 elementResult.targetIndex = 0;
             }
             if (targetLength === elementResult.targetIndex + 1) {

--- a/src/reports/assessment-report-model-builder.ts
+++ b/src/reports/assessment-report-model-builder.ts
@@ -146,7 +146,7 @@ export class AssessmentReportModelBuilder {
             }
 
             function getAssistedData(): InstanceReportModel[] {
-                if (storeData.generatedAssessmentInstancesMap == undefined) {
+                if (storeData.generatedAssessmentInstancesMap == null) {
                     return [];
                 }
 
@@ -155,7 +155,7 @@ export class AssessmentReportModelBuilder {
                         const testStepResult =
                             storeData.generatedAssessmentInstancesMap[key].testStepResults[stepKey];
                         return (
-                            testStepResult != undefined &&
+                            testStepResult != null &&
                             testStepResult.status ===
                                 storeData.testStepStatus[stepKey].stepFinalResult
                         );

--- a/src/reports/package/combined-results-to-cards-model-converter.ts
+++ b/src/reports/package/combined-results-to-cards-model-converter.ts
@@ -62,7 +62,7 @@ export class CombinedResultsToCardsModelConverter {
     }
 
     private getFailuresGroupedByRule = (groupedFailures: FailuresGroup): CardRuleResult => {
-        if(groupedFailures.failed.length == 0) {
+        if(groupedFailures.failed.length === 0) {
             return null;
         }
         const rule = groupedFailures.failed[0].rule;

--- a/src/tests/end-to-end/common/browser.ts
+++ b/src/tests/end-to-end/common/browser.ts
@@ -149,7 +149,7 @@ export class Browser {
     private async waitForBackgroundPageMatching(
         predicate: (candidate: Playwright.Page) => boolean,
     ): Promise<Playwright.Page> {
-        const apiSupported = (this.underlyingBrowserContext as any).backgroundPages != undefined;
+        const apiSupported = (this.underlyingBrowserContext as any).backgroundPages != null;
         if (!apiSupported) {
             // Tracking issue for native Playwright support: https://github.com/microsoft/playwright/issues/2874
             // Suggested workaround for Firefox: https://github.com/microsoft/playwright/issues/2644#issuecomment-647842059

--- a/src/tests/end-to-end/common/page-controllers/background-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/background-page.ts
@@ -15,7 +15,7 @@ export class BackgroundPage extends Page {
     public async waitForInitialization(): Promise<void> {
         await this.underlyingPage.waitForFunction(
             () => {
-                const initialized = window.insightsUserConfiguration != undefined;
+                const initialized = window.insightsUserConfiguration != null;
                 return initialized;
             },
             null,

--- a/src/tests/miscellaneous/mock-adb/app/bin.js
+++ b/src/tests/miscellaneous/mock-adb/app/bin.js
@@ -69,24 +69,24 @@ async function main() {
 
     const result = resultFromCommand(config, inputCommand);
 
-    if (result.delayMs != undefined) {
+    if (result.delayMs != null) {
         await new Promise(resolve => {
             setTimeout(resolve, result.delayMs);
         });
     }
-    if (result.startTestServer != undefined) {
+    if (result.startTestServer != null) {
         const { port, path } = result.startTestServer;
         stopDetachedPortForwardServer(port);
         result.testServerPid = await startDetachedPortForwardServer(port, path);
     }
-    if (result.stopTestServer != undefined) {
+    if (result.stopTestServer != null) {
         const { port } = result.stopTestServer;
         result.testServerPid = stopDetachedPortForwardServer(port);
     }
-    if (result.stderr != undefined) {
+    if (result.stderr != null) {
         console.error(result.stderr);
     }
-    if (result.stdout != undefined) {
+    if (result.stdout != null) {
         console.log(result.stdout);
     }
 
@@ -97,7 +97,7 @@ async function main() {
     const outputConfigFile = path.join(outputLogsDir, fileWithMockAdbConfig);
     fs.copyFileSync(configPath, outputConfigFile);
 
-    if (result.exitCode != undefined) {
+    if (result.exitCode != null) {
         process.exit(result.exitCode);
     }
 }

--- a/src/tests/miscellaneous/mock-adb/setup-mock-adb-command.js
+++ b/src/tests/miscellaneous/mock-adb/setup-mock-adb-command.js
@@ -19,7 +19,7 @@ if (argv.length !== 3) {
 const configName = argv[2];
 const config = commonAdbConfigs[configName];
 
-if (config == undefined) {
+if (config == null) {
     console.error(`Unrecognized config-name: ${configName}\n`);
     exitWithUsage();
 }

--- a/src/tests/unit/tests/common/get-card-selection-view-data.test.ts
+++ b/src/tests/unit/tests/common/get-card-selection-view-data.test.ts
@@ -90,7 +90,7 @@ describe('getCardSelectionStoreviewData', () => {
     });
 
     test('all rules collapsed, visual helper enabled, resultsFilter passed, expect only filtered highlights', () => {
-        resultsFilter = res => res.uid == 'sampleUid3';
+        resultsFilter = res => res.uid === 'sampleUid3';
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
@@ -244,7 +244,7 @@ describe('getCardSelectionStoreviewData', () => {
     });
 
     test('one rule expanded, visual helper enabled, resultsFilter passed, expect some highlights', () => {
-        resultsFilter = res => res.uid == 'sampleUid2';
+        resultsFilter = res => res.uid === 'sampleUid2';
         initialCardSelectionState.rules['sampleRuleId1'].isExpanded = true;
 
         const viewData = getCardSelectionViewData(
@@ -288,7 +288,7 @@ describe('getCardSelectionStoreviewData', () => {
         initialCardSelectionState.rules['sampleRuleId1'].isExpanded = true;
         initialCardSelectionState.rules['sampleRuleId2'].isExpanded = true;
         initialCardSelectionState.rules['sampleRuleId2'].cards['sampleUid3'] = true;
-        resultsFilter = res => res.uid == 'sampleUid2';
+        resultsFilter = res => res.uid === 'sampleUid2';
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,


### PR DESCRIPTION
#### Description of changes

This PR adds a lint rule enforcing the usage of `===` vs `==` that we've historically encouraged:

* `==`/`!=` is allowed when comparing against `null` or ` undefined` to mean `is null OR undefined`
* `==`/`!=` are banned in favor of `===`/`!==` in all other cases

The eslint `eqeqeq` rule is a little more strict than our historical guidance (it only allows `== null`, not `== undefined`), but there weren't that many cases using the latter, so I just updated them all as part of turning on the rule (having the rule catch dangerous cases is more important than keeping the `== undefined` cases as is for readability's sake).

Thanks @madalynrose for pointing out that we should be enabling this! I hadn't realized it wasn't part of eslint's default recommended set.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
