### PR TITLE
feat(focus-mvp-client): reset tab stops to default state on left nav item select

### DIFF
--- a/src/electron/common/left-nav-item-factory.ts
+++ b/src/electron/common/left-nav-item-factory.ts
@@ -1,24 +1,32 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
+import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import { LeftNavItem } from 'electron/types/left-nav-item';
 import { TestConfig } from 'electron/types/test-config';
 
 export const createLeftNavItems = (
     configs: TestConfig[],
-    actionCreator: LeftNavActionCreator,
+    leftNavActionCreator: LeftNavActionCreator,
+    tabStopsActionCreator: TabStopsActionCreator,
 ): LeftNavItem[] => {
-    return configs.map(config => createLeftNavItem(config, actionCreator));
+    return configs.map(config =>
+        createLeftNavItem(config, leftNavActionCreator, tabStopsActionCreator),
+    );
 };
 
 const createLeftNavItem = (
     config: TestConfig,
     actionCreator: LeftNavActionCreator,
+    tabStopsActionCreator: TabStopsActionCreator,
 ): LeftNavItem => {
     return {
         key: config.key,
         displayName: config.contentPageInfo.title,
         featureFlag: config.featureFlag,
-        onSelect: () => actionCreator.itemSelected(config.key),
+        onSelect: () => {
+            actionCreator.itemSelected(config.key);
+            tabStopsActionCreator.resetTabStopsToDefaultState();
+        },
     };
 };

--- a/src/electron/flux/action/tab-stops-action-creator.ts
+++ b/src/electron/flux/action/tab-stops-action-creator.ts
@@ -57,6 +57,15 @@ export class TabStopsActionCreator {
         }
     };
 
+    public resetTabStopsToDefaultState = async () => {
+        try {
+            this.tabStopsActions.startOver.invoke();
+            await this.deviceFocusController.resetFocusTracking();
+        } catch (e) {
+            this.logger.log('reset tab stops to default state silently failed: ' + e);
+        }
+    };
+
     public sendUpKey = async () => {
         this.publishTelemetryForKeyboardEvent(KeyEventCode.Up);
         await this.wrapActionWithErrorHandling(

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -349,8 +349,26 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
 
         const androidSetupActionCreator = new AndroidSetupActionCreator(androidSetupActions);
 
+        const deviceFocusController = new DeviceFocusController(
+            adbWrapperHolder,
+            createDeviceFocusCommandSender(axios.get),
+            androidSetupStore,
+        );
+
+        const tabStopsActionCreator = new TabStopsActionCreator(
+            tabStopsActions,
+            deviceConnectionActions,
+            deviceFocusController,
+            logger,
+            telemetryEventHandler,
+        );
+
         const leftNavActionCreator = new LeftNavActionCreator(leftNavActions, cardSelectionActions);
-        const leftNavItems = createLeftNavItems(androidTestConfigs, leftNavActionCreator);
+        const leftNavItems = createLeftNavItems(
+            androidTestConfigs,
+            leftNavActionCreator,
+            tabStopsActionCreator,
+        );
         const contentPagesInfo = createContentPagesInfo(androidTestConfigs);
 
         const windowFrameActionCreator = new WindowFrameActionCreator(windowFrameActions);
@@ -420,20 +438,6 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         );
 
         scanController.initialize();
-
-        const deviceFocusController = new DeviceFocusController(
-            adbWrapperHolder,
-            createDeviceFocusCommandSender(axios.get),
-            androidSetupStore,
-        );
-
-        const tabStopsActionCreator = new TabStopsActionCreator(
-            tabStopsActions,
-            deviceConnectionActions,
-            deviceFocusController,
-            logger,
-            telemetryEventHandler,
-        );
 
         const dropdownActionMessageCreator = new DropdownActionMessageCreator(
             telemetryDataFactory,

--- a/src/tests/unit/tests/electron/common/left-nav-item-factory.test.ts
+++ b/src/tests/unit/tests/electron/common/left-nav-item-factory.test.ts
@@ -3,6 +3,7 @@
 
 import { createLeftNavItems } from 'electron/common/left-nav-item-factory';
 import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
+import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import { ContentPageInfo } from 'electron/types/content-page-info';
 import { LeftNavItem } from 'electron/types/left-nav-item';
 import { TestConfig } from 'electron/types/test-config';
@@ -38,8 +39,16 @@ describe('left nav item factory', () => {
             } as LeftNavItem,
         ];
         const actionCreatorMock = Mock.ofType<LeftNavActionCreator>(undefined, MockBehavior.Strict);
+        const tabStopsActionCreator = Mock.ofType<TabStopsActionCreator>(
+            undefined,
+            MockBehavior.Strict,
+        );
 
-        const actualItems = createLeftNavItems(configs, actionCreatorMock.object);
+        const actualItems = createLeftNavItems(
+            configs,
+            actionCreatorMock.object,
+            tabStopsActionCreator.object,
+        );
 
         expect(actualItems).toMatchObject(expectedItems);
 
@@ -55,14 +64,24 @@ describe('left nav item factory', () => {
                 } as ContentPageInfo,
             } as TestConfig,
         ];
-
         const actionCreatorMock = Mock.ofType<LeftNavActionCreator>(undefined, MockBehavior.Strict);
-        actionCreatorMock.setup(m => m.itemSelected('automated-checks')).verifiable();
+        const tabStopsActionCreatorMock = Mock.ofType<TabStopsActionCreator>(
+            undefined,
+            MockBehavior.Strict,
+        );
 
-        const leftNavItems = createLeftNavItems(configs, actionCreatorMock.object);
+        actionCreatorMock.setup(m => m.itemSelected('automated-checks')).verifiable();
+        tabStopsActionCreatorMock.setup(m => m.resetTabStopsToDefaultState()).verifiable();
+
+        const leftNavItems = createLeftNavItems(
+            configs,
+            actionCreatorMock.object,
+            tabStopsActionCreatorMock.object,
+        );
 
         leftNavItems[0].onSelect();
 
         actionCreatorMock.verifyAll();
+        tabStopsActionCreatorMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/flux/action-creator/tab-stops-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/tab-stops-action-creator.test.ts
@@ -100,6 +100,18 @@ describe('TabStopsActionCreator', () => {
             verifyAllMocks();
         });
 
+        it('resetTabStopsToDefaultState', async () => {
+            deviceFocusControllerMock
+                .setup(m => m.resetFocusTracking())
+                .returns(() => Promise.resolve());
+            tabStopsActionsMock.setup(m => m.startOver).returns(() => actionMock.object);
+
+            await testSubject.resetTabStopsToDefaultState();
+
+            actionMock.verify(m => m.invoke(), Times.once());
+            verifyAllMocks();
+        });
+
         it('sendUpKey', async () => {
             await testSendKeyEventSuccess(KeyEventCode.Up, 'sendUpKey');
         });
@@ -198,6 +210,22 @@ describe('TabStopsActionCreator', () => {
             await testSubject.startOver();
 
             actionMock.verify(m => m.invoke(), Times.never());
+            verifyAllMocks();
+        });
+
+        it('resetTabStopsToDefaultState', async () => {
+            const thrownErrorMessage = 'some error message';
+            const expectedLoggedMessage =
+                'reset tab stops to default state silently failed: ' + thrownErrorMessage;
+            deviceFocusControllerMock
+                .setup(m => m.resetFocusTracking())
+                .returns(() => Promise.reject(thrownErrorMessage));
+            tabStopsActionsMock.setup(m => m.startOver).returns(() => actionMock.object);
+            loggerMock.setup(m => m.log(expectedLoggedMessage)).verifiable();
+
+            await testSubject.resetTabStopsToDefaultState();
+
+            actionMock.verify(m => m.invoke(), Times.once());
             verifyAllMocks();
         });
 


### PR DESCRIPTION
#### Details

Left nav items disable/reset tests (like tab stops) on select.

##### Motivation

feature work.

##### Context

In the web product, we also reset all tests when left nav items are changed (and then enable the selected one). This does the same, except we do not currently have a method to "disable all tests". However, I suspect in the future we will specifically remove the dependency on tabstops action creator and add something that can do that for us.

Important to note:
1. For UX reasons, this will NOT trigger the device disconnected dialog if there is an error thrown (unlike other interactions).
2. This will also not publish telemetry in this scenario for resetting the tab stops state (outside of the telemetry that would otherwise be published for left nav item switching).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
