### PR TITLE
feat(save-load-validation): update E2E test to account for invalid data dialog

### DIFF
--- a/src/DetailsView/components/invalid-load-assessment-dialog.tsx
+++ b/src/DetailsView/components/invalid-load-assessment-dialog.tsx
@@ -5,6 +5,8 @@ import * as styles from 'DetailsView/components/invalid-load-assessment-dialog.s
 import { Dialog, DialogFooter, DialogType, PrimaryButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
+export const invalidLoadAssessmentDialogOkButtonAutomationId =
+    'invalid-load-assessment-dialog-ok-button';
 export interface InvalidLoadAssessmentDialogProps {
     isOpen: boolean;
     onClose: () => void;
@@ -33,7 +35,12 @@ export const InvalidLoadAssessmentDialog = NamedFC<InvalidLoadAssessmentDialogPr
                 }}
             >
                 <DialogFooter>
-                    <PrimaryButton onClick={props.onClose}>OK</PrimaryButton>
+                    <PrimaryButton
+                        data-automation-id={invalidLoadAssessmentDialogOkButtonAutomationId}
+                        onClick={props.onClose}
+                    >
+                        OK
+                    </PrimaryButton>
                 </DialogFooter>
             </Dialog>
         );

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -6,6 +6,7 @@ import { instanceTableTextContentAutomationId } from 'DetailsView/components/ass
 import { visualHelperToggleAutomationId } from 'DetailsView/components/base-visual-helper-toggle';
 import { settingsPanelAutomationId } from 'DetailsView/components/details-view-overlay/settings-panel/settings-panel';
 import { IframeWarningContainerAutomationId } from 'DetailsView/components/iframe-warning';
+import { invalidLoadAssessmentDialogOkButtonAutomationId } from 'DetailsView/components/invalid-load-assessment-dialog';
 import { loadAssessmentButtonAutomationId } from 'DetailsView/components/load-assessment-button';
 import { loadAssessmentDialogLoadButtonAutomationId } from 'DetailsView/components/load-assessment-dialog';
 import { overviewContainerAutomationId } from 'DetailsView/components/overview-content/overview-content-container';
@@ -79,6 +80,9 @@ export const overviewSelectors = {
         getAutomationIdSelector(testSummaryStatusAutomationId(testName)) + ' .outcome-chip',
     loadAssessmentDialogLoadButton: getAutomationIdSelector(
         loadAssessmentDialogLoadButtonAutomationId,
+    ),
+    invalidLoadAssessmentDialogOkButton: getAutomationIdSelector(
+        invalidLoadAssessmentDialogOkButtonAutomationId,
     ),
 };
 

--- a/src/tests/end-to-end/tests/details-view/overview.test.ts
+++ b/src/tests/end-to-end/tests/details-view/overview.test.ts
@@ -102,7 +102,9 @@ describe('Details View -> Overview Page', () => {
                 `${__dirname}/../../test-resources/saved-assessment-files/${file}`,
             );
 
-            await overviewPage.waitForTimeout(750);
+            await overviewPage.clickSelector(overviewSelectors.loadAssessmentButton);
+
+            await overviewPage.clickSelector(overviewSelectors.invalidLoadAssessmentDialogOkButton);
 
             let currentOutcomeSummaryAriaLabel: string;
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/invalid-load-assessment-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/invalid-load-assessment-dialog.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`InvalidLoadAssessmentDialog should show when isOpen is set to true 1`] 
 >
   <StyledDialogFooterBase>
     <CustomizedPrimaryButton
+      data-automation-id="invalid-load-assessment-dialog-ok-button"
       onClick={[Function]}
     >
       OK


### PR DESCRIPTION
#### Details

This incorporates the invalid data dialog into the E2E tests for the save and load assessment.

##### Motivation

feature work

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
