### PR TITLE
feat(focus-mvp-client): add unit test to verify call order of browser cleanup tasks

### DIFF
--- a/src/electron/platform/android/setup/android-browser-close-cleanup-tasks.ts
+++ b/src/electron/platform/android/setup/android-browser-close-cleanup-tasks.ts
@@ -18,17 +18,20 @@ export class AndroidBrowserCloseCleanupTasks {
         this.ipcRendererShim.fromBrowserWindowClose.addAsyncListener(this.executeCleanupTasks);
     }
 
-    private executeCleanupTasks = async () => {
+    private executeCleanupTasks = async (): Promise<void> => {
+        await this.resetFocusTracking();
+        await this.disconnectDevice();
+    };
+
+    private resetFocusTracking = async (): Promise<void> => {
         try {
             await this.deviceFocusController.resetFocusTracking();
         } catch (error) {
             this.logger.log(error);
         }
-
-        await this.disconnectDevice();
     };
 
-    private disconnectDevice = async () => {
+    private disconnectDevice = async (): Promise<void> => {
         try {
             await this.androidPortCleaner.removeRemainingPorts();
         } catch (error) {

--- a/src/tests/unit/tests/electron/platform/android/setup/android-browser-close-cleanup-tasks.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/android-browser-close-cleanup-tasks.test.ts
@@ -48,18 +48,23 @@ describe('AndroidBrowserCloseCleanupTasks', () => {
         loggerMock.verifyAll();
     }
 
-    it('All cleanup tasks are called', async () => {
+    it('All cleanup tasks are called and in order', async () => {
+        const callHistory = [];
         deviceFocusControllerMock
             .setup(tsvc => tsvc.resetFocusTracking())
+            .callback(() => callHistory.push('resetFocusTracking'))
             .returns(() => Promise.resolve())
             .verifiable(Times.once());
 
         androidPortCleanerMock
             .setup(apc => apc.removeRemainingPorts())
+            .callback(() => callHistory.push('removeRemainingPorts'))
             .returns(() => Promise.resolve())
             .verifiable(Times.once());
 
         await callback();
+
+        expect(callHistory).toEqual(['resetFocusTracking', 'removeRemainingPorts']);
 
         verifyAllMocks();
     });


### PR DESCRIPTION
#### Details

- Ensures all cleanup tasks are run in the correct order as disconnectDevice must be the last cleanup task to run.

##### Motivation

To ensure calls are executed in the proper order

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
