### PR TITLE
chore(build): fix PR build failures with docker e2e false exit codes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,9 @@
 # reference: https://stackoverflow.com/a/51683309/3711475
 # reference: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
 
-FROM mcr.microsoft.com/playwright:bionic
+FROM mcr.microsoft.com/playwright:v1.12.0-focal
 
 USER root
-
-# Install node 14 (per https://github.com/microsoft/playwright/pull/4262#issuecomment-719745883)
-RUN apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g yarn@1.22.10
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # reference: https://stackoverflow.com/a/51683309/3711475
 # reference: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
 
-FROM mcr.microsoft.com/playwright:v1.12.0-focal
+FROM mcr.microsoft.com/playwright:v1.11.0-focal
 
 USER root
 

--- a/pipeline/e2e-test-from-docker.yaml
+++ b/pipeline/e2e-test-from-docker.yaml
@@ -4,7 +4,7 @@ steps:
     - script: docker build -t app .
       displayName: setup docker
 
-    - script: docker run --network=host -i app --ci
+    - bash: docker run --network=host -i app --ci
       displayName: run e2e tests on docker
 
     - bash: |

--- a/pipeline/e2e-test-from-docker.yaml
+++ b/pipeline/e2e-test-from-docker.yaml
@@ -4,7 +4,7 @@ steps:
     - script: docker build -t app .
       displayName: setup docker
 
-    - bash: docker run --network=host -i app --ci
+    - script: docker run --network=host -i app --ci
       displayName: run e2e tests on docker
 
     - bash: |


### PR DESCRIPTION
#### Details

Our PR builds started failing with the Playwright 1.12.0 release and the corresponding release of a new `mcr.microsoft.com/playwright:bionic` image, which we use for docker/e2e tests in PR builds.

@karanbirsingh and I have done some root cause analysis but haven't narrowed down an exact cause yet. To work around the issue in the meantime, this PR reverts our builds to use a v1.11.0 docker image, which seems to prevent the issue.

##### Motivation

Fix build breaks

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
