### PR TITLE
fix: Add display workaround for linux in Parallels VM's

### DIFF
--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -32,6 +32,7 @@ log.transports.file.level = 'info';
 autoUpdater.logger = log;
 
 if (platformInfo.isLinux()) {
+    // Avoid a conflict between Parallels VM and Electron. See https://github.com/microsoft/accessibility-insights-web/issues/4140
     app.disableHardwareAcceleration();
 }
 

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -31,6 +31,10 @@ const nativeHighContrastModeListener = new NativeHighContrastModeListener(
 log.transports.file.level = 'info';
 autoUpdater.logger = log;
 
+if (platformInfo.isLinux()) {
+    app.disableHardwareAcceleration();
+}
+
 let recurringUpdateCheck;
 const electronAutoUpdateCheck = new AutoUpdaterClient(autoUpdater);
 

--- a/src/electron/window-management/platform-info.ts
+++ b/src/electron/window-management/platform-info.ts
@@ -25,6 +25,10 @@ export class PlatformInfo {
         return this.getOs() === OSType.Mac;
     }
 
+    public isLinux(): boolean {
+        return this.getOs() === OSType.Linux;
+    }
+
     public getOsName(): string {
         return this.currentProcess.platform || null;
     }

--- a/src/tests/unit/tests/electron/window-management/platform-info.test.ts
+++ b/src/tests/unit/tests/electron/window-management/platform-info.test.ts
@@ -34,6 +34,12 @@ describe(PlatformInfo, () => {
         expect(testSubject.isMac()).toBe(true);
     });
 
+    it('isLinux', () => {
+        processMock.setup(p => p.platform).returns(() => 'linux');
+
+        expect(testSubject.isLinux()).toBe(true);
+    });
+
     describe('getOsName', () => {
         type GetOsTestCase = { platformName: typeof process.platform; osType: OSType };
 


### PR DESCRIPTION
#### Details

Disable hardware acceleration when running on Linux as a workaround for an issue in the Parallels VM software.

##### Motivation

Address issue #4140  

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
This is an unfortunately broad change, impacting all linux installations, including those not running in a VM. I'd love to scope it down to apply only when running in a Parallels VM (or even only in a VM), but found no javascript-friendly to make that determination. It might be possible to exec **systemd-detect-virt**, but that felt "heavy". Our graphics are very limited (display a screenshot with highlights), so disabling hardware acceleration doesn't seem to have a discernible impact on the product.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Screenshots
These are taken on the same machine running Ubuntu 20.04 in a Parallels VM:
 Before | After
--- | ---
![image](https://user-images.githubusercontent.com/45672944/115795088-19469a00-a384-11eb-9030-0e5d7a545a63.png) | ![image](https://user-images.githubusercontent.com/45672944/115794903-b94ff380-a383-11eb-96f6-bef8c7d21679.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4140
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
