### PR TITLE
feat(web-compliance-21h1): bump report version to validate npmjs secret rotation

### DIFF
--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-report",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Accessibility Insights Report",
     "license": "MIT",
     "files": [


### PR DESCRIPTION
#### Details

As per the instructions for validating the npmjs secret rotation, this bumps the patch version for the report so that we can release a new version of accessibility-insights-report to test that the rotation succeeded.

##### Motivation

Compliance Feature Work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
