### PR TITLE
feat(complete-save-load-assessment): rewire load assessment dialog to fix reflow issue

### DIFF
--- a/src/DetailsView/components/change-assessment-dialog.tsx
+++ b/src/DetailsView/components/change-assessment-dialog.tsx
@@ -22,7 +22,7 @@ export interface ChangeAssessmentDialogProps {
     dialogFirstText: JSX.Element;
     dialogNoteText: string;
     dialogWarningText: string;
-    show: boolean;
+    isOpen: boolean;
     rightButtonStyle: string;
     rightButtonDataAutomationId: string;
 }
@@ -30,8 +30,8 @@ export interface ChangeAssessmentDialogProps {
 export const ChangeAssessmentDialog = NamedFC<ChangeAssessmentDialogProps>(
     'ChangeAssessmentDialog',
     props => {
-        const { show } = props;
-        if (!show) {
+        const { isOpen } = props;
+        if (!isOpen) {
             return null;
         }
 

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -9,9 +9,14 @@ import { AssessmentCommandBar } from 'DetailsView/components/assessment-command-
 import { AutomatedChecksCommandBar } from 'DetailsView/components/automated-checks-command-bar';
 import {
     CommandBarProps,
+    LoadAssessmentDialogFactory,
     ReportExportDialogFactory,
     SaveAssessmentFactory,
 } from 'DetailsView/components/details-view-command-bar';
+import {
+    getLoadAssessmentDialogForAssessment,
+    getLoadAssessmentDialogForFastPass,
+} from 'DetailsView/components/load-assessment-dialog-factory';
 import {
     getReportExportDialogForAssessment,
     getReportExportDialogForFastPass,
@@ -68,6 +73,7 @@ export type DetailsViewSwitcherNavConfiguration = Readonly<{
     getSelectedDetailsView: (props: GetSelectedDetailsViewProps) => VisualizationType;
     warningConfiguration: WarningConfiguration;
     leftNavHamburgerButton: ReactFCWithDisplayName<ExpandCollpaseLeftNavButtonProps>;
+    loadAssessmentDialogFactory: LoadAssessmentDialogFactory;
 }>;
 
 type InternalDetailsViewSwitcherNavConfiguration = Readonly<{
@@ -80,6 +86,7 @@ type InternalDetailsViewSwitcherNavConfiguration = Readonly<{
     getSelectedDetailsView: (props: GetSelectedDetailsViewProps) => VisualizationType;
     warningConfiguration: WarningConfiguration;
     leftNavHamburgerButton: ReactFCWithDisplayName<ExpandCollpaseLeftNavButtonProps>;
+    loadAssessmentDialogFactory: LoadAssessmentDialogFactory;
 }>;
 
 export type GetDetailsSwitcherNavConfigurationProps = {
@@ -99,6 +106,7 @@ const detailsViewSwitcherNavs: {
         getSelectedDetailsView: getAssessmentSelectedDetailsView,
         warningConfiguration: assessmentWarningConfiguration,
         leftNavHamburgerButton: AssessmentLeftNavHamburgerButton,
+        loadAssessmentDialogFactory: getLoadAssessmentDialogForAssessment,
     },
     [DetailsViewPivotType.fastPass]: {
         CommandBar: AutomatedChecksCommandBar,
@@ -110,6 +118,7 @@ const detailsViewSwitcherNavs: {
         getSelectedDetailsView: getFastPassSelectedDetailsView,
         warningConfiguration: fastpassWarningConfiguration,
         leftNavHamburgerButton: FastPassLeftNavHamburgerButton,
+        loadAssessmentDialogFactory: getLoadAssessmentDialogForFastPass,
     },
 };
 

--- a/src/DetailsView/components/load-assessment-button.tsx
+++ b/src/DetailsView/components/load-assessment-button.tsx
@@ -5,10 +5,8 @@ import { AssessmentDataParser } from 'common/assessment-data-parser';
 import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
-import { VersionedAssessmentData } from 'common/types/versioned-assessment-data';
 import { UrlParser } from 'common/url-parser';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
-import { LoadAssessmentDialog } from 'DetailsView/components/load-assessment-dialog';
 import { LoadAssessmentHelper } from 'DetailsView/components/load-assessment-helper';
 import * as React from 'react';
 
@@ -22,65 +20,21 @@ export interface LoadAssessmentButtonProps {
     deps: LoadAssessmentButtonDeps;
     tabStoreData: TabStoreData;
     assessmentStoreData: AssessmentStoreData;
-}
-export interface LoadAssessmentButtonState {
-    loadedAssessmentData: VersionedAssessmentData;
-    show: boolean;
+    handleLoadAssessmentButtonClick: () => void;
 }
 
 export const loadAssessmentButtonAutomationId = 'load-assessment-button';
 
-export class LoadAssessmentButton extends React.Component<
-    LoadAssessmentButtonProps,
-    LoadAssessmentButtonState
-> {
-    public constructor(props) {
-        super(props);
-        this.state = {
-            loadedAssessmentData: null,
-            show: false,
-        };
-    }
-
-    private toggleLoadDialog = () => {
-        this.setState(prevState => ({ show: !prevState.show }));
-    };
-
-    private setAssessmentState = (parsedAssessmentData: VersionedAssessmentData) => {
-        this.setState(_ => ({
-            loadedAssessmentData: parsedAssessmentData,
-        }));
-    };
-
-    private handleLoadButtonClick = () => {
-        this.props.deps.loadAssessmentHelper.getAssessmentForLoad(
-            this.setAssessmentState,
-            this.toggleLoadDialog,
-            this.props.assessmentStoreData.persistedTabInfo,
-            this.props.tabStoreData.id,
-        );
-    };
-
+export class LoadAssessmentButton extends React.Component<LoadAssessmentButtonProps> {
     public render(): JSX.Element {
         return (
-            <>
-                <InsightsCommandButton
-                    data-automation-id={loadAssessmentButtonAutomationId}
-                    iconProps={{ iconName: 'FabricOpenFolderHorizontal' }}
-                    onClick={this.handleLoadButtonClick}
-                >
-                    Load assessment
-                </InsightsCommandButton>
-
-                <LoadAssessmentDialog
-                    {...this.props}
-                    tabId={this.props.tabStoreData.id}
-                    loadedAssessmentData={this.state.loadedAssessmentData}
-                    prevTab={this.props.assessmentStoreData.persistedTabInfo}
-                    show={this.state.show}
-                    onClose={this.toggleLoadDialog}
-                ></LoadAssessmentDialog>
-            </>
+            <InsightsCommandButton
+                data-automation-id={loadAssessmentButtonAutomationId}
+                iconProps={{ iconName: 'FabricOpenFolderHorizontal' }}
+                onClick={this.props.handleLoadAssessmentButtonClick}
+            >
+                Load assessment
+            </InsightsCommandButton>
         );
     }
 }

--- a/src/DetailsView/components/load-assessment-dialog-factory.tsx
+++ b/src/DetailsView/components/load-assessment-dialog-factory.tsx
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Tab } from 'common/itab';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { VersionedAssessmentData } from 'common/types/versioned-assessment-data';
+import {
+    LoadAssessmentDialog,
+    LoadAssessmentDialogDeps,
+} from 'DetailsView/components/load-assessment-dialog';
+import * as React from 'react';
+
+export type LoadAssessmentDialogFactoryDeps = LoadAssessmentDialogDeps;
+
+export type LoadAssessmentDialogFactoryProps = {
+    deps: LoadAssessmentDialogFactoryDeps;
+    assessmentStoreData: AssessmentStoreData;
+    tabStoreData: TabStoreData;
+    isOpen: boolean;
+    prevTab: Tab;
+    loadedAssessmentData: VersionedAssessmentData;
+    tabId: number;
+    onClose: () => void;
+};
+
+export function getLoadAssessmentDialogForAssessment(
+    props: LoadAssessmentDialogFactoryProps,
+): JSX.Element {
+    return <LoadAssessmentDialog {...props} />;
+}
+
+export function getLoadAssessmentDialogForFastPass(
+    props: LoadAssessmentDialogFactoryProps,
+): JSX.Element | null {
+    return null;
+}

--- a/src/DetailsView/components/load-assessment-dialog.tsx
+++ b/src/DetailsView/components/load-assessment-dialog.tsx
@@ -22,7 +22,7 @@ export const loadAssessmentDialogLoadButtonAutomationId = 'load-assessment-dialo
 export interface LoadAssessmentDialogProps {
     deps: LoadAssessmentDialogDeps;
     prevTab: Tab;
-    show: boolean;
+    isOpen: boolean;
     loadedAssessmentData: VersionedAssessmentData;
     tabId: number;
     onClose: () => void;
@@ -58,7 +58,7 @@ export const LoadAssessmentDialog = NamedFC<LoadAssessmentDialogProps>('LoadAsse
         dialogNoteText:
             "If 'Continue previous' is selected, the assessment selected will not be loaded.",
         dialogWarningText: "If 'Load assessment’ is selected, all previous progress will be lost.",
-        show: props.show,
+        isOpen: props.isOpen,
         rightButtonStyle: styles.loadButton,
         rightButtonDataAutomationId: loadAssessmentDialogLoadButtonAutomationId,
     };

--- a/src/DetailsView/components/target-change-dialog.tsx
+++ b/src/DetailsView/components/target-change-dialog.tsx
@@ -47,7 +47,7 @@ export const TargetChangeDialog = NamedFC<TargetChangeDialogProps>('TargetChange
         dialogNoteText:
             "If 'Continue previous' is selected, the previous assessment will be connected to this new page.",
         dialogWarningText: "If 'Start new' is selected, all previous progress will be lost.",
-        show: showTargetChangeDialog(props.prevTab, props.newTab, props.deps.urlParser),
+        isOpen: showTargetChangeDialog(props.prevTab, props.newTab, props.deps.urlParser),
         rightButtonStyle: styles.restartButton,
         rightButtonDataAutomationId: 'target-change-start-new-button',
     };

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = 
     </NewTabLinkWithTooltip>
   </div>
   <CommandBarButtonsMenu renderExportReportButton={[Function]} renderSaveAssessmentButton={[Function]} renderLoadAssessmentButton={[Function]} featureFlagStoreData={{...}} getStartOverMenuItem={[Function]} buttonRef={[Function: buttonRef]} />
-  <StartOverDialog deps={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} featureFlagStoreData={{...}} dialogState=\\"none\\" dismissDialog={[Function]} />
+  <StartOverDialog deps={{...}} assessmentStoreData={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} featureFlagStoreData={{...}} dialogState=\\"none\\" dismissDialog={[Function]} />
 </div>"
 `;
 
@@ -57,6 +57,16 @@ exports[`DetailsViewCommandBar renders with export button, save assessment, load
       Save assessment
     </div>
     <LoadAssessmentButton
+      assessmentStoreData={
+        Object {
+          "persistedTabInfo": Object {
+            "appRefreshed": false,
+            "id": 5,
+            "isClosed": false,
+            "title": "command-bar-test-tab-title",
+          },
+        }
+      }
       deps={
         Object {
           "detailsViewActionMessageCreator": proxy {
@@ -95,11 +105,13 @@ exports[`DetailsViewCommandBar renders with export button, save assessment, load
           "saveAndLoadAssessment": true,
         }
       }
+      handleLoadAssessmentButtonClick={[Function]}
       narrowModeStatus={
         Object {
           "isCommandBarCollapsed": false,
         }
       }
+      onClose={[Function]}
       scanMetadata={
         Object {
           "targetAppInfo": Object {
@@ -117,6 +129,7 @@ exports[`DetailsViewCommandBar renders with export button, save assessment, load
           "StartOverComponentFactory": Object {
             "getStartOverComponent": [Function],
           },
+          "loadAssessmentDialogFactory": [Function],
           "shouldShowReportExportButton": [Function],
         }
       }
@@ -136,6 +149,16 @@ exports[`DetailsViewCommandBar renders with export button, save assessment, load
     Export dialog
   </div>
   <StartOverDialog
+    assessmentStoreData={
+      Object {
+        "persistedTabInfo": Object {
+          "appRefreshed": false,
+          "id": 5,
+          "isClosed": false,
+          "title": "command-bar-test-tab-title",
+        },
+      }
+    }
     deps={
       Object {
         "detailsViewActionMessageCreator": proxy {
@@ -198,6 +221,7 @@ exports[`DetailsViewCommandBar renders with export button, save assessment, load
         "StartOverComponentFactory": Object {
           "getStartOverComponent": [Function],
         },
+        "loadAssessmentDialogFactory": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -253,6 +277,16 @@ exports[`DetailsViewCommandBar renders with export button, without save assessme
     Export dialog
   </div>
   <StartOverDialog
+    assessmentStoreData={
+      Object {
+        "persistedTabInfo": Object {
+          "appRefreshed": false,
+          "id": 5,
+          "isClosed": false,
+          "title": "command-bar-test-tab-title",
+        },
+      }
+    }
     deps={
       Object {
         "detailsViewActionMessageCreator": proxy {
@@ -315,6 +349,7 @@ exports[`DetailsViewCommandBar renders with export button, without save assessme
         "StartOverComponentFactory": Object {
           "getStartOverComponent": [Function],
         },
+        "loadAssessmentDialogFactory": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -330,37 +365,19 @@ exports[`DetailsViewCommandBar renders with export button, without save assessme
 `;
 
 exports[`DetailsViewCommandBar renders with load assessment button 1`] = `
-<React.Fragment>
-  <InsightsCommandButton
-    data-automation-id="load-assessment-button"
-    iconProps={
-      Object {
-        "iconName": "FabricOpenFolderHorizontal",
-      }
+<InsightsCommandButton
+  data-automation-id="load-assessment-button"
+  iconProps={
+    Object {
+      "iconName": "FabricOpenFolderHorizontal",
     }
-    onClick={[Function]}
-  >
-    Load assessment
-  </InsightsCommandButton>
-  <LoadAssessment
-    assessmentStoreData={Object {}}
-    deps={Object {}}
-    loadedAssessmentData={null}
-    onClose={[Function]}
-    show={false}
-    tabId={5}
-    tabStoreData={
-      Object {
-        "id": 5,
-        "isClosed": false,
-        "title": "command-bar-test-tab-title",
-      }
-    }
-  />
-</React.Fragment>
+  }
+>
+  Load assessment
+</InsightsCommandButton>
 `;
 
-exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
+exports[`DetailsViewCommandBar renders with load assessment dialog open 1`] = `
 <div
   aria-label="command bar"
   className="detailsViewCommandBar"
@@ -398,9 +415,19 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
     />
   </div>
   <div>
-    Export dialog
+    Load Assessment
   </div>
   <StartOverDialog
+    assessmentStoreData={
+      Object {
+        "persistedTabInfo": Object {
+          "appRefreshed": false,
+          "id": 5,
+          "isClosed": false,
+          "title": "command-bar-test-tab-title",
+        },
+      }
+    }
     deps={
       Object {
         "detailsViewActionMessageCreator": proxy {
@@ -459,6 +486,131 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
         "StartOverComponentFactory": Object {
           "getStartOverComponent": [Function],
         },
+        "loadAssessmentDialogFactory": [Function],
+        "shouldShowReportExportButton": [Function],
+      }
+    }
+    tabStoreData={
+      Object {
+        "id": 5,
+        "isClosed": false,
+        "title": "command-bar-test-tab-title",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
+<div
+  aria-label="command bar"
+  className="detailsViewCommandBar"
+  role="region"
+>
+  <div
+    aria-labelledby="switch-to-target"
+    className="detailsViewTargetPage"
+  >
+    <span
+      id="switch-to-target"
+    >
+      Target page: 
+    </span>
+    <NewTabLinkWithTooltip
+      aria-label="Switch to target page: command-bar-test-tab-title"
+      className="targetPageLink"
+      onClick={[Function]}
+      role="link"
+      tooltipContent="Switch to target page: command-bar-test-tab-title"
+    >
+      <span
+        className="targetPageTitle"
+      >
+        command-bar-test-tab-title
+      </span>
+    </NewTabLinkWithTooltip>
+  </div>
+  <div
+    className="detailsViewCommandButtons"
+  >
+    <ReportExportButton
+      buttonRef={[Function]}
+      showReportExportDialog={[Function]}
+    />
+  </div>
+  <div>
+    Export dialog
+  </div>
+  <StartOverDialog
+    assessmentStoreData={
+      Object {
+        "persistedTabInfo": Object {
+          "appRefreshed": false,
+          "id": 5,
+          "isClosed": false,
+          "title": "command-bar-test-tab-title",
+        },
+      }
+    }
+    deps={
+      Object {
+        "detailsViewActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "addPathForValidation": [Function],
+          "cancelStartOver": [Function],
+          "cancelStartOverAllAssessments": [Function],
+          "changeAssessmentVisualizationState": [Function],
+          "changeManualRequirementStatus": [Function],
+          "changeManualTestStatus": [Function],
+          "clearPathSnippetData": [Function],
+          "closePreviewFeaturesPanel": [Function],
+          "closeScopingPanel": [Function],
+          "closeSettingsPanel": [Function],
+          "continuePreviousAssessment": [Function],
+          "copyIssueDetailsClicked": [Function],
+          "dispatcher": undefined,
+          "editFailureInstance": [Function],
+          "leftNavPanelExpanded": [Function],
+          "loadAssessment": [Function],
+          "removeFailureInstance": [Function],
+          "rescanVisualization": [Function],
+          "saveAssessment": [Function],
+          "setAllUrlsPermissionState": [Function],
+          "setFeatureFlag": [Function],
+          "startOverAllAssessments": [Function],
+          "switchToTargetTab": [Function],
+          "telemetryFactory": undefined,
+          "undoManualRequirementStatusChange": [Function],
+          "undoManualTestStatusChange": [Function],
+        },
+      }
+    }
+    dialogState="none"
+    dismissDialog={[Function]}
+    featureFlagStoreData={Object {}}
+    narrowModeStatus={
+      Object {
+        "isCommandBarCollapsed": false,
+      }
+    }
+    scanMetadata={
+      Object {
+        "targetAppInfo": Object {
+          "name": "command-bar-test-tab-title",
+          "url": "command-bar-test-url",
+        },
+      }
+    }
+    switcherNavConfiguration={
+      Object {
+        "CommandBar": [Function],
+        "LeftNav": [Function],
+        "ReportExportDialogFactory": [Function],
+        "SaveAssessmentFactory": [Function],
+        "StartOverComponentFactory": Object {
+          "getStartOverComponent": [Function],
+        },
+        "loadAssessmentDialogFactory": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -503,7 +655,7 @@ exports[`DetailsViewCommandBar renders with start assessment over dialog open 1`
   <div className=\\"detailsViewCommandButtons\\">
     <ReportExportButton showReportExportDialog={[Function]} buttonRef={[Function: buttonRef]} />
   </div>
-  <StartOverDialog deps={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} featureFlagStoreData={{...}} dialogState=\\"assessment\\" dismissDialog={[Function]} />
+  <StartOverDialog deps={{...}} assessmentStoreData={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} featureFlagStoreData={{...}} dialogState=\\"assessment\\" dismissDialog={[Function]} />
 </div>"
 `;
 
@@ -522,7 +674,7 @@ exports[`DetailsViewCommandBar renders with start test over dialog open 1`] = `
   <div className=\\"detailsViewCommandButtons\\">
     <ReportExportButton showReportExportDialog={[Function]} buttonRef={[Function: buttonRef]} />
   </div>
-  <StartOverDialog deps={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} featureFlagStoreData={{...}} dialogState=\\"test\\" dismissDialog={[Function]} />
+  <StartOverDialog deps={{...}} assessmentStoreData={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} featureFlagStoreData={{...}} dialogState=\\"test\\" dismissDialog={[Function]} />
 </div>"
 `;
 
@@ -559,6 +711,16 @@ exports[`DetailsViewCommandBar renders without export button, save assessment, l
     Export dialog
   </div>
   <StartOverDialog
+    assessmentStoreData={
+      Object {
+        "persistedTabInfo": Object {
+          "appRefreshed": false,
+          "id": 5,
+          "isClosed": false,
+          "title": "command-bar-test-tab-title",
+        },
+      }
+    }
     deps={
       Object {
         "detailsViewActionMessageCreator": proxy {
@@ -621,6 +783,7 @@ exports[`DetailsViewCommandBar renders without export button, save assessment, l
         "StartOverComponentFactory": Object {
           "getStartOverComponent": [Function],
         },
+        "loadAssessmentDialogFactory": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -675,6 +838,16 @@ exports[`DetailsViewCommandBar renders without export button, without save asses
     Export dialog
   </div>
   <StartOverDialog
+    assessmentStoreData={
+      Object {
+        "persistedTabInfo": Object {
+          "appRefreshed": false,
+          "id": 5,
+          "isClosed": false,
+          "title": "command-bar-test-tab-title",
+        },
+      }
+    }
     deps={
       Object {
         "detailsViewActionMessageCreator": proxy {
@@ -737,6 +910,7 @@ exports[`DetailsViewCommandBar renders without export button, without save asses
         "StartOverComponentFactory": Object {
           "getStartOverComponent": [Function],
         },
+        "loadAssessmentDialogFactory": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/load-assessment-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/load-assessment-button.test.tsx.snap
@@ -1,76 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LoadAssessmentButton should render per the snapshot 1`] = `
-<React.Fragment>
-  <InsightsCommandButton
-    data-automation-id="load-assessment-button"
-    iconProps={
-      Object {
-        "iconName": "FabricOpenFolderHorizontal",
-      }
+<InsightsCommandButton
+  data-automation-id="load-assessment-button"
+  iconProps={
+    Object {
+      "iconName": "FabricOpenFolderHorizontal",
     }
-    onClick={[Function]}
-  >
-    Load assessment
-  </InsightsCommandButton>
-  <LoadAssessment
-    assessmentStoreData={Object {}}
-    deps={
-      Object {
-        "assessmentDataParser": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "parseAssessmentData": [Function],
-        },
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
-        "loadAssessmentHelper": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "assessmentDataParser": undefined,
-          "detailsViewActionMessageCreator": undefined,
-          "document": undefined,
-          "fileReader": undefined,
-        },
-        "urlParser": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        },
-      }
-    }
-    loadedAssessmentData={null}
-    onClose={[Function]}
-    show={false}
-    tabId={5}
-    tabStoreData={
-      Object {
-        "id": 5,
-      }
-    }
-  />
-</React.Fragment>
+  }
+>
+  Load assessment
+</InsightsCommandButton>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   dialogNoteText="If 'Continue previous' is selected, the previous assessment will be connected to this new page."
   dialogWarningText="If 'Start new' is selected, all previous progress will be lost."
   divId="target-change-dialog-description"
+  isOpen={true}
   leftButtonOnClick={[Function]}
   leftButtonText="Continue previous"
   prevTab={
@@ -79,7 +80,6 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   rightButtonOnClick={[Function]}
   rightButtonStyle="restartButton"
   rightButtonText="Start new"
-  show={true}
   subtitleAriaId="target-change-dialog-description"
 />
 `;
@@ -152,6 +152,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   dialogNoteText="If 'Continue previous' is selected, the previous assessment will be connected to this new page."
   dialogWarningText="If 'Start new' is selected, all previous progress will be lost."
   divId="target-change-dialog-description"
+  isOpen={true}
   leftButtonOnClick={[Function]}
   leftButtonText="Continue previous"
   prevTab={
@@ -166,7 +167,6 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   rightButtonOnClick={[Function]}
   rightButtonStyle="restartButton"
   rightButtonText="Start new"
-  show={true}
   subtitleAriaId="target-change-dialog-description"
 />
 `;
@@ -239,6 +239,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   dialogNoteText="If 'Continue previous' is selected, the previous assessment will be connected to this new page."
   dialogWarningText="If 'Start new' is selected, all previous progress will be lost."
   divId="target-change-dialog-description"
+  isOpen={true}
   leftButtonOnClick={[Function]}
   leftButtonText="Continue previous"
   prevTab={
@@ -253,7 +254,6 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   rightButtonOnClick={[Function]}
   rightButtonStyle="restartButton"
   rightButtonText="Start new"
-  show={true}
   subtitleAriaId="target-change-dialog-description"
 />
 `;
@@ -326,6 +326,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   dialogNoteText="If 'Continue previous' is selected, the previous assessment will be connected to this new page."
   dialogWarningText="If 'Start new' is selected, all previous progress will be lost."
   divId="target-change-dialog-description"
+  isOpen={true}
   leftButtonOnClick={[Function]}
   leftButtonText="Continue previous"
   prevTab={
@@ -340,7 +341,6 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   rightButtonOnClick={[Function]}
   rightButtonStyle="restartButton"
   rightButtonText="Start new"
-  show={true}
   subtitleAriaId="target-change-dialog-description"
 />
 `;
@@ -413,6 +413,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   dialogNoteText="If 'Continue previous' is selected, the previous assessment will be connected to this new page."
   dialogWarningText="If 'Start new' is selected, all previous progress will be lost."
   divId="target-change-dialog-description"
+  isOpen={true}
   leftButtonOnClick={[Function]}
   leftButtonText="Continue previous"
   prevTab={
@@ -427,7 +428,6 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
   rightButtonOnClick={[Function]}
   rightButtonStyle="restartButton"
   rightButtonText="Start new"
-  show={true}
   subtitleAriaId="target-change-dialog-description"
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
-import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import {
+    AssessmentStoreData,
+    PersistedTabInfo,
+} from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
@@ -10,6 +13,7 @@ import {
     CommandBarProps,
     DetailsViewCommandBar,
     DetailsViewCommandBarProps,
+    LoadAssessmentDialogFactory,
     ReportExportDialogFactory,
     SaveAssessmentFactory,
 } from 'DetailsView/components/details-view-command-bar';
@@ -21,6 +25,7 @@ import {
     LoadAssessmentButton,
     LoadAssessmentButtonProps,
 } from 'DetailsView/components/load-assessment-button';
+import { LoadAssessmentDialogFactoryProps } from 'DetailsView/components/load-assessment-dialog-factory';
 import { ReportExportDialogFactoryProps } from 'DetailsView/components/report-export-dialog-factory';
 import {
     SaveAssessmentButton,
@@ -42,6 +47,7 @@ describe('DetailsViewCommandBar', () => {
     const thePageUrl = 'command-bar-test-url';
     const reportExportDialogStub = <div>Export dialog</div>;
     const saveAssessmentStub = <div>Save assessment</div>;
+    const loadAssessmentDialogStub = <div>Load Assessment</div>;
 
     let assessmentStoreData: AssessmentStoreData;
     let tabStoreData: TabStoreData;
@@ -53,6 +59,7 @@ describe('DetailsViewCommandBar', () => {
     let showReportExportButton: boolean;
     let reportExportDialogFactory: IMock<ReportExportDialogFactory>;
     let saveAssessmentFactory: IMock<SaveAssessmentFactory>;
+    let loadAssessmentDialogFactory: IMock<LoadAssessmentDialogFactory>;
     let getStartOverComponentMock: IMock<(Props: StartOverFactoryProps) => JSX.Element>;
 
     beforeEach(() => {
@@ -62,6 +69,7 @@ describe('DetailsViewCommandBar', () => {
         );
         reportExportDialogFactory = Mock.ofInstance(props => null);
         saveAssessmentFactory = Mock.ofInstance(props => null);
+        loadAssessmentDialogFactory = Mock.ofInstance(props => null);
         getStartOverComponentMock = Mock.ofInstance(props => null);
         tabStoreData = {
             id: 5,
@@ -78,6 +86,12 @@ describe('DetailsViewCommandBar', () => {
         };
 
         assessmentStoreData = {} as AssessmentStoreData;
+        assessmentStoreData.persistedTabInfo = {
+            id: 5,
+            title: thePageTitle,
+            isClosed: false,
+            appRefreshed: false,
+        } as PersistedTabInfo;
 
         loadAssessmentButtonPropsStub = {
             deps: {},
@@ -103,6 +117,7 @@ describe('DetailsViewCommandBar', () => {
             StartOverComponentFactory: {
                 getStartOverComponent: getStartOverComponentMock.object,
             } as StartOverComponentFactory,
+            loadAssessmentDialogFactory: loadAssessmentDialogFactory.object,
             LeftNav: LeftNavStub,
         } as DetailsViewSwitcherNavConfiguration;
         const scanMetadata = {
@@ -116,6 +131,7 @@ describe('DetailsViewCommandBar', () => {
             deps: {
                 detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
             },
+            assessmentStoreData,
             tabStoreData,
             switcherNavConfiguration: switcherNavConfiguration,
             scanMetadata: scanMetadata,
@@ -163,6 +179,15 @@ describe('DetailsViewCommandBar', () => {
 
         const rendered = shallow(<DetailsViewCommandBar {...props} />);
         rendered.setState({ isReportExportDialogOpen: true });
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    test('renders with load assessment dialog open', () => {
+        const props = getProps();
+        setupLoadAssessmentDialogFactory({ isOpen: true });
+        const rendered = shallow(<DetailsViewCommandBar {...props} />);
+        rendered.setState({ isLoadAssessmentDialogOpen: true });
 
         expect(rendered.getElement()).toMatchSnapshot();
     });
@@ -341,6 +366,15 @@ describe('DetailsViewCommandBar', () => {
     ): void {
         const argMatcher = isNil(expectedProps) ? It.isAny() : It.isObjectWith(expectedProps);
         reportExportDialogFactory.setup(r => r(argMatcher)).returns(() => reportExportDialogStub);
+    }
+
+    function setupLoadAssessmentDialogFactory(
+        expectedProps?: Partial<LoadAssessmentDialogFactoryProps>,
+    ): void {
+        const argMatcher = isNil(expectedProps) ? It.isAny() : It.isObjectWith(expectedProps);
+        loadAssessmentDialogFactory
+            .setup(ladf => ladf(argMatcher))
+            .returns(() => loadAssessmentDialogStub);
     }
 
     function setupSaveAssessmentFactory(expectedProps?: Partial<SaveAssessmentFactoryProps>): void {

--- a/src/tests/unit/tests/DetailsView/components/load-assessment-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/load-assessment-dialog-factory.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Tab } from 'common/itab';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { VersionedAssessmentData } from 'common/types/versioned-assessment-data';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { DetailsViewCommandBarDeps } from 'DetailsView/components/details-view-command-bar';
+import {
+    getLoadAssessmentDialogForAssessment,
+    getLoadAssessmentDialogForFastPass,
+    LoadAssessmentDialogFactoryProps,
+} from 'DetailsView/components/load-assessment-dialog-factory';
+import { IMock, Mock } from 'typemoq';
+
+describe('LoadAssessmentDialogFactory', () => {
+    const isOpen: boolean = true;
+
+    let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
+    let assessmentStoreData: AssessmentStoreData;
+    let tabStoreData: TabStoreData;
+    let deps: DetailsViewCommandBarDeps;
+    let props: LoadAssessmentDialogFactoryProps;
+    let loadedAssessmentData: VersionedAssessmentData;
+    let tabId: number;
+    let prevTab: Tab;
+
+    beforeEach(() => {
+        detailsViewActionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator);
+        assessmentStoreData = {} as AssessmentStoreData;
+        loadedAssessmentData = {} as VersionedAssessmentData;
+        tabStoreData = {} as TabStoreData;
+        tabId = 5;
+        prevTab = {} as Tab;
+        deps = {
+            detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
+        } as DetailsViewCommandBarDeps;
+
+        props = {
+            deps,
+            loadedAssessmentData,
+            prevTab,
+            tabId,
+            assessmentStoreData,
+            tabStoreData,
+            isOpen,
+            onClose: () => {},
+        } as LoadAssessmentDialogFactoryProps;
+    });
+
+    test('renders load assessment dialog for Assessment', () => {
+        const rendered = getLoadAssessmentDialogForAssessment(props);
+        expect(rendered).toMatchSnapshot;
+    });
+
+    test('renders load assessment dialog as null for fast pass', () => {
+        const rendered = getLoadAssessmentDialogForFastPass(props);
+        expect(rendered).toBeNull();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/load-assessment-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/load-assessment-dialog.test.tsx
@@ -47,7 +47,7 @@ describe('LoadAssessmentDialog', () => {
             tabId: 5,
             loadedAssessmentData: {} as VersionedAssessmentData,
             onClose: () => {},
-            show: true,
+            isOpen: true,
         };
     });
 


### PR DESCRIPTION
#### Details

This rewires the load assessment dialog to render it from the details view command bar rather than from the load assessment button.  This was necessary because when the button would reflow the dialog would disappear.

##### Motivation

To fix the reflow issue

##### Context

I debated whether to put the state in the details view command bar or on the load assessment dialog itself.  I decided to handle it similar to how things are handled for other rendered dialogs in the details view command bar and kept the stateful information in that component.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
