### PR TITLE
Chore: Add eslint rule react/no-unused-state

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
         'react/no-unescaped-entities': 'off',
         'react/jsx-key': 'off',
         'react/no-access-state-in-setstate': 'error',
+        'react/no-unused-state': 'error',
         'react/no-direct-mutation-state': 'off',
         'react/jsx-no-target-blank': 'off',
         'react/no-unknown-property': 'off',

--- a/src/injected/components/details-dialog.tsx
+++ b/src/injected/components/details-dialog.tsx
@@ -111,7 +111,9 @@ export class DetailsDialog extends React.Component<DetailsDialogProps, DetailsDi
         this.state = {
             showDialog: true,
             currentRuleIndex: 0,
+            // eslint-disable-next-line react/no-unused-state
             canInspect: true,
+            // eslint-disable-next-line react/no-unused-state
             showInspectMessage: false,
             userConfigurationStoreData: props.userConfigStore.getState(),
         };

--- a/src/popup/components/launch-panel-header.tsx
+++ b/src/popup/components/launch-panel-header.tsx
@@ -29,9 +29,7 @@ export interface LaunchPanelHeaderProps {
     featureFlags: FeatureFlagStoreData;
 }
 
-export type LaunchPanelHeaderState = {
-    isContextMenuVisible: boolean;
-} & Pick<IContextualMenuItem, 'target'>;
+export type LaunchPanelHeaderState = Pick<IContextualMenuItem, 'target'>;
 
 export class LaunchPanelHeader extends React.Component<
     LaunchPanelHeaderProps,
@@ -40,9 +38,7 @@ export class LaunchPanelHeader extends React.Component<
     constructor(props: LaunchPanelHeaderProps) {
         super(props);
 
-        this.state = {
-            isContextMenuVisible: false,
-        };
+        this.state = {};
     }
 
     public render(): JSX.Element {

--- a/src/popup/handlers/launch-panel-header-click-handler.ts
+++ b/src/popup/handlers/launch-panel-header-click-handler.ts
@@ -30,12 +30,7 @@ export class LaunchPanelHeaderClickHandler {
         });
     }
 
-    public onDismissFeedbackMenu(header: LaunchPanelHeader, event?: any): void {
-        header.setState({ isContextMenuVisible: false });
-    }
-
     public openAdhocToolsPanel(header: LaunchPanelHeader): void {
         header.props.openAdhocToolsPanel();
-        header.props.deps.launchPanelHeaderClickHandler.onDismissFeedbackMenu(header);
     }
 }

--- a/src/tests/unit/tests/popup/components/__snapshots__/launch-panel-header.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/launch-panel-header.test.tsx.snap
@@ -58,9 +58,7 @@ exports[`LaunchPanelHeaderTest renders 1`] = `
           },
           "refs": Object {},
           "setState": [Function],
-          "state": Object {
-            "isContextMenuVisible": false,
-          },
+          "state": Object {},
           "updater": Updater {
             "_callbacks": Array [],
             "_renderer": ReactShallowRenderer {

--- a/src/tests/unit/tests/popup/handlers/launch-panel-header-click-handler.test.ts
+++ b/src/tests/unit/tests/popup/handlers/launch-panel-header-click-handler.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { It, Mock, Times } from 'typemoq';
+import { It, Mock, MockBehavior, Times } from 'typemoq';
 
 import {
     LaunchPanelHeader,
@@ -88,40 +88,6 @@ describe('FeedbackMenuClickHandlerTest', () => {
         setStateMock.verifyAll();
     });
 
-    test('onDismissFeedbackMenu', () => {
-        const setStateMock = Mock.ofInstance((state: any) => {});
-        const stateStub = {
-            isContextMenuVisible: false,
-        };
-        const eventStub = {
-            currentTarget: 'currentTarget',
-        };
-        setStateMock.setup(sm => sm(It.isValue(stateStub))).verifiable();
-
-        const deps: LaunchPanelHeaderDeps = {
-            popupActionMessageCreator: null,
-            dropdownClickHandler: null,
-            launchPanelHeaderClickHandler: null,
-        };
-
-        const props: LaunchPanelHeaderProps = {
-            deps: deps,
-            title: 'title',
-            subtitle: 'subtitle',
-            supportLinkHandler: null,
-            popupWindow: null,
-            featureFlags: null,
-            openAdhocToolsPanel: null,
-            dropdownClickHandler: null,
-        };
-        const header = new LaunchPanelHeader(props);
-        header.setState = setStateMock.object;
-
-        testObject.onDismissFeedbackMenu(header, eventStub as any);
-
-        setStateMock.verifyAll();
-    });
-
     test('openAdhocToolsPanel', () => {
         const openAdhocToolsPanelMock = Mock.ofInstance(() => {});
         openAdhocToolsPanelMock.setup(o => o()).verifiable();
@@ -145,11 +111,8 @@ describe('FeedbackMenuClickHandlerTest', () => {
 
         const header = new LaunchPanelHeader(props);
 
-        const setStateMock = Mock.ofInstance((state: LaunchPanelHeaderState) => {});
-
-        setStateMock
-            .setup(setter => setter({ isContextMenuVisible: false }))
-            .verifiable(Times.once());
+        const setStateMock = Mock.ofInstance((state: LaunchPanelHeaderState) => {},
+        MockBehavior.Strict);
 
         header.setState = setStateMock.object;
 


### PR DESCRIPTION
#### Description of changes

This is one of the warnings found by lgtm.com.

While `isContextMenuVisible` was set, it's value was never read. Therefore, it could be removed.

There are two instances where the rule is disabled because it is finding false positives.

In launch-panel-header-click-handler.test.ts, I chose to leave `setStateMock` when it could also have been removed because this ensures that calling `openAdhocToolsPanel` has no unexpected side-effects related to the header object's state.

