### PR TITLE
fix: remove unnecessary prop from renderLoadAssessmentButton

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -252,7 +252,6 @@ export class DetailsViewCommandBar extends React.Component<
                 enableJSXElement={this.props.switcherNavConfiguration.LoadAssessmentButton({
                     ...this.props,
                     handleLoadAssessmentButtonClick: this.handleLoadAssessmentButtonClick,
-                    onClose: this.toggleLoadAssessmentDialog,
                 })}
             />
         );


### PR DESCRIPTION
#### Details

an extra prop was being passed to renderLoadAssessmentButton in the DetailsViewCommandBar.  This made the code more confusing to follow.

##### Motivation

Cleaning up the code.

##### Context


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
