### PR TITLE
feat(focus-mvp-client): Add device disconnected status updates

### DIFF
--- a/src/electron/common/electron-telemetry-events.ts
+++ b/src/electron/common/electron-telemetry-events.ts
@@ -12,6 +12,7 @@ export const DEVICE_FOCUS_ENABLE: string = 'DeviceFocusEnable';
 export const DEVICE_FOCUS_DISABLE: string = 'DeviceFocusDisable';
 export const DEVICE_FOCUS_RESET: string = 'DeviceFocusReset';
 export const DEVICE_FOCUS_KEYEVENT: string = 'DeviceFocusKeyEvent';
+export const DEVICE_FOCUS_ERROR: string = 'DeviceFocusError';
 
 export type AndroidSetupStepTelemetryData = {
     prevStep: string;

--- a/src/electron/flux/action/focus-actions.ts
+++ b/src/electron/flux/action/focus-actions.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ScanActions } from 'electron/flux/action/scan-actions';
+
+// TODO: This class is a placeholder for now...
+export class FocusActions extends ScanActions {}

--- a/src/electron/platform/android/device-focus-controller-factory.ts
+++ b/src/electron/platform/android/device-focus-controller-factory.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { Logger } from 'common/logging/logger';
+import { FocusActions } from 'electron/flux/action/focus-actions';
 import { AdbWrapper } from 'electron/platform/android/adb-wrapper';
 import { DeviceFocusCommandSender } from 'electron/platform/android/device-focus-command-sender';
 import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
@@ -10,6 +12,8 @@ export class DeviceFocusControllerFactory {
     constructor(
         private readonly focusCommandSender: DeviceFocusCommandSender,
         private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly focusActions: FocusActions,
+        private readonly logger: Logger,
     ) {}
 
     public getDeviceFocusController = (adbWrapper: AdbWrapper): DeviceFocusController => {
@@ -17,6 +21,8 @@ export class DeviceFocusControllerFactory {
             adbWrapper,
             this.focusCommandSender,
             this.telemetryEventHandler,
+            this.focusActions,
+            this.logger,
         );
     };
 }

--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -37,46 +37,46 @@ export class DeviceFocusController {
         this.port = port;
     }
 
-    public EnableFocusTracking = () => {
+    public enableFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ENABLE, {});
         this.wrapActionWithErrorHandling(this.commandSender(this.port, DeviceFocusCommand.Enable));
     };
 
-    public DisableFocusTracking = () => {
+    public disableFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_DISABLE, {});
         this.wrapActionWithErrorHandling(this.commandSender(this.port, DeviceFocusCommand.Disable));
     };
 
-    public ResetFocusTracking = () => {
+    public resetFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_RESET, {});
         this.wrapActionWithErrorHandling(this.commandSender(this.port, DeviceFocusCommand.Reset));
     };
 
-    public SendUpKey = () => {
-        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Up));
+    public sendUpKey = () => {
+        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Up));
     };
 
-    public SendDownKey = () => {
-        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Down));
+    public sendDownKey = () => {
+        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Down));
     };
 
-    public SendLeftKey = () => {
-        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Left));
+    public sendLeftKey = () => {
+        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Left));
     };
 
-    public SendRightKey = () => {
-        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Right));
+    public sendRightKey = () => {
+        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Right));
     };
 
-    public SendEnterKey = () => {
-        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Enter));
+    public sendEnterKey = () => {
+        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Enter));
     };
 
-    public SendTabKey = () => {
-        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Tab));
+    public sendTabKey = () => {
+        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Tab));
     };
 
-    private SendKeyEvent = (keyEventCode: KeyEventCode) => {
+    private sendKeyEvent = (keyEventCode: KeyEventCode) => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_KEYEVENT, {
             telemetry: {
                 keyEventCode,

--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -2,12 +2,15 @@
 // Licensed under the MIT License.
 
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { Logger } from 'common/logging/logger';
 import {
     DEVICE_FOCUS_DISABLE,
     DEVICE_FOCUS_ENABLE,
+    DEVICE_FOCUS_ERROR,
     DEVICE_FOCUS_KEYEVENT,
     DEVICE_FOCUS_RESET,
 } from 'electron/common/electron-telemetry-events';
+import { FocusActions } from 'electron/flux/action/focus-actions';
 import { AdbWrapper, KeyEventCode } from 'electron/platform/android/adb-wrapper';
 import {
     DeviceFocusCommand,
@@ -22,6 +25,8 @@ export class DeviceFocusController {
         private readonly adbWrapper: AdbWrapper,
         private readonly commandSender: DeviceFocusCommandSender,
         private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly focusActions: FocusActions,
+        private readonly logger: Logger,
     ) {}
 
     public setDeviceId(deviceId: string) {
@@ -34,41 +39,41 @@ export class DeviceFocusController {
 
     public EnableFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ENABLE, {});
-        return this.commandSender(this.port, DeviceFocusCommand.Enable);
+        this.wrapActionWithErrorHandling(this.commandSender(this.port, DeviceFocusCommand.Enable));
     };
 
     public DisableFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_DISABLE, {});
-        return this.commandSender(this.port, DeviceFocusCommand.Disable);
+        this.wrapActionWithErrorHandling(this.commandSender(this.port, DeviceFocusCommand.Disable));
     };
 
     public ResetFocusTracking = () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_RESET, {});
-        return this.commandSender(this.port, DeviceFocusCommand.Reset);
+        this.wrapActionWithErrorHandling(this.commandSender(this.port, DeviceFocusCommand.Reset));
     };
 
     public SendUpKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Up);
+        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Up));
     };
 
     public SendDownKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Down);
+        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Down));
     };
 
     public SendLeftKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Left);
+        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Left));
     };
 
     public SendRightKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Right);
+        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Right));
     };
 
     public SendEnterKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Enter);
+        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Enter));
     };
 
     public SendTabKey = () => {
-        return this.SendKeyEvent(KeyEventCode.Tab);
+        this.wrapActionWithErrorHandling(this.SendKeyEvent(KeyEventCode.Tab));
     };
 
     private SendKeyEvent = (keyEventCode: KeyEventCode) => {
@@ -79,4 +84,14 @@ export class DeviceFocusController {
         });
         return this.adbWrapper.sendKeyEvent(this.deviceId, keyEventCode);
     };
+
+    private wrapActionWithErrorHandling(innerAction: Promise<void>): void {
+        innerAction.then().catch(this.commandFailed.bind(this));
+    }
+
+    private commandFailed(error: Error): void {
+        this.logger.log('focus controller failure: ' + error);
+        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ERROR, {});
+        this.focusActions.scanFailed.invoke(null);
+    }
 }

--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -37,46 +37,52 @@ export class DeviceFocusController {
         this.port = port;
     }
 
-    public enableFocusTracking = () => {
+    public enableFocusTracking = async () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ENABLE, {});
-        this.wrapActionWithErrorHandling(this.commandSender(this.port, DeviceFocusCommand.Enable));
+        await this.wrapActionWithErrorHandling(
+            this.commandSender(this.port, DeviceFocusCommand.Enable),
+        );
     };
 
-    public disableFocusTracking = () => {
+    public disableFocusTracking = async () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_DISABLE, {});
-        this.wrapActionWithErrorHandling(this.commandSender(this.port, DeviceFocusCommand.Disable));
+        await this.wrapActionWithErrorHandling(
+            this.commandSender(this.port, DeviceFocusCommand.Disable),
+        );
     };
 
-    public resetFocusTracking = () => {
+    public resetFocusTracking = async () => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_RESET, {});
-        this.wrapActionWithErrorHandling(this.commandSender(this.port, DeviceFocusCommand.Reset));
+        await this.wrapActionWithErrorHandling(
+            this.commandSender(this.port, DeviceFocusCommand.Reset),
+        );
     };
 
-    public sendUpKey = () => {
-        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Up));
+    public sendUpKey = async () => {
+        await this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Up));
     };
 
-    public sendDownKey = () => {
-        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Down));
+    public sendDownKey = async () => {
+        await this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Down));
     };
 
-    public sendLeftKey = () => {
-        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Left));
+    public sendLeftKey = async () => {
+        await this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Left));
     };
 
-    public sendRightKey = () => {
-        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Right));
+    public sendRightKey = async () => {
+        await this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Right));
     };
 
-    public sendEnterKey = () => {
-        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Enter));
+    public sendEnterKey = async () => {
+        await this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Enter));
     };
 
-    public sendTabKey = () => {
-        this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Tab));
+    public sendTabKey = async () => {
+        await this.wrapActionWithErrorHandling(this.sendKeyEvent(KeyEventCode.Tab));
     };
 
-    private sendKeyEvent = (keyEventCode: KeyEventCode) => {
+    private sendKeyEvent = (keyEventCode: KeyEventCode): Promise<void> => {
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_KEYEVENT, {
             telemetry: {
                 keyEventCode,
@@ -86,7 +92,7 @@ export class DeviceFocusController {
     };
 
     private wrapActionWithErrorHandling(innerAction: Promise<void>): void {
-        innerAction.then().catch(this.commandFailed.bind(this));
+        innerAction.catch(this.commandFailed.bind(this));
     }
 
     private commandFailed(error: Error): void {

--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -92,7 +92,11 @@ export class DeviceFocusController {
     };
 
     private wrapActionWithErrorHandling(innerAction: Promise<void>): void {
-        innerAction.catch(this.commandFailed.bind(this));
+        innerAction.then(this.commandSucceeded.bind(this)).catch(this.commandFailed.bind(this));
+    }
+
+    private commandSucceeded(): void {
+        this.focusActions.scanCompleted.invoke(null);
     }
 
     private commandFailed(error: Error): void {

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -416,6 +416,8 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         const deviceFocusControllerFactory = new DeviceFocusControllerFactory(
             createDeviceFocusCommandSender(axios.get),
             telemetryEventHandler,
+            scanActions,
+            logger,
         );
 
         const dropdownActionMessageCreator = new DropdownActionMessageCreator(

--- a/src/electron/views/virtual-keyboard/virtual-keyboard-buttons.tsx
+++ b/src/electron/views/virtual-keyboard/virtual-keyboard-buttons.tsx
@@ -48,22 +48,22 @@ export const VirtualKeyboardButtons = NamedFC<VirtualKeyboardButtonsProps>(
         );
         deviceFocusController.setDeviceId(props.deviceId);
         const isVirtualKeyboardCollapsed = props.narrowModeStatus.isVirtualKeyboardCollapsed;
-        const upButton = getArrowButton('Up', deviceFocusController.SendUpKey);
-        const leftButton = getArrowButton('Left', deviceFocusController.SendLeftKey, styles.left);
+        const upButton = getArrowButton('Up', deviceFocusController.sendUpKey);
+        const leftButton = getArrowButton('Left', deviceFocusController.sendLeftKey, styles.left);
         const rightButton = getArrowButton(
             'Right',
-            deviceFocusController.SendRightKey,
+            deviceFocusController.sendRightKey,
             styles.right,
         );
-        const downButton = getArrowButton('Down', deviceFocusController.SendDownKey, styles.down);
+        const downButton = getArrowButton('Down', deviceFocusController.sendDownKey, styles.down);
         const tabButton = getLargeButton(
             'Tab',
-            deviceFocusController.SendTabKey,
+            deviceFocusController.sendTabKey,
             isVirtualKeyboardCollapsed ? undefined : styles.rectangleButton,
         );
         const enterButton = getLargeButton(
             'Enter',
-            deviceFocusController.SendEnterKey,
+            deviceFocusController.sendEnterKey,
             isVirtualKeyboardCollapsed ? undefined : styles.rectangleButton,
         );
 

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller-factory.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller-factory.test.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { Logger } from 'common/logging/logger';
+import { FocusActions } from 'electron/flux/action/focus-actions';
 import { AdbWrapper } from 'electron/platform/android/adb-wrapper';
 import { DeviceFocusCommandSender } from 'electron/platform/android/device-focus-command-sender';
 import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
@@ -10,6 +12,8 @@ import { IMock, Mock, MockBehavior } from 'typemoq';
 
 describe('DeviceFocusControllerFactory tests', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let focusActionsMock: IMock<FocusActions>;
+    let loggerMock: IMock<Logger>;
     let testSubject: DeviceFocusControllerFactory;
 
     const focusCommandSenderMock: IMock<DeviceFocusCommandSender> = Mock.ofType<DeviceFocusCommandSender>(
@@ -22,9 +26,13 @@ describe('DeviceFocusControllerFactory tests', () => {
             undefined,
             MockBehavior.Strict,
         );
+        focusActionsMock = Mock.ofType<FocusActions>(undefined, MockBehavior.Strict);
+        loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
         testSubject = new DeviceFocusControllerFactory(
             focusCommandSenderMock.object,
             telemetryEventHandlerMock.object,
+            focusActionsMock.object,
+            loggerMock.object,
         );
     });
 

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { Logger } from 'common/logging/logger';
 import {
     DEVICE_FOCUS_DISABLE,
     DEVICE_FOCUS_ENABLE,
     DEVICE_FOCUS_KEYEVENT,
     DEVICE_FOCUS_RESET,
 } from 'electron/common/electron-telemetry-events';
+import { FocusActions } from 'electron/flux/action/focus-actions';
 import { AdbWrapper, KeyEventCode } from 'electron/platform/android/adb-wrapper';
 import {
     DeviceFocusCommand,
@@ -23,6 +25,8 @@ describe('DeviceFocusController tests', () => {
     let adbWrapperMock: IMock<AdbWrapper>;
     let commandSenderMock: IMock<DeviceFocusCommandSender>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let focusActionsMock: IMock<FocusActions>;
+    let loggerMock: IMock<Logger>;
     let testSubject: DeviceFocusController;
 
     beforeEach(() => {
@@ -32,10 +36,14 @@ describe('DeviceFocusController tests', () => {
             undefined,
             MockBehavior.Strict,
         );
+        focusActionsMock = Mock.ofType<FocusActions>(undefined, MockBehavior.Strict);
+        loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
         testSubject = new DeviceFocusController(
             adbWrapperMock.object,
             commandSenderMock.object,
             telemetryEventHandlerMock.object,
+            focusActionsMock.object,
+            loggerMock.object,
         );
         testSubject.setDeviceId(deviceId);
         testSubject.setPort(port);

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { Action } from 'common/flux/action';
 import { Logger } from 'common/logging/logger';
 import {
     DEVICE_FOCUS_DISABLE,
     DEVICE_FOCUS_ENABLE,
+    DEVICE_FOCUS_ERROR,
     DEVICE_FOCUS_KEYEVENT,
     DEVICE_FOCUS_RESET,
 } from 'electron/common/electron-telemetry-events';
@@ -16,17 +18,19 @@ import {
     DeviceFocusCommandSender,
 } from 'electron/platform/android/device-focus-command-sender';
 import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('DeviceFocusController tests', () => {
     const deviceId: string = 'some device';
     const port: number = 23456;
+    const errorMessage: string = 'Welcome to the dark side';
 
     let adbWrapperMock: IMock<AdbWrapper>;
     let commandSenderMock: IMock<DeviceFocusCommandSender>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let focusActionsMock: IMock<FocusActions>;
     let loggerMock: IMock<Logger>;
+    let scanFailedMock: IMock<Action<void>>;
     let testSubject: DeviceFocusController;
 
     beforeEach(() => {
@@ -38,6 +42,7 @@ describe('DeviceFocusController tests', () => {
         );
         focusActionsMock = Mock.ofType<FocusActions>(undefined, MockBehavior.Strict);
         loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
+        scanFailedMock = Mock.ofType<Action<void>>();
         testSubject = new DeviceFocusController(
             adbWrapperMock.object,
             commandSenderMock.object,
@@ -49,119 +54,269 @@ describe('DeviceFocusController tests', () => {
         testSubject.setPort(port);
     });
 
-    it('enableFocusTracking sends correct command and telemetry', async () => {
-        commandSenderMock
-            .setup(getter => getter(port, DeviceFocusCommand.Enable))
-            .verifiable(Times.once());
-        telemetryEventHandlerMock
-            .setup(m => m.publishTelemetry(DEVICE_FOCUS_ENABLE, {}))
-            .verifiable(Times.once());
-
-        await testSubject.enableFocusTracking();
-
+    function verifyAllMocks(): void {
+        adbWrapperMock.verifyAll();
         commandSenderMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
+        focusActionsMock.verifyAll();
+        loggerMock.verifyAll();
+        scanFailedMock.verifyAll();
+    }
+
+    describe('Success paths', () => {
+        it('enableFocusTracking sends correct command and telemetry', async () => {
+            commandSenderMock
+                .setup(getter => getter(port, DeviceFocusCommand.Enable))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+            telemetryEventHandlerMock
+                .setup(m => m.publishTelemetry(DEVICE_FOCUS_ENABLE, {}))
+                .verifiable(Times.once());
+
+            await testSubject.enableFocusTracking();
+
+            verifyAllMocks();
+        });
+
+        it('disableFocusTracking sends correct command and telemetry', async () => {
+            commandSenderMock
+                .setup(getter => getter(port, DeviceFocusCommand.Disable))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+            telemetryEventHandlerMock
+                .setup(m => m.publishTelemetry(DEVICE_FOCUS_DISABLE, {}))
+                .verifiable(Times.once());
+
+            await testSubject.disableFocusTracking();
+
+            verifyAllMocks();
+        });
+
+        it('resetFocusTracking sends correct command and telemetry', async () => {
+            commandSenderMock
+                .setup(getter => getter(port, DeviceFocusCommand.Reset))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+            telemetryEventHandlerMock
+                .setup(m => m.publishTelemetry(DEVICE_FOCUS_RESET, {}))
+                .verifiable(Times.once());
+
+            await testSubject.resetFocusTracking();
+
+            verifyAllMocks();
+        });
+
+        it('sendUpKey sends correct command and telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Up))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Up);
+
+            await testSubject.sendUpKey();
+
+            verifyAllMocks();
+        });
+
+        it('sendDownKey sends correct command and telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Down))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Down);
+
+            await testSubject.sendDownKey();
+
+            verifyAllMocks();
+        });
+
+        it('sendLeftKey sends correct command and telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Left))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Left);
+
+            await testSubject.sendLeftKey();
+
+            verifyAllMocks();
+        });
+
+        it('sendRightKey sends correct command and telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Right))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Right);
+
+            await testSubject.sendRightKey();
+
+            verifyAllMocks();
+        });
+
+        it('sendEnterKey sends correct command and telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Enter))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Enter);
+
+            await testSubject.sendEnterKey();
+
+            verifyAllMocks();
+        });
+
+        it('sendTabKey sends correct command and telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Tab))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Tab);
+
+            await testSubject.sendTabKey();
+
+            verifyAllMocks();
+        });
     });
 
-    it('disableFocusTracking sends correct command and telemetry', async () => {
-        commandSenderMock
-            .setup(getter => getter(port, DeviceFocusCommand.Disable))
-            .verifiable(Times.once());
+    describe('Error paths', () => {
+        it('enableFocusTracking sets error, logs, sends telemetry', async () => {
+            commandSenderMock
+                .setup(getter => getter(port, DeviceFocusCommand.Enable))
+                .returns(() => Promise.reject(errorMessage))
+                .verifiable(Times.once());
+            telemetryEventHandlerMock
+                .setup(m => m.publishTelemetry(DEVICE_FOCUS_ENABLE, {}))
+                .verifiable(Times.once());
+            setMocksForFocusError();
+
+            await testSubject.enableFocusTracking();
+
+            verifyAllMocks();
+        });
+
+        it('disableFocusTracking sets error, logs, sends telemetry', async () => {
+            commandSenderMock
+                .setup(getter => getter(port, DeviceFocusCommand.Disable))
+                .returns(() => Promise.reject(errorMessage))
+                .verifiable(Times.once());
+            telemetryEventHandlerMock
+                .setup(m => m.publishTelemetry(DEVICE_FOCUS_DISABLE, {}))
+                .verifiable(Times.once());
+            setMocksForFocusError();
+
+            await testSubject.disableFocusTracking();
+
+            verifyAllMocks();
+        });
+
+        it('resetFocusTracking sets error, logs, sends telemetry', async () => {
+            commandSenderMock
+                .setup(getter => getter(port, DeviceFocusCommand.Reset))
+                .returns(() => Promise.reject(errorMessage))
+                .verifiable(Times.once());
+            telemetryEventHandlerMock
+                .setup(m => m.publishTelemetry(DEVICE_FOCUS_RESET, {}))
+                .verifiable(Times.once());
+            setMocksForFocusError();
+
+            await testSubject.resetFocusTracking();
+
+            verifyAllMocks();
+        });
+
+        it('sendUpKey sets error, logs, sends telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Up))
+                .returns(() => Promise.reject(errorMessage))
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Up);
+            setMocksForFocusError();
+
+            await testSubject.sendUpKey();
+
+            verifyAllMocks();
+        });
+
+        it('sendDownKey sets error, logs, sends telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Down))
+                .returns(() => Promise.reject(errorMessage))
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Down);
+            setMocksForFocusError();
+
+            await testSubject.sendDownKey();
+
+            verifyAllMocks();
+        });
+
+        it('sendLeftKey sets error, logs, sends telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Left))
+                .returns(() => Promise.reject(errorMessage))
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Left);
+            setMocksForFocusError();
+
+            await testSubject.sendLeftKey();
+
+            verifyAllMocks();
+        });
+
+        it('sendRightKey sets error, logs, sends telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Right))
+                .returns(() => Promise.reject(errorMessage))
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Right);
+            setMocksForFocusError();
+
+            await testSubject.sendRightKey();
+
+            verifyAllMocks();
+        });
+
+        it('sendEnterKey sets error, logs, sends telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Enter))
+                .returns(() => Promise.reject(errorMessage))
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Enter);
+            setMocksForFocusError();
+
+            await testSubject.sendEnterKey();
+
+            verifyAllMocks();
+        });
+
+        it('sendTabKey sets error, logs, sends telemetry', async () => {
+            adbWrapperMock
+                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Tab))
+                .returns(() => Promise.reject(errorMessage))
+                .verifiable(Times.once());
+            setTelemetryMockForKeyEvent(KeyEventCode.Tab);
+            setMocksForFocusError();
+
+            await testSubject.sendTabKey();
+
+            verifyAllMocks();
+        });
+    });
+
+    function setMocksForFocusError(): void {
         telemetryEventHandlerMock
-            .setup(m => m.publishTelemetry(DEVICE_FOCUS_DISABLE, {}))
+            .setup(m => m.publishTelemetry(DEVICE_FOCUS_ERROR, {}))
             .verifiable(Times.once());
-
-        await testSubject.disableFocusTracking();
-
-        commandSenderMock.verifyAll();
-        telemetryEventHandlerMock.verifyAll();
-    });
-
-    it('resetFocusTracking sends correct command and telemetry', async () => {
-        commandSenderMock
-            .setup(getter => getter(port, DeviceFocusCommand.Reset))
+        loggerMock
+            .setup(m => m.log('focus controller failure: ' + errorMessage))
             .verifiable(Times.once());
-        telemetryEventHandlerMock
-            .setup(m => m.publishTelemetry(DEVICE_FOCUS_RESET, {}))
+        scanFailedMock.setup(m => m.invoke((It.isAny(), It.isAny()))).verifiable(Times.once());
+        focusActionsMock
+            .setup(m => m.scanFailed)
+            .returns(() => scanFailedMock.object)
             .verifiable(Times.once());
-
-        await testSubject.resetFocusTracking();
-
-        commandSenderMock.verifyAll();
-        telemetryEventHandlerMock.verifyAll();
-    });
-
-    it('SendUpKey sends correct command and telemetry', async () => {
-        adbWrapperMock
-            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Up))
-            .verifiable(Times.once());
-        setTelemetryMockForKeyEvent(KeyEventCode.Up);
-
-        await testSubject.sendUpKey();
-
-        adbWrapperMock.verifyAll();
-        telemetryEventHandlerMock.verifyAll();
-    });
-
-    it('sendDownKey sends correct command and telemetry', async () => {
-        adbWrapperMock
-            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Down))
-            .verifiable(Times.once());
-        setTelemetryMockForKeyEvent(KeyEventCode.Down);
-
-        await testSubject.sendDownKey();
-
-        adbWrapperMock.verifyAll();
-        telemetryEventHandlerMock.verifyAll();
-    });
-
-    it('sendLeftKey sends correct command and telemetry', async () => {
-        adbWrapperMock
-            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Left))
-            .verifiable(Times.once());
-        setTelemetryMockForKeyEvent(KeyEventCode.Left);
-
-        await testSubject.sendLeftKey();
-
-        adbWrapperMock.verifyAll();
-        telemetryEventHandlerMock.verifyAll();
-    });
-
-    it('sendRightKey sends correct command and telemetry', async () => {
-        adbWrapperMock
-            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Right))
-            .verifiable(Times.once());
-        setTelemetryMockForKeyEvent(KeyEventCode.Right);
-
-        await testSubject.sendRightKey();
-
-        adbWrapperMock.verifyAll();
-        telemetryEventHandlerMock.verifyAll();
-    });
-
-    it('sendEnterKey sends correct command and telemetry', async () => {
-        adbWrapperMock
-            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Enter))
-            .verifiable(Times.once());
-        setTelemetryMockForKeyEvent(KeyEventCode.Enter);
-
-        await testSubject.sendEnterKey();
-
-        adbWrapperMock.verifyAll();
-        telemetryEventHandlerMock.verifyAll();
-    });
-
-    it('sendTabKey sends correct command and telemetry', async () => {
-        adbWrapperMock
-            .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Tab))
-            .verifiable(Times.once());
-        setTelemetryMockForKeyEvent(KeyEventCode.Tab);
-
-        await testSubject.sendTabKey();
-
-        adbWrapperMock.verifyAll();
-        telemetryEventHandlerMock.verifyAll();
-    });
+    }
 
     function setTelemetryMockForKeyEvent(keyEventCode: KeyEventCode): void {
         telemetryEventHandlerMock

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
@@ -49,7 +49,7 @@ describe('DeviceFocusController tests', () => {
         testSubject.setPort(port);
     });
 
-    it('EnableFocusTracking sends correct command and telemetry', async () => {
+    it('enableFocusTracking sends correct command and telemetry', async () => {
         commandSenderMock
             .setup(getter => getter(port, DeviceFocusCommand.Enable))
             .verifiable(Times.once());
@@ -57,13 +57,13 @@ describe('DeviceFocusController tests', () => {
             .setup(m => m.publishTelemetry(DEVICE_FOCUS_ENABLE, {}))
             .verifiable(Times.once());
 
-        await testSubject.EnableFocusTracking();
+        await testSubject.enableFocusTracking();
 
         commandSenderMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('DisableFocusTracking sends correct command and telemetry', async () => {
+    it('disableFocusTracking sends correct command and telemetry', async () => {
         commandSenderMock
             .setup(getter => getter(port, DeviceFocusCommand.Disable))
             .verifiable(Times.once());
@@ -71,13 +71,13 @@ describe('DeviceFocusController tests', () => {
             .setup(m => m.publishTelemetry(DEVICE_FOCUS_DISABLE, {}))
             .verifiable(Times.once());
 
-        await testSubject.DisableFocusTracking();
+        await testSubject.disableFocusTracking();
 
         commandSenderMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('ResetFocusTracking sends correct command and telemetry', async () => {
+    it('resetFocusTracking sends correct command and telemetry', async () => {
         commandSenderMock
             .setup(getter => getter(port, DeviceFocusCommand.Reset))
             .verifiable(Times.once());
@@ -85,7 +85,7 @@ describe('DeviceFocusController tests', () => {
             .setup(m => m.publishTelemetry(DEVICE_FOCUS_RESET, {}))
             .verifiable(Times.once());
 
-        await testSubject.ResetFocusTracking();
+        await testSubject.resetFocusTracking();
 
         commandSenderMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
@@ -97,7 +97,7 @@ describe('DeviceFocusController tests', () => {
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Up);
 
-        await testSubject.SendUpKey();
+        await testSubject.sendUpKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
@@ -109,7 +109,7 @@ describe('DeviceFocusController tests', () => {
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Down);
 
-        await testSubject.SendDownKey();
+        await testSubject.sendDownKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
@@ -121,43 +121,43 @@ describe('DeviceFocusController tests', () => {
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Left);
 
-        await testSubject.SendLeftKey();
+        await testSubject.sendLeftKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendRightKey sends correct command and telemetry', async () => {
+    it('sendRightKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Right))
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Right);
 
-        await testSubject.SendRightKey();
+        await testSubject.sendRightKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendEnterKey sends correct command and telemetry', async () => {
+    it('sendEnterKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Enter))
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Enter);
 
-        await testSubject.SendEnterKey();
+        await testSubject.sendEnterKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });
 
-    it('SendTabKey sends correct command and telemetry', async () => {
+    it('sendTabKey sends correct command and telemetry', async () => {
         adbWrapperMock
             .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Tab))
             .verifiable(Times.once());
         setTelemetryMockForKeyEvent(KeyEventCode.Tab);
 
-        await testSubject.SendTabKey();
+        await testSubject.sendTabKey();
 
         adbWrapperMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();


### PR DESCRIPTION
#### Details

This is still a draft, sharing for conversation purposes. It uses a placeholder FocusActions class, since I suspect that @waabid has already started to work on this and I didn't want to duplicate effort here. I'm assuming that there will be some sort of store that holds the toggle state for visualizations, and that both the actions and the UI will be associated with that store.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
