### PR TITLE
fix: aria heading level for android tab stops test

### DIFF
--- a/src/electron/views/tab-stops/tab-stops-testing-content.tsx
+++ b/src/electron/views/tab-stops/tab-stops-testing-content.tsx
@@ -18,7 +18,7 @@ export type TabStopsTestingContentProps = {
 
 export const tabStopsToggleAutomationId = 'tab-stops-toggle';
 
-const ariaLevelForHowToTestHeading: number = 3;
+const ariaLevelForHowToTestHeading: number = 2;
 
 export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
     'TabStopsTestingContent',

--- a/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/tab-stops/__snapshots__/tab-stops-testing-content.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`TabStopsTestingContent renders 1`] = `
     onText="On"
   />
   <span
-    aria-level={3}
+    aria-level={2}
     role="heading"
   >
     <strong>


### PR DESCRIPTION
#### Details

This PR fixes a skipped heading level on the tab stops test in AI-Android that was discovered during the accessibility pass.

##### Motivation

To ensure that AI-Android meets all accessibility guidelines.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
