### PR TITLE
feat(focus-mvp-client): Add initial AI-Android Tab Stops E2E test

### DIFF
--- a/src/tests/electron/tests/tab-stops-view.test.ts
+++ b/src/tests/electron/tests/tab-stops-view.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as path from 'path';
+import { getNarrowModeThresholdsForUnified } from 'electron/common/narrow-mode-thresholds';
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
+import { createApplication } from 'tests/electron/common/create-application';
+import { ResultsViewSelectors } from 'tests/electron/common/element-identifiers/results-view-selectors';
+import { scanForAccessibilityIssuesInAllModes } from 'tests/electron/common/scan-for-accessibility-issues';
+import { AppController } from 'tests/electron/common/view-controllers/app-controller';
+import { ResultsViewController } from 'tests/electron/common/view-controllers/results-view-controller';
+import { commonAdbConfigs, setupMockAdb } from 'tests/miscellaneous/mock-adb/setup-mock-adb';
+
+describe('TabStopsView', () => {
+    let app: AppController;
+    let resultsViewController: ResultsViewController;
+    const windowWidth = getNarrowModeThresholdsForUnified().collapseHeaderAndNavThreshold + 5;
+    const windowHeight = 1000;
+
+    beforeEach(async () => {
+        await setupMockAdb(
+            commonAdbConfigs['single-device'],
+            path.basename(__filename),
+            'beforeEach',
+        );
+
+        app = await createApplication({ suppressFirstTimeDialog: true });
+        app.setFeatureFlag(UnifiedFeatureFlags.tabStops, true);
+        app.client.browserWindow.setSize(windowWidth, windowHeight);
+        resultsViewController = await app.openResultsView();
+        await resultsViewController.clickLeftNavItem('tab-stops');
+    });
+
+    afterEach(async () => {
+        if (app != null) {
+            await app.stop();
+        }
+    });
+
+    it('should use the expected window title', async () => {
+        await app.waitForTitle('Accessibility Insights for Android - Tab stops');
+    });
+
+    it('should pass accessibility validation in all contrast modes', async () => {
+        await scanForAccessibilityIssuesInAllModes(app);
+    });
+
+    it('export report button does not exist', async () => {
+        await resultsViewController.waitForSelectorToDisappear(
+            ResultsViewSelectors.exportReportButton,
+        );
+    });
+});


### PR DESCRIPTION
#### Details
This PR adds an initial E2E test for AI-Android's Tab Stops. Since Tab Stops' functionality is not yet implemented, this just runs some basic validation on the Tab Stops view.

##### Motivation
Adds E2E coverage for Tab Stops.

##### Context
Future PRs will enhance this test to validate more Tab Stops functionality.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
