### PR TITLE
refactor(focus-mvp-client): Move LeftNavItem feature flag filtering from initialization to rendering

### DIFF
--- a/src/electron/common/left-nav-item-factory.ts
+++ b/src/electron/common/left-nav-item-factory.ts
@@ -18,6 +18,7 @@ const createLeftNavItem = (
     return {
         key: config.key,
         displayName: config.contentPageInfo.title,
+        featureFlag: config.featureFlag,
         onSelect: () => actionCreator.itemSelected(config.key),
     };
 };

--- a/src/electron/common/left-nav-item-factory.ts
+++ b/src/electron/common/left-nav-item-factory.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { LeftNavItem } from 'electron/types/left-nav-item';
 import { TestConfig } from 'electron/types/test-config';
@@ -8,18 +7,8 @@ import { TestConfig } from 'electron/types/test-config';
 export const createLeftNavItems = (
     configs: TestConfig[],
     actionCreator: LeftNavActionCreator,
-    featureFlagStoreData: FeatureFlagStoreData,
 ): LeftNavItem[] => {
-    return configs
-        .filter(config => filterForFeatureFlag(config, featureFlagStoreData))
-        .map(config => createLeftNavItem(config, actionCreator));
-};
-
-const filterForFeatureFlag = (
-    config: TestConfig,
-    featureFlagStoreData: FeatureFlagStoreData,
-): boolean => {
-    return config.featureFlag === undefined || featureFlagStoreData[config.featureFlag];
+    return configs.map(config => createLeftNavItem(config, actionCreator));
 };
 
 const createLeftNavItem = (

--- a/src/electron/types/left-nav-item.ts
+++ b/src/electron/types/left-nav-item.ts
@@ -6,5 +6,6 @@ import { LeftNavItemKey } from './left-nav-item-key';
 export type LeftNavItem = {
     key: LeftNavItemKey;
     displayName: string;
+    featureFlag?: string;
     onSelect: () => void;
 };

--- a/src/electron/views/left-nav/fluent-left-nav.tsx
+++ b/src/electron/views/left-nav/fluent-left-nav.tsx
@@ -7,7 +7,7 @@ import { GenericPanel } from 'DetailsView/components/generic-panel';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 import * as styles from 'electron/views/left-nav/fluent-left-nav.scss';
-import { LeftNav, LeftNavDeps } from 'electron/views/left-nav/left-nav';
+import { LeftNav, LeftNavDeps, LeftNavProps } from 'electron/views/left-nav/left-nav';
 import { PanelType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
@@ -21,11 +21,24 @@ export type FluentLeftNavProps = {
     selectedKey: LeftNavItemKey;
     isNavOpen: boolean;
     setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
-};
+} & LeftNavProps;
 
 export const FluentLeftNav = NamedFC<FluentLeftNavProps>('LeftNav', props => {
-    const { narrowModeStatus, selectedKey, isNavOpen, deps, setSideNavOpen } = props;
-    const leftNav = <LeftNav selectedKey={selectedKey} deps={deps} />;
+    const {
+        narrowModeStatus,
+        selectedKey,
+        isNavOpen,
+        deps,
+        setSideNavOpen,
+        featureFlagStoreData,
+    } = props;
+    const leftNav = (
+        <LeftNav
+            selectedKey={selectedKey}
+            deps={deps}
+            featureFlagStoreData={featureFlagStoreData}
+        />
+    );
 
     if (!narrowModeStatus.isHeaderAndNavCollapsed) {
         return leftNav;

--- a/src/electron/views/left-nav/left-nav.tsx
+++ b/src/electron/views/left-nav/left-nav.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { NamedFC } from 'common/react/named-fc';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { BaseLeftNav, BaseLeftNavLink } from 'DetailsView/components/base-left-nav';
 import { NavLinkRenderer } from 'DetailsView/components/left-nav/nav-link-renderer';
 import { LeftNavItem } from 'electron/types/left-nav-item';
@@ -18,13 +19,17 @@ export type LeftNavDeps = {
 export type LeftNavProps = {
     deps: LeftNavDeps;
     selectedKey: LeftNavItemKey;
+    featureFlagStoreData: FeatureFlagStoreData;
 };
 
 export const leftNavAutomationId = 'left-nav';
 
 export const LeftNav = NamedFC<LeftNavProps>('LeftNav', props => {
     const { deps } = props;
-    const leftLinkItems: BaseLeftNavLink[] = deps.leftNavItems.map((item, index) => ({
+    const leftNavItemsFiltered = deps.leftNavItems.filter(item =>
+        filterForFeatureFlag(item, props.featureFlagStoreData),
+    );
+    const leftLinkItems: BaseLeftNavLink[] = leftNavItemsFiltered.map((item, index) => ({
         name: item.displayName,
         key: item.key,
         onClickNavLink: item.onSelect,
@@ -47,3 +52,10 @@ export const LeftNav = NamedFC<LeftNavProps>('LeftNav', props => {
         </div>
     );
 });
+
+const filterForFeatureFlag = (
+    config: LeftNavItem,
+    featureFlagStoreData: FeatureFlagStoreData,
+): boolean => {
+    return config.featureFlag === undefined || featureFlagStoreData[config.featureFlag];
+};

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -338,11 +338,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         const androidSetupActionCreator = new AndroidSetupActionCreator(androidSetupActions);
 
         const leftNavActionCreator = new LeftNavActionCreator(leftNavActions, cardSelectionActions);
-        const leftNavItems = createLeftNavItems(
-            androidTestConfigs,
-            leftNavActionCreator,
-            featureFlagStore.getState(),
-        );
+        const leftNavItems = createLeftNavItems(androidTestConfigs, leftNavActionCreator);
         const contentPagesInfo = createContentPagesInfo(androidTestConfigs);
 
         const deviceConnectActionCreator = new DeviceConnectActionCreator(

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -168,6 +168,7 @@ export class ResultsView extends React.Component<ResultsViewProps> {
                 narrowModeStatus={this.props.narrowModeStatus}
                 selectedKey={this.props.leftNavStoreData.selectedKey}
                 setSideNavOpen={this.props.deps.leftNavActionCreator.setLeftNavVisible}
+                featureFlagStoreData={this.props.featureFlagStoreData}
             />
         );
     }

--- a/src/tests/unit/tests/electron/common/left-nav-item-factory.test.ts
+++ b/src/tests/unit/tests/electron/common/left-nav-item-factory.test.ts
@@ -22,14 +22,6 @@ describe('left nav item factory', () => {
                 contentPageInfo: {
                     title: 'my title2',
                 } as ContentPageInfo,
-                featureFlag: 'disabled-flag',
-            } as TestConfig,
-            {
-                key: 'needs-review',
-                contentPageInfo: {
-                    title: 'my title3',
-                } as ContentPageInfo,
-                featureFlag: 'enabled-flag',
             } as TestConfig,
         ];
 
@@ -40,17 +32,12 @@ describe('left nav item factory', () => {
             } as LeftNavItem,
             {
                 key: 'needs-review',
-                displayName: 'my title3',
+                displayName: 'my title2',
             } as LeftNavItem,
         ];
-        const featureFlagStoreData = { 'disabled-flag': false, 'enabled-flag': true };
         const actionCreatorMock = Mock.ofType<LeftNavActionCreator>(undefined, MockBehavior.Strict);
 
-        const actualItems = createLeftNavItems(
-            configs,
-            actionCreatorMock.object,
-            featureFlagStoreData,
-        );
+        const actualItems = createLeftNavItems(configs, actionCreatorMock.object);
 
         expect(actualItems).toMatchObject(expectedItems);
 
@@ -70,7 +57,7 @@ describe('left nav item factory', () => {
         const actionCreatorMock = Mock.ofType<LeftNavActionCreator>(undefined, MockBehavior.Strict);
         actionCreatorMock.setup(m => m.itemSelected('automated-checks')).verifiable();
 
-        const leftNavItems = createLeftNavItems(configs, actionCreatorMock.object, {});
+        const leftNavItems = createLeftNavItems(configs, actionCreatorMock.object);
 
         leftNavItems[0].onSelect();
 

--- a/src/tests/unit/tests/electron/common/left-nav-item-factory.test.ts
+++ b/src/tests/unit/tests/electron/common/left-nav-item-factory.test.ts
@@ -22,6 +22,7 @@ describe('left nav item factory', () => {
                 contentPageInfo: {
                     title: 'my title2',
                 } as ContentPageInfo,
+                featureFlag: 'my-feature-flag',
             } as TestConfig,
         ];
 
@@ -33,6 +34,7 @@ describe('left nav item factory', () => {
             {
                 key: 'needs-review',
                 displayName: 'my title2',
+                featureFlag: 'my-feature-flag',
             } as LeftNavItem,
         ];
         const actionCreatorMock = Mock.ofType<LeftNavActionCreator>(undefined, MockBehavior.Strict);

--- a/src/tests/unit/tests/electron/views/left-nav/__snapshots__/fluent-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/left-nav/__snapshots__/fluent-left-nav.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`FluentLeftNav render left nav by itself 1`] = `
 <LeftNav
   deps={Object {}}
+  featureFlagStoreData={Object {}}
   selectedKey="automated-checks"
 />
 `;
@@ -34,6 +35,7 @@ exports[`FluentLeftNav render left nav inside panel 1`] = `
   </div>
   <LeftNav
     deps={Object {}}
+    featureFlagStoreData={Object {}}
     selectedKey="automated-checks"
   />
 </GenericPanel>

--- a/src/tests/unit/tests/electron/views/left-nav/__snapshots__/left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/left-nav/__snapshots__/left-nav.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`LeftNav render 1`] = `
           },
           "index": 2,
           "key": "needs-review",
-          "name": "some display name 2",
+          "name": "some display name 3",
           "onClickNavLink": [Function],
           "onRenderNavLink": [Function],
           "url": "",

--- a/src/tests/unit/tests/electron/views/left-nav/fluent-left-nav.test.tsx
+++ b/src/tests/unit/tests/electron/views/left-nav/fluent-left-nav.test.tsx
@@ -27,6 +27,7 @@ describe('FluentLeftNav', () => {
 
         props = {
             deps: {} as FluentLeftNavDeps,
+            featureFlagStoreData: {},
             selectedKey: 'automated-checks',
             isNavOpen: true,
             narrowModeStatus: narrowModeStatusStub,

--- a/src/tests/unit/tests/electron/views/left-nav/left-nav.test.tsx
+++ b/src/tests/unit/tests/electron/views/left-nav/left-nav.test.tsx
@@ -11,6 +11,7 @@ describe('LeftNav', () => {
     let leftNavItemsStub: LeftNavItem[];
     let navLinkRendererStub: NavLinkRenderer;
     let props: LeftNavProps;
+    const featureFlagStoreData = { 'disabled-flag': false, 'enabled-flag': true };
 
     beforeEach(() => {
         leftNavItemsStub = [
@@ -23,6 +24,13 @@ describe('LeftNav', () => {
                 key: 'needs-review',
                 displayName: 'some display name 2',
                 onSelect: () => null,
+                featureFlag: 'disabled-flag',
+            },
+            {
+                key: 'needs-review',
+                displayName: 'some display name 3',
+                onSelect: () => null,
+                featureFlag: 'enabled-flag',
             },
         ];
         navLinkRendererStub = {
@@ -33,6 +41,7 @@ describe('LeftNav', () => {
                 navLinkRenderer: navLinkRendererStub,
                 leftNavItems: leftNavItemsStub,
             },
+            featureFlagStoreData,
             selectedKey: 'automated-checks',
         };
     });


### PR DESCRIPTION
#### Details
A previous PR (#3861) added feature flags to TestConfig to allow easily hiding feature left nav items. This PR moves the filtering of left nav items out of the initialization logic into the rendering logic. This allows the feature flag to be toggled without restarting the app.

##### Motivation
The primary motivation for this PR is to make the Tab Stops feature flag easier to enable during e2e tests. 

##### Context
The only user impact of this PR is that toggling a left nav related feature flag will now take immediate effect instead of requiring an app restart.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
