### PR TITLE
fix: Explicitly use CanvasText for HC checkbox check

### DIFF
--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -54,7 +54,7 @@ div.insights-dialog-main-override.telemetry-permission-dialog {
 
     .ms-Checkbox-checkmark {
         @media screen and (forced-colors: active) {
-            color: inherit;
+            color: CanvasText !important;
         }
     }
 


### PR DESCRIPTION
#### Details

The checkmark in the telemetry checkbox was not rendering properly in Edge (worked fine in Chrome) with black-themed Windows HC modes. Explicitly set the checkmark color to the CanvasText color to force proper rendering

##### Screenshots

HC Mode | Prod Chrome | Updated Chrome | Prod Edge | Updated Edge
--- | --- | --- | --- | ---
None | ![image](https://user-images.githubusercontent.com/45672944/119536534-0a198a00-bd3e-11eb-9de1-cad9180ef9aa.png) | ![image](https://user-images.githubusercontent.com/45672944/119536481-fa01aa80-bd3d-11eb-8cd9-21e4b510e6e9.png) | ![image](https://user-images.githubusercontent.com/45672944/119536412-ea826180-bd3d-11eb-9820-0cb1e9758299.png) | ![image](https://user-images.githubusercontent.com/45672944/119536359-d9d1eb80-bd3d-11eb-9bc5-ec99da6fdb82.png)
HC 1 | ![image](https://user-images.githubusercontent.com/45672944/119535114-8b701d00-bd3c-11eb-896a-50b74c9c51a4.png) | ![image](https://user-images.githubusercontent.com/45672944/119535584-046f7480-bd3d-11eb-85f3-4a5f27033ff5.png) | ![image](https://user-images.githubusercontent.com/45672944/119535736-3254b900-bd3d-11eb-8263-cd3ab3bff013.png) | ![image](https://user-images.githubusercontent.com/45672944/119536252-b870ff80-bd3d-11eb-8f86-8c4a77b4a15b.png)
HC 2 | ![image](https://user-images.githubusercontent.com/45672944/119535051-76938980-bd3c-11eb-8ee2-3bb9add997c0.png) | ![image](https://user-images.githubusercontent.com/45672944/119535515-ef92e100-bd3c-11eb-8f70-687ca0647118.png) | ![image](https://user-images.githubusercontent.com/45672944/119535823-48627980-bd3d-11eb-8210-7bab5352bc1d.png) | ![image](https://user-images.githubusercontent.com/45672944/119536200-a98a4d00-bd3d-11eb-85fd-1b025310ede0.png)
HC Black | ![image](https://user-images.githubusercontent.com/45672944/119535211-a04cb080-bd3c-11eb-9d74-8de8c1236f05.png) | ![image](https://user-images.githubusercontent.com/45672944/119535455-dc801100-bd3c-11eb-8d95-53dd24cf1cf0.png) | ![image](https://user-images.githubusercontent.com/45672944/119535898-5912ef80-bd3d-11eb-8abf-686fb02a328f.png) | ![image](https://user-images.githubusercontent.com/45672944/119536151-9a0b0400-bd3d-11eb-969c-59981a85ce22.png)
HC White | ![image](https://user-images.githubusercontent.com/45672944/119535293-b490ad80-bd3c-11eb-8463-ca7c7bbe5f65.png) | ![image](https://user-images.githubusercontent.com/45672944/119535390-c96d4100-bd3c-11eb-9bda-9ee75ddf438a.png) | ![image](https://user-images.githubusercontent.com/45672944/119535981-6f20b000-bd3d-11eb-99a7-5dc0fd04d3a8.png) | ![image](https://user-images.githubusercontent.com/45672944/119536077-88c1f780-bd3d-11eb-9b2f-a06dfbdd311c.png)

##### Motivation

Accessibility

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
I'm not sure why the **inherit** attribute isn't working here. I spot-checked some other places where we use the **inherit** attribute in HC modes, but didn't find anything unusual.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
I tried using `inherit !important`, but that didn't work, so I went with `CanvasText !important`

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4261
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
