### PR TITLE
feat(android-signing-binskim): Add codesign validation to Windows signing job

### DIFF
--- a/pipeline/unified/channel/sign-release-package-windows.yaml
+++ b/pipeline/unified/channel/sign-release-package-windows.yaml
@@ -113,6 +113,12 @@ jobs:
                         }
                     ]
 
+          - task: securedevelopmentteam.vss-secure-development-tools.build-task-codesignvalidation.CodeSign@1
+            displayName: codesign validation
+            inputs:
+                Path: $(System.DefaultWorkingDirectory)
+                Targets: +:f|signing-in-progress/**.exe;+:f|drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.dll;drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.exe;
+
           - script: node ./pipeline/scripts/update-latest-yml.js signing-in-progress/${{ parameters.signedArtifactName }} windows
             displayName: update electron-builder latest.yml after signing
 

--- a/pipeline/unified/channel/sign-release-package-windows.yaml
+++ b/pipeline/unified/channel/sign-release-package-windows.yaml
@@ -118,6 +118,7 @@ jobs:
             inputs:
                 Path: $(System.DefaultWorkingDirectory)
                 Targets: +:f|signing-in-progress/**.exe;+:f|drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.dll;drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.exe;
+                ExcludePassesFromLog: false
 
           - script: node ./pipeline/scripts/update-latest-yml.js signing-in-progress/${{ parameters.signedArtifactName }} windows
             displayName: update electron-builder latest.yml after signing


### PR DESCRIPTION
#### Details
Now that we are signing all Windows files, we are ready to run the Codesign Validation task on them.

##### Motivation
Validates that our EXEs and DLLs are signed.

##### Context
[I validated that the task succeeds here](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=21710&view=results) (different branch; same yaml). 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
