### PR TITLE
chore: Tweak HC icons and scoping

### DIFF
--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -131,13 +131,14 @@
         }
     }
 
-    .file-issue-button,
-    .copy-issue-details-button,
-    .insights-dialog-button-inspect {
+    .insights-dialog-main-override .file-issue-button,
+    .insights-dialog-main-override .copy-issue-details-button,
+    .insights-dialog-main-override .insights-dialog-button-inspect {
         svg path {
             @media screen and (forced-colors) {
                 forced-color-adjust: none !important;
                 stroke: ButtonText !important;
+                fill: ButtonFace !important;
             }
         }
     }

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -267,14 +267,14 @@
         text-align: center !important;
     }
 
-    .insights-highlight-box {
+    .insights-highlight-container .insights-highlight-box {
         @include ms-high-contrast-override {
             forced-color-adjust: none;
             outline-color: Highlight !important;
         }
     }
 
-    .insights-highlight-text {
+    .insights-highlight-container .insights-highlight-text {
         @include ms-high-contrast-override {
             forced-color-adjust: none;
             color: HighlightText !important;


### PR DESCRIPTION
#### Details

The changes in #4253 weren't quite correct. They omitted a bit of scoping for the styles, and they introduced some inconsistency in how icons (especially the file bug icon) were represented in HC White mode. This corrects those errors.

##### Screenshots

Note how the fill in the "Before" column of HC White is inconsistent with other HC modes, making the icons kind of "splotchy". In the "After" column, the fill is the same color as the button, so the icon appearance is cleaner and consistent across all HC modes.

HC Mode | Before | After
--- | --- | ---
None | ![image](https://user-images.githubusercontent.com/45672944/119560585-f6c7e800-bd58-11eb-9ba3-e04924f11ebf.png) | ![image](https://user-images.githubusercontent.com/45672944/119561312-dd736b80-bd59-11eb-89db-c216240fc3a0.png)
HC 1 | ![image](https://user-images.githubusercontent.com/45672944/119560671-0e9f6c00-bd59-11eb-9eec-b464052de5a8.png) | ![image](https://user-images.githubusercontent.com/45672944/119561228-c5035100-bd59-11eb-80bf-4800f5eb9f59.png)
HC 2 | ![image](https://user-images.githubusercontent.com/45672944/119560742-27a81d00-bd59-11eb-9a53-49f68eae1050.png) | ![image](https://user-images.githubusercontent.com/45672944/119561165-b2891780-bd59-11eb-85d0-b09dd4047f37.png)
HC Black | ![image](https://user-images.githubusercontent.com/45672944/119560797-3d1d4700-bd59-11eb-86f1-2477427b338d.png) | ![image](https://user-images.githubusercontent.com/45672944/119561071-96857600-bd59-11eb-8341-eeea1bfa8cc8.png)
HC White | ![image](https://user-images.githubusercontent.com/45672944/119560853-50301700-bd59-11eb-807c-d68c45878100.png) | ![image](https://user-images.githubusercontent.com/45672944/119561019-81a8e280-bd59-11eb-9c0b-c5f9cbdb610a.png)

##### Motivation

Better user experience

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
I tried unsuccessfully to get the file bug icon to have the same fill in HC that it has in non-HC. I think that would require reauthoring the SVG.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
