### PR TITLE
Chore: Add two new eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,9 @@ module.exports = {
             },
         ],
 
+        'react/no-unused-state': 'error',
+        'react/no-access-state-in-setstate': 'error',
+
         // Disabled due to high existing-positive count during initial tslint -> eslint migration
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/src/DetailsView/components/export-dialog-with-local-state.tsx
+++ b/src/DetailsView/components/export-dialog-with-local-state.tsx
@@ -49,11 +49,10 @@ export class ExportDialogWithLocalState extends React.Component<
     };
 
     private generateHtml = () => {
-        const exportData = this.props.htmlGenerator(this.state.exportDescription);
-        this.setState({
-            exportData,
+        this.setState(prevState => ({
+            exportData: this.props.htmlGenerator(prevState.exportDescription),
             exportDescription: '',
-        });
+        }));
     };
 
     public render(): JSX.Element {

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -69,9 +69,9 @@ export class FailureInstancePanelControl extends React.Component<
 
     public componentDidUpdate(prevProps: Readonly<FailureInstancePanelControlProps>): void {
         if (isEqual(prevProps, this.props) === false) {
-            this.setState(() => ({
+            this.setState(prevState => ({
                 currentInstance: {
-                    failureDescription: this.state.currentInstance.failureDescription,
+                    failureDescription: prevState.currentInstance.failureDescription,
                     path: this.props.failureInstance.path,
                     snippet: this.props.failureInstance.snippet,
                 },
@@ -198,15 +198,21 @@ export class FailureInstancePanelControl extends React.Component<
     };
 
     protected onFailureDescriptionChange = (event, value: string): void => {
-        const updatedInstance = clone(this.state.currentInstance);
-        updatedInstance.failureDescription = value;
-        this.setState({ currentInstance: updatedInstance });
+        this.setState(prevState => {
+            const updatedInstance = clone(prevState.currentInstance);
+            updatedInstance.failureDescription = value;
+
+            return { currentInstance: updatedInstance };
+        });
     };
 
     private onSelectorChange = (event, value: string): void => {
-        const updatedInstance = clone(this.state.currentInstance);
-        updatedInstance.path = value;
-        this.setState({ currentInstance: updatedInstance });
+        this.setState(prevState => {
+            const updatedInstance = clone(prevState.currentInstance);
+            updatedInstance.path = value;
+
+            return { currentInstance: updatedInstance };
+        });
     };
 
     private onValidateSelector = (event): void => {

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -58,8 +58,10 @@ export class ReportExportComponent extends React.Component<
 
     private generateHtml = () => {
         const { htmlGenerator } = this.props;
-        const exportData = htmlGenerator(this.state.exportDescription);
-        this.setState({ exportDescription: '', exportData });
+        this.setState(prevState => ({
+            exportDescription: '',
+            exportData: htmlGenerator(prevState.exportDescription),
+        }));
     };
 
     private onExportButtonClick = () => {

--- a/src/common/components/collapsible-component.tsx
+++ b/src/common/components/collapsible-component.tsx
@@ -29,8 +29,7 @@ export class CollapsibleComponent extends React.Component<
     }
 
     private onClick = (): void => {
-        const newState = !this.state.showContent;
-        this.setState({ showContent: newState });
+        this.setState(prevState => ({ showContent: !prevState.showContent }));
     };
 
     public render(): JSX.Element {

--- a/src/debug-tools/components/telemetry-viewer/telemetry-viewer.tsx
+++ b/src/debug-tools/components/telemetry-viewer/telemetry-viewer.tsx
@@ -78,8 +78,8 @@ export class TelemetryViewer extends React.Component<TelemetryViewerProps, Telem
     );
 
     private onTelemetryMessage = (telemetryMessage: DebugToolsTelemetryMessage) => {
-        this.setState({
-            telemetryMessages: [telemetryMessage, ...this.state.telemetryMessages],
-        });
+        this.setState(prevState => ({
+            telemetryMessages: [telemetryMessage, ...prevState.telemetryMessages],
+        }));
     };
 }

--- a/src/injected/components/details-dialog.tsx
+++ b/src/injected/components/details-dialog.tsx
@@ -53,9 +53,7 @@ export interface DetailsDialogProps {
 export interface DetailsDialogState {
     showDialog: boolean;
     currentRuleIndex: number;
-    canInspect: boolean;
     userConfigurationStoreData: UserConfigurationStoreData;
-    showInspectMessage: boolean;
 }
 
 export class DetailsDialog extends React.Component<DetailsDialogProps, DetailsDialogState> {
@@ -111,8 +109,6 @@ export class DetailsDialog extends React.Component<DetailsDialogProps, DetailsDi
         this.state = {
             showDialog: true,
             currentRuleIndex: 0,
-            canInspect: true,
-            showInspectMessage: false,
             userConfigurationStoreData: props.userConfigStore.getState(),
         };
     }

--- a/src/popup/components/launch-panel-header.tsx
+++ b/src/popup/components/launch-panel-header.tsx
@@ -29,9 +29,7 @@ export interface LaunchPanelHeaderProps {
     featureFlags: FeatureFlagStoreData;
 }
 
-export type LaunchPanelHeaderState = {
-    isContextMenuVisible: boolean;
-} & Pick<IContextualMenuItem, 'target'>;
+export type LaunchPanelHeaderState = {} & Pick<IContextualMenuItem, 'target'>;
 
 export class LaunchPanelHeader extends React.Component<
     LaunchPanelHeaderProps,
@@ -40,9 +38,7 @@ export class LaunchPanelHeader extends React.Component<
     constructor(props: LaunchPanelHeaderProps) {
         super(props);
 
-        this.state = {
-            isContextMenuVisible: false,
-        };
+        this.state = {};
     }
 
     public render(): JSX.Element {


### PR DESCRIPTION
#### Description of changes

- react/no-unused-state	ensures state objects for react components have no unused properties
- react/no-access-state-in-setstate	ensures the current (soon to be previous) state of a react component is accessed from within the `setState` callback in order to protect against the possibility of the state being set by out-of-date data when calls to setState are batched.

