### PR TITLE
feat(focus-mvp-client): Update Device Disconnected dialog to be more generic

### DIFF
--- a/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
@@ -40,16 +40,17 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
             >
                 <div>
                     <p>
-                        Uh-oh! It seems the <strong>{deviceName}</strong> device has disconnected.
+                        Uh-oh! It seems the device <strong>{deviceName}</strong> has disconnected.
                     </p>
                     <p>
-                        Make sure your device is properly connected, and try rescanning or
-                        connecting a different device.
+                        To continue using that device, make sure it’s properly connected and then
+                        select <strong>Start over</strong>. To use a different device, select{' '}
+                        <strong>Connect a new device</strong>.
                     </p>
                 </div>
                 <DialogFooter>
-                    <DefaultButton text="Connect a new device" onClick={onConnectNewDevice} />
                     <DefaultButton text="Rescan device" onClick={onRescanDevice} />
+                    <DefaultButton text="Connect a new device" onClick={onConnectNewDevice} />
                 </DialogFooter>
             </Dialog>
         );

--- a/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
@@ -49,7 +49,7 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
                     </p>
                 </div>
                 <DialogFooter>
-                    <DefaultButton text="Rescan device" onClick={onRescanDevice} />
+                    <DefaultButton text="Start over" onClick={onRescanDevice} />
                     <DefaultButton text="Connect a new device" onClick={onConnectNewDevice} />
                 </DialogFooter>
             </Dialog>

--- a/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
@@ -40,8 +40,7 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
             >
                 <div>
                     <p>
-                        Uh-oh! It seems the <strong>{deviceName}</strong> device has disconnected
-                        before the snapshot completed its analysis.
+                        Uh-oh! It seems the <strong>{deviceName}</strong> device has disconnected.
                     </p>
                     <p>
                         Make sure your device is properly connected, and try rescanning or

--- a/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
       <strong>
         test device name
       </strong>
-       device has disconnected before the snapshot completed its analysis.
+       device has disconnected.
     </p>
     <p>
       Make sure your device is properly connected, and try rescanning or connecting a different device.

--- a/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -29,22 +29,31 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
 >
   <div>
     <p>
-      Uh-oh! It seems the 
+      Uh-oh! It seems the device 
       <strong>
         test device name
       </strong>
-       device has disconnected.
+       has disconnected.
     </p>
     <p>
-      Make sure your device is properly connected, and try rescanning or connecting a different device.
+      To continue using that device, make sure it’s properly connected and then select 
+      <strong>
+        Start over
+      </strong>
+      . To use a different device, select
+       
+      <strong>
+        Connect a new device
+      </strong>
+      .
     </p>
   </div>
   <StyledDialogFooterBase>
     <CustomizedDefaultButton
-      text="Connect a new device"
+      text="Rescan device"
     />
     <CustomizedDefaultButton
-      text="Rescan device"
+      text="Connect a new device"
     />
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>

--- a/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
   </div>
   <StyledDialogFooterBase>
     <CustomizedDefaultButton
-      text="Rescan device"
+      text="Start over"
     />
     <CustomizedDefaultButton
       text="Connect a new device"

--- a/src/tests/unit/tests/electron/views/device-disconnected-popup/device-disconnected-popup.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-disconnected-popup/device-disconnected-popup.test.tsx
@@ -41,7 +41,7 @@ describe('DeviceDisconnectedPopup', () => {
 
             const wrapper = shallow(<DeviceDisconnectedPopup {...props} />);
 
-            wrapper.find('[text="Rescan device"]').simulate('click');
+            wrapper.find('[text="Start over"]').simulate('click');
 
             expect(onRescanDeviceMock).toBeCalledTimes(1);
         });


### PR DESCRIPTION
#### Details

- Updated Device Disconnected dialog to be more generic

##### Motivation

The dialog had specific language surrounding scanning.  With the addition of tab stops, they may not be scanning at all when the device disconnects, so we've made the dialog more generic to accommodate a wider variety of scenarios.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
