### PR TITLE
chore: fix cyclic deps around property-bag, details-dialog, drawing-controller

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -932,24 +932,6 @@
         height: 1px;
         overflow: hidden;
       }
-      .toast-container--YaZxW {
-        display: inline-block;
-      }
-      .toast-content--Wt0Lj {
-        background: var(--neutral-70);
-        border-radius: 4px;
-        color: var(--neutral-0);
-        padding-left: 20px;
-        padding-top: 14px;
-        padding-bottom: 14px;
-        padding-right: 20px;
-        width: 316px;
-        margin-left: calc(316px / -2 - 20px);
-        left: 50%;
-        bottom: 20px;
-        z-index: 1000;
-        position: absolute;
-      }
       .how-to-fix-content--2-Pc1 {
         margin-bottom: 16px;
       }
@@ -998,6 +980,24 @@
         .action-cancel-button-col--2EdOO
         + .action-cancel-button-col--2EdOO {
         margin-left: 8px;
+      }
+      .toast-container--YaZxW {
+        display: inline-block;
+      }
+      .toast-content--Wt0Lj {
+        background: var(--neutral-70);
+        border-radius: 4px;
+        color: var(--neutral-0);
+        padding-left: 20px;
+        padding-top: 14px;
+        padding-bottom: 14px;
+        padding-right: 20px;
+        width: 316px;
+        margin-left: calc(316px / -2 - 20px);
+        left: 50%;
+        bottom: 20px;
+        z-index: 1000;
+        position: absolute;
       }
       div.kebab-menu-callout--14fgT {
         box-shadow: 0px 6.4px 14.4px var(--box-shadow-132),

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -932,24 +932,6 @@
         height: 1px;
         overflow: hidden;
       }
-      .toast-container--YaZxW {
-        display: inline-block;
-      }
-      .toast-content--Wt0Lj {
-        background: var(--neutral-70);
-        border-radius: 4px;
-        color: var(--neutral-0);
-        padding-left: 20px;
-        padding-top: 14px;
-        padding-bottom: 14px;
-        padding-right: 20px;
-        width: 316px;
-        margin-left: calc(316px / -2 - 20px);
-        left: 50%;
-        bottom: 20px;
-        z-index: 1000;
-        position: absolute;
-      }
       .how-to-fix-content--2-Pc1 {
         margin-bottom: 16px;
       }
@@ -998,6 +980,24 @@
         .action-cancel-button-col--2EdOO
         + .action-cancel-button-col--2EdOO {
         margin-left: 8px;
+      }
+      .toast-container--YaZxW {
+        display: inline-block;
+      }
+      .toast-content--Wt0Lj {
+        background: var(--neutral-70);
+        border-radius: 4px;
+        color: var(--neutral-0);
+        padding-left: 20px;
+        padding-top: 14px;
+        padding-bottom: 14px;
+        padding-right: 20px;
+        width: 316px;
+        margin-left: calc(316px / -2 - 20px);
+        left: 50%;
+        bottom: 20px;
+        z-index: 1000;
+        position: absolute;
       }
       div.kebab-menu-callout--14fgT {
         box-shadow: 0px 6.4px 14.4px var(--box-shadow-132),

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -932,24 +932,6 @@
         height: 1px;
         overflow: hidden;
       }
-      .toast-container--YaZxW {
-        display: inline-block;
-      }
-      .toast-content--Wt0Lj {
-        background: var(--neutral-70);
-        border-radius: 4px;
-        color: var(--neutral-0);
-        padding-left: 20px;
-        padding-top: 14px;
-        padding-bottom: 14px;
-        padding-right: 20px;
-        width: 316px;
-        margin-left: calc(316px / -2 - 20px);
-        left: 50%;
-        bottom: 20px;
-        z-index: 1000;
-        position: absolute;
-      }
       .how-to-fix-content--2-Pc1 {
         margin-bottom: 16px;
       }
@@ -998,6 +980,24 @@
         .action-cancel-button-col--2EdOO
         + .action-cancel-button-col--2EdOO {
         margin-left: 8px;
+      }
+      .toast-container--YaZxW {
+        display: inline-block;
+      }
+      .toast-content--Wt0Lj {
+        background: var(--neutral-70);
+        border-radius: 4px;
+        color: var(--neutral-0);
+        padding-left: 20px;
+        padding-top: 14px;
+        padding-bottom: 14px;
+        padding-right: 20px;
+        width: 316px;
+        margin-left: calc(316px / -2 - 20px);
+        left: 50%;
+        bottom: 20px;
+        z-index: 1000;
+        position: absolute;
       }
       div.kebab-menu-callout--14fgT {
         box-shadow: 0px 6.4px 14.4px var(--box-shadow-132),

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -932,24 +932,6 @@
         height: 1px;
         overflow: hidden;
       }
-      .toast-container--YaZxW {
-        display: inline-block;
-      }
-      .toast-content--Wt0Lj {
-        background: var(--neutral-70);
-        border-radius: 4px;
-        color: var(--neutral-0);
-        padding-left: 20px;
-        padding-top: 14px;
-        padding-bottom: 14px;
-        padding-right: 20px;
-        width: 316px;
-        margin-left: calc(316px / -2 - 20px);
-        left: 50%;
-        bottom: 20px;
-        z-index: 1000;
-        position: absolute;
-      }
       .how-to-fix-content--2-Pc1 {
         margin-bottom: 16px;
       }
@@ -998,6 +980,24 @@
         .action-cancel-button-col--2EdOO
         + .action-cancel-button-col--2EdOO {
         margin-left: 8px;
+      }
+      .toast-container--YaZxW {
+        display: inline-block;
+      }
+      .toast-content--Wt0Lj {
+        background: var(--neutral-70);
+        border-radius: 4px;
+        color: var(--neutral-0);
+        padding-left: 20px;
+        padding-top: 14px;
+        padding-bottom: 14px;
+        padding-right: 20px;
+        width: 316px;
+        margin-left: calc(316px / -2 - 20px);
+        left: 50%;
+        bottom: 20px;
+        z-index: 1000;
+        position: absolute;
       }
       div.kebab-menu-callout--14fgT {
         box-shadow: 0px 6.4px 14.4px var(--box-shadow-132),

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -932,24 +932,6 @@
         height: 1px;
         overflow: hidden;
       }
-      .toast-container--YaZxW {
-        display: inline-block;
-      }
-      .toast-content--Wt0Lj {
-        background: var(--neutral-70);
-        border-radius: 4px;
-        color: var(--neutral-0);
-        padding-left: 20px;
-        padding-top: 14px;
-        padding-bottom: 14px;
-        padding-right: 20px;
-        width: 316px;
-        margin-left: calc(316px / -2 - 20px);
-        left: 50%;
-        bottom: 20px;
-        z-index: 1000;
-        position: absolute;
-      }
       .how-to-fix-content--2-Pc1 {
         margin-bottom: 16px;
       }
@@ -998,6 +980,24 @@
         .action-cancel-button-col--2EdOO
         + .action-cancel-button-col--2EdOO {
         margin-left: 8px;
+      }
+      .toast-container--YaZxW {
+        display: inline-block;
+      }
+      .toast-content--Wt0Lj {
+        background: var(--neutral-70);
+        border-radius: 4px;
+        color: var(--neutral-0);
+        padding-left: 20px;
+        padding-top: 14px;
+        padding-bottom: 14px;
+        padding-right: 20px;
+        width: 316px;
+        margin-left: calc(316px / -2 - 20px);
+        left: 50%;
+        bottom: 20px;
+        z-index: 1000;
+        position: absolute;
       }
       div.kebab-menu-callout--14fgT {
         box-shadow: 0px 6.4px 14.4px var(--box-shadow-132),

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -932,24 +932,6 @@
         height: 1px;
         overflow: hidden;
       }
-      .toast-container--YaZxW {
-        display: inline-block;
-      }
-      .toast-content--Wt0Lj {
-        background: var(--neutral-70);
-        border-radius: 4px;
-        color: var(--neutral-0);
-        padding-left: 20px;
-        padding-top: 14px;
-        padding-bottom: 14px;
-        padding-right: 20px;
-        width: 316px;
-        margin-left: calc(316px / -2 - 20px);
-        left: 50%;
-        bottom: 20px;
-        z-index: 1000;
-        position: absolute;
-      }
       .how-to-fix-content--2-Pc1 {
         margin-bottom: 16px;
       }
@@ -998,6 +980,24 @@
         .action-cancel-button-col--2EdOO
         + .action-cancel-button-col--2EdOO {
         margin-left: 8px;
+      }
+      .toast-container--YaZxW {
+        display: inline-block;
+      }
+      .toast-content--Wt0Lj {
+        background: var(--neutral-70);
+        border-radius: 4px;
+        color: var(--neutral-0);
+        padding-left: 20px;
+        padding-top: 14px;
+        padding-bottom: 14px;
+        padding-right: 20px;
+        width: 316px;
+        margin-left: calc(316px / -2 - 20px);
+        left: 50%;
+        bottom: 20px;
+        z-index: 1000;
+        position: absolute;
       }
       div.kebab-menu-callout--14fgT {
         box-shadow: 0px 6.4px 14.4px var(--box-shadow-132),

--- a/src/assessments/adaptable-content/test-steps/contrast.tsx
+++ b/src/assessments/adaptable-content/test-steps/contrast.tsx
@@ -6,6 +6,10 @@ import {
     WindowsContrastCheckerAppLink,
 } from 'common/components/contrast-checker-app-links';
 import { ContrastPropertyBag } from 'common/types/property-bag/contrast';
+import {
+    NoValue,
+    PropertyBagColumnRendererConfig,
+} from 'common/types/property-bag/property-bag-column-renderer-config';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
@@ -17,10 +21,6 @@ import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
-import {
-    NoValue,
-    PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { Requirement } from '../../types/requirement';

--- a/src/assessments/common/property-bag-column-renderer-factory.tsx
+++ b/src/assessments/common/property-bag-column-renderer-factory.tsx
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ColumnValueBag } from 'common/types/property-bag/column-value-bag';
+import { PropertyBagColumnRendererConfig } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { AssessmentInstanceRowData } from 'DetailsView/components/assessment-instance-table';
-import {
-    propertyBagColumnRenderer,
-    PropertyBagColumnRendererConfig,
-} from './property-bag-column-renderer';
+import { propertyBagColumnRenderer } from './property-bag-column-renderer';
 
 export class PropertyBagColumnRendererFactory {
     public static getRenderer<TPropertyBag extends ColumnValueBag>(

--- a/src/assessments/common/property-bag-column-renderer.tsx
+++ b/src/assessments/common/property-bag-column-renderer.tsx
@@ -3,18 +3,10 @@
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 
-import { ColumnValue, ColumnValueBag } from 'common/types/property-bag/column-value-bag';
+import { ColumnValueBag } from 'common/types/property-bag/column-value-bag';
+import { PropertyBagColumnRendererConfig } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { AssessmentInstanceRowData } from 'DetailsView/components/assessment-instance-table';
 import { DictionaryStringTo } from 'types/common-types';
-
-export const NoValue = '(no value)';
-
-export interface PropertyBagColumnRendererConfig<TPropertyBag extends ColumnValueBag> {
-    propertyName: keyof TPropertyBag & string;
-    displayName: string;
-    defaultValue?: ColumnValue;
-    expand?: boolean;
-}
 
 export function propertyBagColumnRenderer<TPropertyBag extends ColumnValueBag>(
     item: AssessmentInstanceRowData<TPropertyBag>,

--- a/src/assessments/contrast/test-steps/graphics.tsx
+++ b/src/assessments/contrast/test-steps/graphics.tsx
@@ -6,6 +6,10 @@ import {
 } from 'common/components/contrast-checker-app-links';
 import { NewTabLink } from 'common/components/new-tab-link';
 import { MeaningfulImagePropertyBag } from 'common/types/property-bag/meaningful-image';
+import {
+    NoValue,
+    PropertyBagColumnRendererConfig,
+} from 'common/types/property-bag/property-bag-column-renderer-config';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/contrast/graphics';
@@ -14,10 +18,6 @@ import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
-import {
-    NoValue,
-    PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { Requirement } from '../../types/requirement';

--- a/src/assessments/contrast/test-steps/state-changes.tsx
+++ b/src/assessments/contrast/test-steps/state-changes.tsx
@@ -4,6 +4,10 @@ import {
     MacContrastCheckerAppLink,
     WindowsContrastCheckerAppLink,
 } from 'common/components/contrast-checker-app-links';
+import {
+    NoValue,
+    PropertyBagColumnRendererConfig,
+} from 'common/types/property-bag/property-bag-column-renderer-config';
 import { StateChangesPropertyBag } from 'common/types/property-bag/state-changes';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
@@ -14,10 +18,6 @@ import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
-import {
-    NoValue,
-    PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';

--- a/src/assessments/contrast/test-steps/ui-components.tsx
+++ b/src/assessments/contrast/test-steps/ui-components.tsx
@@ -4,20 +4,20 @@ import {
     MacContrastCheckerAppLink,
     WindowsContrastCheckerAppLink,
 } from 'common/components/contrast-checker-app-links';
-import { link } from 'content/link';
-import * as content from 'content/test/contrast/ui-components';
-import * as React from 'react';
-
-import { UIComponentsPropertyBag } from '../../../common/types/property-bag/ui-components';
-import { VisualizationType } from '../../../common/types/visualization-type';
-import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
-import { ScannerUtils } from '../../../injected/scanner-utils';
-import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
-import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
 import {
     NoValue,
     PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
+} from 'common/types/property-bag/property-bag-column-renderer-config';
+import { UIComponentsPropertyBag } from 'common/types/property-bag/ui-components';
+import { VisualizationType } from 'common/types/visualization-type';
+import { link } from 'content/link';
+import * as content from 'content/test/contrast/ui-components';
+import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { ScannerUtils } from 'injected/scanner-utils';
+import * as React from 'react';
+
+import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
+import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { Requirement } from '../../types/requirement';

--- a/src/assessments/custom-widgets/custom-widgets-column-renderer-factory.tsx
+++ b/src/assessments/custom-widgets/custom-widgets-column-renderer-factory.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ColumnValueBag } from 'common/types/property-bag/column-value-bag';
+import { PropertyBagColumnRendererConfig } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { AssessmentInstanceRowData } from 'DetailsView/components/assessment-instance-table';
-import { PropertyBagColumnRendererConfig } from '../common/property-bag-column-renderer';
 import { customWidgetsColumnRenderer } from './custom-widgets-column-renderer';
 
 export class CustomWidgetsColumnRendererFactory {

--- a/src/assessments/custom-widgets/custom-widgets-column-renderer.tsx
+++ b/src/assessments/custom-widgets/custom-widgets-column-renderer.tsx
@@ -4,9 +4,9 @@ import * as React from 'react';
 
 import { NewTabLink } from 'common/components/new-tab-link';
 import { ColumnValueBag } from 'common/types/property-bag/column-value-bag';
+import { PropertyBagColumnRendererConfig } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { AssessmentInstanceRowData } from 'DetailsView/components/assessment-instance-table';
 import { DictionaryStringTo } from 'types/common-types';
-import { PropertyBagColumnRendererConfig } from '../common/property-bag-column-renderer';
 import { PropertyBagColumnRendererFactory } from '../common/property-bag-column-renderer-factory';
 
 export function customWidgetsColumnRenderer<TPropertyBag extends ColumnValueBag>(

--- a/src/assessments/custom-widgets/test-steps/cues.tsx
+++ b/src/assessments/custom-widgets/test-steps/cues.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
+import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
@@ -12,7 +13,6 @@ import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/ass
 import { ScannerUtils } from 'injected/scanner-utils';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
-import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { Requirement } from '../../types/requirement';

--- a/src/assessments/custom-widgets/test-steps/design-pattern.tsx
+++ b/src/assessments/custom-widgets/test-steps/design-pattern.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { NewTabLink } from 'common/components/new-tab-link';
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
+import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
@@ -13,7 +14,6 @@ import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/ass
 import { ScannerUtils } from 'injected/scanner-utils';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
-import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { Requirement } from '../../types/requirement';

--- a/src/assessments/custom-widgets/test-steps/expected-input.tsx
+++ b/src/assessments/custom-widgets/test-steps/expected-input.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
+import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
@@ -11,7 +12,6 @@ import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/ass
 import { ScannerUtils } from 'injected/scanner-utils';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
-import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { Requirement } from '../../types/requirement';

--- a/src/assessments/custom-widgets/test-steps/instructions.tsx
+++ b/src/assessments/custom-widgets/test-steps/instructions.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { NewTabLink } from 'common/components/new-tab-link';
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
+import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/custom-widgets/instructions';
@@ -11,7 +12,6 @@ import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
 import { InstructionsAndLabelsNotes } from '../../common/instructions-and-labels-note';
-import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { Requirement } from '../../types/requirement';

--- a/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
+++ b/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
+import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
@@ -12,7 +13,6 @@ import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/ass
 import { ScannerUtils } from 'injected/scanner-utils';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
-import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { Requirement } from '../../types/requirement';

--- a/src/assessments/custom-widgets/test-steps/role-state-property.tsx
+++ b/src/assessments/custom-widgets/test-steps/role-state-property.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { NewTabLink } from 'common/components/new-tab-link';
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
+import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
@@ -13,7 +14,6 @@ import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/ass
 import { ScannerUtils } from 'injected/scanner-utils';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
-import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { Requirement } from '../../types/requirement';

--- a/src/assessments/images/test-steps/image-function.tsx
+++ b/src/assessments/images/test-steps/image-function.tsx
@@ -3,7 +3,7 @@
 import {
     NoValue,
     PropertyBagColumnRendererConfig,
-} from 'assessments/common/property-bag-column-renderer';
+} from 'common/types/property-bag/property-bag-column-renderer-config';
 import { ImageFunctionPropertyBag } from 'common/types/property-bag/image-function';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';

--- a/src/assessments/images/test-steps/images-of-text.tsx
+++ b/src/assessments/images/test-steps/images-of-text.tsx
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { MeaningfulImagePropertyBag } from 'common/types/property-bag/meaningful-image';
+import {
+    NoValue,
+    PropertyBagColumnRendererConfig,
+} from 'common/types/property-bag/property-bag-column-renderer-config';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
@@ -10,10 +14,6 @@ import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/ass
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
-import {
-    NoValue,
-    PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { Requirement } from '../../types/requirement';

--- a/src/assessments/images/test-steps/text-alternative.tsx
+++ b/src/assessments/images/test-steps/text-alternative.tsx
@@ -13,7 +13,7 @@ import { AssistedTestRecordYourResults } from '../../common/assisted-test-record
 import {
     NoValue,
     PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
+} from '../../../common/types/property-bag/property-bag-column-renderer-config';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';

--- a/src/assessments/links/test-steps/link-function.tsx
+++ b/src/assessments/links/test-steps/link-function.tsx
@@ -15,7 +15,7 @@ import { AssistedTestRecordYourResults } from '../../common/assisted-test-record
 import {
     NoValue,
     PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
+} from '../../../common/types/property-bag/property-bag-column-renderer-config';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';

--- a/src/assessments/links/test-steps/link-purpose.tsx
+++ b/src/assessments/links/test-steps/link-purpose.tsx
@@ -15,7 +15,7 @@ import { AssistedTestRecordYourResults } from '../../common/assisted-test-record
 import {
     NoValue,
     PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
+} from '../../../common/types/property-bag/property-bag-column-renderer-config';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';

--- a/src/assessments/native-widgets/test-steps/autocomplete.tsx
+++ b/src/assessments/native-widgets/test-steps/autocomplete.tsx
@@ -14,7 +14,7 @@ import { AssistedTestRecordYourResults } from '../../common/assisted-test-record
 import {
     NoValue,
     PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
+} from '../../../common/types/property-bag/property-bag-column-renderer-config';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';

--- a/src/assessments/native-widgets/test-steps/cues.tsx
+++ b/src/assessments/native-widgets/test-steps/cues.tsx
@@ -14,7 +14,7 @@ import { AssistedTestRecordYourResults } from '../../common/assisted-test-record
 import {
     NoValue,
     PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
+} from '../../../common/types/property-bag/property-bag-column-renderer-config';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';

--- a/src/assessments/native-widgets/test-steps/expected-input.tsx
+++ b/src/assessments/native-widgets/test-steps/expected-input.tsx
@@ -14,7 +14,7 @@ import { AssistedTestRecordYourResults } from '../../common/assisted-test-record
 import {
     NoValue,
     PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
+} from '../../../common/types/property-bag/property-bag-column-renderer-config';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';

--- a/src/assessments/native-widgets/test-steps/instructions.tsx
+++ b/src/assessments/native-widgets/test-steps/instructions.tsx
@@ -14,7 +14,7 @@ import { InstructionsAndLabelsNotes } from '../../common/instructions-and-labels
 import {
     NoValue,
     PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
+} from '../../../common/types/property-bag/property-bag-column-renderer-config';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';

--- a/src/assessments/native-widgets/test-steps/widget-function.tsx
+++ b/src/assessments/native-widgets/test-steps/widget-function.tsx
@@ -15,7 +15,7 @@ import { AssistedTestRecordYourResults } from '../../common/assisted-test-record
 import {
     NoValue,
     PropertyBagColumnRendererConfig,
-} from '../../common/property-bag-column-renderer';
+} from '../../../common/types/property-bag/property-bag-column-renderer-config';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';

--- a/src/assessments/types/report-instance-field.ts
+++ b/src/assessments/types/report-instance-field.ts
@@ -5,8 +5,8 @@ import {
     ColumnValueBag,
     isScalarColumnValue,
 } from 'common/types/property-bag/column-value-bag';
+import { PropertyBagColumnRendererConfig } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { TestStepInstance } from 'common/types/store-data/assessment-result-data';
-import { PropertyBagColumnRendererConfig } from '../common/property-bag-column-renderer';
 
 export type ReportInstanceField = {
     key: string;

--- a/src/common/components/cards/how-to-fix-card-row.tsx
+++ b/src/common/components/cards/how-to-fix-card-row.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { CardRowProps } from '../../../common/configs/unified-result-property-configurations';
 import { NamedFC } from '../../../common/react/named-fc';
-import { CheckType } from '../../../injected/components/details-dialog';
+import { CheckType } from '../../types/check-type';
 import { FixInstructionPanel } from '../fix-instruction-panel';
 import * as styles from './how-to-fix-card-row.scss';
 import { SimpleCardRow } from './simple-card-row';

--- a/src/common/components/fix-instruction-panel.tsx
+++ b/src/common/components/fix-instruction-panel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
-import { CheckType } from 'injected/components/details-dialog';
+import { CheckType } from 'common/types/check-type';
 import * as React from 'react';
 import * as styles from './fix-instruction-panel.scss';
 

--- a/src/common/types/check-type.ts
+++ b/src/common/types/check-type.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export enum CheckType {
+    All,
+    Any,
+    None,
+}

--- a/src/common/types/property-bag/property-bag-column-renderer-config.ts
+++ b/src/common/types/property-bag/property-bag-column-renderer-config.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ColumnValue, ColumnValueBag } from './column-value-bag';
+
+export const NoValue = '(no value)';
+export interface PropertyBagColumnRendererConfig<TPropertyBag extends ColumnValueBag> {
+    propertyName: keyof TPropertyBag & string;
+    displayName: string;
+    defaultValue?: ColumnValue;
+    expand?: boolean;
+}

--- a/src/injected/components/details-dialog.tsx
+++ b/src/injected/components/details-dialog.tsx
@@ -29,12 +29,7 @@ import {
     IssueDetailsNavigationControls,
     IssueDetailsNavigationControlsProps,
 } from './issue-details-navigation-controls';
-
-export enum CheckType {
-    All,
-    Any,
-    None,
-}
+import { CheckType } from '../../common/types/check-type';
 
 export type DetailsDialogDeps = {
     targetPageActionMessageCreator: TargetPageActionMessageCreator;

--- a/src/injected/drawing-controller.ts
+++ b/src/injected/drawing-controller.ts
@@ -16,8 +16,6 @@ import {
 import { FrameMessageResponseCallback } from './frameCommunicators/window-message-handler';
 import { Drawer } from './visualization/drawer';
 
-export type RegisterDrawer = (id: string, drawer: Drawer) => void;
-
 export interface VisualizationWindowMessage {
     visualizationType?: VisualizationType;
     isEnabled: boolean;
@@ -45,7 +43,7 @@ export class DrawingController {
         );
     }
 
-    public registerDrawer: RegisterDrawer = (id: string, drawer: Drawer) => {
+    public registerDrawer = (id: string, drawer: Drawer) => {
         if (this.drawers[id]) {
             throw new Error(`Drawer already registered to id: ${id}`);
         }

--- a/src/injected/drawing-controller.ts
+++ b/src/injected/drawing-controller.ts
@@ -14,8 +14,9 @@ import {
     HTMLIFrameResult,
 } from './frameCommunicators/html-element-axe-results-helper';
 import { FrameMessageResponseCallback } from './frameCommunicators/window-message-handler';
-import { RegisterDrawer } from './visualization-type-drawer-registrar';
 import { Drawer } from './visualization/drawer';
+
+export type RegisterDrawer = (id: string, drawer: Drawer) => void;
 
 export interface VisualizationWindowMessage {
     visualizationType?: VisualizationType;

--- a/src/injected/visualization-type-drawer-registrar.ts
+++ b/src/injected/visualization-type-drawer-registrar.ts
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { RegisterDrawer } from 'injected/drawing-controller';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { VisualizationType } from '../common/types/visualization-type';
-import { Drawer } from './visualization/drawer';
 import { DrawerProvider } from './visualization/drawer-provider';
-
-export type RegisterDrawer = (id: string, drawer: Drawer) => void;
 
 export class VisualizationTypeDrawerRegistrar {
     constructor(

--- a/src/injected/visualization-type-drawer-registrar.ts
+++ b/src/injected/visualization-type-drawer-registrar.ts
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { RegisterDrawer } from 'injected/drawing-controller';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { VisualizationType } from '../common/types/visualization-type';
+import { Drawer } from './visualization/drawer';
 import { DrawerProvider } from './visualization/drawer-provider';
+
+export type RegisterDrawer = (id: string, drawer: Drawer) => void;
 
 export class VisualizationTypeDrawerRegistrar {
     constructor(

--- a/src/tests/unit/tests/assessments/common/property-bag-column-renderer-factory.test.tsx
+++ b/src/tests/unit/tests/assessments/common/property-bag-column-renderer-factory.test.tsx
@@ -3,7 +3,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { PropertyBagColumnRendererConfig } from 'assessments/common/property-bag-column-renderer';
+import { PropertyBagColumnRendererConfig } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { PropertyBagColumnRendererFactory } from 'assessments/common/property-bag-column-renderer-factory';
 import { ColumnValueBag } from '../../../../../common/types/property-bag/column-value-bag';
 import { AssessmentInstanceRowData } from '../../../../../DetailsView/components/assessment-instance-table';

--- a/src/tests/unit/tests/assessments/common/property-bag-column-renderer.test.tsx
+++ b/src/tests/unit/tests/assessments/common/property-bag-column-renderer.test.tsx
@@ -3,10 +3,8 @@
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as React from 'react';
 
-import {
-    propertyBagColumnRenderer,
-    PropertyBagColumnRendererConfig,
-} from 'assessments/common/property-bag-column-renderer';
+import { propertyBagColumnRenderer } from 'assessments/common/property-bag-column-renderer';
+import { PropertyBagColumnRendererConfig } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { ColumnValueBag } from '../../../../../common/types/property-bag/column-value-bag';
 import { AssessmentInstanceRowData } from '../../../../../DetailsView/components/assessment-instance-table';
 import { DictionaryStringTo } from '../../../../../types/common-types';

--- a/src/tests/unit/tests/assessments/custom-widgets/custom-widgets-column-renderer-factory.test.tsx
+++ b/src/tests/unit/tests/assessments/custom-widgets/custom-widgets-column-renderer-factory.test.tsx
@@ -3,7 +3,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { PropertyBagColumnRendererConfig } from 'assessments/common/property-bag-column-renderer';
+import { PropertyBagColumnRendererConfig } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { CustomWidgetsColumnRendererFactory } from 'assessments/custom-widgets/custom-widgets-column-renderer-factory';
 import { ColumnValueBag } from '../../../../../common/types/property-bag/column-value-bag';
 import { AssessmentInstanceRowData } from '../../../../../DetailsView/components/assessment-instance-table';

--- a/src/tests/unit/tests/assessments/custom-widgets/custom-widgets-column-renderer.test.tsx
+++ b/src/tests/unit/tests/assessments/custom-widgets/custom-widgets-column-renderer.test.tsx
@@ -3,7 +3,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { PropertyBagColumnRendererConfig } from 'assessments/common/property-bag-column-renderer';
+import { PropertyBagColumnRendererConfig } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { customWidgetsColumnRenderer } from 'assessments/custom-widgets/custom-widgets-column-renderer';
 import { ColumnValueBag } from '../../../../../common/types/property-bag/column-value-bag';
 import { AssessmentInstanceRowData } from '../../../../../DetailsView/components/assessment-instance-table';

--- a/src/tests/unit/tests/assessments/report-instance-field.test.ts
+++ b/src/tests/unit/tests/assessments/report-instance-field.test.ts
@@ -3,7 +3,7 @@
 import { ReportInstanceField } from 'assessments/types/report-instance-field';
 import { BagOf } from 'common/types/property-bag/column-value-bag';
 
-import { PropertyBagColumnRendererConfig } from 'assessments/common/property-bag-column-renderer';
+import { PropertyBagColumnRendererConfig } from 'common/types/property-bag/property-bag-column-renderer-config';
 
 describe('ReportInstanceField', () => {
     type Bag = { one?: string; two?: string; attr?: BagOf<string> };

--- a/src/tests/unit/tests/injected/components/fix-instruction-panel.test.tsx
+++ b/src/tests/unit/tests/injected/components/fix-instruction-panel.test.tsx
@@ -6,7 +6,7 @@ import {
 } from 'common/components/fix-instruction-panel';
 import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { shallow } from 'enzyme';
-import { CheckType } from 'injected/components/details-dialog';
+import { CheckType } from 'common/types/check-type';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
 

--- a/src/tests/unit/tests/injected/visualization-type-drawer-registrar.test.ts
+++ b/src/tests/unit/tests/injected/visualization-type-drawer-registrar.test.ts
@@ -5,8 +5,10 @@ import { Requirement } from 'assessments/types/requirement';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { VisualizationType } from 'common/types/visualization-type';
-import { RegisterDrawer } from 'injected/drawing-controller';
-import { VisualizationTypeDrawerRegistrar } from 'injected/visualization-type-drawer-registrar';
+import {
+    RegisterDrawer,
+    VisualizationTypeDrawerRegistrar,
+} from 'injected/visualization-type-drawer-registrar';
 import { Drawer } from 'injected/visualization/drawer';
 import { DrawerProvider } from 'injected/visualization/drawer-provider';
 import { IMock, Mock } from 'typemoq';

--- a/src/tests/unit/tests/injected/visualization-type-drawer-registrar.test.ts
+++ b/src/tests/unit/tests/injected/visualization-type-drawer-registrar.test.ts
@@ -2,16 +2,14 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Requirement } from 'assessments/types/requirement';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { VisualizationType } from 'common/types/visualization-type';
+import { RegisterDrawer } from 'injected/drawing-controller';
+import { VisualizationTypeDrawerRegistrar } from 'injected/visualization-type-drawer-registrar';
+import { Drawer } from 'injected/visualization/drawer';
+import { DrawerProvider } from 'injected/visualization/drawer-provider';
 import { IMock, Mock } from 'typemoq';
-import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
-import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
-import { VisualizationType } from '../../../../common/types/visualization-type';
-import {
-    RegisterDrawer,
-    VisualizationTypeDrawerRegistrar,
-} from '../../../../injected/visualization-type-drawer-registrar';
-import { Drawer } from '../../../../injected/visualization/drawer';
-import { DrawerProvider } from '../../../../injected/visualization/drawer-provider';
 
 describe('VisualizationTypeDrawerRegistrar', () => {
     let registerDrawerMock: IMock<RegisterDrawer>;


### PR DESCRIPTION
#### Description of changes

This PR addresses a few cyclic dependencies by breaking out a few types from implemenation files with a lot of dependencies into separate type files with fewer deps:

* `NoValue` and `PropertyBagColumnRendererConfig` move from `assessments/common/property-bag-column-renderer.ts` to `common/types/property-bag/property-bag-column-renderer-config.ts`
* `CheckType` moves from `injected/components/details-dialog.tsx` to `common/types/check-type.ts`
* removes use of `RegisterDrawer` in `drawing-controller` (it isn't necessary for type safety and creates a cyclic dep)

The report e2e snapshots get updates because removing the cyclic deps changed the flattened import order of a few components based on css modules; there is no functional change.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: unblocks progress on #2869
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
