### PR TITLE
fix: needs review feature flag ON by default

### DIFF
--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -112,7 +112,7 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
         },
         {
             id: FeatureFlags.needsReview,
-            defaultValue: false,
+            defaultValue: true,
             displayableName: 'Needs review',
             displayableDescription:
                 'Enable a new test to show automated check rules that might have an accessibility issue and need to be reviewed.',

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
@@ -140,13 +140,13 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
                       Needs review
                     </div>
                     <div
-                      class="ms-Toggle is-enabled toggle--{{CSS_MODULE_HASH}} root-000"
+                      class="ms-Toggle is-checked is-enabled toggle--{{CSS_MODULE_HASH}} root-000"
                     >
                       <div
                         class="ms-Toggle-innerContainer container-000"
                       >
                         <button
-                          aria-checked="false"
+                          aria-checked="true"
                           aria-label="Needs review"
                           class="ms-Toggle-background pill-000"
                           data-is-focusable="true"
@@ -163,7 +163,7 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
                           for="needsReview"
                           id="needsReview-stateText"
                         >
-                          Off
+                          On
                         </label>
                       </div>
                     </div>

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -26,7 +26,7 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.manualInstanceDetails]: false,
             [FeatureFlags.debugTools]: false,
             [FeatureFlags.exportReportOptions]: false,
-            [FeatureFlags.needsReview]: false,
+            [FeatureFlags.needsReview]: true,
             [FeatureFlags.saveAndLoadAssessment]: false,
         };
 


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->
changed the Needs Review test feature flag to on by default.
![preview features with Needs review ON](https://user-images.githubusercontent.com/9062104/101553097-eec1ea80-3968-11eb-85d5-4a645196ba71.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ x] Addresses an existing issue: #3710
- [ x] Ran `yarn fastpass`
- [ N/A] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
