### PR TITLE
chore: remove VisualizationConfigurationFactory dep from rule analyzers

### DIFF
--- a/src/common/telemetry-data-factory.ts
+++ b/src/common/telemetry-data-factory.ts
@@ -299,11 +299,16 @@ export class TelemetryDataFactory {
         analyzerResult,
         scanDuration,
         elementsScanned,
-        testName,
+        testVisualizationType,
         requirementName,
     ) => {
         const telemetry: AssessmentRequirementScanTelemetryData = {
-            ...this.forTestScan(analyzerResult, scanDuration, elementsScanned, testName),
+            ...this.forTestScan(
+                analyzerResult,
+                scanDuration,
+                elementsScanned,
+                testVisualizationType,
+            ),
             requirementName,
         };
 
@@ -314,14 +319,14 @@ export class TelemetryDataFactory {
         analyzerResult,
         scanDuration,
         elementsScanned,
-        testName,
+        testVisualizationType,
     ) => {
         const telemetry: RuleAnalyzerScanTelemetryData = {
             scanDuration: scanDuration,
             NumberOfElementsScanned: elementsScanned,
             include: analyzerResult.include,
             exclude: analyzerResult.exclude,
-            testName,
+            testName: VisualizationType[testVisualizationType],
         };
 
         return telemetry;
@@ -331,7 +336,7 @@ export class TelemetryDataFactory {
         analyzerResult,
         scanDuration,
         elementsScanned,
-        testName,
+        testVisualizationType,
     ) => {
         const passedRuleResults: DictionaryStringTo<number> = this.generateTelemetryRuleResult(
             analyzerResult.originalResult.passes,
@@ -340,7 +345,12 @@ export class TelemetryDataFactory {
             analyzerResult.originalResult.violations,
         );
         const telemetry: IssuesAnalyzerScanTelemetryData = {
-            ...this.forTestScan(analyzerResult, scanDuration, elementsScanned, testName),
+            ...this.forTestScan(
+                analyzerResult,
+                scanDuration,
+                elementsScanned,
+                testVisualizationType,
+            ),
             passedRuleResults: JSON.stringify(passedRuleResults),
             failedRuleResults: JSON.stringify(failedRuleResults),
         };
@@ -352,7 +362,7 @@ export class TelemetryDataFactory {
         analyzerResult,
         scanDuration,
         elementsScanned,
-        testName,
+        testVisualizationType,
     ) => {
         const passedRuleResults: DictionaryStringTo<number> = this.generateTelemetryRuleResult(
             analyzerResult.originalResult.passes,
@@ -364,7 +374,12 @@ export class TelemetryDataFactory {
             analyzerResult.originalResult.incomplete,
         );
         const telemetry: NeedsReviewAnalyzerScanTelemetryData = {
-            ...this.forTestScan(analyzerResult, scanDuration, elementsScanned, testName),
+            ...this.forTestScan(
+                analyzerResult,
+                scanDuration,
+                elementsScanned,
+                testVisualizationType,
+            ),
             passedRuleResults: JSON.stringify(passedRuleResults),
             failedRuleResults: JSON.stringify(failedRuleResults),
             incompleteRuleResults: JSON.stringify(incompleteRuleResults),

--- a/src/common/types/analyzer-telemetry-callbacks.ts
+++ b/src/common/types/analyzer-telemetry-callbacks.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
+import { VisualizationType } from 'common/types/visualization-type';
 import {
     RuleAnalyzerScanTelemetryData,
     IssuesAnalyzerScanTelemetryData,
@@ -13,7 +14,7 @@ export type ForRuleAnalyzerScanCallback = (
     analyzerResult: AxeAnalyzerResult,
     scanDuration: number,
     elementsScanned: number,
-    testName: string,
+    testVisualizationType: VisualizationType,
     requirementName?: string,
 ) => RuleAnalyzerScanTelemetryData;
 
@@ -21,12 +22,12 @@ export type ForIssuesAnalyzerScanCallback = (
     analyzerResult: AxeAnalyzerResult,
     scanDuration: number,
     elementsScanned: number,
-    testName: string,
+    testVisualizationType: VisualizationType,
 ) => IssuesAnalyzerScanTelemetryData;
 
 export type ForNeedsReviewAnalyzerScanCallback = (
     analyzerResult: AxeAnalyzerResult,
     scanDuration: number,
     elementsScanned: number,
-    testName: string,
+    testVisualizationType: VisualizationType,
 ) => NeedsReviewAnalyzerScanTelemetryData;

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -4,7 +4,6 @@ import { Logger } from 'common/logging/logger';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 
 import { BaseStore } from '../../common/base-store';
-import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
 import { ScopingStoreData } from '../../common/types/store-data/scoping-store-data';
 import { WindowUtils } from '../../common/window-utils';
@@ -29,7 +28,6 @@ export class AnalyzerProvider {
         private readonly scanner: ScannerUtils,
         private readonly telemetryDataFactory: TelemetryDataFactory,
         private readonly dateGetter: () => Date,
-        private readonly visualizationConfigFactory: VisualizationConfigurationFactory,
         private readonly filterResultsByRules: IResultRuleFilter,
         private readonly sendConvertedResults: PostResolveCallback,
         private readonly sendNeedsReviewResults: PostResolveCallback,
@@ -52,7 +50,6 @@ export class AnalyzerProvider {
             this.sendMessageDelegate,
             this.dateGetter,
             this.telemetryDataFactory,
-            this.visualizationConfigFactory,
             null,
             this.scanIncompleteWarningDetector,
             this.logger,
@@ -69,7 +66,6 @@ export class AnalyzerProvider {
             this.sendMessageDelegate,
             this.dateGetter,
             this.telemetryDataFactory,
-            this.visualizationConfigFactory,
             this.sendConvertedResults,
             this.scanIncompleteWarningDetector,
             this.logger,
@@ -86,7 +82,6 @@ export class AnalyzerProvider {
             this.sendMessageDelegate,
             this.dateGetter,
             this.telemetryDataFactory,
-            this.visualizationConfigFactory,
             this.sendNeedsReviewResults,
             this.scanIncompleteWarningDetector,
             this.logger,
@@ -101,7 +96,6 @@ export class AnalyzerProvider {
             this.sendMessageDelegate,
             this.dateGetter,
             this.telemetryDataFactory,
-            this.visualizationConfigFactory,
             this.filterResultsByRules,
             this.scanIncompleteWarningDetector,
             this.logger,

--- a/src/injected/analyzers/batched-rule-analyzer.ts
+++ b/src/injected/analyzers/batched-rule-analyzer.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BaseStore } from 'common/base-store';
-import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { Logger } from 'common/logging/logger';
 import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
@@ -25,7 +24,6 @@ export class BatchedRuleAnalyzer extends RuleAnalyzer {
         protected sendMessageDelegate: (message) => void,
         protected dateGetter: () => Date,
         protected telemetryFactory: TelemetryDataFactory,
-        protected readonly visualizationConfigFactory: VisualizationConfigurationFactory,
         private postScanFilter: IResultRuleFilter,
         scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
         logger: Logger,
@@ -37,7 +35,6 @@ export class BatchedRuleAnalyzer extends RuleAnalyzer {
             sendMessageDelegate,
             dateGetter,
             telemetryFactory,
-            visualizationConfigFactory,
             null,
             scanIncompleteWarningDetector,
             logger,

--- a/src/injected/analyzers/rule-analyzer.ts
+++ b/src/injected/analyzers/rule-analyzer.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { ScopingInputTypes } from 'background/scoping-input-types';
 import { BaseStore } from 'common/base-store';
-import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { Logger } from 'common/logging/logger';
 import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { ForRuleAnalyzerScanCallback } from 'common/types/analyzer-telemetry-callbacks';
@@ -31,7 +30,6 @@ export class RuleAnalyzer extends BaseAnalyzer {
         protected sendMessageDelegate: (message) => void,
         protected dateGetter: () => Date,
         protected telemetryFactory: TelemetryDataFactory,
-        protected readonly visualizationConfigFactory: VisualizationConfigurationFactory,
         private postOnResolve: PostResolveCallback | null,
         scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
         logger: Logger,
@@ -90,13 +88,11 @@ export class RuleAnalyzer extends BaseAnalyzer {
         const telemetryGetter: ForRuleAnalyzerScanCallback = config.telemetryProcessor(
             this.telemetryFactory,
         );
-        const testName = this.visualizationConfigFactory.getConfiguration(config.testType)
-            .displayableData.title;
         const telemetry = telemetryGetter(
             analyzerResult,
             elapsedTime,
             this.elementsScanned,
-            testName,
+            config.testType,
             config.key,
         );
 

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -316,7 +316,6 @@ export class MainWindowInitializer extends WindowInitializer {
             new ScannerUtils(scan, logger, generateUID),
             telemetryDataFactory,
             DateProvider.getCurrentDate,
-            this.visualizationConfigurationFactory,
             filterResultsByRules,
             unifiedResultSender.sendAutomatedChecksResults,
             unifiedResultSender.sendNeedsReviewResults,

--- a/src/tests/unit/tests/common/telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/common/telemetry-data-factory.test.ts
@@ -449,7 +449,7 @@ describe('TelemetryDataFactoryTest', () => {
     });
 
     test('forAssessmentRequirementScan', () => {
-        const testName = 'test';
+        const testVisualizationType = VisualizationType.Color;
         const requirementName = 'requirement';
         const analyzerResultStub = {
             include: [],
@@ -461,7 +461,7 @@ describe('TelemetryDataFactoryTest', () => {
             analyzerResultStub,
             elapsedTime,
             elementsScanned,
-            testName,
+            testVisualizationType,
             requirementName,
         );
         const expected: RuleAnalyzerScanTelemetryData = {
@@ -469,7 +469,7 @@ describe('TelemetryDataFactoryTest', () => {
             NumberOfElementsScanned: elementsScanned,
             include: analyzerResultStub.include,
             exclude: analyzerResultStub.exclude,
-            testName,
+            testName: VisualizationType[testVisualizationType],
             requirementName,
         };
 
@@ -477,7 +477,7 @@ describe('TelemetryDataFactoryTest', () => {
     });
 
     test('forTestScan', () => {
-        const testName = 'test';
+        const testVisualizationType = VisualizationType.ContrastAssessment;
         const analyzerResultStub = {
             include: [],
             exclude: [],
@@ -488,21 +488,21 @@ describe('TelemetryDataFactoryTest', () => {
             analyzerResultStub,
             elapsedTime,
             elementsScanned,
-            testName,
+            testVisualizationType,
         );
         const expected: RuleAnalyzerScanTelemetryData = {
             scanDuration: elapsedTime,
             NumberOfElementsScanned: elementsScanned,
             include: analyzerResultStub.include,
             exclude: analyzerResultStub.exclude,
-            testName,
+            testName: VisualizationType[testVisualizationType],
         };
 
         expect(actual).toEqual(expected);
     });
 
     test('forIssuesAnalyzerScan', () => {
-        const testName = 'test';
+        const testVisualizationType = VisualizationType.CustomWidgets;
         const analyzerResultStub = {
             include: [],
             exclude: [],
@@ -531,7 +531,7 @@ describe('TelemetryDataFactoryTest', () => {
             analyzerResultStub,
             elapsedTime,
             elementsScanned,
-            testName,
+            testVisualizationType,
         );
         const passedRuleResultsStub = {
             test: 2,
@@ -545,7 +545,7 @@ describe('TelemetryDataFactoryTest', () => {
     });
 
     test('forNeedsReviewAnalyzerScan', () => {
-        const testName = 'test';
+        const testVisualizationType = VisualizationType.Headings;
         const analyzerResultStub = {
             include: [],
             exclude: [],
@@ -580,7 +580,7 @@ describe('TelemetryDataFactoryTest', () => {
             analyzerResultStub,
             elapsedTime,
             elementsScanned,
-            testName,
+            testVisualizationType,
         );
         const passedRuleResultsStub = {
             test: 2,

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -5,7 +5,6 @@ import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, Mock } from 'typemoq';
 
-import { VisualizationConfigurationFactory } from '../../../../../common/configs/visualization-configuration-factory';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { WindowUtils } from '../../../../../common/window-utils';
@@ -32,7 +31,6 @@ describe('AnalyzerProviderTests', () => {
     let testObject: AnalyzerProvider;
     let scannerMock: IMock<ScannerUtils>;
     let dateGetterMock: IMock<() => Date>;
-    let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
     let typeStub: VisualizationType;
     let keyStub: string;
     let analyzerMessageTypeStub: string;
@@ -52,7 +50,6 @@ describe('AnalyzerProviderTests', () => {
         scopingStoreMock = Mock.ofType(ScopingStore);
         telemetryFactoryMock = Mock.ofType(TelemetryDataFactory);
         scannerMock = Mock.ofType(ScannerUtils);
-        visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
         filterResultsByRulesMock = Mock.ofInstance(() => null);
         sendConvertedResultsMock = Mock.ofInstance(() => null);
         sendNeedsReviewResultsMock = Mock.ofInstance(() => null);
@@ -65,7 +62,6 @@ describe('AnalyzerProviderTests', () => {
             scannerMock.object,
             telemetryFactoryMock.object,
             dateGetterMock.object,
-            visualizationConfigurationFactoryMock.object,
             filterResultsByRulesMock.object,
             sendConvertedResultsMock.object,
             sendNeedsReviewResultsMock.object,

--- a/src/tests/unit/tests/injected/analyzers/batched-rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/batched-rule-analyzer.test.ts
@@ -7,8 +7,6 @@ import { clone, isFunction } from 'lodash';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
-import { VisualizationConfiguration } from '../../../../../common/configs/visualization-configuration';
-import { VisualizationConfigurationFactory } from '../../../../../common/configs/visualization-configuration-factory';
 import { RuleAnalyzerScanTelemetryData } from '../../../../../common/extension-telemetry-events';
 import { Message } from '../../../../../common/message';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
@@ -30,14 +28,12 @@ describe('BatchedRuleAnalyzer', () => {
     let dateMock: IMock<Date>;
     let scopingStoreMock: IMock<ScopingStore>;
     let scopingState: ScopingStoreData;
-    let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
     const allInstancesMocks: DictionaryStringTo<any> = {
         test: 'test-result-value',
     };
     let sendMessageMock: IMock<(message) => void>;
     let telemetryDataFactoryMock: IMock<TelemetryDataFactory>;
     let typeStub: VisualizationType;
-    const title = 'test-name';
     const scanCallbacks: ((results: ScanResults) => void)[] = [];
     let resultConfigFilterMock: IMock<IResultRuleFilter>;
     let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
@@ -49,7 +45,6 @@ describe('BatchedRuleAnalyzer', () => {
         scannerUtilsMock = Mock.ofType(ScannerUtils);
         scopingStoreMock = Mock.ofType(ScopingStore);
         telemetryDataFactoryMock = Mock.ofType(TelemetryDataFactory);
-        visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
         const dateStub = {
             getTime: () => {
                 return null;
@@ -69,14 +64,6 @@ describe('BatchedRuleAnalyzer', () => {
             .setup(sm => sm.getState())
             .returns(() => scopingState)
             .verifiable();
-        visualizationConfigurationFactoryMock
-            .setup(v => v.getConfiguration(typeStub))
-            .returns(() => {
-                return {
-                    displayableData: { title },
-                } as VisualizationConfiguration;
-            })
-            .verifiable();
         scanIncompleteWarningDetectorMock
             .setup(idm => idm.detectScanIncompleteWarnings())
             .returns(() => []);
@@ -88,12 +75,13 @@ describe('BatchedRuleAnalyzer', () => {
 
     function testGetResults(done: () => void): void {
         const key = 'sample key';
+        const testName = 'sample test name';
         const telemetryProcessorStub = factory => (_, elapsedTime, __) => {
-            return createTelemetryStub(elapsedTime, title, key);
+            return createTelemetryStub(elapsedTime, testName, key);
         };
         const startTime = 10;
         const endTime = 20;
-        const expectedTelemetryStub = createTelemetryStub(endTime - startTime, title, key);
+        const expectedTelemetryStub = createTelemetryStub(endTime - startTime, testName, key);
         const ruleOne = 'the first rule';
         const resultOne: RuleResult = {
             id: ruleOne,
@@ -284,7 +272,6 @@ describe('BatchedRuleAnalyzer', () => {
             sendMessageMock.object,
             dateGetterMock.object,
             telemetryDataFactoryMock.object,
-            visualizationConfigurationFactoryMock.object,
             resultConfigFilterMock.object,
             scanIncompleteWarningDetectorMock.object,
             failTestOnErrorLogger,

--- a/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 import { ScopingInputTypes } from 'background/scoping-input-types';
 import { ScopingStore } from 'background/stores/global/scoping-store';
-import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
-import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { RuleAnalyzerScanTelemetryData } from 'common/extension-telemetry-events';
 import { Message } from 'common/message';
 import { TelemetryDataFactory } from 'common/telemetry-data-factory';
@@ -30,14 +28,12 @@ describe('RuleAnalyzer', () => {
     let dateMock: IMock<Date>;
     let scopingStoreMock: IMock<ScopingStore>;
     let scopingState: ScopingStoreData;
-    let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
     const allInstancesMock: DictionaryStringTo<any> = {
         test: 'test-result-value',
     };
     let sendMessageMock: IMock<(message) => void>;
     let telemetryDataFactoryMock: IMock<TelemetryDataFactory>;
     let typeStub: VisualizationType;
-    const name = 'test-name';
     let configStub: RuleAnalyzerConfiguration;
     let scanCallback: (results: ScanResults) => void;
     let postResolveCallbackMock: IMock<PostResolveCallback>;
@@ -50,7 +46,6 @@ describe('RuleAnalyzer', () => {
         scannerUtilsMock = Mock.ofType(ScannerUtils);
         scopingStoreMock = Mock.ofType(ScopingStore);
         telemetryDataFactoryMock = Mock.ofType(TelemetryDataFactory);
-        visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
         postResolveCallbackMock = Mock.ofInstance(results => null);
 
         const dateStub = {
@@ -71,14 +66,6 @@ describe('RuleAnalyzer', () => {
         scopingStoreMock
             .setup(sm => sm.getState())
             .returns(() => scopingState)
-            .verifiable();
-        visualizationConfigurationFactoryMock
-            .setup(v => v.getConfiguration(typeStub))
-            .returns(() => {
-                return {
-                    displayableData: { title: name },
-                } as VisualizationConfiguration;
-            })
             .verifiable();
         scanIncompleteWarningDetectorMock
             .setup(idm => idm.detectScanIncompleteWarnings())
@@ -107,12 +94,13 @@ describe('RuleAnalyzer', () => {
 
     function testGetResults(done: () => void): void {
         const key = 'sample key';
+        const testName = 'sample test name';
         const telemetryProcessorStub = factory => (_, elapsedTime, __) => {
-            return createTelemetryStub(elapsedTime, name, key);
+            return createTelemetryStub(elapsedTime, testName, key);
         };
         const startTime = 10;
         const endTime = 20;
-        const expectedTelemetryStub = createTelemetryStub(endTime - startTime, name, key);
+        const expectedTelemetryStub = createTelemetryStub(endTime - startTime, testName, key);
 
         configStub = {
             rules: ['fake-rule'],
@@ -131,7 +119,6 @@ describe('RuleAnalyzer', () => {
             sendMessageMock.object,
             dateGetterMock.object,
             telemetryDataFactoryMock.object,
-            visualizationConfigurationFactoryMock.object,
             postResolveCallbackMock.object,
             scanIncompleteWarningDetectorMock.object,
             failTestOnErrorLogger,


### PR DESCRIPTION
#### Description of changes

This PR breaks a cyclic dependency which is transitively included by a wide variety of components:

* analyzer-provider.ts
* visualization-configuration-factory.ts
* visualization-configuration.ts
* assessment-visualization-configuration.ts
* analyzer-provider.ts

It does so by recognizing that `analyzer-provider`'s dep on `visualization-configuration-factory` is unnecessary; it is only used to map from a `VisualizationType` to a string injected into telemetry, but most of the similar telemetry already uses `VisualizationType[theVisualizationType]` for this rather than going through the configuration factory; making this particular telemetry consistent with the rest eliminates the need for the dependency.

@ferBonnin / @juchampa as an FYI: there is no user-facing impact for this change. The impact of this change on our telemetry will be that for the `AssessmentScanCompleted` and `AdhocScanCompleted` events, some values of the `testName` property will change to start being reported consistently with how the `selectedTest` property shows up in most other events (eg, `selectRequirement` and `selectGettingStarted`). For example, the Headings assessment will start showing a `testName` of `HeadingsAssessment` rather than `Headings`. The full list of possible values are the values of [the `VisualizationType` enum](https://github.com/microsoft/accessibility-insights-web/blob/master/src/common/types/visualization-type.ts).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: unblocks progression on #2869
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
