### PR TITLE
chore(focus-mvp-client): Correct casing of method names

### DIFF
--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -32,46 +32,46 @@ export class DeviceFocusController {
         this.port = port;
     }
 
-    public EnableFocusTracking = () => {
+    public enableFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ENABLE, {});
         return this.commandSender(this.port, DeviceFocusCommand.Enable);
     };
 
-    public DisableFocusTracking = () => {
+    public disableFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_DISABLE, {});
         return this.commandSender(this.port, DeviceFocusCommand.Disable);
     };
 
-    public ResetFocusTracking = () => {
+    public resetFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_RESET, {});
         return this.commandSender(this.port, DeviceFocusCommand.Reset);
     };
 
-    public SendUpKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Up);
+    public sendUpKey = () => {
+        return this.sendKeyEvent(KeyEventCode.Up);
     };
 
-    public SendDownKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Down);
+    public sendDownKey = () => {
+        return this.sendKeyEvent(KeyEventCode.Down);
     };
 
-    public SendLeftKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Left);
+    public sendLeftKey = () => {
+        return this.sendKeyEvent(KeyEventCode.Left);
     };
 
-    public SendRightKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Right);
+    public sendRightKey = () => {
+        return this.sendKeyEvent(KeyEventCode.Right);
     };
 
-    public SendEnterKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Enter);
+    public sendEnterKey = () => {
+        return this.sendKeyEvent(KeyEventCode.Enter);
     };
 
-    public SendTabKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Tab);
+    public sendTabKey = () => {
+        return this.sendKeyEvent(KeyEventCode.Tab);
     };
 
-    private SendKeyEvent = (keyEventCode: KeyEventCode) => {
+    private sendKeyEvent = (keyEventCode: KeyEventCode) => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_KEYEVENT, {
             telemetry: {
                 keyEventCode,

--- a/src/electron/views/virtual-keyboard/virtual-keyboard-buttons.tsx
+++ b/src/electron/views/virtual-keyboard/virtual-keyboard-buttons.tsx
@@ -48,22 +48,22 @@ export const VirtualKeyboardButtons = NamedFC<VirtualKeyboardButtonsProps>(
         );
         deviceFocusController.setDeviceId(props.deviceId);
         const isVirtualKeyboardCollapsed = props.narrowModeStatus.isVirtualKeyboardCollapsed;
-        const upButton = getArrowButton('Up', deviceFocusController.SendUpKey);
-        const leftButton = getArrowButton('Left', deviceFocusController.SendLeftKey, styles.left);
+        const upButton = getArrowButton('Up', deviceFocusController.sendUpKey);
+        const leftButton = getArrowButton('Left', deviceFocusController.sendLeftKey, styles.left);
         const rightButton = getArrowButton(
             'Right',
-            deviceFocusController.SendRightKey,
+            deviceFocusController.sendRightKey,
             styles.right,
         );
-        const downButton = getArrowButton('Down', deviceFocusController.SendDownKey, styles.down);
+        const downButton = getArrowButton('Down', deviceFocusController.sendDownKey, styles.down);
         const tabButton = getLargeButton(
             'Tab',
-            deviceFocusController.SendTabKey,
+            deviceFocusController.sendTabKey,
             isVirtualKeyboardCollapsed ? undefined : styles.rectangleButton,
         );
         const enterButton = getLargeButton(
             'Enter',
-            deviceFocusController.SendEnterKey,
+            deviceFocusController.sendEnterKey,
             isVirtualKeyboardCollapsed ? undefined : styles.rectangleButton,
         );
 

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
@@ -41,7 +41,7 @@ describe('DeviceFocusController tests', () => {
         testSubject.setPort(port);
     });
 
-    it('EnableFocusTracking sends correct command and telemetry', async () => {
+    it('enableFocusTracking sends correct command and telemetry', async () => {
         commandSenderMock
             .setup(getter => getter(port, DeviceFocusCommand.Enable))
             .verifiable(Times.once());
@@ -49,13 +49,13 @@ describe('DeviceFocusController tests', () => {
             .setup(m => m.publishTelemetry(DEVICE_FOCUS_ENABLE, {}))
             .verifiable(Times.once());
 
-        await testSubject.EnableFocusTracking();
+        await testSubject.enableFocusTracking();
 
         commandSenderMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('DisableFocusTracking sends correct command and telemetry', async () => {
+    it('disableFocusTracking sends correct command and telemetry', async () => {
         commandSenderMock
             .setup(getter => getter(port, DeviceFocusCommand.Disable))
             .verifiable(Times.once());
@@ -63,13 +63,13 @@ describe('DeviceFocusController tests', () => {
             .setup(m => m.publishTelemetry(DEVICE_FOCUS_DISABLE, {}))
             .verifiable(Times.once());
 
-        await testSubject.DisableFocusTracking();
+        await testSubject.disableFocusTracking();
 
         commandSenderMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('ResetFocusTracking sends correct command and telemetry', async () => {
+    it('resetFocusTracking sends correct command and telemetry', async () => {
         commandSenderMock
             .setup(getter => getter(port, DeviceFocusCommand.Reset))
             .verifiable(Times.once());
@@ -77,7 +77,7 @@ describe('DeviceFocusController tests', () => {
             .setup(m => m.publishTelemetry(DEVICE_FOCUS_RESET, {}))
             .verifiable(Times.once());
 
-        await testSubject.ResetFocusTracking();
+        await testSubject.resetFocusTracking();
 
         commandSenderMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
@@ -89,67 +89,67 @@ describe('DeviceFocusController tests', () => {
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Up);
 
-        await testSubject.SendUpKey();
+        await testSubject.sendUpKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendDownKey sends correct command and telemetry', async () => {
+    it('sendDownKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Down))
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Down);
 
-        await testSubject.SendDownKey();
+        await testSubject.sendDownKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendLeftKey sends correct command and telemetry', async () => {
+    it('sendLeftKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Left))
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Left);
 
-        await testSubject.SendLeftKey();
+        await testSubject.sendLeftKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendRightKey sends correct command and telemetry', async () => {
+    it('sendRightKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Right))
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Right);
 
-        await testSubject.SendRightKey();
+        await testSubject.sendRightKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendEnterKey sends correct command and telemetry', async () => {
+    it('sendEnterKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Enter))
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Enter);
 
-        await testSubject.SendEnterKey();
+        await testSubject.sendEnterKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendTabKey sends correct command and telemetry', async () => {
+    it('sendTabKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Tab))
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Tab);
 
-        await testSubject.SendTabKey();
+        await testSubject.sendTabKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();


### PR DESCRIPTION
#### Details

I followed the wrong casing conventions for method names in a recent commit. This changes the function names

##### Motivation

Follow style guidelines

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
