### PR TITLE
fix: Use default title bar for unified client running on mac

### DIFF
--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -39,7 +39,7 @@ const createWindow = () => {
         show: false,
         // enableRemoteModule required for spectron (https://github.com/electron-userland/spectron/issues/693#issuecomment-696957538)
         webPreferences: { nodeIntegration: true, enableRemoteModule: true },
-        titleBarStyle: 'hidden',
+        titleBarStyle: platformInfo.isMac() ? 'default' : 'hidden',
         width: mainWindowConfig.defaultWidth,
         height: mainWindowConfig.defaultHeight,
         frame: os === OSType.Mac,
@@ -47,10 +47,6 @@ const createWindow = () => {
         minWidth: mainWindowConfig.minWidth,
         icon: getElectronIconPath(config, os),
     });
-    if (platformInfo.isMac()) {
-        // We need this so that if there are any system dialog, they will not be placed on top of the title bar.
-        mainWindow.setSheetOffset(22);
-    }
 
     const mainWindowMessageSink: IpcMessageSink = (id, msg) => mainWindow.webContents.send(id, msg);
 

--- a/src/electron/views/common/window-title/window-title.tsx
+++ b/src/electron/views/common/window-title/window-title.tsx
@@ -49,9 +49,7 @@ export const WindowTitle = NamedFC<WindowTitleProps>('WindowTitle', (props: Wind
 });
 
 function getIconsContainer(props: WindowTitleProps): JSX.Element | null {
-    const { platformInfo } = props.deps;
-
-    if (platformInfo.isMac() || isEmpty(props.actionableIcons)) {
+    if (isEmpty(props.actionableIcons)) {
         return null;
     }
 

--- a/src/electron/views/common/window-title/window-title.tsx
+++ b/src/electron/views/common/window-title/window-title.tsx
@@ -28,6 +28,10 @@ export const WindowTitle = NamedFC<WindowTitleProps>('WindowTitle', (props: Wind
         return null;
     }
 
+    if (props.deps.platformInfo.isMac()) {
+        return null;
+    }
+
     return (
         <header className={css(styles.windowTitle, props.className)}>
             <Helmet>

--- a/src/tests/unit/tests/electron/views/common/window-title/__snapshots__/window-title.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/common/window-title/__snapshots__/window-title.test.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`WindowTitleTest renders nothing for mac 1`] = `null`;
+
 exports[`WindowTitleTest renders nothing if fullscreen 1`] = `null`;
 
 exports[`WindowTitleTest renders with actionable icons 1`] = `
@@ -115,35 +117,6 @@ exports[`WindowTitleTest renders with custom header text class name 1`] = `
     <div>
       icon2
     </div>
-  </div>
-</header>
-`;
-
-exports[`WindowTitleTest renders without actionable buttons for mac 1`] = `
-<header
-  className="windowTitle"
->
-  <HelmetWrapper
-    defer={true}
-    encodeSpecialCharacters={true}
-  >
-    <title>
-      Accessibility Insights for Android
-       - 
-      page title 1
-    </title>
-  </HelmetWrapper>
-  <div
-    className="titleContainer"
-  >
-    <span>
-      logo
-    </span>
-    <span
-      className="headerText"
-    >
-      Accessibility Insights
-    </span>
   </div>
 </header>
 `;

--- a/src/tests/unit/tests/electron/views/common/window-title/window-title.test.tsx
+++ b/src/tests/unit/tests/electron/views/common/window-title/window-title.test.tsx
@@ -42,15 +42,15 @@ describe('WindowTitleTest', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    it('renders with actionable icons', () => {
+    it('renders nothing for mac', () => {
+        platformInfoMock.setup(p => p.isMac()).returns(() => true);
+
         const rendered = shallow(<WindowTitle {...props} />);
 
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    it('renders nothing for mac', () => {
-        platformInfoMock.setup(p => p.isMac()).returns(() => true);
-
+    it('renders with actionable icons', () => {
         const rendered = shallow(<WindowTitle {...props} />);
 
         expect(rendered.getElement()).toMatchSnapshot();

--- a/src/tests/unit/tests/electron/views/common/window-title/window-title.test.tsx
+++ b/src/tests/unit/tests/electron/views/common/window-title/window-title.test.tsx
@@ -48,7 +48,7 @@ describe('WindowTitleTest', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    it('renders without actionable buttons for mac', () => {
+    it('renders nothing for mac', () => {
         platformInfoMock.setup(p => p.isMac()).returns(() => true);
 
         const rendered = shallow(<WindowTitle {...props} />);


### PR DESCRIPTION
#### Details

The unified app currently uses a custom title bar that works OK on Windows and Linux, but it has some funny behaviors on Mac when we lose the focus, as pointed out in #3263. We did some investigation here and found that this is a side effect of Electron on Mac in dark mode. We could potentially create a full dark mode option to address this, but it's a lot simpler to simply use the default title bar on Mac. We may revert this change if/when we create a dark mode for the unified app.

##### Motivation

Addresses issue #3263

##### Context

I tested the traffic light buttons, including saving the app size and state, and didn't detect any regressions. The one thing I noticed was that the system menu says "Electon" instead of "Accessibility Insights for Android", but the same thing also occurs when running a local build from the master branch. As it turns out, the string shown in the system menu comes from the app package, and isn't explicitly set by our code.

The titles are being rendered by the OS, not by our code, so we inherit system behavior automatically.

Screenshots (shadows omitted so they're all the same size, although in some cases the screenshots look like there's no border at all, which isn't really the case)

Description | Image
--- | ---
Dark mode, unfocused | <img width="600" alt="Dark-Unfocused" src="https://user-images.githubusercontent.com/45672944/107441354-f5e0b280-6ae9-11eb-8138-c8c4ab57c5f0.png">
Dark mode, focused | <img width="600" alt="Dark-Focused" src="https://user-images.githubusercontent.com/45672944/107441339-ef523b00-6ae9-11eb-8cbf-e7870df92017.png">
Light mode, unfocused | <img width="600" alt="Light-Unfocused" src="https://user-images.githubusercontent.com/45672944/107441604-596ae000-6aea-11eb-993b-c815eac30480.png">
Light mode, focused | <img width="600" alt="Light-Focused" src="https://user-images.githubusercontent.com/45672944/107441582-52dc6880-6aea-11eb-817a-80aed60aa207.png">
High Contrast, unfocused | <img width="600" alt="High Contrast-Unfocused" src="https://user-images.githubusercontent.com/45672944/107441926-faf23180-6aea-11eb-9cab-993728fdbecd.png">
High Contrast, focused | <img width="600" alt="High Contrast-Focused" src="https://user-images.githubusercontent.com/45672944/107441901-ef066f80-6aea-11eb-83bb-d877d5f5b7a0.png">


<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3263 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
