### PR TITLE
chore: break cyclic imports in action-payloads.ts

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -21,17 +21,17 @@ import {
     ToggleActionPayload,
 } from 'background/actions/action-payloads';
 import { FeatureFlagPayload } from 'background/actions/feature-flag-actions';
+import * as TelemetryEvents from 'common/extension-telemetry-events';
+import { ReportExportFormat } from 'common/extension-telemetry-events';
+import { Message } from 'common/message';
+import { DevToolActionMessageCreator } from 'common/message-creators/dev-tool-action-message-creator';
+import { Messages } from 'common/messages';
 import { SupportedMouseEvent } from 'common/telemetry-data-factory';
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { FailureInstanceData } from 'common/types/failure-instance-data';
+import { ManualTestStatus } from 'common/types/manual-test-status';
+import { VisualizationType } from 'common/types/visualization-type';
 import * as React from 'react';
-import * as TelemetryEvents from '../../common/extension-telemetry-events';
-import { ReportExportFormat } from '../../common/extension-telemetry-events';
-import { Message } from '../../common/message';
-import { DevToolActionMessageCreator } from '../../common/message-creators/dev-tool-action-message-creator';
-import { Messages } from '../../common/messages';
-import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
-import { ManualTestStatus } from '../../common/types/manual-test-status';
-import { VisualizationType } from '../../common/types/visualization-type';
-import { FailureInstanceData } from '../components/failure-instance-panel-control';
 import { DetailsViewRightContentPanelType } from '../components/left-nav/details-view-right-content-panel-type';
 
 const messages = Messages.Visualizations;

--- a/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
+++ b/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import * as styles from 'DetailsView/components/assessment-instance-edit-and-remove-control.scss';
+import { FailureInstanceData } from 'common/types/failure-instance-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
 import { Icon, Link } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { VisualizationType } from '../../common/types/visualization-type';
+import * as styles from './assessment-instance-edit-and-remove-control.scss';
 import {
     CapturedInstanceActionType,
-    FailureInstanceData,
     FailureInstancePanelControl,
 } from './failure-instance-panel-control';
 

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { FlaggedComponent } from 'common/components/flagged-component';
+import { FeatureFlags } from 'common/feature-flags';
+import { FailureInstanceData } from 'common/types/failure-instance-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
 import { clone, isEqual } from 'lodash';
 import { ActionButton } from 'office-ui-fabric-react';
 import { Icon } from 'office-ui-fabric-react';
@@ -9,10 +14,6 @@ import { Link } from 'office-ui-fabric-react';
 import { ITextFieldStyles, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 
-import { FlaggedComponent } from '../../common/components/flagged-component';
-import { FeatureFlags } from '../../common/feature-flags';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { VisualizationType } from '../../common/types/visualization-type';
 import { ActionAndCancelButtonsComponent } from './action-and-cancel-buttons-component';
 import { FailureInstancePanelDetails } from './failure-instance-panel-details';
 import * as styles from './failure-instance-panel.scss';
@@ -31,12 +32,6 @@ export interface FailureInstancePanelControlProps {
     assessmentsProvider: AssessmentsProvider;
     featureFlagStoreData: FeatureFlagStoreData;
 }
-
-export type FailureInstanceData = {
-    failureDescription?: string;
-    path?: string;
-    snippet?: string;
-};
 
 export interface FailureInstancePanelControlState {
     isPanelOpen: boolean;

--- a/src/DetailsView/components/manual-test-step-view.tsx
+++ b/src/DetailsView/components/manual-test-step-view.tsx
@@ -1,19 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { FailureInstanceData } from 'common/types/failure-instance-data';
+import { ManualTestStatus } from 'common/types/manual-test-status';
+import { ManualTestStepResult } from 'common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { PathSnippetStoreData } from 'common/types/store-data/path-snippet-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
 import { CheckboxVisibility, ConstrainMode, DetailsList } from 'office-ui-fabric-react';
 import * as React from 'react';
-
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { ManualTestStatus } from '../../common/types/manual-test-status';
-import { ManualTestStepResult } from '../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { PathSnippetStoreData } from '../../common/types/store-data/path-snippet-store-data';
-import { VisualizationType } from '../../common/types/visualization-type';
-import { DictionaryStringTo } from '../../types/common-types';
+import { DictionaryStringTo } from 'types/common-types';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
 import {
     CapturedInstanceActionType,
-    FailureInstanceData,
     FailureInstancePanelControl,
 } from './failure-instance-panel-control';
 import { TestStatusChoiceGroup } from './test-status-choice-group';

--- a/src/DetailsView/handlers/assessment-instance-table-handler.tsx
+++ b/src/DetailsView/handlers/assessment-instance-table-handler.tsx
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IColumn } from 'office-ui-fabric-react';
-import * as React from 'react';
-
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { ManualTestStatus } from '../../common/types/manual-test-status';
+import { FailureInstanceData } from 'common/types/failure-instance-data';
+import { ManualTestStatus } from 'common/types/manual-test-status';
 import {
     AssessmentNavState,
     GeneratedAssessmentInstance,
     UserCapturedInstance,
-} from '../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { PathSnippetStoreData } from '../../common/types/store-data/path-snippet-store-data';
-import { VisualizationType } from '../../common/types/visualization-type';
-import { DictionaryStringTo } from '../../types/common-types';
+} from 'common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { PathSnippetStoreData } from 'common/types/store-data/path-snippet-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import { IColumn } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { DictionaryStringTo } from 'types/common-types';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { AssessmentInstanceEditAndRemoveControl } from '../components/assessment-instance-edit-and-remove-control';
 import { AssessmentInstanceSelectedButton } from '../components/assessment-instance-selected-button';
@@ -22,7 +22,6 @@ import {
     CapturedInstanceRowData,
 } from '../components/assessment-instance-table';
 import { AssessmentTableColumnConfigHandler } from '../components/assessment-table-column-config-handler';
-import { FailureInstanceData } from '../components/failure-instance-panel-control';
 import { TestStatusChoiceGroup } from '../components/test-status-choice-group';
 
 export class AssessmentInstanceTableHandler {

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -9,6 +9,7 @@ import {
 import { Tab } from 'common/itab';
 import { CreateIssueDetailsTextData } from 'common/types/create-issue-details-text-data';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { FailureInstanceData } from 'common/types/failure-instance-data';
 import { ManualTestStatus } from 'common/types/manual-test-status';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
@@ -23,7 +24,6 @@ import {
 import { IssueFilingServiceProperties } from 'common/types/store-data/user-configuration-store';
 import { TabStopEvent } from 'common/types/tab-stop-event';
 import { VisualizationType } from 'common/types/visualization-type';
-import { FailureInstanceData } from 'DetailsView/components/failure-instance-panel-control';
 import { Rectangle } from 'electron';
 import { WindowState } from 'electron/flux/types/window-state';
 

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -21,11 +21,11 @@ import {
     UnifiedRule,
 } from 'common/types/store-data/unified-data-interface';
 import { IssueFilingServiceProperties } from 'common/types/store-data/user-configuration-store';
+import { TabStopEvent } from 'common/types/tab-stop-event';
 import { VisualizationType } from 'common/types/visualization-type';
 import { FailureInstanceData } from 'DetailsView/components/failure-instance-panel-control';
 import { Rectangle } from 'electron';
 import { WindowState } from 'electron/flux/types/window-state';
-import { TabStopEvent } from 'injected/tab-stops-listener';
 
 export interface BaseActionPayload {
     telemetry?: TelemetryData;

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -11,6 +11,7 @@ import { CreateIssueDetailsTextData } from 'common/types/create-issue-details-te
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { ManualTestStatus } from 'common/types/manual-test-status';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
 import {
     PlatformData,
     ScreenshotData,
@@ -25,7 +26,6 @@ import { FailureInstanceData } from 'DetailsView/components/failure-instance-pan
 import { Rectangle } from 'electron';
 import { WindowState } from 'electron/flux/types/window-state';
 import { TabStopEvent } from 'injected/tab-stops-listener';
-import { LaunchPanelType } from 'popup/components/popup-view';
 
 export interface BaseActionPayload {
     telemetry?: TelemetryData;

--- a/src/background/actions/launch-panel-state-action.ts
+++ b/src/background/actions/launch-panel-state-action.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Action } from 'common/flux/action';
-import { LaunchPanelType } from '../../popup/components/popup-view';
+import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
 
 export class LaunchPanelStateActions {
     public readonly setLaunchPanelType = new Action<LaunchPanelType>();

--- a/src/background/assessment-data-converter.ts
+++ b/src/background/assessment-data-converter.ts
@@ -2,18 +2,18 @@
 // Licensed under the MIT License.
 import { forOwn, isEmpty } from 'lodash';
 
-import { ManualTestStatus } from '../common/types/manual-test-status';
+import { ManualTestStatus } from 'common/types/manual-test-status';
 import {
     AssessmentInstancesMap,
     GeneratedAssessmentInstance,
     ManualTestStepResult,
     TestStepResult,
     UserCapturedInstance,
-} from '../common/types/store-data/assessment-result-data';
-import { DecoratedAxeNodeResult, HtmlElementAxeResults } from '../injected/scanner-utils';
-import { PartialTabOrderPropertyBag } from '../injected/tab-order-property-bag';
-import { TabStopEvent } from '../injected/tab-stops-listener';
-import { DictionaryStringTo } from '../types/common-types';
+} from 'common/types/store-data/assessment-result-data';
+import { TabStopEvent } from 'common/types/tab-stop-event';
+import { DecoratedAxeNodeResult, HtmlElementAxeResults } from 'injected/scanner-utils';
+import { PartialTabOrderPropertyBag } from 'injected/tab-order-property-bag';
+import { DictionaryStringTo } from 'types/common-types';
 import { UniquelyIdentifiableInstances } from './instance-identifier-generator';
 
 export class AssessmentDataConverter {

--- a/src/background/storage-data.ts
+++ b/src/background/storage-data.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FeatureFlagStoreData } from '../common/types/store-data/feature-flag-store-data';
-import { LaunchPanelType } from '../popup/components/popup-view';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
 import { InstallationData } from './installation-data';
 
 export interface LocalStorageData {

--- a/src/background/stores/global/launch-panel-store.ts
+++ b/src/background/stores/global/launch-panel-store.ts
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 import { StorageAdapter } from 'common/browser-adapters/storage-adapter';
 import { StoreNames } from 'common/stores/store-names';
-import { LaunchPanelStoreData } from 'common/types/store-data/launch-panel-store-data';
-import { LaunchPanelType } from 'popup/components/popup-view';
+import {
+    LaunchPanelStoreData,
+    LaunchPanelType,
+} from 'common/types/store-data/launch-panel-store-data';
 import { LocalStorageDataKeys } from '../../local-storage-data-keys';
 import { LocalStorageData } from '../../storage-data';
 import { BaseStoreImpl } from '../base-store-impl';

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 import { forOwn, map } from 'lodash';
 
-import { StoreNames } from '../../common/stores/store-names';
-import { VisualizationScanResultData } from '../../common/types/store-data/visualization-scan-result-data';
-import { ScanCompletedPayload } from '../../injected/analyzers/analyzer';
-import { DecoratedAxeNodeResult, HtmlElementAxeResults } from '../../injected/scanner-utils';
-import { TabStopEvent } from '../../injected/tab-stops-listener';
-import { DictionaryStringTo } from '../../types/common-types';
+import { StoreNames } from 'common/stores/store-names';
+import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
+import { TabStopEvent } from 'common/types/tab-stop-event';
+import { ScanCompletedPayload } from 'injected/analyzers/analyzer';
+import { DecoratedAxeNodeResult, HtmlElementAxeResults } from 'injected/scanner-utils';
+import { DictionaryStringTo } from 'types/common-types';
 import { AddTabbedElementPayload } from '../actions/action-payloads';
 import { TabActions } from '../actions/tab-actions';
 import { VisualizationScanResultActions } from '../actions/visualization-scan-result-actions';

--- a/src/common/types/failure-instance-data.ts
+++ b/src/common/types/failure-instance-data.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export type FailureInstanceData = {
+    failureDescription?: string;
+    path?: string;
+    snippet?: string;
+};

--- a/src/common/types/store-data/launch-panel-store-data.ts
+++ b/src/common/types/store-data/launch-panel-store-data.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { LaunchPanelType } from '../../../popup/components/popup-view';
-
+export enum LaunchPanelType {
+    AdhocToolsPanel,
+    LaunchPad,
+}
 export interface LaunchPanelStoreData {
     launchPanelType: LaunchPanelType;
 }

--- a/src/common/types/store-data/visualization-scan-result-data.ts
+++ b/src/common/types/store-data/visualization-scan-result-data.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DecoratedAxeNodeResult, HtmlElementAxeResults } from '../../../injected/scanner-utils';
-import { TabOrderPropertyBag } from '../../../injected/tab-order-property-bag';
-import { TabStopEvent } from '../../../injected/tab-stops-listener';
-import { ScanResults } from '../../../scanner/iruleresults';
-import { DictionaryStringTo } from '../../../types/common-types';
+import { TabStopEvent } from 'common/types/tab-stop-event';
+import { DecoratedAxeNodeResult, HtmlElementAxeResults } from 'injected/scanner-utils';
+import { TabOrderPropertyBag } from 'injected/tab-order-property-bag';
+import { ScanResults } from 'scanner/iruleresults';
+import { DictionaryStringTo } from 'types/common-types';
 
 interface IssuesScanResultData {
     scanResult?: ScanResults;

--- a/src/common/types/tab-stop-event.ts
+++ b/src/common/types/tab-stop-event.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export interface TabStopEvent {
+    timestamp: number;
+    target: string[];
+    html: string;
+}

--- a/src/injected/analyzers/analyzer.ts
+++ b/src/injected/analyzers/analyzer.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BaseActionPayload } from 'background/actions/action-payloads';
+import { IAnalyzerTelemetryCallback } from 'common/types/analyzer-telemetry-callbacks';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
-import { IAnalyzerTelemetryCallback } from '../../common/types/analyzer-telemetry-callbacks';
-import { TelemetryProcessor } from '../../common/types/telemetry-processor';
-import { VisualizationType } from '../../common/types/visualization-type';
-import { ScanResults } from '../../scanner/iruleresults';
-import { DictionaryStringTo } from '../../types/common-types';
+import { TabStopEvent } from 'common/types/tab-stop-event';
+import { TelemetryProcessor } from 'common/types/telemetry-processor';
+import { VisualizationType } from 'common/types/visualization-type';
+import { ScanResults } from 'scanner/iruleresults';
+import { DictionaryStringTo } from 'types/common-types';
 import { HtmlElementAxeResults, ScannerUtils } from '../scanner-utils';
-import { TabStopEvent } from '../tab-stops-listener';
 
 export interface Analyzer {
     analyze(): void;

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 import { Logger } from 'common/logging/logger';
 import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
+import { TabStopEvent } from 'common/types/tab-stop-event';
 import { WindowUtils } from 'common/window-utils';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import * as Q from 'q';
 
-import { TabStopEvent, TabStopsListener } from '../tab-stops-listener';
+import { TabStopsListener } from '../tab-stops-listener';
 import { FocusAnalyzerConfiguration, ScanBasePayload, ScanUpdatePayload } from './analyzer';
 import { BaseAnalyzer } from './base-analyzer';
 

--- a/src/injected/tab-stops-listener.ts
+++ b/src/injected/tab-stops-listener.ts
@@ -1,19 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DateProvider } from '../common/date-provider';
-import { HTMLElementUtils } from '../common/html-element-utils';
-import { WindowUtils } from '../common/window-utils';
+import { DateProvider } from 'common/date-provider';
+import { HTMLElementUtils } from 'common/html-element-utils';
+import { TabStopEvent } from 'common/types/tab-stop-event';
+import { WindowUtils } from 'common/window-utils';
 import { VisualizationWindowMessage } from './drawing-controller';
 import { ErrorMessageContent } from './frameCommunicators/error-message-content';
 import { FrameCommunicator, MessageRequest } from './frameCommunicators/frame-communicator';
 import { FrameMessageResponseCallback } from './frameCommunicators/window-message-handler';
 import { ScannerUtils } from './scanner-utils';
-
-export interface TabStopEvent {
-    timestamp: number;
-    target: string[];
-    html: string;
-}
 
 export class TabStopsListener {
     private frameCommunicator: FrameCommunicator;

--- a/src/popup/actions/popup-action-message-creator.ts
+++ b/src/popup/actions/popup-action-message-creator.ts
@@ -7,6 +7,7 @@ import {
 } from 'background/actions/action-payloads';
 import { Tab } from 'common/itab';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
+import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
 import * as React from 'react';
 
 import { TelemetryEventSource } from '../../common/extension-telemetry-events';
@@ -16,7 +17,6 @@ import { SupportedMouseEvent, TelemetryDataFactory } from '../../common/telemetr
 import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { WindowUtils } from '../../common/window-utils';
-import { LaunchPanelType } from '../components/popup-view';
 
 const visualizationMessages = Messages.Visualizations;
 

--- a/src/popup/components/popup-view.tsx
+++ b/src/popup/components/popup-view.tsx
@@ -15,7 +15,10 @@ import {
 import { DisplayableStrings } from '../../common/constants/displayable-strings';
 import { DropdownClickHandler } from '../../common/dropdown-click-handler';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { LaunchPanelStoreData } from '../../common/types/store-data/launch-panel-store-data';
+import {
+    LaunchPanelStoreData,
+    LaunchPanelType,
+} from '../../common/types/store-data/launch-panel-store-data';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { UrlValidator } from '../../common/url-validator';
 import { PopupHandlers } from '../handlers/popup-handlers';
@@ -52,11 +55,6 @@ export type PopupViewControllerDeps = LaunchPadDeps &
     WithStoreSubscriptionDeps<PopupViewControllerState> & {
         browserAdapter: BrowserAdapter;
     };
-
-export enum LaunchPanelType {
-    AdhocToolsPanel,
-    LaunchPad,
-}
 
 export interface PopupViewControllerState {
     featureFlagStoreData: FeatureFlagStoreData;

--- a/src/popup/handlers/popup-view-controller-handler.ts
+++ b/src/popup/handlers/popup-view-controller-handler.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { LaunchPanelType, PopupView } from '../components/popup-view';
+import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
+import { PopupView } from '../components/popup-view';
 
 export class PopupViewControllerHandler {
     public openLaunchPad(component: PopupView): void {

--- a/src/tests/unit/tests/background/assessment-data-converter.test.ts
+++ b/src/tests/unit/tests/background/assessment-data-converter.test.ts
@@ -4,14 +4,14 @@ import { IMock, It, Mock } from 'typemoq';
 
 import { AssessmentDataConverter } from 'background/assessment-data-converter';
 import { UniquelyIdentifiableInstances } from 'background/instance-identifier-generator';
-import { ManualTestStatus } from '../../../../common/types/manual-test-status';
+import { ManualTestStatus } from 'common/types/manual-test-status';
 import {
     AssessmentInstancesMap,
     TestStepResult,
-} from '../../../../common/types/store-data/assessment-result-data';
-import { DecoratedAxeNodeResult, HtmlElementAxeResults } from '../../../../injected/scanner-utils';
-import { TabStopEvent } from '../../../../injected/tab-stops-listener';
-import { DictionaryStringTo } from '../../../../types/common-types';
+} from 'common/types/store-data/assessment-result-data';
+import { TabStopEvent } from 'common/types/tab-stop-event';
+import { DecoratedAxeNodeResult, HtmlElementAxeResults } from 'injected/scanner-utils';
+import { DictionaryStringTo } from 'types/common-types';
 
 describe('AssessmentDataConverter', () => {
     let testSubject: AssessmentDataConverter;

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -12,11 +12,11 @@ import { GlobalActionCreator } from 'background/global-action-creators/global-ac
 import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { Action } from 'common/flux/action';
+import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { CommandsAdapter } from '../../../../../common/browser-adapters/commands-adapter';
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import { LaunchPanelType } from '../../../../../popup/components/popup-view';
 import { DictionaryStringTo } from '../../../../../types/common-types';
 
 describe('GlobalActionCreatorTest', () => {

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -41,13 +41,13 @@ import {
     PersistedTabInfo,
     TestStepResult,
 } from 'common/types/store-data/assessment-result-data';
+import { TabStopEvent } from 'common/types/tab-stop-event';
 import { VisualizationType } from 'common/types/visualization-type';
 import {
     ScanBasePayload,
     ScanCompletedPayload,
     ScanUpdatePayload,
 } from 'injected/analyzers/analyzer';
-import { TabStopEvent } from 'injected/tab-stops-listener';
 import { cloneDeep, isFunction } from 'lodash';
 import { ScanResults } from 'scanner/iruleresults';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';

--- a/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
@@ -11,6 +11,7 @@ import { LaunchPanelStore } from 'background/stores/global/launch-panel-store';
 import { PermissionsStateStore } from 'background/stores/global/permissions-state-store';
 import { ScopingStore } from 'background/stores/global/scoping-store';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
+import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
 import { cloneDeep } from 'lodash';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, Mock, Times } from 'typemoq';
@@ -18,7 +19,6 @@ import { BaseStore } from '../../../../../../common/base-store';
 import { IndexedDBAPI } from '../../../../../../common/indexedDB/indexedDB';
 import { PersistedTabInfo } from '../../../../../../common/types/store-data/assessment-result-data';
 import { StoreType } from '../../../../../../common/types/store-type';
-import { LaunchPanelType } from '../../../../../../popup/components/popup-view';
 import { CreateTestAssessmentProvider } from '../../../../common/test-assessment-provider';
 
 describe('GlobalStoreHubTest', () => {

--- a/src/tests/unit/tests/background/stores/global/launch-panel-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/launch-panel-state-store.test.ts
@@ -6,8 +6,10 @@ import { LocalStorageData } from 'background/storage-data';
 import { LaunchPanelStore } from 'background/stores/global/launch-panel-store';
 import { StorageAdapter } from 'common/browser-adapters/storage-adapter';
 import { StoreNames } from 'common/stores/store-names';
-import { LaunchPanelStoreData } from 'common/types/store-data/launch-panel-store-data';
-import { LaunchPanelType } from 'popup/components/popup-view';
+import {
+    LaunchPanelStoreData,
+    LaunchPanelType,
+} from 'common/types/store-data/launch-panel-store-data';
 import { IMock, It, Mock } from 'typemoq';
 import { createStoreWithNullParams, StoreTester } from '../../../../common/store-tester';
 

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -3,12 +3,13 @@
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { Message } from 'common/message';
+import { TabStopEvent } from 'common/types/tab-stop-event';
 import { VisualizationType } from 'common/types/visualization-type';
 import { WindowUtils } from 'common/window-utils';
 import { FocusAnalyzerConfiguration, ScanBasePayload } from 'injected/analyzers/analyzer';
 import { TabStopsAnalyzer } from 'injected/analyzers/tab-stops-analyzer';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
-import { TabStopEvent, TabStopsListener } from 'injected/tab-stops-listener';
+import { TabStopsListener } from 'injected/tab-stops-listener';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { itIsFunction } from 'tests/unit/common/it-is-function';
 

--- a/src/tests/unit/tests/injected/tab-stops-listener.test.ts
+++ b/src/tests/unit/tests/injected/tab-stops-listener.test.ts
@@ -2,17 +2,15 @@
 // Licensed under the MIT License.
 import { IMock, It, Mock, Times } from 'typemoq';
 
-import { HTMLElementUtils } from '../../../../common/html-element-utils';
-import { WindowUtils } from '../../../../common/window-utils';
-import { VisualizationWindowMessage } from '../../../../injected/drawing-controller';
-import { ErrorMessageContent } from '../../../../injected/frameCommunicators/error-message-content';
-import {
-    FrameCommunicator,
-    MessageRequest,
-} from '../../../../injected/frameCommunicators/frame-communicator';
-import { FrameMessageResponseCallback } from '../../../../injected/frameCommunicators/window-message-handler';
-import { ScannerUtils } from '../../../../injected/scanner-utils';
-import { TabStopEvent, TabStopsListener } from '../../../../injected/tab-stops-listener';
+import { HTMLElementUtils } from 'common/html-element-utils';
+import { TabStopEvent } from 'common/types/tab-stop-event';
+import { WindowUtils } from 'common/window-utils';
+import { VisualizationWindowMessage } from 'injected/drawing-controller';
+import { ErrorMessageContent } from 'injected/frameCommunicators/error-message-content';
+import { FrameCommunicator, MessageRequest } from 'injected/frameCommunicators/frame-communicator';
+import { FrameMessageResponseCallback } from 'injected/frameCommunicators/window-message-handler';
+import { ScannerUtils } from 'injected/scanner-utils';
+import { TabStopsListener } from 'injected/tab-stops-listener';
 
 describe('TabStopsListenerTest', () => {
     const frameCommunicatorMock: IMock<FrameCommunicator> = Mock.ofType(FrameCommunicator);

--- a/src/tests/unit/tests/popup/actions/popup-action-message-creator.test.ts
+++ b/src/tests/unit/tests/popup/actions/popup-action-message-creator.test.ts
@@ -16,10 +16,10 @@ import { Tab } from 'common/itab';
 import { Messages } from 'common/messages';
 import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import { WindowUtils } from 'common/window-utils';
 import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-creator';
-import { LaunchPanelType } from 'popup/components/popup-view';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 
 describe('PopupActionMessageCreatorTest', () => {

--- a/src/tests/unit/tests/popup/components/popup-view-controller-handler.test.tsx
+++ b/src/tests/unit/tests/popup/components/popup-view-controller-handler.test.tsx
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 import { It, Mock, Times } from 'typemoq';
 
-import { PopupActionMessageCreator } from '../../../../../popup/actions/popup-action-message-creator';
-import { LaunchPanelType } from '../../../../../popup/components/popup-view';
-import { PopupViewControllerHandler } from '../../../../../popup/handlers/popup-view-controller-handler';
+import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
+import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-creator';
+import { PopupViewControllerHandler } from 'popup/handlers/popup-view-controller-handler';
 
 describe('PopupViewControllerHandlerTest', () => {
     test('openAdhocToolsPanel', () => {

--- a/src/tests/unit/tests/popup/components/popup-view.test.tsx
+++ b/src/tests/unit/tests/popup/components/popup-view.test.tsx
@@ -5,13 +5,15 @@ import { NewTabLink } from 'common/components/new-tab-link';
 import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { StoreActionMessageCreatorImpl } from 'common/message-creators/store-action-message-creator-impl';
 import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
-import { LaunchPanelStoreData } from 'common/types/store-data/launch-panel-store-data';
+import {
+    LaunchPanelStoreData,
+    LaunchPanelType,
+} from 'common/types/store-data/launch-panel-store-data';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { shallow } from 'enzyme';
 import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-creator';
 import { LaunchPanelHeader } from 'popup/components/launch-panel-header';
 import {
-    LaunchPanelType,
     PopupView,
     PopupViewControllerDeps,
     PopupViewControllerState,


### PR DESCRIPTION
#### Description of changes

This PR fixes cyclic import chains that went through `action-payloads.ts`. In particular, anything that transitively referenced any action payload type (ie, a huge number of react components) ended up transitively referencing a few different import cycles, where a type used in some action payload definition was itself defined as part of a react component that invoked actions. This Pr moves 3 types out of such components and into new/existing `/common/types/` files:

* `LaunchPanelType` moves from `/src/popup/components/popup-view.tsx` to `src/common/types/store-data/launch-panel-store-data.ts`
* `TabStopEvent` moves from `/src/injected/tab-stops-listener.ts` to `src/common/types/tab-stop-event.ts`
* `FailureInstanceData` moves from `src/DetailsView/components/failure-instance-panel-control.tsx` to `src/common/types/failure-instance-data.ts`

This reduces the line count of `yarn null:find-cycles` by 60%:

Before:

```
C:\repos\accessibility-insights-web [master ≡] | 115 | 16:53:45 12/07
> yarn null:find-cycles | measure
Count             : 9850
```

After:

```
C:\repos\accessibility-insights-web [break-action-payload-cycle] | 112 | 16:48:41 12/07
> yarn null:find-cycles | measure
Count             : 3968
```

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: unblocks progress on #2869
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
