### PR TITLE
feat(focus-mvp-client): Add E2E test for exit scenario

### DIFF
--- a/src/electron/platform/android/setup/android-browser-close-cleanup-tasks.ts
+++ b/src/electron/platform/android/setup/android-browser-close-cleanup-tasks.ts
@@ -20,7 +20,7 @@ export class AndroidBrowserCloseCleanupTasks {
 
     private executeCleanupTasks = async () => {
         try {
-            await this.deviceFocusController.disableFocusTracking();
+            await this.deviceFocusController.resetFocusTracking();
         } catch (error) {
             this.logger.log(error);
         }

--- a/src/tests/electron/tests/__snapshots__/tab-stops-view.test.ts.snap
+++ b/src/tests/electron/tests/__snapshots__/tab-stops-view.test.ts.snap
@@ -5,6 +5,11 @@ exports[`TabStopsView clicking start over sends corresponding service command 1`
 "
 `;
 
+exports[`TabStopsView exiting while tab stops are active sends reset service command 1`] = `
+"GET /AccessibilityInsights/FocusTracking/Reset
+"
+`;
+
 exports[`TabStopsView leaving tab stops sends reset service command 1`] = `
 "GET /AccessibilityInsights/FocusTracking/Reset
 "

--- a/src/tests/electron/tests/tab-stops-view.test.ts
+++ b/src/tests/electron/tests/tab-stops-view.test.ts
@@ -99,6 +99,21 @@ describe('TabStopsView', () => {
         expect(serverLog).toMatchSnapshot();
     });
 
+    it('exiting while tab stops are active sends reset service command', async () => {
+        logController.resetServerLog();
+        await tabStopsViewController.clickToggleTabStops();
+        await logController.waitForServerLogToContain('Enable');
+        logController.resetServerLog();
+
+        if (app != null) {
+            await app.stop();
+        }
+
+        await logController.waitForServerLogToContain('Reset');
+        const serverLog = await logController.getServerLog();
+        expect(serverLog).toMatchSnapshot();
+    });
+
     it('should pass accessibility validation in all contrast modes', async () => {
         await scanForAccessibilityIssuesInAllModes(app);
     });

--- a/src/tests/unit/tests/electron/platform/android/setup/android-browser-close-cleanup-tasks.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/android-browser-close-cleanup-tasks.test.ts
@@ -50,7 +50,7 @@ describe('AndroidBrowserCloseCleanupTasks', () => {
 
     it('All cleanup tasks are called', async () => {
         deviceFocusControllerMock
-            .setup(tsvc => tsvc.disableFocusTracking())
+            .setup(tsvc => tsvc.resetFocusTracking())
             .returns(() => Promise.resolve())
             .verifiable(Times.once());
 
@@ -68,7 +68,7 @@ describe('AndroidBrowserCloseCleanupTasks', () => {
         const errorMessage = 'threw in visualization cleaner';
 
         deviceFocusControllerMock
-            .setup(tsvc => tsvc.disableFocusTracking())
+            .setup(tsvc => tsvc.resetFocusTracking())
             .returns(() => Promise.reject(errorMessage))
             .verifiable(Times.once());
 
@@ -88,7 +88,7 @@ describe('AndroidBrowserCloseCleanupTasks', () => {
         const errorMessage = 'threw in port cleaner';
 
         deviceFocusControllerMock
-            .setup(tsvc => tsvc.disableFocusTracking())
+            .setup(tsvc => tsvc.resetFocusTracking())
             .returns(() => Promise.resolve())
             .verifiable(Times.once());
 


### PR DESCRIPTION
#### Details

This is the final E2E test for this feature. It gets the app into the state where focus tracking is enabled, then it exits the app and confirms that we have sent the command to disable focus tracking. It also corrects a small error in the cleanup code, which was sending the Disable command instead of the Reset command. Eventually, the difference between them will be that Disable will retain a list of Views that have received the focus, while Reset will clear that list. 

##### Motivation

Part of the feature

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
