### PR TITLE
feat(focus-mvp-android-device) Grant overlay permission

### DIFF
--- a/src/electron/platform/android/adb-wrapper.ts
+++ b/src/electron/platform/android/adb-wrapper.ts
@@ -30,6 +30,7 @@ export interface AdbWrapper {
     setTcpForwarding(deviceId: string, localPort: number, devicePort: number): Promise<number>;
     removeTcpForwarding(deviceId: string, devicePort: number): Promise<void>;
     sendKeyEvent(deviceId: string, keyEventCode: KeyEventCode): Promise<void>;
+    grantOverlayPermission: (deviceId: string) => Promise<void>;
 }
 
 export interface AdbWrapperFactory {

--- a/src/electron/platform/android/adb-wrapper.ts
+++ b/src/electron/platform/android/adb-wrapper.ts
@@ -30,7 +30,7 @@ export interface AdbWrapper {
     setTcpForwarding(deviceId: string, localPort: number, devicePort: number): Promise<number>;
     removeTcpForwarding(deviceId: string, devicePort: number): Promise<void>;
     sendKeyEvent(deviceId: string, keyEventCode: KeyEventCode): Promise<void>;
-    grantOverlayPermission: (deviceId: string) => Promise<void>;
+    grantOverlayPermission: (deviceId: string, packageName: string) => Promise<void>;
 }
 
 export interface AdbWrapperFactory {

--- a/src/electron/platform/android/appium-adb-wrapper.ts
+++ b/src/electron/platform/android/appium-adb-wrapper.ts
@@ -89,18 +89,16 @@ export class AppiumAdbWrapper implements AdbWrapper {
         await this.adb.shell(['input', 'keyevent', keyEventCode]);
     };
 
-    public grantOverlayPermission = async (deviceId: string): Promise<void> => {
+    public grantOverlayPermission = async (
+        deviceId: string,
+        packageName: string,
+    ): Promise<void> => {
         this.adb.setDeviceId(deviceId);
-        await this.adb.shell([
-            'cmd',
-            'appops',
-            'reset',
-            'com.microsoft.accessibilityinsightsforandroidservice',
-        ]);
+        await this.adb.shell(['cmd', 'appops', 'reset', packageName]);
         await this.adb.shell([
             'pm',
             'grant',
-            'com.microsoft.accessibilityinsightsforandroidservice',
+            packageName,
             'android.permission.SYSTEM_ALERT_WINDOW',
         ]);
     };

--- a/src/electron/platform/android/appium-adb-wrapper.ts
+++ b/src/electron/platform/android/appium-adb-wrapper.ts
@@ -88,4 +88,20 @@ export class AppiumAdbWrapper implements AdbWrapper {
         this.adb.setDeviceId(deviceId);
         await this.adb.shell(['input', 'keyevent', keyEventCode]);
     };
+
+    public grantOverlayPermission = async (deviceId: string): Promise<void> => {
+        this.adb.setDeviceId(deviceId);
+        await this.adb.shell([
+            'cmd',
+            'appops',
+            'reset',
+            'com.microsoft.accessibilityinsightsforandroidservice',
+        ]);
+        await this.adb.shell([
+            'pm',
+            'grant',
+            'com.microsoft.accessibilityinsightsforandroidservice',
+            'android.permission.SYSTEM_ALERT_WINDOW',
+        ]);
+    };
 }

--- a/src/electron/platform/android/setup/android-service-configurator.ts
+++ b/src/electron/platform/android/setup/android-service-configurator.ts
@@ -85,7 +85,10 @@ export class AndroidServiceConfigurator implements ServiceConfigurator {
     };
 
     public grantOverlayPermission = async (): Promise<void> => {
-        return await this.adbWrapper.grantOverlayPermission(this.selectedDeviceId);
+        return await this.adbWrapper.grantOverlayPermission(
+            this.selectedDeviceId,
+            this.servicePackageName,
+        );
     };
 
     public setupTcpForwarding = async (): Promise<number> => {

--- a/src/electron/platform/android/setup/android-service-configurator.ts
+++ b/src/electron/platform/android/setup/android-service-configurator.ts
@@ -15,6 +15,7 @@ export interface ServiceConfigurator {
     hasRequiredServiceVersion(): Promise<boolean>;
     installRequiredServiceVersion(): Promise<void>;
     hasRequiredPermissions(): Promise<boolean>;
+    grantOverlayPermission(): Promise<void>;
     setupTcpForwarding(): Promise<number>;
     removeTcpForwarding(hostPort: number): Promise<void>;
 }
@@ -81,6 +82,10 @@ export class AndroidServiceConfigurator implements ServiceConfigurator {
         );
         const screenshotGranted: boolean = mediaProjectionOutput.includes(this.servicePackageName);
         return screenshotGranted;
+    };
+
+    public grantOverlayPermission = async (): Promise<void> => {
+        return await this.adbWrapper.grantOverlayPermission(this.selectedDeviceId);
     };
 
     public setupTcpForwarding = async (): Promise<number> => {

--- a/src/electron/platform/android/setup/android-setup-deps.ts
+++ b/src/electron/platform/android/setup/android-setup-deps.ts
@@ -12,6 +12,7 @@ export type AndroidSetupDeps = {
     hasExpectedServiceVersion: () => Promise<boolean>;
     installService: () => Promise<boolean>;
     hasExpectedPermissions: () => Promise<boolean>;
+    grantOverlayPermission: () => Promise<void>;
     setupTcpForwarding: () => Promise<number>;
     removeTcpForwarding: (hostPort: number) => Promise<void>;
     fetchDeviceConfig: (port: number) => Promise<DeviceConfig>;

--- a/src/electron/platform/android/setup/android-setup-step-id.ts
+++ b/src/electron/platform/android/setup/android-setup-step-id.ts
@@ -13,6 +13,7 @@ export type AndroidSetupStepId =
     | 'prompt-install-failed'
     | 'detect-permissions'
     | 'prompt-grant-permissions'
+    | 'grant-overlay-permission'
     | 'configuring-port-forwarding'
     | 'prompt-configuring-port-forwarding-failed'
     | 'prompt-connected-start-testing';

--- a/src/electron/platform/android/setup/android-setup-steps-configs.ts
+++ b/src/electron/platform/android/setup/android-setup-steps-configs.ts
@@ -9,6 +9,7 @@ import { configuringPortForwarding } from 'electron/platform/android/setup/steps
 import { detectDevices } from 'electron/platform/android/setup/steps/detect-devices';
 import { detectPermissions } from 'electron/platform/android/setup/steps/detect-permissions';
 import { detectService } from 'electron/platform/android/setup/steps/detect-service';
+import { grantOverlayPermission } from 'electron/platform/android/setup/steps/grant-overlay-permission';
 import { installingService } from 'electron/platform/android/setup/steps/installing-service';
 import { promptChooseDevice } from 'electron/platform/android/setup/steps/prompt-choose-device';
 import { promptConfiguringPortForwardingFailed } from 'electron/platform/android/setup/steps/prompt-configuring-port-forwarding-failed';
@@ -51,6 +52,7 @@ export const allAndroidSetupStepConfigs: AndroidSetupStepConfigs = {
     'prompt-install-failed': promptInstallService,
     'detect-permissions': detectPermissions,
     'prompt-grant-permissions': promptGrantPermissions,
+    'grant-overlay-permission': grantOverlayPermission,
     'configuring-port-forwarding': configuringPortForwarding,
     'prompt-configuring-port-forwarding-failed': promptConfiguringPortForwardingFailed,
     'prompt-connected-start-testing': promptConnectedStartTesting,

--- a/src/electron/platform/android/setup/live-android-setup-deps.ts
+++ b/src/electron/platform/android/setup/live-android-setup-deps.ts
@@ -79,6 +79,14 @@ export class LiveAndroidSetupDeps implements AndroidSetupDeps {
         return false;
     };
 
+    public grantOverlayPermission = async (): Promise<void> => {
+        try {
+            return await this.serviceConfig.grantOverlayPermission();
+        } catch (error) {
+            this.logger.log(error);
+        }
+    };
+
     public setupTcpForwarding = async (): Promise<number> => {
         return await this.serviceConfig.setupTcpForwarding();
     };

--- a/src/electron/platform/android/setup/port-cleaning-service-configurator.ts
+++ b/src/electron/platform/android/setup/port-cleaning-service-configurator.ts
@@ -31,6 +31,10 @@ export class PortCleaningServiceConfigurator implements ServiceConfigurator {
         return this.innerObject.hasRequiredPermissions();
     };
 
+    public grantOverlayPermission = (): Promise<void> => {
+        return this.innerObject.grantOverlayPermission();
+    };
+
     public setupTcpForwarding = async (): Promise<number> => {
         const assignedPort = await this.innerObject.setupTcpForwarding();
         this.portCleaner.addPort(assignedPort);

--- a/src/electron/platform/android/setup/steps/grant-overlay-permission.ts
+++ b/src/electron/platform/android/setup/steps/grant-overlay-permission.ts
@@ -3,10 +3,10 @@
 
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-export const detectPermissions: AndroidSetupStepConfig = (stepTransition, deps) => ({
+export const grantOverlayPermission: AndroidSetupStepConfig = (stepTransition, deps) => ({
     actions: {},
     onEnter: async () => {
-        const detected = await deps.hasExpectedPermissions();
-        stepTransition(detected ? 'grant-overlay-permission' : 'prompt-grant-permissions');
+        await deps.grantOverlayPermission();
+        stepTransition('configuring-port-forwarding');
     },
 });

--- a/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
@@ -6,6 +6,7 @@ import { DetectAdbStep } from 'electron/views/device-connect-view/components/and
 import { DetectDevicesStep } from 'electron/views/device-connect-view/components/android-setup/detect-devices-step';
 import { DetectPermissionsStep } from 'electron/views/device-connect-view/components/android-setup/detect-permissions-step';
 import { DetectServiceStep } from 'electron/views/device-connect-view/components/android-setup/detect-service-step';
+import { GrantOverlayPermissionStep } from 'electron/views/device-connect-view/components/android-setup/grant-overlay-permission-step';
 import { InstallingServiceStep } from 'electron/views/device-connect-view/components/android-setup/installing-service-step';
 import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
 import { PromptConfiguringPortForwardingFailedStep } from 'electron/views/device-connect-view/components/android-setup/prompt-configuring-port-forwarding-failed-step';
@@ -27,6 +28,7 @@ export const defaultAndroidSetupComponents: AndroidSetupStepComponentProvider = 
     'prompt-install-failed': PromptInstallFailedStep,
     'prompt-grant-permissions': PromptGrantPermissionsStep,
     'detect-permissions': DetectPermissionsStep,
+    'grant-overlay-permission': GrantOverlayPermissionStep,
     'installing-service': InstallingServiceStep,
     'detect-devices': DetectDevicesStep,
     'detect-service': DetectServiceStep,

--- a/src/electron/views/device-connect-view/components/android-setup/grant-overlay-permission-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/grant-overlay-permission-step.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { AndroidSetupSpinnerStep } from 'electron/views/device-connect-view/components/android-setup/android-setup-spinner-step';
+import * as React from 'react';
+import { CommonAndroidSetupStepProps } from './android-setup-types';
+
+export const GrantOverlayPermissionStep = NamedFC<CommonAndroidSetupStepProps>(
+    'GrantOverlayPermissionStep',
+    (props: CommonAndroidSetupStepProps) => {
+        return (
+            <AndroidSetupSpinnerStep
+                deps={props.deps}
+                spinnerLabel="Granting overlay permission..."
+                disableCancel={true}
+            />
+        );
+    },
+);

--- a/src/tests/miscellaneous/mock-adb/common-adb-configs.js
+++ b/src/tests/miscellaneous/mock-adb/common-adb-configs.js
@@ -16,6 +16,10 @@ const serviceIsRunningCommandMatch = 'shell dumpsys accessibility';
 const portForwardingCommandMatch = 'forward tcp:';
 const sdkVersionCommandMatch = 'shell getprop ro.build.version.sdk';
 const inputKeyeventCommandMatch = 'shell input keyevent';
+const resetOverlayPermissionCommandMatch =
+    'shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice';
+const grantOverlayPermissionCommandMatch =
+    'shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW';
 
 function addDeviceEnumerationCommands(id, output) {
     output[`-s ${id} ${devicesCommandMatch}`] = cloneDeep(output.devices);
@@ -113,6 +117,11 @@ function addInputKeyeventCommands(id, output) {
     }
 }
 
+function addGrantOverlayPermissionCommands(id, output) {
+    output[`-s ${id} ${resetOverlayPermissionCommandMatch}`] = {};
+    output[`-s ${id} ${grantOverlayPermissionCommandMatch}`] = {};
+}
+
 function workingDeviceCommands(deviceIds, port) {
     const output = {
         'start-server': {},
@@ -132,6 +141,7 @@ function workingDeviceCommands(deviceIds, port) {
         addDetectServiceCommands(id, output);
         addInstallServiceCommands(id, output);
         addCheckPermissionsCommands(id, output);
+        addGrantOverlayPermissionCommands(id, output);
         addPortForwardingCommands(id, output, port);
         addInputKeyeventCommands(id, output);
     }

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/mock-adb.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/mock-adb.test.ts.snap
@@ -42,6 +42,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -82,6 +83,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s device-2 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -122,6 +124,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-2 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-2 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -162,6 +165,7 @@ Success
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-2 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s emulator-3 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -202,6 +206,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s emulator-3 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s emulator-3 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -242,6 +247,7 @@ Success
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s emulator-3 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -305,6 +311,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -345,6 +352,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -405,6 +413,9 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "delayMs": 5000,
+  },
   "-s device-1 shell dumpsys accessibility": Object {
     "delayMs": 5000,
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
@@ -457,6 +468,9 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
+  },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {
+    "delayMs": 5000,
   },
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "delayMs": 5000,
@@ -517,6 +531,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -557,6 +572,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s device-2 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -597,6 +613,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-2 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-2 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -637,6 +654,7 @@ Success
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-2 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s emulator-3 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -677,6 +695,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s emulator-3 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s emulator-3 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -717,6 +736,7 @@ Success
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s emulator-3 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -780,6 +800,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -820,6 +841,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -880,6 +902,9 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "delayMs": 5000,
+  },
   "-s device-1 shell dumpsys accessibility": Object {
     "delayMs": 5000,
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
@@ -926,6 +951,9 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
+  },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {
+    "delayMs": 5000,
   },
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "delayMs": 5000,
@@ -982,6 +1010,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -1022,6 +1051,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s device-2 devices": Object {
     "stderr": "Disabled by test config",
   },
@@ -1058,6 +1088,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-2 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-2 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -1098,6 +1129,7 @@ Success
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-2 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s emulator-3 devices": Object {
     "stderr": "Disabled by test config",
   },
@@ -1134,6 +1166,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s emulator-3 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s emulator-3 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -1174,6 +1207,7 @@ Success
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s emulator-3 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -1231,6 +1265,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -1271,6 +1306,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -1326,6 +1362,9 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "delayMs": 5000,
+  },
   "-s device-1 shell dumpsys accessibility": Object {
     "delayMs": 5000,
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
@@ -1378,6 +1417,9 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
+  },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {
+    "delayMs": 5000,
   },
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "delayMs": 5000,
@@ -1432,6 +1474,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -1472,6 +1515,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s device-2 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -1509,6 +1553,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-2 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-2 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -1549,6 +1594,7 @@ Success
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-2 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s emulator-3 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -1586,6 +1632,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s emulator-3 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s emulator-3 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -1626,6 +1673,7 @@ Success
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s emulator-3 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -1686,6 +1734,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -1726,6 +1775,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -1782,6 +1832,9 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "delayMs": 5000,
+  },
   "-s device-1 shell dumpsys accessibility": Object {
     "delayMs": 5000,
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
@@ -1834,6 +1887,9 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
+  },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {
+    "delayMs": 5000,
   },
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "delayMs": 5000,
@@ -1894,6 +1950,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -1934,6 +1991,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s device-2 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -1974,6 +2032,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-2 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-2 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -2014,6 +2073,7 @@ Success
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-2 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s emulator-3 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -2054,6 +2114,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s emulator-3 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s emulator-3 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -2094,6 +2155,7 @@ Success
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s emulator-3 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -2157,6 +2219,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -2197,6 +2260,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -2257,6 +2321,9 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "delayMs": 5000,
+  },
   "-s device-1 shell dumpsys accessibility": Object {
     "delayMs": 5000,
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
@@ -2308,6 +2375,9 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
+  },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {
+    "delayMs": 5000,
   },
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "delayMs": 5000,
@@ -2368,6 +2438,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stderr": "Disabled by test config",
   },
@@ -2408,6 +2479,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s device-2 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -2448,6 +2520,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-2 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-2 shell dumpsys accessibility": Object {
     "stderr": "Disabled by test config",
   },
@@ -2488,6 +2561,7 @@ Success
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-2 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s emulator-3 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -2528,6 +2602,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s emulator-3 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s emulator-3 shell dumpsys accessibility": Object {
     "stderr": "Disabled by test config",
   },
@@ -2568,6 +2643,7 @@ Success
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s emulator-3 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -2631,6 +2707,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stderr": "Disabled by test config",
   },
@@ -2671,6 +2748,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -2731,6 +2809,9 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "delayMs": 5000,
+  },
   "-s device-1 shell dumpsys accessibility": Object {
     "stderr": "Disabled by test config",
   },
@@ -2782,6 +2863,9 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
+  },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {
+    "delayMs": 5000,
   },
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "delayMs": 5000,
@@ -2842,6 +2926,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -2881,6 +2966,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s device-2 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -2921,6 +3007,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-2 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-2 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -2960,6 +3047,7 @@ Success
   "-s device-2 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-2 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "-s emulator-3 devices": Object {
     "stdout": "List of devices attached
 device-1	device
@@ -3000,6 +3088,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s emulator-3 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s emulator-3 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -3039,6 +3128,7 @@ Success
   "-s emulator-3 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s emulator-3 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -3102,6 +3192,7 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {},
   "-s device-1 shell dumpsys accessibility": Object {
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
   },
@@ -3141,6 +3232,7 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "stdout": "",
   },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {},
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "regexTarget": "^-s device-1 push .*android-service.apk /data/local/tmp/appium_cache",
     "stdout": "(truncated-package-path)...ed. 32.0 MB/s (181531 bytes in 0.005s)",
@@ -3201,6 +3293,9 @@ Success
     "exitCode": 0,
     "stdout": "",
   },
+  "-s device-1 shell cmd appops reset com.microsoft.accessibilityinsightsforandroidservice": Object {
+    "delayMs": 5000,
+  },
   "-s device-1 shell dumpsys accessibility": Object {
     "delayMs": 5000,
     "stdout": "                     Service[label=Accessibility Insights for…, feedbackType[FEEDBACK_SPOKEN, FEEDBACK_HAPTIC, FEEDBACK_AUDIBLE, FEEDBACK_VISUAL, FEEDBACK_GENERIC, FEEDBACK_BRAILLE], capabilities=1, eventTypes=TYPES_ALL_MASK, notificationTimeout=0]}",
@@ -3251,6 +3346,9 @@ Success
   "-s device-1 shell ls -t -1 /data/local/tmp/appium_cache 2>&1 || echo _ERROR_": Object {
     "delayMs": 5000,
     "stdout": "",
+  },
+  "-s device-1 shell pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW": Object {
+    "delayMs": 5000,
   },
   "PUSH PLACEHOLDER for 'device-1' - MATCH IS VIA REGEX": Object {
     "delayMs": 5000,

--- a/src/tests/unit/tests/electron/platform/android/appium-adb-wrapper.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/appium-adb-wrapper.test.ts
@@ -372,10 +372,8 @@ describe('AppiumAdbWrapper tests', () => {
     });
 
     it('grantOverlayPermission, calls expected adb commands', async () => {
-        const resetCommand =
-            'cmd appops reset com.microsoft.accessibilityinsightsforandroidservice';
-        const grantCommand =
-            'pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW';
+        const resetCommand = `cmd appops reset ${testPackageName}`;
+        const grantCommand = `pm grant ${testPackageName} android.permission.SYSTEM_ALERT_WINDOW`;
 
         adbMock
             .setup(m => m.setDeviceId(emulatorId))
@@ -387,7 +385,7 @@ describe('AppiumAdbWrapper tests', () => {
             .setup(m => m.shell(grantCommand.split(/\s+/)))
             .verifiable(Times.once(), ExpectedCallType.InSequence);
 
-        await testSubject.grantOverlayPermission(emulatorId);
+        await testSubject.grantOverlayPermission(emulatorId, testPackageName);
 
         adbMock.verifyAll();
     });
@@ -401,9 +399,9 @@ describe('AppiumAdbWrapper tests', () => {
             .throws(new Error(expectedMessage))
             .verifiable(Times.once());
 
-        await expect(testSubject.grantOverlayPermission(emulatorId)).rejects.toThrowError(
-            expectedMessage,
-        );
+        await expect(
+            testSubject.grantOverlayPermission(emulatorId, testPackageName),
+        ).rejects.toThrowError(expectedMessage);
 
         adbMock.verifyAll();
     });

--- a/src/tests/unit/tests/electron/platform/android/appium-adb-wrapper.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/appium-adb-wrapper.test.ts
@@ -4,7 +4,7 @@
 import ADB from 'appium-adb';
 import { KeyEventCode, PackageInfo } from 'electron/platform/android/adb-wrapper';
 import { AppiumAdbWrapper } from 'electron/platform/android/appium-adb-wrapper';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { ExpectedCallType, IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('AppiumAdbWrapper tests', () => {
     let adbMock: IMock<ADB>;
@@ -370,6 +370,44 @@ describe('AppiumAdbWrapper tests', () => {
             adbMock.verifyAll();
         });
     });
+
+    it('grantOverlayPermission, calls expected adb commands', async () => {
+        const resetCommand =
+            'cmd appops reset com.microsoft.accessibilityinsightsforandroidservice';
+        const grantCommand =
+            'pm grant com.microsoft.accessibilityinsightsforandroidservice android.permission.SYSTEM_ALERT_WINDOW';
+
+        adbMock
+            .setup(m => m.setDeviceId(emulatorId))
+            .verifiable(Times.once(), ExpectedCallType.InSequence);
+        adbMock
+            .setup(m => m.shell(resetCommand.split(/\s+/)))
+            .verifiable(Times.once(), ExpectedCallType.InSequence);
+        adbMock
+            .setup(m => m.shell(grantCommand.split(/\s+/)))
+            .verifiable(Times.once(), ExpectedCallType.InSequence);
+
+        await testSubject.grantOverlayPermission(emulatorId);
+
+        adbMock.verifyAll();
+    });
+
+    it('grantOverlayPermission, propagates error', async () => {
+        const expectedMessage: string = 'Thrown during grantOverlayPermission';
+
+        adbMock.setup(m => m.setDeviceId(emulatorId)).verifiable(Times.once());
+        adbMock
+            .setup(m => m.shell(It.isAny()))
+            .throws(new Error(expectedMessage))
+            .verifiable(Times.once());
+
+        await expect(testSubject.grantOverlayPermission(emulatorId)).rejects.toThrowError(
+            expectedMessage,
+        );
+
+        adbMock.verifyAll();
+    });
+
     /*
     // For live testing, set ANDROID_HOME or ANDROID_SDK_ROOT to point
     // to your local installation, then add this line just before

--- a/src/tests/unit/tests/electron/platform/android/setup/android-service-configurator.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/android-service-configurator.test.ts
@@ -341,6 +341,21 @@ describe('AndroidServiceConfigurator', () => {
         verifyAllMocks();
     });
 
+    it('grantOverlayPermission propagates thrown errors', async () => {
+        // This test has the side effect of ensuring grantOverlayPermission is called
+        // So there is no need for a separate test.
+
+        const expectedMessage = 'Error thrown during grantOverlayPermission';
+        adbWrapperMock
+            .setup(m => m.grantOverlayPermission(testDeviceId))
+            .throws(new Error(expectedMessage))
+            .verifiable(Times.once());
+
+        await expect(testSubject.grantOverlayPermission()).rejects.toThrowError(expectedMessage);
+
+        verifyAllMocks();
+    });
+
     describe('setupTcpForwarding', () => {
         it('propagates error from portFinder', async () => {
             const expectedMessage: string = 'Thrown from portFinder';

--- a/src/tests/unit/tests/electron/platform/android/setup/android-service-configurator.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/android-service-configurator.test.ts
@@ -347,7 +347,7 @@ describe('AndroidServiceConfigurator', () => {
 
         const expectedMessage = 'Error thrown during grantOverlayPermission';
         adbWrapperMock
-            .setup(m => m.grantOverlayPermission(testDeviceId))
+            .setup(m => m.grantOverlayPermission(testDeviceId, servicePackageName))
             .throws(new Error(expectedMessage))
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/electron/platform/android/setup/live-android-setup-deps.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/live-android-setup-deps.test.ts
@@ -259,6 +259,22 @@ describe('LiveAndroidSetupDeps', () => {
         verifyAllMocks();
     });
 
+    it('grantOverlayPermission catches thrown errors', async () => {
+        // This test has the side effect of ensuring grantOverlayPermission is called
+        // So there is no need for a separate test.
+
+        serviceConfigMock
+            .setup(m => m.grantOverlayPermission())
+            .throws(new Error('Threw during grantOverlayPermission'))
+            .verifiable(Times.once());
+
+        await initializeServiceConfig();
+
+        await testSubject.grantOverlayPermission();
+
+        verifyAllMocks();
+    });
+
     it('setupTcpForwarding propagates error from serviceConfig.setupTcpForwarding', async () => {
         const serviceConfigErrorMessage = 'error from serviceConfig';
         serviceConfigMock

--- a/src/tests/unit/tests/electron/platform/android/setup/port-cleaning-service-configurator.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/port-cleaning-service-configurator.test.ts
@@ -94,6 +94,14 @@ describe('PortCleaningServiceConfigurator', () => {
         verifyAllMocks();
     });
 
+    it('grantOverlayPermission chains through', async () => {
+        innerObjectMock.setup(m => m.grantOverlayPermission()).verifiable(Times.once());
+
+        await testSubject.grantOverlayPermission();
+
+        verifyAllMocks();
+    });
+
     it('setupTcpForwarding chains through', async () => {
         const expectedPort: number = 123;
         innerObjectMock

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/grant-overlay-permission.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/grant-overlay-permission.test.ts
@@ -7,11 +7,11 @@ import {
 } from 'electron/flux/types/android-setup-state-machine-types';
 import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
-import { detectPermissions } from 'electron/platform/android/setup/steps/detect-permissions';
+import { grantOverlayPermission } from 'electron/platform/android/setup/steps/grant-overlay-permission';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
-describe('Android setup step: detectPermissions', () => {
+describe('Android setup step: grantOverlayPermission', () => {
     let depsMock: IMock<AndroidSetupDeps>;
     let storeCallbacksMock: IMock<AndroidSetupStoreCallbacks>;
     let stepTransitionMock: IMock<AndroidSetupStepTransitionCallback>;
@@ -33,40 +33,22 @@ describe('Android setup step: detectPermissions', () => {
 
     it('has expected properties', () => {
         const deps = {} as AndroidSetupDeps;
-        const step = detectPermissions(null, deps);
+        const step = grantOverlayPermission(null, deps);
         checkExpectedActionsAreDefined(step, []);
         expect(step.onEnter).toBeDefined();
     });
 
-    it('onEnter transitions to grant overlay permission', async () => {
-        const p = Promise.resolve(true);
+    it('onEnter transitions to configuring-port-forwarding on success', async () => {
+        const p = Promise.resolve();
 
         depsMock
-            .setup(m => m.hasExpectedPermissions())
+            .setup(m => m.grantOverlayPermission())
             .returns(_ => p)
             .verifiable(Times.once());
 
-        stepTransitionMock.setup(m => m('grant-overlay-permission')).verifiable();
+        stepTransitionMock.setup(m => m('configuring-port-forwarding')).verifiable();
 
-        const step = detectPermissions(
-            stepTransitionMock.object,
-            depsMock.object,
-            storeCallbacksMock.object,
-        );
-        await step.onEnter();
-    });
-
-    it('onEnter transitions to prompt-grant-permissions on failure', async () => {
-        const p = Promise.resolve(false);
-
-        depsMock
-            .setup(m => m.hasExpectedPermissions())
-            .returns(_ => p)
-            .verifiable(Times.once());
-
-        stepTransitionMock.setup(m => m('prompt-grant-permissions')).verifiable(Times.once());
-
-        const step = detectPermissions(
+        const step = grantOverlayPermission(
             stepTransitionMock.object,
             depsMock.object,
             storeCallbacksMock.object,

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/grant-overlay-permission-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/grant-overlay-permission-step.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GrantOverlayPermissionStep renders 1`] = `
+<AndroidSetupSpinnerStep
+  deps={
+    Object {
+      "LinkComponent": [Function],
+    }
+  }
+  disableCancel={true}
+  spinnerLabel="Granting overlay permission..."
+/>
+`;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/grant-overlay-permission-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/grant-overlay-permission-step.test.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { GrantOverlayPermissionStep } from 'electron/views/device-connect-view/components/android-setup/grant-overlay-permission-step';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
+
+describe('GrantOverlayPermissionStep', () => {
+    const props = new AndroidSetupStepPropsBuilder('grant-overlay-permission').build();
+
+    it('renders', () => {
+        const rendered = shallow(<GrantOverlayPermissionStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Details

Add a step to the Android setup state machine which automatically grants the overlay permission required to display tabstops indicators on the Android device screen.

##### Motivation

Part of the tabstops feature

##### Context

The reason for automatically granting the permission is that in Android SDK version 30, the overlay permission is silently granted by the system when the media projection permission (`SYSTEM_ALERT_WINDOW`) is granted. If the user has a device running SDK version 29 or lower, since the user must grant the media projection permission, we believe it is acceptable to automatically grant the overlay permission as Google has chosen to do in SDK 30. If there is any objection to granting the overlay permission silently, we can of course add UX later to inform the user the permission is being granted on their behalf.

The granting of the permission is not currently behind the tabstops feature flag because 

- There is a lot of plumbing that would need to be done to add it, and then almost immediately undone when the feature is released soon.
- Granting the permission causes no ill effects even when an older version of the Accessibility Insights service, one which does not require the `SYSTEM_ALERT_WINDOW` permission, is installed on the device.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
