### PR TITLE
feat(focus-mvp-client): Add e2e test for the leaving Tab Stops scenario

### DIFF
--- a/src/tests/electron/tests/__snapshots__/tab-stops-view.test.ts.snap
+++ b/src/tests/electron/tests/__snapshots__/tab-stops-view.test.ts.snap
@@ -5,6 +5,11 @@ exports[`TabStopsView clicking start over sends corresponding service command 1`
 "
 `;
 
+exports[`TabStopsView leaving tab stops sends reset service command 1`] = `
+"GET /AccessibilityInsights/FocusTracking/Reset
+"
+`;
+
 exports[`TabStopsView toggling show tab stops sends corresponding service commands 1`] = `
 "GET /AccessibilityInsights/FocusTracking/Enable
 GET /AccessibilityInsights/FocusTracking/Disable

--- a/src/tests/electron/tests/tab-stops-view.test.ts
+++ b/src/tests/electron/tests/tab-stops-view.test.ts
@@ -90,6 +90,15 @@ describe('TabStopsView', () => {
         expect(serverLog).toMatchSnapshot();
     });
 
+    it('leaving tab stops sends reset service command', async () => {
+        logController.resetServerLog();
+
+        await resultsViewController.clickLeftNavItem('automated-checks');
+
+        const serverLog = await logController.getServerLog();
+        expect(serverLog).toMatchSnapshot();
+    });
+
     it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });


### PR DESCRIPTION
#### Details
Leaving Tab Stops in unified sends a reset command to the service for Android. This PR adds an e2e test to validate that scenario.

##### Motivation
Feature spec

##### Context
n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
