### PR TITLE
feat(focus-mvp-client): Add new test config for Tab Stops

### DIFF
--- a/src/electron/common/unified-feature-flags.ts
+++ b/src/electron/common/unified-feature-flags.ts
@@ -6,6 +6,7 @@ export class UnifiedFeatureFlags {
     public static readonly logTelemetryToConsole = 'logTelemetryToConsole';
     public static readonly showAllFeatureFlags = 'showAllFeatureFlags';
     public static readonly exportReport = 'exportReport';
+    public static readonly tabStops = 'tabStops';
 }
 
 export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
@@ -34,6 +35,14 @@ export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
             displayableDescription: 'Show the export report button on the automated checks window',
             isPreviewFeature: false,
             forceDefault: true,
+        },
+        {
+            id: UnifiedFeatureFlags.tabStops,
+            defaultValue: false,
+            displayableName: 'Show Tab Stops test',
+            displayableDescription: 'Show the Tab Stops test on the Left Nav',
+            isPreviewFeature: false,
+            forceDefault: false,
         },
     ];
 }

--- a/src/electron/platform/android/test-configs/android-test-configs.ts
+++ b/src/electron/platform/android/test-configs/android-test-configs.ts
@@ -3,6 +3,11 @@
 
 import { automatedChecksTestConfig } from 'electron/platform/android/test-configs/automated-checks/test-config';
 import { needsReviewTestConfig } from 'electron/platform/android/test-configs/needs-review/test-config';
+import { tabStopsTestConfig } from 'electron/platform/android/test-configs/tab-stops/test-config';
 import { TestConfig } from 'electron/types/test-config';
 
-export const androidTestConfigs: TestConfig[] = [automatedChecksTestConfig, needsReviewTestConfig];
+export const androidTestConfigs: TestConfig[] = [
+    automatedChecksTestConfig,
+    tabStopsTestConfig,
+    needsReviewTestConfig,
+];

--- a/src/electron/platform/android/test-configs/tab-stops/test-config.tsx
+++ b/src/electron/platform/android/test-configs/tab-stops/test-config.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NeedsReviewInstancesSection } from 'common/components/cards/needs-review-instances-section';
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
+import { TestConfig } from 'electron/types/test-config';
+import { ScreenshotView } from 'electron/views/screenshot/screenshot-view';
+import * as React from 'react';
+
+export const tabStopsTestConfig: TestConfig = {
+    key: 'tab-stops',
+    contentPageInfo: {
+        title: 'Tab stops',
+        description: (
+            <>
+                <strong>How to test:</strong>
+                <ol>
+                    <li>Navigate to the screen you want to test in your app.</li>
+                    <li>
+                        Turn on the Show tab stops toggle. An empty circle will highlight the
+                        element with focus.
+                    </li>
+                    <li>
+                        If you are connected to an emulator, select your emulator app to bring it
+                        into focus and use your keyboard.
+                    </li>
+                    <li>
+                        Or If you are connected to a physical mobile device use the keyboard
+                        key-buttons below.
+                    </li>
+                    <li>
+                        Move input focus through all the interactive elements in the page:
+                        <ul>
+                            <li>Use Tab and Shift+Tab to navigate between standalone controls.</li>
+                            <li>
+                                Use the arrow keys to navigate between the focusable elements within
+                                a composite control.
+                            </li>
+                        </ul>
+                    </li>
+                    <li>
+                        As you navigate to each element, look for these accessibility problems:
+                        <ul>
+                            <li>
+                                An interactive element can't be reached using the Tab and arrow
+                                keys.
+                            </li>
+                            <li>
+                                An interactive element "traps" input focus and prevents navigating
+                                away.
+                            </li>
+                            <li>
+                                An interactive element doesn't give a visible indication when it has
+                                input focus.
+                            </li>
+                            <li>
+                                The tab order is inconsistent with the logical order that's
+                                communicated visually.
+                            </li>
+                            <li>Input focus moves unexpectedly without the user initiating it.</li>
+                        </ul>
+                    </li>
+                </ol>
+            </>
+        ),
+        instancesSectionComponent: NeedsReviewInstancesSection,
+        resultsFilter: _ => false,
+        allowsExportReport: false,
+        visualHelperSection: ScreenshotView,
+    },
+    featureFlag: UnifiedFeatureFlags.tabStops,
+};

--- a/src/electron/types/test-key.ts
+++ b/src/electron/types/test-key.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export type TestKey = 'automated-checks' | 'needs-review';
+export type TestKey = 'automated-checks' | 'needs-review' | 'tab-stops';

--- a/src/tests/electron/tests/results-view.test.ts
+++ b/src/tests/electron/tests/results-view.test.ts
@@ -47,7 +47,10 @@ describe('ResultsView', () => {
 
     it('left nav allows to change between tests', async () => {
         const testIndex = 1;
-        const expectedTestTitle = androidTestConfigs[testIndex].contentPageInfo.title;
+        const expectedTestTitle = androidTestConfigs.filter(
+            config => config.featureFlag === undefined,
+        )[testIndex].contentPageInfo.title;
+
         await app.client.browserWindow.setSize(
             narrowModeThresholds.collapseCommandBarThreshold + 1,
             height,

--- a/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
+++ b/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
@@ -23,6 +23,7 @@ describe('FeatureFlagsTest', () => {
             [UnifiedFeatureFlags.logTelemetryToConsole]: false,
             [UnifiedFeatureFlags.showAllFeatureFlags]: false,
             [UnifiedFeatureFlags.exportReport]: true,
+            [UnifiedFeatureFlags.tabStops]: false,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Description of changes
We need a new test config to add the Tab Stops test to AI-Android.

This PR adds such a config with the proper title and description. Because new components are not yet ready, it uses existing components for `instancesSectionComponent` and `visualHelperSection`. To avoid showing the new test, it introduces a tab stops feature flag as well.

This PR does not attempt to update how test configs are displayed to match the Tab Stops UI spec, so the screenshot will not look like the final product.

Screenshot of Tab Stops:
![image](https://user-images.githubusercontent.com/4615491/106969582-f18a5300-66ff-11eb-8bef-92c58d4d98e8.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
