### PR TITLE
fix: fix telemetry for tab stops in android

### DIFF
--- a/src/electron/flux/action/tab-stops-action-creator.ts
+++ b/src/electron/flux/action/tab-stops-action-creator.ts
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { TelemetryEventSource, TriggeredByNotApplicable } from 'common/extension-telemetry-events';
 import { Logger } from 'common/logging/logger';
+import { SupportedMouseEvent, TelemetryDataFactory } from 'common/telemetry-data-factory';
 import {
     DEVICE_FOCUS_DISABLE,
     DEVICE_FOCUS_ENABLE,
@@ -22,11 +24,18 @@ export class TabStopsActionCreator {
         private readonly deviceFocusController: DeviceFocusController,
         private readonly logger: Logger,
         private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly telemetryDataFactory: TelemetryDataFactory,
     ) {}
 
-    public enableTabStops = async () => {
+    public enableTabStops = async (event: SupportedMouseEvent) => {
         try {
-            this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ENABLE, {});
+            const telemetry = this.telemetryDataFactory.withTriggeredByAndSource(
+                event,
+                TelemetryEventSource.ElectronResultsView,
+            );
+            this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ENABLE, {
+                telemetry,
+            });
             await this.deviceFocusController.enableFocusTracking();
             this.tabStopsActions.enableFocusTracking.invoke();
             this.deviceConnectionActions.statusConnected.invoke();
@@ -35,9 +44,15 @@ export class TabStopsActionCreator {
         }
     };
 
-    public disableTabStops = async () => {
+    public disableTabStops = async (event: SupportedMouseEvent) => {
         try {
-            this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_DISABLE, {});
+            const telemetry = this.telemetryDataFactory.withTriggeredByAndSource(
+                event,
+                TelemetryEventSource.ElectronResultsView,
+            );
+            this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_DISABLE, {
+                telemetry,
+            });
             await this.deviceFocusController.disableFocusTracking();
             this.tabStopsActions.disableFocusTracking.invoke();
             this.deviceConnectionActions.statusConnected.invoke();
@@ -46,9 +61,15 @@ export class TabStopsActionCreator {
         }
     };
 
-    public startOver = async () => {
+    public startOver = async (event: SupportedMouseEvent) => {
         try {
-            this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_RESET, {});
+            const telemetry = this.telemetryDataFactory.withTriggeredByAndSource(
+                event,
+                TelemetryEventSource.ElectronResultsView,
+            );
+            this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_RESET, {
+                telemetry,
+            });
             await this.deviceFocusController.resetFocusTracking();
             this.tabStopsActions.startOver.invoke();
             this.deviceConnectionActions.statusConnected.invoke();
@@ -131,7 +152,12 @@ export class TabStopsActionCreator {
 
     private commandFailed(error: Error): void {
         this.logger.log('focus controller failure: ' + error);
-        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ERROR, {});
+        this.telemetryEventHandler.publishTelemetry(DEVICE_FOCUS_ERROR, {
+            telemetry: {
+                source: TelemetryEventSource.ElectronResultsView,
+                triggeredBy: TriggeredByNotApplicable,
+            },
+        });
         this.deviceConnectionActions.statusDisconnected.invoke();
     }
 }

--- a/src/electron/types/content-page-info.ts
+++ b/src/electron/types/content-page-info.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ReactFCWithDisplayName } from 'common/react/named-fc';
+import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import { ResultsFilter } from 'common/types/results-filter';
 import { TestingContentProps } from 'electron/platform/android/testing-content';
 import { VisualHelperSection } from 'electron/types/visual-helper-section';
@@ -8,7 +9,7 @@ import { ReflowCommandBarProps } from 'electron/views/results/components/reflow-
 import { LeftNavItemKey } from './left-nav-item-key';
 
 export type StartOverButtonSettings = {
-    onClick: () => void;
+    onClick: (event: SupportedMouseEvent) => void;
     disabled: boolean;
 };
 

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -363,6 +363,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
             deviceFocusController,
             logger,
             telemetryEventHandler,
+            telemetryDataFactory,
         );
 
         const leftNavActionCreator = new LeftNavActionCreator(leftNavActions, cardSelectionActions);

--- a/src/electron/views/tab-stops/tab-stops-testing-content.tsx
+++ b/src/electron/views/tab-stops/tab-stops-testing-content.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { NamedFC } from 'common/react/named-fc';
+import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import { Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -24,11 +25,11 @@ export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
     'TabStopsTestingContent',
     props => {
         const tabStopsActionCreator = props.deps.tabStopsActionCreator;
-        const onToggle = () => {
+        const onToggle = (e: SupportedMouseEvent) => {
             if (props.tabStopsEnabled) {
-                tabStopsActionCreator.disableTabStops();
+                tabStopsActionCreator.disableTabStops(e);
             } else {
-                tabStopsActionCreator.enableTabStops();
+                tabStopsActionCreator.enableTabStops(e);
             }
         };
 

--- a/src/tests/unit/tests/electron/platform/android/test-configs/shared-scan-results/start-over-button-settings.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/test-configs/shared-scan-results/start-over-button-settings.test.ts
@@ -55,7 +55,7 @@ describe('sharedScanResultsStartOverButtonSettings', () => {
         } as ReflowCommandBarDeps;
         props.scanPort = scanPort;
 
-        sharedScanResultsStartOverButtonSettings(props).onClick();
+        sharedScanResultsStartOverButtonSettings(props).onClick(null);
 
         scanActionCreatorMock.verifyAll();
     });

--- a/src/tests/unit/tests/electron/views/results/components/reflow-command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/components/reflow-command-bar.test.tsx
@@ -15,6 +15,7 @@ import {
     ReflowCommandBarProps,
 } from 'electron/views/results/components/reflow-command-bar';
 import { mount, shallow } from 'enzyme';
+import { isMatch } from 'lodash';
 import { IButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
@@ -72,7 +73,7 @@ describe('ReflowCommandBar', () => {
                 allowsExportReport: true,
                 startOverButtonSettings: _ => {
                     return {
-                        onClick: _ => {},
+                        onClick: e => {},
                         disabled: false,
                     };
                 },
@@ -117,8 +118,11 @@ describe('ReflowCommandBar', () => {
 
             props.currentContentPageInfo.startOverButtonSettings = _ => {
                 return {
-                    onClick: () => {
+                    onClick: e => {
                         clickWasCalled = true;
+
+                        // The event passed through is decorated with other properties so we only check subset.
+                        expect(isMatch(e, eventStub)).toBeTruthy();
                     },
                     disabled: false,
                 };

--- a/src/tests/unit/tests/electron/views/results/components/reflow-command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/components/reflow-command-bar.test.tsx
@@ -72,7 +72,7 @@ describe('ReflowCommandBar', () => {
                 allowsExportReport: true,
                 startOverButtonSettings: _ => {
                     return {
-                        onClick: () => {},
+                        onClick: _ => {},
                         disabled: false,
                     };
                 },

--- a/src/tests/unit/tests/electron/views/tab-stops/tab-stops-testing-content.test.tsx
+++ b/src/tests/unit/tests/electron/views/tab-stops/tab-stops-testing-content.test.tsx
@@ -14,8 +14,10 @@ import { IMock, Mock, MockBehavior } from 'typemoq';
 describe('TabStopsTestingContent', () => {
     let tabStopsActionCreatorMock: IMock<TabStopsActionCreator>;
     let props: TabStopsTestingContentProps;
+    let eventStub: any;
 
     beforeEach(() => {
+        eventStub = {};
         tabStopsActionCreatorMock = Mock.ofType<TabStopsActionCreator>(
             undefined,
             MockBehavior.Strict,
@@ -32,10 +34,9 @@ describe('TabStopsTestingContent', () => {
     });
 
     test('toggles tab stops off', () => {
-        tabStopsActionCreatorMock.setup(m => m.disableTabStops()).verifiable();
+        tabStopsActionCreatorMock.setup(m => m.disableTabStops(eventStub)).verifiable();
         const testSubject = shallow(<TabStopsTestingContent {...props} />);
         const onToggle = testSubject.find(Toggle).prop('onClick');
-        const eventStub = null;
         onToggle(eventStub);
 
         tabStopsActionCreatorMock.verifyAll();
@@ -43,10 +44,9 @@ describe('TabStopsTestingContent', () => {
 
     test('toggles tab stops on', () => {
         props.tabStopsEnabled = false;
-        tabStopsActionCreatorMock.setup(m => m.enableTabStops()).verifiable();
+        tabStopsActionCreatorMock.setup(m => m.enableTabStops(eventStub)).verifiable();
         const testSubject = shallow(<TabStopsTestingContent {...props} />);
         const onToggle = testSubject.find(Toggle).prop('onClick');
-        const eventStub = null;
         onToggle(eventStub);
 
         tabStopsActionCreatorMock.verifyAll();


### PR DESCRIPTION
#### Details

Passes through telemetry for publishing unlike before.

##### Motivation

Need telemetry on tab stop usage.

##### Context

The main "fix" is around the fact that the payload for publish telemetry cannot be null. If it is, nothing is published. This is why key event telemetry already works.

Passed through events from UI so I can use the telemetry data factory. Seemed appropriate considering that's how we usually do things.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
