### PR TITLE
chore: Add mac instructions to install Xcode

### DIFF
--- a/docs/building-web.md
+++ b/docs/building-web.md
@@ -16,7 +16,12 @@ You will need the following tools installed:
 -   [Node](https://nodejs.org) >= 14.15.0 (check by running `node --version`) - This is the version being enforced on our builds
 -   [Yarn](https://yarnpkg.com/getting-started/install) >= 1.22.10 (check by running `yarn --version`)
     -    Note: There is a [known name collision](https://github.com/yarnpkg/yarn/issues/673) between Yarn package manager and Hadoop YARN. If you have Hadoop YARN installed, replace `yarn` with `yarnpkg` in the commands below.
-
+-   **macOS only** [Xcode](https://wilsonmar.github.io/xcode/#XcodeInstall). This is needed when installing some dev dependencies (like spectron). After installing Xcode, run the following commands from a command terminal:
+```
+    xcode-select --install
+    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+    sudo xcodebuild -license accept
+```
 
 We recommend [VS Code](https://code.visualstudio.com/) for [editing/debugging](#using-vs-code), but you can use whichever editor you prefer. The [extensions we recommend](../.vscode/extensions.json) should be automatically suggested to you when opening this repository's folder in VS Code.
 


### PR DESCRIPTION
#### Details

`yarn install` is failing on my Mac because Spectron assumes that Xcode is present on the system. This isn't currently documented.

##### Motivation

Make it easier to get a new machine to a usable state.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
