### PR TITLE
feat(android-signing-binskim): Separate unified installer creation from grunt build command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -588,7 +588,7 @@ module.exports = function (grunt) {
                 unpackedDirName = 'mac';
                 break;
             case 'linux':
-                unpackedDirName = 'linux';
+                unpackedDirName = 'linux-unpacked';
                 break;
         }
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "null:find": "node ./tools/strict-null-checks/find.js",
         "null:find-cycles": "node ./tools/strict-null-checks/find-cycles.js",
         "null:progress": "node ./tools/strict-null-checks/progress.js",
+        "pack:unified:all": "grunt pack-unified-all",
         "react-devtools": "react-devtools",
         "run:binskim": "node ./pipeline/scripts/run-binskim.js",
         "scss:build": "tsm \"src/**/*.scss\"",

--- a/pipeline/unified/build-unsigned-release-packages.yaml
+++ b/pipeline/unified/build-unsigned-release-packages.yaml
@@ -46,6 +46,9 @@ steps:
     - script: yarn build:unified:all --unified-version=$(Build.BuildNumber) --unified-canary-instrumentation-key=$(UnifiedCanaryInstrumentationKey) --unified-insider-instrumentation-key=$(UnifiedInsiderInstrumentationKey) --unified-prod-instrumentation-key=$(UnifiedProdInstrumentationKey)
       displayName: yarn build:unified:all
 
+    - script: yarn pack:unified:all
+      displayName: yarn pack:unified:all
+
     - script: node ./pipeline/scripts/print-file-hash-info.js $(System.DefaultWorkingDirectory)/drop/electron/unified-canary/packed
       displayName: print out canary file hashes
 


### PR DESCRIPTION
#### Details
Currently, our `build-unified-<channel>` grunt commands build the unified product and then run electron-builder to create packed installers. This PR creates a new `pack-unified-<channel>` grunt command and shifts responsibility as follows:
- `build-unified-<channel>` builds the unified product and runs electron-builder to prepare the unpacked files in the drop folder
- `pack-unified-<channel>` runs electron-builder to pack the unpacked files from the drop folder into installers

With this PR, running `build-unified-<channel>` and then `pack-unified-<channel>` is equivalent to running the previous `build-unified-<channel>` command. As such, there is no net impact on our unsigned build pipeline.

##### Motivation
We currently only sign the packed installers. Now that we want to sign the contents of those installers, we need the ability to create the installers without running a fresh build and remaking their contents.

##### Context
A follow up PR will leverage this PR and update our unsigned and signed build pipelines to sign the desired files.

I considered leaving the grunt task as-is and instead signing the electron files directly (in `node_modules`). This would not work because electron-builder tweaks the electron executable, which would break its signature. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
