### PR TITLE
fix: E2E test for invalid data validation looking for element that doesn't exist

### DIFF
--- a/src/tests/end-to-end/tests/details-view/overview.test.ts
+++ b/src/tests/end-to-end/tests/details-view/overview.test.ts
@@ -107,9 +107,8 @@ describe('Details View -> Overview Page', () => {
             await overviewPage.setFileForUpload(
                 `${__dirname}/../../test-resources/saved-assessment-files/${file}`,
             );
-            await overviewPage.clickSelector(overviewSelectors.loadAssessmentButton);
 
-            await overviewPage.waitForTimeout(500);
+            await overviewPage.waitForTimeout(750);
 
             let currentOutcomeSummaryAriaLabel: string;
 


### PR DESCRIPTION
#### Details

This is holding up some additional PRs due to the E2E tests failing in a scenario that wasn't accounted for in the initial PR.

##### Motivation

Fix failing PR builds

##### Context

The click selector for the LoadAssessmentDialog was a leftover from a previous test that we had copied from and we neglected to remove it, which was an oversight.  Because the validation piece was not complete the load assessment dialog was still rendered so the click selector worked properly.  Now that we're implementing the validation piece, the load assessment dialog doesn't exist when this test runs, causing the test to fail.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
