### PR TITLE
feat(save-and-load-assessment): update persistedTabInfo to tabStoreData

### DIFF
--- a/src/DetailsView/components/save-assessment-factory.tsx
+++ b/src/DetailsView/components/save-assessment-factory.tsx
@@ -3,6 +3,7 @@
 import { AssessmentDataFormatter } from 'common/assessment-data-formatter';
 import { FileNameBuilder } from 'common/filename-builder';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { SaveAssessmentButton } from 'DetailsView/components/save-assessment-button';
 import * as React from 'react';
 import { FileURLProvider } from '../../common/file-url-provider';
@@ -17,6 +18,7 @@ export type SaveAssessmentFactoryDeps = {
 export type SaveAssessmentFactoryProps = {
     deps: SaveAssessmentFactoryDeps;
     assessmentStoreData: AssessmentStoreData;
+    tabStoreData: TabStoreData;
 };
 
 export function getSaveButtonForAssessment(props: SaveAssessmentFactoryProps): JSX.Element {
@@ -26,7 +28,7 @@ export function getSaveButtonForAssessment(props: SaveAssessmentFactoryProps): J
 
     const currentDate = props.deps.getCurrentDate();
     const fileDate = props.deps.fileNameBuilder.getDateSegment(currentDate);
-    const targetPageTitle = props.assessmentStoreData.persistedTabInfo.title;
+    const targetPageTitle = props.tabStoreData.title;
     const fileTitle = props.deps.fileNameBuilder.getTitleSegment(targetPageTitle);
     const fileName = `SavedAssessment_${fileDate}_${fileTitle}.a11ywebassessment`;
     const fileURL = props.deps.fileURLProvider.provideURL([assessmentData], 'application/json');

--- a/src/tests/unit/tests/DetailsView/components/save-assessment-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/save-assessment-factory.test.tsx
@@ -7,6 +7,7 @@ import {
     AssessmentStoreData,
     AssessmentData,
 } from 'common/types/store-data/assessment-result-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import {
     getSaveButtonForAssessment,
     getSaveButtonForFastPass,
@@ -48,6 +49,10 @@ describe('SaveAssessmentFactory', () => {
             persistedTabInfo: { title: 'SavedAssessment123' },
         } as AssessmentStoreData;
 
+        const tabStoreData = {
+            title: 'title',
+        } as TabStoreData;
+
         deps = {
             assessmentDataFormatter: assessmentDataFormatterMock.object,
             fileURLProvider: fileURLProviderMock.object,
@@ -57,6 +62,7 @@ describe('SaveAssessmentFactory', () => {
         props = {
             deps,
             assessmentStoreData,
+            tabStoreData,
         } as SaveAssessmentFactoryProps;
     });
 
@@ -64,7 +70,7 @@ describe('SaveAssessmentFactory', () => {
         test('renders save assessment button', () => {
             const assessmentData = props.assessmentStoreData;
             const formattedAssessmentData = JSON.stringify(assessmentData);
-            const title = props.assessmentStoreData.persistedTabInfo.title;
+            const title = props.tabStoreData.title;
 
             assessmentDataFormatterMock
                 .setup(a => a.formatAssessmentData(assessmentData))


### PR DESCRIPTION
#### Details

This PR addresses a bug and updates the save assessment functionality from using `persistedTabInfo` to `tabStoreData` to get the assessment title. 

##### Motivation

When running AI for the first time, `persistedTabInfo` is null and currently breaks the extension. 

##### Context

Using `scanMetadata` is also an alternative. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #653
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
