### PR TITLE
chore: Fixed the typos in issue#4148

### DIFF
--- a/docs/building-unified.md
+++ b/docs/building-unified.md
@@ -39,7 +39,7 @@ See guidance [here](../src/tests/miscellaneous/mock-adb/README.md).
 
 #### Connecting to a real device/emulator
 
-If you _do_ need to work with an actual Android device/VM, you'll want to install [Android Studio](https://developer.android.com/studio/) and use it to connect to a device and/or start an emulator. You'll need to install the [Accessibility Insights for Android Service](https://github.com/microsoft/accessibility-insights-for-android-service) beforehand; see [Getting Started with Accessiblity Insights for Android](https://accessibilityinsights.io/docs/en/android/getstarted/setup#getting-started-with-accessibility-insights-for-android) for instructions on how to prepare a device/emulator with the Accessibility Insights for Android Service (follow its steps up until "Install the Accessibility Insights for Android app").
+If you _do_ need to work with an actual Android device/VM, you'll want to install [Android Studio](https://developer.android.com/studio/) and use it to connect to a device and/or start an emulator. You'll need to install the [Accessibility Insights for Android Service](https://github.com/microsoft/accessibility-insights-for-android-service) beforehand; see [Getting Started with Accessibility Insights for Android](https://accessibilityinsights.io/docs/en/android/getstarted/setup#getting-started-with-accessibility-insights-for-android) for instructions on how to prepare a device/emulator with the Accessibility Insights for Android Service (follow its steps up until "Install the Accessibility Insights for Android app").
 
 ```sh
 # You can leave off the with:mock-service-for-android if

--- a/src/content/test/custom-widgets/keyboard-interaction.tsx
+++ b/src/content/test/custom-widgets/keyboard-interaction.tsx
@@ -8,8 +8,8 @@ export const infoAndExamples = create(({ Markup, Link }) => (
         <h2>Why it matters</h2>
         <p>
             For a web page to be accessible, all of its interactive interface components—including custom widgets—must be operable using a
-            keyboard. Supporting the standard keybord interactions specified by the design patterns makes it easy for keyboard and assistive
-            technology users to interact with custom controls.
+            keyboard. Supporting the standard keyboard interactions specified by the design patterns makes it easy for keyboard and
+            assistive technology users to interact with custom controls.
         </p>
         <ol>
             <li>

--- a/src/content/test/repetitive-content/consistent-identification.tsx
+++ b/src/content/test/repetitive-content/consistent-identification.tsx
@@ -58,7 +58,7 @@ export const infoAndExamples = create(({ Markup }) => (
             </Markup.HyperLink>
         </Markup.Links>
 
-        <h3>Sufficent techniques</h3>
+        <h3>Sufficient techniques</h3>
         <Markup.Links>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G197">
                 Using labels, names, and text alternatives consistently for content that has the same functionality

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -6992,7 +6992,7 @@ exports[`Guidance Content pages test/customWidgets/keyboardInteraction/infoAndEx
         Why it matters
       </h2>
       <p>
-        For a web page to be accessible, all of its interactive interface components—including custom widgets—must be operable using a keyboard. Supporting the standard keybord interactions specified by the design patterns makes it easy for keyboard and assistive technology users to interact with custom controls.
+        For a web page to be accessible, all of its interactive interface components—including custom widgets—must be operable using a keyboard. Supporting the standard keyboard interactions specified by the design patterns makes it easy for keyboard and assistive technology users to interact with custom controls.
       </p>
       <ol>
         <li>
@@ -26468,7 +26468,7 @@ exports[`Guidance Content pages test/repetitiveContent/consistentIdentification/
         </a>
       </div>
       <h3>
-        Sufficent techniques
+        Sufficient techniques
       </h3>
       <div
         class="content-hyperlinks"


### PR DESCRIPTION
#### Details

Fixed a few typos after successful build relative to issue 4148.

* Assessment > Custom Widgets > Keyboard Interaction > Info and Examples > Why It Matters (keybord is missing an a)

![image](https://user-images.githubusercontent.com/49768450/116762704-1a08ad00-a9d0-11eb-93dd-bce1c294f054.png)

* Assessment > Repetitive Content > Consistent identification > Info & Examples > Sufficent techniques (Sufficent is missing an i)

![image](https://user-images.githubusercontent.com/49768450/116762759-4b817880-a9d0-11eb-9f90-bfd0a13d1f43.png)

* Accessiblity is misspelled in \docs\building-unified.md

![image](https://user-images.githubusercontent.com/49768450/116763002-14f82d80-a9d1-11eb-9286-61c6fd94f801.png)




##### Motivation

Milestone 1 - Project Checklist

##### Context

No typos

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4148
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
