### PR TITLE
chore: Limit mac and windows unified e2e jobs to CI build

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -143,6 +143,7 @@ jobs:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/unified/unified-e2e-test-interactive.yaml
           - template: pipeline/unified/unified-e2e-publish-results.yaml
+      condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
 
     - job: 'e2e_unified_linux'
       pool:
@@ -159,3 +160,4 @@ jobs:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/unified/unified-e2e-test-interactive.yaml
           - template: pipeline/unified/unified-e2e-publish-results.yaml
+      condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))


### PR DESCRIPTION
#### Details
This PR limits the mac and windows unified e2e jobs to only run on the CI build, not the PR build.

##### Motivation
We're having some unified e2e test unreliability issues which will be investigated in an upcoming feature. In the meantime. this should help PR velocity without losing all of the benefits of our e2e tests.

##### Context
As discussed in the team retrospective.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
