### PR TITLE
feat(focus-mvp-client): Add start over button e2e test

### DIFF
--- a/src/tests/electron/common/element-identifiers/results-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/results-view-selectors.ts
@@ -5,7 +5,10 @@ import { testViewLeftNavLinkAutomationId } from 'DetailsView/components/left-nav
 import { exportReportCommandBarButtonId } from 'DetailsView/components/report-export-component';
 import { fluentLeftNavAutomationId } from 'electron/views/left-nav/fluent-left-nav';
 import { leftNavAutomationId } from 'electron/views/left-nav/left-nav';
-import { commandButtonSettingsId } from 'electron/views/results/components/reflow-command-bar';
+import {
+    commandButtonRefreshId,
+    commandButtonSettingsId,
+} from 'electron/views/results/components/reflow-command-bar';
 import { resultsViewAutomationId } from 'electron/views/results/results-view';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 
@@ -22,4 +25,5 @@ export const ResultsViewSelectors = {
         )} li:nth-of-type(${position}) ${getAutomationIdSelector(testViewLeftNavLinkAutomationId)}`,
 
     settingsButton: getAutomationIdSelector(commandButtonSettingsId),
+    startOverButton: getAutomationIdSelector(commandButtonRefreshId),
 };

--- a/src/tests/electron/common/view-controllers/results-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/results-view-controller.ts
@@ -60,4 +60,9 @@ export class ResultsViewController extends ViewController {
 
         await this.waitForSelector(toggleInStateSelector);
     }
+
+    public async clickStartOver(): Promise<void> {
+        await this.waitForSelector(ResultsViewSelectors.startOverButton);
+        return this.click(ResultsViewSelectors.startOverButton);
+    }
 }

--- a/src/tests/electron/tests/__snapshots__/tab-stops-view.test.ts.snap
+++ b/src/tests/electron/tests/__snapshots__/tab-stops-view.test.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TabStopsView clicking start over sends corresponding service command 1`] = `
+"GET /AccessibilityInsights/FocusTracking/Reset
+"
+`;
+
 exports[`TabStopsView toggling show tab stops sends corresponding service commands 1`] = `
 "GET /AccessibilityInsights/FocusTracking/Enable
 GET /AccessibilityInsights/FocusTracking/Disable

--- a/src/tests/electron/tests/tab-stops-view.test.ts
+++ b/src/tests/electron/tests/tab-stops-view.test.ts
@@ -81,6 +81,15 @@ describe('TabStopsView', () => {
         expect(serverLog).toMatchSnapshot();
     });
 
+    it('clicking start over sends corresponding service command', async () => {
+        logController.resetServerLog();
+
+        await resultsViewController.clickStartOver();
+
+        const serverLog = await logController.getServerLog();
+        expect(serverLog).toMatchSnapshot();
+    });
+
     it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });


### PR DESCRIPTION
#### Details
This PR adds an e2e test to validate that the start over button on the tab stops test sends the reset command to the service.

##### Motivation
Feature spec

##### Context
Looks a lot like #3961 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
