### PR TITLE
fix: avoid telemetry dialog cutting off in Chromium 91

### DIFF
--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -23,6 +23,27 @@ div.insights-dialog-main-override.telemetry-permission-dialog {
     box-shadow: 0 0 10px 0 $neutral-alpha-60;
     width: 368px;
 
+    // Hack workaround for issue https://github.com/microsoft/accessibility-insights-web/issues/4178
+    //
+    // The bug seems to affect only Chromium 91 (not 90 or 92); the workaround can be removed after
+    // once Edge/Chrome stable have been on 92 for a few weeks (ie, around September 2021).
+    > .ms-Modal-scrollableContent {
+        // This is normally 100vh, but #4178 causes "100vh" to be miscalculated as a very small
+        // number. We can unset it in our case because the fixed popup window size means the dialog
+        // height is fixed at a value that doesn't actually engage max-height anyway.
+        max-height: unset;
+        // Normally, office fabric uses padding of 0/24/24/24 and uses a media query to change it to
+        // 0/16/16/16 at small window widths. #4178 means that the media query doesn't get triggered
+        // like it's supposed to, but since the popup's window width is fixed, we can just force the
+        // correct padding values without using the media query as a workaround.
+        .ms-Dialog-inner {
+            padding-top: 0px;
+            padding-right: 16px;
+            padding-bottom: 16px;
+            padding-left: 16px;
+        }
+    }
+
     .ms-Dialog-title {
         font-weight: $fontWeightSemiBold;
     }

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -23,7 +23,7 @@ div.insights-dialog-main-override.telemetry-permission-dialog {
     box-shadow: 0 0 10px 0 $neutral-alpha-60;
     width: 368px;
 
-    // Hack workaround for issue https://github.com/microsoft/accessibility-insights-web/issues/4178
+    // Workaround for issue https://github.com/microsoft/accessibility-insights-web/issues/4178
     //
     // The bug seems to affect only Chromium 91 (not 90 or 92); the workaround can be removed after
     // once Edge/Chrome stable have been on 92 for a few weeks (ie, around September 2021).


### PR DESCRIPTION
#### Details

This PR resolves #4178 by adding a few CSS workarounds that replace office fabric styles based on window size calculations with styles that have the same effects without relying on window size. No visual impact on Chromium 90/92.

##### Screenshots in Edge Stable (`Version 90.0.818.46 (Official build) (64-bit)`)

**Before (prod 2.26.0)**:
![image](https://user-images.githubusercontent.com/376284/117207316-d6dc7e80-adc1-11eb-89ef-5066453226c6.png)

**After (dev with this PR)**:
![image](https://user-images.githubusercontent.com/376284/117207338-dd6af600-adc1-11eb-83f9-ca37ff3ed686.png)

##### Screenshots in Chrome Beta (`Version 91.0.4472.38 (Official Build) beta (64-bit)`)

**Before (prod 2.26.0)**:
![image](https://user-images.githubusercontent.com/376284/117207429-efe52f80-adc1-11eb-8621-dc90605c552a.png)

**After (dev with this PR)**:
![image](https://user-images.githubusercontent.com/376284/117207471-fb385b00-adc1-11eb-85d4-b14afb0611cc.png)

##### Screenshots in Chrome Dev (`Version 92.0.4496.3 (Official Build) dev (64-bit)`)

**Before (prod 2.26.0)**:
![image](https://user-images.githubusercontent.com/376284/117207528-09867700-adc2-11eb-9c40-7a163ee56154.png)

**After (dev with this PR)**:
![image](https://user-images.githubusercontent.com/376284/117207573-186d2980-adc2-11eb-8a4b-d76eb27609f3.png)

##### Motivation

See #4178

##### Context

@peterdur and I both searched for a related looking Chromium bug but weren't able to find one. The issue doesn't impact Chromium 92 so I didn't bother filing a tracking issue there.

Thanks @waabid for helping to investigate the issue

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4178
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
