### PR TITLE
fix: Revert linux signing to use detached signature

### DIFF
--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -22,18 +22,50 @@ jobs:
                 artifact: ${{ parameters.unsignedArtifactName }}
                 path: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 
-          - template: sign-release-package.yaml
-            parameters:
-                filePattern: '*.AppImage'
-                platform: linux
-                signedArtifactName: ${{ parameters.signedArtifactName }}
-                inlineSignParams: |
+          - task: CopyFiles@2
+            displayName: 'Copy the AppImage file to detachedSignature'
+            inputs:
+                SourceFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}/packed'
+                contents: |
+                    Accessibility_Insights_for_Android*.*
+                TargetFolder: '$(System.DefaultWorkingDirectory)/detachedSignature'
+
+          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+            displayName: 'sign dist/detachedSignature'
+            inputs:
+                ConnectedServiceName: 'ESRP Code Signing'
+                FolderPath: '$(System.DefaultWorkingDirectory)/detachedSignature'
+                Pattern: '*.AppImage'
+                signConfigType: inlineSignParams
+                inlineOperation: |
                     [
                         {
                             "keyCode": "CP-450779-Pgp",
-                            "operationSetCode": "PgpClearSign",
+                            "operationSetCode": "LinuxSign",
                             "parameters": [],
                             "toolName": "sign",
                             "toolVersion": "1.0"
                         }
                     ]
+
+          - script: 'sudo apt-get install rename'
+            displayName: 'Install rename'
+
+          - script: 'rename "s/\.AppImage$/.sig/" $(System.DefaultWorkingDirectory)/detachedSignature/*.AppImage'
+            displayName: 'Change signature file extension to sig'
+
+          - task: CopyFiles@2
+            displayName: 'Copy the detachedSignature file to working folder'
+            inputs:
+                SourceFolder: $(System.DefaultWorkingDirectory)/detachedSignature
+                contents: |
+                    Accessibility_Insights_for_Android*.*
+                TargetFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}/packed'
+
+          - script: node ./pipeline/scripts/update-latest-yml.js signing-in-progress/${{ parameters.signedArtifactName }}/packed linux
+            displayName: update electron-builder latest yaml after signing
+
+          - template: ../publish-packed-build-output.yaml
+            parameters:
+                packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}/packed'
+                artifactName: ${{ parameters.signedArtifactName }}


### PR DESCRIPTION
#### Details
This PR undoes the linux signing change from #4167 with slight organizational changes. A successful signed build [can be found here.](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=22344&view=results)

##### Motivation
We found some issues with the ClearSign signed AppImage in release validation. This unblocks release.

##### Context
Further investigation is required to determine if we can use ClearSign signing in the future.

I verified an AppImage from the signed build locally.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
