### PR TITLE
Chore: Add eslint rule react/no-access-state-in-setstate

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,8 @@ module.exports = {
             },
         ],
 
+        'react/no-access-state-in-setstate': 'error',
+
         // Disabled due to high existing-positive count during initial tslint -> eslint migration
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,8 +42,6 @@ module.exports = {
             },
         ],
 
-        'react/no-access-state-in-setstate': 'error',
-
         // Disabled due to high existing-positive count during initial tslint -> eslint migration
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
@@ -73,6 +71,7 @@ module.exports = {
         'react/display-name': 'off',
         'react/no-unescaped-entities': 'off',
         'react/jsx-key': 'off',
+        'react/no-access-state-in-setstate': 'error',
         'react/no-direct-mutation-state': 'off',
         'react/jsx-no-target-blank': 'off',
         'react/no-unknown-property': 'off',

--- a/src/DetailsView/components/export-dialog-with-local-state.tsx
+++ b/src/DetailsView/components/export-dialog-with-local-state.tsx
@@ -49,11 +49,10 @@ export class ExportDialogWithLocalState extends React.Component<
     };
 
     private generateHtml = () => {
-        const exportData = this.props.htmlGenerator(this.state.exportDescription);
-        this.setState({
-            exportData,
+        this.setState(prevState => ({
+            exportData: this.props.htmlGenerator(prevState.exportDescription),
             exportDescription: '',
-        });
+        }));
     };
 
     public render(): JSX.Element {

--- a/src/DetailsView/components/export-dialog-with-local-state.tsx
+++ b/src/DetailsView/components/export-dialog-with-local-state.tsx
@@ -49,8 +49,8 @@ export class ExportDialogWithLocalState extends React.Component<
     };
 
     private generateHtml = () => {
-        this.setState(prevState => ({
-            exportData: this.props.htmlGenerator(prevState.exportDescription),
+        this.setState((prevState, prevProps) => ({
+            exportData: prevProps.htmlGenerator(prevState.exportDescription),
             exportDescription: '',
         }));
     };

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -69,9 +69,9 @@ export class FailureInstancePanelControl extends React.Component<
 
     public componentDidUpdate(prevProps: Readonly<FailureInstancePanelControlProps>): void {
         if (isEqual(prevProps, this.props) === false) {
-            this.setState(() => ({
+            this.setState(prevState => ({
                 currentInstance: {
-                    failureDescription: this.state.currentInstance.failureDescription,
+                    failureDescription: prevState.currentInstance.failureDescription,
                     path: this.props.failureInstance.path,
                     snippet: this.props.failureInstance.snippet,
                 },
@@ -198,15 +198,21 @@ export class FailureInstancePanelControl extends React.Component<
     };
 
     protected onFailureDescriptionChange = (event, value: string): void => {
-        const updatedInstance = clone(this.state.currentInstance);
-        updatedInstance.failureDescription = value;
-        this.setState({ currentInstance: updatedInstance });
+        this.setState(prevState => {
+            const updatedInstance = clone(prevState.currentInstance);
+            updatedInstance.failureDescription = value;
+
+            return { currentInstance: updatedInstance };
+        });
     };
 
     private onSelectorChange = (event, value: string): void => {
-        const updatedInstance = clone(this.state.currentInstance);
-        updatedInstance.path = value;
-        this.setState({ currentInstance: updatedInstance });
+        this.setState(prevState => {
+            const updatedInstance = clone(prevState.currentInstance);
+            updatedInstance.path = value;
+
+            return { currentInstance: updatedInstance };
+        });
     };
 
     private onValidateSelector = (event): void => {

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -69,11 +69,11 @@ export class FailureInstancePanelControl extends React.Component<
 
     public componentDidUpdate(prevProps: Readonly<FailureInstancePanelControlProps>): void {
         if (isEqual(prevProps, this.props) === false) {
-            this.setState(prevState => ({
+            this.setState((prevState, prevProps) => ({
                 currentInstance: {
                     failureDescription: prevState.currentInstance.failureDescription,
-                    path: this.props.failureInstance.path,
-                    snippet: this.props.failureInstance.snippet,
+                    path: prevProps.failureInstance.path,
+                    snippet: prevProps.failureInstance.snippet,
                 },
             }));
         }

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -57,11 +57,14 @@ export class ReportExportComponent extends React.Component<
     };
 
     private generateHtml = () => {
-        const { htmlGenerator } = this.props;
-        this.setState(prevState => ({
-            exportDescription: '',
-            exportData: htmlGenerator(prevState.exportDescription),
-        }));
+        this.setState((prevState, prevProps) => {
+            const { htmlGenerator } = prevProps;
+
+            return {
+                exportDescription: '',
+                exportData: htmlGenerator(prevState.exportDescription),
+            };
+        });
     };
 
     private onExportButtonClick = () => {

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -58,8 +58,10 @@ export class ReportExportComponent extends React.Component<
 
     private generateHtml = () => {
         const { htmlGenerator } = this.props;
-        const exportData = htmlGenerator(this.state.exportDescription);
-        this.setState({ exportDescription: '', exportData });
+        this.setState(prevState => ({
+            exportDescription: '',
+            exportData: htmlGenerator(prevState.exportDescription),
+        }));
     };
 
     private onExportButtonClick = () => {

--- a/src/common/components/collapsible-component.tsx
+++ b/src/common/components/collapsible-component.tsx
@@ -29,8 +29,7 @@ export class CollapsibleComponent extends React.Component<
     }
 
     private onClick = (): void => {
-        const newState = !this.state.showContent;
-        this.setState({ showContent: newState });
+        this.setState(prevState => ({ showContent: !prevState.showContent }));
     };
 
     public render(): JSX.Element {

--- a/src/debug-tools/components/telemetry-viewer/telemetry-viewer.tsx
+++ b/src/debug-tools/components/telemetry-viewer/telemetry-viewer.tsx
@@ -78,8 +78,8 @@ export class TelemetryViewer extends React.Component<TelemetryViewerProps, Telem
     );
 
     private onTelemetryMessage = (telemetryMessage: DebugToolsTelemetryMessage) => {
-        this.setState({
-            telemetryMessages: [telemetryMessage, ...this.state.telemetryMessages],
-        });
+        this.setState(prevState => ({
+            telemetryMessages: [telemetryMessage, ...prevState.telemetryMessages],
+        }));
     };
 }


### PR DESCRIPTION
#### Description of changes

Ensures the current (soon to be previous) state of a react component is accessed from within the `setState` callback in order to protect against the possibility of the state being set by out-of-date data when calls to setState are batched.
