### PR TITLE
feat(focus-mvp-client): Add browser close cleanup tasks and turnoff visualizations on close

### DIFF
--- a/src/electron/platform/android/setup/android-browser-close-cleanup-tasks.ts
+++ b/src/electron/platform/android/setup/android-browser-close-cleanup-tasks.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Logger } from 'common/logging/logger';
+import { IpcRendererShim } from 'electron/ipc/ipc-renderer-shim';
+import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
+import { AndroidPortCleaner } from 'electron/platform/android/setup/android-port-cleaner';
+
+export class AndroidBrowserCloseCleanupTasks {
+    constructor(
+        private readonly ipcRendererShim: IpcRendererShim,
+        private readonly deviceFocusController: DeviceFocusController,
+        private readonly androidPortCleaner: AndroidPortCleaner,
+        private readonly logger: Logger,
+    ) {}
+
+    public addBrowserCloseListener(): void {
+        this.ipcRendererShim.fromBrowserWindowClose.addAsyncListener(this.executeCleanupTasks);
+    }
+
+    private executeCleanupTasks = async () => {
+        try {
+            await this.deviceFocusController.disableFocusTracking();
+        } catch (error) {
+            this.logger.log(error);
+        }
+
+        await this.disconnectDevice();
+    };
+
+    private disconnectDevice = async () => {
+        try {
+            await this.androidPortCleaner.removeRemainingPorts();
+        } catch (error) {
+            this.logger.log(error);
+        }
+    };
+}

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -92,6 +92,7 @@ import { createScanResultsFetcher } from 'electron/platform/android/fetch-scan-r
 import { LiveAppiumAdbCreator } from 'electron/platform/android/live-appium-adb-creator';
 import { ScanController } from 'electron/platform/android/scan-controller';
 import { AdbWrapperHolder } from 'electron/platform/android/setup/adb-wrapper-holder';
+import { AndroidBrowserCloseCleanupTasks } from 'electron/platform/android/setup/android-browser-close-cleanup-tasks';
 import { AndroidPortCleaner } from 'electron/platform/android/setup/android-port-cleaner';
 import {
     AndroidServiceConfiguratorFactory,
@@ -219,11 +220,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
 
         const fetchDeviceConfig = createDeviceConfigFetcher(axios.get, parseDeviceConfig);
 
-        const androidPortCleaner: AndroidPortCleaner = new AndroidPortCleaner(
-            ipcRendererShim,
-            logger,
-        );
-        androidPortCleaner.initialize();
+        const androidPortCleaner: AndroidPortCleaner = new AndroidPortCleaner(logger);
 
         const apkLocator: AndroidServiceApkLocator = new AndroidServiceApkLocator(
             ipcRendererShim.getAppPath,
@@ -354,6 +351,14 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
             createDeviceFocusCommandSender(axios.get),
             androidSetupStore,
         );
+
+        const androidBrowserCloseCleanupTasks = new AndroidBrowserCloseCleanupTasks(
+            ipcRendererShim,
+            deviceFocusController,
+            androidPortCleaner,
+            logger,
+        );
+        androidBrowserCloseCleanupTasks.addBrowserCloseListener();
 
         const tabStopsActionCreator = new TabStopsActionCreator(
             tabStopsActions,

--- a/src/tests/unit/tests/electron/platform/android/setup/android-browser-close-cleanup-tasks.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/android-browser-close-cleanup-tasks.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Logger } from 'common/logging/logger';
+import { AsyncAction } from 'electron/ipc/async-action';
+import { IpcRendererShim } from 'electron/ipc/ipc-renderer-shim';
+import { DeviceFocusController } from 'electron/platform/android/device-focus-controller';
+import { AndroidBrowserCloseCleanupTasks } from 'electron/platform/android/setup/android-browser-close-cleanup-tasks';
+import { AndroidPortCleaner } from 'electron/platform/android/setup/android-port-cleaner';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
+describe('AndroidBrowserCloseCleanupTasks', () => {
+    let asyncActionMock: IMock<AsyncAction>;
+    let deviceFocusControllerMock: IMock<DeviceFocusController>;
+    let androidPortCleanerMock: IMock<AndroidPortCleaner>;
+    let loggerMock: IMock<Logger>;
+    let testSubject: AndroidBrowserCloseCleanupTasks;
+    let callback: () => Promise<void>;
+
+    beforeEach(() => {
+        asyncActionMock = Mock.ofType<AsyncAction>(undefined, MockBehavior.Strict);
+        deviceFocusControllerMock = Mock.ofType<DeviceFocusController>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        androidPortCleanerMock = Mock.ofType<AndroidPortCleaner>(undefined, MockBehavior.Strict);
+        loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
+
+        const ipcRendererShimStub = {
+            fromBrowserWindowClose: asyncActionMock.object,
+        } as IpcRendererShim;
+
+        testSubject = new AndroidBrowserCloseCleanupTasks(
+            ipcRendererShimStub,
+            deviceFocusControllerMock.object,
+            androidPortCleanerMock.object,
+            loggerMock.object,
+        );
+
+        asyncActionMock.setup(m => m.addAsyncListener(It.isAny())).callback(cb => (callback = cb));
+
+        testSubject.addBrowserCloseListener();
+    });
+
+    function verifyAllMocks() {
+        deviceFocusControllerMock.verifyAll();
+        androidPortCleanerMock.verifyAll();
+        loggerMock.verifyAll();
+    }
+
+    it('All cleanup tasks are called', async () => {
+        deviceFocusControllerMock
+            .setup(tsvc => tsvc.disableFocusTracking())
+            .returns(() => Promise.resolve())
+            .verifiable(Times.once());
+
+        androidPortCleanerMock
+            .setup(apc => apc.removeRemainingPorts())
+            .returns(() => Promise.resolve())
+            .verifiable(Times.once());
+
+        await callback();
+
+        verifyAllMocks();
+    });
+
+    it('Calls removeRemainingPorts if visualizationCleaner throws', async () => {
+        const errorMessage = 'threw in visualization cleaner';
+
+        deviceFocusControllerMock
+            .setup(tsvc => tsvc.disableFocusTracking())
+            .returns(() => Promise.reject(errorMessage))
+            .verifiable(Times.once());
+
+        androidPortCleanerMock
+            .setup(apc => apc.removeRemainingPorts())
+            .returns(() => Promise.resolve())
+            .verifiable(Times.once());
+
+        loggerMock.setup(m => m.log(errorMessage)).verifiable(Times.once());
+
+        await callback();
+
+        verifyAllMocks();
+    });
+
+    it('calls disableFocusTracking if portCleaner throws', async () => {
+        const errorMessage = 'threw in port cleaner';
+
+        deviceFocusControllerMock
+            .setup(tsvc => tsvc.disableFocusTracking())
+            .returns(() => Promise.resolve())
+            .verifiable(Times.once());
+
+        androidPortCleanerMock
+            .setup(apc => apc.removeRemainingPorts())
+            .returns(() => Promise.reject(errorMessage))
+            .verifiable(Times.once());
+
+        loggerMock.setup(m => m.log(errorMessage)).verifiable(Times.once());
+
+        await callback();
+
+        verifyAllMocks();
+    });
+});


### PR DESCRIPTION
#### Details
- Adds android browser close cleanup tasks
- Disables visualizations on device when the client is closed.

##### Motivation

To handle all browser close cleanup tasks in one place. Also improved UX, focus tracking visualizations will be turned off when the client is closed.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
