### PR TITLE
feat(focus-mvp-client): Introduce and use unified TestConfig feature flags

### DIFF
--- a/src/electron/common/left-nav-item-factory.ts
+++ b/src/electron/common/left-nav-item-factory.ts
@@ -1,15 +1,25 @@
-import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { LeftNavItem } from 'electron/types/left-nav-item';
 import { TestConfig } from 'electron/types/test-config';
 
 export const createLeftNavItems = (
     configs: TestConfig[],
     actionCreator: LeftNavActionCreator,
+    featureFlagStoreData: FeatureFlagStoreData,
 ): LeftNavItem[] => {
-    return configs.map(config => createLeftNavItem(config, actionCreator));
+    return configs
+        .filter(config => filterForFeatureFlag(config, featureFlagStoreData))
+        .map(config => createLeftNavItem(config, actionCreator));
+};
+
+const filterForFeatureFlag = (
+    config: TestConfig,
+    featureFlagStoreData: FeatureFlagStoreData,
+): boolean => {
+    return config.featureFlag === undefined || featureFlagStoreData[config.featureFlag];
 };
 
 const createLeftNavItem = (

--- a/src/electron/types/test-config.ts
+++ b/src/electron/types/test-config.ts
@@ -6,4 +6,5 @@ import { LeftNavItemKey } from './left-nav-item-key';
 export type TestConfig = {
     key: LeftNavItemKey;
     contentPageInfo: ContentPageInfo;
+    featureFlag?: string;
 };

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -335,7 +335,11 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         const androidSetupActionCreator = new AndroidSetupActionCreator(androidSetupActions);
 
         const leftNavActionCreator = new LeftNavActionCreator(leftNavActions, cardSelectionActions);
-        const leftNavItems = createLeftNavItems(androidTestConfigs, leftNavActionCreator);
+        const leftNavItems = createLeftNavItems(
+            androidTestConfigs,
+            leftNavActionCreator,
+            featureFlagStore.getState(),
+        );
         const contentPagesInfo = createContentPagesInfo(androidTestConfigs);
 
         const deviceConnectActionCreator = new DeviceConnectActionCreator(

--- a/src/tests/unit/tests/electron/common/left-nav-item-factory.test.ts
+++ b/src/tests/unit/tests/electron/common/left-nav-item-factory.test.ts
@@ -22,6 +22,14 @@ describe('left nav item factory', () => {
                 contentPageInfo: {
                     title: 'my title2',
                 } as ContentPageInfo,
+                featureFlag: 'disabled-flag',
+            } as TestConfig,
+            {
+                key: 'needs-review',
+                contentPageInfo: {
+                    title: 'my title3',
+                } as ContentPageInfo,
+                featureFlag: 'enabled-flag',
             } as TestConfig,
         ];
 
@@ -32,13 +40,17 @@ describe('left nav item factory', () => {
             } as LeftNavItem,
             {
                 key: 'needs-review',
-                displayName: 'my title2',
+                displayName: 'my title3',
             } as LeftNavItem,
         ];
-
+        const featureFlagStoreData = { 'disabled-flag': false, 'enabled-flag': true };
         const actionCreatorMock = Mock.ofType<LeftNavActionCreator>(undefined, MockBehavior.Strict);
 
-        const actualItems = createLeftNavItems(configs, actionCreatorMock.object);
+        const actualItems = createLeftNavItems(
+            configs,
+            actionCreatorMock.object,
+            featureFlagStoreData,
+        );
 
         expect(actualItems).toMatchObject(expectedItems);
 
@@ -58,7 +70,7 @@ describe('left nav item factory', () => {
         const actionCreatorMock = Mock.ofType<LeftNavActionCreator>(undefined, MockBehavior.Strict);
         actionCreatorMock.setup(m => m.itemSelected('automated-checks')).verifiable();
 
-        const leftNavItems = createLeftNavItems(configs, actionCreatorMock.object);
+        const leftNavItems = createLeftNavItems(configs, actionCreatorMock.object, {});
 
         leftNavItems[0].onSelect();
 


### PR DESCRIPTION
#### Description of changes
Now that we're adding more left nav items to ai-unified, we'd like an easy way to hide them with feature flags.

To accomplish this, this PR:
- introduces a `featureFlag` property to `TestConfig` 
- modifies left nav item creation such that if a given `TestConfig` has a `featureFlag` value that refers to a disabled feature flag, no left nav item is created
- if `featureFlag` is undefined, behavior is unchanged.

Because no test configs are currently behind feature flags, this PR has no user impact.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
