### PR TITLE
chore: fix Point vs IPoint type confusion in svg-shape-factory.test.ts

### DIFF
--- a/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
@@ -1,17 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IPoint } from '@uifabric/utilities';
-import { Mock } from 'typemoq';
-
-import { DrawerUtils } from '../../../../../injected/visualization/drawer-utils';
+import { DrawerUtils } from 'injected/visualization/drawer-utils';
 import {
     CircleConfiguration,
     LineConfiguration,
     TextConfiguration,
-} from '../../../../../injected/visualization/formatter';
-import { SVGShapeFactory } from '../../../../../injected/visualization/svg-shape-factory';
+} from 'injected/visualization/formatter';
+import { Point } from 'injected/visualization/point';
+import { SVGShapeFactory } from 'injected/visualization/svg-shape-factory';
+import { Mock } from 'typemoq';
 
-describe('SVGShapeFactoryTest', () => {
+describe('SVGShapeFactory', () => {
     const drawerUtilsMock = Mock.ofType(DrawerUtils);
     let testObject: SVGShapeFactory;
     const defaultTestLineConfiguration: LineConfiguration = {
@@ -35,12 +34,12 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create line, destination is on quadrant I', () => {
-        const source: IPoint = {
+        const source: Point = {
             x: 0,
             y: 0,
         };
 
-        const destination: IPoint = {
+        const destination: Point = {
             x: 100,
             y: 100,
         };
@@ -54,12 +53,12 @@ describe('SVGShapeFactoryTest', () => {
         );
 
         const angle = Math.PI / 4;
-        const expectedSource: IPoint = {
+        const expectedSource: Point = {
             x: (defaultCircleRadius + expectedLineBuffer) * Math.cos(angle),
             y: (defaultCircleRadius + expectedLineBuffer) * Math.sin(angle),
         };
 
-        const expectedDestination: IPoint = {
+        const expectedDestination: Point = {
             x: 100 - (defaultCircleRadius + expectedLineBuffer) * Math.cos(angle),
             y: 100 - (defaultCircleRadius + expectedLineBuffer) * Math.sin(angle),
         };
@@ -68,12 +67,12 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create line, destination on quadrant II', () => {
-        const source: IPoint = {
+        const source: Point = {
             x: 0,
             y: 0,
         };
 
-        const destination: IPoint = {
+        const destination: Point = {
             x: -100,
             y: 100,
         };
@@ -87,12 +86,12 @@ describe('SVGShapeFactoryTest', () => {
         );
 
         const angle = (3 * Math.PI) / 4;
-        const expectedSource: IPoint = {
+        const expectedSource: Point = {
             x: (defaultCircleRadius + expectedLineBuffer) * Math.cos(angle),
             y: (defaultCircleRadius + expectedLineBuffer) * Math.sin(angle),
         };
 
-        const expectedDestination: IPoint = {
+        const expectedDestination: Point = {
             x: -100 - (defaultCircleRadius + expectedLineBuffer) * Math.cos(angle),
             y: 100 - (defaultCircleRadius + expectedLineBuffer) * Math.sin(angle),
         };
@@ -101,12 +100,12 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create line, destination on quadrant III', () => {
-        const source: IPoint = {
+        const source: Point = {
             x: 0,
             y: 0,
         };
 
-        const destination: IPoint = {
+        const destination: Point = {
             x: -100,
             y: -100,
         };
@@ -120,12 +119,12 @@ describe('SVGShapeFactoryTest', () => {
         );
 
         const angle = (5 * Math.PI) / 4;
-        const expectedSource: IPoint = {
+        const expectedSource: Point = {
             x: (defaultCircleRadius + expectedLineBuffer) * Math.cos(angle),
             y: (defaultCircleRadius + expectedLineBuffer) * Math.sin(angle),
         };
 
-        const expectedDestination: IPoint = {
+        const expectedDestination: Point = {
             x: -100 - (defaultCircleRadius + expectedLineBuffer) * Math.cos(angle),
             y: -100 - (defaultCircleRadius + expectedLineBuffer) * Math.sin(angle),
         };
@@ -134,12 +133,12 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create line, destination on quadrant IV', () => {
-        const source: IPoint = {
+        const source: Point = {
             x: 0,
             y: 0,
         };
 
-        const destination: IPoint = {
+        const destination: Point = {
             x: 100,
             y: -100,
         };
@@ -153,12 +152,12 @@ describe('SVGShapeFactoryTest', () => {
         );
 
         const angle = (7 * Math.PI) / 4;
-        const expectedSource: IPoint = {
+        const expectedSource: Point = {
             x: (defaultCircleRadius + expectedLineBuffer) * Math.cos(angle),
             y: (defaultCircleRadius + expectedLineBuffer) * Math.sin(angle),
         };
 
-        const expectedDestination: IPoint = {
+        const expectedDestination: Point = {
             x: 100 - (defaultCircleRadius + expectedLineBuffer) * Math.cos(angle),
             y: -100 - (defaultCircleRadius + expectedLineBuffer) * Math.sin(angle),
         };
@@ -167,12 +166,12 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create line, horizontal, left to right', () => {
-        const source: IPoint = {
+        const source: Point = {
             x: 0,
             y: 0,
         };
 
-        const destination: IPoint = {
+        const destination: Point = {
             x: 100,
             y: 0,
         };
@@ -185,12 +184,12 @@ describe('SVGShapeFactoryTest', () => {
             defaultCircleRadius,
         );
 
-        const expectedSource: IPoint = {
+        const expectedSource: Point = {
             x: defaultCircleRadius + expectedLineBuffer,
             y: 0,
         };
 
-        const expectedDestination: IPoint = {
+        const expectedDestination: Point = {
             x: 100 - (defaultCircleRadius + expectedLineBuffer),
             y: 0,
         };
@@ -199,12 +198,12 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create line, horizontal, right to left', () => {
-        const source: IPoint = {
+        const source: Point = {
             x: 100,
             y: 0,
         };
 
-        const destination: IPoint = {
+        const destination: Point = {
             x: 0,
             y: 0,
         };
@@ -217,12 +216,12 @@ describe('SVGShapeFactoryTest', () => {
             defaultCircleRadius,
         );
 
-        const expectedSource: IPoint = {
+        const expectedSource: Point = {
             x: 100 - (defaultCircleRadius + expectedLineBuffer),
             y: 0,
         };
 
-        const expectedDestination: IPoint = {
+        const expectedDestination: Point = {
             x: defaultCircleRadius + expectedLineBuffer,
             y: 0,
         };
@@ -231,12 +230,12 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create line, vertical, top to bottom', () => {
-        const source: IPoint = {
+        const source: Point = {
             x: 0,
             y: 100,
         };
 
-        const destination: IPoint = {
+        const destination: Point = {
             x: 0,
             y: 0,
         };
@@ -249,12 +248,12 @@ describe('SVGShapeFactoryTest', () => {
             defaultCircleRadius,
         );
 
-        const expectedSource: IPoint = {
+        const expectedSource: Point = {
             x: 0,
             y: 100 - (defaultCircleRadius + expectedLineBuffer),
         };
 
-        const expectedDestination: IPoint = {
+        const expectedDestination: Point = {
             x: 0,
             y: defaultCircleRadius + expectedLineBuffer,
         };
@@ -263,12 +262,12 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create line, vertical, bottom to top', () => {
-        const source: IPoint = {
+        const source: Point = {
             x: 0,
             y: 0,
         };
 
-        const destination: IPoint = {
+        const destination: Point = {
             x: 0,
             y: 100,
         };
@@ -281,12 +280,12 @@ describe('SVGShapeFactoryTest', () => {
             defaultCircleRadius,
         );
 
-        const expectedSource: IPoint = {
+        const expectedSource: Point = {
             x: 0,
             y: defaultCircleRadius + expectedLineBuffer,
         };
 
-        const expectedDestination: IPoint = {
+        const expectedDestination: Point = {
             x: 0,
             y: 100 - (defaultCircleRadius + expectedLineBuffer),
         };
@@ -295,12 +294,12 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create line (full params)', () => {
-        const source: IPoint = {
+        const source: Point = {
             x: 0,
             y: 0,
         };
 
-        const destination: IPoint = {
+        const destination: Point = {
             x: 100,
             y: 100,
         };
@@ -317,12 +316,12 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create line (no stroke dash array)', () => {
-        const source: IPoint = {
+        const source: Point = {
             x: 0,
             y: 0,
         };
 
-        const destination: IPoint = {
+        const destination: Point = {
             x: 100,
             y: 100,
         };
@@ -344,7 +343,7 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create circle', () => {
-        const center: IPoint = {
+        const center: Point = {
             x: 100,
             y: 100,
         };
@@ -362,7 +361,7 @@ describe('SVGShapeFactoryTest', () => {
     });
 
     test('create label', () => {
-        const center: IPoint = {
+        const center: Point = {
             x: 100,
             y: 100,
         };
@@ -379,7 +378,7 @@ describe('SVGShapeFactoryTest', () => {
     function verifyTabIndexLabelParams(
         label: Element,
         configuration: TextConfiguration,
-        center: IPoint,
+        center: Point,
         tabOrder: number,
     ): void {
         expect(label.tagName).toEqual('text');
@@ -394,7 +393,7 @@ describe('SVGShapeFactoryTest', () => {
     function verifyCircleParams(
         circle: Element,
         configuration: CircleConfiguration,
-        center: IPoint,
+        center: Point,
     ): void {
         expect(circle.tagName).toEqual('ellipse');
         expect(circle.getAttributeNS(null, 'fill')).toEqual(configuration.fill);
@@ -432,8 +431,8 @@ describe('SVGShapeFactoryTest', () => {
 
     function verifyLinePoints(
         line: Element,
-        expectedSource: IPoint,
-        expectedDestination: IPoint,
+        expectedSource: Point,
+        expectedDestination: Point,
     ): void {
         const fractionDigits: number = 12;
         const x1 = parseFloat(line.getAttributeNS(null, 'x1'));


### PR DESCRIPTION
#### Details

`svg-shape-factory.test.ts` is written in terms of a `@uifabric/utilities` `IPoint` class, but the `svg-shape-factory.ts` implementation under test doesn't use fabric's `IPoint`, it uses our own `Point` type. This is a benign issue right now but will be broken in a future update to `@uifabric/utilities`.

##### Motivation

Preempt a future build break

##### Context

Noticed this during an overzealous lockfile regeneration while working on #4320

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
