### PR TITLE
chore: Add succeeded condition to pack:unified:all build step

### DIFF
--- a/pipeline/unified/build-unsigned-release-packages.yaml
+++ b/pipeline/unified/build-unsigned-release-packages.yaml
@@ -48,7 +48,7 @@ steps:
 
     - script: yarn pack:unified:all
       displayName: yarn pack:unified:all
-      condition: ne(variables.platform, 'windows')
+      condition: and(succeeded(), ne(variables.platform, 'windows'))
 
     - script: node ./pipeline/scripts/print-file-hash-info.js $(System.DefaultWorkingDirectory)/drop/electron/unified-canary/packed
       displayName: print out canary file hashes


### PR DESCRIPTION
#### Details
The unified pack command in the unsigned build currently has a condition to not run on Windows. The condition should have included `succeeded()`, as well. This PR corrects that.

##### Motivation
If a previous build step fails, `pack:unified:all` shouldn't run.

##### Context
n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
