### PR TITLE
chore: Remove elevate.exe from Unified packages

### DIFF
--- a/src/electron/electron-builder/electron-builder.template.yaml
+++ b/src/electron/electron-builder/electron-builder.template.yaml
@@ -52,6 +52,7 @@ nsis:
     perMachine: false
     deleteAppDataOnUninstall: true
     include: src/electron/resources/installer.nsh
+    packElevateHelper: false
 publish:
     provider: generic
 


### PR DESCRIPTION
#### Details

By default, electron-builder includes elevate.exe to allow the installer to make per-machine changes. Since we install only per-user changes, this functionality is not necessary, and by removing elevate.exe, we remove a potential attack surface. [Electron-builder docs](https://www.electron.build/generated/nsisoptions)

##### Motivation

Reduce attack surface.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
