### PR TITLE
feat(focus-mvp-client): Add telemetry to DeviceFocusController

### DIFF
--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -227,6 +227,10 @@ export type ScanIncompleteWarningsTelemetryData = {
     scanIncompleteWarnings: ScanIncompleteWarningId[];
 };
 
+export type DeviceFocusKeyEventTelemetryData = {
+    keyEventCode: number;
+};
+
 export type TelemetryData =
     | BaseTelemetryData
     | ToggleTelemetryData
@@ -250,5 +254,6 @@ export type TelemetryData =
     | ValidatePortTelemetryData
     | AndroidScanCompletedTelemetryData
     | AndroidScanFailedTelemetryData
+    | DeviceFocusKeyEventTelemetryData
     | ScanIncompleteWarningsTelemetryData
     | SetAllUrlsPermissionTelemetryData;

--- a/src/electron/common/electron-telemetry-events.ts
+++ b/src/electron/common/electron-telemetry-events.ts
@@ -8,6 +8,10 @@ export const SCAN_STARTED: string = 'ScanStarted';
 export const SCAN_COMPLETED: string = 'ScanCompleted';
 export const SCAN_FAILED: string = 'ScanFailed';
 export const DEVICE_SETUP_STEP: string = 'DeviceSetupStep';
+export const DEVICE_FOCUS_ENABLE: string = 'DeviceFocusEnable';
+export const DEVICE_FOCUS_DISABLE: string = 'DeviceFocusDisable';
+export const DEVICE_FOCUS_RESET: string = 'DeviceFocusReset';
+export const DEVICE_FOCUS_KEYEVENT: string = 'DeviceFocusKeyEvent';
 
 export type AndroidSetupStepTelemetryData = {
     prevStep: string;

--- a/src/electron/platform/android/device-focus-controller-factory.ts
+++ b/src/electron/platform/android/device-focus-controller-factory.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { AdbWrapper, AdbWrapperFactory } from 'electron/platform/android/adb-wrapper';
 import { DeviceFocusCommandSender } from 'electron/platform/android/device-focus-command-sender';
 import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
@@ -9,6 +10,7 @@ export class DeviceFocusControllerFactory {
     constructor(
         private readonly adbWrapperFactory: AdbWrapperFactory,
         private readonly focusCommandSender: DeviceFocusCommandSender,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
     ) {}
 
     public initialize(): void {
@@ -21,6 +23,10 @@ export class DeviceFocusControllerFactory {
         const adbWrapper: AdbWrapper = await this.adbWrapperFactory.createValidatedAdbWrapper(
             adbLocation,
         );
-        return new DeviceFocusController(adbWrapper, this.focusCommandSender);
+        return new DeviceFocusController(
+            adbWrapper,
+            this.focusCommandSender,
+            this.telemetryEventHandler,
+        );
     };
 }

--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import {
+    DEVICE_FOCUS_DISABLE,
+    DEVICE_FOCUS_ENABLE,
+    DEVICE_FOCUS_KEYEVENT,
+    DEVICE_FOCUS_RESET,
+} from 'electron/common/electron-telemetry-events';
 import { AdbWrapper, KeyEventCode } from 'electron/platform/android/adb-wrapper';
 import {
     DeviceFocusCommand,
@@ -14,6 +21,7 @@ export class DeviceFocusController {
     constructor(
         private readonly adbWrapper: AdbWrapper,
         private readonly commandSender: DeviceFocusCommandSender,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
     ) {}
 
     public setDeviceId(deviceId: string) {
@@ -25,14 +33,17 @@ export class DeviceFocusController {
     }
 
     public EnableFocusTracking(): Promise<void> {
+        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ENABLE, {});
         return this.commandSender(this.port, DeviceFocusCommand.Enable);
     }
 
     public DisableFocusTracking(): Promise<void> {
+        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_DISABLE, {});
         return this.commandSender(this.port, DeviceFocusCommand.Disable);
     }
 
     public ResetFocusTracking(): Promise<void> {
+        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_RESET, {});
         return this.commandSender(this.port, DeviceFocusCommand.Reset);
     }
 
@@ -61,6 +72,11 @@ export class DeviceFocusController {
     }
 
     private SendKeyEvent(keyEventCode: KeyEventCode): Promise<void> {
+        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_KEYEVENT, {
+            telemetry: {
+                keyEventCode,
+            },
+        });
         return this.adbWrapper.sendKeyEvent(this.deviceId, keyEventCode);
     }
 }

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -416,6 +416,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         const deviceFocusControllerFactory = new DeviceFocusControllerFactory(
             appiumAdbWrapperFactory,
             createDeviceFocusCommandSender(axios.get),
+            telemetryEventHandler,
         );
 
         // Placeholder--remove once we include deviceFocusControllerFactory in the deps

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller-factory.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller-factory.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { AdbWrapper, AdbWrapperFactory } from 'electron/platform/android/adb-wrapper';
 import { DeviceFocusCommandSender } from 'electron/platform/android/device-focus-command-sender';
 import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
@@ -9,6 +10,7 @@ import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('DeviceFocusControllerFactory tests', () => {
     let adbWrapperFactoryMock: IMock<AdbWrapperFactory>;
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let testSubject: DeviceFocusControllerFactory;
 
     const focusCommandSenderMock: IMock<DeviceFocusCommandSender> = Mock.ofType<DeviceFocusCommandSender>(
@@ -18,9 +20,14 @@ describe('DeviceFocusControllerFactory tests', () => {
 
     beforeEach(() => {
         adbWrapperFactoryMock = Mock.ofType<AdbWrapperFactory>(undefined, MockBehavior.Strict);
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>(
+            undefined,
+            MockBehavior.Strict,
+        );
         testSubject = new DeviceFocusControllerFactory(
             adbWrapperFactoryMock.object,
             focusCommandSenderMock.object,
+            telemetryEventHandlerMock.object,
         );
     });
 

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import {
+    DEVICE_FOCUS_DISABLE,
+    DEVICE_FOCUS_ENABLE,
+    DEVICE_FOCUS_KEYEVENT,
+    DEVICE_FOCUS_RESET,
+} from 'electron/common/electron-telemetry-events';
 import { AdbWrapper, KeyEventCode } from 'electron/platform/android/adb-wrapper';
 import {
     DeviceFocusCommand,
@@ -15,103 +22,148 @@ describe('DeviceFocusController tests', () => {
 
     let adbWrapperMock: IMock<AdbWrapper>;
     let commandSenderMock: IMock<DeviceFocusCommandSender>;
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let testSubject: DeviceFocusController;
 
     beforeEach(() => {
         adbWrapperMock = Mock.ofType<AdbWrapper>(undefined, MockBehavior.Strict);
         commandSenderMock = Mock.ofType<DeviceFocusCommandSender>(undefined, MockBehavior.Strict);
-        testSubject = new DeviceFocusController(adbWrapperMock.object, commandSenderMock.object);
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        testSubject = new DeviceFocusController(
+            adbWrapperMock.object,
+            commandSenderMock.object,
+            telemetryEventHandlerMock.object,
+        );
         testSubject.setDeviceId(deviceId);
         testSubject.setPort(port);
     });
 
-    it('EnableFocusTracking sends correct command', async () => {
+    it('EnableFocusTracking sends correct command and telemetry', async () => {
         commandSenderMock
             .setup(getter => getter(port, DeviceFocusCommand.Enable))
+            .verifiable(Times.once());
+        telemetryEventHandlerMock
+            .setup(m => m.publishTelemetry(DEVICE_FOCUS_ENABLE, {}))
             .verifiable(Times.once());
 
         await testSubject.EnableFocusTracking();
 
         commandSenderMock.verifyAll();
+        telemetryEventHandlerMock.verifyAll();
     });
 
-    it('DisableFocusTracking sends correct command', async () => {
+    it('DisableFocusTracking sends correct command and telemetry', async () => {
         commandSenderMock
             .setup(getter => getter(port, DeviceFocusCommand.Disable))
+            .verifiable(Times.once());
+        telemetryEventHandlerMock
+            .setup(m => m.publishTelemetry(DEVICE_FOCUS_DISABLE, {}))
             .verifiable(Times.once());
 
         await testSubject.DisableFocusTracking();
 
         commandSenderMock.verifyAll();
+        telemetryEventHandlerMock.verifyAll();
     });
 
-    it('ResetFocusTracking sends correct command', async () => {
+    it('ResetFocusTracking sends correct command and telemetry', async () => {
         commandSenderMock
             .setup(getter => getter(port, DeviceFocusCommand.Reset))
+            .verifiable(Times.once());
+        telemetryEventHandlerMock
+            .setup(m => m.publishTelemetry(DEVICE_FOCUS_RESET, {}))
             .verifiable(Times.once());
 
         await testSubject.ResetFocusTracking();
 
         commandSenderMock.verifyAll();
+        telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendUpKey sends correct command', async () => {
+    it('SendUpKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Up))
             .verifiable(Times.once());
+        setTelemetryMockForKeyEvent(KeyEventCode.Up);
 
         await testSubject.SendUpKey();
 
         adbWrapperMock.verifyAll();
+        telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendDownKey sends correct command', async () => {
+    it('SendDownKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Down))
             .verifiable(Times.once());
+        setTelemetryMockForKeyEvent(KeyEventCode.Down);
 
         await testSubject.SendDownKey();
 
         adbWrapperMock.verifyAll();
+        telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendLeftKey sends correct command', async () => {
+    it('SendLeftKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Left))
             .verifiable(Times.once());
+        setTelemetryMockForKeyEvent(KeyEventCode.Left);
 
         await testSubject.SendLeftKey();
 
         adbWrapperMock.verifyAll();
+        telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendRightKey sends correct command', async () => {
+    it('SendRightKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Right))
             .verifiable(Times.once());
+        setTelemetryMockForKeyEvent(KeyEventCode.Right);
 
         await testSubject.SendRightKey();
 
         adbWrapperMock.verifyAll();
+        telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendEnterKey sends correct command', async () => {
+    it('SendEnterKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Enter))
             .verifiable(Times.once());
+        setTelemetryMockForKeyEvent(KeyEventCode.Enter);
 
         await testSubject.SendEnterKey();
 
         adbWrapperMock.verifyAll();
+        telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendTabKey sends correct command', async () => {
+    it('SendTabKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Tab))
             .verifiable(Times.once());
+        setTelemetryMockForKeyEvent(KeyEventCode.Tab);
 
         await testSubject.SendTabKey();
 
         adbWrapperMock.verifyAll();
+        telemetryEventHandlerMock.verifyAll();
     });
+
+    function setTelemetryMockForKeyEvent(keyEventCode: KeyEventCode): void {
+        telemetryEventHandlerMock
+            .setup(m =>
+                m.publishTelemetry(DEVICE_FOCUS_KEYEVENT, {
+                    telemetry: {
+                        keyEventCode,
+                    },
+                }),
+            )
+            .verifiable(Times.once());
+    }
 });


### PR DESCRIPTION
#### Details

This adds telemetry to the DeviceFocusController, per the requirements in the spec

##### Motivation

Spec requirement

##### Context

I had to add the Android-specific telemetry payload (the KeyEventCode value) in a file called extension-telemetry-events. That seems odd since there's also a file called electron-telemetry-events, but I noticed that we have other Android-specific stuff in that file, so I didn't try to fix it in this PR. 

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
