### PR TITLE
feat(focus-mvp-client): Add mock adb + android service command logging for future E2E tests

### DIFF
--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as fs from 'fs';
-import * as path from 'path';
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { Application } from 'spectron';
 import { AndroidSetupViewController } from 'tests/electron/common/view-controllers/android-setup-view-controller';
@@ -125,38 +123,6 @@ export class AppController {
                 timeout: DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS,
                 timeoutMsg: `was expecting window.${propertyName} to be defined`,
             },
-        );
-    }
-
-    public getServerLog(logName: string, extraLogNames: string): string {
-        return fs
-            .readFileSync(
-                path.normalize(
-                    `drop/mock-adb/logs/${logName}/${extraLogNames}/testLogs/server.log`,
-                ),
-            )
-            .toString();
-    }
-
-    public getAdbLog(logName: string, extraLogNames: string): string {
-        return fs
-            .readFileSync(
-                path.normalize(`drop/mock-adb/logs/${logName}/${extraLogNames}/testLogs/adb.log`),
-            )
-            .toString();
-    }
-
-    public resetServerLog(logName: string, extraLogNames: string): void {
-        fs.rmdirSync(
-            path.normalize(`drop/mock-adb/logs/${logName}/${extraLogNames}/testLogs/server.log`),
-            { recursive: true },
-        );
-    }
-
-    public resetAdbLog(logName: string, extraLogNames: string): void {
-        fs.rmdirSync(
-            path.normalize(`drop/mock-adb/logs/${logName}/${extraLogNames}/testLogs/adb.log`),
-            { recursive: true },
         );
     }
 }

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -145,4 +145,18 @@ export class AppController {
             )
             .toString();
     }
+
+    public resetServerLog(logName: string, extraLogNames: string): void {
+        fs.rmdirSync(
+            path.normalize(`drop/mock-adb/logs/${logName}/${extraLogNames}/testLogs/server.log`),
+            { recursive: true },
+        );
+    }
+
+    public resetAdbLog(logName: string, extraLogNames: string): void {
+        fs.rmdirSync(
+            path.normalize(`drop/mock-adb/logs/${logName}/${extraLogNames}/testLogs/adb.log`),
+            { recursive: true },
+        );
+    }
 }

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as fs from 'fs';
+import * as path from 'path';
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { Application } from 'spectron';
 import { AndroidSetupViewController } from 'tests/electron/common/view-controllers/android-setup-view-controller';
@@ -124,5 +126,23 @@ export class AppController {
                 timeoutMsg: `was expecting window.${propertyName} to be defined`,
             },
         );
+    }
+
+    public getServerLog(logName: string, extraLogNames: string): string {
+        return fs
+            .readFileSync(
+                path.normalize(
+                    `drop/mock-adb/logs/${logName}/${extraLogNames}/testLogs/server.log`,
+                ),
+            )
+            .toString();
+    }
+
+    public getAdbLog(logName: string, extraLogNames: string): string {
+        return fs
+            .readFileSync(
+                path.normalize(`drop/mock-adb/logs/${logName}/${extraLogNames}/testLogs/adb.log`),
+            )
+            .toString();
     }
 }

--- a/src/tests/electron/common/view-controllers/log-controller.ts
+++ b/src/tests/electron/common/view-controllers/log-controller.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as fs from 'fs';
+import {
+    generateAdbLogPath,
+    generateOutputLogsDir,
+    generateServerLogPath,
+} from '../../../miscellaneous/mock-adb/generate-log-paths';
+
+export class LogController {
+    constructor(private mockAdbPath: string) {}
+
+    private getOutputLogsDir(currentContext: string): string {
+        return generateOutputLogsDir(this.mockAdbPath, currentContext);
+    }
+
+    public getServerLog(currentContext: string): string {
+        return fs
+            .readFileSync(generateServerLogPath(this.getOutputLogsDir(currentContext)))
+            .toString();
+    }
+
+    public getAdbLog(currentContext: string): string {
+        return fs
+            .readFileSync(generateAdbLogPath(this.getOutputLogsDir(currentContext)))
+            .toString();
+    }
+
+    public resetAdbLog(currentContext: string): void {
+        fs.unlinkSync(generateAdbLogPath(this.getOutputLogsDir(currentContext)));
+    }
+
+    public resetServerLog(currentContext: string): void {
+        fs.unlinkSync(generateServerLogPath(this.getOutputLogsDir(currentContext)));
+    }
+}

--- a/src/tests/miscellaneous/mock-adb/app/bin.js
+++ b/src/tests/miscellaneous/mock-adb/app/bin.js
@@ -58,6 +58,10 @@ async function main() {
     const outputLogsDir = path.join(path.dirname(process.execPath), 'logs', currentContext);
     fs.mkdirSync(outputLogsDir, { recursive: true });
 
+    const testLogsDir = path.join(outputLogsDir, 'testLogs');
+    fs.rmdirSync(testLogsDir);
+    fs.mkdirSync(testLogsDir);
+
     const outputFile = path.join(outputLogsDir, 'mock_adb_output.json');
 
     let ignoredPrefixArgs = 2; // node.exe bin.js
@@ -77,7 +81,7 @@ async function main() {
     if (result.startTestServer != null) {
         const { port, path } = result.startTestServer;
         stopDetachedPortForwardServer(port);
-        result.testServerPid = await startDetachedPortForwardServer(port, path);
+        result.testServerPid = await startDetachedPortForwardServer(port, path, testLogsDir);
     }
     if (result.stopTestServer != null) {
         const { port } = result.stopTestServer;
@@ -92,6 +96,10 @@ async function main() {
 
     result.input = process.argv;
     result.inputCommand = inputCommand;
+
+    fs.writeFileSync(path.join(testLogsDir, 'adb.log'), `ADB ${inputCommand}\n`, {
+        flag: 'a',
+    });
     fs.writeFileSync(outputFile, JSON.stringify(result, null, '    ') + EOL, { flag: 'a' });
 
     const outputConfigFile = path.join(outputLogsDir, fileWithMockAdbConfig);

--- a/src/tests/miscellaneous/mock-adb/app/bin.js
+++ b/src/tests/miscellaneous/mock-adb/app/bin.js
@@ -59,8 +59,7 @@ async function main() {
     fs.mkdirSync(outputLogsDir, { recursive: true });
 
     const testLogsDir = path.join(outputLogsDir, 'testLogs');
-    fs.rmdirSync(testLogsDir, { recursive: true });
-    fs.mkdirSync(testLogsDir);
+    fs.mkdirSync(testLogsDir, { recursive: true });
 
     const outputFile = path.join(outputLogsDir, 'mock_adb_output.json');
 

--- a/src/tests/miscellaneous/mock-adb/app/bin.js
+++ b/src/tests/miscellaneous/mock-adb/app/bin.js
@@ -59,7 +59,7 @@ async function main() {
     fs.mkdirSync(outputLogsDir, { recursive: true });
 
     const testLogsDir = path.join(outputLogsDir, 'testLogs');
-    fs.rmdirSync(testLogsDir);
+    fs.rmdirSync(testLogsDir, { recursive: true });
     fs.mkdirSync(testLogsDir);
 
     const outputFile = path.join(outputLogsDir, 'mock_adb_output.json');

--- a/src/tests/miscellaneous/mock-adb/app/port-forward-server.js
+++ b/src/tests/miscellaneous/mock-adb/app/port-forward-server.js
@@ -26,8 +26,9 @@ async function tryHandleAsPortForwardServer(argv) {
 
     const port = parseInt(process.argv[3], 10);
     const path = process.argv[4];
+    const testLogsDir = process.argv[5];
 
-    await startMockService(port, path);
+    await startMockService(port, path, testLogsDir);
 
     process.send(portForwardProcessReadyMessage);
     return true;
@@ -57,10 +58,10 @@ async function waitForReadyMessage(testServerProcess) {
     });
 }
 
-async function startDetachedPortForwardServer(port, path) {
+async function startDetachedPortForwardServer(port, path, testLogsDir) {
     const testServerProcess = child_process.fork(
         process.argv[1],
-        [portForwardSentinelArgument, port, path],
+        [portForwardSentinelArgument, port, path, testLogsDir],
         {
             detached: true, // avoid having test server exit when adb exits
             stdio: LOG_DETACHED_PROCESS

--- a/src/tests/miscellaneous/mock-adb/generate-log-paths.d.ts
+++ b/src/tests/miscellaneous/mock-adb/generate-log-paths.d.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export function generateAdbLogPath(outputLogsDir: string): string;
+export function generateOutputLogsDir(rootDir: string, currentContext: string): string;
+export function generateServerLogPath(outputLogsDir: string): string;

--- a/src/tests/miscellaneous/mock-adb/generate-log-paths.js
+++ b/src/tests/miscellaneous/mock-adb/generate-log-paths.js
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const path = require('path');
+
+function generateOutputLogsDir(rootDir, currentContext) {
+    return path.join(rootDir, 'logs', currentContext);
+}
+
+function generateAdbLogPath(outputLogsDir) {
+    return path.join(outputLogsDir, 'adb.log');
+}
+
+function generateServerLogPath(outputLogsDir) {
+    return path.join(outputLogsDir, 'server.log');
+}
+
+module.exports = {
+    generateAdbLogPath,
+    generateOutputLogsDir,
+    generateServerLogPath,
+};

--- a/src/tests/miscellaneous/mock-service-for-android/mock-service.js
+++ b/src/tests/miscellaneous/mock-service-for-android/mock-service.js
@@ -7,15 +7,18 @@ const express = require('express');
 function startMockService(port, filesPath, testLogsDir) {
     return new Promise(resolve => {
         const options = { extensions: 'json' };
-        const testLogsPath = path.join(testLogsDir, 'server.log');
         const app = express();
 
-        app.use(function (req, res, next) {
-            fs.writeFileSync(testLogsPath, `${req.method} ${req.url}\n`, {
-                flag: 'a',
+        if (testLogsDir) {
+            const testLogsPath = path.join(testLogsDir, 'server.log');
+            app.use(function (req, res, next) {
+                fs.writeFileSync(testLogsPath, `${req.method} ${req.url}\n`, {
+                    flag: 'a',
+                });
+                next();
             });
-            next();
-        });
+        }
+
         app.use('/AccessibilityInsights', express.static(filesPath, options));
 
         app.listen(parseInt(port, 10), 'localhost', () => {

--- a/src/tests/miscellaneous/mock-service-for-android/mock-service.js
+++ b/src/tests/miscellaneous/mock-service-for-android/mock-service.js
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 const fs = require('fs');
-const express = require('express');
 const path = require('path');
+const express = require('express');
 
 function startMockService(port, filesPath, testLogsDir) {
     return new Promise(resolve => {

--- a/src/tests/miscellaneous/mock-service-for-android/mock-service.js
+++ b/src/tests/miscellaneous/mock-service-for-android/mock-service.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-const express = require('express');
 const fs = require('fs');
+const express = require('express');
 const path = require('path');
 
 function startMockService(port, filesPath, testLogsDir) {

--- a/src/tests/miscellaneous/mock-service-for-android/mock-service.js
+++ b/src/tests/miscellaneous/mock-service-for-android/mock-service.js
@@ -1,18 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 const fs = require('fs');
-const path = require('path');
 const express = require('express');
 
-function startMockService(port, filesPath, testLogsDir) {
+function startMockService(port, filesPath, logPath) {
     return new Promise(resolve => {
         const options = { extensions: 'json' };
         const app = express();
 
-        if (testLogsDir) {
-            const testLogsPath = path.join(testLogsDir, 'server.log');
+        if (logPath) {
             app.use(function (req, res, next) {
-                fs.writeFileSync(testLogsPath, `${req.method} ${req.url}\n`, {
+                fs.writeFileSync(logPath, `${req.method} ${req.url}\n`, {
                     flag: 'a',
                 });
                 next();

--- a/src/tests/miscellaneous/mock-service-for-android/mock-service.js
+++ b/src/tests/miscellaneous/mock-service-for-android/mock-service.js
@@ -1,13 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
 
-function startMockService(port, path) {
+function startMockService(port, filesPath, testLogsDir) {
     return new Promise(resolve => {
         const options = { extensions: 'json' };
-
+        const testLogsPath = path.join(testLogsDir, 'server.log');
         const app = express();
-        app.use('/AccessibilityInsights', express.static(path, options));
+
+        app.use(function (req, res, next) {
+            fs.writeFileSync(testLogsPath, `${req.method} ${req.url}\n`, {
+                flag: 'a',
+            });
+            next();
+        });
+        app.use('/AccessibilityInsights', express.static(filesPath, options));
 
         app.listen(parseInt(port, 10), 'localhost', () => {
             console.log(`Running mock Accessibility Insights Service for Android on port ${port}`);


### PR DESCRIPTION
#### Details
This PR updates mock adb and the mock service for Android to log their received commands. These logs can then be referenced in E2E tests to confirm that the proper adb and service commands occurred. This PR has no other impact on current E2E tests and does not impact preexisting logging behavior.

##### Motivation
Currently, our E2E tests implicitly validate that adb and service commands occurred because the UI updates based on the results of the commands. The new Tab stops UI will allow users to send adb and service commands without displaying UI feedback for those commands. This creates a new testing requirement--we need to explicitly validate that the proper commands were sent.

##### Context
This PR does not add or modify any E2E tests. Instead, it adds the backing infrastructure to support future E2E tests. New tests will be able to validate mock adb and service commands in the following manner:
```ts
it('does service for Android stuff', async () => {
    // start with an empty log
    logController.resetServerLog(logsContext);

    // do some test stuff related to the mock server

    // verify that mock server's log is as expected
    const serverLog = logController.getServerLog(logsContext);
    expect(serverLog).toMatchSnapshot();
});

it('does adb stuff', async () => {
    // start with an empty log
    logController.resetAdbLog(logsContext);

    // do some test stuff related to mock adb

    // verify that mock ADB's log is as expected
    const adbLog = logController.getAdbLog(logsContext);
    expect(adbLog).toMatchSnapshot();
});
```

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
