### PR TITLE
fix: add telemetry for next requirement button specifically

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -173,6 +173,27 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
+    public selectNextRequirement(
+        event: React.MouseEvent<HTMLElement>,
+        nextRequirement: string,
+        visualizationType: VisualizationType,
+    ): void {
+        const payload: SelectTestSubviewPayload = {
+            telemetry: this.telemetryFactory.forSelectRequirement(
+                event,
+                visualizationType,
+                nextRequirement,
+            ),
+            selectedTestSubview: nextRequirement,
+            selectedTest: visualizationType,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.SelectNextRequirement,
+            payload: payload,
+        });
+    }
+
     public selectGettingStarted(
         event: React.MouseEvent<HTMLElement>,
         visualizationType: VisualizationType,

--- a/src/DetailsView/components/next-requirement-button.tsx
+++ b/src/DetailsView/components/next-requirement-button.tsx
@@ -26,7 +26,7 @@ export const NextRequirementButton = NamedFC<NextRequirementButtonProps>(
         }
 
         const selectNextRequirement = (event: React.MouseEvent<HTMLElement>) => {
-            props.deps.detailsViewActionMessageCreator.selectRequirement(
+            props.deps.detailsViewActionMessageCreator.selectNextRequirement(
                 event,
                 props.nextRequirement.key,
                 props.currentTest,

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -46,6 +46,10 @@ export class AssessmentActionCreator {
             this.onSelectTestRequirement,
         );
         this.interpreter.registerTypeToPayloadCallback(
+            AssessmentMessages.SelectNextRequirement,
+            this.onSelectNextTestRequirement,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
             AssessmentMessages.SelectGettingStarted,
             this.onSelectGettingStarted,
         );
@@ -253,6 +257,14 @@ export class AssessmentActionCreator {
     private onSelectTestRequirement = (payload: SelectTestSubviewPayload): void => {
         this.assessmentActions.selectTestSubview.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.SELECT_REQUIREMENT, payload);
+    };
+
+    private onSelectNextTestRequirement = (payload: SelectTestSubviewPayload): void => {
+        this.assessmentActions.selectTestSubview.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(
+            TelemetryEvents.SELECT_NEXT_REQUIREMENT,
+            payload,
+        );
     };
 
     private onSelectGettingStarted = (payload: SelectGettingStartedPayload): void => {

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -22,6 +22,7 @@ export const INSPECT_OPEN: string = 'InspectOpen';
 export const COPY_ISSUE_DETAILS: string = 'CopyIssueDetails';
 export const FILE_ISSUE_CLICK: string = 'FileIssueClick';
 export const SELECT_REQUIREMENT: string = 'selectRequirement';
+export const SELECT_NEXT_REQUIREMENT: string = 'selectNextRequirement';
 export const SELECT_GETTING_STARTED: string = 'selectGettingStarted';
 export const START_OVER_TEST: string = 'startOverTest';
 export const CANCEL_START_OVER_TEST: string = 'cancelStartOverTest';

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -71,6 +71,7 @@ export const Messages = {
 
     Assessment: {
         SelectTestRequirement: `${messagePrefix}/details-view/requirement/select`,
+        SelectNextRequirement: `${messagePrefix}/details-view/requirement/select-next`,
         SelectGettingStarted: `${messagePrefix}/details-view/select-getting-started`,
         ExpandTestNav: `${messagePrefix}/details-view/expand-test-nav`,
         CollapseTestNav: `${messagePrefix}/details-view/collapse-test-nav`,

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -155,6 +155,38 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         );
     });
 
+    test('selectNextRequirement', () => {
+        const view = VisualizationType.Headings;
+        const selectedRequirement = HeadingsTestStep.headingFunction;
+        const event = eventStubFactory.createKeypressEvent() as any;
+        const telemetry: RequirementSelectTelemetryData = {
+            triggeredBy: 'keypress',
+            selectedTest: VisualizationType[view],
+            selectedRequirement: selectedRequirement,
+            source: testSource,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.SelectNextRequirement,
+            payload: {
+                telemetry: telemetry,
+                selectedTestSubview: selectedRequirement,
+                selectedTest: view,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tf => tf.forSelectRequirement(event, view, selectedRequirement))
+            .returns(() => telemetry);
+
+        testSubject.selectNextRequirement(event, HeadingsTestStep.headingFunction, view);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
     test('selectGettingStarted', () => {
         const view = VisualizationType.Headings;
         const event = eventStubFactory.createKeypressEvent() as any;

--- a/src/tests/unit/tests/DetailsView/components/next-requirement-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/next-requirement-button.test.tsx
@@ -39,7 +39,7 @@ describe('NextRequirementButton', () => {
     it('validate next requirement button', () => {
         messageCreatorMock
             .setup(mock =>
-                mock.selectRequirement(eventStub, props.nextRequirement.key, props.currentTest),
+                mock.selectNextRequirement(eventStub, props.nextRequirement.key, props.currentTest),
             )
             .verifiable();
 

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -556,6 +556,34 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
+    it('handles SelectNextRequirement message', () => {
+        const payload: SelectTestSubviewPayload = {
+            selectedTestSubview: 'test-requirement',
+            ...telemetryOnlyPayload,
+        } as SelectTestSubviewPayload;
+
+        const selectNextRequirement = createActionMock(payload);
+        const actionsMock = createActionsMock('selectTestSubview', selectNextRequirement.object);
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.SelectNextRequirement,
+            payload,
+        );
+
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        selectNextRequirement.verifyAll();
+        telemetryEventHandlerMock.verify(
+            tp => tp.publishTelemetry(TelemetryEvents.SELECT_NEXT_REQUIREMENT, payload),
+            Times.once(),
+        );
+    });
+
     it('handles SelectGettingStarted message', () => {
         const payload: SelectGettingStartedPayload = {
             ...telemetryOnlyPayload,


### PR DESCRIPTION
#### Details

Creates new methods on action-creator/message-action-creator side to fire telemetry specifically for next requirement button.

##### Motivation

We currently don't have telemetry specifically for this scenario so it is hard to know when users are using this next requirement button vs. normally selecting a requirement.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
