### PR TITLE
Enabled label-content-name mismatch rule for needs-review

### DIFF
--- a/src/ad-hoc-visualizations/needs-review/visualization.tsx
+++ b/src/ad-hoc-visualizations/needs-review/visualization.tsx
@@ -17,7 +17,13 @@ const needsReviewTestKey = AdHocTestkeys.NeedsReview;
 const issuesTestKey = AdHocTestkeys.Issues;
 
 const needsReviewRuleAnalyzerConfiguration: RuleAnalyzerConfiguration = {
-    rules: ['aria-input-field-name', 'color-contrast', 'th-has-data-cells', 'link-in-text-block'],
+    rules: [
+        'aria-input-field-name',
+        'color-contrast',
+        'th-has-data-cells',
+        'link-in-text-block',
+        'label-content-name-mismatch',
+    ],
     resultProcessor: (scanner: ScannerUtils) => scanner.getFailingInstances,
     telemetryProcessor: (telemetryFactory: TelemetryDataFactory) =>
         telemetryFactory.forNeedsReviewAnalyzerScan,

--- a/src/injected/analyzers/filter-results.ts
+++ b/src/injected/analyzers/filter-results.ts
@@ -10,7 +10,8 @@ export const filterNeedsReviewResults = (results: ScanResults): ScanResults => {
         v =>
             v.id !== 'aria-input-field-name' &&
             v.id !== 'color-contrast' &&
-            v.id !== 'th-has-data-cells',
+            v.id !== 'th-has-data-cells' &&
+            v.id !== 'label-content-name-mismatch',
     );
     results.incomplete = results.incomplete.filter(i => i.id !== 'link-in-text-block');
 

--- a/src/scanner/get-rule-inclusions.ts
+++ b/src/scanner/get-rule-inclusions.ts
@@ -24,6 +24,10 @@ export const explicitRuleOverrides: DictionaryStringTo<RuleIncluded> = {
         status: 'excluded',
         reason: 'Based on feedback from users we tested to check the user impact of duplicate ID failures on static elements. We found no user impact on the experience with any of the ATs including Narrator, JAWS, NVDA, Dragon, and Windows Speech Recognition. After further discussions with the Tooling Advisory Board, we decided to make this a best practice rule. See #4102.',
     },
+    'label-content-name-mismatch': {
+        status: 'included',
+        reason: 'for parity with video-caption, which axe-core includes by default',
+    },
 };
 
 export const getRuleInclusions = (

--- a/src/tests/unit/tests/injected/analyzers/filter-results.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/filter-results.test.ts
@@ -10,6 +10,7 @@ describe('filterNeedsReviewResults', () => {
         const inapplicableOnlyRule0 = 'color-contrast';
         const inapplicableOnlyRule1 = 'aria-input-field-name';
         const inapplicableOnlyRule2 = 'th-has-data-cells';
+        const inapplicableOnlyRule3 = 'label-content-name-mismatch';
         const testRule = 'test rule';
         const given: ScanResults = {
             violations: [
@@ -18,6 +19,7 @@ describe('filterNeedsReviewResults', () => {
                 getRuleResultStub(inapplicableOnlyRule0),
                 getRuleResultStub(inapplicableOnlyRule1),
                 getRuleResultStub(inapplicableOnlyRule2),
+                getRuleResultStub(inapplicableOnlyRule3),
             ],
             incomplete: [
                 getRuleResultStub(testRule),
@@ -25,6 +27,7 @@ describe('filterNeedsReviewResults', () => {
                 getRuleResultStub(inapplicableOnlyRule0),
                 getRuleResultStub(inapplicableOnlyRule1),
                 getRuleResultStub(inapplicableOnlyRule2),
+                getRuleResultStub(inapplicableOnlyRule3),
             ],
             passes: [getRuleResultStub(testRule)],
             inapplicable: [getRuleResultStub(testRule)],
@@ -40,6 +43,7 @@ describe('filterNeedsReviewResults', () => {
                 getRuleResultStub(inapplicableOnlyRule0),
                 getRuleResultStub(inapplicableOnlyRule1),
                 getRuleResultStub(inapplicableOnlyRule2),
+                getRuleResultStub(inapplicableOnlyRule3),
             ],
         };
 

--- a/src/tests/unit/tests/scanner/__snapshots__/get-rule-inclusions.test.ts.snap
+++ b/src/tests/unit/tests/scanner/__snapshots__/get-rule-inclusions.test.ts.snap
@@ -186,8 +186,8 @@ Object {
     "status": "included",
   },
   "label-content-name-mismatch": Object {
-    "reason": "rule is tagged experimental",
-    "status": "excluded",
+    "reason": "for parity with video-caption, which axe-core includes by default",
+    "status": "included",
   },
   "label-title-only": Object {
     "reason": "rule is tagged best-practice",


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->

The axe experimental rule label-content-name-mismatch was added in FastPass

![image](https://user-images.githubusercontent.com/32908302/120873800-7ecba000-c558-11eb-8a85-437ef5584ce2.png)
![image](https://user-images.githubusercontent.com/32908302/120873830-9d319b80-c558-11eb-8967-9575bc0dc319.png)

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Addresses issue #3959

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3959
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
