### PR TITLE
fix: add info to contrast's state changes requirement 

### DIFF
--- a/src/content/test/contrast/state-changes.tsx
+++ b/src/content/test/contrast/state-changes.tsx
@@ -65,7 +65,5 @@ export const infoAndExamples = create(({ Markup, Link }) => (
                 where color alone is used to identify them
             </Markup.HyperLink>
         </Markup.Links>
-
-        <p></p>
     </>
 ));

--- a/src/content/test/contrast/state-changes.tsx
+++ b/src/content/test/contrast/state-changes.tsx
@@ -1,4 +1,71 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { create, React } from '../../common';
 
-export const infoAndExamples = undefined;
+export const infoAndExamples = create(({ Markup, Link }) => (
+    <>
+        <p>
+            If the only visual indication of a control's change of state is a change of color, the different colors must have sufficient
+            contrast.
+        </p>
+
+        <h2>Why it matters</h2>
+
+        <p>
+            A control's state changes can be indicated through changes in visual characteristics, such as shape, size, and color. Sufficient
+            contrast between states makes it easier for people with mild visual disabilities, low vision, limited color perception, or
+            presbyopia to perceive such changes.
+        </p>
+
+        <h2>How to fix</h2>
+
+        <p>Make the control's state changes visually perceptible:</p>
+        <ul>
+            <li>Good: Ensure colors used to indicate different states have a contrast ratio ≥ 3:1. </li>
+            <li>
+                Better: Indicate state changes by changing both color and another visual characteristic, such as shape, size, or styling.
+            </li>
+        </ul>
+
+        <h2>Example</h2>
+        <Markup.PassFail
+            failText={
+                <p>
+                    A button uses changes in its border color alone to indicate whether it is enabled or disabled. When the button is
+                    enabled, its border is medium gray (#777777). When it is disabled, the border is a lighter gray (#949494). The contrast
+                    ratio between the two border colors is insufficient (1.476:1).
+                </p>
+            }
+            passText={<p>When the button is disabled, its border becomes both lighter and dashed.</p>}
+        />
+        <h2>More examples</h2>
+        <h3>WCAG success criteria</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html">
+                Understanding Success Criterion 1.4.11: Non-text Contrast
+            </Markup.HyperLink>
+        </Markup.Links>
+        <h3>Sufficient techniques</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G195">
+                Using an author-supplied, highly visible focus indicator
+            </Markup.HyperLink>
+        </Markup.Links>
+        <h3>Common failures</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F78">
+                Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible
+                the visual focus indicator
+            </Markup.HyperLink>
+        </Markup.Links>
+        <h3>Additional guidance</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G183">
+                Using a contrast ratio of 3:1 with surrounding text and providing additional visual cues on focus for links or controls
+                where color alone is used to identify them
+            </Markup.HyperLink>
+        </Markup.Links>
+
+        <p></p>
+    </>
+));


### PR DESCRIPTION
#### Details

This PR adds information to the Contrast > State changes"  assessment requirement, per issue #3778. The 'i' icon has been added and on click opens with additional information. 

![image](https://user-images.githubusercontent.com/18401275/108286649-53a27980-713e-11eb-844a-31fbb606baa0.png)
![image](https://user-images.githubusercontent.com/18401275/108287312-800ac580-713f-11eb-95b4-812515dc9d28.png)



##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3778
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
