### PR TITLE
feat(focus-mvp-client): Add shell input keyevent commands to mock-adb

### DIFF
--- a/src/tests/miscellaneous/mock-adb/common-adb-configs.js
+++ b/src/tests/miscellaneous/mock-adb/common-adb-configs.js
@@ -15,6 +15,7 @@ const serviceInfoCommandMatch =
 const serviceIsRunningCommandMatch = 'shell dumpsys accessibility';
 const portForwardingCommandMatch = 'forward tcp:';
 const sdkVersionCommandMatch = 'shell getprop ro.build.version.sdk';
+const inputKeyeventCommandMatch = 'shell input keyevent';
 
 function addDeviceEnumerationCommands(id, output) {
     output[`-s ${id} ${devicesCommandMatch}`] = cloneDeep(output.devices);
@@ -93,6 +94,16 @@ function addPortForwardingCommands(id, output, port) {
     };
 }
 
+function addInputKeyeventCommands(id, output) {
+    const keyeventCodes = [19, 20, 21, 22, 61, 66];
+
+    keyeventCodes.forEach(keyeventCode => {
+        output[`-s ${id} ${inputKeyeventCommandMatch} ${keyeventCode}`] = {
+            stdout: '',
+        };
+    });
+}
+
 function workingDeviceCommands(deviceIds, port) {
     const output = {
         'start-server': {},
@@ -113,6 +124,7 @@ function workingDeviceCommands(deviceIds, port) {
         addInstallServiceCommands(id, output);
         addCheckPermissionsCommands(id, output);
         addPortForwardingCommands(id, output, port);
+        addInputKeyeventCommands(id, output);
     }
 
     return output;
@@ -163,6 +175,10 @@ function simulatePortForwardingError(oldConfig) {
     return cloneWithDisabledPattern(oldConfig, portForwardingCommandMatch);
 }
 
+function simulateInputKeyeventError(oldConfig) {
+    return cloneWithDisabledPattern(oldConfig, inputKeyeventCommandMatch);
+}
+
 const physicalDeviceName1 = 'device-1';
 const physicalDeviceName2 = 'device-2';
 const emulatorDeviceName = 'emulator-3';
@@ -188,4 +204,5 @@ module.exports = {
     simulateServiceNotInstalled,
     simulateServiceLacksPermissions,
     simulatePortForwardingError,
+    simulateInputKeyeventError,
 };

--- a/src/tests/miscellaneous/mock-adb/common-adb-configs.js
+++ b/src/tests/miscellaneous/mock-adb/common-adb-configs.js
@@ -95,13 +95,22 @@ function addPortForwardingCommands(id, output, port) {
 }
 
 function addInputKeyeventCommands(id, output) {
-    const keyeventCodes = [19, 20, 21, 22, 61, 66];
+    // These are the values thr virtual keyboard uses for focus testing.
+    // See KevEventCode in src/electron/platform/android/adb-wrapper.ts
+    const keyeventCodeMap = {
+        up: 19,
+        down: 20,
+        left: 21,
+        right: 22,
+        tab: 61,
+        enter: 66,
+    };
 
-    keyeventCodes.forEach(keyeventCode => {
+    for (const keyeventCode of Object.values(keyeventCodeMap)) {
         output[`-s ${id} ${inputKeyeventCommandMatch} ${keyeventCode}`] = {
             stdout: '',
         };
-    });
+    }
 }
 
 function workingDeviceCommands(deviceIds, port) {

--- a/src/tests/miscellaneous/mock-adb/setup-mock-adb.d.ts
+++ b/src/tests/miscellaneous/mock-adb/setup-mock-adb.d.ts
@@ -32,6 +32,7 @@ export function simulatePortForwardingError(config: MockAdbConfig): MockAdbConfi
 export function simulateServiceLacksPermissions(config: MockAdbConfig): MockAdbConfig;
 export function simulateServiceNotInstalled(config: MockAdbConfig): MockAdbConfig;
 export function simulateServiceInstallationError(config: MockAdbConfig): MockAdbConfig;
+export function simulateInputKeyeventError(config: MockAdbConfig): MockAdbConfig;
 export function delayAllCommands(delayMs: number, config: MockAdbConfig): MockAdbConfig;
 export const emulatorDeviceName: string;
 export const physicalDeviceName1: string;

--- a/src/tests/miscellaneous/mock-adb/setup-mock-adb.js
+++ b/src/tests/miscellaneous/mock-adb/setup-mock-adb.js
@@ -14,6 +14,7 @@ const {
     simulateServiceInstallationError,
     simulateServiceLacksPermissions,
     simulatePortForwardingError,
+    simulateInputKeyeventError,
 } = require('./common-adb-configs');
 const { fileWithExpectedLoggingPath, fileWithMockAdbConfig } = require('./common-file-names.js');
 
@@ -52,4 +53,5 @@ module.exports = {
     simulateServiceInstallationError,
     simulateServiceLacksPermissions,
     simulatePortForwardingError,
+    simulateInputKeyeventError,
 };

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/mock-adb.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/mock-adb.test.ts.snap
@@ -61,6 +61,24 @@ Success
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
   },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -123,6 +141,24 @@ Success
   "-s device-2 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-2)",
   },
+  "-s device-2 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -184,6 +220,24 @@ Success
   },
   "-s emulator-3 shell getprop ro.product.model": Object {
     "stdout": "working mock device (emulator-3)",
+  },
+  "-s emulator-3 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -269,6 +323,24 @@ Success
   },
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
+  },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -358,6 +430,499 @@ Success
     "delayMs": 5000,
     "stdout": "working mock device (device-1)",
   },
+  "-s device-1 shell input keyevent 19": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
+    "delayMs": 5000,
+    "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
+    "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
+  },
+  "devices": Object {
+    "delayMs": 5000,
+    "stdout": "List of devices attached
+device-1	device
+",
+  },
+  "start-server": Object {
+    "delayMs": 5000,
+  },
+}
+`;
+
+exports[`mock-adb tests match snapshots after normalizing path simulateInputKeyeventError(commonAdbConfigs['multiple-devices']) 1`] = `
+Object {
+  "-s device-1 devices": Object {
+    "stdout": "List of devices attached
+device-1	device
+device-2	device
+emulator-3	emulator
+",
+  },
+  "-s device-1 features": Object {
+    "stdout": "abb_exec
+fixed_push_symlink_timestamp
+abb
+stat_v2
+apex
+shell_v2
+fixed_push_mkdir
+cmd",
+  },
+  "-s device-1 forward --remove tcp:62442": Object {
+    "stopTestServer": Object {
+      "port": 62442,
+    },
+  },
+  "-s device-1 forward tcp:62442 tcp:62442": Object {
+    "startTestServer": Object {
+      "path": "./src/tests/miscellaneous/mock-service-for-android/AccessibilityInsights",
+      "port": 62442,
+    },
+  },
+  "-s device-1 help": Object {
+    "stdout": "--streaming: force streaming APK directly into Package Manager",
+  },
+  "-s device-1 install -r ./drop/electron/unified-dev/product/android-service/android-service.apk": Object {
+    "stdout": "Performing Streamed Install
+Success
+",
+  },
+  "-s device-1 mkdir -p /data/local/tmp/appium_cache": Object {
+    "exitCode": 0,
+    "stdout": "",
+  },
+  "-s device-1 shell dumpsys accessibility": Object {
+    "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
+  },
+  "-s device-1 shell dumpsys media_projection": Object {
+    "stdout": "(com.microsoft.accessibilityinsightsforandroidservice, uid=12354): TYPE_SCREEN_CAPTURE",
+  },
+  "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
+    versionName=1.2.1",
+  },
+  "-s device-1 shell getprop ro.build.version.release": Object {
+    "stdout": "10",
+  },
+  "-s device-1 shell getprop ro.build.version.sdk": Object {
+    "stdout": "29",
+  },
+  "-s device-1 shell getprop ro.product.model": Object {
+    "stdout": "working mock device (device-1)",
+  },
+  "-s device-1 shell input keyevent 19": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
+    "stdout": "",
+  },
+  "-s device-2 devices": Object {
+    "stdout": "List of devices attached
+device-1	device
+device-2	device
+emulator-3	emulator
+",
+  },
+  "-s device-2 features": Object {
+    "stdout": "abb_exec
+fixed_push_symlink_timestamp
+abb
+stat_v2
+apex
+shell_v2
+fixed_push_mkdir
+cmd",
+  },
+  "-s device-2 forward --remove tcp:62442": Object {
+    "stopTestServer": Object {
+      "port": 62442,
+    },
+  },
+  "-s device-2 forward tcp:62442 tcp:62442": Object {
+    "startTestServer": Object {
+      "path": "./src/tests/miscellaneous/mock-service-for-android/AccessibilityInsights",
+      "port": 62442,
+    },
+  },
+  "-s device-2 help": Object {
+    "stdout": "--streaming: force streaming APK directly into Package Manager",
+  },
+  "-s device-2 install -r ./drop/electron/unified-dev/product/android-service/android-service.apk": Object {
+    "stdout": "Performing Streamed Install
+Success
+",
+  },
+  "-s device-2 mkdir -p /data/local/tmp/appium_cache": Object {
+    "exitCode": 0,
+    "stdout": "",
+  },
+  "-s device-2 shell dumpsys accessibility": Object {
+    "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
+  },
+  "-s device-2 shell dumpsys media_projection": Object {
+    "stdout": "(com.microsoft.accessibilityinsightsforandroidservice, uid=12354): TYPE_SCREEN_CAPTURE",
+  },
+  "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
+    versionName=1.2.1",
+  },
+  "-s device-2 shell getprop ro.build.version.release": Object {
+    "stdout": "10",
+  },
+  "-s device-2 shell getprop ro.build.version.sdk": Object {
+    "stdout": "29",
+  },
+  "-s device-2 shell getprop ro.product.model": Object {
+    "stdout": "working mock device (device-2)",
+  },
+  "-s device-2 shell input keyevent 19": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-2 shell input keyevent 20": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-2 shell input keyevent 21": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-2 shell input keyevent 22": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-2 shell input keyevent 61": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-2 shell input keyevent 66": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 devices": Object {
+    "stdout": "List of devices attached
+device-1	device
+device-2	device
+emulator-3	emulator
+",
+  },
+  "-s emulator-3 features": Object {
+    "stdout": "abb_exec
+fixed_push_symlink_timestamp
+abb
+stat_v2
+apex
+shell_v2
+fixed_push_mkdir
+cmd",
+  },
+  "-s emulator-3 forward --remove tcp:62442": Object {
+    "stopTestServer": Object {
+      "port": 62442,
+    },
+  },
+  "-s emulator-3 forward tcp:62442 tcp:62442": Object {
+    "startTestServer": Object {
+      "path": "./src/tests/miscellaneous/mock-service-for-android/AccessibilityInsights",
+      "port": 62442,
+    },
+  },
+  "-s emulator-3 help": Object {
+    "stdout": "--streaming: force streaming APK directly into Package Manager",
+  },
+  "-s emulator-3 install -r ./drop/electron/unified-dev/product/android-service/android-service.apk": Object {
+    "stdout": "Performing Streamed Install
+Success
+",
+  },
+  "-s emulator-3 mkdir -p /data/local/tmp/appium_cache": Object {
+    "exitCode": 0,
+    "stdout": "",
+  },
+  "-s emulator-3 shell dumpsys accessibility": Object {
+    "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
+  },
+  "-s emulator-3 shell dumpsys media_projection": Object {
+    "stdout": "(com.microsoft.accessibilityinsightsforandroidservice, uid=12354): TYPE_SCREEN_CAPTURE",
+  },
+  "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
+    versionName=1.2.1",
+  },
+  "-s emulator-3 shell getprop ro.build.version.release": Object {
+    "stdout": "10",
+  },
+  "-s emulator-3 shell getprop ro.build.version.sdk": Object {
+    "stdout": "29",
+  },
+  "-s emulator-3 shell getprop ro.product.model": Object {
+    "stdout": "working mock device (emulator-3)",
+  },
+  "-s emulator-3 shell input keyevent 19": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s emulator-3 shell input keyevent 20": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s emulator-3 shell input keyevent 21": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s emulator-3 shell input keyevent 22": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s emulator-3 shell input keyevent 61": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s emulator-3 shell input keyevent 66": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
+    "stdout": "",
+  },
+  "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
+    "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
+    "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
+  },
+  "PUSH PLACEHOLDER for 'device-2' - MATCH IS VIA REGEX": Object {
+    "regexTarget": "^-s device-2 push .*android-service.apk /data/local/tmp/appium_cache",
+    "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
+  },
+  "PUSH PLACEHOLDER for 'emulator-3' - MATCH IS VIA REGEX": Object {
+    "regexTarget": "^-s emulator-3 push .*android-service.apk /data/local/tmp/appium_cache",
+    "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
+  },
+  "devices": Object {
+    "stdout": "List of devices attached
+device-1	device
+device-2	device
+emulator-3	emulator
+",
+  },
+  "start-server": Object {},
+}
+`;
+
+exports[`mock-adb tests match snapshots after normalizing path simulateInputKeyeventError(commonAdbConfigs['single-device']) 1`] = `
+Object {
+  "-s device-1 devices": Object {
+    "stdout": "List of devices attached
+device-1	device
+",
+  },
+  "-s device-1 features": Object {
+    "stdout": "abb_exec
+fixed_push_symlink_timestamp
+abb
+stat_v2
+apex
+shell_v2
+fixed_push_mkdir
+cmd",
+  },
+  "-s device-1 forward --remove tcp:62442": Object {
+    "stopTestServer": Object {
+      "port": 62442,
+    },
+  },
+  "-s device-1 forward tcp:62442 tcp:62442": Object {
+    "startTestServer": Object {
+      "path": "./src/tests/miscellaneous/mock-service-for-android/AccessibilityInsights",
+      "port": 62442,
+    },
+  },
+  "-s device-1 help": Object {
+    "stdout": "--streaming: force streaming APK directly into Package Manager",
+  },
+  "-s device-1 install -r ./drop/electron/unified-dev/product/android-service/android-service.apk": Object {
+    "stdout": "Performing Streamed Install
+Success
+",
+  },
+  "-s device-1 mkdir -p /data/local/tmp/appium_cache": Object {
+    "exitCode": 0,
+    "stdout": "",
+  },
+  "-s device-1 shell dumpsys accessibility": Object {
+    "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
+  },
+  "-s device-1 shell dumpsys media_projection": Object {
+    "stdout": "(com.microsoft.accessibilityinsightsforandroidservice, uid=12354): TYPE_SCREEN_CAPTURE",
+  },
+  "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
+    versionName=1.2.1",
+  },
+  "-s device-1 shell getprop ro.build.version.release": Object {
+    "stdout": "10",
+  },
+  "-s device-1 shell getprop ro.build.version.sdk": Object {
+    "stdout": "29",
+  },
+  "-s device-1 shell getprop ro.product.model": Object {
+    "stdout": "working mock device (device-1)",
+  },
+  "-s device-1 shell input keyevent 19": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
+    "stdout": "",
+  },
+  "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
+    "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
+    "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
+  },
+  "devices": Object {
+    "stdout": "List of devices attached
+device-1	device
+",
+  },
+  "start-server": Object {},
+}
+`;
+
+exports[`mock-adb tests match snapshots after normalizing path simulateInputKeyeventError(commonAdbConfigs['slow-single-device']) 1`] = `
+Object {
+  "-s device-1 devices": Object {
+    "delayMs": 5000,
+    "stdout": "List of devices attached
+device-1	device
+",
+  },
+  "-s device-1 features": Object {
+    "delayMs": 5000,
+    "stdout": "abb_exec
+fixed_push_symlink_timestamp
+abb
+stat_v2
+apex
+shell_v2
+fixed_push_mkdir
+cmd",
+  },
+  "-s device-1 forward --remove tcp:62442": Object {
+    "delayMs": 5000,
+    "stopTestServer": Object {
+      "port": 62442,
+    },
+  },
+  "-s device-1 forward tcp:62442 tcp:62442": Object {
+    "delayMs": 5000,
+    "startTestServer": Object {
+      "path": "./src/tests/miscellaneous/mock-service-for-android/AccessibilityInsights",
+      "port": 62442,
+    },
+  },
+  "-s device-1 help": Object {
+    "delayMs": 5000,
+    "stdout": "--streaming: force streaming APK directly into Package Manager",
+  },
+  "-s device-1 install -r ./drop/electron/unified-dev/product/android-service/android-service.apk": Object {
+    "delayMs": 5000,
+    "stdout": "Performing Streamed Install
+Success
+",
+  },
+  "-s device-1 mkdir -p /data/local/tmp/appium_cache": Object {
+    "delayMs": 5000,
+    "exitCode": 0,
+    "stdout": "",
+  },
+  "-s device-1 shell dumpsys accessibility": Object {
+    "delayMs": 5000,
+    "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
+  },
+  "-s device-1 shell dumpsys media_projection": Object {
+    "delayMs": 5000,
+    "stdout": "(com.microsoft.accessibilityinsightsforandroidservice, uid=12354): TYPE_SCREEN_CAPTURE",
+  },
+  "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "delayMs": 5000,
+    "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
+    versionName=1.2.1",
+  },
+  "-s device-1 shell getprop ro.build.version.release": Object {
+    "delayMs": 5000,
+    "stdout": "10",
+  },
+  "-s device-1 shell getprop ro.build.version.sdk": Object {
+    "delayMs": 5000,
+    "stdout": "29",
+  },
+  "-s device-1 shell getprop ro.product.model": Object {
+    "delayMs": 5000,
+    "stdout": "working mock device (device-1)",
+  },
+  "-s device-1 shell input keyevent 19": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stderr": "Disabled by test config",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stderr": "Disabled by test config",
+  },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
@@ -436,6 +1001,24 @@ Success
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
   },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -494,6 +1077,24 @@ Success
   "-s device-2 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-2)",
   },
+  "-s device-2 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -551,6 +1152,24 @@ Success
   },
   "-s emulator-3 shell getprop ro.product.model": Object {
     "stdout": "working mock device (emulator-3)",
+  },
+  "-s emulator-3 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -630,6 +1249,24 @@ Success
   },
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
+  },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -714,6 +1351,30 @@ Success
     "delayMs": 5000,
     "stdout": "working mock device (device-1)",
   },
+  "-s device-1 shell input keyevent 19": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
@@ -790,6 +1451,24 @@ Success
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
   },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -849,6 +1528,24 @@ Success
   "-s device-2 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-2)",
   },
+  "-s device-2 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -907,6 +1604,24 @@ Success
   },
   "-s emulator-3 shell getprop ro.product.model": Object {
     "stdout": "working mock device (emulator-3)",
+  },
+  "-s emulator-3 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -989,6 +1704,24 @@ Success
   },
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
+  },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -1074,6 +1807,30 @@ Success
     "delayMs": 5000,
     "stdout": "working mock device (device-1)",
   },
+  "-s device-1 shell input keyevent 19": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
@@ -1156,6 +1913,24 @@ Success
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
   },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -1218,6 +1993,24 @@ Success
   "-s device-2 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-2)",
   },
+  "-s device-2 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -1279,6 +2072,24 @@ Success
   },
   "-s emulator-3 shell getprop ro.product.model": Object {
     "stdout": "working mock device (emulator-3)",
+  },
+  "-s emulator-3 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -1364,6 +2175,24 @@ Success
   },
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
+  },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -1452,6 +2281,30 @@ Success
     "delayMs": 5000,
     "stdout": "working mock device (device-1)",
   },
+  "-s device-1 shell input keyevent 19": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
@@ -1534,6 +2387,24 @@ Success
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
   },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -1596,6 +2467,24 @@ Success
   "-s device-2 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-2)",
   },
+  "-s device-2 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -1657,6 +2546,24 @@ Success
   },
   "-s emulator-3 shell getprop ro.product.model": Object {
     "stdout": "working mock device (emulator-3)",
+  },
+  "-s emulator-3 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -1742,6 +2649,24 @@ Success
   },
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
+  },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -1830,6 +2755,30 @@ Success
     "delayMs": 5000,
     "stdout": "working mock device (device-1)",
   },
+  "-s device-1 shell input keyevent 19": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
@@ -1911,6 +2860,24 @@ Success
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
   },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -1972,6 +2939,24 @@ Success
   "-s device-2 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-2)",
   },
+  "-s device-2 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-2 shell input keyevent 66": Object {
+    "stdout": "",
+  },
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
@@ -2032,6 +3017,24 @@ Success
   },
   "-s emulator-3 shell getprop ro.product.model": Object {
     "stdout": "working mock device (emulator-3)",
+  },
+  "-s emulator-3 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s emulator-3 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -2116,6 +3119,24 @@ Success
   },
   "-s device-1 shell getprop ro.product.model": Object {
     "stdout": "working mock device (device-1)",
+  },
+  "-s device-1 shell input keyevent 19": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "stdout": "",
   },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
@@ -2202,6 +3223,30 @@ Success
   "-s device-1 shell getprop ro.product.model": Object {
     "delayMs": 5000,
     "stdout": "working mock device (device-1)",
+  },
+  "-s device-1 shell input keyevent 19": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 20": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 21": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 22": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 61": Object {
+    "delayMs": 5000,
+    "stdout": "",
+  },
+  "-s device-1 shell input keyevent 66": Object {
+    "delayMs": 5000,
+    "stdout": "",
   },
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,

--- a/src/tests/unit/tests/electron/platform/android/mock-adb.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/mock-adb.test.ts
@@ -11,6 +11,7 @@ import {
     simulateServiceInstallationError,
     simulateServiceLacksPermissions,
     simulateServiceNotInstalled,
+    simulateInputKeyeventError,
 } from 'tests/miscellaneous/mock-adb/setup-mock-adb';
 
 describe('mock-adb tests match snapshots after normalizing path', () => {
@@ -91,6 +92,11 @@ describe('mock-adb tests match snapshots after normalizing path', () => {
 
     it.each(definedConfigs)("simulatePortForwardingError(commonAdbConfigs['%s'])", config => {
         const mockAdbConfig = simulatePortForwardingError(commonAdbConfigs[config]);
+        expect(standardizeAllPaths(mockAdbConfig)).toMatchSnapshot();
+    });
+
+    it.each(definedConfigs)("simulateInputKeyeventError(commonAdbConfigs['%s'])", config => {
+        const mockAdbConfig = simulateInputKeyeventError(commonAdbConfigs[config]);
         expect(standardizeAllPaths(mockAdbConfig)).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Details

Teach mock-adb how to handle ADB's `shell input keyevent` commands for keyevent codes of 19, 20, 21, 22, 61, and 66 (these are the codes that we intend to use for this feature, and are added in #3873).

##### Motivation

We're using these commands as part of the android focus feature. In order to validate these in E2E tests, we need to make sure that mock-adb is able to handle these commands.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
The spec calls for Shift+Tab, but we believe that to be infeasible at the moment, so we're doing only the 4 arrow keys (codes 19-22), Tab (code 61), and Enter (code 66). It would have been nice to pull these from the TypeScript enum, but I couldn't find a clean way to do that with the configurator being in straight JavaScript.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
