### PR TITLE
fix: text changes in native and custom widgets instructions

### DIFF
--- a/src/assessments/common/instructions-and-labels-note.tsx
+++ b/src/assessments/common/instructions-and-labels-note.tsx
@@ -7,8 +7,8 @@ import * as Markup from '../markup';
 
 export const InstructionsAndLabelsNotes = () => (
     <Markup.Emphasis>
-        Note: For WCAG 2.1 compliance, both visible instructions and labels must be programmatically
-        related to a widget. For WCAG 2.0 compliance, only visible instructions must be
-        programmatically related to a widget.
+        Note: Both WCAG 2.0 and 2.1 require a widget's visible label and instructions (if present)
+        to be programmatically determinable. WCAG 2.1 also requires a widget's visible label and
+        instructions (if present) to be included in its accessible name and description.
     </Markup.Emphasis>
 );

--- a/src/assessments/custom-widgets/test-steps/instructions.tsx
+++ b/src/assessments/custom-widgets/test-steps/instructions.tsx
@@ -8,11 +8,11 @@ import * as content from 'content/test/custom-widgets/instructions';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
-
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
 import { InstructionsAndLabelsNotes } from '../../common/instructions-and-labels-note';
 import { NoValue } from '../../common/property-bag-column-renderer';
+import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { Requirement } from '../../types/requirement';
 import { getFlatDesignPatternStringFromRole } from '../custom-widgets-column-renderer';
@@ -21,7 +21,8 @@ import { CustomWidgetsTestStep } from './test-steps';
 
 const instructionsDescription: JSX.Element = (
     <span>
-        If a custom widget has visible instructions, they must be programmatically related to it.
+        If a custom widget has a visible label or instructions, they must be programmatically
+        determinable.
     </span>
 );
 
@@ -42,11 +43,17 @@ const instructionsHowToTest: JSX.Element = (
                 visible label or instructions.
             </li>
             <li>
-                Verify that all visible labels and instructions are displayed in the Instances list:
+                If a widget does have a visible label or instructions, verify that they are also
+                displayed in the <Markup.Term>Instances</Markup.Term> list:
                 <ol>
-                    <li>Any label should appear in the accessible name.</li>
                     <li>
-                        Any additional instructions should appear in the accessible description.
+                        The accessible name must be (or include) an exact match of the visible text
+                        label.
+                    </li>
+                    <li>
+                        The accessible description must include any additional visible instructions.
+                        If any non-text instructions are provided (for example, icons or color
+                        changes), the accessible description must include a text equivalent.
                     </li>
                 </ol>
             </li>

--- a/src/assessments/native-widgets/test-steps/instructions.tsx
+++ b/src/assessments/native-widgets/test-steps/instructions.tsx
@@ -24,7 +24,7 @@ import { NativeWidgetsTestStep } from './test-steps';
 const description: JSX.Element = (
     <span>
         If a native widget has a visible label or instructions, they must be programmatically
-        related to it.
+        determinable.
     </span>
 );
 
@@ -48,11 +48,17 @@ const howToTest: JSX.Element = (
                 visible label or instructions.
             </li>
             <li>
-                Verify that all visible labels and instructions are displayed in the Instances list:
+                If a widget does have a visible label or instructions, verify that they are also
+                displayed in the <Markup.Term>Instances</Markup.Term> list:
                 <ol>
-                    <li>Any label should appear in the accessible name.</li>
                     <li>
-                        Any additional instructions should appear in the accessible description.
+                        The accessible name must be (or include) an exact match of any visible text
+                        label.
+                    </li>
+                    <li>
+                        The accessible description must include any additional visible instructions.
+                        If any non-text instructions are provided (for example, icons or color
+                        changes), the accessible description must include a text equivalent.
                     </li>
                 </ol>
             </li>

--- a/src/content/test/custom-widgets/instructions.tsx
+++ b/src/content/test/custom-widgets/instructions.tsx
@@ -4,7 +4,7 @@ import { create, React } from '../../common';
 
 export const infoAndExamples = create(({ Markup, Link }) => (
     <>
-        <p>If a custom widget has visible label or instructions, they must be programmatically related to it.</p>
+        <p>If a custom widget has a visible label or instructions, they must be programmatically determinable.</p>
 
         <h2>Why it matters</h2>
         <p>

--- a/src/content/test/native-widgets/instructions.tsx
+++ b/src/content/test/native-widgets/instructions.tsx
@@ -4,7 +4,7 @@ import { create, React } from '../../common';
 
 export const infoAndExamples = create(({ Markup, Link }) => (
     <>
-        <p>If a native widget has visible label or instructions, they must be programmatically related to it.</p>
+        <p>If a native widget has visible label or instructions, they must be programmatically determinable.</p>
 
         <h2>Why it matters</h2>
         <p>

--- a/src/content/test/native-widgets/instructions.tsx
+++ b/src/content/test/native-widgets/instructions.tsx
@@ -4,7 +4,7 @@ import { create, React } from '../../common';
 
 export const infoAndExamples = create(({ Markup, Link }) => (
     <>
-        <p>If a native widget has visible label or instructions, they must be programmatically determinable.</p>
+        <p>If a native widget has a visible label or instructions, they must be programmatically determinable.</p>
 
         <h2>Why it matters</h2>
         <p>

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -6495,7 +6495,7 @@ exports[`Guidance Content pages test/customWidgets/instructions/infoAndExamples 
       class="content"
     >
       <p>
-        If a custom widget has visible label or instructions, they must be programmatically related to it.
+        If a custom widget has a visible label or instructions, they must be programmatically determinable.
       </p>
       <h2>
         Why it matters
@@ -22743,7 +22743,7 @@ exports[`Guidance Content pages test/nativeWidgets/instructions/infoAndExamples 
       class="content"
     >
       <p>
-        If a native widget has visible label or instructions, they must be programmatically related to it.
+        If a native widget has visible label or instructions, they must be programmatically determinable.
       </p>
       <h2>
         Why it matters

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -22743,7 +22743,7 @@ exports[`Guidance Content pages test/nativeWidgets/instructions/infoAndExamples 
       class="content"
     >
       <p>
-        If a native widget has visible label or instructions, they must be programmatically determinable.
+        If a native widget has a visible label or instructions, they must be programmatically determinable.
       </p>
       <h2>
         Why it matters

--- a/src/tests/unit/tests/assessments/common/__snapshots__/instructions-and-labels-note.test.tsx.snap
+++ b/src/tests/unit/tests/assessments/common/__snapshots__/instructions-and-labels-note.test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`InstructionsAndLabelsNote renders 1`] = `
 <Emphasis>
-  Note: For WCAG 2.1 compliance, both visible instructions and labels must be programmatically related to a widget. For WCAG 2.0 compliance, only visible instructions must be programmatically related to a widget.
+  Note: Both WCAG 2.0 and 2.1 require a widget's visible label and instructions (if present) to be programmatically determinable. WCAG 2.1 also requires a widget's visible label and instructions (if present) to be included in its accessible name and description.
 </Emphasis>
 `;


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

These text changes address #3752, making the instructions better align with WCAG SC 2.5.3 Label in Name.

**Screenshot of Native widgets > Instructions**
![image](https://user-images.githubusercontent.com/48259897/102437163-edc73380-3fce-11eb-87d8-ba527d0c9034.png)

**Screenshot of Native widgets > Instructions > more info icon**
![image](https://user-images.githubusercontent.com/48259897/102437190-00416d00-3fcf-11eb-8615-64201b9e4fe0.png)

**Screenshot of Custom widgets > Instructions**
![image](https://user-images.githubusercontent.com/48259897/102437220-0cc5c580-3fcf-11eb-98a6-07b870ce93a3.png)

**Screenshot of Custom widgets > Instructions > more info icon**
![image](https://user-images.githubusercontent.com/48259897/102437271-1ea76880-3fcf-11eb-808a-1bdedc484ed7.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3752
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
