### PR TITLE
fix: change --colors flag to --color to fix webpack CLI build

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
         "watch:scss": "tsm \"src/**/*.scss\" --watch",
         "watch:grunt": "grunt watch",
         "watch:test": "jest --watch --projects src/tests/unit --coverage false --colors",
-        "watch:webpack-dev-browser": "webpack --watch --config-name dev --colors --progress",
-        "watch:webpack-unified": "webpack --watch --config-name unified --colors --progress",
+        "watch:webpack-dev-browser": "webpack --watch --config-name dev --color --progress",
+        "watch:webpack-unified": "webpack --watch --config-name unified --color --progress",
         "with:mock-service-for-android": "npm-run-all --race --parallel serve:mock-service-for-android"
     },
     "devDependencies": {


### PR DESCRIPTION
#### Description of changes

This changes the --colors flag to --color on any webpack scripts in package.json to fix an error that occurs when those scripts are run on newer versions of webpack.

The --color flag without the 's' is the official flag in the [Webpack CLI API](https://webpack.js.org/api/cli/)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
