### PR TITLE
chore: Make AxeRule.description required again

### DIFF
--- a/src/injected/scanner.d.ts
+++ b/src/injected/scanner.d.ts
@@ -8,7 +8,7 @@ declare interface AxeResult {
 declare interface AxeRule {
     id: string;
     nodes: AxeNodeResult[];
-    description?: string;
+    description: string;
     help?: string;
 }
 

--- a/src/scanner/iruleresults.d.ts
+++ b/src/scanner/iruleresults.d.ts
@@ -3,7 +3,7 @@
 export interface AxeRule {
     id: string;
     nodes: AxeNodeResult[];
-    description?: string;
+    description: string;
     helpUrl?: string;
     help?: string;
     tags?: string[];

--- a/src/scanner/message-decorator.ts
+++ b/src/scanner/message-decorator.ts
@@ -20,7 +20,7 @@ export class MessageDecorator {
             return;
         }
 
-        results.description = ruleConfiguration.rule.description;
+        results.description = ruleConfiguration.rule.description ?? 'No description is available';
         results.help = ruleConfiguration.rule.help;
 
         results.nodes.forEach(resultNode => {


### PR DESCRIPTION
#### Details

While working on strict null checks, I noticed that `AxeRule.description` is optional, which seemed counterintuitive since we'd presumably always want to have a description for a rule. My curiosity piqued, I checked the history and learned that this was changed in #3606, which was early in the strict null check work. As an experiment, I reverted 2 changes related to the description and found only 1 place where it was still flagged as a problem. I added a placeholder string for the description in a place where we used to have no description at all.

##### Motivation

Undo what was apparently intended to be a temporary change, hopefully simply future strict null check efforts

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
`IRuleConfiguration.description` should arguably be non-optional, but that goes back to well before the strict null check work. I tried the change locally and it broke multiple custom rules and multiple tests, so that feels like a separate conversation than restoring the intent before #3606.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
