### PR TITLE
feat(complete-save-load-assessment): wire up load assessment

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -543,12 +543,18 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
-    public loadAssessment = (assessmentData: VersionedAssessmentData): void => {
+    public loadAssessment = (assessmentData: VersionedAssessmentData, tabId: number): void => {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: LoadAssessmentPayload = {
             telemetry: telemetry,
             versionedAssessmentData: assessmentData,
+            tabId,
         };
+        const setDetailsViewRightContentPanelPayload: DetailsViewRightContentPanelType = 'Overview';
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
+            payload: setDetailsViewRightContentPanelPayload,
+        });
         this.dispatcher.dispatchMessage({
             messageType: Messages.Assessment.LoadAssessment,
             payload,

--- a/src/DetailsView/components/load-assessment-helper.ts
+++ b/src/DetailsView/components/load-assessment-helper.ts
@@ -9,6 +9,7 @@ export class LoadAssessmentHelper {
         private readonly detailsViewActionMessageCreator: DetailsViewActionMessageCreator,
         private readonly fileReader: FileReader,
         private readonly document: Document,
+        private readonly tabId: number,
     ) {}
 
     public getAssessmentForLoad() {
@@ -19,7 +20,7 @@ export class LoadAssessmentHelper {
         const onReaderLoad = (readerEvent: ProgressEvent<FileReader>) => {
             const content = readerEvent.target.result as string;
             const assessmentData = this.assessmentDataParser.parseAssessmentData(content);
-            this.detailsViewActionMessageCreator.loadAssessment(assessmentData);
+            this.detailsViewActionMessageCreator.loadAssessment(assessmentData, this.tabId);
         };
         const onInputChange = (e: Event) => {
             const file = (e.target as HTMLInputElement).files[0];

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -396,6 +396,7 @@ if (tabId != null) {
                 detailsViewActionMessageCreator,
                 fileReader,
                 document,
+                tab.id,
             );
 
             const fileNameBuilder = new FileNameBuilder();

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -55,6 +55,7 @@ export interface AssessmentActionInstancePayload extends AssessmentToggleActionP
 
 export interface LoadAssessmentPayload extends BaseActionPayload {
     versionedAssessmentData: VersionedAssessmentData;
+    tabId: number;
 }
 export interface ChangeRequirementStatusPayload extends AssessmentToggleActionPayload {
     status?: ManualTestStatus;

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -61,7 +61,7 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         super(StoreNames.AssessmentStore);
     }
 
-    public generateDefaultState(persistedData: AssessmentStoreData = null): AssessmentStoreData {
+    private generateDefaultState(persistedData: AssessmentStoreData = null): AssessmentStoreData {
         return this.initialAssessmentStoreDataGenerator.generateInitialState(persistedData);
     }
 
@@ -149,7 +149,10 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
     };
 
     private onLoadAssessment = (payload: LoadAssessmentPayload): void => {
-        //update state - ADO #1784187
+        this.state = this.initialAssessmentStoreDataGenerator.generateInitialState(
+            payload.versionedAssessmentData.assessmentData,
+        );
+        this.updateTargetTabWithId(payload.tabId);
     };
 
     private onUpdateTargetTabId = (tabId: number): void => {

--- a/src/tests/unit/tests/DetailsView/components/load-assessment-helper.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/load-assessment-helper.test.tsx
@@ -12,6 +12,7 @@ describe('LoadAssessmentHelper', () => {
     const fileReaderMock = Mock.ofType(FileReader);
     const documentMock = Mock.ofType(Document);
     const clickMock = Mock.ofType<() => void>();
+    const tabIdStub = -1;
     let assessmentData: VersionedAssessmentData;
     let content: string;
     let file: File;
@@ -26,7 +27,7 @@ describe('LoadAssessmentHelper', () => {
             .verifiable(Times.once());
 
         detailsViewActionMessageCreatorMock
-            .setup(d => d.loadAssessment(assessmentData))
+            .setup(d => d.loadAssessment(assessmentData, tabIdStub))
             .verifiable(Times.once());
 
         fileReaderMock.setup(f => f.readAsText(file, 'UTF-8')).verifiable(Times.once());
@@ -61,6 +62,7 @@ describe('LoadAssessmentHelper', () => {
             detailsViewActionMessageCreatorMock.object,
             fileReaderMock.object,
             documentMock.object,
+            tabIdStub,
         );
 
         testLoadAssessmentHelper.getAssessmentForLoad();


### PR DESCRIPTION
#### Details

Wires up the load assessment button, passing through data back into store.

##### Motivation

Feature work.

##### Context

TabId is included in the data for the payload so we can set the tab that sent the request as the current tab for the assessment after we load the data in. Also navigates to Overview, like resetting an assessment does.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
