### PR TITLE
fix: fixes spacing issue in AI Android when some tests are selected

### DIFF
--- a/src/electron/views/results/results-view.scss
+++ b/src/electron/views/results/results-view.scss
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../../common/styles/colors.scss';
+@import '../../../common/styles/common.scss';
 @import '../common/window-title/window-title-const.scss';
 
 :global(.is-mac-os) {
@@ -33,6 +34,7 @@
         display: flex;
         flex-direction: column;
         overflow: hidden;
+        min-width: calc(100% - (#{$reflowLeftNavWidth}));
     }
 
     .results-panel-layout {

--- a/src/electron/views/results/results-view.scss
+++ b/src/electron/views/results/results-view.scss
@@ -34,7 +34,7 @@
         display: flex;
         flex-direction: column;
         overflow: hidden;
-        min-width: calc(100% - (#{$reflowLeftNavWidth}));
+        min-width: calc(100% - (#{$reflowLeftNavWidth} + (#{$reflowLeftNavBorderWidth})));
     }
 
     .results-panel-layout {


### PR DESCRIPTION
#### Details

Sets a min-width for the results area, basing it on the left nav width.

##### Motivation

Bug fix.

##### Context

This only happens in Tab Stops/Needs Review because those tests don't have the appropriate length in their instructions/description. That content was implicitly setting the width that we wanted (because it filled the required area).

Before:

![image](https://user-images.githubusercontent.com/32555133/113927865-e22c9200-97a2-11eb-987a-88b62c0f967e.png)

After:

![image](https://user-images.githubusercontent.com/32555133/113928180-48191980-97a3-11eb-8cf7-b5167baca2c7.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
