### PR TITLE
feat(focus-mvp-android-device): Set default value of feature flag to true

### DIFF
--- a/src/electron/common/unified-feature-flags.ts
+++ b/src/electron/common/unified-feature-flags.ts
@@ -38,7 +38,7 @@ export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
         },
         {
             id: UnifiedFeatureFlags.tabStops,
-            defaultValue: false,
+            defaultValue: true,
             displayableName: 'Show Tab Stops test',
             displayableDescription: 'Show the Tab Stops test on the Left Nav',
             isPreviewFeature: false,

--- a/src/electron/platform/android/test-configs/tab-stops/test-config.tsx
+++ b/src/electron/platform/android/test-configs/tab-stops/test-config.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import { tabStopsStartOverButtonSettings } from 'electron/platform/android/test-configs/tab-stops/start-over-button-settings';
 import { TestConfig } from 'electron/types/test-config';
 import { TabStopsTestingContent } from 'electron/views/tab-stops/tab-stops-testing-content';
@@ -16,5 +15,4 @@ export const tabStopsTestConfig: TestConfig = {
         instancesSectionComponent: TabStopsTestingContent,
         startOverButtonSettings: tabStopsStartOverButtonSettings,
     },
-    featureFlag: UnifiedFeatureFlags.tabStops,
 };

--- a/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
+++ b/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
@@ -23,7 +23,7 @@ describe('FeatureFlagsTest', () => {
             [UnifiedFeatureFlags.logTelemetryToConsole]: false,
             [UnifiedFeatureFlags.showAllFeatureFlags]: false,
             [UnifiedFeatureFlags.exportReport]: true,
-            [UnifiedFeatureFlags.tabStops]: false,
+            [UnifiedFeatureFlags.tabStops]: true,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Details

Set the default value of the tabstops visualization for Android to true in preparation for release.
