### PR TITLE
feat(focus-mvp-client): updated tab stops testing text

### DIFF
--- a/src/electron/views/tab-stops/tab-stops-testing-content.tsx
+++ b/src/electron/views/tab-stops/tab-stops-testing-content.tsx
@@ -30,31 +30,27 @@ export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
                     <strong>How to test:</strong>
                 </span>
                 <ol className={styles.howToTestList}>
-                    <li>Navigate to the screen you want to test in your app.</li>
+                    <li>In your target app, navigate to the screen you want to test.</li>
                     <li>
-                        Turn on the Show tab stops toggle. An empty circle will highlight the
-                        element with focus.
+                        Turn on the <strong>Show tab stops</strong> toggle. An empty circle will
+                        highlight the element in the target app that currently has input focus.
                     </li>
                     <li>
-                        If you are connected to an emulator, select your emulator app to bring it
-                        into focus and use your keyboard.
+                        If you're testing on a virtual device, switch to the emulator app by
+                        clicking it or pressing Alt+Tab.
                     </li>
                     <li>
-                        Or If you are connected to a physical mobile device use the keyboard
-                        key-buttons below.
-                    </li>
-                    <li>
-                        Move input focus through all the interactive elements in the page:
+                        Use the virtual keyboard to the right (or a physical keyboard) to:
                         <ul>
-                            <li>Use Tab and Shift+Tab to navigate between standalone controls.</li>
                             <li>
-                                Use the arrow keys to navigate between the focusable elements within
-                                a composite control.
+                                Navigate to each interactive element and then use the arrow keys to
+                                navigate away in each direction (up/down/left/right).
                             </li>
                         </ul>
                     </li>
                     <li>
-                        As you navigate to each element, look for these accessibility problems:
+                        As you navigate to each element, look for these{' '}
+                        <strong>accessibility problems</strong>:
                         <ul>
                             <li>
                                 An interactive element can't be reached using the Tab and arrow
@@ -69,7 +65,7 @@ export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
                                 input focus.
                             </li>
                             <li>
-                                The tab order is inconsistent with the logical order that's
+                                The navigation order is inconsistent with the logical order that's
                                 communicated visually.
                             </li>
                             <li>Input focus moves unexpectedly without the user initiating it.</li>

--- a/src/electron/views/tab-stops/tab-stops-testing-content.tsx
+++ b/src/electron/views/tab-stops/tab-stops-testing-content.tsx
@@ -37,7 +37,8 @@ export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
                     </li>
                     <li>
                         If you're testing on a virtual device, switch to the emulator app by
-                        clicking it or pressing Alt+Tab.
+                        clicking it or by pressing <strong>Alt+Tab</strong> (Windows or Linux) or{' '}
+                        <strong>Command+Tab</strong> (Mac).
                     </li>
                     <li>
                         Use the virtual keyboard to the right (or a physical keyboard) to:

--- a/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
@@ -31,7 +31,16 @@ exports[`TabStopsTestingContent renders 1`] = `
        toggle. An empty circle will highlight the element in the target app that currently has input focus.
     </li>
     <li>
-      If you're testing on a virtual device, switch to the emulator app by clicking it or pressing Alt+Tab.
+      If you're testing on a virtual device, switch to the emulator app by clicking it or by pressing 
+      <strong>
+        Alt+Tab
+      </strong>
+       (Windows or Linux) or
+       
+      <strong>
+        Command+Tab
+      </strong>
+       (Mac).
     </li>
     <li>
       Use the virtual keyboard to the right (or a physical keyboard) to:

--- a/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
@@ -21,30 +21,33 @@ exports[`TabStopsTestingContent renders 1`] = `
     className="howToTestList"
   >
     <li>
-      Navigate to the screen you want to test in your app.
+      In your target app, navigate to the screen you want to test.
     </li>
     <li>
-      Turn on the Show tab stops toggle. An empty circle will highlight the element with focus.
+      Turn on the 
+      <strong>
+        Show tab stops
+      </strong>
+       toggle. An empty circle will highlight the element in the target app that currently has input focus.
     </li>
     <li>
-      If you are connected to an emulator, select your emulator app to bring it into focus and use your keyboard.
+      If you're testing on a virtual device, switch to the emulator app by clicking it or pressing Alt+Tab.
     </li>
     <li>
-      Or If you are connected to a physical mobile device use the keyboard key-buttons below.
-    </li>
-    <li>
-      Move input focus through all the interactive elements in the page:
+      Use the virtual keyboard to the right (or a physical keyboard) to:
       <ul>
         <li>
-          Use Tab and Shift+Tab to navigate between standalone controls.
-        </li>
-        <li>
-          Use the arrow keys to navigate between the focusable elements within a composite control.
+          Navigate to each interactive element and then use the arrow keys to navigate away in each direction (up/down/left/right).
         </li>
       </ul>
     </li>
     <li>
-      As you navigate to each element, look for these accessibility problems:
+      As you navigate to each element, look for these
+       
+      <strong>
+        accessibility problems
+      </strong>
+      :
       <ul>
         <li>
           An interactive element can't be reached using the Tab and arrow keys.
@@ -56,7 +59,7 @@ exports[`TabStopsTestingContent renders 1`] = `
           An interactive element doesn't give a visible indication when it has input focus.
         </li>
         <li>
-          The tab order is inconsistent with the logical order that's communicated visually.
+          The navigation order is inconsistent with the logical order that's communicated visually.
         </li>
         <li>
           Input focus moves unexpectedly without the user initiating it.


### PR DESCRIPTION
#### Details

This updates the instructions for testing tab stops on unified. These are suggestions from Lisa Louise.

![image](https://user-images.githubusercontent.com/13286385/108886360-bcb24300-75bd-11eb-80f8-3c6affa1c1d5.png)


##### Motivation

Updated copy to better communicate how to test.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
