### PR TITLE
fix: adding in missing 4a step and unifying tab stops testing content with web

### DIFF
--- a/src/electron/views/tab-stops/tab-stops-testing-content.scss
+++ b/src/electron/views/tab-stops/tab-stops-testing-content.scss
@@ -4,7 +4,9 @@
 .how-to-test-list {
     padding-left: 1em;
 }
-
+.disc-style-type {
+    list-style-type: disc !important;
+}
 .toggle {
     display: flex;
     align-items: center;

--- a/src/electron/views/tab-stops/tab-stops-testing-content.tsx
+++ b/src/electron/views/tab-stops/tab-stops-testing-content.tsx
@@ -59,10 +59,10 @@ export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
                     </li>
                     <li>
                         Use the virtual keyboard to the right (or a physical keyboard) to:
-                        <ul>
+                        <ul className={styles.discStyleType}>
                             <li>
                                 Navigate linearly through all the interactive elements using only
-                                the Tab key.
+                                the <strong>Tab</strong> key.
                             </li>
                             <li>
                                 Navigate to each interactive element and then use the arrow keys to
@@ -73,10 +73,10 @@ export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
                     <li>
                         As you navigate to each element, look for these{' '}
                         <strong>accessibility problems</strong>:
-                        <ul>
+                        <ul className={styles.discStyleType}>
                             <li>
-                                An interactive element can't be reached using the Tab and arrow
-                                keys.
+                                An interactive element can't be reached using the{' '}
+                                <strong>Tab</strong> and arrow keys.
                             </li>
                             <li>
                                 An interactive element "traps" input focus and prevents navigating

--- a/src/electron/views/tab-stops/tab-stops-testing-content.tsx
+++ b/src/electron/views/tab-stops/tab-stops-testing-content.tsx
@@ -61,6 +61,10 @@ export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
                         Use the virtual keyboard to the right (or a physical keyboard) to:
                         <ul>
                             <li>
+                                Navigate linearly through all the interactive elements using only
+                                the Tab key.
+                            </li>
+                            <li>
                                 Navigate to each interactive element and then use the arrow keys to
                                 navigate away in each direction (up/down/left/right).
                             </li>

--- a/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
@@ -48,6 +48,9 @@ exports[`TabStopsTestingContent renders 1`] = `
       Use the virtual keyboard to the right (or a physical keyboard) to:
       <ul>
         <li>
+          Navigate linearly through all the interactive elements using only the Tab key.
+        </li>
+        <li>
           Navigate to each interactive element and then use the arrow keys to navigate away in each direction (up/down/left/right).
         </li>
       </ul>

--- a/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
@@ -46,9 +46,15 @@ exports[`TabStopsTestingContent renders 1`] = `
     </li>
     <li>
       Use the virtual keyboard to the right (or a physical keyboard) to:
-      <ul>
+      <ul
+        className="discStyleType"
+      >
         <li>
-          Navigate linearly through all the interactive elements using only the Tab key.
+          Navigate linearly through all the interactive elements using only the 
+          <strong>
+            Tab
+          </strong>
+           key.
         </li>
         <li>
           Navigate to each interactive element and then use the arrow keys to navigate away in each direction (up/down/left/right).
@@ -62,9 +68,16 @@ exports[`TabStopsTestingContent renders 1`] = `
         accessibility problems
       </strong>
       :
-      <ul>
+      <ul
+        className="discStyleType"
+      >
         <li>
-          An interactive element can't be reached using the Tab and arrow keys.
+          An interactive element can't be reached using the
+           
+          <strong>
+            Tab
+          </strong>
+           and arrow keys.
         </li>
         <li>
           An interactive element "traps" input focus and prevents navigating away.


### PR DESCRIPTION
#### Details

Some of the testing text was accidentally omitted in a previous commit, this restores it. This also bolds mentions of the "Tab" key and makes the sublists type of "disc" to bring it more in-line with Web's appearance for the tab stops test.

![image](https://user-images.githubusercontent.com/13286385/109734131-56a55d00-7b75-11eb-910f-2035111deca4.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
