### PR TITLE
fix: Improve disconnected device experience

### DIFF
--- a/src/electron/flux/action/android-setup-actions.ts
+++ b/src/electron/flux/action/android-setup-actions.ts
@@ -4,7 +4,7 @@ import { Action } from 'common/flux/action';
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 
 // This class needs only to represent possible simultaneously invokable actions
-// So, for example, the 'next' action may represent 'continue', 'str again', or 'start scanning'
+// So, for example, the 'next' action may represent 'continue', 'try again', or 'start scanning'
 export class AndroidSetupActions {
     public readonly cancel = new Action<void>();
     public readonly next = new Action<void>();

--- a/src/electron/flux/action/android-setup-actions.ts
+++ b/src/electron/flux/action/android-setup-actions.ts
@@ -4,7 +4,7 @@ import { Action } from 'common/flux/action';
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 
 // This class needs only to represent possible simultaneously invokable actions
-// So, for example, the 'next' action may represent 'continue', 'try again', or 'start scanning'
+// So, for example, the 'next' action may represent 'continue', 'str again', or 'start scanning'
 export class AndroidSetupActions {
     public readonly cancel = new Action<void>();
     public readonly next = new Action<void>();

--- a/src/electron/platform/android/setup/steps/configuring-port-forwarding.ts
+++ b/src/electron/platform/android/setup/steps/configuring-port-forwarding.ts
@@ -1,11 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { AndroidSetupStoreCallbacks } from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
 import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-setup-steps-configs';
 
-const removeOldForwardedPort = async (deps, store) => {
+const removeOldForwardedPort = async (
+    deps: AndroidSetupDeps,
+    store: AndroidSetupStoreCallbacks,
+) => {
     const existingPort = store.getScanPort();
-    if (existingPort != null) {
+    if (existingPort) {
         try {
             deps.logger.log(`removing old tcp:${existingPort} forwarding`);
             await deps.removeTcpForwarding(existingPort);
@@ -16,7 +21,11 @@ const removeOldForwardedPort = async (deps, store) => {
     }
 };
 
-export const configuringPortForwarding: AndroidSetupStepConfig = (stepTransition, deps, store) => ({
+export const configuringPortForwarding: AndroidSetupStepConfig = (
+    stepTransition,
+    deps: AndroidSetupDeps,
+    store: AndroidSetupStoreCallbacks,
+) => ({
     actions: {},
     onEnter: async () => {
         try {

--- a/src/electron/platform/android/setup/steps/configuring-port-forwarding.ts
+++ b/src/electron/platform/android/setup/steps/configuring-port-forwarding.ts
@@ -14,10 +14,10 @@ const removeOldForwardedPort = async (
         try {
             deps.logger.log(`removing old tcp:${existingPort} forwarding`);
             await deps.removeTcpForwarding(existingPort);
-            store.setScanPort(null);
         } catch (e) {
             deps.logger.log(`Ignoring error : ${e}`);
         }
+        store.setScanPort(null);
     }
 };
 

--- a/src/electron/platform/android/setup/steps/prompt-connected-start-testing.ts
+++ b/src/electron/platform/android/setup/steps/prompt-connected-start-testing.ts
@@ -7,5 +7,6 @@ export const promptConnectedStartTesting: AndroidSetupStepConfig = (stepTransiti
     actions: {
         cancel: () => stepTransition('prompt-choose-device'),
         rescan: () => stepTransition('detect-devices'),
+        readyToStart: () => stepTransition('prompt-connect-to-device'), // Reset state after leaving setup dialogs
     },
 });

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
@@ -13,6 +13,11 @@ import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 
+const startTestingAndResetState = (props: CommonAndroidSetupStepProps) => {
+    props.deps.startTesting();
+    props.deps.androidSetupActionCreator.readyToStart(); // Overloaded to reset to 'connect device state'
+};
+
 export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptConnectedStartTestingStep',
     (props: CommonAndroidSetupStepProps) => {
@@ -32,7 +37,7 @@ export const PromptConnectedStartTestingStep = NamedFC<CommonAndroidSetupStepPro
             rightFooterButtonProps: {
                 text: 'Start testing',
                 disabled: false,
-                onClick: props.deps.startTesting,
+                onClick: _ => startTestingAndResetState(props),
             },
         };
 

--- a/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
@@ -42,11 +42,11 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
                         Uh-oh! It seems the device <strong>{deviceName}</strong> has disconnected.
                     </p>
                     <p>
-                        Select <strong>Redetect device</strong> to continue.
+                        Select <strong>Re-detect device</strong> to continue.
                     </p>
                 </div>
                 <DialogFooter>
-                    <DefaultButton text="Redetect device" onClick={onRedetectDevice} />
+                    <DefaultButton text="Re-detect device" onClick={onRedetectDevice} />
                 </DialogFooter>
             </Dialog>
         );

--- a/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
@@ -9,14 +9,13 @@ import * as styles from './device-disconnected-popup.scss';
 import { StatusCautionIcon } from './status-caution-icon';
 
 export type DeviceDisconnectedPopupProps = {
-    onConnectNewDevice: () => void;
-    onRescanDevice: () => void;
+    onRedetectDevice: () => void;
     deviceName: string;
 };
 
 export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
     'DeviceDisconnectedPopup',
-    ({ deviceName, onConnectNewDevice, onRescanDevice }) => {
+    ({ deviceName, onRedetectDevice }) => {
         const title: JSX.Element = (
             <div className={styles.titleContainer}>
                 <StatusCautionIcon />
@@ -43,14 +42,11 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
                         Uh-oh! It seems the device <strong>{deviceName}</strong> has disconnected.
                     </p>
                     <p>
-                        To continue using that device, make sure it’s properly connected and then
-                        select <strong>Start over</strong>. To use a different device, select{' '}
-                        <strong>Connect a new device</strong>.
+                        Select <strong>Redetect device</strong> to continue.
                     </p>
                 </div>
                 <DialogFooter>
-                    <DefaultButton text="Start over" onClick={onRescanDevice} />
-                    <DefaultButton text="Connect a new device" onClick={onConnectNewDevice} />
+                    <DefaultButton text="Redetect device" onClick={onRedetectDevice} />
                 </DialogFooter>
             </Dialog>
         );

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -245,12 +245,11 @@ export class ResultsView extends React.Component<ResultsViewProps> {
         return (
             <DeviceDisconnectedPopup
                 deviceName={this.getConnectedDeviceName()}
-                onConnectNewDevice={() =>
+                onRedetectDevice={() =>
                     this.props.deps.windowStateActionCreator.setRoute({
                         routeId: 'deviceConnectView',
                     })
                 }
-                onRescanDevice={() => this.props.deps.scanActionCreator.scan(this.getScanPort())}
             />
         );
     }

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -17,7 +17,6 @@ import {
     SettingsPanelDeps,
 } from 'DetailsView/components/details-view-overlay/settings-panel/settings-panel';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
-import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
@@ -57,7 +56,6 @@ export type ResultsViewDeps = ReflowCommandBarDeps &
     TestViewDeps &
     VisualHelperSectionDeps &
     SettingsPanelDeps & {
-        androidSetupActionCreator: AndroidSetupActionCreator;
         scanActionCreator: ScanActionCreator;
         leftNavActionCreator: LeftNavActionCreator;
         windowStateActionCreator: WindowStateActionCreator;
@@ -239,11 +237,6 @@ export class ResultsView extends React.Component<ResultsViewProps> {
         );
     }
 
-    private reconnectDevice = (): void => {
-        this.props.deps.windowStateActionCreator.setRoute({ routeId: 'deviceConnectView' });
-        this.props.deps.androidSetupActionCreator.rescan();
-    };
-
     private renderDeviceDisconnected(): JSX.Element {
         if (this.props.deviceConnectionStoreData.status !== DeviceConnectionStatus.Disconnected) {
             return;
@@ -252,7 +245,11 @@ export class ResultsView extends React.Component<ResultsViewProps> {
         return (
             <DeviceDisconnectedPopup
                 deviceName={this.getConnectedDeviceName()}
-                onConnectNewDevice={this.reconnectDevice}
+                onConnectNewDevice={() =>
+                    this.props.deps.windowStateActionCreator.setRoute({
+                        routeId: 'deviceConnectView',
+                    })
+                }
                 onRescanDevice={() => this.props.deps.scanActionCreator.scan(this.getScanPort())}
             />
         );

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -17,6 +17,7 @@ import {
     SettingsPanelDeps,
 } from 'DetailsView/components/details-view-overlay/settings-panel/settings-panel';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
+import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
@@ -56,6 +57,7 @@ export type ResultsViewDeps = ReflowCommandBarDeps &
     TestViewDeps &
     VisualHelperSectionDeps &
     SettingsPanelDeps & {
+        androidSetupActionCreator: AndroidSetupActionCreator;
         scanActionCreator: ScanActionCreator;
         leftNavActionCreator: LeftNavActionCreator;
         windowStateActionCreator: WindowStateActionCreator;
@@ -237,6 +239,11 @@ export class ResultsView extends React.Component<ResultsViewProps> {
         );
     }
 
+    private reconnectDevice = (): void => {
+        this.props.deps.windowStateActionCreator.setRoute({ routeId: 'deviceConnectView' });
+        this.props.deps.androidSetupActionCreator.rescan();
+    };
+
     private renderDeviceDisconnected(): JSX.Element {
         if (this.props.deviceConnectionStoreData.status !== DeviceConnectionStatus.Disconnected) {
             return;
@@ -245,11 +252,7 @@ export class ResultsView extends React.Component<ResultsViewProps> {
         return (
             <DeviceDisconnectedPopup
                 deviceName={this.getConnectedDeviceName()}
-                onConnectNewDevice={() =>
-                    this.props.deps.windowStateActionCreator.setRoute({
-                        routeId: 'deviceConnectView',
-                    })
-                }
+                onConnectNewDevice={this.reconnectDevice}
                 onRescanDevice={() => this.props.deps.scanActionCreator.scan(this.getScanPort())}
             />
         );

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-connected-start-testing.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/prompt-connected-start-testing.test.ts
@@ -34,7 +34,7 @@ describe('Android setup step: promptConnectedStartTesting', () => {
     it('has expected properties', () => {
         const deps = {} as AndroidSetupDeps;
         const step = promptConnectedStartTesting(null, deps);
-        checkExpectedActionsAreDefined(step, ['cancel', 'rescan']);
+        checkExpectedActionsAreDefined(step, ['cancel', 'rescan', 'readyToStart']);
         expect(step.onEnter).not.toBeDefined();
     });
 
@@ -58,5 +58,16 @@ describe('Android setup step: promptConnectedStartTesting', () => {
             storeCallbacksMock.object,
         );
         step.actions.rescan();
+    });
+
+    it('readyToStart transitions to prompt-connect-to-device as expected', () => {
+        stepTransitionMock.setup(m => m('prompt-connect-to-device')).verifiable(Times.once());
+
+        const step = promptConnectedStartTesting(
+            stepTransitionMock.object,
+            depsMock.object,
+            storeCallbacksMock.object,
+        );
+        step.actions.readyToStart();
     });
 });

--- a/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -38,14 +38,14 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
     <p>
       Select 
       <strong>
-        Redetect device
+        Re-detect device
       </strong>
        to continue.
     </p>
   </div>
   <StyledDialogFooterBase>
     <CustomizedDefaultButton
-      text="Redetect device"
+      text="Re-detect device"
     />
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>

--- a/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -36,24 +36,16 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
        has disconnected.
     </p>
     <p>
-      To continue using that device, make sure it’s properly connected and then select 
+      Select 
       <strong>
-        Start over
+        Redetect device
       </strong>
-      . To use a different device, select
-       
-      <strong>
-        Connect a new device
-      </strong>
-      .
+       to continue.
     </p>
   </div>
   <StyledDialogFooterBase>
     <CustomizedDefaultButton
-      text="Start over"
-    />
-    <CustomizedDefaultButton
-      text="Connect a new device"
+      text="Redetect device"
     />
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>

--- a/src/tests/unit/tests/electron/views/device-disconnected-popup/device-disconnected-popup.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-disconnected-popup/device-disconnected-popup.test.tsx
@@ -19,17 +19,17 @@ describe('DeviceDisconnectedPopup', () => {
 
     describe('user interaction', () => {
         it('handles on redetect device', () => {
-            const onConnectNewDeviceMock: () => void = jest.fn(() => {});
+            const onRedecteDeviceMock: () => void = jest.fn(() => {});
 
             const props = {
-                onRedetectDevice: onConnectNewDeviceMock,
+                onRedetectDevice: onRedecteDeviceMock,
             } as DeviceDisconnectedPopupProps;
 
             const wrapper = shallow(<DeviceDisconnectedPopup {...props} />);
 
-            wrapper.find('[text="Redetect device"]').simulate('click');
+            wrapper.find('[text="Re-detect device"]').simulate('click');
 
-            expect(onConnectNewDeviceMock).toBeCalledTimes(1);
+            expect(onRedecteDeviceMock).toBeCalledTimes(1);
         });
     });
 });

--- a/src/tests/unit/tests/electron/views/device-disconnected-popup/device-disconnected-popup.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-disconnected-popup/device-disconnected-popup.test.tsx
@@ -18,32 +18,18 @@ describe('DeviceDisconnectedPopup', () => {
     });
 
     describe('user interaction', () => {
-        it('handles on connect a new device', () => {
+        it('handles on redetect device', () => {
             const onConnectNewDeviceMock: () => void = jest.fn(() => {});
 
             const props = {
-                onConnectNewDevice: onConnectNewDeviceMock,
+                onRedetectDevice: onConnectNewDeviceMock,
             } as DeviceDisconnectedPopupProps;
 
             const wrapper = shallow(<DeviceDisconnectedPopup {...props} />);
 
-            wrapper.find('[text="Connect a new device"]').simulate('click');
+            wrapper.find('[text="Redetect device"]').simulate('click');
 
             expect(onConnectNewDeviceMock).toBeCalledTimes(1);
-        });
-
-        it('handles on rescan device', () => {
-            const onRescanDeviceMock: () => void = jest.fn(() => {});
-
-            const props = {
-                onRescanDevice: onRescanDeviceMock,
-            } as DeviceDisconnectedPopupProps;
-
-            const wrapper = shallow(<DeviceDisconnectedPopup {...props} />);
-
-            wrapper.find('[text="Start over"]').simulate('click');
-
-            expect(onRescanDeviceMock).toBeCalledTimes(1);
         });
     });
 });

--- a/src/tests/unit/tests/electron/views/device-disconnected-popup/device-disconnected-popup.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-disconnected-popup/device-disconnected-popup.test.tsx
@@ -19,17 +19,17 @@ describe('DeviceDisconnectedPopup', () => {
 
     describe('user interaction', () => {
         it('handles on redetect device', () => {
-            const onRedecteDeviceMock: () => void = jest.fn(() => {});
+            const onRedectDeviceMock: () => void = jest.fn(() => {});
 
             const props = {
-                onRedetectDevice: onRedecteDeviceMock,
+                onRedetectDevice: onRedectDeviceMock,
             } as DeviceDisconnectedPopupProps;
 
             const wrapper = shallow(<DeviceDisconnectedPopup {...props} />);
 
             wrapper.find('[text="Re-detect device"]').simulate('click');
 
-            expect(onRedecteDeviceMock).toBeCalledTimes(1);
+            expect(onRedectDeviceMock).toBeCalledTimes(1);
         });
     });
 });

--- a/src/tests/unit/tests/electron/views/results/__snapshots__/results-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/results/__snapshots__/results-view.test.tsx.snap
@@ -950,8 +950,7 @@ exports[`ResultsView when status scan <Failed> 1`] = `
           }
         />
         <DeviceDisconnectedPopup
-          onConnectNewDevice={[Function]}
-          onRescanDevice={[Function]}
+          onRedetectDevice={[Function]}
         />
       </div>
     </div>

--- a/src/tests/unit/tests/electron/views/results/results-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/results-view.test.tsx
@@ -30,7 +30,6 @@ import { ScanStatus } from 'electron/flux/types/scan-status';
 import { TabStopsStoreData } from 'electron/flux/types/tab-stops-store-data';
 import { ContentPageInfo, ContentPagesInfo } from 'electron/types/content-page-info';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
-import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
 import { TitleBar } from 'electron/views/results/components/title-bar';
 import { ResultsView, ResultsViewProps } from 'electron/views/results/results-view';
 import { TestView } from 'electron/views/results/test-view';
@@ -245,23 +244,6 @@ describe('ResultsView', () => {
 
             expect(wrapped.find(TitleBar).props().pageTitle).toEqual(expectedTitle);
             expect(wrapped.find(TestView).getElement()).toMatchSnapshot();
-        });
-    });
-
-    describe('DeviceDisconnectedPopup event handlers', () => {
-        it('onRescanDevice', () => {
-            const scanActionCreatorMock = Mock.ofType(ScanActionCreator);
-            props.deps.scanActionCreator = scanActionCreatorMock.object;
-            props.scanStoreData.status = ScanStatus.Failed;
-            props.deviceConnectionStoreData.status = DeviceConnectionStatus.Disconnected;
-            props.androidSetupStoreData.scanPort = scanPort;
-            const wrapped = shallow(<ResultsView {...props} />);
-
-            scanActionCreatorMock.reset(); // this mock is used on componentDidMount, which is not in the scope of this unit test
-
-            wrapped.find(DeviceDisconnectedPopup).prop('onRescanDevice')();
-
-            scanActionCreatorMock.verify(creator => creator.scan(scanPort), Times.once());
         });
     });
 });


### PR DESCRIPTION
#### Details

Improve our disconnected device scenario. As called out in #3938, when the device connection is removed, ADB automatically removes port forwarding, which breaks assumptions in the reconnect code (which pre-dates the auto-configuration of port forwarding).

The PR basically consists of 3 pieces:
1. We already try to remove previously configured port forwarding, but we don't account for the error that gets thrown if we're removing a non-existent port. Fix this.
2. The notion of the "Start over" button is doomed to fail if we've really lost the connection, because we've lost our port forwarding and can only restore it by going through the device setup steps. I've updated the disconnected dialog to remove the "Start over" button.
3. When the user clicks the "Connect a new device" button, we return to the device setup view. Its state is still on the "start testing" page, which is doomed to fail because it's after the port forwarding step. I've changed the code to reset the state to the "connect-device" step when the users presses "Start testing", so there's always a consistent experience for reconnecting. To better reflect the workflow, I changed the "Connect a new device" button (in the disconnected dialog) to "Re-detect device", then we let the user connect an appropriate device before proceeding. @juchampa has reviewed and approved the user experience.

##### Motivation

Address #3938.

##### Screenshots

Connection dialog 
Before | After
--- | ---
![image](https://user-images.githubusercontent.com/45672944/116300960-5b8d2400-a754-11eb-974c-8d341ea9d4a3.png) | ![image](https://user-images.githubusercontent.com/45672944/116472277-89dd3300-a82a-11eb-9b68-30cede2e1e0f.png)

Destination dialog after clicking through (these dialogs are unchanged, but shown purely to convey the user experience--note that the old experience landed in the "start testing" step with all previous information intact, while the new experience lands in the "connect your device" step):
Before | After
--- | ---
![image](https://user-images.githubusercontent.com/45672944/116301267-b7f04380-a754-11eb-9c60-8d0b718b45dc.png) | ![image](https://user-images.githubusercontent.com/45672944/116301302-bfafe800-a754-11eb-8a43-6f511ca19b2e.png)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
This assumes that we're really disconnected when we display the device disconnected dialog. If the service were to throw an error (as opposed to being disconnected), then it's overkill to reconnect the device. I'm not aware of any user feedback to suggest that we're getting service errors, but I'd argue for a separate error handler dialog if/when we feel the need to make the distinction between the 2 error conditions.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
I experimented with auto-detecting the newly connected device when the user clicked from the disconnected device dialog, but it added some unfortunate coupling between the results view (where the disconnected dialog is hosted) and the setup action creator. Always returning to the "Connect a device" step avoided this. Users may need to click 1 more button, but it lets us leverage an existing esperience.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3938
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
