### PR TITLE
fix(focus-mvp-client): Improve e2e reliability by testing each virtual keyboard key separately

### DIFF
--- a/src/tests/electron/common/view-controllers/log-controller.ts
+++ b/src/tests/electron/common/view-controllers/log-controller.ts
@@ -13,7 +13,7 @@ import {
 const readFile = util.promisify(fs.readFile);
 
 export class LogController {
-    constructor(private mockAdbPath: string) {}
+    constructor(private mockAdbPath: string, private client: SpectronAsyncClient) {}
 
     private getOutputLogsDir(currentContext: string): string {
         return generateOutputLogsDir(this.mockAdbPath, currentContext);
@@ -37,12 +37,8 @@ export class LogController {
         fs.unlinkSync(generateServerLogPath(this.getOutputLogsDir(currentContext)));
     }
 
-    public async waitForAdbLogToContain(
-        contains: string,
-        currentContext: string,
-        client: SpectronAsyncClient,
-    ) {
+    public async waitForAdbLogToContain(contains: string, currentContext: string) {
         const isLogReady = async () => (await this.getAdbLog(currentContext)).includes(contains);
-        return client.waitUntil(isLogReady, { timeout: DEFAULT_WAIT_FOR_LOG_TIMEOUT_MS });
+        return this.client.waitUntil(isLogReady, { timeout: DEFAULT_WAIT_FOR_LOG_TIMEOUT_MS });
     }
 }

--- a/src/tests/electron/setup/timeouts.ts
+++ b/src/tests/electron/setup/timeouts.ts
@@ -21,4 +21,4 @@ export const DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS = 5000;
 export const DEFAULT_CLICK_HOVER_DELAY_MS = 100;
 
 // How long to wait for a mock adb or service log to contain a value
-export const DEFAULT_WAIT_FOR_LOG_TIMEOUT_MS = 1000;
+export const DEFAULT_WAIT_FOR_LOG_TIMEOUT_MS = 1500;

--- a/src/tests/electron/tests/__snapshots__/tab-stops-view.test.ts.snap
+++ b/src/tests/electron/tests/__snapshots__/tab-stops-view.test.ts.snap
@@ -1,11 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TabStopsView virtual keyboard keys send corresponding adb commands 1`] = `
+exports[`TabStopsView virtual keyboard sends keyevent 19 1`] = `
 "ADB -s device-1 shell input keyevent 19
-ADB -s device-1 shell input keyevent 20
-ADB -s device-1 shell input keyevent 21
-ADB -s device-1 shell input keyevent 22
-ADB -s device-1 shell input keyevent 61
-ADB -s device-1 shell input keyevent 66
+"
+`;
+
+exports[`TabStopsView virtual keyboard sends keyevent 20 1`] = `
+"ADB -s device-1 shell input keyevent 20
+"
+`;
+
+exports[`TabStopsView virtual keyboard sends keyevent 21 1`] = `
+"ADB -s device-1 shell input keyevent 21
+"
+`;
+
+exports[`TabStopsView virtual keyboard sends keyevent 22 1`] = `
+"ADB -s device-1 shell input keyevent 22
+"
+`;
+
+exports[`TabStopsView virtual keyboard sends keyevent 61 1`] = `
+"ADB -s device-1 shell input keyevent 61
+"
+`;
+
+exports[`TabStopsView virtual keyboard sends keyevent 66 1`] = `
+"ADB -s device-1 shell input keyevent 66
 "
 `;

--- a/src/tests/electron/tests/tab-stops-view.test.ts
+++ b/src/tests/electron/tests/tab-stops-view.test.ts
@@ -34,7 +34,7 @@ describe('TabStopsView', () => {
         app = await createApplication({ suppressFirstTimeDialog: true });
         app.setFeatureFlag(UnifiedFeatureFlags.tabStops, true);
         app.client.browserWindow.setSize(windowWidth, windowHeight);
-        logController = new LogController(mockAdbFolder, app.client);
+        logController = new LogController(logsContext, mockAdbFolder, app.client);
         virtualKeyboardViewController = new VirtualKeyboardViewController(app.client);
         resultsViewController = await app.openResultsView();
         await resultsViewController.clickLeftNavItem('tab-stops');
@@ -58,12 +58,12 @@ describe('TabStopsView', () => {
         KeyEventCode.Tab,
         KeyEventCode.Enter,
     ])('virtual keyboard sends keyevent %s', async (keyCode: KeyEventCode) => {
-        logController.resetAdbLog(logsContext);
+        logController.resetAdbLog();
 
         await virtualKeyboardViewController.clickVirtualKey(keyCode);
-        await logController.waitForAdbLogToContain(keyCode.toString(), logsContext);
+        await logController.waitForAdbLogToContain(keyCode.toString());
 
-        const adbLog = await logController.getAdbLog(logsContext);
+        const adbLog = await logController.getAdbLog();
         expect(adbLog).toMatchSnapshot();
     });
 


### PR DESCRIPTION
#### Details
Currently, the tab stops e2e tests click all the virtual keyboard keys, wait for the last one to have a result, and then validate the results. This PR updates the tab stops e2e tests to click, wait for a result, and validate each virtual keyboard key individually.

##### Motivation
Timing issues cause the existing test to be flaky. 

##### Context
A refactor to `LogController` is included.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
