### PR TITLE
chore: fix spurious prettier errors with .a11ywebassessment files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,17 +1,18 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+**/*.a11ywebassessment
 **/*.dockerignore
 **/*.gitattributes
 **/*.gitignore
 **/*.icns
 **/*.ico
+**/*.md
 **/*.mp3
 **/*.nsh
 **/*.png
 **/*.snap
 **/*.snap.html
-**/*.md
 **/Dockerfile
 
 .DS_Store


### PR DESCRIPTION
#### Details

The save/load feature recently added some `.a11ywebassessment` files to our end to end tests. Prettier doesn't understand this file extension, so it throws some spurious errors during `yarn format:check`. This PR updates `.prettierignore` to ignore these files (they aren't intended to be human-readable).

I also sorted the list of ignored file extensions while I was here.

Before:

```
> yarn format:check
yarn run v1.22.10
$ prettier --config prettier.config.js --check "**/*"
Checking formatting...
src\tests\end-to-end\test-resources\saved-assessment-files\web@2.25.0-valid-mixed-results.a11ywebassessment[error] No parser could be inferred for file: src\tests\end-to-end\test-resources\saved-assessment-files\web@2.25.0-valid-mixed-results.a11ywebassessment
src\tests\end-to-end\test-resources\saved-assessment-files\web@2.26.0-valid-mixed-results.a11ywebassessment[error] No parser could be inferred for file: src\tests\end-to-end\test-resources\saved-assessment-files\web@2.26.0-valid-mixed-results.a11ywebassessment
All matched files use Prettier code style!
```

After:

```
> yarn format:check
yarn run v1.22.10
$ prettier --config prettier.config.js --check "**/*"
Checking formatting...
All matched files use Prettier code style!
```

##### Motivation

Avoid spurious errors in `yarn fastpass`

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
