### PR TITLE
fix: Use current app name in Azure Boards issue tag

### DIFF
--- a/src/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.ts
+++ b/src/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ToolData } from 'common/types/store-data/unified-data-interface';
-import { title } from 'content/strings/application';
 import { CreateIssueDetailsTextData } from '../../../common/types/create-issue-details-text-data';
 import { HTTPQueryBuilder } from '../../common/http-query-builder';
 import { IssueDetailsBuilder } from '../../common/issue-details-builder';
@@ -14,8 +13,12 @@ import {
     AzureBoardsWorkItemType,
 } from './azure-boards-issue-filing-settings';
 
-const buildTags = (createIssueData: CreateIssueDetailsTextData, standardTags: string[]): string => {
-    const tags = ['Accessibility', title, `rule: ${createIssueData.rule.id}`, ...standardTags];
+const buildTags = (
+    createIssueData: CreateIssueDetailsTextData,
+    standardTags: string[],
+    toolTitle: string,
+): string => {
+    const tags = ['Accessibility', toolTitle, `rule: ${createIssueData.rule.id}`, ...standardTags];
     return tags.join('; ');
 };
 
@@ -31,7 +34,7 @@ export const createAzureBoardsIssueFilingUrlProvider = (
     ) => {
         const titleField = stringUtils.getTitle(issueData);
         const standardTags = stringUtils.standardizeTags(issueData);
-        const tags = buildTags(issueData, standardTags);
+        const tags = buildTags(issueData, standardTags, toolData.applicationProperties.name);
         const body = issueDetailsBuilder(toolData, issueData);
 
         let bodyField: string = '[Microsoft.VSTS.TCM.ReproSteps]';

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.test.ts
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.test.ts
@@ -3,7 +3,6 @@
 import { IMock, Mock } from 'typemoq';
 
 import { ToolData } from 'common/types/store-data/unified-data-interface';
-import { title } from 'content/strings/application';
 import { CreateIssueDetailsTextData } from '../../../../../../common/types/create-issue-details-text-data';
 import { HTTPQueryBuilder } from '../../../../../../issue-filing/common/http-query-builder';
 import { IssueDetailsBuilder } from '../../../../../../issue-filing/common/issue-details-builder';
@@ -60,7 +59,7 @@ describe('createAzureBoardsIssueFilingUrl', () => {
             issueDetailsField: 'description',
         };
 
-        baseTags = `Accessibility; ${title}; rule: ${sampleIssueDetailsData.rule.id}`;
+        baseTags = `Accessibility; ${toolData.applicationProperties.name}; rule: ${sampleIssueDetailsData.rule.id}`;
 
         stringUtilsMock = Mock.ofType<IssueUrlCreationUtils>();
         const testTitle = 'test title';


### PR DESCRIPTION
#### Description of changes
Addresses issue #3438- Accessibility Insights for Android bugs are filed with Web tags in ADO.

Currently, the global title string ("Accessibility Insights for Web") is used for all Azure Boards issue filing tags. This PR updates `createAzureBoardsIssueFilingUrlProvider` to use the current app name from `ToolData`. This has no impact on the Web product and causes the unified issue filing tag to be "Accessibility Insights for Android".

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3438 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
