### PR TITLE
feat(focus-mvp-client): Disable focus tracking when leaving tabstops tab

### DIFF
--- a/src/electron/platform/android/device-focus-minder.ts
+++ b/src/electron/platform/android/device-focus-minder.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { LeftNavStore } from 'electron/flux/store/left-nav-store';
+import { TabStopsStore } from 'electron/flux/store/tab-stops-store';
+import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
+import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
+
+export class DeviceFocusMinder {
+    private lastSelectedKey: LeftNavItemKey;
+
+    constructor(
+        private readonly deviceFocusController: DeviceFocusController,
+        private readonly tabStopsStore: TabStopsStore,
+        private readonly leftNavStore: LeftNavStore,
+    ) {}
+
+    public initialize() {
+        this.leftNavStore.addChangedListener(this.onLeftNavChanged);
+    }
+
+    private onLeftNavChanged = (): void => {
+        const selectedKey: LeftNavItemKey = this.leftNavStore.getState().selectedKey;
+
+        const disableTracking =
+            selectedKey !== this.lastSelectedKey &&
+            this.lastSelectedKey === 'tab-stops' &&
+            this.tabStopsStore.getState().focusTracking;
+
+        this.lastSelectedKey = selectedKey;
+
+        if (disableTracking) {
+            // Suppress the disconnected device popup on error
+            this.deviceFocusController.resetFocusTracking().then().catch();
+        }
+    };
+}

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -88,6 +88,7 @@ import { parseDeviceConfig } from 'electron/platform/android/device-config';
 import { createDeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
 import { createDeviceFocusCommandSender } from 'electron/platform/android/device-focus-command-sender';
 import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
+import { DeviceFocusMinder } from 'electron/platform/android/device-focus-minder';
 import { createScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
 import { LiveAppiumAdbCreator } from 'electron/platform/android/live-appium-adb-creator';
 import { ScanController } from 'electron/platform/android/scan-controller';
@@ -538,6 +539,13 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         const startTesting = () => {
             windowStateActionCreator.setRoute({ routeId: 'resultsView' });
         };
+
+        const deviceFocusMinder = new DeviceFocusMinder(
+            deviceFocusController,
+            tabStopsStore,
+            leftNavStore,
+        );
+        deviceFocusMinder.initialize();
 
         const deps: RootContainerRendererDeps = {
             ipcRendererShim: ipcRendererShim,

--- a/src/tests/unit/tests/electron/platform/android/device-focus-minder.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-focus-minder.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { LeftNavStore } from 'electron/flux/store/left-nav-store';
+import { TabStopsStore } from 'electron/flux/store/tab-stops-store';
+import { LeftNavStoreData } from 'electron/flux/types/left-nav-store-data';
+import { TabStopsStoreData } from 'electron/flux/types/tab-stops-store-data';
+import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
+import { DeviceFocusMinder } from 'electron/platform/android/device-focus-minder';
+import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
+describe('DeviceFocusMinder', () => {
+    let deviceFocusControllerMock: IMock<DeviceFocusController>;
+    let tabStopsStoreMock: IMock<TabStopsStore>;
+    let leftNavStoreMock: IMock<LeftNavStore>;
+    let testSubject: DeviceFocusMinder;
+
+    beforeEach(() => {
+        deviceFocusControllerMock = Mock.ofType<DeviceFocusController>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        tabStopsStoreMock = Mock.ofType<TabStopsStore>(undefined, MockBehavior.Strict);
+        leftNavStoreMock = Mock.ofType<LeftNavStore>(undefined, MockBehavior.Strict);
+
+        testSubject = new DeviceFocusMinder(
+            deviceFocusControllerMock.object,
+            tabStopsStoreMock.object,
+            leftNavStoreMock.object,
+        );
+    });
+
+    function verifyAllMocks() {
+        deviceFocusControllerMock.verifyAll();
+        tabStopsStoreMock.verifyAll();
+        leftNavStoreMock.verifyAll();
+    }
+
+    it('constructor changes nothing', () => {});
+
+    it('initialize registers listener', () => {
+        leftNavStoreMock.setup(m => m.addChangedListener(It.isAny())).verifiable(Times.once());
+
+        testSubject.initialize();
+
+        verifyAllMocks();
+    });
+
+    describe('Subject is initialized', () => {
+        let changeListener;
+
+        beforeEach(() => {
+            leftNavStoreMock
+                .setup(m => m.addChangedListener(It.is(p => p instanceof Function)))
+                .callback(cb => (changeListener = cb))
+                .verifiable(Times.once());
+
+            testSubject.initialize();
+        });
+
+        const leftNavItemKeys: LeftNavItemKey[] = [
+            'automated-checks',
+            'tab-stops',
+            'needs-review',
+            'overview',
+        ];
+
+        it.each(leftNavItemKeys)(
+            'Starting not in tab-stops, transitioning to <%s>',
+            newSelectedItemKey => {
+                const data: LeftNavStoreData = {
+                    selectedKey: newSelectedItemKey,
+                } as LeftNavStoreData;
+
+                leftNavStoreMock
+                    .setup(m => m.getState())
+                    .returns(() => data)
+                    .verifiable(Times.once());
+
+                changeListener();
+
+                verifyAllMocks();
+            },
+        );
+
+        describe('Starting in tab-stops', () => {
+            let leftNavStoreData: LeftNavStoreData;
+
+            beforeEach(() => {
+                leftNavStoreData = {
+                    selectedKey: 'tab-stops',
+                } as LeftNavStoreData;
+
+                leftNavStoreMock
+                    .setup(m => m.getState())
+                    .returns(() => leftNavStoreData)
+                    .verifiable(Times.exactly(2));
+
+                changeListener();
+            });
+
+            function setupTabStopsMock(focusTracking: boolean): void {
+                const tabStopsStoreData = {
+                    focusTracking,
+                } as TabStopsStoreData;
+
+                tabStopsStoreMock
+                    .setup(m => m.getState())
+                    .returns(() => tabStopsStoreData)
+                    .verifiable(Times.once());
+            }
+
+            function simulateLeftNavStateChange(newSelectedItemKey: LeftNavItemKey): void {
+                leftNavStoreData.selectedKey = newSelectedItemKey;
+                changeListener();
+            }
+
+            it.each(leftNavItemKeys)(
+                'transitioning to <%s>, focus tracking is disabled',
+                newSelectedItemKey => {
+                    if (newSelectedItemKey !== 'tab-stops') {
+                        setupTabStopsMock(false);
+                    }
+
+                    simulateLeftNavStateChange(newSelectedItemKey);
+
+                    verifyAllMocks();
+                },
+            );
+
+            it.each(leftNavItemKeys)(
+                'transitioning to <%s>, focus tracking is enabled',
+                newSelectedItemKey => {
+                    if (newSelectedItemKey !== 'tab-stops') {
+                        setupTabStopsMock(true);
+                        deviceFocusControllerMock
+                            .setup(m => m.resetFocusTracking())
+                            .returns(() => Promise.resolve())
+                            .verifiable(Times.once());
+                    }
+
+                    simulateLeftNavStateChange(newSelectedItemKey);
+
+                    verifyAllMocks();
+                },
+            );
+
+            it('DeviceController errors when transitioning are silently handled', () => {
+                setupTabStopsMock(true);
+
+                deviceFocusControllerMock
+                    .setup(m => m.resetFocusTracking())
+                    .returns(() => Promise.reject())
+                    .verifiable(Times.once());
+
+                simulateLeftNavStateChange('automated-checks');
+
+                verifyAllMocks();
+            });
+        });
+    });
+});


### PR DESCRIPTION
#### Details

The spec calls for focus tracking to only be active when the user is on the tabstops tab, and to be disabled each time the user enters the tabstops page. To accomplish that, the `DeviceFocusMinder` class watches for tab changes, then automatically resets focus tracking on the device when leaving the tabstops tab.

##### Motivation

Spec for focus tracking MVP

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
