### PR TITLE
refactor(focus-mvp-client): telemetry moved to action creator for tab stops

### DIFF
--- a/src/electron/flux/action/tab-stops-action-creator.ts
+++ b/src/electron/flux/action/tab-stops-action-creator.ts
@@ -3,7 +3,13 @@
 
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { Logger } from 'common/logging/logger';
-import { DEVICE_FOCUS_ERROR } from 'electron/common/electron-telemetry-events';
+import {
+    DEVICE_FOCUS_DISABLE,
+    DEVICE_FOCUS_ENABLE,
+    DEVICE_FOCUS_ERROR,
+    DEVICE_FOCUS_KEYEVENT,
+    DEVICE_FOCUS_RESET,
+} from 'electron/common/electron-telemetry-events';
 import { DeviceConnectionActions } from 'electron/flux/action/device-connection-actions';
 import { TabStopsActions } from 'electron/flux/action/tab-stops-actions';
 import { KeyEventCode } from 'electron/platform/android/adb-wrapper';
@@ -20,6 +26,7 @@ export class TabStopsActionCreator {
 
     public enableTabStops = async () => {
         try {
+            this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ENABLE, {});
             await this.deviceFocusController.enableFocusTracking();
             this.tabStopsActions.enableFocusTracking.invoke();
             this.deviceConnectionActions.statusConnected.invoke();
@@ -30,6 +37,7 @@ export class TabStopsActionCreator {
 
     public disableTabStops = async () => {
         try {
+            this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_DISABLE, {});
             await this.deviceFocusController.disableFocusTracking();
             this.tabStopsActions.disableFocusTracking.invoke();
             this.deviceConnectionActions.statusConnected.invoke();
@@ -40,6 +48,7 @@ export class TabStopsActionCreator {
 
     public startOver = async () => {
         try {
+            this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_RESET, {});
             await this.deviceFocusController.resetFocusTracking();
             this.tabStopsActions.startOver.invoke();
             this.deviceConnectionActions.statusConnected.invoke();
@@ -49,40 +58,54 @@ export class TabStopsActionCreator {
     };
 
     public sendUpKey = async () => {
+        this.publishTelemetryForKeyboardEvent(KeyEventCode.Up);
         await this.wrapActionWithErrorHandling(
             this.deviceFocusController.sendKeyEvent(KeyEventCode.Up),
         );
     };
 
     public sendDownKey = async () => {
+        this.publishTelemetryForKeyboardEvent(KeyEventCode.Down);
         await this.wrapActionWithErrorHandling(
             this.deviceFocusController.sendKeyEvent(KeyEventCode.Down),
         );
     };
 
     public sendLeftKey = async () => {
+        this.publishTelemetryForKeyboardEvent(KeyEventCode.Left);
         await this.wrapActionWithErrorHandling(
             this.deviceFocusController.sendKeyEvent(KeyEventCode.Left),
         );
     };
 
     public sendRightKey = async () => {
+        this.publishTelemetryForKeyboardEvent(KeyEventCode.Right);
         await this.wrapActionWithErrorHandling(
             this.deviceFocusController.sendKeyEvent(KeyEventCode.Right),
         );
     };
 
     public sendTabKey = async () => {
+        this.publishTelemetryForKeyboardEvent(KeyEventCode.Tab);
         await this.wrapActionWithErrorHandling(
             this.deviceFocusController.sendKeyEvent(KeyEventCode.Tab),
         );
     };
 
     public sendEnterKey = async () => {
+        this.publishTelemetryForKeyboardEvent(KeyEventCode.Enter);
         await this.wrapActionWithErrorHandling(
             this.deviceFocusController.sendKeyEvent(KeyEventCode.Enter),
         );
     };
+
+    private publishTelemetryForKeyboardEvent(keyEventCode: KeyEventCode): void {
+        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_KEYEVENT, {
+            telemetry: {
+                keyEventCode,
+            },
+        });
+    }
 
     private wrapActionWithErrorHandling = async (innerAction: Promise<void>) => {
         try {

--- a/src/electron/platform/android/device-focus-controller.ts
+++ b/src/electron/platform/android/device-focus-controller.ts
@@ -1,13 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import {
-    DEVICE_FOCUS_DISABLE,
-    DEVICE_FOCUS_ENABLE,
-    DEVICE_FOCUS_KEYEVENT,
-    DEVICE_FOCUS_RESET,
-} from 'electron/common/electron-telemetry-events';
 import { AndroidSetupStore } from 'electron/flux/store/android-setup-store';
 import { KeyEventCode } from 'electron/platform/android/adb-wrapper';
 import {
@@ -20,35 +13,26 @@ export class DeviceFocusController {
     constructor(
         private readonly adbWrapperHolder: AdbWrapperHolder,
         private readonly commandSender: DeviceFocusCommandSender,
-        private readonly telemetryEventHandler: TelemetryEventHandler,
         private readonly androidSetupStore: AndroidSetupStore,
     ) {}
 
     public enableFocusTracking = async () => {
         const scanPort = this.getScanPort();
-        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ENABLE, {});
         await this.commandSender(scanPort, DeviceFocusCommand.Enable);
     };
 
     public disableFocusTracking = async () => {
         const scanPort = this.getScanPort();
-        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_DISABLE, {});
         await this.commandSender(scanPort, DeviceFocusCommand.Disable);
     };
 
     public resetFocusTracking = async () => {
         const scanPort = this.getScanPort();
-        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_RESET, {});
         await this.commandSender(scanPort, DeviceFocusCommand.Reset);
     };
 
     public sendKeyEvent = async (keyEventCode: KeyEventCode) => {
         const selectedDevice = this.getSelectedDevice();
-        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_KEYEVENT, {
-            telemetry: {
-                keyEventCode,
-            },
-        });
         return this.adbWrapperHolder.getAdb().sendKeyEvent(selectedDevice.id, keyEventCode);
     };
 

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -424,7 +424,6 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         const deviceFocusController = new DeviceFocusController(
             adbWrapperHolder,
             createDeviceFocusCommandSender(axios.get),
-            telemetryEventHandler,
             androidSetupStore,
         );
 


### PR DESCRIPTION
#### Details

Moves telemetry to a sole location in the action creator.

##### Motivation

Keeps telemetry in one place.

##### Context

From a previous PR comment.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
