### PR TITLE
fix(performance): avoid unnecessary drawer updates

### DIFF
--- a/src/injected/drawing-initiator.ts
+++ b/src/injected/drawing-initiator.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
 import { FeatureFlagStoreData } from '../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../common/types/visualization-type';
-import { DictionaryStringTo } from '../types/common-types';
 import { DrawingController, VisualizationWindowMessage } from './drawing-controller';
 import {
     AssessmentVisualizationInstance,
@@ -20,7 +20,7 @@ export class DrawingInitiator {
     public enableVisualization(
         visualizationType: VisualizationType,
         featureFlagStoreData: FeatureFlagStoreData,
-        selectorMap: DictionaryStringTo<AssessmentVisualizationInstance>,
+        selectorMap: SelectorToVisualizationMap,
         configId: string,
         processor: VisualizationInstanceProcessorCallback,
     ): void {
@@ -69,7 +69,7 @@ export class DrawingInitiator {
     }
 
     private getElementResults(
-        selectorMap: DictionaryStringTo<AssessmentVisualizationInstance>,
+        selectorMap: SelectorToVisualizationMap,
     ): AssessmentVisualizationInstance[] {
         return Object.keys(selectorMap).map(key => selectorMap[key]);
     }

--- a/src/injected/element-based-view-model-creator.ts
+++ b/src/injected/element-based-view-model-creator.ts
@@ -7,10 +7,9 @@ import {
     UnifiedResult,
     UnifiedScanResultStoreData,
 } from 'common/types/store-data/unified-data-interface';
-import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
 import { GetDecoratedAxeNodeCallback } from 'injected/get-decorated-axe-node';
+import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
 import { find } from 'lodash';
-import { DictionaryStringTo } from 'types/common-types';
 
 export interface CheckData {
     // tslint:disable-next-line: no-reserved-keywords
@@ -22,7 +21,7 @@ export interface CheckData {
 export type GetElementBasedViewModelCallback = (
     unifiedScanResultStoreData: UnifiedScanResultStoreData,
     cardSelectionData: CardSelectionStoreData,
-) => DictionaryStringTo<AssessmentVisualizationInstance> | null;
+) => SelectorToVisualizationMap | null;
 
 export class ElementBasedViewModelCreator {
     constructor(
@@ -40,7 +39,7 @@ export class ElementBasedViewModelCreator {
             return null;
         }
 
-        const resultDictionary: DictionaryStringTo<AssessmentVisualizationInstance> = {};
+        const resultDictionary: SelectorToVisualizationMap = {};
         const resultsHighlightStatus = this.getHighlightedResultInstanceIds(
             cardSelectionData,
             unifiedScanResultStoreData,

--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -5,6 +5,7 @@ import { CardSelectionStoreData } from 'common/types/store-data/card-selection-s
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { TargetPageStoreData } from 'injected/client-store-listener';
 import { GetElementBasedViewModelCallback } from 'injected/element-based-view-model-creator';
+import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
 import { includes } from 'lodash';
 
 import { ManualTestStatus } from '../common/types/manual-test-status';
@@ -12,7 +13,6 @@ import { GeneratedAssessmentInstance } from '../common/types/store-data/assessme
 import { VisualizationScanResultData } from '../common/types/store-data/visualization-scan-result-data';
 import { VisualizationType } from '../common/types/visualization-type';
 import { DictionaryStringTo } from '../types/common-types';
-import { AssessmentVisualizationInstance } from './frameCommunicators/html-element-axe-results-helper';
 
 export type VisualizationRelatedStoreData = Pick<
     TargetPageStoreData,
@@ -32,7 +32,7 @@ export class SelectorMapHelper {
         visualizationType: VisualizationType,
         stepKey: string,
         visualizationRelatedStoreData: VisualizationRelatedStoreData,
-    ): DictionaryStringTo<AssessmentVisualizationInstance> {
+    ): SelectorToVisualizationMap {
         let selectorMap = {};
         const {
             visualizationScanResultStoreData,
@@ -80,7 +80,7 @@ export class SelectorMapHelper {
         visualizationScanResultData: VisualizationScanResultData,
         unifiedScanData: UnifiedScanResultStoreData,
         cardSelectionStoreData: CardSelectionStoreData,
-    ): DictionaryStringTo<AssessmentVisualizationInstance> {
+    ): SelectorToVisualizationMap {
         let selectorMap = {};
         switch (visualizationType) {
             case VisualizationType.NeedsReview:
@@ -110,12 +110,12 @@ export class SelectorMapHelper {
     private getFilteredSelectorMap(
         generatedAssessmentInstancesMap: DictionaryStringTo<GeneratedAssessmentInstance>,
         testStep: string,
-    ): DictionaryStringTo<AssessmentVisualizationInstance> {
+    ): SelectorToVisualizationMap {
         if (generatedAssessmentInstancesMap == null) {
             return null;
         }
 
-        const selectorMap: DictionaryStringTo<AssessmentVisualizationInstance> = {};
+        const selectorMap: SelectorToVisualizationMap = {};
         Object.keys(generatedAssessmentInstancesMap).forEach(identifier => {
             const instance = generatedAssessmentInstancesMap[identifier];
             const stepResult = instance.testStepResults[testStep];

--- a/src/injected/selector-to-visualization-map.ts
+++ b/src/injected/selector-to-visualization-map.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AssessmentVisualizationInstance } from './frameCommunicators/html-element-axe-results-helper';
+
+// A selectorChain is a semicolon-delimited lists of CSS selectors based on axe-core target
+// properties, eg, of format "#top-frame-iframe;.inner-frame-element"
+export type SelectorToVisualizationMap = {
+    [selectorChain: string]: AssessmentVisualizationInstance;
+};

--- a/src/injected/target-page-visualization-updater.ts
+++ b/src/injected/target-page-visualization-updater.ts
@@ -15,7 +15,7 @@ import {
 } from './visualization-needs-update';
 
 type TestStepVisualizationStateMap = {
-    [visualizationType in VisualizationType]: {
+    [visualizationType: number]: {
         [testStepConfigId: string]: TestStepVisualizationState;
     };
 };
@@ -26,7 +26,7 @@ export type UpdateVisualization = (
     storeData: TargetPageStoreData,
 ) => void;
 export class TargetPageVisualizationUpdater {
-    private previousVisualizationStates: TestStepVisualizationStateMap;
+    private previousVisualizationStates: TestStepVisualizationStateMap = {};
 
     constructor(
         private visualizationConfigurationFactory: VisualizationConfigurationFactory,

--- a/src/injected/target-page-visualization-updater.ts
+++ b/src/injected/target-page-visualization-updater.ts
@@ -55,7 +55,7 @@ export class TargetPageVisualizationUpdater {
             configuration,
             configId,
         );
-        this.previousVisualizationSelectorMapStates[configId] = selectorMap;
+        this.previousVisualizationSelectorMapStates[visualizationType] = selectorMap;
     };
 
     private executeUpdate = (

--- a/src/injected/visualization-needs-update.ts
+++ b/src/injected/visualization-needs-update.ts
@@ -27,8 +27,14 @@ export const visualizationNeedsUpdate: VisualizationNeedsUpdateCallback = (
         return newVisualizationEnabledState;
     }
 
-    return (
-        previousVisualizationStates[id] !== newVisualizationEnabledState ||
-        !isEqual(newSelectorMapState, previousVisualizationSelectorMapData[visualizationType])
+    if (previousVisualizationStates[id] !== newVisualizationEnabledState) {
+        return true;
+    }
+
+    const selectorMapUpdated = !isEqual(
+        newSelectorMapState,
+        previousVisualizationSelectorMapData[visualizationType],
     );
+
+    return newVisualizationEnabledState && selectorMapUpdated;
 };

--- a/src/injected/visualization-needs-update.ts
+++ b/src/injected/visualization-needs-update.ts
@@ -1,40 +1,33 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { VisualizationType } from 'common/types/visualization-type';
-import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
-import { VisualizationSelectorMapContainer } from 'injected/target-page-visualization-updater';
+import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
 import { isEqual } from 'lodash';
-import { DictionaryStringTo } from 'types/common-types';
+
+export type TestStepVisualizationState = {
+    enabled: boolean;
+    selectorMap: SelectorToVisualizationMap;
+};
 
 export type VisualizationNeedsUpdateCallback = (
-    visualizationType: VisualizationType,
-    id: string,
-    newVisualizationEnabledState: boolean,
-    newSelectorMapState: SelectorToVisualizationMap,
-    previousVisualizationStates: DictionaryStringTo<boolean>,
-    previousVisualizationSelectorMapData: VisualizationSelectorMapContainer,
+    oldVisualizationState: TestStepVisualizationState,
+    newVisualizationState: TestStepVisualizationState,
 ) => boolean;
 
 export const visualizationNeedsUpdate: VisualizationNeedsUpdateCallback = (
-    visualizationType,
-    id,
-    newVisualizationEnabledState,
-    newSelectorMapState,
-    previousVisualizationStates,
-    previousVisualizationSelectorMapData,
+    newState: TestStepVisualizationState,
+    oldState: TestStepVisualizationState | undefined,
 ) => {
-    if (id in previousVisualizationStates === false) {
-        return newVisualizationEnabledState;
+    if (oldState === undefined) {
+        return newState.enabled;
     }
 
-    if (previousVisualizationStates[id] !== newVisualizationEnabledState) {
+    if (oldState.enabled !== newState.enabled) {
         return true;
     }
 
-    const selectorMapUpdated = !isEqual(
-        newSelectorMapState,
-        previousVisualizationSelectorMapData[visualizationType],
-    );
+    if (!oldState.enabled && !newState.enabled) {
+        return false; // even if selectorMap changed
+    }
 
-    return newVisualizationEnabledState && selectorMapUpdated;
+    return !isEqual(oldState.selectorMap, newState.selectorMap);
 };

--- a/src/injected/visualization-needs-update.ts
+++ b/src/injected/visualization-needs-update.ts
@@ -10,7 +10,7 @@ export type VisualizationNeedsUpdateCallback = (
     visualizationType: VisualizationType,
     id: string,
     newVisualizationEnabledState: boolean,
-    newSelectorMapState: DictionaryStringTo<AssessmentVisualizationInstance>,
+    newSelectorMapState: SelectorToVisualizationMap,
     previousVisualizationStates: DictionaryStringTo<boolean>,
     previousVisualizationSelectorMapData: VisualizationSelectorMapContainer,
 ) => boolean;

--- a/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
+++ b/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Assessments } from 'assessments/assessments';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { each } from 'lodash';
 import { EnumHelper } from '../../../../../common/enum-helper';
@@ -158,6 +159,20 @@ describe('WebVisualizationConfigurationFactory', () => {
             expect(configuration).toBeDefined();
             expect(configuration.key).toBe(key);
         });
+    });
+
+    test("manually specified visualizaton keys don't overlap with requirement visualization keys", () => {
+        for (const assessment of Assessments.all()) {
+            const assessmentConfig = testObject.getConfiguration(assessment.visualizationType);
+            for (const requirement of assessment.requirements) {
+                const requirementVisualizationKey = assessmentConfig.getIdentifier(requirement.key);
+                const correspondingManuallyKeyedConfiguration = testObject.getConfigurationByKey(
+                    requirementVisualizationKey,
+                );
+
+                expect(correspondingManuallyKeyedConfiguration).toBeUndefined();
+            }
+        }
     });
 
     function testDisplayableData(visualizationType: VisualizationType): void {

--- a/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
+++ b/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
@@ -161,6 +161,7 @@ describe('WebVisualizationConfigurationFactory', () => {
         });
     });
 
+    // This is important for any data structure which assumes it's safe to use configIds as keys
     test("manually specified visualizaton keys don't overlap with requirement visualization keys", () => {
         for (const assessment of Assessments.all()) {
             const assessmentConfig = testObject.getConfiguration(assessment.visualizationType);

--- a/src/tests/unit/tests/injected/drawing-initiator.test.ts
+++ b/src/tests/unit/tests/injected/drawing-initiator.test.ts
@@ -1,17 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { getDefaultFeatureFlagsWeb } from 'common/feature-flags';
+import { VisualizationType } from 'common/types/visualization-type';
+import { DrawingController, VisualizationWindowMessage } from 'injected/drawing-controller';
+import { DrawingInitiator } from 'injected/drawing-initiator';
+import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
+import { VisualizationInstanceProcessorCallback } from 'injected/visualization-instance-processor';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
-import { getDefaultFeatureFlagsWeb } from '../../../../common/feature-flags';
-import { VisualizationType } from '../../../../common/types/visualization-type';
-import {
-    DrawingController,
-    VisualizationWindowMessage,
-} from '../../../../injected/drawing-controller';
-import { DrawingInitiator } from '../../../../injected/drawing-initiator';
-import { AssessmentVisualizationInstance } from '../../../../injected/frameCommunicators/html-element-axe-results-helper';
-import { VisualizationInstanceProcessorCallback } from '../../../../injected/visualization-instance-processor';
-import { DictionaryStringTo } from '../../../../types/common-types';
 
 class DrawingControllerStub extends DrawingController {
     public processRequest = (message: VisualizationWindowMessage): void => {};

--- a/src/tests/unit/tests/injected/drawing-initiator.test.ts
+++ b/src/tests/unit/tests/injected/drawing-initiator.test.ts
@@ -36,7 +36,7 @@ describe('DrawingInitiatorTest', () => {
     test('enableVisualization', () => {
         const visualizationType = -1 as VisualizationType;
         const configId = 'id';
-        const selectorMap: DictionaryStringTo<AssessmentVisualizationInstance> = {
+        const selectorMap: SelectorToVisualizationMap = {
             key1: {
                 target: ['element1'],
                 isFailure: false,

--- a/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
+++ b/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
@@ -5,16 +5,15 @@ import { VisualizationConfigurationFactory } from 'common/configs/visualization-
 import { VisualizationType } from 'common/types/visualization-type';
 import { TargetPageStoreData } from 'injected/client-store-listener';
 import { DrawingInitiator } from 'injected/drawing-initiator';
-import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
 import { IsVisualizationEnabledCallback } from 'injected/is-visualization-enabled';
 import { SelectorMapHelper } from 'injected/selector-map-helper';
+import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
+import { TargetPageVisualizationUpdater } from 'injected/target-page-visualization-updater';
 import {
-    TargetPageVisualizationUpdater,
-    VisualizationSelectorMapContainer,
-} from 'injected/target-page-visualization-updater';
-import { VisualizationNeedsUpdateCallback } from 'injected/visualization-needs-update';
+    TestStepVisualizationState,
+    VisualizationNeedsUpdateCallback,
+} from 'injected/visualization-needs-update';
 import { IMock, It, Mock, Times } from 'typemoq';
-import { DictionaryStringTo } from 'types/common-types';
 
 describe('TargetPageVisualizationUpdater', () => {
     let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
@@ -28,9 +27,12 @@ describe('TargetPageVisualizationUpdater', () => {
     let selectorMapStub: SelectorToVisualizationMap;
     let stepKeyStub: string;
     let storeDataStub: TargetPageStoreData;
-    let newVisualizationEnabledStateStub: boolean;
     let visualizationTypeStub: VisualizationType;
     let configIdStub: string;
+
+    let expectedNewState: TestStepVisualizationState;
+    let expectedPreviousState: TestStepVisualizationState | undefined;
+    let isVisualizationEnabledResult: boolean;
 
     beforeEach(() => {
         visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
@@ -52,7 +54,12 @@ describe('TargetPageVisualizationUpdater', () => {
         } as TargetPageStoreData;
         visualizationTypeStub = -1;
 
-        newVisualizationEnabledStateStub = true;
+        expectedPreviousState = undefined;
+        isVisualizationEnabledResult = true;
+        expectedNewState = {
+            enabled: isVisualizationEnabledResult,
+            selectorMap: selectorMapStub,
+        };
 
         selectorMapHelperMock
             .setup(smhm => smhm.getSelectorMap(visualizationTypeStub, stepKeyStub, storeDataStub))
@@ -71,7 +78,7 @@ describe('TargetPageVisualizationUpdater', () => {
                     storeDataStub.tabStoreData,
                 ),
             )
-            .returns(() => newVisualizationEnabledStateStub);
+            .returns(() => isVisualizationEnabledResult);
 
         testSubject = new TargetPageVisualizationUpdater(
             visualizationConfigurationFactoryMock.object,
@@ -83,7 +90,9 @@ describe('TargetPageVisualizationUpdater', () => {
     });
 
     test('visualization does need not to be updated', () => {
+        expectedNewState.enabled = isVisualizationEnabledResult = true;
         setupVisualizationNeedsUpdateMock(false);
+
         drawingInitiatorMock
             .setup(dim => dim.disableVisualization(It.isAny(), It.isAny(), It.isAny()))
             .verifiable(Times.never());
@@ -96,15 +105,19 @@ describe('TargetPageVisualizationUpdater', () => {
         testSubject.updateVisualization(visualizationTypeStub, stepKeyStub, storeDataStub);
 
         drawingInitiatorMock.verifyAll();
-        verifyPreviousStates({}, { [visualizationTypeStub]: selectorMapStub });
+        visualizationNeedsUpdateMock.verifyAll();
+
+        verifyPreviousState(expectedPreviousState);
     });
 
     test('visualization needs to be enabled', () => {
+        expectedNewState.enabled = isVisualizationEnabledResult = true;
+        setupVisualizationNeedsUpdateMock(true);
+
         const visualizationInstanceProcessorStub = () => null;
         configMock
             .setup(cm => cm.visualizationInstanceProcessor(stepKeyStub))
             .returns(() => visualizationInstanceProcessorStub);
-        setupVisualizationNeedsUpdateMock(true);
         drawingInitiatorMock
             .setup(dim =>
                 dim.enableVisualization(
@@ -120,15 +133,15 @@ describe('TargetPageVisualizationUpdater', () => {
         testSubject.updateVisualization(visualizationTypeStub, stepKeyStub, storeDataStub);
 
         drawingInitiatorMock.verifyAll();
-        verifyPreviousStates(
-            { [configIdStub]: newVisualizationEnabledStateStub },
-            { [visualizationTypeStub]: selectorMapStub },
-        );
+        visualizationNeedsUpdateMock.verifyAll();
+
+        verifyPreviousState(expectedNewState);
     });
 
     test('visualization needs to be disabled', () => {
+        expectedNewState.enabled = isVisualizationEnabledResult = false;
         setupVisualizationNeedsUpdateMock(true);
-        newVisualizationEnabledStateStub = false;
+
         drawingInitiatorMock
             .setup(dim =>
                 dim.disableVisualization(
@@ -142,43 +155,21 @@ describe('TargetPageVisualizationUpdater', () => {
         testSubject.updateVisualization(visualizationTypeStub, stepKeyStub, storeDataStub);
 
         drawingInitiatorMock.verifyAll();
-        verifyPreviousStates(
-            { [configIdStub]: newVisualizationEnabledStateStub },
-            { [visualizationTypeStub]: selectorMapStub },
-        );
+        visualizationNeedsUpdateMock.verifyAll();
+
+        verifyPreviousState(expectedNewState);
     });
 
     function setupVisualizationNeedsUpdateMock(needsUpdate: boolean): void {
         visualizationNeedsUpdateMock
-            .setup(vnum =>
-                vnum(
-                    visualizationTypeStub,
-                    configIdStub,
-                    newVisualizationEnabledStateStub,
-                    selectorMapStub,
-                    It.isValue({}),
-                    It.isValue({}),
-                ),
-            )
+            .setup(vnum => vnum(expectedNewState, expectedPreviousState))
             .returns(() => needsUpdate);
     }
 
-    function verifyPreviousStates(
-        expectedVisualizationStates: DictionaryStringTo<boolean>,
-        expectedSelectorMapStates: VisualizationSelectorMapContainer,
-    ): void {
+    function verifyPreviousState(expectedPreviousState: TestStepVisualizationState): void {
         visualizationNeedsUpdateMock.reset();
         visualizationNeedsUpdateMock
-            .setup(vnum =>
-                vnum(
-                    visualizationTypeStub,
-                    configIdStub,
-                    newVisualizationEnabledStateStub,
-                    selectorMapStub,
-                    It.isValue(expectedVisualizationStates),
-                    It.isValue(expectedSelectorMapStates),
-                ),
-            )
+            .setup(vnum => vnum(It.isAny(), It.isValue(expectedPreviousState)))
             .returns(() => false)
             .verifiable();
 

--- a/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
+++ b/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
@@ -25,7 +25,7 @@ describe('TargetPageVisualizationUpdater', () => {
     let configMock: IMock<VisualizationConfiguration>;
     let testSubject: TargetPageVisualizationUpdater;
 
-    let selectorMapStub: DictionaryStringTo<AssessmentVisualizationInstance>;
+    let selectorMapStub: SelectorToVisualizationMap;
     let stepKeyStub: string;
     let storeDataStub: TargetPageStoreData;
     let newVisualizationEnabledStateStub: boolean;

--- a/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
+++ b/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
@@ -96,7 +96,7 @@ describe('TargetPageVisualizationUpdater', () => {
         testSubject.updateVisualization(visualizationTypeStub, stepKeyStub, storeDataStub);
 
         drawingInitiatorMock.verifyAll();
-        verifyPreviousStates({}, { [configIdStub]: selectorMapStub });
+        verifyPreviousStates({}, { [visualizationTypeStub]: selectorMapStub });
     });
 
     test('visualization needs to be enabled', () => {
@@ -122,7 +122,7 @@ describe('TargetPageVisualizationUpdater', () => {
         drawingInitiatorMock.verifyAll();
         verifyPreviousStates(
             { [configIdStub]: newVisualizationEnabledStateStub },
-            { [configIdStub]: selectorMapStub },
+            { [visualizationTypeStub]: selectorMapStub },
         );
     });
 
@@ -144,7 +144,7 @@ describe('TargetPageVisualizationUpdater', () => {
         drawingInitiatorMock.verifyAll();
         verifyPreviousStates(
             { [configIdStub]: newVisualizationEnabledStateStub },
-            { [configIdStub]: selectorMapStub },
+            { [visualizationTypeStub]: selectorMapStub },
         );
     });
 

--- a/src/tests/unit/tests/injected/visualization-needs-update.test.ts
+++ b/src/tests/unit/tests/injected/visualization-needs-update.test.ts
@@ -35,7 +35,7 @@ describe('visualizationNeedsUpdate', () => {
         });
     });
 
-    test('previous visualization state for given config id is not the same as the new visualization state', () => {
+    it('returns true when previously-disabled visualization is enabled', () => {
         previousVisualizationStates = {
             [id]: false,
         };
@@ -53,14 +53,11 @@ describe('visualizationNeedsUpdate', () => {
         ).toEqual(true);
     });
 
-    test('previous visualization state for given config id is the same as the new visualization state but selector map has changed', () => {
-        const newVisualizationEnabledState = true;
+    it('returns true when previously-enabled visualization is disabled', () => {
         previousVisualizationStates = {
-            [id]: newVisualizationEnabledState,
+            [id]: true,
         };
-
-        newSelectorMapState = {};
-        previousVisualizationSelectorMapData[visualizationType] = null;
+        const newVisualizationEnabledState = false;
 
         expect(
             visualizationNeedsUpdate(
@@ -74,7 +71,49 @@ describe('visualizationNeedsUpdate', () => {
         ).toEqual(true);
     });
 
-    test('previous visualization state for given config id is equivalent to new visualization state and selector map has not changed', () => {
+    it('returns false when previously-disabled visualization is still disabled and selector map has not changed', () => {
+        const newVisualizationEnabledState = false;
+        previousVisualizationStates = {
+            [id]: false,
+        };
+
+        newSelectorMapState = {};
+        previousVisualizationSelectorMapData[visualizationType] = newSelectorMapState;
+
+        expect(
+            visualizationNeedsUpdate(
+                visualizationType,
+                id,
+                newVisualizationEnabledState,
+                newSelectorMapState,
+                previousVisualizationStates,
+                previousVisualizationSelectorMapData,
+            ),
+        ).toEqual(false);
+    });
+
+    it('returns false when previously-disabled visualization is still disabled, regardless of selector map changing,', () => {
+        const newVisualizationEnabledState = false;
+        previousVisualizationStates = {
+            [id]: false,
+        };
+
+        newSelectorMapState = { 'new-state': null };
+        previousVisualizationSelectorMapData[visualizationType] = { 'old-state': null };
+
+        expect(
+            visualizationNeedsUpdate(
+                visualizationType,
+                id,
+                newVisualizationEnabledState,
+                newSelectorMapState,
+                previousVisualizationStates,
+                previousVisualizationSelectorMapData,
+            ),
+        ).toEqual(false);
+    });
+
+    it('returns false when previously-enabled visualization is still enabled and selector map has not changed', () => {
         const newVisualizationEnabledState = true;
         previousVisualizationStates = {
             [id]: newVisualizationEnabledState,
@@ -93,5 +132,26 @@ describe('visualizationNeedsUpdate', () => {
                 previousVisualizationSelectorMapData,
             ),
         ).toEqual(false);
+    });
+
+    it('returns true when previously-enabled visualization is still enabled, but selector map has changed', () => {
+        const newVisualizationEnabledState = true;
+        previousVisualizationStates = {
+            [id]: newVisualizationEnabledState,
+        };
+
+        newSelectorMapState = { 'new-state': null };
+        previousVisualizationSelectorMapData[visualizationType] = { 'old-state': null };
+
+        expect(
+            visualizationNeedsUpdate(
+                visualizationType,
+                id,
+                newVisualizationEnabledState,
+                newSelectorMapState,
+                previousVisualizationStates,
+                previousVisualizationSelectorMapData,
+            ),
+        ).toEqual(true);
     });
 });

--- a/src/tests/unit/tests/injected/visualization-needs-update.test.ts
+++ b/src/tests/unit/tests/injected/visualization-needs-update.test.ts
@@ -1,157 +1,101 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { VisualizationType } from 'common/types/visualization-type';
 import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
-import { VisualizationSelectorMapContainer } from 'injected/target-page-visualization-updater';
-import { visualizationNeedsUpdate } from 'injected/visualization-needs-update';
-import { DictionaryStringTo } from 'types/common-types';
+import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
+import {
+    TestStepVisualizationState,
+    visualizationNeedsUpdate,
+} from 'injected/visualization-needs-update';
 
 describe('visualizationNeedsUpdate', () => {
-    let visualizationType: VisualizationType;
-    let id: string;
-    let newSelectorMapState: SelectorToVisualizationMap;
-    let previousVisualizationStates: DictionaryStringTo<boolean>;
-    let previousVisualizationSelectorMapData: VisualizationSelectorMapContainer;
+    const selectorMapA: SelectorToVisualizationMap = {
+        'selector-a': {} as AssessmentVisualizationInstance,
+    };
+    const selectorMapB: SelectorToVisualizationMap = {
+        'selector-b': {} as AssessmentVisualizationInstance,
+    };
+    const irrelevantSelectorMap = selectorMapA;
 
-    beforeEach(() => {
-        visualizationType = -1;
-        id = 'some id';
-        previousVisualizationStates = {};
-        previousVisualizationSelectorMapData = {};
-    });
-
-    [true, false].forEach(newVisualizationEnabledState => {
-        test(`config id does not exist in previous visualization state should return new visualization state ${newVisualizationEnabledState}`, () => {
-            expect(
-                visualizationNeedsUpdate(
-                    visualizationType,
-                    id,
-                    newVisualizationEnabledState,
-                    newSelectorMapState,
-                    previousVisualizationStates,
-                    previousVisualizationSelectorMapData,
-                ),
-            ).toEqual(newVisualizationEnabledState);
+    describe('when there is no previous state', () => {
+        it.each([true, false])('should return %p if new state has enabled=%p', newEnabled => {
+            const oldState: TestStepVisualizationState = undefined;
+            const newState: TestStepVisualizationState = {
+                enabled: newEnabled,
+                selectorMap: irrelevantSelectorMap,
+            };
+            expect(visualizationNeedsUpdate(newState, oldState)).toBe(newEnabled);
         });
     });
 
     it('returns true when previously-disabled visualization is enabled', () => {
-        previousVisualizationStates = {
-            [id]: false,
+        const oldState: TestStepVisualizationState = {
+            enabled: false,
+            selectorMap: irrelevantSelectorMap,
         };
-        const newVisualizationEnabledState = true;
-
-        expect(
-            visualizationNeedsUpdate(
-                visualizationType,
-                id,
-                newVisualizationEnabledState,
-                newSelectorMapState,
-                previousVisualizationStates,
-                previousVisualizationSelectorMapData,
-            ),
-        ).toEqual(true);
+        const newState: TestStepVisualizationState = {
+            enabled: true,
+            selectorMap: irrelevantSelectorMap,
+        };
+        expect(visualizationNeedsUpdate(newState, oldState)).toBe(true);
     });
 
     it('returns true when previously-enabled visualization is disabled', () => {
-        previousVisualizationStates = {
-            [id]: true,
+        const oldState: TestStepVisualizationState = {
+            enabled: true,
+            selectorMap: irrelevantSelectorMap,
         };
-        const newVisualizationEnabledState = false;
-
-        expect(
-            visualizationNeedsUpdate(
-                visualizationType,
-                id,
-                newVisualizationEnabledState,
-                newSelectorMapState,
-                previousVisualizationStates,
-                previousVisualizationSelectorMapData,
-            ),
-        ).toEqual(true);
+        const newState: TestStepVisualizationState = {
+            enabled: false,
+            selectorMap: irrelevantSelectorMap,
+        };
+        expect(visualizationNeedsUpdate(newState, oldState)).toBe(true);
     });
 
     it('returns false when previously-disabled visualization is still disabled and selector map has not changed', () => {
-        const newVisualizationEnabledState = false;
-        previousVisualizationStates = {
-            [id]: false,
+        const oldState: TestStepVisualizationState = {
+            enabled: false,
+            selectorMap: selectorMapA,
         };
-
-        newSelectorMapState = {};
-        previousVisualizationSelectorMapData[visualizationType] = newSelectorMapState;
-
-        expect(
-            visualizationNeedsUpdate(
-                visualizationType,
-                id,
-                newVisualizationEnabledState,
-                newSelectorMapState,
-                previousVisualizationStates,
-                previousVisualizationSelectorMapData,
-            ),
-        ).toEqual(false);
+        const newState: TestStepVisualizationState = {
+            enabled: false,
+            selectorMap: selectorMapA,
+        };
+        expect(visualizationNeedsUpdate(newState, oldState)).toBe(false);
     });
 
     it('returns false when previously-disabled visualization is still disabled, regardless of selector map changing,', () => {
-        const newVisualizationEnabledState = false;
-        previousVisualizationStates = {
-            [id]: false,
+        const oldState: TestStepVisualizationState = {
+            enabled: false,
+            selectorMap: selectorMapA,
         };
-
-        newSelectorMapState = { 'new-state': null };
-        previousVisualizationSelectorMapData[visualizationType] = { 'old-state': null };
-
-        expect(
-            visualizationNeedsUpdate(
-                visualizationType,
-                id,
-                newVisualizationEnabledState,
-                newSelectorMapState,
-                previousVisualizationStates,
-                previousVisualizationSelectorMapData,
-            ),
-        ).toEqual(false);
+        const newState: TestStepVisualizationState = {
+            enabled: false,
+            selectorMap: selectorMapB,
+        };
+        expect(visualizationNeedsUpdate(newState, oldState)).toBe(false);
     });
 
     it('returns false when previously-enabled visualization is still enabled and selector map has not changed', () => {
-        const newVisualizationEnabledState = true;
-        previousVisualizationStates = {
-            [id]: newVisualizationEnabledState,
+        const oldState: TestStepVisualizationState = {
+            enabled: true,
+            selectorMap: selectorMapA,
         };
-
-        newSelectorMapState = {};
-        previousVisualizationSelectorMapData[visualizationType] = newSelectorMapState;
-
-        expect(
-            visualizationNeedsUpdate(
-                visualizationType,
-                id,
-                newVisualizationEnabledState,
-                newSelectorMapState,
-                previousVisualizationStates,
-                previousVisualizationSelectorMapData,
-            ),
-        ).toEqual(false);
+        const newState: TestStepVisualizationState = {
+            enabled: true,
+            selectorMap: selectorMapA,
+        };
+        expect(visualizationNeedsUpdate(newState, oldState)).toBe(false);
     });
 
     it('returns true when previously-enabled visualization is still enabled, but selector map has changed', () => {
-        const newVisualizationEnabledState = true;
-        previousVisualizationStates = {
-            [id]: newVisualizationEnabledState,
+        const oldState: TestStepVisualizationState = {
+            enabled: true,
+            selectorMap: selectorMapA,
         };
-
-        newSelectorMapState = { 'new-state': null };
-        previousVisualizationSelectorMapData[visualizationType] = { 'old-state': null };
-
-        expect(
-            visualizationNeedsUpdate(
-                visualizationType,
-                id,
-                newVisualizationEnabledState,
-                newSelectorMapState,
-                previousVisualizationStates,
-                previousVisualizationSelectorMapData,
-            ),
-        ).toEqual(true);
+        const newState: TestStepVisualizationState = {
+            enabled: true,
+            selectorMap: selectorMapB,
+        };
+        expect(visualizationNeedsUpdate(newState, oldState)).toBe(true);
     });
 });

--- a/src/tests/unit/tests/injected/visualization-needs-update.test.ts
+++ b/src/tests/unit/tests/injected/visualization-needs-update.test.ts
@@ -9,7 +9,7 @@ import { DictionaryStringTo } from 'types/common-types';
 describe('visualizationNeedsUpdate', () => {
     let visualizationType: VisualizationType;
     let id: string;
-    let newSelectorMapState: DictionaryStringTo<AssessmentVisualizationInstance>;
+    let newSelectorMapState: SelectorToVisualizationMap;
     let previousVisualizationStates: DictionaryStringTo<boolean>;
     let previousVisualizationSelectorMapData: VisualizationSelectorMapContainer;
 


### PR DESCRIPTION
#### Details

`TargetPageVisualizationUpdater` is responsible for tracking the current state of visualizers in a specific target page and responding to changes to the visualization store by checking whether a new store state mismatches a tracked visualizer state, triggering the appropriate `drawerInitiator` methods if any drawer needs to be updated to a new state.

The `previousVisualizationSelectorMapStates` it maintains is a mapping from `VisualizationType` to a `SelectorMap`, where ~a `SelectorMap` is a mapping from a particular step/requirement's `configId` to an `AssessmentVisualizationInstance` with information about which selector(s) are relevant to that requirement.~ edit: see comment below

The point where this map is *read* (L84, where it's passed it to `visualizationNeedsUpdate`) correctly uses this state by indexing into it using `visualizationType`s, but the point where it is *written* (L58) was incorrectly indexing into it using `configId`s. The compiler doesn't catch this because our compiler settings are not strict enough; it does detect this as an error with `"noImplicitAny": true` added to `tsconfig.base.ts`, but unfortunately it also catches 938 other errors, many of which are false positives.

The actual error is mostly-benign because of the way `visualization-needs-update` uses this field; there is no overlap between `configId`s (strings) and `visualizationType`s (int enums), so `visualizationNeedsUpdate` always ends up thinking that the previous selector map for the visualization it's considering was `undefined`. It compares it to the output of `SelectorMapHelper.getSelectorMap`, which is not very consistent (it uses empty objects for some empty cases and `null` for others) but does consistently avoid returning `undefined`), and that comparison always shows as "unequal". The practical effect is that it will say that *every* visualization type which has ever been enabled previously on that target page will always show as needing an update.

The three cases where these updates aren't necessary are:
1. A previously-enabled visualization is still enabled, and selector map state hasn't changed.
2. A previously-disabled visualization is still disabled, and selector map state hasn't changed.
3. A previously-disabled visualization is still disabled, even if selector map state has changed.

The bug fix in `target-page-visualization-updater` fixes cases 1 and 2 to not result in updates. The fix in `visualization-needs-update` is for case 3.

##### Motivation

In pages with iframes, each drawer intitiation involves a lot of messaging traffic between the frames, which slightly delays the legitimate messages for drawer updates that are actually required. The result is that after this PR, toggling visualizations will feel a little snappier in pages with lots of iframes (especially nested iframes).

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
