### PR TITLE
fix: Combined report UI changes

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -5809,10 +5809,11 @@
       ><div class="report-footer" role="contentinfo"
         >This automated checks result was generated using the Service Name for
         Axe Results With Issues that helps find some of the most common
-        accessibility issues. The scan was performed using axe-core 3.3.2 and
-        Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
-        like Gecko) HeadlessChrome/78.0.3904.108 Safari/537.36. For a complete
-        WCAG 2.1 compliance assessment please visit
+        accessibility issues. The scan was performed in a clean browser
+        environment, using axe-core 3.3.2 and Mozilla/5.0 (Windows NT 10.0;
+        Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)
+        HeadlessChrome/78.0.3904.108 Safari/537.36 with a display resolution of
+        800x600. For a complete WCAG 2.1 compliance assessment please visit
         <a
           target="_blank"
           href="http://aka.ms/AccessibilityInsights"

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -3815,10 +3815,11 @@
       ><div class="report-footer" role="contentinfo"
         >This automated checks result was generated using the Service Name for
         Axe Results Without Issues that helps find some of the most common
-        accessibility issues. The scan was performed using axe-core 3.3.2 and
-        Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
-        like Gecko) HeadlessChrome/78.0.3904.108 Safari/537.36. For a complete
-        WCAG 2.1 compliance assessment please visit
+        accessibility issues. The scan was performed in a clean browser
+        environment, using axe-core 3.3.2 and Mozilla/5.0 (Windows NT 10.0;
+        Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)
+        HeadlessChrome/78.0.3904.108 Safari/537.36 with a display resolution of
+        800x600. For a complete WCAG 2.1 compliance assessment please visit
         <a
           target="_blank"
           href="http://aka.ms/AccessibilityInsights"

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.input.ts
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.input.ts
@@ -13,6 +13,7 @@ export const combinedResultsWithIssues: CombinedReportParameters = {
         durationSeconds: 1 * 60 * 60,
     },
     userAgent: 'Mock user agent',
+    browserResolution: '1920x1080',
     results: {
         urlResults: {
             failedUrls: 3,

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -1792,9 +1792,9 @@
                   aria-expanded="false"
                   aria-controls="content-container-undefined"
                   ><span class="combined-report-result-section-title--3lkTt"
-                    ><span class="screen-reader-only">Failed 2</span
+                    ><span class="screen-reader-only">Failed rules 2</span
                     ><span class="heading--AZCs6" aria-hidden="true"
-                      >Failed (2)</span
+                      >Failed rules (2)</span
                     ></span
                   ></button
                 ></div
@@ -2415,180 +2415,11 @@
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
-                  aria-controls="content-container-inapplicable-checks-section"
-                  ><span class="combined-report-result-section-title--3lkTt"
-                    ><span class="screen-reader-only">Not applicable 3</span
-                    ><span class="heading--AZCs6" aria-hidden="true"
-                      >Not applicable (3)</span
-                    ></span
-                  ></button
-                ></div
-              ><div
-                id="content-container-inapplicable-checks-section"
-                class="collapsible-content"
-                aria-hidden="true"
-                ><div class="rule-details-group--39A1d"
-                  ><div class="rule-detail"
-                    ><div>
-                      <span class="rule-details-id"
-                        ><a
-                          target="_blank"
-                          href="https://accessibilityinsights.io/info-examples/web/aria-input-field-name"
-                          class="ms-Link insights-link root-49"
-                          aria-label="rule aria-input-field-name"
-                          aria-describedby="not-applicable-rule-aria-input-field-name-description"
-                          >aria-input-field-name</a
-                        ></span
-                      >:
-                      <span
-                        class="rule-details-description"
-                        id="not-applicable-rule-aria-input-field-name-description"
-                        >Ensures every ARIA input field has an accessible
-                        name</span
-                      >(<span class="guidance-links"
-                        ><a
-                          target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
-                          class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__9"
-                          >WCAG 4.1.2</a
-                        ><script>
-                          (function (linkId, doc, confirmCallback) {
-                            const targetPageLink = doc.getElementById(linkId);
-                            targetPageLink.addEventListener(
-                              "click",
-                              function (event) {
-                                const result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
-                                );
-                                if (result === false) {
-                                  event.preventDefault();
-                                }
-                              }
-                            );
-                          })(
-                            "new-tab-link-with-confirmation-dialog__9",
-                            document,
-                            confirm
-                          );
-                        </script></span
-                      >)</div
-                    ></div
-                  ><div class="rule-detail"
-                    ><div>
-                      <span class="rule-details-id"
-                        ><a
-                          target="_blank"
-                          href="https://accessibilityinsights.io/info-examples/web/aria-toggle-field-name"
-                          class="ms-Link insights-link root-49"
-                          aria-label="rule aria-toggle-field-name"
-                          aria-describedby="not-applicable-rule-aria-toggle-field-name-description"
-                          >aria-toggle-field-name</a
-                        ></span
-                      >:
-                      <span
-                        class="rule-details-description"
-                        id="not-applicable-rule-aria-toggle-field-name-description"
-                        >Ensures every ARIA toggle field has an accessible
-                        name</span
-                      >(<span class="guidance-links"
-                        ><a
-                          target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
-                          class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__10"
-                          >WCAG 4.1.2</a
-                        ><script>
-                          (function (linkId, doc, confirmCallback) {
-                            const targetPageLink = doc.getElementById(linkId);
-                            targetPageLink.addEventListener(
-                              "click",
-                              function (event) {
-                                const result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
-                                );
-                                if (result === false) {
-                                  event.preventDefault();
-                                }
-                              }
-                            );
-                          })(
-                            "new-tab-link-with-confirmation-dialog__10",
-                            document,
-                            confirm
-                          );
-                        </script></span
-                      >)</div
-                    ></div
-                  ><div class="rule-detail"
-                    ><div>
-                      <span class="rule-details-id"
-                        ><a
-                          target="_blank"
-                          href="https://accessibilityinsights.io/info-examples/web/autocomplete-valid"
-                          class="ms-Link insights-link root-49"
-                          aria-label="rule autocomplete-valid"
-                          aria-describedby="not-applicable-rule-autocomplete-valid-description"
-                          >autocomplete-valid</a
-                        ></span
-                      >:
-                      <span
-                        class="rule-details-description"
-                        id="not-applicable-rule-autocomplete-valid-description"
-                        >Ensure the autocomplete attribute is correct and
-                        suitable for the form field</span
-                      >(<span class="guidance-links"
-                        ><a
-                          target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html"
-                          class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__11"
-                          >WCAG 1.3.5</a
-                        ><script>
-                          (function (linkId, doc, confirmCallback) {
-                            const targetPageLink = doc.getElementById(linkId);
-                            targetPageLink.addEventListener(
-                              "click",
-                              function (event) {
-                                const result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
-                                );
-                                if (result === false) {
-                                  event.preventDefault();
-                                }
-                              }
-                            );
-                          })(
-                            "new-tab-link-with-confirmation-dialog__11",
-                            document,
-                            confirm
-                          );
-                        </script></span
-                      >)<span class="guidance-tags"
-                        ><span>New for WCAG 2.1</span></span
-                      ></div
-                    ></div
-                  ></div
-                ></div
-              ></div
-            ></div
-          ><div class="result-section"
-            ><div class="collapsible-container collapsed"
-              ><div class="title-container" role="heading" aria-level="3"
-                ><button
-                  class="collapsible-control"
-                  aria-expanded="false"
                   aria-controls="content-container-pass-checks-section"
                   ><span class="combined-report-result-section-title--3lkTt"
-                    ><span class="screen-reader-only">Passed 2</span
+                    ><span class="screen-reader-only">Passed rules 2</span
                     ><span class="heading--AZCs6" aria-hidden="true"
-                      >Passed (2)</span
+                      >Passed rules (2)</span
                     ></span
                   ></button
                 ></div
@@ -2619,8 +2450,156 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__12"
+                          id="new-tab-link-with-confirmation-dialog__9"
                           >WCAG 1.1.1</a
+                        ><script>
+                          (function (linkId, doc, confirmCallback) {
+                            const targetPageLink = doc.getElementById(linkId);
+                            targetPageLink.addEventListener(
+                              "click",
+                              function (event) {
+                                const result = confirmCallback(
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                                    "Cancel to stay on the current page."
+                                );
+                                if (result === false) {
+                                  event.preventDefault();
+                                }
+                              }
+                            );
+                          })(
+                            "new-tab-link-with-confirmation-dialog__9",
+                            document,
+                            confirm
+                          );
+                        </script></span
+                      >)</div
+                    ></div
+                  ><div class="rule-detail"
+                    ><div>
+                      <span class="rule-details-id"
+                        ><a
+                          target="_blank"
+                          href="https://accessibilityinsights.io/info-examples/web/aria-hidden-focus"
+                          class="ms-Link insights-link root-49"
+                          aria-label="rule aria-hidden-focus"
+                          aria-describedby="passed-rule-aria-hidden-focus-description"
+                          >aria-hidden-focus</a
+                        ></span
+                      >:
+                      <span
+                        class="rule-details-description"
+                        id="passed-rule-aria-hidden-focus-description"
+                        >Ensures aria-hidden elements do not contain focusable
+                        elements</span
+                      >(<span class="guidance-links"
+                        ><a
+                          target="_blank"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                          class="ms-Link insights-link root-49"
+                          id="new-tab-link-with-confirmation-dialog__10"
+                          >WCAG 1.3.1</a
+                        ><script>
+                          (function (linkId, doc, confirmCallback) {
+                            const targetPageLink = doc.getElementById(linkId);
+                            targetPageLink.addEventListener(
+                              "click",
+                              function (event) {
+                                const result = confirmCallback(
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                                    "Cancel to stay on the current page."
+                                );
+                                if (result === false) {
+                                  event.preventDefault();
+                                }
+                              }
+                            );
+                          })(
+                            "new-tab-link-with-confirmation-dialog__10",
+                            document,
+                            confirm
+                          );</script
+                        ><span>, </span
+                        ><a
+                          target="_blank"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                          class="ms-Link insights-link root-49"
+                          id="new-tab-link-with-confirmation-dialog__11"
+                          >WCAG 4.1.2</a
+                        ><script>
+                          (function (linkId, doc, confirmCallback) {
+                            const targetPageLink = doc.getElementById(linkId);
+                            targetPageLink.addEventListener(
+                              "click",
+                              function (event) {
+                                const result = confirmCallback(
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                                    "Cancel to stay on the current page."
+                                );
+                                if (result === false) {
+                                  event.preventDefault();
+                                }
+                              }
+                            );
+                          })(
+                            "new-tab-link-with-confirmation-dialog__11",
+                            document,
+                            confirm
+                          );
+                        </script></span
+                      >)</div
+                    ></div
+                  ></div
+                ></div
+              ></div
+            ></div
+          ><div class="result-section"
+            ><div class="collapsible-container collapsed"
+              ><div class="title-container" role="heading" aria-level="3"
+                ><button
+                  class="collapsible-control"
+                  aria-expanded="false"
+                  aria-controls="content-container-inapplicable-checks-section"
+                  ><span class="combined-report-result-section-title--3lkTt"
+                    ><span class="screen-reader-only"
+                      >Not applicable rules 3</span
+                    ><span class="heading--AZCs6" aria-hidden="true"
+                      >Not applicable rules (3)</span
+                    ></span
+                  ></button
+                ></div
+              ><div
+                id="content-container-inapplicable-checks-section"
+                class="collapsible-content"
+                aria-hidden="true"
+                ><div class="rule-details-group--39A1d"
+                  ><div class="rule-detail"
+                    ><div>
+                      <span class="rule-details-id"
+                        ><a
+                          target="_blank"
+                          href="https://accessibilityinsights.io/info-examples/web/aria-input-field-name"
+                          class="ms-Link insights-link root-49"
+                          aria-label="rule aria-input-field-name"
+                          aria-describedby="not-applicable-rule-aria-input-field-name-description"
+                          >aria-input-field-name</a
+                        ></span
+                      >:
+                      <span
+                        class="rule-details-description"
+                        id="not-applicable-rule-aria-input-field-name-description"
+                        >Ensures every ARIA input field has an accessible
+                        name</span
+                      >(<span class="guidance-links"
+                        ><a
+                          target="_blank"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                          class="ms-Link insights-link root-49"
+                          id="new-tab-link-with-confirmation-dialog__12"
+                          >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
                             const targetPageLink = doc.getElementById(linkId);
@@ -2650,25 +2629,25 @@
                       <span class="rule-details-id"
                         ><a
                           target="_blank"
-                          href="https://accessibilityinsights.io/info-examples/web/aria-hidden-focus"
+                          href="https://accessibilityinsights.io/info-examples/web/aria-toggle-field-name"
                           class="ms-Link insights-link root-49"
-                          aria-label="rule aria-hidden-focus"
-                          aria-describedby="passed-rule-aria-hidden-focus-description"
-                          >aria-hidden-focus</a
+                          aria-label="rule aria-toggle-field-name"
+                          aria-describedby="not-applicable-rule-aria-toggle-field-name-description"
+                          >aria-toggle-field-name</a
                         ></span
                       >:
                       <span
                         class="rule-details-description"
-                        id="passed-rule-aria-hidden-focus-description"
-                        >Ensures aria-hidden elements do not contain focusable
-                        elements</span
+                        id="not-applicable-rule-aria-toggle-field-name-description"
+                        >Ensures every ARIA toggle field has an accessible
+                        name</span
                       >(<span class="guidance-links"
                         ><a
                           target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
                           id="new-tab-link-with-confirmation-dialog__13"
-                          >WCAG 1.3.1</a
+                          >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
                             const targetPageLink = doc.getElementById(linkId);
@@ -2689,14 +2668,34 @@
                             "new-tab-link-with-confirmation-dialog__13",
                             document,
                             confirm
-                          );</script
-                        ><span>, </span
+                          );
+                        </script></span
+                      >)</div
+                    ></div
+                  ><div class="rule-detail"
+                    ><div>
+                      <span class="rule-details-id"
                         ><a
                           target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                          href="https://accessibilityinsights.io/info-examples/web/autocomplete-valid"
+                          class="ms-Link insights-link root-49"
+                          aria-label="rule autocomplete-valid"
+                          aria-describedby="not-applicable-rule-autocomplete-valid-description"
+                          >autocomplete-valid</a
+                        ></span
+                      >:
+                      <span
+                        class="rule-details-description"
+                        id="not-applicable-rule-autocomplete-valid-description"
+                        >Ensure the autocomplete attribute is correct and
+                        suitable for the form field</span
+                      >(<span class="guidance-links"
+                        ><a
+                          target="_blank"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html"
                           class="ms-Link insights-link root-49"
                           id="new-tab-link-with-confirmation-dialog__14"
-                          >WCAG 4.1.2</a
+                          >WCAG 1.3.5</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
                             const targetPageLink = doc.getElementById(linkId);
@@ -2719,7 +2718,9 @@
                             confirm
                           );
                         </script></span
-                      >)</div
+                      >)<span class="guidance-tags"
+                        ><span>New for WCAG 2.1</span></span
+                      ></div
                     ></div
                   ></div
                 ></div
@@ -2772,8 +2773,9 @@
       ><div class="report-footer" role="contentinfo"
         >This automated checks result was generated using the Mock Service Name
         that helps find some of the most common accessibility issues. The scan
-        was performed using axe-core mock.axe.version and Mock user agent. For a
-        complete WCAG 2.1 compliance assessment please visit
+        was performed in a clean browser environment, using axe-core
+        mock.axe.version and Mock user agent with a display resolution of
+        1920x1080. For a complete WCAG 2.1 compliance assessment please visit
         <a
           target="_blank"
           href="http://aka.ms/AccessibilityInsights"

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.input.ts
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.input.ts
@@ -13,6 +13,7 @@ export const combinedResultsWithoutIssues: CombinedReportParameters = {
         durationSeconds: 1 * 60 * 60,
     },
     userAgent: 'Mock user agent',
+    browserResolution: '1920x1080',
     results: {
         urlResults: {
             failedUrls: 0,

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -1792,9 +1792,9 @@
                   aria-expanded="false"
                   aria-controls="content-container-undefined"
                   ><span class="combined-report-result-section-title--3lkTt"
-                    ><span class="screen-reader-only">Failed 0</span
+                    ><span class="screen-reader-only">Failed rules 0</span
                     ><span class="heading--AZCs6" aria-hidden="true"
-                      >Failed (0)</span
+                      >Failed rules (0)</span
                     ></span
                   ></button
                 ></div
@@ -1820,180 +1820,11 @@
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
-                  aria-controls="content-container-inapplicable-checks-section"
-                  ><span class="combined-report-result-section-title--3lkTt"
-                    ><span class="screen-reader-only">Not applicable 3</span
-                    ><span class="heading--AZCs6" aria-hidden="true"
-                      >Not applicable (3)</span
-                    ></span
-                  ></button
-                ></div
-              ><div
-                id="content-container-inapplicable-checks-section"
-                class="collapsible-content"
-                aria-hidden="true"
-                ><div class="rule-details-group--39A1d"
-                  ><div class="rule-detail"
-                    ><div>
-                      <span class="rule-details-id"
-                        ><a
-                          target="_blank"
-                          href="https://accessibilityinsights.io/info-examples/web/aria-input-field-name"
-                          class="ms-Link insights-link root-49"
-                          aria-label="rule aria-input-field-name"
-                          aria-describedby="not-applicable-rule-aria-input-field-name-description"
-                          >aria-input-field-name</a
-                        ></span
-                      >:
-                      <span
-                        class="rule-details-description"
-                        id="not-applicable-rule-aria-input-field-name-description"
-                        >Ensures every ARIA input field has an accessible
-                        name</span
-                      >(<span class="guidance-links"
-                        ><a
-                          target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
-                          class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__1"
-                          >WCAG 4.1.2</a
-                        ><script>
-                          (function (linkId, doc, confirmCallback) {
-                            const targetPageLink = doc.getElementById(linkId);
-                            targetPageLink.addEventListener(
-                              "click",
-                              function (event) {
-                                const result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
-                                );
-                                if (result === false) {
-                                  event.preventDefault();
-                                }
-                              }
-                            );
-                          })(
-                            "new-tab-link-with-confirmation-dialog__1",
-                            document,
-                            confirm
-                          );
-                        </script></span
-                      >)</div
-                    ></div
-                  ><div class="rule-detail"
-                    ><div>
-                      <span class="rule-details-id"
-                        ><a
-                          target="_blank"
-                          href="https://accessibilityinsights.io/info-examples/web/aria-toggle-field-name"
-                          class="ms-Link insights-link root-49"
-                          aria-label="rule aria-toggle-field-name"
-                          aria-describedby="not-applicable-rule-aria-toggle-field-name-description"
-                          >aria-toggle-field-name</a
-                        ></span
-                      >:
-                      <span
-                        class="rule-details-description"
-                        id="not-applicable-rule-aria-toggle-field-name-description"
-                        >Ensures every ARIA toggle field has an accessible
-                        name</span
-                      >(<span class="guidance-links"
-                        ><a
-                          target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
-                          class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__2"
-                          >WCAG 4.1.2</a
-                        ><script>
-                          (function (linkId, doc, confirmCallback) {
-                            const targetPageLink = doc.getElementById(linkId);
-                            targetPageLink.addEventListener(
-                              "click",
-                              function (event) {
-                                const result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
-                                );
-                                if (result === false) {
-                                  event.preventDefault();
-                                }
-                              }
-                            );
-                          })(
-                            "new-tab-link-with-confirmation-dialog__2",
-                            document,
-                            confirm
-                          );
-                        </script></span
-                      >)</div
-                    ></div
-                  ><div class="rule-detail"
-                    ><div>
-                      <span class="rule-details-id"
-                        ><a
-                          target="_blank"
-                          href="https://accessibilityinsights.io/info-examples/web/autocomplete-valid"
-                          class="ms-Link insights-link root-49"
-                          aria-label="rule autocomplete-valid"
-                          aria-describedby="not-applicable-rule-autocomplete-valid-description"
-                          >autocomplete-valid</a
-                        ></span
-                      >:
-                      <span
-                        class="rule-details-description"
-                        id="not-applicable-rule-autocomplete-valid-description"
-                        >Ensure the autocomplete attribute is correct and
-                        suitable for the form field</span
-                      >(<span class="guidance-links"
-                        ><a
-                          target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html"
-                          class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__3"
-                          >WCAG 1.3.5</a
-                        ><script>
-                          (function (linkId, doc, confirmCallback) {
-                            const targetPageLink = doc.getElementById(linkId);
-                            targetPageLink.addEventListener(
-                              "click",
-                              function (event) {
-                                const result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
-                                );
-                                if (result === false) {
-                                  event.preventDefault();
-                                }
-                              }
-                            );
-                          })(
-                            "new-tab-link-with-confirmation-dialog__3",
-                            document,
-                            confirm
-                          );
-                        </script></span
-                      >)<span class="guidance-tags"
-                        ><span>New for WCAG 2.1</span></span
-                      ></div
-                    ></div
-                  ></div
-                ></div
-              ></div
-            ></div
-          ><div class="result-section"
-            ><div class="collapsible-container collapsed"
-              ><div class="title-container" role="heading" aria-level="3"
-                ><button
-                  class="collapsible-control"
-                  aria-expanded="false"
                   aria-controls="content-container-pass-checks-section"
                   ><span class="combined-report-result-section-title--3lkTt"
-                    ><span class="screen-reader-only">Passed 2</span
+                    ><span class="screen-reader-only">Passed rules 2</span
                     ><span class="heading--AZCs6" aria-hidden="true"
-                      >Passed (2)</span
+                      >Passed rules (2)</span
                     ></span
                   ></button
                 ></div
@@ -2024,8 +1855,156 @@
                           target="_blank"
                           href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
                           class="ms-Link insights-link root-49"
-                          id="new-tab-link-with-confirmation-dialog__4"
+                          id="new-tab-link-with-confirmation-dialog__1"
                           >WCAG 1.1.1</a
+                        ><script>
+                          (function (linkId, doc, confirmCallback) {
+                            const targetPageLink = doc.getElementById(linkId);
+                            targetPageLink.addEventListener(
+                              "click",
+                              function (event) {
+                                const result = confirmCallback(
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                                    "Cancel to stay on the current page."
+                                );
+                                if (result === false) {
+                                  event.preventDefault();
+                                }
+                              }
+                            );
+                          })(
+                            "new-tab-link-with-confirmation-dialog__1",
+                            document,
+                            confirm
+                          );
+                        </script></span
+                      >)</div
+                    ></div
+                  ><div class="rule-detail"
+                    ><div>
+                      <span class="rule-details-id"
+                        ><a
+                          target="_blank"
+                          href="https://accessibilityinsights.io/info-examples/web/aria-hidden-focus"
+                          class="ms-Link insights-link root-49"
+                          aria-label="rule aria-hidden-focus"
+                          aria-describedby="passed-rule-aria-hidden-focus-description"
+                          >aria-hidden-focus</a
+                        ></span
+                      >:
+                      <span
+                        class="rule-details-description"
+                        id="passed-rule-aria-hidden-focus-description"
+                        >Ensures aria-hidden elements do not contain focusable
+                        elements</span
+                      >(<span class="guidance-links"
+                        ><a
+                          target="_blank"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                          class="ms-Link insights-link root-49"
+                          id="new-tab-link-with-confirmation-dialog__2"
+                          >WCAG 1.3.1</a
+                        ><script>
+                          (function (linkId, doc, confirmCallback) {
+                            const targetPageLink = doc.getElementById(linkId);
+                            targetPageLink.addEventListener(
+                              "click",
+                              function (event) {
+                                const result = confirmCallback(
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                                    "Cancel to stay on the current page."
+                                );
+                                if (result === false) {
+                                  event.preventDefault();
+                                }
+                              }
+                            );
+                          })(
+                            "new-tab-link-with-confirmation-dialog__2",
+                            document,
+                            confirm
+                          );</script
+                        ><span>, </span
+                        ><a
+                          target="_blank"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                          class="ms-Link insights-link root-49"
+                          id="new-tab-link-with-confirmation-dialog__3"
+                          >WCAG 4.1.2</a
+                        ><script>
+                          (function (linkId, doc, confirmCallback) {
+                            const targetPageLink = doc.getElementById(linkId);
+                            targetPageLink.addEventListener(
+                              "click",
+                              function (event) {
+                                const result = confirmCallback(
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
+                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
+                                    "Cancel to stay on the current page."
+                                );
+                                if (result === false) {
+                                  event.preventDefault();
+                                }
+                              }
+                            );
+                          })(
+                            "new-tab-link-with-confirmation-dialog__3",
+                            document,
+                            confirm
+                          );
+                        </script></span
+                      >)</div
+                    ></div
+                  ></div
+                ></div
+              ></div
+            ></div
+          ><div class="result-section"
+            ><div class="collapsible-container collapsed"
+              ><div class="title-container" role="heading" aria-level="3"
+                ><button
+                  class="collapsible-control"
+                  aria-expanded="false"
+                  aria-controls="content-container-inapplicable-checks-section"
+                  ><span class="combined-report-result-section-title--3lkTt"
+                    ><span class="screen-reader-only"
+                      >Not applicable rules 3</span
+                    ><span class="heading--AZCs6" aria-hidden="true"
+                      >Not applicable rules (3)</span
+                    ></span
+                  ></button
+                ></div
+              ><div
+                id="content-container-inapplicable-checks-section"
+                class="collapsible-content"
+                aria-hidden="true"
+                ><div class="rule-details-group--39A1d"
+                  ><div class="rule-detail"
+                    ><div>
+                      <span class="rule-details-id"
+                        ><a
+                          target="_blank"
+                          href="https://accessibilityinsights.io/info-examples/web/aria-input-field-name"
+                          class="ms-Link insights-link root-49"
+                          aria-label="rule aria-input-field-name"
+                          aria-describedby="not-applicable-rule-aria-input-field-name-description"
+                          >aria-input-field-name</a
+                        ></span
+                      >:
+                      <span
+                        class="rule-details-description"
+                        id="not-applicable-rule-aria-input-field-name-description"
+                        >Ensures every ARIA input field has an accessible
+                        name</span
+                      >(<span class="guidance-links"
+                        ><a
+                          target="_blank"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                          class="ms-Link insights-link root-49"
+                          id="new-tab-link-with-confirmation-dialog__4"
+                          >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
                             const targetPageLink = doc.getElementById(linkId);
@@ -2055,25 +2034,25 @@
                       <span class="rule-details-id"
                         ><a
                           target="_blank"
-                          href="https://accessibilityinsights.io/info-examples/web/aria-hidden-focus"
+                          href="https://accessibilityinsights.io/info-examples/web/aria-toggle-field-name"
                           class="ms-Link insights-link root-49"
-                          aria-label="rule aria-hidden-focus"
-                          aria-describedby="passed-rule-aria-hidden-focus-description"
-                          >aria-hidden-focus</a
+                          aria-label="rule aria-toggle-field-name"
+                          aria-describedby="not-applicable-rule-aria-toggle-field-name-description"
+                          >aria-toggle-field-name</a
                         ></span
                       >:
                       <span
                         class="rule-details-description"
-                        id="passed-rule-aria-hidden-focus-description"
-                        >Ensures aria-hidden elements do not contain focusable
-                        elements</span
+                        id="not-applicable-rule-aria-toggle-field-name-description"
+                        >Ensures every ARIA toggle field has an accessible
+                        name</span
                       >(<span class="guidance-links"
                         ><a
                           target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
                           class="ms-Link insights-link root-49"
                           id="new-tab-link-with-confirmation-dialog__5"
-                          >WCAG 1.3.1</a
+                          >WCAG 4.1.2</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
                             const targetPageLink = doc.getElementById(linkId);
@@ -2094,14 +2073,34 @@
                             "new-tab-link-with-confirmation-dialog__5",
                             document,
                             confirm
-                          );</script
-                        ><span>, </span
+                          );
+                        </script></span
+                      >)</div
+                    ></div
+                  ><div class="rule-detail"
+                    ><div>
+                      <span class="rule-details-id"
                         ><a
                           target="_blank"
-                          href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                          href="https://accessibilityinsights.io/info-examples/web/autocomplete-valid"
+                          class="ms-Link insights-link root-49"
+                          aria-label="rule autocomplete-valid"
+                          aria-describedby="not-applicable-rule-autocomplete-valid-description"
+                          >autocomplete-valid</a
+                        ></span
+                      >:
+                      <span
+                        class="rule-details-description"
+                        id="not-applicable-rule-autocomplete-valid-description"
+                        >Ensure the autocomplete attribute is correct and
+                        suitable for the form field</span
+                      >(<span class="guidance-links"
+                        ><a
+                          target="_blank"
+                          href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html"
                           class="ms-Link insights-link root-49"
                           id="new-tab-link-with-confirmation-dialog__6"
-                          >WCAG 4.1.2</a
+                          >WCAG 1.3.5</a
                         ><script>
                           (function (linkId, doc, confirmCallback) {
                             const targetPageLink = doc.getElementById(linkId);
@@ -2124,7 +2123,9 @@
                             confirm
                           );
                         </script></span
-                      >)</div
+                      >)<span class="guidance-tags"
+                        ><span>New for WCAG 2.1</span></span
+                      ></div
                     ></div
                   ></div
                 ></div
@@ -2177,8 +2178,9 @@
       ><div class="report-footer" role="contentinfo"
         >This automated checks result was generated using the Mock Service Name
         that helps find some of the most common accessibility issues. The scan
-        was performed using axe-core mock.axe.version and Mock user agent. For a
-        complete WCAG 2.1 compliance assessment please visit
+        was performed in a clean browser environment, using axe-core
+        mock.axe.version and Mock user agent with a display resolution of
+        1920x1080. For a complete WCAG 2.1 compliance assessment please visit
         <a
           target="_blank"
           href="http://aka.ms/AccessibilityInsights"

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.input.ts
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.input.ts
@@ -13,6 +13,7 @@ export const summaryScanWithIssues: SummaryReportParameters = {
         durationSeconds: 1 * 60 * 60,
     },
     userAgent: 'Mock user agent',
+    browserResolution: '1920x1080',
     results: {
         failed: [
             {

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -2145,8 +2145,9 @@
       ><div class="report-footer" role="contentinfo"
         >This automated checks result was generated using the Mock Service Name
         that helps find some of the most common accessibility issues. The scan
-        was performed using axe-core mock.axe.version and Mock user agent. For a
-        complete WCAG 2.1 compliance assessment please visit
+        was performed in a clean browser environment, using axe-core
+        mock.axe.version and Mock user agent with a display resolution of
+        1920x1080. For a complete WCAG 2.1 compliance assessment please visit
         <a
           target="_blank"
           href="http://aka.ms/AccessibilityInsights"

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.input.ts
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.input.ts
@@ -13,6 +13,7 @@ export const summaryScanWithoutIssues: SummaryReportParameters = {
         durationSeconds: 1 * 60 * 60,
     },
     userAgent: 'Mock user agent',
+    browserResolution: '1920x1080',
     results: {
         failed: [],
         passed: [

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -2086,8 +2086,9 @@
       ><div class="report-footer" role="contentinfo"
         >This automated checks result was generated using the Mock Service Name
         that helps find some of the most common accessibility issues. The scan
-        was performed using axe-core mock.axe.version and Mock user agent. For a
-        complete WCAG 2.1 compliance assessment please visit
+        was performed in a clean browser environment, using axe-core
+        mock.axe.version and Mock user agent with a display resolution of
+        1920x1080. For a complete WCAG 2.1 compliance assessment please visit
         <a
           target="_blank"
           href="http://aka.ms/AccessibilityInsights"

--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-report",
-    "version": "4.1.0",
+    "version": "4.0.0",
     "description": "Accessibility Insights Report",
     "license": "MIT",
     "files": [

--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-report",
-    "version": "3.1.0",
+    "version": "4.1.0",
     "description": "Accessibility Insights Report",
     "license": "MIT",
     "files": [

--- a/src/common/application-properties-provider.ts
+++ b/src/common/application-properties-provider.ts
@@ -8,6 +8,7 @@ export const createToolData = (
     toolName: string,
     toolVersion?: string,
     environmentName?: string,
+    resolution?: string,
 ): ToolData => {
     return {
         scanEngineProperties: {
@@ -18,6 +19,7 @@ export const createToolData = (
             name: toolName,
             version: toolVersion,
             environmentName: environmentName,
+            resolution: resolution,
         },
     };
 };

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -15,6 +15,7 @@ export interface ApplicationProperties {
     name: string;
     version?: string;
     environmentName?: string;
+    resolution?: string;
 }
 
 export interface OSProperties {

--- a/src/reports/components/report-sections/combined-report-failed-section.tsx
+++ b/src/reports/components/report-sections/combined-report-failed-section.tsx
@@ -30,7 +30,7 @@ export const CombinedReportFailedSection = NamedFC<CombinedReportFailedSectionPr
                 <CombinedReportResultSectionTitle
                     outcomeCount={ruleCount}
                     outcomeType="fail"
-                    title="Failed"
+                    title="Failed rules"
                 />
             ),
             content: (

--- a/src/reports/components/report-sections/combined-report-rules-only-sections.tsx
+++ b/src/reports/components/report-sections/combined-report-rules-only-sections.tsx
@@ -50,10 +50,10 @@ const makeCombinedReportRulesOnlySection = (options: {
 
 export const CombinedReportPassedSection = makeCombinedReportRulesOnlySection({
     outcomeType: 'pass',
-    title: 'Passed',
+    title: 'Passed rules',
 });
 
 export const CombinedReportNotApplicableSection = makeCombinedReportRulesOnlySection({
     outcomeType: 'inapplicable',
-    title: 'Not applicable',
+    title: 'Not applicable rules',
 });

--- a/src/reports/components/report-sections/combined-report-section-factory.ts
+++ b/src/reports/components/report-sections/combined-report-section-factory.ts
@@ -22,7 +22,6 @@ import { BodySection } from './body-section';
 import { ContentContainer } from './content-container';
 import { ReportFooter } from './report-footer';
 import { ReportSectionFactory } from './report-section-factory';
-import { ResultsContainer } from './results-container';
 import { TitleSection } from './title-section';
 
 export type CombinedReportSectionDeps = ResultSectionDeps;
@@ -48,5 +47,5 @@ export const CombinedReportSectionFactory: ReportSectionFactory<CombinedReportSe
     NotApplicableChecksSection: CombinedReportNotApplicableSection,
     FooterSection: ReportFooter,
     FooterText: FooterTextForService,
-    resultSectionsOrder: ['failed', 'notApplicable', 'passed'],
+    resultSectionsOrder: ['failed', 'passed', 'notApplicable'],
 };

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -50,6 +50,7 @@ declare namespace AccessibilityInsightsReport {
         serviceName: string,
         axeVersion: string,
         userAgent: string,
+        browserResolution: string,
         scanDetails: ScanSummaryDetails,
         results: SummaryScanResults,
     };
@@ -108,6 +109,7 @@ declare namespace AccessibilityInsightsReport {
         serviceName: string,
         axeVersion: string,
         userAgent: string,
+        browserResolution: string,
         scanDetails: ScanSummaryDetails,
         results: CombinedReportResults,
     }

--- a/src/reports/package/footer-text-for-service.tsx
+++ b/src/reports/package/footer-text-for-service.tsx
@@ -11,8 +11,10 @@ export const FooterTextForService = NamedFC<FooterTextProps>('FooterTextForServi
     return (
         <>
             This automated checks result was generated using the {toolData.applicationProperties.name}{' '}
-            that helps find some of the most common accessibility issues. The scan was
-            performed using {toolData.scanEngineProperties.name} {toolData.scanEngineProperties.version} and {toolData.applicationProperties.environmentName}. For a complete
+            that helps find some of the most common accessibility issues. The scan was{' '}
+            performed in a clean browser environment, using {toolData.scanEngineProperties.name}{' '}
+            {toolData.scanEngineProperties.version} and {toolData.applicationProperties.environmentName}{' '}
+            with a display resolution of {toolData.applicationProperties.resolution}. For a complete{' '}
             WCAG 2.1 compliance assessment please visit{' '}<ToolLink />.
         </>
     );

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -47,6 +47,8 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
             },
             testEnvironment: {
                 userAgent,
+                windowHeight,
+                windowWidth,
             },
         },
         scanContext: {
@@ -64,6 +66,7 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
         serviceName,
         null,
         userAgent,
+        `${windowWidth}x${windowHeight}`
     );
 
     const sectionFactory: ReportSectionFactory<SectionProps> = {
@@ -107,7 +110,7 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
 };
 
 const summaryResultsReportGenerator = (parameters: SummaryReportParameters) => {
-    const { serviceName, axeVersion, userAgent } = parameters;
+    const { serviceName, axeVersion, userAgent, browserResolution } = parameters;
 
     const toolData = createToolData(
         'axe-core',
@@ -115,6 +118,7 @@ const summaryResultsReportGenerator = (parameters: SummaryReportParameters) => {
         serviceName,
         null,
         userAgent,
+        browserResolution,
     );
 
     const reportHtmlGenerator = new SummaryReportHtmlGenerator(
@@ -133,7 +137,7 @@ const summaryResultsReportGenerator = (parameters: SummaryReportParameters) => {
 };
 
 const combinedResultsReportGenerator = (parameters: CombinedReportParameters) => {
-    const { serviceName, axeVersion, userAgent } = parameters;
+    const { serviceName, axeVersion, userAgent, browserResolution } = parameters;
 
     const toolData = createToolData(
         'axe-core',
@@ -141,6 +145,7 @@ const combinedResultsReportGenerator = (parameters: CombinedReportParameters) =>
         serviceName,
         null,
         userAgent,
+        browserResolution,
     );
 
     const fixInstructionProcessor = new FixInstructionProcessor();

--- a/src/tests/unit/common/application-properties-provider.test.ts
+++ b/src/tests/unit/common/application-properties-provider.test.ts
@@ -10,6 +10,7 @@ describe('createToolData', () => {
             'test-tool-name',
             'test-tool-version',
             'test-environment-name',
+            'test-resolution',
         );
 
         expect(result).toMatchInlineSnapshot(`
@@ -17,6 +18,7 @@ describe('createToolData', () => {
               "applicationProperties": Object {
                 "environmentName": "test-environment-name",
                 "name": "test-tool-name",
+                "resolution": "test-resolution",
                 "version": "test-tool-version",
               },
               "scanEngineProperties": Object {

--- a/src/tests/unit/tests/electron/common/application-properties-provider.test.ts
+++ b/src/tests/unit/tests/electron/common/application-properties-provider.test.ts
@@ -22,6 +22,7 @@ describe('ToolDataDelegate', () => {
               "applicationProperties": Object {
                 "environmentName": undefined,
                 "name": "Accessibility Insights for Android",
+                "resolution": undefined,
                 "version": "test-version",
               },
               "scanEngineProperties": Object {

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/combined-report-failed-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/combined-report-failed-section.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CombinedReportFailedSection renders 1`] = `
 "<div className=\\"result-section\\">
   <div id=\\"collapsible-header\\">
-    <CombinedResultSectionTitle outcomeCount={1} outcomeType=\\"fail\\" title=\\"Failed\\" />
+    <CombinedResultSectionTitle outcomeCount={1} outcomeType=\\"fail\\" title=\\"Failed rules\\" />
   </div>
   <div id=\\"collapsible-content\\">
     <ResultSectionContent deps={{...}} outcomeType=\\"fail\\" targetAppInfo={[undefined]} results={{...}} visualHelperEnabled={true} allCardsCollapsed={true} userConfigurationStoreData={{...}} outcomeCounter={[Function: countByIdentifierUrls]} headingLevel={4} />

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/combined-report-rules-only-sections.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/combined-report-rules-only-sections.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CombinedReportRulesOnlySections CombinedReportNotApplicableSection renders 1`] = `
 "<div className=\\"result-section\\">
   <div id=\\"collapsible-header\\">
-    <CombinedResultSectionTitle outcomeCount={0} outcomeType=\\"inapplicable\\" title=\\"Not applicable\\" titleSize=\\"title\\" />
+    <CombinedResultSectionTitle outcomeCount={0} outcomeType=\\"inapplicable\\" title=\\"Not applicable rules\\" titleSize=\\"title\\" />
   </div>
   <div id=\\"collapsible-content\\">
     <RulesOnly deps={{...}} cardRuleResults={{...}} outcomeType=\\"inapplicable\\" />
@@ -14,7 +14,7 @@ exports[`CombinedReportRulesOnlySections CombinedReportNotApplicableSection rend
 exports[`CombinedReportRulesOnlySections CombinedReportPassedSection renders 1`] = `
 "<div className=\\"result-section\\">
   <div id=\\"collapsible-header\\">
-    <CombinedResultSectionTitle outcomeCount={0} outcomeType=\\"pass\\" title=\\"Passed\\" titleSize=\\"title\\" />
+    <CombinedResultSectionTitle outcomeCount={0} outcomeType=\\"pass\\" title=\\"Passed rules\\" titleSize=\\"title\\" />
   </div>
   <div id=\\"collapsible-content\\">
     <RulesOnly deps={{...}} cardRuleResults={{...}} outcomeType=\\"pass\\" />

--- a/src/tests/unit/tests/reports/package/__snapshots__/footer-text-for-service.test.tsx.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/footer-text-for-service.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`FooterTextForService renders: footer 1`] = `
   environmentName
    
   with a display resolution of 
+  800x600
   . For a complete
    
   WCAG 2.1 compliance assessment please visit

--- a/src/tests/unit/tests/reports/package/__snapshots__/footer-text-for-service.test.tsx.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/footer-text-for-service.test.tsx.snap
@@ -5,13 +5,19 @@ exports[`FooterTextForService renders: footer 1`] = `
   This automated checks result was generated using the 
   app-name
    
-  that helps find some of the most common accessibility issues. The scan was performed using 
+  that helps find some of the most common accessibility issues. The scan was
+   
+  performed in a clean browser environment, using 
   engine-name
    
   engine-version
    and 
   environmentName
-  . For a complete WCAG 2.1 compliance assessment please visit
+   
+  with a display resolution of 
+  . For a complete
+   
+  WCAG 2.1 compliance assessment please visit
    
   <ToolLink />
   .

--- a/src/tests/unit/tests/reports/package/combined-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/combined-results-report.test.ts
@@ -59,6 +59,7 @@ describe('CombinedResultsReport', () => {
         serviceName: 'service name',
         axeVersion: 'axe version',
         userAgent: 'browser spec',
+        browserResolution: '1920x1080',
         scanDetails: scanDetails,
         results,
     };

--- a/src/tests/unit/tests/reports/package/footer-text-for-service.test.tsx
+++ b/src/tests/unit/tests/reports/package/footer-text-for-service.test.tsx
@@ -16,6 +16,7 @@ describe('FooterTextForService', () => {
                 name: 'app-name',
                 version: 'app-version',
                 environmentName: 'environmentName',
+                resolution: '800x600',
             },
         };
         const scanMetadata = {

--- a/src/tests/unit/tests/reports/package/summary-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/summary-results-report.test.ts
@@ -62,6 +62,7 @@ describe('SummaryResultsReport', () => {
         serviceName: 'service name',
         axeVersion: 'axe version',
         userAgent: 'browser spec',
+        browserResolution: '1920x1080',
         scanDetails: scanDetails,
         results,
     };


### PR DESCRIPTION
#### Description of changes

Addresses the combined report changes requested in #3729
- Add "rules" to the result section title names (i.e. "failed rules" instead of just "failed")
- Reorder result sections (failed, passed, then not applicable)
- Add browser resolution as a package parameter
- Update service report footer text (affects all service reports)
- Bump package version from 3.1.0 to 4.1.0 (major update b/c of the breaking change to the interface to include browser resolution)

<img width="786" alt="combined-report-updates" src="https://user-images.githubusercontent.com/55459788/102248881-9170f080-3eb6-11eb-8b2e-a97bb046359f.PNG">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3729
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
