### PR TITLE
feat(focus-mvp-client): Add code to send commands to device

### DIFF
--- a/src/electron/platform/android/adb-wrapper.ts
+++ b/src/electron/platform/android/adb-wrapper.ts
@@ -12,6 +12,15 @@ export type PackageInfo = {
     versionName?: string;
 };
 
+export enum KeyEventCode {
+    Up = 19,
+    Down = 20,
+    Left = 21,
+    Right = 22,
+    Tab = 61,
+    Enter = 66,
+}
+
 export interface AdbWrapper {
     getConnectedDevices(): Promise<Array<DeviceInfo>>;
     getPackageInfo(deviceId: string, packageName: string): Promise<PackageInfo>;
@@ -20,6 +29,7 @@ export interface AdbWrapper {
     uninstallService(deviceId: string, packageName: string): Promise<void>;
     setTcpForwarding(deviceId: string, localPort: number, devicePort: number): Promise<number>;
     removeTcpForwarding(deviceId: string, devicePort: number): Promise<void>;
+    sendKeyEvent(deviceId: string, keyEventCode: KeyEventCode): Promise<void>;
 }
 
 export interface AdbWrapperFactory {

--- a/src/electron/platform/android/appium-adb-wrapper.ts
+++ b/src/electron/platform/android/appium-adb-wrapper.ts
@@ -86,6 +86,6 @@ export class AppiumAdbWrapper implements AdbWrapper {
 
     public sendKeyEvent = async (deviceId: string, keyEventCode: KeyEventCode): Promise<void> => {
         this.adb.setDeviceId(deviceId);
-        return await this.adb.shell(['input', 'keyevent', keyEventCode]);
+        await this.adb.shell(['input', 'keyevent', keyEventCode]);
     };
 }

--- a/src/electron/platform/android/appium-adb-wrapper.ts
+++ b/src/electron/platform/android/appium-adb-wrapper.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT License.
 
 import ADB from 'appium-adb';
-import { AdbWrapper, DeviceInfo, PackageInfo } from 'electron/platform/android/adb-wrapper';
+import {
+    AdbWrapper,
+    DeviceInfo,
+    KeyEventCode,
+    PackageInfo,
+} from 'electron/platform/android/adb-wrapper';
 import { DictionaryStringTo } from 'types/common-types';
 
 type AdbDevice = {
@@ -77,5 +82,10 @@ export class AppiumAdbWrapper implements AdbWrapper {
     public removeTcpForwarding = async (deviceId: string, localPort: number): Promise<void> => {
         this.adb.setDeviceId(deviceId);
         await this.adb.removePortForward(localPort);
+    };
+
+    public sendKeyEvent = async (deviceId: string, keyEventCode: KeyEventCode): Promise<void> => {
+        this.adb.setDeviceId(deviceId);
+        return await this.adb.shell(['input', 'keyevent', keyEventCode]);
     };
 }

--- a/src/electron/platform/android/device-focus-command-sender.ts
+++ b/src/electron/platform/android/device-focus-command-sender.ts
@@ -3,10 +3,11 @@
 import axios from 'axios';
 
 export enum DeviceFocusCommand {
-    'Enable',
-    'Disable',
-    'Reset',
+    Enable = 'Enable',
+    Disable = 'Disable',
+    Reset = 'Reset',
 }
+
 export type DeviceFocusCommandSender = (port: number, command: DeviceFocusCommand) => Promise<void>;
 
 export type HttpGet = typeof axios.get;

--- a/src/electron/platform/android/device-focus-command-sender.ts
+++ b/src/electron/platform/android/device-focus-command-sender.ts
@@ -7,11 +7,11 @@ export enum DeviceFocusCommand {
     'Pause',
     'End',
 }
-export type FocusCommandSender = (port: number, command: DeviceFocusCommand) => Promise<void>;
+export type DeviceFocusCommandSender = (port: number, command: DeviceFocusCommand) => Promise<void>;
 
 export type HttpGet = typeof axios.get;
 
-export const createFocusCommandSender = (httpGet: HttpGet): FocusCommandSender => {
+export const createDeviceFocusCommandSender = (httpGet: HttpGet): DeviceFocusCommandSender => {
     return async (port: number, command: DeviceFocusCommand) => {
         await httpGet(`http://localhost:${port}/AccessibilityInsights/FocusTracking/${command}`);
     };

--- a/src/electron/platform/android/device-focus-command-sender.ts
+++ b/src/electron/platform/android/device-focus-command-sender.ts
@@ -3,9 +3,9 @@
 import axios from 'axios';
 
 export enum DeviceFocusCommand {
-    'Resume',
-    'Pause',
-    'End',
+    'Enable',
+    'Disable',
+    'Reset',
 }
 export type DeviceFocusCommandSender = (port: number, command: DeviceFocusCommand) => Promise<void>;
 

--- a/src/electron/platform/android/device-focus-controller-factory.ts
+++ b/src/electron/platform/android/device-focus-controller-factory.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 import { AdbWrapper, AdbWrapperFactory } from 'electron/platform/android/adb-wrapper';
-import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
 import { DeviceFocusCommandSender } from 'electron/platform/android/device-focus-command-sender';
+import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
 
 export class DeviceFocusControllerFactory {
     constructor(
@@ -12,7 +12,7 @@ export class DeviceFocusControllerFactory {
     ) {}
 
     public initialize(): void {
-        // Temporary placeholder to let me call this class
+        // Temporary placeholder to let me call this class from renderer-initializer
     }
 
     public getDeviceFocusController = async (

--- a/src/electron/platform/android/device-focus-controller-factory.ts
+++ b/src/electron/platform/android/device-focus-controller-factory.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AdbWrapper, AdbWrapperFactory } from 'electron/platform/android/adb-wrapper';
+import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
+import { FocusCommandSender } from 'electron/platform/android/send-focus-command';
+
+export class DeviceFocusControllerFactory {
+    constructor(
+        private readonly adbWrapperFactory: AdbWrapperFactory,
+        private readonly focusCommandSender: FocusCommandSender,
+    ) {}
+
+    public initialize(): void {
+        // Temporary placeholder to let me call this class
+    }
+
+    public getDeviceFocusController = async (
+        adbLocation: string,
+    ): Promise<DeviceFocusController> => {
+        const adbWrapper: AdbWrapper = await this.adbWrapperFactory.createValidatedAdbWrapper(
+            adbLocation,
+        );
+        return new DeviceFocusController(adbWrapper, this.focusCommandSender);
+    };
+}

--- a/src/electron/platform/android/device-focus-controller-factory.ts
+++ b/src/electron/platform/android/device-focus-controller-factory.ts
@@ -3,12 +3,12 @@
 
 import { AdbWrapper, AdbWrapperFactory } from 'electron/platform/android/adb-wrapper';
 import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
-import { FocusCommandSender } from 'electron/platform/android/send-focus-command';
+import { DeviceFocusCommandSender } from 'electron/platform/android/device-focus-command-sender';
 
 export class DeviceFocusControllerFactory {
     constructor(
         private readonly adbWrapperFactory: AdbWrapperFactory,
-        private readonly focusCommandSender: FocusCommandSender,
+        private readonly focusCommandSender: DeviceFocusCommandSender,
     ) {}
 
     public initialize(): void {

--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -4,8 +4,8 @@
 import { AdbWrapper, KeyEventCode } from 'electron/platform/android/adb-wrapper';
 import {
     DeviceFocusCommand,
-    FocusCommandSender,
-} from 'electron/platform/android/send-focus-command';
+    DeviceFocusCommandSender,
+} from 'electron/platform/android/device-focus-command-sender';
 
 export class DeviceFocusController {
     private deviceId: string;
@@ -13,7 +13,7 @@ export class DeviceFocusController {
 
     constructor(
         private readonly adbWrapper: AdbWrapper,
-        private readonly commandSender: FocusCommandSender,
+        private readonly commandSender: DeviceFocusCommandSender,
     ) {}
 
     public setDeviceId(deviceId: string) {

--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -52,7 +52,7 @@ export class DeviceFocusController {
         return this.SendKeyEvent(KeyEventCode.Right);
     }
 
-    public SendEnter(): Promise<void> {
+    public SendEnterKey(): Promise<void> {
         return this.SendKeyEvent(KeyEventCode.Enter);
     }
 

--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AdbWrapper, KeyEventCode } from 'electron/platform/android/adb-wrapper';
+import {
+    DeviceFocusCommand,
+    FocusCommandSender,
+} from 'electron/platform/android/send-focus-command';
+
+export class DeviceFocusController {
+    private deviceId: string;
+    private port: number;
+
+    constructor(
+        private readonly adbWrapper: AdbWrapper,
+        private readonly commandSender: FocusCommandSender,
+    ) {}
+
+    public setDeviceId(deviceId: string) {
+        this.deviceId = deviceId;
+    }
+
+    public setPort(port: number) {
+        this.port = port;
+    }
+
+    public SendResumeTrackingCommandToDevice(): Promise<void> {
+        return this.commandSender(this.port, DeviceFocusCommand.Resume);
+    }
+
+    public SendPauseTrackingCommandToDevice(): Promise<void> {
+        return this.commandSender(this.port, DeviceFocusCommand.Pause);
+    }
+
+    public SendEndTrackingCommandToDevice(): Promise<void> {
+        return this.commandSender(this.port, DeviceFocusCommand.End);
+    }
+
+    public SendUpKeyToDevice(): Promise<void> {
+        return this.SendKeyEventToDevice(KeyEventCode.Up);
+    }
+
+    public SendDownKeyToDevice(): Promise<void> {
+        return this.SendKeyEventToDevice(KeyEventCode.Down);
+    }
+
+    public SendLeftKeyToDevice(): Promise<void> {
+        return this.SendKeyEventToDevice(KeyEventCode.Left);
+    }
+
+    public SendRightKeyToDevice(): Promise<void> {
+        return this.SendKeyEventToDevice(KeyEventCode.Right);
+    }
+
+    public SendEnterToDevice(): Promise<void> {
+        return this.SendKeyEventToDevice(KeyEventCode.Enter);
+    }
+
+    public SendTabKeyToDevice(): Promise<void> {
+        return this.SendKeyEventToDevice(KeyEventCode.Tab);
+    }
+
+    private SendKeyEventToDevice(keyEventCode: KeyEventCode): Promise<void> {
+        return this.adbWrapper.sendKeyEvent(this.deviceId, keyEventCode);
+    }
+}

--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -24,43 +24,43 @@ export class DeviceFocusController {
         this.port = port;
     }
 
-    public SendResumeTrackingCommandToDevice(): Promise<void> {
-        return this.commandSender(this.port, DeviceFocusCommand.Resume);
+    public EnableFocusTracking(): Promise<void> {
+        return this.commandSender(this.port, DeviceFocusCommand.Enable);
     }
 
-    public SendPauseTrackingCommandToDevice(): Promise<void> {
-        return this.commandSender(this.port, DeviceFocusCommand.Pause);
+    public DisableFocusTracking(): Promise<void> {
+        return this.commandSender(this.port, DeviceFocusCommand.Disable);
     }
 
-    public SendEndTrackingCommandToDevice(): Promise<void> {
-        return this.commandSender(this.port, DeviceFocusCommand.End);
+    public ResetFocusTracking(): Promise<void> {
+        return this.commandSender(this.port, DeviceFocusCommand.Reset);
     }
 
-    public SendUpKeyToDevice(): Promise<void> {
-        return this.SendKeyEventToDevice(KeyEventCode.Up);
+    public SendUpKey(): Promise<void> {
+        return this.SendKeyEvent(KeyEventCode.Up);
     }
 
-    public SendDownKeyToDevice(): Promise<void> {
-        return this.SendKeyEventToDevice(KeyEventCode.Down);
+    public SendDownKey(): Promise<void> {
+        return this.SendKeyEvent(KeyEventCode.Down);
     }
 
-    public SendLeftKeyToDevice(): Promise<void> {
-        return this.SendKeyEventToDevice(KeyEventCode.Left);
+    public SendLeftKey(): Promise<void> {
+        return this.SendKeyEvent(KeyEventCode.Left);
     }
 
-    public SendRightKeyToDevice(): Promise<void> {
-        return this.SendKeyEventToDevice(KeyEventCode.Right);
+    public SendRightKey(): Promise<void> {
+        return this.SendKeyEvent(KeyEventCode.Right);
     }
 
-    public SendEnterToDevice(): Promise<void> {
-        return this.SendKeyEventToDevice(KeyEventCode.Enter);
+    public SendEnter(): Promise<void> {
+        return this.SendKeyEvent(KeyEventCode.Enter);
     }
 
-    public SendTabKeyToDevice(): Promise<void> {
-        return this.SendKeyEventToDevice(KeyEventCode.Tab);
+    public SendTabKey(): Promise<void> {
+        return this.SendKeyEvent(KeyEventCode.Tab);
     }
 
-    private SendKeyEventToDevice(keyEventCode: KeyEventCode): Promise<void> {
+    private SendKeyEvent(keyEventCode: KeyEventCode): Promise<void> {
         return this.adbWrapper.sendKeyEvent(this.deviceId, keyEventCode);
     }
 }

--- a/src/electron/platform/android/send-focus-command.ts
+++ b/src/electron/platform/android/send-focus-command.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import axios from 'axios';
+
+export enum DeviceFocusCommand {
+    'Resume',
+    'Pause',
+    'End',
+}
+export type FocusCommandSender = (port: number, command: DeviceFocusCommand) => Promise<void>;
+
+export type HttpGet = typeof axios.get;
+
+export const createFocusCommandSender = (httpGet: HttpGet): FocusCommandSender => {
+    return async (port: number, command: DeviceFocusCommand) => {
+        await httpGet(`http://localhost:${port}/AccessibilityInsights/FocusTracking/${command}`);
+    };
+};

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -81,11 +81,11 @@ import { AndroidSetupTelemetrySender } from 'electron/platform/android/android-s
 import { AppiumAdbWrapperFactory } from 'electron/platform/android/appium-adb-wrapper-factory';
 import { parseDeviceConfig } from 'electron/platform/android/device-config';
 import { createDeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
+import { createDeviceFocusCommandSender } from 'electron/platform/android/device-focus-command-sender';
 import { DeviceFocusControllerFactory } from 'electron/platform/android/device-focus-controller-factory';
 import { createScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
 import { LiveAppiumAdbCreator } from 'electron/platform/android/live-appium-adb-creator';
 import { ScanController } from 'electron/platform/android/scan-controller';
-import { createFocusCommandSender } from 'electron/platform/android/send-focus-command';
 import { AndroidPortCleaner } from 'electron/platform/android/setup/android-port-cleaner';
 import {
     AndroidServiceConfiguratorFactory,
@@ -415,7 +415,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
 
         const deviceFocusControllerFactory = new DeviceFocusControllerFactory(
             appiumAdbWrapperFactory,
-            createFocusCommandSender(axios.get),
+            createDeviceFocusCommandSender(axios.get),
         );
 
         // Placeholder--remove once we include deviceFocusControllerFactory in the deps

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -81,9 +81,11 @@ import { AndroidSetupTelemetrySender } from 'electron/platform/android/android-s
 import { AppiumAdbWrapperFactory } from 'electron/platform/android/appium-adb-wrapper-factory';
 import { parseDeviceConfig } from 'electron/platform/android/device-config';
 import { createDeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
+import { DeviceFocusControllerFactory } from 'electron/platform/android/device-focus-controller-factory';
 import { createScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
 import { LiveAppiumAdbCreator } from 'electron/platform/android/live-appium-adb-creator';
 import { ScanController } from 'electron/platform/android/scan-controller';
+import { createFocusCommandSender } from 'electron/platform/android/send-focus-command';
 import { AndroidPortCleaner } from 'electron/platform/android/setup/android-port-cleaner';
 import {
     AndroidServiceConfiguratorFactory,
@@ -221,9 +223,10 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         const apkLocator: AndroidServiceApkLocator = new AndroidServiceApkLocator(
             ipcRendererShim.getAppPath,
         );
+        const appiumAdbWrapperFactory = new AppiumAdbWrapperFactory(new LiveAppiumAdbCreator());
         const serviceConfigFactory: ServiceConfiguratorFactory = new PortCleaningServiceConfiguratorFactory(
             new AndroidServiceConfiguratorFactory(
-                new AppiumAdbWrapperFactory(new LiveAppiumAdbCreator()),
+                appiumAdbWrapperFactory,
                 apkLocator,
                 getPortPromise,
             ),
@@ -409,6 +412,14 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         );
 
         scanController.initialize();
+
+        const deviceFocusControllerFactory = new DeviceFocusControllerFactory(
+            appiumAdbWrapperFactory,
+            createFocusCommandSender(axios.get),
+        );
+
+        // Placeholder--remove once we include deviceFocusControllerFactory in the deps
+        deviceFocusControllerFactory.initialize();
 
         const dropdownActionMessageCreator = new DropdownActionMessageCreator(
             telemetryDataFactory,

--- a/src/tests/unit/tests/electron/platform/android/device-focus-comand-sender.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-comand-sender.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    createDeviceFocusCommandSender,
+    DeviceFocusCommand,
+    DeviceFocusCommandSender,
+    HttpGet,
+} from 'electron/platform/android/device-focus-command-sender';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+
+describe('DeviceFocusCommandSender tests', () => {
+    let httpGetMock: IMock<HttpGet>;
+    let testSubject: DeviceFocusCommandSender;
+
+    const port = 12345;
+
+    beforeEach(() => {
+        httpGetMock = Mock.ofType<HttpGet>(undefined, MockBehavior.Strict);
+        testSubject = createDeviceFocusCommandSender(httpGetMock.object);
+    });
+
+    it('propagates errors properly', async () => {
+        const reason = 'Something went wrong';
+
+        httpGetMock
+            .setup(getter =>
+                getter('http://localhost:12345/AccessibilityInsights/FocusTracking/Enable'),
+            )
+            .returns(() => Promise.reject(reason));
+
+        await expect(testSubject(port, DeviceFocusCommand.Enable)).rejects.toMatch(reason);
+    });
+
+    describe('send commands, get no error', () => {
+        test.each([
+            DeviceFocusCommand.Enable,
+            DeviceFocusCommand.Disable,
+            DeviceFocusCommand.Reset,
+        ])('sending command: %p', async (command: DeviceFocusCommand) => {
+            httpGetMock
+                .setup(getter =>
+                    getter('http://localhost:12345/AccessibilityInsights/FocusTracking/' + command),
+                )
+                .verifiable(Times.once());
+
+            await testSubject(port, command);
+
+            httpGetMock.verifyAll();
+        });
+    });
+});

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller-factory.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller-factory.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AdbWrapper, AdbWrapperFactory } from 'electron/platform/android/adb-wrapper';
+import { DeviceFocusCommandSender } from 'electron/platform/android/device-focus-command-sender';
+import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
+import { DeviceFocusControllerFactory } from 'electron/platform/android/device-focus-controller-factory';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+
+describe('DeviceFocusControllerFactory tests', () => {
+    let adbWrapperFactoryMock: IMock<AdbWrapperFactory>;
+    let testSubject: DeviceFocusControllerFactory;
+
+    const focusCommandSenderMock: IMock<DeviceFocusCommandSender> = Mock.ofType<DeviceFocusCommandSender>(
+        undefined,
+        MockBehavior.Strict,
+    );
+
+    beforeEach(() => {
+        adbWrapperFactoryMock = Mock.ofType<AdbWrapperFactory>(undefined, MockBehavior.Strict);
+        testSubject = new DeviceFocusControllerFactory(
+            adbWrapperFactoryMock.object,
+            focusCommandSenderMock.object,
+        );
+    });
+
+    it('initialize is just a placeholder', () => {
+        testSubject.initialize();
+    });
+
+    it('getDeviceFocusController returns correct type', async () => {
+        const adbLocation = 'In a galaxy far, far away';
+
+        const adbWrapperMock: IMock<AdbWrapper> = Mock.ofType<AdbWrapper>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        adbWrapperFactoryMock
+            .setup(m => m.createValidatedAdbWrapper(adbLocation))
+            .returns(() => Promise.resolve<AdbWrapper>(adbWrapperMock.object))
+            .verifiable(Times.once());
+
+        const promise = testSubject.getDeviceFocusController(adbLocation);
+
+        expect(promise).resolves.toBeInstanceOf(DeviceFocusController);
+
+        adbWrapperMock.verifyAll();
+        adbWrapperFactoryMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AdbWrapper, KeyEventCode } from 'electron/platform/android/adb-wrapper';
+import {
+    DeviceFocusCommand,
+    DeviceFocusCommandSender,
+} from 'electron/platform/android/device-focus-command-sender';
+import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+
+describe('DeviceFocusControllerFactory tests', () => {
+    const deviceId: string = 'some device';
+    const port: number = 23456;
+
+    let adbWrapperMock: IMock<AdbWrapper>;
+    let commandSenderMock: IMock<DeviceFocusCommandSender>;
+    let testSubject: DeviceFocusController;
+
+    beforeEach(() => {
+        adbWrapperMock = Mock.ofType<AdbWrapper>(undefined, MockBehavior.Strict);
+        commandSenderMock = Mock.ofType<DeviceFocusCommandSender>(undefined, MockBehavior.Strict);
+        testSubject = new DeviceFocusController(adbWrapperMock.object, commandSenderMock.object);
+        testSubject.setDeviceId(deviceId);
+        testSubject.setPort(port);
+    });
+
+    it('EnableFocusTracking sends correct command', async () => {
+        commandSenderMock
+            .setup(getter => getter(port, DeviceFocusCommand.Enable))
+            .verifiable(Times.once());
+
+        await testSubject.EnableFocusTracking();
+
+        commandSenderMock.verifyAll();
+    });
+
+    it('DisableFocusTracking sends correct command', async () => {
+        commandSenderMock
+            .setup(getter => getter(port, DeviceFocusCommand.Disable))
+            .verifiable(Times.once());
+
+        await testSubject.DisableFocusTracking();
+
+        commandSenderMock.verifyAll();
+    });
+
+    it('ResetFocusTracking sends correct command', async () => {
+        commandSenderMock
+            .setup(getter => getter(port, DeviceFocusCommand.Reset))
+            .verifiable(Times.once());
+
+        await testSubject.ResetFocusTracking();
+
+        commandSenderMock.verifyAll();
+    });
+
+    it('SendUpKey sends correct command', async () => {
+        adbWrapperMock
+            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Up))
+            .verifiable(Times.once());
+
+        await testSubject.SendUpKey();
+
+        adbWrapperMock.verifyAll();
+    });
+
+    it('SendDownKey sends correct command', async () => {
+        adbWrapperMock
+            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Down))
+            .verifiable(Times.once());
+
+        await testSubject.SendDownKey();
+
+        adbWrapperMock.verifyAll();
+    });
+
+    it('SendLeftKey sends correct command', async () => {
+        adbWrapperMock
+            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Left))
+            .verifiable(Times.once());
+
+        await testSubject.SendLeftKey();
+
+        adbWrapperMock.verifyAll();
+    });
+
+    it('SendRightKey sends correct command', async () => {
+        adbWrapperMock
+            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Right))
+            .verifiable(Times.once());
+
+        await testSubject.SendRightKey();
+
+        adbWrapperMock.verifyAll();
+    });
+
+    it('SendEnterKey sends correct command', async () => {
+        adbWrapperMock
+            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Enter))
+            .verifiable(Times.once());
+
+        await testSubject.SendEnterKey();
+
+        adbWrapperMock.verifyAll();
+    });
+
+    it('SendTabKey sends correct command', async () => {
+        adbWrapperMock
+            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Tab))
+            .verifiable(Times.once());
+
+        await testSubject.SendTabKey();
+
+        adbWrapperMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
@@ -9,7 +9,7 @@ import {
 import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
-describe('DeviceFocusControllerFactory tests', () => {
+describe('DeviceFocusController tests', () => {
     const deviceId: string = 'some device';
     const port: number = 23456;
 


### PR DESCRIPTION
#### Details

Adds code to communicate with the Android client for the focus order feature. It uses ADB to send keystrokes to the device, and calls new service endpoints (which will be implemented in the service in the next feature) to control the service state. 

The intended use is to add the `DeviceFocusControllerFactory` to the deps that get passed into the TabStops page. When loading, the TabStop page will need to call the factory with the port and the ADB location (both in the store, and both determined during device connection, which is why the TabStops page needs to use the factory to generate a `DeviceFocusController` object). It then uses the `DeviceFocusController` object to send commands to the device. Errors are bubbled up to the caller for error handling.

##### Motivation

Part of the Android focus order feature

##### Context

Telemetry will be added as a separate PR.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
