### PR TITLE
feat(focus-mvp-client): wire up tabstops

### DIFF
--- a/src/electron/platform/android/test-configs/tab-stops/start-over-button-settings.ts
+++ b/src/electron/platform/android/test-configs/tab-stops/start-over-button-settings.ts
@@ -8,7 +8,7 @@ export const tabStopsStartOverButtonSettings = (
     props: ReflowCommandBarProps,
 ): StartOverButtonSettings => {
     return {
-        onClick: () => {},
-        disabled: true,
+        onClick: props.deps.tabStopsActionCreator.startOver,
+        disabled: false,
     };
 };

--- a/src/electron/types/content-page-info.ts
+++ b/src/electron/types/content-page-info.ts
@@ -16,7 +16,7 @@ export type ContentPageInfo = {
     title: string;
     allowsExportReport: boolean;
     description?: JSX.Element;
-    instancesSectionComponent?: ReactFCWithDisplayName<TestingContentProps>;
+    instancesSectionComponent: ReactFCWithDisplayName<TestingContentProps>;
     resultsFilter: ResultsFilter;
     visualHelperSection: VisualHelperSection;
     startOverButtonSettings: (props: ReflowCommandBarProps) => StartOverButtonSettings;

--- a/src/electron/views/results/components/reflow-command-bar.tsx
+++ b/src/electron/views/results/components/reflow-command-bar.tsx
@@ -16,6 +16,7 @@ import {
 } from 'DetailsView/components/report-export-component';
 import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { ContentPageInfo } from 'electron/types/content-page-info';
 import { css, IButton } from 'office-ui-fabric-react';
@@ -27,6 +28,7 @@ export type ReflowCommandBarDeps = {
     scanActionCreator: ScanActionCreator;
     dropdownClickHandler: DropdownClickHandler;
     reportGenerator: ReportGenerator;
+    tabStopsActionCreator: TabStopsActionCreator;
 } & ReportExportComponentDeps;
 
 export interface ReflowCommandBarProps {

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -26,6 +26,7 @@ import { DeviceConnectionStoreData } from 'electron/flux/types/device-connection
 import { LeftNavStoreData } from 'electron/flux/types/left-nav-store-data';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
+import { TabStopsStoreData } from 'electron/flux/types/tab-stops-store-data';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { ContentPageInfo } from 'electron/types/content-page-info';
 import {
@@ -78,6 +79,7 @@ export type ResultsViewProps = {
     androidSetupStoreData: AndroidSetupStoreData;
     leftNavStoreData: LeftNavStoreData;
     narrowModeStatus: NarrowModeStatus;
+    tabStopsStoreData: TabStopsStoreData;
 };
 
 export class ResultsView extends React.Component<ResultsViewProps> {
@@ -152,6 +154,7 @@ export class ResultsView extends React.Component<ResultsViewProps> {
                                         userConfigurationStoreData={userConfigurationStoreData}
                                         cardsViewData={cardsViewData}
                                         contentPageInfo={contentPageInfo}
+                                        showTabStops={this.props.tabStopsStoreData.focusTracking}
                                     />
                                 </main>
                             </div>

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -154,7 +154,7 @@ export class ResultsView extends React.Component<ResultsViewProps> {
                                         userConfigurationStoreData={userConfigurationStoreData}
                                         cardsViewData={cardsViewData}
                                         contentPageInfo={contentPageInfo}
-                                        showTabStops={this.props.tabStopsStoreData.focusTracking}
+                                        tabStopsEnabled={this.props.tabStopsStoreData.focusTracking}
                                     />
                                 </main>
                             </div>

--- a/src/electron/views/results/test-view.tsx
+++ b/src/electron/views/results/test-view.tsx
@@ -19,7 +19,7 @@ export type TestViewProps = {
     cardsViewData: CardsViewModel;
     userConfigurationStoreData: UserConfigurationStoreData;
     contentPageInfo: ContentPageInfo;
-    showTabStops: boolean;
+    tabStopsEnabled: boolean;
 };
 
 export const TestView = NamedFC<TestViewProps>('TestView', props => {
@@ -57,7 +57,7 @@ export const TestView = NamedFC<TestViewProps>('TestView', props => {
                 scanMetadata={scanMetadata}
                 shouldAlertFailuresCount={true}
                 cardsViewData={cardsViewData}
-                showTabStops={props.showTabStops}
+                tabStopsEnabled={props.tabStopsEnabled}
             />
         </div>
     );

--- a/src/electron/views/results/test-view.tsx
+++ b/src/electron/views/results/test-view.tsx
@@ -19,6 +19,7 @@ export type TestViewProps = {
     cardsViewData: CardsViewModel;
     userConfigurationStoreData: UserConfigurationStoreData;
     contentPageInfo: ContentPageInfo;
+    showTabStops: boolean;
 };
 
 export const TestView = NamedFC<TestViewProps>('TestView', props => {
@@ -33,10 +34,6 @@ export const TestView = NamedFC<TestViewProps>('TestView', props => {
 
     const { title, description } = contentPageInfo;
     const headerSection = <HeaderSection title={title} description={description} />;
-
-    if (contentPageInfo.instancesSectionComponent == null) {
-        return <div>{headerSection}</div>;
-    }
 
     if (scanStatus !== ScanStatus.Completed) {
         return (
@@ -60,6 +57,7 @@ export const TestView = NamedFC<TestViewProps>('TestView', props => {
                 scanMetadata={scanMetadata}
                 shouldAlertFailuresCount={true}
                 cardsViewData={cardsViewData}
+                showTabStops={props.showTabStops}
             />
         </div>
     );

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import './root-container.scss';
-
 import {
     withStoreSubscription,
     WithStoreSubscriptionDeps,
@@ -20,6 +18,7 @@ import { AndroidSetupStoreData } from 'electron/flux/types/android-setup-store-d
 import { DeviceConnectionStoreData } from 'electron/flux/types/device-connection-store-data';
 import { LeftNavStoreData } from 'electron/flux/types/left-nav-store-data';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
+import { TabStopsStoreData } from 'electron/flux/types/tab-stops-store-data';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import {
     DeviceConnectViewContainer,
@@ -31,6 +30,7 @@ import {
     ResultsViewProps,
 } from 'electron/views/results/results-view';
 import * as React from 'react';
+import './root-container.scss';
 
 export type RootContainerDeps = WithStoreSubscriptionDeps<RootContainerState> &
     DeviceConnectViewContainerDeps &
@@ -53,6 +53,7 @@ export type RootContainerState = {
     featureFlagStoreData: FeatureFlagStoreData;
     androidSetupStoreData: AndroidSetupStoreData;
     leftNavStoreData: LeftNavStoreData;
+    tabStopsStoreData: TabStopsStoreData;
 };
 
 export const RootContainerInternal = NamedFC<RootContainerProps>('RootContainerInternal', props => {

--- a/src/electron/views/tab-stops/tab-stops-testing-content.tsx
+++ b/src/electron/views/tab-stops/tab-stops-testing-content.tsx
@@ -13,7 +13,7 @@ export type TabStopsTestingContentDeps = {
 
 export type TabStopsTestingContentProps = {
     deps: TabStopsTestingContentDeps;
-    showTabStops: boolean;
+    tabStopsEnabled: boolean;
 };
 
 const ariaLevelForHowToTestHeading: number = 3;
@@ -23,7 +23,7 @@ export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
     props => {
         const tabStopsActionCreator = props.deps.tabStopsActionCreator;
         const onToggle = () => {
-            if (props.showTabStops) {
+            if (props.tabStopsEnabled) {
                 tabStopsActionCreator.disableTabStops();
             } else {
                 tabStopsActionCreator.enableTabStops();
@@ -34,7 +34,7 @@ export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
             <>
                 <Toggle
                     label={'Show tab stops'}
-                    checked={props.showTabStops}
+                    checked={props.tabStopsEnabled}
                     offText="Off"
                     onText="On"
                     className={styles.toggle}

--- a/src/electron/views/tab-stops/tab-stops-testing-content.tsx
+++ b/src/electron/views/tab-stops/tab-stops-testing-content.tsx
@@ -2,11 +2,15 @@
 // Licensed under the MIT License.
 
 import { NamedFC } from 'common/react/named-fc';
+import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import { Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './tab-stops-testing-content.scss';
 
-export type TabStopsTestingContentDeps = {};
+export type TabStopsTestingContentDeps = {
+    tabStopsActionCreator: TabStopsActionCreator;
+};
+
 export type TabStopsTestingContentProps = {
     deps: TabStopsTestingContentDeps;
     showTabStops: boolean;
@@ -17,6 +21,15 @@ const ariaLevelForHowToTestHeading: number = 3;
 export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
     'TabStopsTestingContent',
     props => {
+        const tabStopsActionCreator = props.deps.tabStopsActionCreator;
+        const onToggle = () => {
+            if (props.showTabStops) {
+                tabStopsActionCreator.disableTabStops();
+            } else {
+                tabStopsActionCreator.enableTabStops();
+            }
+        };
+
         return (
             <>
                 <Toggle
@@ -25,6 +38,7 @@ export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
                     offText="Off"
                     onText="On"
                     className={styles.toggle}
+                    onClick={onToggle}
                 />
                 <span role="heading" aria-level={ariaLevelForHowToTestHeading}>
                     <strong>How to test:</strong>

--- a/src/tests/unit/tests/electron/platform/android/test-configs/tab-stops/start-over-button-settings.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/test-configs/tab-stops/start-over-button-settings.test.ts
@@ -1,21 +1,32 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import { tabStopsStartOverButtonSettings } from 'electron/platform/android/test-configs/tab-stops/start-over-button-settings';
 import { ReflowCommandBarProps } from 'electron/views/results/components/reflow-command-bar';
+import { IMock, Mock } from 'typemoq';
 
 describe('tabStopsStartOverButtonSettings', () => {
     let props: ReflowCommandBarProps;
+    let tabStopsActionCreatorMock: IMock<TabStopsActionCreator>;
 
     beforeEach(() => {
-        props = {} as ReflowCommandBarProps;
+        tabStopsActionCreatorMock = Mock.ofType(TabStopsActionCreator);
+
+        props = {
+            deps: {
+                tabStopsActionCreator: tabStopsActionCreatorMock.object,
+            },
+        } as ReflowCommandBarProps;
     });
 
-    it('Disabled is true', () => {
-        expect(tabStopsStartOverButtonSettings(props).disabled).toBeTruthy();
+    it('Disabled is false', () => {
+        expect(tabStopsStartOverButtonSettings(props).disabled).toBe(false);
     });
 
-    it('clickHandler is stubbed out', () => {
-        tabStopsStartOverButtonSettings(props).onClick();
+    it('clickHandler is correct', () => {
+        expect(tabStopsStartOverButtonSettings(props).onClick).toEqual(
+            tabStopsActionCreatorMock.object.startOver,
+        );
     });
 });

--- a/src/tests/unit/tests/electron/views/results/__snapshots__/results-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/results/__snapshots__/results-view.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`ResultsView right content panel info changes when left nav selected key
     }
   }
   scanMetadata={null}
+  tabStopsEnabled={true}
   userConfigurationStoreData={
     Object {
       "isFirstTime": false,
@@ -156,6 +157,7 @@ exports[`ResultsView right content panel info renders with default/initial value
     }
   }
   scanMetadata={null}
+  tabStopsEnabled={true}
   userConfigurationStoreData={
     Object {
       "isFirstTime": false,
@@ -472,6 +474,7 @@ exports[`ResultsView when status scan <Completed> 1`] = `
                 }
               }
               scanStatus={2}
+              tabStopsEnabled={true}
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,
@@ -879,6 +882,7 @@ exports[`ResultsView when status scan <Failed> 1`] = `
               }
               scanMetadata={null}
               scanStatus={3}
+              tabStopsEnabled={true}
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,
@@ -1290,6 +1294,7 @@ exports[`ResultsView when status scan <Scanning> 1`] = `
               }
               scanMetadata={null}
               scanStatus={1}
+              tabStopsEnabled={true}
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,
@@ -1696,6 +1701,7 @@ exports[`ResultsView when status scan <undefined> 1`] = `
                 }
               }
               scanMetadata={null}
+              tabStopsEnabled={true}
               userConfigurationStoreData={
                 Object {
                   "isFirstTime": false,

--- a/src/tests/unit/tests/electron/views/results/__snapshots__/test-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/results/__snapshots__/test-view.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`TestView when status scan <Completed> 1`] = `
       }
     }
     shouldAlertFailuresCount={true}
+    showTabStops={true}
     userConfigurationStoreData={
       Object {
         "isFirstTime": false,

--- a/src/tests/unit/tests/electron/views/results/__snapshots__/test-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/results/__snapshots__/test-view.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`TestView when status scan <Completed> 1`] = `
       }
     }
     shouldAlertFailuresCount={true}
-    showTabStops={true}
+    tabStopsEnabled={true}
     userConfigurationStoreData={
       Object {
         "isFirstTime": false,

--- a/src/tests/unit/tests/electron/views/results/results-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/results-view.test.tsx
@@ -27,6 +27,7 @@ import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-crea
 import { DeviceConnectionStatus } from 'electron/flux/types/device-connection-status';
 import { LeftNavStoreData } from 'electron/flux/types/left-nav-store-data';
 import { ScanStatus } from 'electron/flux/types/scan-status';
+import { TabStopsStoreData } from 'electron/flux/types/tab-stops-store-data';
 import { ContentPageInfo, ContentPagesInfo } from 'electron/types/content-page-info';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
@@ -94,6 +95,10 @@ describe('ResultsView', () => {
             leftNavVisible: true,
         };
 
+        const tabStopsStoreData: TabStopsStoreData = {
+            focusTracking: true,
+        };
+
         const ruleResultsByStatusStub = {
             fail: [{ id: 'test-fail-id' } as CardRuleResult],
         } as CardRuleResultsByStatus;
@@ -143,6 +148,7 @@ describe('ResultsView', () => {
             },
             unifiedScanResultStoreData,
             leftNavStoreData,
+            tabStopsStoreData,
         } as ResultsViewProps;
 
         getCardSelectionViewDataMock

--- a/src/tests/unit/tests/electron/views/results/test-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/test-view.test.tsx
@@ -53,7 +53,7 @@ describe('TestView', () => {
             cardsViewData: cardsViewDataStub,
             scanStatus: ScanStatus[scanStatusName],
             contentPageInfo: contentPageInfo,
-            showTabStops: true,
+            tabStopsEnabled: true,
         };
 
         const testSubject = shallow(<TestView {...props} />);

--- a/src/tests/unit/tests/electron/views/results/test-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/test-view.test.tsx
@@ -53,6 +53,7 @@ describe('TestView', () => {
             cardsViewData: cardsViewDataStub,
             scanStatus: ScanStatus[scanStatusName],
             contentPageInfo: contentPageInfo,
+            showTabStops: true,
         };
 
         const testSubject = shallow(<TestView {...props} />);

--- a/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`TabStopsTestingContent renders 1`] = `
     className="toggle"
     label="Show tab stops"
     offText="Off"
+    onClick={[Function]}
     onText="On"
   />
   <span

--- a/src/tests/unit/tests/electron/views/tab-stops/tab-stops-testing-content.test.tsx
+++ b/src/tests/unit/tests/electron/views/tab-stops/tab-stops-testing-content.test.tsx
@@ -22,7 +22,7 @@ describe('TabStopsTestingContent', () => {
         );
         props = {
             deps: { tabStopsActionCreator: tabStopsActionCreatorMock.object },
-            showTabStops: true,
+            tabStopsEnabled: true,
         };
     });
 
@@ -42,7 +42,7 @@ describe('TabStopsTestingContent', () => {
     });
 
     test('toggles tab stops on', () => {
-        props.showTabStops = false;
+        props.tabStopsEnabled = false;
         tabStopsActionCreatorMock.setup(m => m.enableTabStops()).verifiable();
         const testSubject = shallow(<TabStopsTestingContent {...props} />);
         const onToggle = testSubject.find(Toggle).prop('onClick');

--- a/src/tests/unit/tests/electron/views/tab-stops/tab-stops-testing-content.test.tsx
+++ b/src/tests/unit/tests/electron/views/tab-stops/tab-stops-testing-content.test.tsx
@@ -1,19 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import {
-    TabStopsTestingContentProps,
     TabStopsTestingContent,
+    TabStopsTestingContentProps,
 } from 'electron/views/tab-stops/tab-stops-testing-content';
 import { shallow } from 'enzyme';
+import { Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
+import { IMock, Mock, MockBehavior } from 'typemoq';
 
 describe('TabStopsTestingContent', () => {
+    let tabStopsActionCreatorMock: IMock<TabStopsActionCreator>;
     let props: TabStopsTestingContentProps;
 
     beforeEach(() => {
+        tabStopsActionCreatorMock = Mock.ofType<TabStopsActionCreator>(
+            undefined,
+            MockBehavior.Strict,
+        );
         props = {
-            deps: {},
+            deps: { tabStopsActionCreator: tabStopsActionCreatorMock.object },
             showTabStops: true,
         };
     });
@@ -21,5 +29,26 @@ describe('TabStopsTestingContent', () => {
     test('renders', () => {
         const testSubject = shallow(<TabStopsTestingContent {...props} />);
         expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    test('toggles tab stops off', () => {
+        tabStopsActionCreatorMock.setup(m => m.disableTabStops()).verifiable();
+        const testSubject = shallow(<TabStopsTestingContent {...props} />);
+        const onToggle = testSubject.find(Toggle).prop('onClick');
+        const eventStub = null;
+        onToggle(eventStub);
+
+        tabStopsActionCreatorMock.verifyAll();
+    });
+
+    test('toggles tab stops on', () => {
+        props.showTabStops = false;
+        tabStopsActionCreatorMock.setup(m => m.enableTabStops()).verifiable();
+        const testSubject = shallow(<TabStopsTestingContent {...props} />);
+        const onToggle = testSubject.find(Toggle).prop('onClick');
+        const eventStub = null;
+        onToggle(eventStub);
+
+        tabStopsActionCreatorMock.verifyAll();
     });
 });


### PR DESCRIPTION
#### Details

wires up the tab stops test with the store/action creators recently created.
##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
