### PR TITLE
refactor: break common to non-common dep in analyzer-telemetry-callbacks

### DIFF
--- a/src/common/types/analyzer-telemetry-callbacks.ts
+++ b/src/common/types/analyzer-telemetry-callbacks.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AxeAnalyzerResult } from '../../injected/analyzers/analyzer';
+import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
 import {
     RuleAnalyzerScanTelemetryData,
     IssuesAnalyzerScanTelemetryData,

--- a/src/common/types/axe-analyzer-result.ts
+++ b/src/common/types/axe-analyzer-result.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { SingleElementSelector } from 'common/types/store-data/scoping-store-data';
+import { ScanResults } from 'scanner/iruleresults';
+import { DictionaryStringTo } from 'types/common-types';
+
+export interface AxeAnalyzerResult {
+    results: DictionaryStringTo<any>;
+    originalResult: ScanResults;
+    include?: SingleElementSelector[];
+    exclude?: SingleElementSelector[];
+}

--- a/src/injected/analyzers/analyzer.ts
+++ b/src/injected/analyzers/analyzer.ts
@@ -1,23 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import { BaseActionPayload } from 'background/actions/action-payloads';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { IAnalyzerTelemetryCallback } from '../../common/types/analyzer-telemetry-callbacks';
-import { SingleElementSelector } from '../../common/types/store-data/scoping-store-data';
 import { TelemetryProcessor } from '../../common/types/telemetry-processor';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { ScanResults } from '../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../types/common-types';
 import { HtmlElementAxeResults, ScannerUtils } from '../scanner-utils';
 import { TabStopEvent } from '../tab-stops-listener';
-
-export interface AxeAnalyzerResult {
-    results: DictionaryStringTo<any>;
-    originalResult: ScanResults;
-    include?: SingleElementSelector[];
-    exclude?: SingleElementSelector[];
-}
 
 export interface Analyzer {
     analyze(): void;

--- a/src/injected/analyzers/base-analyzer.ts
+++ b/src/injected/analyzers/base-analyzer.ts
@@ -1,17 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Logger } from 'common/logging/logger';
+import { Message } from 'common/message';
+import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
+import { VisualizationType } from 'common/types/visualization-type';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import * as Q from 'q';
 
-import { Message } from '../../common/message';
-import { VisualizationType } from '../../common/types/visualization-type';
-import {
-    Analyzer,
-    AnalyzerConfiguration,
-    AxeAnalyzerResult,
-    ScanCompletedPayload,
-} from './analyzer';
+import { Analyzer, AnalyzerConfiguration, ScanCompletedPayload } from './analyzer';
 
 export class BaseAnalyzer implements Analyzer {
     protected visualizationType: VisualizationType;

--- a/src/injected/analyzers/batched-rule-analyzer.ts
+++ b/src/injected/analyzers/batched-rule-analyzer.ts
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BaseStore } from 'common/base-store';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { Logger } from 'common/logging/logger';
+import { TelemetryDataFactory } from 'common/telemetry-data-factory';
+import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
+import { ScopingStoreData } from 'common/types/store-data/scoping-store-data';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { ScanResults } from 'scanner/iruleresults';
 
-import { BaseStore } from '../../common/base-store';
-import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
-import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
-import { ScopingStoreData } from '../../common/types/store-data/scoping-store-data';
-import { ScanResults } from '../../scanner/iruleresults';
 import { ScannerUtils } from '../scanner-utils';
-import { AxeAnalyzerResult, RuleAnalyzerConfiguration } from './analyzer';
+import { RuleAnalyzerConfiguration } from './analyzer';
 import { RuleAnalyzer } from './rule-analyzer';
 
 export type IResultRuleFilter = (results: ScanResults, rules: string[]) => ScanResults;

--- a/src/injected/analyzers/rule-analyzer.ts
+++ b/src/injected/analyzers/rule-analyzer.ts
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScopingInputTypes } from 'background/scoping-input-types';
+import { BaseStore } from 'common/base-store';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { Logger } from 'common/logging/logger';
+import { TelemetryDataFactory } from 'common/telemetry-data-factory';
+import { ForRuleAnalyzerScanCallback } from 'common/types/analyzer-telemetry-callbacks';
+import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
+import { ScopingStoreData } from 'common/types/store-data/scoping-store-data';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import * as Q from 'q';
+import { ScanResults } from 'scanner/iruleresults';
+import { ScanOptions } from 'scanner/scan-options';
 
-import { BaseStore } from '../../common/base-store';
-import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
-import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
-import { ForRuleAnalyzerScanCallback } from '../../common/types/analyzer-telemetry-callbacks';
-import { ScopingStoreData } from '../../common/types/store-data/scoping-store-data';
-import { ScanResults } from '../../scanner/iruleresults';
-import { ScanOptions } from '../../scanner/scan-options';
 import { ScannerUtils } from '../scanner-utils';
-import { AxeAnalyzerResult, RuleAnalyzerConfiguration } from './analyzer';
+import { RuleAnalyzerConfiguration } from './analyzer';
 import { BaseAnalyzer } from './base-analyzer';
 
 export type MessageDelegate = (message: any) => void;

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -1,17 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Logger } from 'common/logging/logger';
+import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
 import { WindowUtils } from 'common/window-utils';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import * as Q from 'q';
 
 import { TabStopEvent, TabStopsListener } from '../tab-stops-listener';
-import {
-    AxeAnalyzerResult,
-    FocusAnalyzerConfiguration,
-    ScanBasePayload,
-    ScanUpdatePayload,
-} from './analyzer';
+import { FocusAnalyzerConfiguration, ScanBasePayload, ScanUpdatePayload } from './analyzer';
 import { BaseAnalyzer } from './base-analyzer';
 
 export interface ProgressResult<T> {

--- a/src/injected/analyzers/unified-result-sender.ts
+++ b/src/injected/analyzers/unified-result-sender.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
 import { ScanIncompleteWarningsTelemetryData } from 'common/extension-telemetry-events';
+import { Messages } from 'common/messages';
+import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { FilterResults } from 'injected/analyzers/filter-results';
 import {
@@ -10,14 +13,12 @@ import {
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { isEmpty } from 'lodash';
 import { ScanResults } from 'scanner/iruleresults';
-import { UnifiedScanCompletedPayload } from '../../background/actions/action-payloads';
-import { Messages } from '../../common/messages';
+
 import {
     ConvertScanResultsToUnifiedResults,
     ConvertScanResultsToUnifiedResultsDelegate,
 } from '../adapters/scan-results-to-unified-results';
 import { ConvertScanResultsToUnifiedRulesDelegate } from '../adapters/scan-results-to-unified-rules';
-import { AxeAnalyzerResult } from './analyzer';
 import { MessageDelegate, PostResolveCallback } from './rule-analyzer';
 
 export class UnifiedResultSender {

--- a/src/tests/unit/tests/common/telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/common/telemetry-data-factory.test.ts
@@ -20,11 +20,12 @@ import {
     TelemetryEventSource,
     ToggleTelemetryData,
     TriggeredByNotApplicable,
-} from '../../../../common/extension-telemetry-events';
-import { TelemetryDataFactory } from '../../../../common/telemetry-data-factory';
-import { DetailsViewPivotType } from '../../../../common/types/details-view-pivot-type';
-import { VisualizationType } from '../../../../common/types/visualization-type';
-import { AxeAnalyzerResult } from '../../../../injected/analyzers/analyzer';
+} from 'common/extension-telemetry-events';
+import { TelemetryDataFactory } from 'common/telemetry-data-factory';
+import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { VisualizationType } from 'common/types/visualization-type';
+
 import { EventStubFactory } from './../../common/event-stub-factory';
 
 describe('TelemetryDataFactoryTest', () => {

--- a/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
@@ -2,27 +2,24 @@
 // Licensed under the MIT License.
 import { ScopingInputTypes } from 'background/scoping-input-types';
 import { ScopingStore } from 'background/stores/global/scoping-store';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { RuleAnalyzerScanTelemetryData } from 'common/extension-telemetry-events';
+import { Message } from 'common/message';
+import { TelemetryDataFactory } from 'common/telemetry-data-factory';
+import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
+import { ScopingStoreData } from 'common/types/store-data/scoping-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import { RuleAnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { PostResolveCallback, RuleAnalyzer } from 'injected/analyzers/rule-analyzer';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { HtmlElementAxeResults, ScannerUtils } from 'injected/scanner-utils';
 import { isFunction } from 'lodash';
+import { ScanResults } from 'scanner/iruleresults';
+import { ScanOptions } from 'scanner/scan-options';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, It, Mock, Times } from 'typemoq';
-
-import { VisualizationConfiguration } from '../../../../../common/configs/visualization-configuration';
-import { VisualizationConfigurationFactory } from '../../../../../common/configs/visualization-configuration-factory';
-import { RuleAnalyzerScanTelemetryData } from '../../../../../common/extension-telemetry-events';
-import { Message } from '../../../../../common/message';
-import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
-import { ScopingStoreData } from '../../../../../common/types/store-data/scoping-store-data';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
-import {
-    AxeAnalyzerResult,
-    RuleAnalyzerConfiguration,
-} from '../../../../../injected/analyzers/analyzer';
-import { PostResolveCallback, RuleAnalyzer } from '../../../../../injected/analyzers/rule-analyzer';
-import { HtmlElementAxeResults, ScannerUtils } from '../../../../../injected/scanner-utils';
-import { ScanResults } from '../../../../../scanner/iruleresults';
-import { ScanOptions } from '../../../../../scanner/scan-options';
-import { DictionaryStringTo } from '../../../../../types/common-types';
+import { DictionaryStringTo } from 'types/common-types';
 
 describe('RuleAnalyzer', () => {
     let scannerUtilsMock: IMock<ScannerUtils>;


### PR DESCRIPTION
#### Description of changes

This PR fixes one of the big reasons `yarn null:find-cycles` finds so many results; specifically, it breaks a dependency from `common/types/analyzer-telemetry-callbacks.ts` to `injected/analyzers/analyzer.ts` by moving the `AxeAnalyzerResult` type out of `analyzer.ts` into its own file under `common/types`.

Previously, this dependency was creating *tons* of cycles (essentially, any code that touched anything telemetry related transitively included the telemetry callbacks, which then ended up going through analyzers implementation, which involves some telemetry).

Line counts of `yarn null:find-cycles` (reduced by 38% with this PR):

Before:
```
C:\repos\accessibility-insights-web [master ≡] | 59 | 14:34:24 12/04
> yarn null:find-cycles | measure
Count             : 15839
```

After:
```
C:\repos\accessibility-insights-web [break-axe-analyzer-result-cycle ≡] | 54 | 14:33:17 12/04
> yarn null:find-cycles | measure
Count             : 9850
```

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: unblocks #2869
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
