### PR TITLE
feat(focus-mvp-client): add tab stops actions/creator

### DIFF
--- a/src/electron/flux/action/tab-stops-action-creator.ts
+++ b/src/electron/flux/action/tab-stops-action-creator.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TabStopsActions } from 'electron/flux/action/tab-stops-actions';
+
+export class TabStopsActionCreator {
+    constructor(private readonly tabStopsActions: TabStopsActions) {}
+
+    public enableTabStops = () => {
+        this.tabStopsActions.enableFocusTracking.invoke();
+    };
+
+    public disableTabStops = () => {
+        this.tabStopsActions.disableFocusTracking.invoke();
+    };
+
+    public startOver = () => {
+        this.tabStopsActions.startOver.invoke();
+    };
+}

--- a/src/electron/flux/action/tab-stops-actions.ts
+++ b/src/electron/flux/action/tab-stops-actions.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Action } from 'common/flux/action';
+
+export class TabStopsActions {
+    public readonly enableFocusTracking = new Action<void>();
+    public readonly disableFocusTracking = new Action<void>();
+    public readonly startOver = new Action<void>();
+}

--- a/src/tests/unit/tests/electron/flux/action-creator/tab-stops-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/tab-stops-action-creator.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Action } from 'common/flux/action';
+import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
+import { TabStopsActions } from 'electron/flux/action/tab-stops-actions';
+import { IMock, Mock, Times } from 'typemoq';
+
+describe('TabStopsActionCreator', () => {
+    let tabStopsActionsMock: IMock<TabStopsActions>;
+    let testSubject: TabStopsActionCreator;
+    let actionMock: IMock<Action<void>>;
+
+    beforeEach(() => {
+        tabStopsActionsMock = Mock.ofType<TabStopsActions>();
+        actionMock = Mock.ofType<Action<void>>();
+
+        testSubject = new TabStopsActionCreator(tabStopsActionsMock.object);
+    });
+
+    it('enableTabStops', () => {
+        tabStopsActionsMock.setup(m => m.enableFocusTracking).returns(() => actionMock.object);
+
+        testSubject.enableTabStops();
+
+        actionMock.verify(m => m.invoke(), Times.once());
+    });
+
+    it('disableTabStops', () => {
+        tabStopsActionsMock.setup(m => m.disableFocusTracking).returns(() => actionMock.object);
+
+        testSubject.disableTabStops();
+
+        actionMock.verify(m => m.invoke(), Times.once());
+    });
+
+    it('startOver', () => {
+        tabStopsActionsMock.setup(m => m.startOver).returns(() => actionMock.object);
+
+        testSubject.startOver();
+
+        actionMock.verify(m => m.invoke(), Times.once());
+    });
+});


### PR DESCRIPTION
#### Details

Simply adding actions/action creator to be used in other PRs.

##### Motivation

For tab stops feature.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
