### PR TITLE
chore: Refactor signed build to use sign-release-package.yaml template (again)

### DIFF
--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -22,14 +22,12 @@ jobs:
                 artifact: ${{ parameters.unsignedArtifactName }}
                 path: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 
-          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-            displayName: 'Send to ESRP Code Signing'
-            inputs:
-                ConnectedServiceName: 'ESRP Code Signing'
-                FolderPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
-                Pattern: '*.AppImage'
-                signConfigType: inlineSignParams
-                inlineOperation: |
+          - template: sign-release-package.yaml
+            parameters:
+                filePattern: '*.AppImage'
+                platform: linux
+                signedArtifactName: ${{ parameters.signedArtifactName }}
+                inlineSignParams: |
                     [
                         {
                             "keyCode": "CP-450779-Pgp",
@@ -39,11 +37,3 @@ jobs:
                             "toolVersion": "1.0"
                         }
                     ]
-
-          - script: node ./pipeline/scripts/update-latest-yml.js signing-in-progress/${{ parameters.signedArtifactName }}/packed linux
-            displayName: update electron-builder latest yaml after signing
-
-          - template: ../publish-packed-build-output.yaml
-            parameters:
-                packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}/packed'
-                artifactName: ${{ parameters.signedArtifactName }}

--- a/pipeline/unified/channel/sign-release-package-mac.yaml
+++ b/pipeline/unified/channel/sign-release-package-mac.yaml
@@ -22,14 +22,12 @@ jobs:
                 artifact: ${{ parameters.unsignedArtifactName }}
                 path: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 
-          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-            displayName: 'Send to ESRP Code Signing service'
-            inputs:
-                ConnectedServiceName: 'ESRP Code Signing'
-                FolderPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}/packed'
-                Pattern: '*.dmg, *.zip'
-                signConfigType: inlineSignParams
-                inlineOperation: |
+          - template: sign-release-package.yaml
+            parameters:
+                filePattern: '*.dmg, *.zip'
+                platform: mac
+                signedArtifactName: ${{ parameters.signedArtifactName }}
+                inlineSignParams: |
                     [
                         {
                             "keyCode": "CP-401337-Apple",
@@ -39,11 +37,3 @@ jobs:
                             "toolVersion": "1.0"
                         }
                     ]
-
-          - script: node ./pipeline/scripts/update-latest-yml.js signing-in-progress/${{ parameters.signedArtifactName }}/packed mac
-            displayName: update electron-builder latest.yml after signing
-
-          - template: ../publish-packed-build-output.yaml
-            parameters:
-                packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}/packed'
-                artifactName: ${{ parameters.signedArtifactName }}

--- a/pipeline/unified/channel/sign-release-package-windows.yaml
+++ b/pipeline/unified/channel/sign-release-package-windows.yaml
@@ -110,3 +110,10 @@ jobs:
                         "toolVersion": "6.2.9304.0"
                         }
                     ]
+
+          - task: securedevelopmentteam.vss-secure-development-tools.build-task-codesignvalidation.CodeSign@1
+            displayName: codesign validation
+            inputs:
+                Path: $(System.DefaultWorkingDirectory)
+                Targets: +:f|signing-in-progress/**.exe;+:f|drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.dll;drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.exe;
+                ExcludePassesFromLog: false

--- a/pipeline/unified/channel/sign-release-package-windows.yaml
+++ b/pipeline/unified/channel/sign-release-package-windows.yaml
@@ -74,14 +74,12 @@ jobs:
                     Accessibility?Insights?for?Android*.*
                 TargetFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 
-          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-            displayName: 'ESRP: Sign packed binary'
-            inputs:
-                ConnectedServiceName: 'ESRP Code Signing'
-                FolderPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
-                Pattern: '*.exe'
-                signConfigType: inlineSignParams
-                inlineOperation: |
+          - template: sign-release-package.yaml
+            parameters:
+                filePattern: '*.exe'
+                platform: windows
+                signedArtifactName: ${{ parameters.signedArtifactName }}
+                inlineSignParams: |
                     [
                         {
                         "keyCode": "CP-230012",
@@ -112,18 +110,3 @@ jobs:
                         "toolVersion": "6.2.9304.0"
                         }
                     ]
-
-          - task: securedevelopmentteam.vss-secure-development-tools.build-task-codesignvalidation.CodeSign@1
-            displayName: codesign validation
-            inputs:
-                Path: $(System.DefaultWorkingDirectory)
-                Targets: +:f|signing-in-progress/**.exe;+:f|drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.dll;drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.exe;
-                ExcludePassesFromLog: false
-
-          - script: node ./pipeline/scripts/update-latest-yml.js signing-in-progress/${{ parameters.signedArtifactName }} windows
-            displayName: update electron-builder latest.yml after signing
-
-          - template: ../publish-packed-build-output.yaml
-            parameters:
-                packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
-                artifactName: ${{ parameters.signedArtifactName }}

--- a/pipeline/unified/channel/sign-release-package-windows.yaml
+++ b/pipeline/unified/channel/sign-release-package-windows.yaml
@@ -72,7 +72,7 @@ jobs:
                 contents: |
                     latest*.yml
                     Accessibility?Insights?for?Android*.*
-                TargetFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
+                TargetFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}/packed'
 
           - template: sign-release-package.yaml
             parameters:

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    filePattern: null
+    inlineSignParams: null
+    signedArtifactName: null
+    platform: null
+
+steps:
+    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+      displayName: 'Send to ESRP Code Signing service'
+      inputs:
+          ConnectedServiceName: 'ESRP Code Signing'
+          FolderPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
+          Pattern: ${{ parameters.filePattern }}
+          signConfigType: inlineSignParams
+          inlineOperation: ${{ parameters.inlineSignParams }}
+
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-codesignvalidation.CodeSign@1
+      displayName: codesign validation
+      condition: and(succeeded(), eq(variables.platform, 'windows'))
+      inputs:
+          Path: $(System.DefaultWorkingDirectory)
+          Targets: +:f|signing-in-progress/**.exe;+:f|drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.dll;drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.exe;
+          ExcludePassesFromLog: false
+
+    - script: node ./pipeline/scripts/update-latest-yml.js signing-in-progress/${{ parameters.signedArtifactName }} ${{ parameters.platform }}
+      displayName: update electron-builder latest.yml after signing
+
+    - template: ../publish-packed-build-output.yaml
+      parameters:
+          packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
+          artifactName: ${{ parameters.signedArtifactName }}

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 parameters:

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -16,14 +16,6 @@ steps:
           signConfigType: inlineSignParams
           inlineOperation: ${{ parameters.inlineSignParams }}
 
-    - task: securedevelopmentteam.vss-secure-development-tools.build-task-codesignvalidation.CodeSign@1
-      displayName: codesign validation
-      condition: and(succeeded(), eq(variables.platform, 'windows'))
-      inputs:
-          Path: $(System.DefaultWorkingDirectory)
-          Targets: +:f|signing-in-progress/**.exe;+:f|drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.dll;drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.exe;
-          ExcludePassesFromLog: false
-
     - script: node ./pipeline/scripts/update-latest-yml.js signing-in-progress/${{ parameters.signedArtifactName }}/packed ${{ parameters.platform }}
       displayName: update electron-builder latest.yml after signing
 

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -8,7 +8,7 @@ parameters:
 
 steps:
     - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-      displayName: 'Send to ESRP Code Signing service'
+      displayName: 'ESRP signing installer'
       inputs:
           ConnectedServiceName: 'ESRP Code Signing'
           FolderPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}/packed'

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -11,7 +11,7 @@ steps:
       displayName: 'Send to ESRP Code Signing service'
       inputs:
           ConnectedServiceName: 'ESRP Code Signing'
-          FolderPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
+          FolderPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}/packed'
           Pattern: ${{ parameters.filePattern }}
           signConfigType: inlineSignParams
           inlineOperation: ${{ parameters.inlineSignParams }}
@@ -24,10 +24,10 @@ steps:
           Targets: +:f|signing-in-progress/**.exe;+:f|drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.dll;drop/electron/unified-${{ parameters.channel }}/packed/win-unpacked/**.exe;
           ExcludePassesFromLog: false
 
-    - script: node ./pipeline/scripts/update-latest-yml.js signing-in-progress/${{ parameters.signedArtifactName }} ${{ parameters.platform }}
+    - script: node ./pipeline/scripts/update-latest-yml.js signing-in-progress/${{ parameters.signedArtifactName }}/packed ${{ parameters.platform }}
       displayName: update electron-builder latest.yml after signing
 
     - template: ../publish-packed-build-output.yaml
       parameters:
-          packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
+          packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}/packed'
           artifactName: ${{ parameters.signedArtifactName }}


### PR DESCRIPTION
#### Details
A previous PR (#4160) removed the use of sign-release-package.yaml. Now that the build process has settled, this PR brings it back with a few fewer steps. This time, the Linux signed build uses sign-release-package.yaml, too!

##### Motivation
Consolidate redundant build steps into a template.

##### Context
[Test signed build with this update here.](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=21736&view=results)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
