### PR TITLE
Chore: Suppress resolved lgtm.com warning

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -401,7 +401,7 @@ module.exports = function (grunt) {
                 const cssFile = path.resolve(cssPath, cssName);
                 grunt.log.writeln(`    embedding from ${cssFile}`);
                 const styles = grunt.file.read(cssFile, fileOptions);
-                return styles.replace(/"/g, '\\"').replace(/\n/g, '\\\n');
+                return styles.replace(/"/g, '\\"').replace(/\n/g, '\\\n'); // lgtm [js/incomplete-sanitization]
             });
             grunt.file.write(dest, output, fileOptions);
             grunt.log.writeln(`    written to ${dest}`);


### PR DESCRIPTION
#### Details

Suppress [this warning](https://lgtm.com/rules/1506222917439/) from the [list of warnings](https://lgtm.com/projects/g/microsoft/accessibility-insights-web/?mode=list) on lgtm.com.

##### Motivation

Remove a noisy warning that is essentially already resolved. Removing such warnings will allow us to add more codeql checks on PR's in this repo.

##### Context

The recommendations [here](https://lgtm.com/rules/1506222917439/) suggest using the 'g' flag as part of the regex is a sufficient mitigation. And it seems to mitigate the problem in this case.

This was a more light-weight alternative to employing a sanitization package from NPM.

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
