### PR TITLE
chore: bump e2e test timeouts

### DIFF
--- a/pipeline/e2e-test-from-agent.yaml
+++ b/pipeline/e2e-test-from-agent.yaml
@@ -7,4 +7,4 @@ steps:
 
     - script: yarn test:e2e --ci
       displayName: run e2e tests
-      timeoutInMinutes: 15
+      timeoutInMinutes: 25

--- a/pipeline/e2e-test-from-docker.yaml
+++ b/pipeline/e2e-test-from-docker.yaml
@@ -3,16 +3,20 @@
 steps:
     - script: docker build -t app .
       displayName: setup docker
+      timeoutInMinutes: 10
 
     - script: docker run --network=host -i app --ci
       displayName: run e2e tests on docker
+      timeoutInMinutes: 25
 
     - bash: |
           export CONTAINERID=$(docker ps -alq)
           echo "##vso[task.setvariable variable=CONTAINER_ID]$CONTAINERID"
       displayName: get container id for docker
       condition: succeededOrFailed()
+      timeoutInMinutes: 1
 
     - script: docker cp $(CONTAINER_ID):/app/test-results/ .
       displayName: copy test results from docker to base agent
       condition: succeededOrFailed()
+      timeoutInMinutes: 1

--- a/pipeline/unified/unified-e2e-test-interactive.yaml
+++ b/pipeline/unified/unified-e2e-test-interactive.yaml
@@ -9,9 +9,9 @@ steps:
     - script: yarn test:unified --ci
       displayName: run unified e2e tests (non-linux)
       condition: and(succeeded(), ne(variables.platform, 'linux'))
-      timeoutInMinutes: 22
+      timeoutInMinutes: 25
 
     - script: xvfb-run --server-args="-screen 0 1024x768x24" yarn test:unified --ci
       displayName: run unified e2e tests (linux)
       condition: and(succeeded(), eq(variables.platform, 'linux'))
-      timeoutInMinutes: 12
+      timeoutInMinutes: 20

--- a/pipeline/unified/unified-e2e-test-linux.yaml
+++ b/pipeline/unified/unified-e2e-test-linux.yaml
@@ -7,4 +7,4 @@ steps:
 
     - script: xvfb-run --server-args="-screen 0 1024x768x24" yarn test:unified --ci
       displayName: run electron e2e tests
-      timeoutInMinutes: 12
+      timeoutInMinutes: 20

--- a/src/tests/electron/setup/timeouts.ts
+++ b/src/tests/electron/setup/timeouts.ts
@@ -1,30 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import os from 'os';
-import process from 'process';
-
-// See https://github.com/microsoft/accessibility-insights-web/issues/4271
-const isMacCIAgent = process.env['CI'] != null && os.platform() === 'darwin';
-const scaleFactor = isMacCIAgent ? 1.5 : 1;
 
 // How long to allow an entire test to execute, including startup/setup
-export const DEFAULT_ELECTRON_TEST_TIMEOUT_MS = 60000 * scaleFactor;
+export const DEFAULT_ELECTRON_TEST_TIMEOUT_MS = 60000;
 
 // These govern how long to allow connection to the test app to take
 // The product of these should be significantly less than the test timeout
-export const DEFAULT_APP_CONNECT_TIMEOUT_MS = 10000 * scaleFactor;
+export const DEFAULT_APP_CONNECT_TIMEOUT_MS = 10000;
 export const DEFAULT_APP_CONNECT_RETRIES = 3;
 
 // These govern how long Spectron should allow for ChromeDriver to start
 // The product of these should be significantly less than the test timeout
-export const DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS = 5000 * scaleFactor;
+export const DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS = 5000;
 export const DEFAULT_CHROMEDRIVER_START_RETRIES = 3;
 
 // How long to wait for an element to be visible
-export const DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS = 5000 * scaleFactor;
+export const DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS = 5000;
 
 // How long of a wait to artificially inject between element hover/mousedown/mouseup during clicks
-export const DEFAULT_CLICK_HOVER_DELAY_MS = 100 * scaleFactor;
+export const DEFAULT_CLICK_HOVER_DELAY_MS = 100;
 
 // How long to wait for a mock adb or service log to contain a value
-export const DEFAULT_WAIT_FOR_LOG_TIMEOUT_MS = 1500 * scaleFactor;
+export const DEFAULT_WAIT_FOR_LOG_TIMEOUT_MS = 1500;

--- a/src/tests/electron/setup/timeouts.ts
+++ b/src/tests/electron/setup/timeouts.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import os from 'os';
-import process from 'process';
+import * as os from 'os';
+import * as process from 'process';
 
 // See https://github.com/microsoft/accessibility-insights-web/issues/4271
 const isMacCIAgent = process.env['CI'] != null && os.platform() === 'darwin';

--- a/src/tests/electron/setup/timeouts.ts
+++ b/src/tests/electron/setup/timeouts.ts
@@ -1,24 +1,30 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import os from 'os';
+import process from 'process';
+
+// See https://github.com/microsoft/accessibility-insights-web/issues/4271
+const isMacCIAgent = process.env['CI'] != null && os.platform() === 'darwin';
+const scaleFactor = isMacCIAgent ? 1.5 : 1;
 
 // How long to allow an entire test to execute, including startup/setup
-export const DEFAULT_ELECTRON_TEST_TIMEOUT_MS = 60000;
+export const DEFAULT_ELECTRON_TEST_TIMEOUT_MS = 60000 * scaleFactor;
 
 // These govern how long to allow connection to the test app to take
 // The product of these should be significantly less than the test timeout
-export const DEFAULT_APP_CONNECT_TIMEOUT_MS = 10000;
+export const DEFAULT_APP_CONNECT_TIMEOUT_MS = 10000 * scaleFactor;
 export const DEFAULT_APP_CONNECT_RETRIES = 3;
 
 // These govern how long Spectron should allow for ChromeDriver to start
 // The product of these should be significantly less than the test timeout
-export const DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS = 5000;
+export const DEFAULT_CHROMEDRIVER_START_TIMEOUT_MS = 5000 * scaleFactor;
 export const DEFAULT_CHROMEDRIVER_START_RETRIES = 3;
 
 // How long to wait for an element to be visible
-export const DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS = 5000;
+export const DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS = 5000 * scaleFactor;
 
 // How long of a wait to artificially inject between element hover/mousedown/mouseup during clicks
-export const DEFAULT_CLICK_HOVER_DELAY_MS = 100;
+export const DEFAULT_CLICK_HOVER_DELAY_MS = 100 * scaleFactor;
 
 // How long to wait for a mock adb or service log to contain a value
-export const DEFAULT_WAIT_FOR_LOG_TIMEOUT_MS = 1500;
+export const DEFAULT_WAIT_FOR_LOG_TIMEOUT_MS = 1500 * scaleFactor;

--- a/src/tests/end-to-end/common/timeouts.ts
+++ b/src/tests/end-to-end/common/timeouts.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import os from 'os';
-import process from 'process';
+import * as os from 'os';
+import * as process from 'process';
 
 // See https://github.com/microsoft/accessibility-insights-web/issues/4271
 const isMacCIAgent = process.env['CI'] != null && os.platform() === 'darwin';

--- a/src/tests/end-to-end/common/timeouts.ts
+++ b/src/tests/end-to-end/common/timeouts.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import os from 'os';
 import process from 'process';
 

--- a/src/tests/end-to-end/common/timeouts.ts
+++ b/src/tests/end-to-end/common/timeouts.ts
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import os from 'os';
+import process from 'process';
+
+// See https://github.com/microsoft/accessibility-insights-web/issues/4271
+const isMacCIAgent = process.env['CI'] != null && os.platform() === 'darwin';
+const scaleFactor = isMacCIAgent ? 1.5 : 1;
+
 // How long to allow an entire test to execute
 //
 // We want this to be greater than default timeout of Playwright's waitFor* functions (30s),
@@ -8,24 +15,24 @@
 // more actionable than test failures of the form "such and such test timed out".
 //
 // Every other default timeout should be lower than this!
-export const DEFAULT_E2E_TEST_TIMEOUT_MS: number = 30000;
+export const DEFAULT_E2E_TEST_TIMEOUT_MS: number = 30000 * scaleFactor;
 
 // How long to wait for a new browser instance to initialize.
-export const DEFAULT_BROWSER_LAUNCH_TIMEOUT_MS = 15000;
+export const DEFAULT_BROWSER_LAUNCH_TIMEOUT_MS = 15000 * scaleFactor;
 
 // How long to wait for an existing page to stop churning in response to a UI action
-export const DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS = 5000;
+export const DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS = 5000 * scaleFactor;
 
 // How long to wait for an operation that involves scanning the target page
-export const DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS = 15000;
+export const DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS = 15000 * scaleFactor;
 
 // How long to wait for a new page to load in response to the UI action that launched it
-export const DEFAULT_NEW_PAGE_WAIT_TIMEOUT_MS = 5000;
+export const DEFAULT_NEW_PAGE_WAIT_TIMEOUT_MS = 5000 * scaleFactor;
 
 // How long of a wait to artificially inject between element hover/mousedown/mouseup during clicks
-export const DEFAULT_CLICK_HOVER_DELAY_MS = 100;
-export const DEFAULT_CLICK_MOUSEUP_DELAY_MS = 50;
+export const DEFAULT_CLICK_HOVER_DELAY_MS = 100 * scaleFactor;
+export const DEFAULT_CLICK_MOUSEUP_DELAY_MS = 50 * scaleFactor;
 
 // How long to allow screenshotOnError to take (we don't want to allow arbitrarily long because the
 // error stacks are better if an individual test operation fails than if the whole test times out)
-export const DEFAULT_SCREENSHOT_TIMEOUT_MS = 5000;
+export const DEFAULT_SCREENSHOT_TIMEOUT_MS = 5000 * scaleFactor;


### PR DESCRIPTION
#### Details

This PR works around recent e2e flakiness (see #4271) by extending some e2e test timeouts. Ideally we'd want instead to reduce the times; this is a stopgap while @waabid is queueing up an engineering feature to drive down build/test times. Specifically:

* Increases per-operation timeouts for mac agents running web e2es (example failures: [20210521.2](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=21116&view=results), [20240524.1](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=21117&view=results))
* Increases per-operation timeouts for mac agents running unified e2es (example failures: [2021.526.5](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=22696&view=logs&j=291b3e6c-60a9-5f30-6b17-b27c7388dcd0&t=cf07a988-eb2d-5b91-d721-4d3077174f85), [2021.527.3](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=22783&view=logs&j=291b3e6c-60a9-5f30-6b17-b27c7388dcd0&t=cf07a988-eb2d-5b91-d721-4d3077174f85)
* Increases e2e step timeouts for windows agents running web e2es (example failures: [20210521.2](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=21116&view=results), [20240524.1](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=21117&view=results))
* Increases unified step timeouts for all agent types (example failures: [2021.525.2](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=22602&view=logs&j=022b0a5d-2698-5f72-7610-a845972a8b4c), [2021.527.1](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=22769&view=logs&j=43d32c17-ff19-5d0a-58b3-52a09bf40d57&t=bd900891-a87d-5872-c849-75f9b0227bfe))

##### Motivation

Improve CI build stability

##### Context

The step timeouts were chosen by taking the average times of 3 recent successful runs, adding 50% buffer, and rounding up to the nearest 5min interval.

The mac-CI-agent scale factor was chosen arbitrarily, since we don't have logs of per-operation success durations to use as a baseline.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4271
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
