### PR TITLE
fix(focus-mvp-client): Wait for server logs to exist in tab stops e2e tests

### DIFF
--- a/src/tests/electron/tests/tab-stops-view.test.ts
+++ b/src/tests/electron/tests/tab-stops-view.test.ts
@@ -85,6 +85,7 @@ describe('TabStopsView', () => {
         logController.resetServerLog();
 
         await resultsViewController.clickStartOver();
+        await logController.waitForServerLogToContain('Reset');
 
         const serverLog = await logController.getServerLog();
         expect(serverLog).toMatchSnapshot();
@@ -94,6 +95,7 @@ describe('TabStopsView', () => {
         logController.resetServerLog();
 
         await resultsViewController.clickLeftNavItem('automated-checks');
+        await logController.waitForServerLogToContain('Reset');
 
         const serverLog = await logController.getServerLog();
         expect(serverLog).toMatchSnapshot();


### PR DESCRIPTION
#### Details
The e2e tests for the tab stops reset command should have waited for the server log to contain the command before moving forward. This PR corrects that absence. 

##### Motivation
This can cause unexpected build failures ([example](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=18754&view=logs&j=f648b298-ed87-530e-70f6-09f20704007e))

##### Context
We're already doing this in the rest of the tab stops e2e tests.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
