### PR TITLE
feat(fastpass-step-text-mvp): remove needs review feature flag

### DIFF
--- a/src/ad-hoc-visualizations/needs-review/visualization.tsx
+++ b/src/ad-hoc-visualizations/needs-review/visualization.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import { AdHocTestkeys } from '../../common/configs/adhoc-test-keys';
 import { TestMode } from '../../common/configs/test-mode';
 import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
-import { FeatureFlags } from '../../common/feature-flags';
 import { Messages } from '../../common/messages';
 import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
 import { VisualizationType } from '../../common/types/visualization-type';
@@ -66,5 +65,4 @@ export const NeedsReviewAdHocVisualization: VisualizationConfiguration = {
     getDrawer: provider => provider.createHighlightBoxDrawer(),
     getSwitchToTargetTabOnScan: () => false,
     getInstanceIdentiferGenerator: () => generateUID,
-    featureFlagToEnable: FeatureFlags.needsReview,
 };

--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -13,7 +13,6 @@ export class FeatureFlags {
     public static readonly manualInstanceDetails = 'manualInstanceDetails';
     public static readonly debugTools = 'debugTools';
     public static readonly exportReportOptions = 'exportReportOptions';
-    public static readonly needsReview = 'needsReview';
     public static readonly saveAndLoadAssessment = 'saveAndLoadAssessment';
 }
 
@@ -96,15 +95,6 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
             defaultValue: false,
             displayableName: 'More export options',
             displayableDescription: 'Enables exporting reports to external services',
-            isPreviewFeature: true,
-            forceDefault: false,
-        },
-        {
-            id: FeatureFlags.needsReview,
-            defaultValue: true,
-            displayableName: 'Needs review',
-            displayableDescription:
-                'Enable a new test to show automated check rules that might have an accessibility issue and need to be reviewed.',
             isPreviewFeature: true,
             forceDefault: false,
         },

--- a/src/fast-pass/fast-pass-provider.ts
+++ b/src/fast-pass/fast-pass-provider.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { FeatureFlags } from 'common/feature-flags';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import { DictionaryStringTo } from 'types/common-types';
@@ -9,11 +8,10 @@ import { DictionaryStringTo } from 'types/common-types';
 const fastPassVisualizationTypes: VisualizationType[] = [
     VisualizationType.Issues,
     VisualizationType.TabStops,
+    VisualizationType.NeedsReview,
 ];
 
-const fastPassFeatureFlagsToVisualizationTypes: DictionaryStringTo<VisualizationType> = {
-    [FeatureFlags.needsReview]: VisualizationType.NeedsReview,
-};
+const fastPassFeatureFlagsToVisualizationTypes: DictionaryStringTo<VisualizationType> = {};
 
 export function createFastPassProviderWithFeatureFlags(featureFlagStoreData: FeatureFlagStoreData) {
     return new FastPassProvider(

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
@@ -128,52 +128,6 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
                     Enables exporting reports to external services
                   </div>
                 </div>
-                <div
-                  class="generic-toggle-component--{{CSS_MODULE_HASH}}"
-                >
-                  <div
-                    class="toggle-container--{{CSS_MODULE_HASH}}"
-                  >
-                    <div
-                      class="toggle-name--{{CSS_MODULE_HASH}}"
-                    >
-                      Needs review
-                    </div>
-                    <div
-                      class="ms-Toggle is-checked is-enabled toggle--{{CSS_MODULE_HASH}} root-000"
-                    >
-                      <div
-                        class="ms-Toggle-innerContainer container-000"
-                      >
-                        <button
-                          aria-checked="true"
-                          aria-label="Needs review"
-                          class="ms-Toggle-background pill-000"
-                          data-is-focusable="true"
-                          id="needsReview"
-                          role="switch"
-                          type="button"
-                        >
-                          <span
-                            class="ms-Toggle-thumb thumb-000"
-                          />
-                        </button>
-                        <label
-                          class="ms-Label ms-Toggle-stateText text-000"
-                          for="needsReview"
-                          id="needsReview-stateText"
-                        >
-                          On
-                        </label>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="toggle-description--{{CSS_MODULE_HASH}}"
-                  >
-                    Enable a new test to show automated check rules that might have an accessibility issue and need to be reviewed.
-                  </div>
-                </div>
               </div>
             </div>
           </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-static-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-static-test-view.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`AdhocStaticTestView render handles content & guidance 1`] = `
                     var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
                     _this._interceptor.intercept(methodInvocation);
                     return methodInvocation.returnValue;
-                }]} stepsText=\\"Step 0 of 2\\" />"
+                }]} stepsText=\\"Step 0 of 3\\" />"
 `;
 
 exports[`AdhocStaticTestView render handles content & no guidance 1`] = `
@@ -55,7 +55,7 @@ exports[`AdhocStaticTestView render handles content & no guidance 1`] = `
                     var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
                     _this._interceptor.intercept(methodInvocation);
                     return methodInvocation.returnValue;
-                }]} guidance={[undefined]} stepsText=\\"Step 0 of 2\\" />"
+                }]} guidance={[undefined]} stepsText=\\"Step 0 of 3\\" />"
 `;
 
 exports[`AdhocStaticTestView render handles no content & guidance 1`] = `
@@ -79,7 +79,7 @@ exports[`AdhocStaticTestView render handles no content & guidance 1`] = `
                     var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
                     _this._interceptor.intercept(methodInvocation);
                     return methodInvocation.returnValue;
-                }]} stepsText=\\"Step 0 of 2\\" />"
+                }]} stepsText=\\"Step 0 of 3\\" />"
 `;
 
 exports[`AdhocStaticTestView render handles no content & no guidance 1`] = `
@@ -93,7 +93,7 @@ exports[`AdhocStaticTestView render handles no content & no guidance 1`] = `
                     var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
                     _this._interceptor.intercept(methodInvocation);
                     return methodInvocation.returnValue;
-                }]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[undefined]} guidance={[undefined]} stepsText=\\"Step 0 of 2\\" />"
+                }]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[undefined]} guidance={[undefined]} stepsText=\\"Step 0 of 3\\" />"
 `;
 
 exports[`AdhocStaticTestView should return target page changed view as tab is changed 1`] = `"<TargetPageChangedView displayableData={{...}} visualizationType={-1} toggleClickHandler={[Function: clickHandlerStub]} featureFlagStoreData={{...}} detailsViewActionMessageCreator={[Function]} />"`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-list-issues-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-list-issues-view.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`DetailsListIssuesView should return issues table with scanning to false
   instancesSection={[Function]}
   issuesEnabled={true}
   scanning={false}
-  stepsText="Step 0 of 2"
+  stepsText="Step 0 of 3"
   subtitle={
     <React.Fragment>
       test subtitle

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/fast-pass-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/fast-pass-left-nav.test.tsx.snap
@@ -1,33 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` includes needs review test when feature flag on 1`] = `
-<VisualizationBasedLeftNav
-  deps={
-    Object {
-      "navLinkHandler": Object {
-        "onFastPassTestClick": [Function],
-      },
-    }
-  }
-  featureFlagStoreData={
-    Object {
-      "needsReview": true,
-    }
-  }
-  onLinkClick={[Function]}
-  onRightPanelContentSwitch={[Function]}
-  selectedKey="some string"
-  setNavComponentRef={[Function]}
-  visualizations={
-    Array [
-      1,
-      3,
-      29,
-    ]
-  }
-/>
-`;
-
 exports[` renders visualization based left nav with appropriate params 1`] = `
 <VisualizationBasedLeftNav
   deps={
@@ -46,6 +18,7 @@ exports[` renders visualization based left nav with appropriate params 1`] = `
     Array [
       1,
       3,
+      29,
     ]
   }
 />

--- a/src/tests/unit/tests/DetailsView/components/left-nav/fast-pass-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/fast-pass-left-nav.test.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FeatureFlags } from 'common/feature-flags';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import {
@@ -36,13 +35,6 @@ describe(FastPassLeftNav, () => {
     });
 
     it('renders visualization based left nav with appropriate params', () => {
-        const actual = shallow(<FastPassLeftNav {...props} />);
-        expect(actual.getElement()).toMatchSnapshot();
-    });
-
-    it('includes needs review test when feature flag on', () => {
-        props.featureFlagStoreData[FeatureFlags.needsReview] = true;
-
         const actual = shallow(<FastPassLeftNav {...props} />);
         expect(actual.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -25,7 +25,6 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.manualInstanceDetails]: false,
             [FeatureFlags.debugTools]: false,
             [FeatureFlags.exportReportOptions]: false,
-            [FeatureFlags.needsReview]: true,
             [FeatureFlags.saveAndLoadAssessment]: false,
         };
 


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
* Remove Needs review feature flag to always show Needs review FastPass test
* Pop-up text has already been updated to say "three [FastPass] tests" in #4123 

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Addresses WI # 1835283

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

Screenshot of FastPass details view page with Needs review as the third FastPass step and no Needs review feature flag present in the Preview features panel
![image](https://user-images.githubusercontent.com/48259897/115445229-7139a100-a1ca-11eb-909a-17465e3c07f0.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: WI # 1835283
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
