### PR TITLE
refactor(side-panel): make closePreviewFeatures handling consistent with other side panels

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
+import { SidePanelActions } from 'background/actions/side-panel-actions';
 import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
 import { TestMode } from 'common/configs/test-mode';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
@@ -29,14 +30,12 @@ import {
     VisualizationTogglePayload,
 } from './action-payloads';
 import { InspectActions } from './inspect-actions';
-import { PreviewFeaturesActions } from './preview-features-actions';
 
 const visualizationMessages = Messages.Visualizations;
 
 export class ActionCreator {
     private visualizationActions: VisualizationActions;
     private visualizationScanResultActions: VisualizationScanResultActions;
-    private previewFeaturesActions: PreviewFeaturesActions;
     private adHocTestTypeToTelemetryEvent: DictionaryNumberTo<string> = {
         [VisualizationType.Color]: TelemetryEvents.COLOR_TOGGLE,
         [VisualizationType.Headings]: TelemetryEvents.HEADINGS_TOGGLE,
@@ -48,6 +47,7 @@ export class ActionCreator {
     private inspectActions: InspectActions;
     private cardSelectionActions: CardSelectionActions;
     private unifiedScanResultActions: UnifiedScanResultActions;
+    private sidePanelActions: SidePanelActions;
 
     constructor(
         private readonly interpreter: Interpreter,
@@ -60,11 +60,11 @@ export class ActionCreator {
         private readonly logger: Logger,
     ) {
         this.visualizationActions = actionHub.visualizationActions;
-        this.previewFeaturesActions = actionHub.previewFeaturesActions;
         this.visualizationScanResultActions = actionHub.visualizationScanResultActions;
         this.inspectActions = actionHub.inspectActions;
         this.cardSelectionActions = actionHub.cardSelectionActions;
         this.unifiedScanResultActions = actionHub.scanResultActions;
+        this.sidePanelActions = actionHub.sidePanelActions;
     }
 
     public registerCallbacks(): void {
@@ -128,12 +128,6 @@ export class ActionCreator {
             visualizationMessages.DetailsView.Close,
             this.onDetailsViewClosed,
         );
-
-        this.interpreter.registerTypeToPayloadCallback(
-            Messages.PreviewFeatures.ClosePanel,
-            this.onClosePreviewFeaturesPanel,
-        );
-
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Assessment.AssessmentScanCompleted,
             this.onAssessmentScanCompleted,
@@ -237,14 +231,6 @@ export class ActionCreator {
         await this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
     };
 
-    private onClosePreviewFeaturesPanel = (payload: BaseActionPayload): void => {
-        this.previewFeaturesActions.closePreviewFeatures.invoke(null);
-        this.telemetryEventHandler.publishTelemetry(
-            TelemetryEvents.PREVIEW_FEATURES_CLOSE,
-            payload,
-        );
-    };
-
     private onTabbedElementAdded = (payload: AddTabbedElementPayload): void => {
         this.visualizationScanResultActions.addTabbedElement.invoke(payload);
     };
@@ -327,7 +313,7 @@ export class ActionCreator {
         payload: OnDetailsViewOpenPayload,
         tabId: number,
     ): Promise<void> => {
-        this.previewFeaturesActions.closePreviewFeatures.invoke(null);
+        this.sidePanelActions.closeSidePanel.invoke('PreviewFeatures');
         this.visualizationActions.updateSelectedPivotChild.invoke(payload);
         await this.detailsViewController
             .showDetailsView(tabId)

--- a/src/background/actions/action-hub.ts
+++ b/src/background/actions/action-hub.ts
@@ -12,7 +12,6 @@ import { DetailsViewActions } from './details-view-actions';
 import { DevToolActions } from './dev-tools-actions';
 import { InspectActions } from './inspect-actions';
 import { PathSnippetActions } from './path-snippet-actions';
-import { PreviewFeaturesActions } from './preview-features-actions';
 import { ScopingActions } from './scoping-actions';
 import { UnifiedScanResultActions } from './unified-scan-result-actions';
 
@@ -21,7 +20,6 @@ export class ActionHub {
     public visualizationScanResultActions: VisualizationScanResultActions;
     public tabActions: TabActions;
     public devToolActions: DevToolActions;
-    public previewFeaturesActions: PreviewFeaturesActions;
     public assessmentActions: AssessmentActions;
     public scopingActions: ScopingActions;
     public inspectActions: InspectActions;
@@ -38,7 +36,6 @@ export class ActionHub {
         this.visualizationScanResultActions = new VisualizationScanResultActions();
         this.tabActions = new TabActions();
         this.devToolActions = new DevToolActions();
-        this.previewFeaturesActions = new PreviewFeaturesActions();
         this.assessmentActions = new AssessmentActions();
         this.scopingActions = new ScopingActions();
         this.inspectActions = new InspectActions();

--- a/src/background/actions/details-view-action-creator.ts
+++ b/src/background/actions/details-view-action-creator.ts
@@ -5,6 +5,7 @@ import { DetailsViewController } from 'background/details-view-controller';
 import { SidePanel } from 'background/stores/side-panel';
 import {
     PREVIEW_FEATURES_OPEN,
+    PREVIEW_FEATURES_CLOSE,
     SCOPING_CLOSE,
     SCOPING_OPEN,
     SETTINGS_PANEL_CLOSE,
@@ -52,6 +53,10 @@ export class DetailsViewActionCreator {
             this.onCloseSidePanel.bind(this, 'Settings'),
         );
         this.interpreter.registerTypeToPayloadCallback(
+            Messages.PreviewFeatures.ClosePanel,
+            this.onCloseSidePanel.bind(this, 'PreviewFeatures'),
+        );
+        this.interpreter.registerTypeToPayloadCallback(
             Messages.Scoping.ClosePanel,
             this.onCloseSidePanel.bind(this, 'Scoping'),
         );
@@ -85,7 +90,7 @@ export class DetailsViewActionCreator {
 
     private sidePanelToClosePanelTelemetryEventName: SidePanelToTelemetryEventName = {
         Settings: SETTINGS_PANEL_CLOSE,
-        PreviewFeatures: null, // not supported here yet,
+        PreviewFeatures: PREVIEW_FEATURES_CLOSE,
         Scoping: SCOPING_CLOSE,
     };
 

--- a/src/background/actions/preview-features-actions.ts
+++ b/src/background/actions/preview-features-actions.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-import { Action } from 'common/flux/action';
-
-export class PreviewFeaturesActions {
-    public readonly closePreviewFeatures = new Action<void>();
-}

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -8,7 +8,6 @@ import { DetailsViewStoreData } from 'common/types/store-data/details-view-store
 import { DetailsViewRightContentPanelType } from 'DetailsView/components/left-nav/details-view-right-content-panel-type';
 import { ContentActions } from '../actions/content-actions';
 import { DetailsViewActions } from '../actions/details-view-actions';
-import { PreviewFeaturesActions } from './../actions/preview-features-actions';
 import { BaseStoreImpl } from './base-store-impl';
 
 type SidePanelToStoreKey = {
@@ -17,7 +16,6 @@ type SidePanelToStoreKey = {
 
 export class DetailsViewStore extends BaseStoreImpl<DetailsViewStoreData> {
     constructor(
-        private previewFeaturesActions: PreviewFeaturesActions,
         private contentActions: ContentActions,
         private detailsViewActions: DetailsViewActions,
         private sidePanelActions: SidePanelActions,
@@ -42,10 +40,6 @@ export class DetailsViewStore extends BaseStoreImpl<DetailsViewStoreData> {
     }
 
     protected addActionListeners(): void {
-        this.previewFeaturesActions.closePreviewFeatures.addListener(() =>
-            this.onClose('isPreviewFeaturesOpen'),
-        );
-
         this.contentActions.openContentPanel.addListener(contentPayload =>
             this.onOpen('isContentOpen', state => {
                 state.contentPath = contentPayload.contentPath;

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -52,7 +52,6 @@ export class TabContextStoreHub implements StoreHub {
         this.devToolStore.initialize();
 
         this.detailsViewStore = new DetailsViewStore(
-            actionHub.previewFeaturesActions,
             actionHub.contentActions,
             actionHub.detailsViewActions,
             actionHub.sidePanelActions,

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -8,7 +8,6 @@ import { ContentActions } from 'background/actions/content-actions';
 import { DetailsViewActionCreator } from 'background/actions/details-view-action-creator';
 import { DetailsViewActions } from 'background/actions/details-view-actions';
 import { FeatureFlagActions } from 'background/actions/feature-flag-actions';
-import { PreviewFeaturesActions } from 'background/actions/preview-features-actions';
 import { SidePanelActions } from 'background/actions/side-panel-actions';
 import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
 import { FeatureFlagsController } from 'background/feature-flags-controller';
@@ -173,7 +172,6 @@ const unifiedScanResultActions = new UnifiedScanResultActions();
 const cardSelectionActions = new CardSelectionActions();
 const detailsViewActions = new DetailsViewActions();
 const sidePanelActions = new SidePanelActions();
-const previewFeaturesActions = new PreviewFeaturesActions(); // not really used but needed by DetailsViewStore
 const contentActions = new ContentActions(); // not really used but needed by DetailsViewStore
 const featureFlagActions = new FeatureFlagActions();
 const leftNavActions = new LeftNavActions();
@@ -266,7 +264,6 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
         cardSelectionStore.initialize();
 
         const detailsViewStore = new DetailsViewStore(
-            previewFeaturesActions,
             contentActions,
             detailsViewActions,
             sidePanelActions,

--- a/src/tests/unit/common/details-view-store-data-builder.ts
+++ b/src/tests/unit/common/details-view-store-data-builder.ts
@@ -8,7 +8,7 @@ import { BaseDataBuilder } from './base-data-builder';
 export class DetailsViewStoreDataBuilder extends BaseDataBuilder<DetailsViewStoreData> {
     constructor() {
         super();
-        this.data = new DetailsViewStore(null, null, null, null).getDefaultState();
+        this.data = new DetailsViewStore(null, null, null).getDefaultState();
     }
 
     public withPreviewFeaturesOpen(isPreviewFeaturesOpen: boolean): DetailsViewStoreDataBuilder {

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -17,8 +17,8 @@ import { CardSelectionActions } from 'background/actions/card-selection-actions'
 import { DetailsViewActions } from 'background/actions/details-view-actions';
 import { DevToolActions } from 'background/actions/dev-tools-actions';
 import { InspectActions } from 'background/actions/inspect-actions';
-import { PreviewFeaturesActions } from 'background/actions/preview-features-actions';
 import { ScopingActions } from 'background/actions/scoping-actions';
+import { SidePanelActions } from 'background/actions/side-panel-actions';
 import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
 import { VisualizationActions } from 'background/actions/visualization-actions';
 import { VisualizationScanResultActions } from 'background/actions/visualization-scan-result-actions';
@@ -52,7 +52,6 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DictionaryStringTo } from 'types/common-types';
 
 const VisualizationMessage = Messages.Visualizations;
-const PreviewFeaturesMessage = Messages.PreviewFeatures;
 
 describe('ActionCreatorTest', () => {
     const testSource: TelemetryEventSource = -1 as TelemetryEventSource;
@@ -500,7 +499,7 @@ describe('ActionCreatorTest', () => {
         const viewType = VisualizationType.Issues;
         const pivotType = DetailsViewPivotType.fastPass;
         const updateViewActionName = 'updateSelectedPivotChild';
-        const closePreviewFeaturesActionName = 'closePreviewFeatures';
+        const closeSidePanelActionName = 'closeSidePanel';
         const tabId = 1;
         const actionCreatorPayload: OnDetailsViewOpenPayload = {
             detailsViewType: viewType,
@@ -523,8 +522,11 @@ describe('ActionCreatorTest', () => {
                     updateViewActionName,
                     actionCreatorPayload,
                 )
-                .setupActionOnPreviewFeaturesActions(closePreviewFeaturesActionName)
-                .setupPreviewFeaturesActionWithInvokeParameter(closePreviewFeaturesActionName, null)
+                .setupActionOnSidePanelActions(closeSidePanelActionName)
+                .setupSidePanelActionWithInvokeParameter(
+                    closeSidePanelActionName,
+                    'PreviewFeatures',
+                )
                 .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, 1)
                 .setupShowDetailsView(tabId, Promise.resolve());
 
@@ -550,8 +552,11 @@ describe('ActionCreatorTest', () => {
                     updateViewActionName,
                     actionCreatorPayload,
                 )
-                .setupActionOnPreviewFeaturesActions(closePreviewFeaturesActionName)
-                .setupPreviewFeaturesActionWithInvokeParameter(closePreviewFeaturesActionName, null)
+                .setupActionOnSidePanelActions(closeSidePanelActionName)
+                .setupSidePanelActionWithInvokeParameter(
+                    closeSidePanelActionName,
+                    'PreviewFeatures',
+                )
                 .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, 1)
                 .setupShowDetailsView(
                     tabId,
@@ -602,31 +607,6 @@ describe('ActionCreatorTest', () => {
             .setupVisualizationScanResultActionWithInvokeParameter(actionName, null);
 
         const actionCreator = validator.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        validator.verifyAll();
-    });
-
-    test('registerCallback for onClosePreviewFeaturesPanel', () => {
-        const tabId = 1;
-        const actionName = 'closePreviewFeatures';
-        const telemetryData: BaseTelemetryData = {
-            triggeredBy: 'stub triggered by' as TriggeredBy,
-            source: testSource,
-        };
-
-        const telemetryInfo = {
-            telemetryData,
-        };
-
-        const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(PreviewFeaturesMessage.ClosePanel, [telemetryInfo, tabId])
-            .setupActionOnPreviewFeaturesActions(actionName)
-            .setupTelemetrySend(TelemetryEvents.PREVIEW_FEATURES_CLOSE, telemetryInfo, tabId)
-            .setupPreviewFeaturesActionWithInvokeParameter(actionName, null);
-
-        const actionCreator = validator.buildActionCreator();
-
         actionCreator.registerCallbacks();
 
         validator.verifyAll();
@@ -950,13 +930,13 @@ class ActionCreatorValidator {
     private visualizationScanResultActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
 
     private detailsViewActionsContainerMock = Mock.ofType(DetailsViewActions);
-    private previewFeaturesActionsContainerMock = Mock.ofType(PreviewFeaturesActions);
+    private sidePanelActionsContainerMock = Mock.ofType(SidePanelActions);
     private scopingActionsContainerMock = Mock.ofType(ScopingActions);
     private assessmentActionsContainerMock = Mock.ofType(AssessmentActions);
     private inspectActionsContainerMock = Mock.ofType(InspectActions);
     private cardSelectionActionsContainerMock = Mock.ofType(CardSelectionActions);
     private unifiedScanResultsActionsContainerMock = Mock.ofType(UnifiedScanResultActions);
-    private previewFeaturesActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
+    private sidePanelActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
     private scopingActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
     private detailsViewActionsMocks: DictionaryStringTo<IMock<Action<any>>> = {};
 
@@ -978,7 +958,7 @@ class ActionCreatorValidator {
         visualizationActions: this.visualizationActionsContainerMock.object,
         visualizationScanResultActions: this.visualizationScanResultActionsContainerMock.object,
         devToolActions: this.devToolActionsContainerMock.object,
-        previewFeaturesActions: this.previewFeaturesActionsContainerMock.object,
+        sidePanelActions: this.sidePanelActionsContainerMock.object,
         scopingActions: this.scopingActionsContainerMock.object,
         assessmentActions: this.assessmentActionsContainerMock.object,
         inspectActions: this.inspectActionsContainerMock.object,
@@ -1059,14 +1039,14 @@ class ActionCreatorValidator {
         return this;
     }
 
-    public setupPreviewFeaturesActionWithInvokeParameter(
-        actionName: keyof PreviewFeaturesActions,
+    public setupSidePanelActionWithInvokeParameter(
+        actionName: keyof SidePanelActions,
         expectedInvokeParam: any,
     ): ActionCreatorValidator {
         this.setupActionWithInvokeParameter(
             actionName,
             expectedInvokeParam,
-            this.previewFeaturesActionMocks,
+            this.sidePanelActionMocks,
         );
         return this;
     }
@@ -1197,14 +1177,10 @@ class ActionCreatorValidator {
         return this;
     }
 
-    public setupActionOnPreviewFeaturesActions(
-        actionName: keyof PreviewFeaturesActions,
+    public setupActionOnSidePanelActions(
+        actionName: keyof SidePanelActions,
     ): ActionCreatorValidator {
-        this.setupAction(
-            actionName,
-            this.previewFeaturesActionMocks,
-            this.previewFeaturesActionsContainerMock,
-        );
+        this.setupAction(actionName, this.sidePanelActionMocks, this.sidePanelActionsContainerMock);
         return this;
     }
 
@@ -1298,7 +1274,7 @@ class ActionCreatorValidator {
         this.verifyAllActions(this.devToolsActionMocks);
         this.verifyAllActions(this.inspectActionsMock);
         this.verifyAllActions(this.detailsViewActionsMocks);
-        this.verifyAllActions(this.previewFeaturesActionMocks);
+        this.verifyAllActions(this.sidePanelActionMocks);
         this.verifyAllActions(this.scopingActionMocks);
         this.verifyAllActions(this.cardSelectionActionsMocks);
     }

--- a/src/tests/unit/tests/background/actions/action-hub.test.ts
+++ b/src/tests/unit/tests/background/actions/action-hub.test.ts
@@ -6,7 +6,6 @@ import { ContentActions } from 'background/actions/content-actions';
 import { DevToolActions } from 'background/actions/dev-tools-actions';
 import { InjectionActions } from 'background/actions/injection-actions';
 import { InspectActions } from 'background/actions/inspect-actions';
-import { PreviewFeaturesActions } from 'background/actions/preview-features-actions';
 import { ScopingActions } from 'background/actions/scoping-actions';
 import { SidePanelActions } from 'background/actions/side-panel-actions';
 import { TabActions } from 'background/actions/tab-actions';
@@ -30,7 +29,6 @@ function runNullAserts(hub: ActionHub): void {
 function runTypeAsserts(hub: ActionHub): void {
     expect(hub.assessmentActions).toBeInstanceOf(AssessmentActions);
     expect(hub.devToolActions).toBeInstanceOf(DevToolActions);
-    expect(hub.previewFeaturesActions).toBeInstanceOf(PreviewFeaturesActions);
     expect(hub.scopingActions).toBeInstanceOf(ScopingActions);
     expect(hub.tabActions).toBeInstanceOf(TabActions);
     expect(hub.visualizationActions).toBeInstanceOf(VisualizationActions);

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -9,6 +9,7 @@ import { Interpreter } from 'background/interpreter';
 import { SidePanel } from 'background/stores/side-panel';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import {
+    PREVIEW_FEATURES_CLOSE,
     PREVIEW_FEATURES_OPEN,
     SCOPING_CLOSE,
     SCOPING_OPEN,
@@ -135,9 +136,10 @@ describe('DetailsViewActionCreatorTest', () => {
 
     describe('handles close side panel message', () => {
         it.each`
-            messageFriendlyName                    | actualMessage                        | sidePanel     | telemetryEventName
-            ${'Messages.SettingsPanel.ClosePanel'} | ${Messages.SettingsPanel.ClosePanel} | ${'Settings'} | ${SETTINGS_PANEL_CLOSE}
-            ${'Messages.Scoping.ClosePanel'}       | ${Messages.Scoping.ClosePanel}       | ${'Scoping'}  | ${SCOPING_CLOSE}
+            messageFriendlyName                      | actualMessage                          | sidePanel            | telemetryEventName
+            ${'Messages.SettingsPanel.ClosePanel'}   | ${Messages.SettingsPanel.ClosePanel}   | ${'Settings'}        | ${SETTINGS_PANEL_CLOSE}
+            ${'Messages.PreviewFeatures.ClosePanel'} | ${Messages.PreviewFeatures.ClosePanel} | ${'PreviewFeatures'} | ${PREVIEW_FEATURES_CLOSE}
+            ${'Messages.Scoping.ClosePanel'}         | ${Messages.Scoping.ClosePanel}         | ${'Scoping'}         | ${SCOPING_CLOSE}
         `('$messageFriendlyName', ({ actualMessage, sidePanel, telemetryEventName }) => {
             const closeSidePanelMock = createActionMock<SidePanel>(sidePanel);
 

--- a/src/tests/unit/tests/background/stores/details-view-store.test.ts
+++ b/src/tests/unit/tests/background/stores/details-view-store.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { ContentActions } from 'background/actions/content-actions';
 import { DetailsViewActions } from 'background/actions/details-view-actions';
-import { PreviewFeaturesActions } from 'background/actions/preview-features-actions';
 import { SidePanelActions } from 'background/actions/side-panel-actions';
 import { DetailsViewStore } from 'background/stores/details-view-store';
 import { StoreNames } from 'common/stores/store-names';
@@ -12,7 +11,7 @@ import { StoreTester } from '../../../common/store-tester';
 
 describe('DetailsViewStoreTest', () => {
     test('getId', () => {
-        const testObject = new DetailsViewStore(null, null, null, null);
+        const testObject = new DetailsViewStore(null, null, null);
         expect(testObject.getId()).toBe(StoreNames[StoreNames.DetailsViewStore]);
     });
 
@@ -53,9 +52,9 @@ describe('DetailsViewStoreTest', () => {
             .withPreviewFeaturesOpen(false)
             .build();
 
-        createStoreTesterForPreviewFeatureActions(
-            'closePreviewFeatures',
-        ).testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForSidePanelActions('closeSidePanel')
+            .withActionParam('PreviewFeatures')
+            .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     test('onOpenScoping', () => {
@@ -125,29 +124,11 @@ describe('DetailsViewStoreTest', () => {
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    function createStoreTesterForPreviewFeatureActions(
-        actionName: keyof PreviewFeaturesActions,
-    ): StoreTester<DetailsViewStoreData, PreviewFeaturesActions> {
-        const factory = (actions: PreviewFeaturesActions) =>
-            new DetailsViewStore(
-                actions,
-                new ContentActions(),
-                new DetailsViewActions(),
-                new SidePanelActions(),
-            );
-        return new StoreTester(PreviewFeaturesActions, actionName, factory);
-    }
-
     function createStoreTesterForContentActions(
         actionName: keyof ContentActions,
     ): StoreTester<DetailsViewStoreData, ContentActions> {
         const factory = (actions: ContentActions) =>
-            new DetailsViewStore(
-                new PreviewFeaturesActions(),
-                actions,
-                new DetailsViewActions(),
-                new SidePanelActions(),
-            );
+            new DetailsViewStore(actions, new DetailsViewActions(), new SidePanelActions());
 
         return new StoreTester(ContentActions, actionName, factory);
     }
@@ -156,12 +137,7 @@ describe('DetailsViewStoreTest', () => {
         actionName: keyof DetailsViewActions,
     ): StoreTester<DetailsViewStoreData, DetailsViewActions> {
         const factory = (actions: DetailsViewActions) =>
-            new DetailsViewStore(
-                new PreviewFeaturesActions(),
-                new ContentActions(),
-                actions,
-                new SidePanelActions(),
-            );
+            new DetailsViewStore(new ContentActions(), actions, new SidePanelActions());
 
         return new StoreTester(DetailsViewActions, actionName, factory);
     }
@@ -170,12 +146,7 @@ describe('DetailsViewStoreTest', () => {
         actionName: keyof SidePanelActions,
     ): StoreTester<DetailsViewStoreData, SidePanelActions> {
         const factory = (actions: SidePanelActions) =>
-            new DetailsViewStore(
-                new PreviewFeaturesActions(),
-                new ContentActions(),
-                new DetailsViewActions(),
-                actions,
-            );
+            new DetailsViewStore(new ContentActions(), new DetailsViewActions(), actions);
 
         return new StoreTester(SidePanelActions, actionName, factory);
     }

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -100,7 +100,6 @@
         "./src/background/actions/path-snippet-actions.ts",
         "./src/background/actions/permissions-state-actions.ts",
         "./src/background/actions/popup-action-creator.ts",
-        "./src/background/actions/preview-features-actions.ts",
         "./src/background/actions/scoping-actions.ts",
         "./src/background/actions/shortcuts-page-action-creator.ts",
         "./src/background/actions/side-panel-actions.ts",


### PR DESCRIPTION
#### Details

This PR replaces the special handling for `onClosePreviewFeaturesPanel` with reuse of a common "close side panel" path already used to close the settings and scoping side panels. This was the only path that used `preview-features-actions`, so that file got removed as part of the PR.

##### Motivation

This finishes a collection of `refactor(side-panel)` PRs that @smoralesd did most of last year. I noticed it when trying to add `details-view-action-creator.ts` to the `strictNullChecks` list, where L88 hit an error due to this unfinished refactor; I decided that it seemed cleaner (net -83 LOC) to finish the refactor rather than update the types to work around the issue.

##### Context

Late followup to #2313, #2420, #2424

Verified manually that closing the preview features panel still appears to work as expected.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: contributes to #2869
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
