### PR TITLE
fix: stop ad-hoc headings from crashing by reusing custom axe rule

### DIFF
--- a/src/ad-hoc-visualizations/headings/visualization.tsx
+++ b/src/ad-hoc-visualizations/headings/visualization.tsx
@@ -17,7 +17,7 @@ const { guidance } = content.headings;
 const headingsTestKey = AdHocTestkeys.Headings;
 
 const headingsRuleAnalyzerConfiguration: RuleAnalyzerConfiguration = {
-    rules: ['heading-order'],
+    rules: ['collect-headings'],
     resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
     telemetryProcessor: (telemetryFactory: TelemetryDataFactory) => telemetryFactory.forTestScan,
     key: headingsTestKey,


### PR DESCRIPTION
#### Details

This PR updates the rule used to gather heading instances in our ad-hoc visualization. There are two reasons to do this:
- the current implementation hangs in scenarios described in #4311 
- our assessment headings visualization is [already using a minimal custom rule](https://github.com/microsoft/accessibility-insights-web/blob/2988c8588d15b90bf5e30a0ec3cd5b6d6b5d5e4e/src/assessments/headings/test-steps/heading-function.tsx#L78). It feels like a good idea to use the same implementation for both visualizations.

validation: run against https://karanbirsingh.github.io/temp-snippets/microsoft/accessibility-insights-web/4311/single-level/

##### Motivation

This PR addresses https://github.com/microsoft/accessibility-insights-web/issues/4311 

##### Context

One alternative approach is to do nothing until a new release of axe-core. I think if we're using a custom rule for assessment it'd be good to use it in both places.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 4311
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
