### PR TITLE
feat(focus-mvp-client): add tab stops store and update tab stops action creator

### DIFF
--- a/src/common/stores/store-names.ts
+++ b/src/common/stores/store-names.ts
@@ -25,4 +25,5 @@ export enum StoreNames {
     LeftNavStore,
     ContentPanelStore,
     DeviceConnectionStore,
+    TabStopsStore,
 }

--- a/src/electron/flux/action/tab-stops-action-creator.ts
+++ b/src/electron/flux/action/tab-stops-action-creator.ts
@@ -2,19 +2,50 @@
 // Licensed under the MIT License.
 
 import { TabStopsActions } from 'electron/flux/action/tab-stops-actions';
+import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
 
 export class TabStopsActionCreator {
-    constructor(private readonly tabStopsActions: TabStopsActions) {}
+    constructor(
+        private readonly tabStopsActions: TabStopsActions,
+        private readonly deviceFocusController: DeviceFocusController,
+    ) {}
 
     public enableTabStops = () => {
         this.tabStopsActions.enableFocusTracking.invoke();
+        this.deviceFocusController.enableFocusTracking();
     };
 
     public disableTabStops = () => {
         this.tabStopsActions.disableFocusTracking.invoke();
+        this.deviceFocusController.disableFocusTracking();
     };
 
     public startOver = () => {
+        this.deviceFocusController.resetFocusTracking();
         this.tabStopsActions.startOver.invoke();
+    };
+
+    public sendUpKey = () => {
+        this.deviceFocusController.sendUpKey();
+    };
+
+    public sendDownKey = () => {
+        this.deviceFocusController.sendDownKey();
+    };
+
+    public sendLeftKey = () => {
+        this.deviceFocusController.sendLeftKey();
+    };
+
+    public sendRightKey = () => {
+        this.deviceFocusController.sendRightKey();
+    };
+
+    public sendTabKey = () => {
+        this.deviceFocusController.sendTabKey();
+    };
+
+    public sendEnterKey = () => {
+        this.deviceFocusController.sendEnterKey();
     };
 }

--- a/src/electron/flux/action/tab-stops-action-creator.ts
+++ b/src/electron/flux/action/tab-stops-action-creator.ts
@@ -21,8 +21,8 @@ export class TabStopsActionCreator {
     };
 
     public startOver = () => {
-        this.deviceFocusController.resetFocusTracking();
         this.tabStopsActions.startOver.invoke();
+        this.deviceFocusController.resetFocusTracking();
     };
 
     public sendUpKey = () => {

--- a/src/electron/flux/action/tab-stops-action-creator.ts
+++ b/src/electron/flux/action/tab-stops-action-creator.ts
@@ -1,51 +1,105 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { Logger } from 'common/logging/logger';
+import { DEVICE_FOCUS_ERROR } from 'electron/common/electron-telemetry-events';
+import { DeviceConnectionActions } from 'electron/flux/action/device-connection-actions';
 import { TabStopsActions } from 'electron/flux/action/tab-stops-actions';
+import { KeyEventCode } from 'electron/platform/android/adb-wrapper';
 import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
 
 export class TabStopsActionCreator {
     constructor(
         private readonly tabStopsActions: TabStopsActions,
+        private readonly deviceConnectionActions: DeviceConnectionActions,
         private readonly deviceFocusController: DeviceFocusController,
+        private readonly logger: Logger,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
     ) {}
 
-    public enableTabStops = () => {
-        this.tabStopsActions.enableFocusTracking.invoke();
-        this.deviceFocusController.enableFocusTracking();
+    public enableTabStops = async () => {
+        try {
+            await this.deviceFocusController.enableFocusTracking();
+            this.tabStopsActions.enableFocusTracking.invoke();
+            this.deviceConnectionActions.statusConnected.invoke();
+        } catch (e) {
+            this.commandFailed(e);
+        }
     };
 
-    public disableTabStops = () => {
-        this.tabStopsActions.disableFocusTracking.invoke();
-        this.deviceFocusController.disableFocusTracking();
+    public disableTabStops = async () => {
+        try {
+            await this.deviceFocusController.disableFocusTracking();
+            this.tabStopsActions.disableFocusTracking.invoke();
+            this.deviceConnectionActions.statusConnected.invoke();
+        } catch (e) {
+            this.commandFailed(e);
+        }
     };
 
-    public startOver = () => {
-        this.tabStopsActions.startOver.invoke();
-        this.deviceFocusController.resetFocusTracking();
+    public startOver = async () => {
+        try {
+            await this.deviceFocusController.resetFocusTracking();
+            this.tabStopsActions.startOver.invoke();
+            this.deviceConnectionActions.statusConnected.invoke();
+        } catch (e) {
+            this.commandFailed(e);
+        }
     };
 
-    public sendUpKey = () => {
-        this.deviceFocusController.sendUpKey();
+    public sendUpKey = async () => {
+        await this.wrapActionWithErrorHandling(
+            this.deviceFocusController.sendKeyEvent(KeyEventCode.Up),
+        );
     };
 
-    public sendDownKey = () => {
-        this.deviceFocusController.sendDownKey();
+    public sendDownKey = async () => {
+        await this.wrapActionWithErrorHandling(
+            this.deviceFocusController.sendKeyEvent(KeyEventCode.Down),
+        );
     };
 
-    public sendLeftKey = () => {
-        this.deviceFocusController.sendLeftKey();
+    public sendLeftKey = async () => {
+        await this.wrapActionWithErrorHandling(
+            this.deviceFocusController.sendKeyEvent(KeyEventCode.Left),
+        );
     };
 
-    public sendRightKey = () => {
-        this.deviceFocusController.sendRightKey();
+    public sendRightKey = async () => {
+        await this.wrapActionWithErrorHandling(
+            this.deviceFocusController.sendKeyEvent(KeyEventCode.Right),
+        );
     };
 
-    public sendTabKey = () => {
-        this.deviceFocusController.sendTabKey();
+    public sendTabKey = async () => {
+        await this.wrapActionWithErrorHandling(
+            this.deviceFocusController.sendKeyEvent(KeyEventCode.Tab),
+        );
     };
 
-    public sendEnterKey = () => {
-        this.deviceFocusController.sendEnterKey();
+    public sendEnterKey = async () => {
+        await this.wrapActionWithErrorHandling(
+            this.deviceFocusController.sendKeyEvent(KeyEventCode.Enter),
+        );
     };
+
+    private wrapActionWithErrorHandling = async (innerAction: Promise<void>) => {
+        try {
+            await innerAction;
+            this.commandSucceeded();
+        } catch (error) {
+            this.commandFailed(error);
+        }
+    };
+
+    private commandSucceeded(): void {
+        this.deviceConnectionActions.statusConnected.invoke();
+    }
+
+    private commandFailed(error: Error): void {
+        this.logger.log('focus controller failure: ' + error);
+        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ERROR, {});
+        this.deviceConnectionActions.statusDisconnected.invoke();
+    }
 }

--- a/src/electron/flux/store/tab-stops-store.ts
+++ b/src/electron/flux/store/tab-stops-store.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BaseStoreImpl } from 'background/stores/base-store-impl';
+import { StoreNames } from 'common/stores/store-names';
+import { TabStopsActions } from 'electron/flux/action/tab-stops-actions';
+import { TabStopsStoreData } from 'electron/flux/types/tab-stops-store-data';
+
+export class TabStopsStore extends BaseStoreImpl<TabStopsStoreData> {
+    constructor(private readonly tabStopsActions: TabStopsActions) {
+        super(StoreNames.TabStopsStore);
+    }
+
+    public getDefaultState(): TabStopsStoreData {
+        return {
+            focusTracking: false,
+        };
+    }
+
+    public addActionListeners(): void {
+        this.tabStopsActions.enableFocusTracking.addListener(this.onEnableFocusTracking);
+        this.tabStopsActions.disableFocusTracking.addListener(this.onDisableFocusTracking);
+        this.tabStopsActions.startOver.addListener(this.onStartOver);
+    }
+
+    private onEnableFocusTracking = () => {
+        this.state.focusTracking = true;
+        this.emitChanged();
+    };
+
+    private onDisableFocusTracking = () => {
+        this.state.focusTracking = false;
+        this.emitChanged();
+    };
+
+    private onStartOver = () => {
+        this.state.focusTracking = false;
+        this.emitChanged();
+    };
+}

--- a/src/electron/flux/types/tab-stops-store-data.ts
+++ b/src/electron/flux/types/tab-stops-store-data.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type TabStopsStoreData = {
+    focusTracking: boolean;
+};

--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -25,45 +25,46 @@ export class DeviceFocusController {
     ) {}
 
     public enableFocusTracking = async () => {
-        const scanPort = this.androidSetupStore.getState().scanPort;
-        if (scanPort == null) {
-            return;
-        }
-
+        const scanPort = this.getScanPort();
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ENABLE, {});
         await this.commandSender(scanPort, DeviceFocusCommand.Enable);
     };
 
     public disableFocusTracking = async () => {
-        const scanPort = this.androidSetupStore.getState().scanPort;
-        if (scanPort == null) {
-            return;
-        }
+        const scanPort = this.getScanPort();
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_DISABLE, {});
         await this.commandSender(scanPort, DeviceFocusCommand.Disable);
     };
 
     public resetFocusTracking = async () => {
-        const scanPort = this.androidSetupStore.getState().scanPort;
-        if (scanPort == null) {
-            return;
-        }
-
+        const scanPort = this.getScanPort();
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_RESET, {});
         await this.commandSender(scanPort, DeviceFocusCommand.Reset);
     };
 
     public sendKeyEvent = async (keyEventCode: KeyEventCode) => {
-        const selectedDevice = this.androidSetupStore.getState().selectedDevice;
-        if (selectedDevice == null) {
-            return;
-        }
-
+        const selectedDevice = this.getSelectedDevice();
         this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_KEYEVENT, {
             telemetry: {
                 keyEventCode,
             },
         });
         return this.adbWrapperHolder.getAdb().sendKeyEvent(selectedDevice.id, keyEventCode);
+    };
+
+    private getScanPort = () => {
+        const scanPort = this.androidSetupStore.getState().scanPort;
+        if (scanPort == null) {
+            throw new Error('scan port not found');
+        }
+        return scanPort;
+    };
+
+    private getSelectedDevice = () => {
+        const selectedDevice = this.androidSetupStore.getState().selectedDevice;
+        if (selectedDevice == null) {
+            throw new Error('selected device not found');
+        }
+        return selectedDevice;
     };
 }

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -69,12 +69,15 @@ import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions'
 import { DeviceConnectionActions } from 'electron/flux/action/device-connection-actions';
 import { LeftNavActions } from 'electron/flux/action/left-nav-actions';
 import { ScanActions } from 'electron/flux/action/scan-actions';
+import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
+import { TabStopsActions } from 'electron/flux/action/tab-stops-actions';
 import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
 import { WindowStateActions } from 'electron/flux/action/window-state-actions';
 import { AndroidSetupStore } from 'electron/flux/store/android-setup-store';
 import { DeviceConnectionStore } from 'electron/flux/store/device-connection-store';
 import { LeftNavStore } from 'electron/flux/store/left-nav-store';
 import { ScanStore } from 'electron/flux/store/scan-store';
+import { TabStopsStore } from 'electron/flux/store/tab-stops-store';
 import { WindowStateStore } from 'electron/flux/store/window-state-store';
 import { IpcMessageReceiver } from 'electron/ipc/ipc-message-receiver';
 import { IpcRendererShim } from 'electron/ipc/ipc-renderer-shim';
@@ -173,6 +176,7 @@ const previewFeaturesActions = new PreviewFeaturesActions(); // not really used 
 const contentActions = new ContentActions(); // not really used but needed by DetailsViewStore
 const featureFlagActions = new FeatureFlagActions();
 const leftNavActions = new LeftNavActions();
+const tabStopsActions = new TabStopsActions();
 
 const ipcRendererShim = new IpcRendererShim(ipcRenderer);
 ipcRendererShim.initialize();
@@ -283,6 +287,9 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         const leftNavStore = new LeftNavStore(leftNavActions);
         leftNavStore.initialize();
 
+        const tabStopsStore = new TabStopsStore(tabStopsActions);
+        tabStopsStore.initialize();
+
         const windowFrameUpdater = new WindowFrameUpdater(windowFrameActions, ipcRendererShim);
         windowFrameUpdater.initialize();
 
@@ -297,6 +304,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
             featureFlagStore,
             androidSetupStore,
             leftNavStore,
+            tabStopsStore,
         ]);
 
         const fetchScanResults = createScanResultsFetcher(axios.get);
@@ -417,11 +425,18 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
             adbWrapperHolder,
             createDeviceFocusCommandSender(axios.get),
             telemetryEventHandler,
-            deviceConnectionActions,
-            logger,
             androidSetupStore,
         );
+
         deviceFocusController.initialize();
+
+        const tabStopsActionCreator = new TabStopsActionCreator(
+            tabStopsActions,
+            deviceConnectionActions,
+            deviceFocusController,
+            logger,
+            telemetryEventHandler,
+        );
 
         const dropdownActionMessageCreator = new DropdownActionMessageCreator(
             telemetryDataFactory,
@@ -562,7 +577,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
             navLinkRenderer: new NavLinkRenderer(),
             getNarrowModeThresholds: getNarrowModeThresholdsForUnified,
             leftNavActionCreator,
-            deviceFocusController,
+            tabStopsActionCreator: tabStopsActionCreator,
         };
 
         window.insightsUserConfiguration = new UserConfigurationController(interpreter);

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -428,8 +428,6 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
             androidSetupStore,
         );
 
-        deviceFocusController.initialize();
-
         const tabStopsActionCreator = new TabStopsActionCreator(
             tabStopsActions,
             deviceConnectionActions,

--- a/src/electron/views/tab-stops/virtual-keyboard-buttons.tsx
+++ b/src/electron/views/tab-stops/virtual-keyboard-buttons.tsx
@@ -3,13 +3,13 @@
 
 import { NamedFC } from 'common/react/named-fc';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
-import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
+import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import * as styles from 'electron/views/tab-stops/virtual-keyboard-buttons.scss';
 import { Button, css, Icon } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export type VirtualKeyboardButtonsDeps = {
-    deviceFocusController: DeviceFocusController;
+    tabStopsActionCreator: TabStopsActionCreator;
 };
 
 export type VirtualKeyboardButtonsProps = {
@@ -52,24 +52,24 @@ export const VirtualKeyboardButtons = NamedFC<VirtualKeyboardButtonsProps>(
         };
 
         const deps = props.deps;
-        const deviceFocusController = deps.deviceFocusController;
+        const tabStopsActionCreator = deps.tabStopsActionCreator;
         const isVirtualKeyboardCollapsed = props.narrowModeStatus.isVirtualKeyboardCollapsed;
-        const upButton = getArrowButton('Up', deviceFocusController.sendUpKey);
-        const leftButton = getArrowButton('Left', deviceFocusController.sendLeftKey, styles.left);
+        const upButton = getArrowButton('Up', tabStopsActionCreator.sendUpKey);
+        const leftButton = getArrowButton('Left', tabStopsActionCreator.sendLeftKey, styles.left);
         const rightButton = getArrowButton(
             'Right',
-            deviceFocusController.sendRightKey,
+            tabStopsActionCreator.sendRightKey,
             styles.right,
         );
-        const downButton = getArrowButton('Down', deviceFocusController.sendDownKey, styles.down);
+        const downButton = getArrowButton('Down', tabStopsActionCreator.sendDownKey, styles.down);
         const tabButton = getLargeButton(
             'Tab',
-            deviceFocusController.sendTabKey,
+            tabStopsActionCreator.sendTabKey,
             isVirtualKeyboardCollapsed ? undefined : styles.rectangleButton,
         );
         const enterButton = getLargeButton(
             'Enter',
-            deviceFocusController.sendEnterKey,
+            tabStopsActionCreator.sendEnterKey,
             isVirtualKeyboardCollapsed ? undefined : styles.rectangleButton,
         );
 

--- a/src/tests/unit/tests/electron/flux/action-creator/tab-stops-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/tab-stops-action-creator.test.ts
@@ -3,18 +3,24 @@
 import { Action } from 'common/flux/action';
 import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import { TabStopsActions } from 'electron/flux/action/tab-stops-actions';
+import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
 import { IMock, Mock, Times } from 'typemoq';
 
 describe('TabStopsActionCreator', () => {
     let tabStopsActionsMock: IMock<TabStopsActions>;
     let testSubject: TabStopsActionCreator;
     let actionMock: IMock<Action<void>>;
+    let deviceFocusControllerMock: IMock<DeviceFocusController>;
 
     beforeEach(() => {
         tabStopsActionsMock = Mock.ofType<TabStopsActions>();
         actionMock = Mock.ofType<Action<void>>();
+        deviceFocusControllerMock = Mock.ofType<DeviceFocusController>();
 
-        testSubject = new TabStopsActionCreator(tabStopsActionsMock.object);
+        testSubject = new TabStopsActionCreator(
+            tabStopsActionsMock.object,
+            deviceFocusControllerMock.object,
+        );
     });
 
     it('enableTabStops', () => {
@@ -23,6 +29,7 @@ describe('TabStopsActionCreator', () => {
         testSubject.enableTabStops();
 
         actionMock.verify(m => m.invoke(), Times.once());
+        deviceFocusControllerMock.verify(m => m.enableFocusTracking(), Times.once());
     });
 
     it('disableTabStops', () => {
@@ -31,6 +38,7 @@ describe('TabStopsActionCreator', () => {
         testSubject.disableTabStops();
 
         actionMock.verify(m => m.invoke(), Times.once());
+        deviceFocusControllerMock.verify(m => m.disableFocusTracking(), Times.once());
     });
 
     it('startOver', () => {
@@ -39,5 +47,36 @@ describe('TabStopsActionCreator', () => {
         testSubject.startOver();
 
         actionMock.verify(m => m.invoke(), Times.once());
+        deviceFocusControllerMock.verify(m => m.resetFocusTracking(), Times.once());
+    });
+
+    it('sendUpKey', () => {
+        testSubject.sendUpKey();
+        deviceFocusControllerMock.verify(m => m.sendUpKey(), Times.once());
+    });
+
+    it('sendDownKey', () => {
+        testSubject.sendDownKey();
+        deviceFocusControllerMock.verify(m => m.sendDownKey(), Times.once());
+    });
+
+    it('sendLeftKey', () => {
+        testSubject.sendLeftKey();
+        deviceFocusControllerMock.verify(m => m.sendLeftKey(), Times.once());
+    });
+
+    it('sendRightKey', () => {
+        testSubject.sendRightKey();
+        deviceFocusControllerMock.verify(m => m.sendRightKey(), Times.once());
+    });
+
+    it('sendTabKey', () => {
+        testSubject.sendTabKey();
+        deviceFocusControllerMock.verify(m => m.sendTabKey(), Times.once());
+    });
+
+    it('sendEnterKey', () => {
+        testSubject.sendEnterKey();
+        deviceFocusControllerMock.verify(m => m.sendEnterKey(), Times.once());
     });
 });

--- a/src/tests/unit/tests/electron/flux/action-creator/tab-stops-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/tab-stops-action-creator.test.ts
@@ -1,82 +1,247 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { Action } from 'common/flux/action';
+import { Logger } from 'common/logging/logger';
+import { DEVICE_FOCUS_ERROR } from 'electron/common/electron-telemetry-events';
+import { DeviceConnectionActions } from 'electron/flux/action/device-connection-actions';
 import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import { TabStopsActions } from 'electron/flux/action/tab-stops-actions';
+import { KeyEventCode } from 'electron/platform/android/adb-wrapper';
 import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('TabStopsActionCreator', () => {
     let tabStopsActionsMock: IMock<TabStopsActions>;
     let testSubject: TabStopsActionCreator;
     let actionMock: IMock<Action<void>>;
     let deviceFocusControllerMock: IMock<DeviceFocusController>;
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let deviceConnectionActionsMock: IMock<DeviceConnectionActions>;
+    let loggerMock: IMock<Logger>;
+    let statusDisconnectedMock: IMock<Action<void>>;
+    let statusConnectedMock: IMock<Action<void>>;
 
     beforeEach(() => {
         tabStopsActionsMock = Mock.ofType<TabStopsActions>();
         actionMock = Mock.ofType<Action<void>>();
-        deviceFocusControllerMock = Mock.ofType<DeviceFocusController>();
+        deviceFocusControllerMock = Mock.ofType<DeviceFocusController>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        deviceConnectionActionsMock = Mock.ofType<DeviceConnectionActions>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
+        statusDisconnectedMock = Mock.ofType<Action<void>>();
+        statusConnectedMock = Mock.ofType<Action<void>>();
 
         testSubject = new TabStopsActionCreator(
             tabStopsActionsMock.object,
+            deviceConnectionActionsMock.object,
             deviceFocusControllerMock.object,
+            loggerMock.object,
+            telemetryEventHandlerMock.object,
         );
     });
 
-    it('enableTabStops', () => {
-        tabStopsActionsMock.setup(m => m.enableFocusTracking).returns(() => actionMock.object);
+    describe('Success paths', () => {
+        it('enableTabStops', async () => {
+            deviceFocusControllerMock
+                .setup(m => m.enableFocusTracking())
+                .returns(() => Promise.resolve());
+            tabStopsActionsMock.setup(m => m.enableFocusTracking).returns(() => actionMock.object);
+            setFocusActionsForSuccess();
 
-        testSubject.enableTabStops();
+            await testSubject.enableTabStops();
 
-        actionMock.verify(m => m.invoke(), Times.once());
-        deviceFocusControllerMock.verify(m => m.enableFocusTracking(), Times.once());
+            actionMock.verify(m => m.invoke(), Times.once());
+            verifyAllMocks();
+        });
+
+        it('disableTabStops', async () => {
+            deviceFocusControllerMock
+                .setup(m => m.disableFocusTracking())
+                .returns(() => Promise.resolve());
+            tabStopsActionsMock.setup(m => m.disableFocusTracking).returns(() => actionMock.object);
+            setFocusActionsForSuccess();
+
+            await testSubject.disableTabStops();
+
+            actionMock.verify(m => m.invoke(), Times.once());
+            verifyAllMocks();
+        });
+
+        it('startOver', async () => {
+            deviceFocusControllerMock
+                .setup(m => m.resetFocusTracking())
+                .returns(() => Promise.resolve());
+            tabStopsActionsMock.setup(m => m.startOver).returns(() => actionMock.object);
+            setFocusActionsForSuccess();
+
+            await testSubject.startOver();
+
+            actionMock.verify(m => m.invoke(), Times.once());
+            verifyAllMocks();
+        });
+
+        it('sendUpKey', async () => {
+            await testSendKeyEventSuccess(KeyEventCode.Up, 'sendUpKey');
+        });
+
+        it('sendDownKey', async () => {
+            await testSendKeyEventSuccess(KeyEventCode.Down, 'sendDownKey');
+        });
+
+        it('sendLeftKey', async () => {
+            await testSendKeyEventSuccess(KeyEventCode.Left, 'sendLeftKey');
+        });
+
+        it('sendRightKey', async () => {
+            await testSendKeyEventSuccess(KeyEventCode.Right, 'sendRightKey');
+        });
+
+        it('sendTabKey', async () => {
+            await testSendKeyEventSuccess(KeyEventCode.Tab, 'sendTabKey');
+        });
+
+        it('sendEnterKey', async () => {
+            await testSendKeyEventSuccess(KeyEventCode.Enter, 'sendEnterKey');
+        });
+
+        function setFocusActionsForSuccess(): void {
+            statusConnectedMock.setup(m => m.invoke()).verifiable(Times.once());
+            deviceConnectionActionsMock
+                .setup(m => m.statusConnected)
+                .returns(() => statusConnectedMock.object)
+                .verifiable(Times.once());
+        }
+
+        async function testSendKeyEventSuccess(
+            keyEventCode: KeyEventCode,
+            funcName: keyof TabStopsActionCreator,
+        ): Promise<void> {
+            setFocusActionsForSuccess();
+            deviceFocusControllerMock
+                .setup(m => m.sendKeyEvent(keyEventCode))
+                .returns(() => Promise.resolve());
+
+            await testSubject[funcName]();
+
+            verifyAllMocks();
+        }
     });
 
-    it('disableTabStops', () => {
-        tabStopsActionsMock.setup(m => m.disableFocusTracking).returns(() => actionMock.object);
+    describe('Error paths', () => {
+        const errorMessage: string = 'error message stub';
 
-        testSubject.disableTabStops();
+        it('enableTabStops', async () => {
+            deviceFocusControllerMock
+                .setup(m => m.enableFocusTracking())
+                .returns(() => Promise.reject(errorMessage));
 
-        actionMock.verify(m => m.invoke(), Times.once());
-        deviceFocusControllerMock.verify(m => m.disableFocusTracking(), Times.once());
+            tabStopsActionsMock.setup(m => m.enableFocusTracking).returns(() => actionMock.object);
+            setMocksForFocusError();
+
+            await testSubject.enableTabStops();
+
+            actionMock.verify(m => m.invoke(), Times.never());
+            verifyAllMocks();
+        });
+
+        it('disableTabStops', async () => {
+            deviceFocusControllerMock
+                .setup(m => m.disableFocusTracking())
+                .returns(() => Promise.reject(errorMessage));
+
+            tabStopsActionsMock.setup(m => m.disableFocusTracking).returns(() => actionMock.object);
+            setMocksForFocusError();
+
+            await testSubject.disableTabStops();
+
+            actionMock.verify(m => m.invoke(), Times.never());
+            verifyAllMocks();
+        });
+
+        it('startOver', async () => {
+            deviceFocusControllerMock
+                .setup(m => m.resetFocusTracking())
+                .returns(() => Promise.reject(errorMessage));
+
+            tabStopsActionsMock.setup(m => m.startOver).returns(() => actionMock.object);
+            setMocksForFocusError();
+
+            await testSubject.startOver();
+
+            actionMock.verify(m => m.invoke(), Times.never());
+            verifyAllMocks();
+        });
+
+        it('sendUpKey', async () => {
+            await testSendKeyEventError(KeyEventCode.Up, 'sendUpKey');
+        });
+
+        it('sendDownKey', async () => {
+            await testSendKeyEventError(KeyEventCode.Down, 'sendDownKey');
+        });
+
+        it('sendLeftKey', async () => {
+            await testSendKeyEventError(KeyEventCode.Left, 'sendLeftKey');
+        });
+
+        it('sendRightKey', async () => {
+            await testSendKeyEventError(KeyEventCode.Right, 'sendRightKey');
+        });
+
+        it('sendTabKey', async () => {
+            await testSendKeyEventError(KeyEventCode.Tab, 'sendTabKey');
+        });
+
+        it('sendEnterKey', async () => {
+            await testSendKeyEventError(KeyEventCode.Enter, 'sendEnterKey');
+        });
+
+        async function testSendKeyEventError(
+            keyEventCode: KeyEventCode,
+            funcName: keyof TabStopsActionCreator,
+        ): Promise<void> {
+            setMocksForFocusError();
+            deviceFocusControllerMock
+                .setup(m => m.sendKeyEvent(keyEventCode))
+                .returns(() => Promise.reject(errorMessage));
+
+            await testSubject[funcName]();
+
+            verifyAllMocks();
+        }
+
+        function setMocksForFocusError(): void {
+            telemetryEventHandlerMock
+                .setup(m => m.publishTelemetry(DEVICE_FOCUS_ERROR, {}))
+                .verifiable(Times.once());
+            loggerMock
+                .setup(m => m.log('focus controller failure: ' + errorMessage))
+                .verifiable(Times.once());
+            statusDisconnectedMock
+                .setup(m => m.invoke((It.isAny(), It.isAny())))
+                .verifiable(Times.once());
+            deviceConnectionActionsMock
+                .setup(m => m.statusDisconnected)
+                .returns(() => statusDisconnectedMock.object)
+                .verifiable(Times.once());
+        }
     });
 
-    it('startOver', () => {
-        tabStopsActionsMock.setup(m => m.startOver).returns(() => actionMock.object);
-
-        testSubject.startOver();
-
-        actionMock.verify(m => m.invoke(), Times.once());
-        deviceFocusControllerMock.verify(m => m.resetFocusTracking(), Times.once());
-    });
-
-    it('sendUpKey', () => {
-        testSubject.sendUpKey();
-        deviceFocusControllerMock.verify(m => m.sendUpKey(), Times.once());
-    });
-
-    it('sendDownKey', () => {
-        testSubject.sendDownKey();
-        deviceFocusControllerMock.verify(m => m.sendDownKey(), Times.once());
-    });
-
-    it('sendLeftKey', () => {
-        testSubject.sendLeftKey();
-        deviceFocusControllerMock.verify(m => m.sendLeftKey(), Times.once());
-    });
-
-    it('sendRightKey', () => {
-        testSubject.sendRightKey();
-        deviceFocusControllerMock.verify(m => m.sendRightKey(), Times.once());
-    });
-
-    it('sendTabKey', () => {
-        testSubject.sendTabKey();
-        deviceFocusControllerMock.verify(m => m.sendTabKey(), Times.once());
-    });
-
-    it('sendEnterKey', () => {
-        testSubject.sendEnterKey();
-        deviceFocusControllerMock.verify(m => m.sendEnterKey(), Times.once());
-    });
+    function verifyAllMocks(): void {
+        telemetryEventHandlerMock.verifyAll();
+        deviceConnectionActionsMock.verifyAll();
+        loggerMock.verifyAll();
+        statusDisconnectedMock.verifyAll();
+        statusConnectedMock.verifyAll();
+    }
 });

--- a/src/tests/unit/tests/electron/flux/store/__snapshots__/tab-stops-store.test.ts.snap
+++ b/src/tests/unit/tests/electron/flux/store/__snapshots__/tab-stops-store.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TabStopsStore returns default state 1`] = `
+Object {
+  "focusTracking": false,
+}
+`;

--- a/src/tests/unit/tests/electron/flux/store/tab-stops-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/tab-stops-store.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TabStopsActions } from 'electron/flux/action/tab-stops-actions';
+import { TabStopsStore } from 'electron/flux/store/tab-stops-store';
+import { TabStopsStoreData } from 'electron/flux/types/tab-stops-store-data';
+import { createStoreWithNullParams, StoreTester } from 'tests/unit/common/store-tester';
+
+describe('TabStopsStore', () => {
+    describe('constructor', () => {
+        it('has no side effects', () => {
+            const store = createStoreWithNullParams(TabStopsStore);
+            expect(store).toBeDefined();
+        });
+    });
+
+    it('returns default state', () => {
+        const actions = new TabStopsActions();
+        const store = new TabStopsStore(actions);
+        store.initialize();
+
+        expect(store.getState()).toMatchSnapshot();
+    });
+
+    it('onEnableFocusTracking', () => {
+        const initialState: TabStopsStoreData = {
+            focusTracking: false,
+        };
+        const expectedState: TabStopsStoreData = {
+            focusTracking: true,
+        };
+
+        CreateStoreTesterForTabStopsActions('enableFocusTracking').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
+    });
+
+    it('onDisableFocusTracking', () => {
+        const initialState: TabStopsStoreData = {
+            focusTracking: true,
+        };
+        const expectedState: TabStopsStoreData = {
+            focusTracking: false,
+        };
+
+        CreateStoreTesterForTabStopsActions('disableFocusTracking').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
+    });
+
+    it('onStartOver', () => {
+        const initialState: TabStopsStoreData = {
+            focusTracking: true,
+        };
+        const expectedState: TabStopsStoreData = {
+            focusTracking: false,
+        };
+
+        CreateStoreTesterForTabStopsActions('startOver').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
+    });
+
+    function CreateStoreTesterForTabStopsActions(
+        actionName: keyof TabStopsActions,
+    ): StoreTester<TabStopsStoreData, TabStopsActions> {
+        const factory = (actions: TabStopsActions) => new TabStopsStore(actions);
+
+        return new StoreTester(TabStopsActions, actionName, factory);
+    }
+});

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
@@ -2,16 +2,12 @@
 // Licensed under the MIT License.
 
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { Action } from 'common/flux/action';
-import { Logger } from 'common/logging/logger';
 import {
     DEVICE_FOCUS_DISABLE,
     DEVICE_FOCUS_ENABLE,
-    DEVICE_FOCUS_ERROR,
     DEVICE_FOCUS_KEYEVENT,
     DEVICE_FOCUS_RESET,
 } from 'electron/common/electron-telemetry-events';
-import { DeviceConnectionActions } from 'electron/flux/action/device-connection-actions';
 import { AndroidSetupStore } from 'electron/flux/store/android-setup-store';
 import { AndroidSetupStoreData } from 'electron/flux/types/android-setup-store-data';
 import { AdbWrapper, KeyEventCode } from 'electron/platform/android/adb-wrapper';
@@ -32,10 +28,6 @@ describe('DeviceFocusController tests', () => {
     let androidSetupStoreMock: IMock<AndroidSetupStore>;
     let commandSenderMock: IMock<DeviceFocusCommandSender>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
-    let deviceConnectionActionsMock: IMock<DeviceConnectionActions>;
-    let loggerMock: IMock<Logger>;
-    let statusDisconnectedMock: IMock<Action<void>>;
-    let statusConnectedMock: IMock<Action<void>>;
     let testSubject: DeviceFocusController;
 
     beforeEach(() => {
@@ -47,13 +39,6 @@ describe('DeviceFocusController tests', () => {
             undefined,
             MockBehavior.Strict,
         );
-        deviceConnectionActionsMock = Mock.ofType<DeviceConnectionActions>(
-            undefined,
-            MockBehavior.Strict,
-        );
-        loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
-        statusDisconnectedMock = Mock.ofType<Action<void>>();
-        statusConnectedMock = Mock.ofType<Action<void>>();
         const androidSetupStoreData: AndroidSetupStoreData = {
             scanPort: port,
             selectedDevice: {
@@ -73,8 +58,6 @@ describe('DeviceFocusController tests', () => {
             adbWrapperHolderMock.object,
             commandSenderMock.object,
             telemetryEventHandlerMock.object,
-            deviceConnectionActionsMock.object,
-            loggerMock.object,
             androidSetupStoreMock.object,
         );
         testSubject.initialize();
@@ -89,7 +72,6 @@ describe('DeviceFocusController tests', () => {
             telemetryEventHandlerMock
                 .setup(m => m.publishTelemetry(DEVICE_FOCUS_ENABLE, {}))
                 .verifiable(Times.once());
-            setFocusActionsForSuccess();
 
             await testSubject.enableFocusTracking();
 
@@ -104,7 +86,6 @@ describe('DeviceFocusController tests', () => {
             telemetryEventHandlerMock
                 .setup(m => m.publishTelemetry(DEVICE_FOCUS_DISABLE, {}))
                 .verifiable(Times.once());
-            setFocusActionsForSuccess();
 
             await testSubject.disableFocusTracking();
 
@@ -119,267 +100,23 @@ describe('DeviceFocusController tests', () => {
             telemetryEventHandlerMock
                 .setup(m => m.publishTelemetry(DEVICE_FOCUS_RESET, {}))
                 .verifiable(Times.once());
-            setFocusActionsForSuccess();
 
             await testSubject.resetFocusTracking();
 
             verifyAllMocks();
         });
 
-        it('sendUpKey sends correct command and telemetry', async () => {
+        it('sendKeyEvent sends correct command and telemetry', async () => {
             adbWrapperMock
                 .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Up))
                 .returns(() => Promise.resolve())
                 .verifiable(Times.once());
             setTelemetryMockForKeyEvent(KeyEventCode.Up);
-            setFocusActionsForSuccess();
 
-            await testSubject.sendUpKey();
-
-            verifyAllMocks();
-        });
-
-        it('sendDownKey sends correct command and telemetry', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Down))
-                .returns(() => Promise.resolve())
-                .verifiable(Times.once());
-            setTelemetryMockForKeyEvent(KeyEventCode.Down);
-            setFocusActionsForSuccess();
-
-            await testSubject.sendDownKey();
+            await testSubject.sendKeyEvent(KeyEventCode.Up);
 
             verifyAllMocks();
         });
-
-        it('sendLeftKey sends correct command and telemetry', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Left))
-                .returns(() => Promise.resolve())
-                .verifiable(Times.once());
-            setTelemetryMockForKeyEvent(KeyEventCode.Left);
-            setFocusActionsForSuccess();
-
-            await testSubject.sendLeftKey();
-
-            verifyAllMocks();
-        });
-
-        it('sendRightKey sends correct command and telemetry', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Right))
-                .returns(() => Promise.resolve())
-                .verifiable(Times.once());
-            setTelemetryMockForKeyEvent(KeyEventCode.Right);
-            setFocusActionsForSuccess();
-
-            await testSubject.sendRightKey();
-
-            verifyAllMocks();
-        });
-
-        it('sendEnterKey sends correct command and telemetry', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Enter))
-                .returns(() => Promise.resolve())
-                .verifiable(Times.once());
-            setTelemetryMockForKeyEvent(KeyEventCode.Enter);
-            setFocusActionsForSuccess();
-
-            await testSubject.sendEnterKey();
-
-            verifyAllMocks();
-        });
-
-        it('sendTabKey sends correct command and telemetry', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Tab))
-                .returns(() => Promise.resolve())
-                .verifiable(Times.once());
-            setTelemetryMockForKeyEvent(KeyEventCode.Tab);
-            setFocusActionsForSuccess();
-
-            await testSubject.sendTabKey();
-
-            verifyAllMocks();
-        });
-
-        function setFocusActionsForSuccess(): void {
-            statusConnectedMock
-                .setup(m => m.invoke((It.isAny(), It.isAny())))
-                .verifiable(Times.once());
-            deviceConnectionActionsMock
-                .setup(m => m.statusConnected)
-                .returns(() => statusConnectedMock.object)
-                .verifiable(Times.once());
-        }
-    });
-
-    describe('Error paths', () => {
-        const errorMessage: string = 'Welcome to the dark side';
-
-        it('enableFocusTracking sets error, logs, sends telemetry', async () => {
-            commandSenderMock
-                .setup(getter => getter(port, DeviceFocusCommand.Enable))
-                .returns(() => Promise.reject(errorMessage))
-                .verifiable(Times.once());
-            telemetryEventHandlerMock
-                .setup(m => m.publishTelemetry(DEVICE_FOCUS_ENABLE, {}))
-                .verifiable(Times.once());
-            setMocksForFocusError();
-
-            await testSubject.enableFocusTracking();
-
-            verifyAllMocks();
-        });
-
-        it('disableFocusTracking sets error, logs, sends telemetry', async () => {
-            commandSenderMock
-                .setup(getter => getter(port, DeviceFocusCommand.Disable))
-                .returns(() => Promise.reject(errorMessage))
-                .verifiable(Times.once());
-            telemetryEventHandlerMock
-                .setup(m => m.publishTelemetry(DEVICE_FOCUS_DISABLE, {}))
-                .verifiable(Times.once());
-            setMocksForFocusError();
-
-            await testSubject.disableFocusTracking();
-
-            verifyAllMocks();
-        });
-
-        it('resetFocusTracking sets error, logs, sends telemetry', async () => {
-            commandSenderMock
-                .setup(getter => getter(port, DeviceFocusCommand.Reset))
-                .returns(() => Promise.reject(errorMessage))
-                .verifiable(Times.once());
-            telemetryEventHandlerMock
-                .setup(m => m.publishTelemetry(DEVICE_FOCUS_RESET, {}))
-                .verifiable(Times.once());
-            setMocksForFocusError();
-
-            await testSubject.resetFocusTracking();
-
-            verifyAllMocks();
-        });
-
-        it('sendUpKey sets error, logs, sends telemetry', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Up))
-                .returns(() => Promise.reject(errorMessage))
-                .verifiable(Times.once());
-            setTelemetryMockForKeyEvent(KeyEventCode.Up);
-            setMocksForFocusError();
-
-            await testSubject.sendUpKey();
-
-            verifyAllMocks();
-        });
-
-        it('sendDownKey sets error, logs, sends telemetry', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Down))
-                .returns(() => Promise.reject(errorMessage))
-                .verifiable(Times.once());
-            setTelemetryMockForKeyEvent(KeyEventCode.Down);
-            setMocksForFocusError();
-
-            await testSubject.sendDownKey();
-
-            verifyAllMocks();
-        });
-
-        it('sendLeftKey sets error, logs, sends telemetry', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Left))
-                .returns(() => Promise.reject(errorMessage))
-                .verifiable(Times.once());
-            setTelemetryMockForKeyEvent(KeyEventCode.Left);
-            setMocksForFocusError();
-
-            await testSubject.sendLeftKey();
-
-            verifyAllMocks();
-        });
-
-        it('sendRightKey sets error, logs, sends telemetry', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Right))
-                .returns(() => Promise.reject(errorMessage))
-                .verifiable(Times.once());
-            setTelemetryMockForKeyEvent(KeyEventCode.Right);
-            setMocksForFocusError();
-
-            await testSubject.sendRightKey();
-
-            verifyAllMocks();
-        });
-
-        it('sendEnterKey sets error, logs, sends telemetry', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Enter))
-                .returns(() => Promise.reject(errorMessage))
-                .verifiable(Times.once());
-            setTelemetryMockForKeyEvent(KeyEventCode.Enter);
-            setMocksForFocusError();
-
-            await testSubject.sendEnterKey();
-
-            verifyAllMocks();
-        });
-
-        it('sendTabKey sets error, logs, sends telemetry', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Tab))
-                .returns(() => Promise.reject(errorMessage))
-                .verifiable(Times.once());
-            setTelemetryMockForKeyEvent(KeyEventCode.Tab);
-            setMocksForFocusError();
-
-            await testSubject.sendTabKey();
-
-            verifyAllMocks();
-        });
-
-        it('does not have device data', async () => {
-            androidSetupStoreMock.reset();
-
-            androidSetupStoreMock
-                .setup(m => m.addChangedListener(It.isAny()))
-                .callback(setDeviceData => setDeviceData(androidSetupStoreMock.object));
-
-            androidSetupStoreMock
-                .setup(m => m.getState())
-                .returns(() => ({} as AndroidSetupStoreData));
-
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(undefined, KeyEventCode.Up))
-                .returns(() => Promise.reject(errorMessage))
-                .verifiable(Times.once());
-
-            setTelemetryMockForKeyEvent(KeyEventCode.Up);
-            setMocksForFocusError();
-
-            testSubject.initialize();
-            await testSubject.sendUpKey();
-            verifyAllMocks();
-        });
-
-        function setMocksForFocusError(): void {
-            telemetryEventHandlerMock
-                .setup(m => m.publishTelemetry(DEVICE_FOCUS_ERROR, {}))
-                .verifiable(Times.once());
-            loggerMock
-                .setup(m => m.log('focus controller failure: ' + errorMessage))
-                .verifiable(Times.once());
-            statusDisconnectedMock
-                .setup(m => m.invoke((It.isAny(), It.isAny())))
-                .verifiable(Times.once());
-            deviceConnectionActionsMock
-                .setup(m => m.statusDisconnected)
-                .returns(() => statusDisconnectedMock.object)
-                .verifiable(Times.once());
-        }
     });
 
     function setTelemetryMockForKeyEvent(keyEventCode: KeyEventCode): void {
@@ -398,9 +135,5 @@ describe('DeviceFocusController tests', () => {
         adbWrapperMock.verifyAll();
         commandSenderMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
-        deviceConnectionActionsMock.verifyAll();
-        loggerMock.verifyAll();
-        statusDisconnectedMock.verifyAll();
-        statusConnectedMock.verifyAll();
     }
 });

--- a/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-controller.test.ts
@@ -115,62 +115,34 @@ describe('DeviceFocusController tests', () => {
         });
     });
 
-    describe('No store data paths', () => {
+    describe('Error: (no store data) paths', () => {
         beforeEach(() => {
             const androidSetupStoreData: AndroidSetupStoreData = {} as AndroidSetupStoreData;
             androidSetupStoreMock.setup(m => m.getState()).returns(() => androidSetupStoreData);
         });
 
         it('enableFocusTracking', async () => {
-            commandSenderMock
-                .setup(getter => getter(port, DeviceFocusCommand.Enable))
-                .returns(() => Promise.resolve())
-                .verifiable(Times.never());
-            telemetryEventHandlerMock
-                .setup(m => m.publishTelemetry(DEVICE_FOCUS_ENABLE, {}))
-                .verifiable(Times.never());
-
-            await testSubject.enableFocusTracking();
-            verifyAllMocks();
+            await expect(testSubject.enableFocusTracking()).rejects.toThrowError(
+                'scan port not found',
+            );
         });
 
         it('disableFocusTracking', async () => {
-            commandSenderMock
-                .setup(getter => getter(port, DeviceFocusCommand.Disable))
-                .returns(() => Promise.resolve())
-                .verifiable(Times.never());
-            telemetryEventHandlerMock
-                .setup(m => m.publishTelemetry(DEVICE_FOCUS_DISABLE, {}))
-                .verifiable(Times.never());
-
-            await testSubject.disableFocusTracking();
-
-            verifyAllMocks();
+            await expect(testSubject.disableFocusTracking()).rejects.toThrowError(
+                'scan port not found',
+            );
         });
 
         it('resetFocusTracking', async () => {
-            commandSenderMock
-                .setup(getter => getter(port, DeviceFocusCommand.Reset))
-                .returns(() => Promise.resolve())
-                .verifiable(Times.never());
-            telemetryEventHandlerMock
-                .setup(m => m.publishTelemetry(DEVICE_FOCUS_RESET, {}))
-                .verifiable(Times.never());
-
-            await testSubject.resetFocusTracking();
-
-            verifyAllMocks();
+            await expect(testSubject.resetFocusTracking()).rejects.toThrowError(
+                'scan port not found',
+            );
         });
 
         it('sendKeyEvent', async () => {
-            adbWrapperMock
-                .setup(m => m.sendKeyEvent(deviceId, KeyEventCode.Up))
-                .returns(() => Promise.resolve())
-                .verifiable(Times.never());
-
-            await testSubject.sendKeyEvent(KeyEventCode.Up);
-
-            verifyAllMocks();
+            await expect(testSubject.sendKeyEvent(KeyEventCode.Up)).rejects.toThrowError(
+                'selected device not found',
+            );
         });
     });
 

--- a/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/virtual-keyboard-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/virtual-keyboard-view.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`VirtualKeyboardView renders 1`] = `
   <VirtualKeyboardButtons
     deps={
       Object {
-        "deviceFocusController": Object {},
+        "tabStopsActionCreator": Object {},
       }
     }
     narrowModeStatus={

--- a/src/tests/unit/tests/electron/views/tab-stops/virtual-keyboard-buttons.test.tsx
+++ b/src/tests/unit/tests/electron/views/tab-stops/virtual-keyboard-buttons.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
-import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
+import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import {
     VirtualKeyboardButtons,
     VirtualKeyboardButtonsDeps,
@@ -15,14 +15,14 @@ import { IMock, Mock } from 'typemoq';
 
 describe('VirtualKeyboardButtons', () => {
     let props: VirtualKeyboardButtonsProps;
-    let deviceFocusControllerMock: IMock<DeviceFocusController>;
+    let tabStopsActionCreatorMock: IMock<TabStopsActionCreator>;
 
     beforeEach(() => {
-        deviceFocusControllerMock = Mock.ofType<DeviceFocusController>();
+        tabStopsActionCreatorMock = Mock.ofType<TabStopsActionCreator>();
 
         props = {
             deps: {
-                deviceFocusController: deviceFocusControllerMock.object,
+                tabStopsActionCreator: tabStopsActionCreatorMock.object,
             } as VirtualKeyboardButtonsDeps,
             narrowModeStatus: {
                 isVirtualKeyboardCollapsed: true,

--- a/src/tests/unit/tests/electron/views/tab-stops/virtual-keyboard-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/tab-stops/virtual-keyboard-view.test.tsx
@@ -17,7 +17,7 @@ describe('VirtualKeyboardView', () => {
 
     beforeEach(() => {
         deps = {
-            deviceFocusController: {},
+            tabStopsActionCreator: {},
         } as VirtualKeyboardViewDeps;
         props = {
             deps,


### PR DESCRIPTION
#### Details

Adds a store for tracking tab stops state. Also updates the action creator to use the device focus controller (and adds functionality).

##### Motivation

Feature work.

##### Context

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

The alternative approach to the action creator changes: we could instead listen to the tab stops store and then act accordingly. However, that would require a lot of state management and make the action creator complicated. What that would require:
- We would need to listen to the store update in device focus controller, compare past state, and then choose accordingly to either enable/disable focus tracking.
- Either inconsistency with how we send keyboard commands (direct device focus controller invocation) vs. enabling/disabling focus tracking (on store update) OR do store related infra work that will contain the virtual keyboard commands to send.

Due to this, I figured direct invocation of methods on the controller was the better approach to take.

Finally: wiring up these changes to the UI will be in a future PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
