### PR TITLE
feat(focus-mvp-client): wire up virtual keyboard view

### DIFF
--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -32,51 +32,51 @@ export class DeviceFocusController {
         this.port = port;
     }
 
-    public EnableFocusTracking(): Promise<void> {
+    public EnableFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ENABLE, {});
         return this.commandSender(this.port, DeviceFocusCommand.Enable);
-    }
+    };
 
-    public DisableFocusTracking(): Promise<void> {
+    public DisableFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_DISABLE, {});
         return this.commandSender(this.port, DeviceFocusCommand.Disable);
-    }
+    };
 
-    public ResetFocusTracking(): Promise<void> {
+    public ResetFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_RESET, {});
         return this.commandSender(this.port, DeviceFocusCommand.Reset);
-    }
+    };
 
-    public SendUpKey(): Promise<void> {
+    public SendUpKey = () => {
         return this.SendKeyEvent(KeyEventCode.Up);
-    }
+    };
 
-    public SendDownKey(): Promise<void> {
+    public SendDownKey = () => {
         return this.SendKeyEvent(KeyEventCode.Down);
-    }
+    };
 
-    public SendLeftKey(): Promise<void> {
+    public SendLeftKey = () => {
         return this.SendKeyEvent(KeyEventCode.Left);
-    }
+    };
 
-    public SendRightKey(): Promise<void> {
+    public SendRightKey = () => {
         return this.SendKeyEvent(KeyEventCode.Right);
-    }
+    };
 
-    public SendEnterKey(): Promise<void> {
+    public SendEnterKey = () => {
         return this.SendKeyEvent(KeyEventCode.Enter);
-    }
+    };
 
-    public SendTabKey(): Promise<void> {
+    public SendTabKey = () => {
         return this.SendKeyEvent(KeyEventCode.Tab);
-    }
+    };
 
-    private SendKeyEvent(keyEventCode: KeyEventCode): Promise<void> {
+    private SendKeyEvent = (keyEventCode: KeyEventCode) => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_KEYEVENT, {
             telemetry: {
                 keyEventCode,
             },
         });
         return this.adbWrapper.sendKeyEvent(this.deviceId, keyEventCode);
-    }
+    };
 }

--- a/src/electron/platform/android/test-configs/tab-stops/test-config.tsx
+++ b/src/electron/platform/android/test-configs/tab-stops/test-config.tsx
@@ -3,7 +3,7 @@
 import { NeedsReviewInstancesSection } from 'common/components/cards/needs-review-instances-section';
 import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import { TestConfig } from 'electron/types/test-config';
-import { ScreenshotView } from 'electron/views/screenshot/screenshot-view';
+import { VirtualKeyboardView } from 'electron/views/virtual-keyboard/virtual-keyboard-view';
 import * as React from 'react';
 
 export const tabStopsTestConfig: TestConfig = {
@@ -65,7 +65,7 @@ export const tabStopsTestConfig: TestConfig = {
         instancesSectionComponent: NeedsReviewInstancesSection,
         resultsFilter: _ => false,
         allowsExportReport: false,
-        visualHelperSection: ScreenshotView,
+        visualHelperSection: VirtualKeyboardView,
     },
     featureFlag: UnifiedFeatureFlags.tabStops,
 };

--- a/src/electron/types/visual-helper-section.ts
+++ b/src/electron/types/visual-helper-section.ts
@@ -3,8 +3,16 @@
 
 import { ReactFCWithDisplayName } from 'common/react/named-fc';
 import { ScreenshotViewProps } from 'electron/views/screenshot/screenshot-view';
-import { VirtualKeyboardViewProps } from 'electron/views/virtual-keyboard/virtual-keyboard-view';
+import {
+    VirtualKeyboardViewProps,
+    VirtualKeyboardViewDeps,
+} from 'electron/views/virtual-keyboard/virtual-keyboard-view';
 
-export type VisualHelperSectionProps = ScreenshotViewProps & VirtualKeyboardViewProps;
+export type VisualHelperSectionProps = ScreenshotViewProps &
+    VirtualKeyboardViewProps & {
+        deps: VirtualKeyboardViewDeps;
+    };
+
+export type VisualHelperSectionDeps = VirtualKeyboardViewDeps;
 
 export type VisualHelperSection = ReactFCWithDisplayName<VisualHelperSectionProps>;

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -26,7 +26,10 @@ import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { ContentPageInfo } from 'electron/types/content-page-info';
-import { VisualHelperSectionProps } from 'electron/types/visual-helper-section';
+import {
+    VisualHelperSectionDeps,
+    VisualHelperSectionProps,
+} from 'electron/types/visual-helper-section';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
 import { ContentPanelDeps } from 'electron/views/left-nav/content-panel-deps';
 import { FluentLeftNav } from 'electron/views/left-nav/fluent-left-nav';
@@ -48,6 +51,7 @@ export type ResultsViewDeps = ReflowCommandBarDeps &
     LeftNavDeps &
     ContentPanelDeps &
     TestViewDeps &
+    VisualHelperSectionDeps &
     SettingsPanelDeps & {
         scanActionCreator: ScanActionCreator;
         leftNavActionCreator: LeftNavActionCreator;
@@ -116,8 +120,10 @@ export class ResultsView extends React.Component<ResultsViewProps> {
         );
 
         const visualHelperSectionProps: VisualHelperSectionProps = {
+            deps: deps,
             viewModel: screenshotViewModel,
             narrowModeStatus: this.props.narrowModeStatus,
+            deviceId: this.props.androidSetupStoreData.selectedDevice.id,
         };
 
         const VisualHelperSectionComponent = contentPageInfo.visualHelperSection;

--- a/src/electron/views/virtual-keyboard/virtual-keyboard-buttons.scss
+++ b/src/electron/views/virtual-keyboard/virtual-keyboard-buttons.scss
@@ -58,17 +58,17 @@
                 margin-right: 0px;
             }
         }
+    }
 
-        .left {
-            transform: rotate(270deg);
-        }
+    .left {
+        transform: rotate(270deg);
+    }
 
-        .down {
-            transform: rotate(180deg);
-        }
+    .down {
+        transform: rotate(180deg);
+    }
 
-        .right {
-            transform: rotate(90deg);
-        }
+    .right {
+        transform: rotate(90deg);
     }
 }

--- a/src/electron/views/virtual-keyboard/virtual-keyboard-buttons.tsx
+++ b/src/electron/views/virtual-keyboard/virtual-keyboard-buttons.tsx
@@ -25,7 +25,7 @@ export const VirtualKeyboardButtons = NamedFC<VirtualKeyboardButtonsProps>(
     props => {
         const getArrowButton = (text: string, onClick: () => void, className?: string) => {
             return (
-                <Button className={styles.button} primary>
+                <Button onClick={onClick} className={styles.button} primary>
                     <span className={styles.innerButtonContainer}>
                         <Icon iconName="upArrow" className={className} />
                         {text}

--- a/src/electron/views/virtual-keyboard/virtual-keyboard-view.tsx
+++ b/src/electron/views/virtual-keyboard/virtual-keyboard-view.tsx
@@ -4,11 +4,19 @@
 import { NamedFC } from 'common/react/named-fc';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import * as commonStyles from 'electron/views/screenshot/common-visual-helper-section-styles.scss';
-import { VirtualKeyboardButtons } from 'electron/views/virtual-keyboard/virtual-keyboard-buttons';
+import {
+    VirtualKeyboardButtons,
+    VirtualKeyboardButtonsDeps,
+} from 'electron/views/virtual-keyboard/virtual-keyboard-buttons';
 import { css } from 'office-ui-fabric-react';
 import * as React from 'react';
 
-export type VirtualKeyboardViewProps = { narrowModeStatus: NarrowModeStatus };
+export type VirtualKeyboardViewDeps = VirtualKeyboardButtonsDeps;
+export type VirtualKeyboardViewProps = {
+    deps: VirtualKeyboardViewDeps;
+    narrowModeStatus: NarrowModeStatus;
+    deviceId: string;
+};
 
 export const VirtualKeyboardView = NamedFC<VirtualKeyboardViewProps>(
     'VirtualKeyboardView',

--- a/src/tests/unit/tests/electron/views/results/__snapshots__/results-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/results/__snapshots__/results-view.test.tsx.snap
@@ -368,6 +368,7 @@ exports[`ResultsView when status scan <Completed> 1`] = `
             },
           }
         }
+        scanPort={11111}
         scanStoreData={
           Object {
             "status": 2,
@@ -480,6 +481,55 @@ exports[`ResultsView when status scan <Completed> 1`] = `
           </main>
         </div>
         <ScreenshotView
+          deps={
+            Object {
+              "contentPagesInfo": Object {
+                "automated-checks": Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "resultsFilter": [Function],
+                  "title": "test-automated-checks-title",
+                  "visualHelperSection": [Function],
+                },
+                "needs-review": Object {
+                  "description": <React.Fragment>
+                    test 
+                    needs-review
+                     description
+                  </React.Fragment>,
+                  "resultsFilter": [Function],
+                  "title": "test-needs-review-title",
+                  "visualHelperSection": [Function],
+                },
+              },
+              "getCardSelectionViewData": [Function],
+              "getCardsViewData": [Function],
+              "getDateFromTimestamp": [Function],
+              "isResultHighlightUnavailable": [Function],
+              "leftNavActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "cardSelectionActions": undefined,
+                "itemSelected": [Function],
+                "leftNavActions": undefined,
+                "setLeftNavVisible": [Function],
+              },
+              "scanActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "deviceActions": undefined,
+                "scanActions": undefined,
+              },
+              "screenshotViewModelProvider": [Function],
+              "toolData": Object {
+                "applicationProperties": Object {
+                  "name": "some app",
+                },
+              },
+            }
+          }
+          deviceId="some-id"
           viewModel={
             Object {
               "screenshotData": Object {
@@ -740,6 +790,7 @@ exports[`ResultsView when status scan <Failed> 1`] = `
         }
         isSideNavOpen={true}
         scanMetadata={null}
+        scanPort={11111}
         scanStoreData={
           Object {
             "status": 3,
@@ -837,6 +888,55 @@ exports[`ResultsView when status scan <Failed> 1`] = `
           </main>
         </div>
         <ScreenshotView
+          deps={
+            Object {
+              "contentPagesInfo": Object {
+                "automated-checks": Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "resultsFilter": [Function],
+                  "title": "test-automated-checks-title",
+                  "visualHelperSection": [Function],
+                },
+                "needs-review": Object {
+                  "description": <React.Fragment>
+                    test 
+                    needs-review
+                     description
+                  </React.Fragment>,
+                  "resultsFilter": [Function],
+                  "title": "test-needs-review-title",
+                  "visualHelperSection": [Function],
+                },
+              },
+              "getCardSelectionViewData": [Function],
+              "getCardsViewData": [Function],
+              "getDateFromTimestamp": [Function],
+              "isResultHighlightUnavailable": [Function],
+              "leftNavActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "cardSelectionActions": undefined,
+                "itemSelected": [Function],
+                "leftNavActions": undefined,
+                "setLeftNavVisible": [Function],
+              },
+              "scanActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "deviceActions": undefined,
+                "scanActions": undefined,
+              },
+              "screenshotViewModelProvider": [Function],
+              "toolData": Object {
+                "applicationProperties": Object {
+                  "name": "some app",
+                },
+              },
+            }
+          }
+          deviceId="some-id"
           viewModel={
             Object {
               "screenshotData": Object {
@@ -1101,6 +1201,7 @@ exports[`ResultsView when status scan <Scanning> 1`] = `
         }
         isSideNavOpen={true}
         scanMetadata={null}
+        scanPort={11111}
         scanStoreData={
           Object {
             "status": 1,
@@ -1198,6 +1299,55 @@ exports[`ResultsView when status scan <Scanning> 1`] = `
           </main>
         </div>
         <ScreenshotView
+          deps={
+            Object {
+              "contentPagesInfo": Object {
+                "automated-checks": Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "resultsFilter": [Function],
+                  "title": "test-automated-checks-title",
+                  "visualHelperSection": [Function],
+                },
+                "needs-review": Object {
+                  "description": <React.Fragment>
+                    test 
+                    needs-review
+                     description
+                  </React.Fragment>,
+                  "resultsFilter": [Function],
+                  "title": "test-needs-review-title",
+                  "visualHelperSection": [Function],
+                },
+              },
+              "getCardSelectionViewData": [Function],
+              "getCardsViewData": [Function],
+              "getDateFromTimestamp": [Function],
+              "isResultHighlightUnavailable": [Function],
+              "leftNavActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "cardSelectionActions": undefined,
+                "itemSelected": [Function],
+                "leftNavActions": undefined,
+                "setLeftNavVisible": [Function],
+              },
+              "scanActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "deviceActions": undefined,
+                "scanActions": undefined,
+              },
+              "screenshotViewModelProvider": [Function],
+              "toolData": Object {
+                "applicationProperties": Object {
+                  "name": "some app",
+                },
+              },
+            }
+          }
+          deviceId="some-id"
           viewModel={
             Object {
               "screenshotData": Object {
@@ -1458,6 +1608,7 @@ exports[`ResultsView when status scan <undefined> 1`] = `
         }
         isSideNavOpen={true}
         scanMetadata={null}
+        scanPort={11111}
         scanStoreData={
           Object {
             "status": undefined,
@@ -1554,6 +1705,55 @@ exports[`ResultsView when status scan <undefined> 1`] = `
           </main>
         </div>
         <ScreenshotView
+          deps={
+            Object {
+              "contentPagesInfo": Object {
+                "automated-checks": Object {
+                  "description": <React.Fragment>
+                    test 
+                    automated-checks
+                     description
+                  </React.Fragment>,
+                  "resultsFilter": [Function],
+                  "title": "test-automated-checks-title",
+                  "visualHelperSection": [Function],
+                },
+                "needs-review": Object {
+                  "description": <React.Fragment>
+                    test 
+                    needs-review
+                     description
+                  </React.Fragment>,
+                  "resultsFilter": [Function],
+                  "title": "test-needs-review-title",
+                  "visualHelperSection": [Function],
+                },
+              },
+              "getCardSelectionViewData": [Function],
+              "getCardsViewData": [Function],
+              "getDateFromTimestamp": [Function],
+              "isResultHighlightUnavailable": [Function],
+              "leftNavActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "cardSelectionActions": undefined,
+                "itemSelected": [Function],
+                "leftNavActions": undefined,
+                "setLeftNavVisible": [Function],
+              },
+              "scanActionCreator": proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "deviceActions": undefined,
+                "scanActions": undefined,
+              },
+              "screenshotViewModelProvider": [Function],
+              "toolData": Object {
+                "applicationProperties": Object {
+                  "name": "some app",
+                },
+              },
+            }
+          }
+          deviceId="some-id"
           viewModel={
             Object {
               "screenshotData": Object {

--- a/src/tests/unit/tests/electron/views/results/results-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/results-view.test.tsx
@@ -47,9 +47,11 @@ describe('ResultsView', () => {
     let getCardSelectionViewDataMock = Mock.ofInstance(getCardSelectionViewData);
     let getUnifiedRuleResultsMock = Mock.ofInstance(getCardViewData);
     let getDateFromTimestampMock: IMock<(timestamp: string) => Date>;
+    let scanPort: number;
     const resultsFilter: ResultsFilter = _ => true;
 
     beforeEach(() => {
+        scanPort = 11111;
         isResultHighlightUnavailableStub = () => null;
         const cardSelectionStoreData = {} as CardSelectionStoreData;
         const resultsHighlightStatus = {
@@ -124,7 +126,12 @@ describe('ResultsView', () => {
                 getDateFromTimestamp: getDateFromTimestampMock.object,
             },
             cardSelectionStoreData,
-            androidSetupStoreData: {},
+            androidSetupStoreData: {
+                scanPort: scanPort,
+                selectedDevice: {
+                    id: 'some-id',
+                },
+            },
             scanStoreData: {},
             userConfigurationStoreData: {
                 isFirstTime: false,
@@ -189,15 +196,12 @@ describe('ResultsView', () => {
         const wrapped = shallow(<ResultsView {...props} />);
 
         expect(wrapped.getElement()).toMatchSnapshot();
-
         getCardSelectionViewDataMock.verifyAll();
         getUnifiedRuleResultsMock.verifyAll();
         screenshotViewModelProviderMock.verifyAll();
     });
 
     it('triggers scan when first mounted', () => {
-        const scanPort = 11111;
-
         const scanActionCreatorMock = Mock.ofType(ScanActionCreator);
         scanActionCreatorMock.setup(creator => creator.scan(scanPort)).verifiable(Times.once());
         props.deps.scanActionCreator = scanActionCreatorMock.object;
@@ -233,8 +237,6 @@ describe('ResultsView', () => {
 
     describe('DeviceDisconnectedPopup event handlers', () => {
         it('onRescanDevice', () => {
-            const scanPort = 11111;
-
             const scanActionCreatorMock = Mock.ofType(ScanActionCreator);
             props.deps.scanActionCreator = scanActionCreatorMock.object;
             props.scanStoreData.status = ScanStatus.Failed;

--- a/src/tests/unit/tests/electron/views/virtual-keyboard/__snapshots__/virtual-keyboard-buttons.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/virtual-keyboard/__snapshots__/virtual-keyboard-buttons.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
 >
   <Button
     className="button"
+    onClick={[Function]}
     primary={true}
   >
     <span
@@ -71,6 +72,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
   </Button>
   <Button
     className="button"
+    onClick={[Function]}
     primary={true}
   >
     <span
@@ -88,6 +90,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
 >
   <Button
     className="rectangleButton button"
+    onClick={[Function]}
     primary={true}
   >
     <span
@@ -161,6 +164,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
   </div>
   <Button
     className="rectangleButton button"
+    onClick={[Function]}
     primary={true}
   >
     <span

--- a/src/tests/unit/tests/electron/views/virtual-keyboard/__snapshots__/virtual-keyboard-buttons.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/virtual-keyboard/__snapshots__/virtual-keyboard-buttons.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
   </Button>
   <Button
     className="button"
+    onClick={[Function]}
     primary={true}
   >
     <span
@@ -30,6 +31,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
   </Button>
   <Button
     className="button"
+    onClick={[Function]}
     primary={true}
   >
     <span
@@ -44,6 +46,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
   </Button>
   <Button
     className="button"
+    onClick={[Function]}
     primary={true}
   >
     <span
@@ -58,6 +61,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard collapsed 1`] = `
   </Button>
   <Button
     className="button"
+    onClick={[Function]}
     primary={true}
   >
     <span
@@ -104,6 +108,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
   >
     <Button
       className="button"
+      onClick={[Function]}
       primary={true}
     >
       <span
@@ -120,6 +125,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
     >
       <Button
         className="button"
+        onClick={[Function]}
         primary={true}
       >
         <span
@@ -134,6 +140,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
       </Button>
       <Button
         className="button"
+        onClick={[Function]}
         primary={true}
       >
         <span
@@ -148,6 +155,7 @@ exports[`VirtualKeyboardButtons renders with virtual keyboard not collapsed 1`] 
       </Button>
       <Button
         className="button"
+        onClick={[Function]}
         primary={true}
       >
         <span

--- a/src/tests/unit/tests/electron/views/virtual-keyboard/__snapshots__/virtual-keyboard-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/virtual-keyboard/__snapshots__/virtual-keyboard-view.test.tsx.snap
@@ -12,6 +12,18 @@ exports[`VirtualKeyboardView renders 1`] = `
   <div>
     Selecting these keyboard buttons will initiate keyboard events directly to your connected device and show ‘Tab Stops’ visualizations on your app.
   </div>
-  <VirtualKeyboardButtons />
+  <VirtualKeyboardButtons
+    deps={
+      Object {
+        "deviceFocusControllerFactory": Object {},
+      }
+    }
+    deviceId="some-device-id"
+    narrowModeStatus={
+      Object {
+        "isVirtualKeyboardCollapsed": true,
+      }
+    }
+  />
 </div>
 `;

--- a/src/tests/unit/tests/electron/views/virtual-keyboard/virtual-keyboard-buttons.test.tsx
+++ b/src/tests/unit/tests/electron/views/virtual-keyboard/virtual-keyboard-buttons.test.tsx
@@ -1,37 +1,66 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
+import { AdbWrapper } from 'electron/platform/android/adb-wrapper';
+import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
+import { DeviceFocusControllerFactory } from 'electron/platform/android/device-focus-controller-factory';
+import { AdbWrapperHolder } from 'electron/platform/android/setup/adb-wrapper-holder';
 import {
     VirtualKeyboardButtons,
+    VirtualKeyboardButtonsDeps,
     VirtualKeyboardButtonsProps,
 } from 'electron/views/virtual-keyboard/virtual-keyboard-buttons';
+import { VirtualKeyboardViewProps } from 'electron/views/virtual-keyboard/virtual-keyboard-view';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { IMock, Mock } from 'typemoq';
 
 describe('VirtualKeyboardButtons', () => {
+    let deviceFocusControllerFactoryMock: IMock<DeviceFocusControllerFactory>;
+    let adbWrapperHolderMock: IMock<AdbWrapperHolder>;
     let props: VirtualKeyboardButtonsProps;
+    let deviceIdStub: string;
+    let adbWrapperStub: AdbWrapper;
+    let deviceFocusControllerMock: IMock<DeviceFocusController>;
 
     beforeEach(() => {
-        props = {} as VirtualKeyboardButtonsProps;
+        deviceFocusControllerFactoryMock = Mock.ofType<DeviceFocusControllerFactory>();
+        adbWrapperHolderMock = Mock.ofType<AdbWrapperHolder>();
+        deviceIdStub = 'some-device-id';
+        adbWrapperStub = {} as AdbWrapper;
+        deviceFocusControllerMock = Mock.ofType<DeviceFocusController>();
+
+        adbWrapperHolderMock.setup(m => m.getAdb()).returns(() => adbWrapperStub);
+
+        deviceFocusControllerFactoryMock
+            .setup(m => m.getDeviceFocusController(adbWrapperStub))
+            .returns(() => deviceFocusControllerMock.object);
+
+        deviceFocusControllerMock.setup(m => m.setDeviceId(deviceIdStub)).verifiable();
+
+        props = {
+            deps: {
+                deviceFocusControllerFactory: deviceFocusControllerFactoryMock.object,
+                adbWrapperHolder: adbWrapperHolderMock.object,
+            } as VirtualKeyboardButtonsDeps,
+            narrowModeStatus: {
+                isVirtualKeyboardCollapsed: true,
+            } as NarrowModeStatus,
+            deviceId: deviceIdStub,
+        } as VirtualKeyboardViewProps;
     });
 
     test('renders with virtual keyboard collapsed', () => {
-        props = {
-            narrowModeStatus: {
-                isVirtualKeyboardCollapsed: true,
-            },
-        } as VirtualKeyboardButtonsProps;
         const render = shallow(<VirtualKeyboardButtons {...props} />);
 
         expect(render.getElement()).toMatchSnapshot();
     });
 
     test('renders with virtual keyboard not collapsed', () => {
-        props = {
-            narrowModeStatus: {
-                isVirtualKeyboardCollapsed: false,
-            },
-        } as VirtualKeyboardButtonsProps;
+        props.narrowModeStatus = {
+            isVirtualKeyboardCollapsed: false,
+        } as NarrowModeStatus;
         const render = shallow(<VirtualKeyboardButtons {...props} />);
 
         expect(render.getElement()).toMatchSnapshot();

--- a/src/tests/unit/tests/electron/views/virtual-keyboard/virtual-keyboard-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/virtual-keyboard/virtual-keyboard-view.test.tsx
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
+import { VirtualKeyboardButtonsDeps } from 'electron/views/virtual-keyboard/virtual-keyboard-buttons';
 import {
     VirtualKeyboardView,
+    VirtualKeyboardViewDeps,
     VirtualKeyboardViewProps,
 } from 'electron/views/virtual-keyboard/virtual-keyboard-view';
 import { shallow } from 'enzyme';
@@ -10,9 +13,19 @@ import * as React from 'react';
 
 describe('VirtualKeyboardView', () => {
     let props: VirtualKeyboardViewProps;
+    let deps: VirtualKeyboardButtonsDeps;
 
     beforeEach(() => {
-        props = {} as VirtualKeyboardViewProps;
+        deps = {
+            deviceFocusControllerFactory: {},
+        } as VirtualKeyboardViewDeps;
+        props = {
+            deps,
+            deviceId: 'some-device-id',
+            narrowModeStatus: {
+                isVirtualKeyboardCollapsed: true,
+            } as NarrowModeStatus,
+        } as VirtualKeyboardViewProps;
     });
 
     test('renders', () => {


### PR DESCRIPTION
#### Details

Uses the device focus controller and adb wrapper holder to allow the virtual keyboard view to work.

##### Motivation

Allows us to control devices in focus order test.

##### Context

Licecap is broken on Mac so I cannot share a gif 😭 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
