### PR TITLE
fix: update scanDate to get current date

### DIFF
--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -32,7 +32,7 @@ export function getReportExportDialogForAssessment(
         deps: deps,
         reportExportFormat: 'Assessment',
         pageTitle: scanMetadata.targetAppInfo.name,
-        scanDate: scanMetadata.timespan.scanComplete,
+        scanDate: props.deps.getCurrentDate(),
         htmlGenerator: description =>
             reportGenerator.generateAssessmentReport(
                 assessmentStoreData,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`ReportExportDialogFactory getReportExportDialogForAssessment expected p
   isOpen={true}
   pageTitle="command-bar-test-tab-title"
   reportExportFormat="Assessment"
-  scanDate={2019-03-12T09:00:00.000Z}
+  scanDate={2021-02-07T05:02:00.000Z}
   updatePersistedDescription={[Function]}
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -26,6 +26,7 @@ import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('ReportExportDialogFactory', () => {
     const theDate = new Date(Date.UTC(2019, 2, 12, 9, 0));
+    const currentDate = new Date(Date.UTC(2021, 1, 7, 5, 2));
     const theToolData: ToolData = { applicationProperties: { name: 'some app' } } as ToolData;
     const thePageTitle = 'command-bar-test-tab-title';
     const theDescription = 'test description';
@@ -71,7 +72,7 @@ describe('ReportExportDialogFactory', () => {
         cardsViewData = null;
         deps = {
             detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
-            getCurrentDate: () => theDate,
+            getCurrentDate: () => currentDate,
             reportGenerator: reportGeneratorMock.object,
             getDateFromTimestamp: value => theDate,
         } as DetailsViewCommandBarDeps;

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -25,7 +25,7 @@ import { ReportGenerator } from 'reports/report-generator';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('ReportExportDialogFactory', () => {
-    const theDate = new Date(Date.UTC(2019, 2, 12, 9, 0));
+    const scanCompleteDate = new Date(Date.UTC(2019, 2, 12, 9, 0));
     const currentDate = new Date(Date.UTC(2021, 1, 7, 5, 2));
     const theToolData: ToolData = { applicationProperties: { name: 'some app' } } as ToolData;
     const thePageTitle = 'command-bar-test-tab-title';
@@ -60,7 +60,7 @@ describe('ReportExportDialogFactory', () => {
             url: thePageUrl,
         };
         scanMetadata = {
-            timespan: { scanComplete: theDate },
+            timespan: { scanComplete: scanCompleteDate },
             toolData: theToolData,
             targetAppInfo: targetAppInfo,
         } as ScanMetadata;
@@ -74,7 +74,7 @@ describe('ReportExportDialogFactory', () => {
             detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
             getCurrentDate: () => currentDate,
             reportGenerator: reportGeneratorMock.object,
-            getDateFromTimestamp: value => theDate,
+            getDateFromTimestamp: value => scanCompleteDate,
         } as DetailsViewCommandBarDeps;
         const switcherNavConfiguration = {
             shouldShowReportExportButton: shouldShowReportExportButtonMock.object,


### PR DESCRIPTION
#### Details

Update scanDate to return current date for the date stamp populated as part of the exported results file title.

##### Motivation

Addresses the bug in issue  #3995.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue:  #3995
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [/] (UI changes only) Added screenshots/GIFs to description above
- [/] (UI changes only) Verified usability with NVDA/JAWS
