### PR TITLE
fix: Improve list structure of color contrast suggestions to fix NVDA output

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -2091,76 +2091,61 @@
                                             insights-fix-instruction-list--1vUZj
                                           "
                                           ><li
-                                            ><span aria-hidden="true"
-                                              ><span
-                                                ><span
-                                                  >Element has insufficient
-                                                  color contrast of 2.52
-                                                  (foreground color:
-                                                  <span
-                                                    class="
-                                                      fix-instruction-color-box--HXJ1A
-                                                    "
-                                                    style="
-                                                      background-color: #8a94a8;
-                                                    "
-                                                  ></span
-                                                  >#8a94a8, background color:
-                                                  <span
-                                                    class="
-                                                      fix-instruction-color-box--HXJ1A
-                                                    "
-                                                    style="
-                                                      background-color: #e7ecd8;
-                                                    "
-                                                  ></span
-                                                  >#e7ecd8, font size: 12.0pt
-                                                  (16px), font weight: normal).
-                                                  Expected contrast ratio of
-                                                  4.5:1
-                                                </span></span
-                                              ><span
-                                                ><ul
-                                                  ><li
-                                                    ><span>
-                                                      Use foreground color:
-                                                      <span
-                                                        class="
-                                                          fix-instruction-color-box--HXJ1A
-                                                        "
-                                                        style="
-                                                          background-color: #5e6572;
-                                                        "
-                                                      ></span
-                                                      >#5e6572 and the original
-                                                      background color:
-                                                      <span
-                                                        class="
-                                                          fix-instruction-color-box--HXJ1A
-                                                        "
-                                                        style="
-                                                          background-color: #e7ecd8;
-                                                        "
-                                                      ></span
-                                                      >#e7ecd8 to meet a
-                                                      contrast ratio of
-                                                      4.86:1</span
-                                                    ></li
-                                                  ></ul
-                                                ></span
-                                              ></span
                                             ><span
-                                              class="screen-reader-only--1uWLQ"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
-                                              color: #8a94a8, background color:
-                                              #e7ecd8, font size: 12.0pt (16px),
-                                              font weight: normal). Expected
-                                              contrast ratio of 4.5:1 Use
-                                              foreground color: #5e6572 and the
-                                              original background color: #e7ecd8
-                                              to meet a contrast ratio of
-                                              4.86:1.</span
+                                              color: </span
+                                            ><span
+                                              aria-hidden="true"
+                                              class="
+                                                fix-instruction-color-box--HXJ1A
+                                              "
+                                              style="background-color: #8a94a8"
+                                            ></span
+                                            ><span
+                                              >#8a94a8, background color: </span
+                                            ><span
+                                              aria-hidden="true"
+                                              class="
+                                                fix-instruction-color-box--HXJ1A
+                                              "
+                                              style="background-color: #e7ecd8"
+                                            ></span
+                                            ><span
+                                              >#e7ecd8, font size: 12.0pt
+                                              (16px), font weight: normal).
+                                              Expected contrast ratio of
+                                              4.5:1</span
+                                            ><ul
+                                              ><li
+                                                ><span>
+                                                  Use foreground color: </span
+                                                ><span
+                                                  aria-hidden="true"
+                                                  class="
+                                                    fix-instruction-color-box--HXJ1A
+                                                  "
+                                                  style="
+                                                    background-color: #5e6572;
+                                                  "
+                                                ></span
+                                                ><span
+                                                  >#5e6572 and the original
+                                                  background color: </span
+                                                ><span
+                                                  aria-hidden="true"
+                                                  class="
+                                                    fix-instruction-color-box--HXJ1A
+                                                  "
+                                                  style="
+                                                    background-color: #e7ecd8;
+                                                  "
+                                                ></span
+                                                ><span
+                                                  >#e7ecd8 to meet a contrast
+                                                  ratio of 4.86:1.</span
+                                                ></li
+                                              ></ul
                                             ></li
                                           ></ul
                                         ></div
@@ -2204,76 +2189,61 @@
                                             insights-fix-instruction-list--1vUZj
                                           "
                                           ><li
-                                            ><span aria-hidden="true"
-                                              ><span
-                                                ><span
-                                                  >Element has insufficient
-                                                  color contrast of 2.52
-                                                  (foreground color:
-                                                  <span
-                                                    class="
-                                                      fix-instruction-color-box--HXJ1A
-                                                    "
-                                                    style="
-                                                      background-color: #8a94a8;
-                                                    "
-                                                  ></span
-                                                  >#8a94a8, background color:
-                                                  <span
-                                                    class="
-                                                      fix-instruction-color-box--HXJ1A
-                                                    "
-                                                    style="
-                                                      background-color: #e7ecd8;
-                                                    "
-                                                  ></span
-                                                  >#e7ecd8, font size: 12.0pt
-                                                  (16px), font weight: normal).
-                                                  Expected contrast ratio of
-                                                  4.5:1
-                                                </span></span
-                                              ><span
-                                                ><ul
-                                                  ><li
-                                                    ><span>
-                                                      Use foreground color:
-                                                      <span
-                                                        class="
-                                                          fix-instruction-color-box--HXJ1A
-                                                        "
-                                                        style="
-                                                          background-color: #5e6572;
-                                                        "
-                                                      ></span
-                                                      >#5e6572 and the original
-                                                      background color:
-                                                      <span
-                                                        class="
-                                                          fix-instruction-color-box--HXJ1A
-                                                        "
-                                                        style="
-                                                          background-color: #e7ecd8;
-                                                        "
-                                                      ></span
-                                                      >#e7ecd8 to meet a
-                                                      contrast ratio of
-                                                      4.86:1</span
-                                                    ></li
-                                                  ></ul
-                                                ></span
-                                              ></span
                                             ><span
-                                              class="screen-reader-only--1uWLQ"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
-                                              color: #8a94a8, background color:
-                                              #e7ecd8, font size: 12.0pt (16px),
-                                              font weight: normal). Expected
-                                              contrast ratio of 4.5:1 Use
-                                              foreground color: #5e6572 and the
-                                              original background color: #e7ecd8
-                                              to meet a contrast ratio of
-                                              4.86:1.</span
+                                              color: </span
+                                            ><span
+                                              aria-hidden="true"
+                                              class="
+                                                fix-instruction-color-box--HXJ1A
+                                              "
+                                              style="background-color: #8a94a8"
+                                            ></span
+                                            ><span
+                                              >#8a94a8, background color: </span
+                                            ><span
+                                              aria-hidden="true"
+                                              class="
+                                                fix-instruction-color-box--HXJ1A
+                                              "
+                                              style="background-color: #e7ecd8"
+                                            ></span
+                                            ><span
+                                              >#e7ecd8, font size: 12.0pt
+                                              (16px), font weight: normal).
+                                              Expected contrast ratio of
+                                              4.5:1</span
+                                            ><ul
+                                              ><li
+                                                ><span>
+                                                  Use foreground color: </span
+                                                ><span
+                                                  aria-hidden="true"
+                                                  class="
+                                                    fix-instruction-color-box--HXJ1A
+                                                  "
+                                                  style="
+                                                    background-color: #5e6572;
+                                                  "
+                                                ></span
+                                                ><span
+                                                  >#5e6572 and the original
+                                                  background color: </span
+                                                ><span
+                                                  aria-hidden="true"
+                                                  class="
+                                                    fix-instruction-color-box--HXJ1A
+                                                  "
+                                                  style="
+                                                    background-color: #e7ecd8;
+                                                  "
+                                                ></span
+                                                ><span
+                                                  >#e7ecd8 to meet a contrast
+                                                  ratio of 4.86:1.</span
+                                                ></li
+                                              ></ul
                                             ></li
                                           ></ul
                                         ></div
@@ -2317,76 +2287,61 @@
                                             insights-fix-instruction-list--1vUZj
                                           "
                                           ><li
-                                            ><span aria-hidden="true"
-                                              ><span
-                                                ><span
-                                                  >Element has insufficient
-                                                  color contrast of 2.52
-                                                  (foreground color:
-                                                  <span
-                                                    class="
-                                                      fix-instruction-color-box--HXJ1A
-                                                    "
-                                                    style="
-                                                      background-color: #8a94a8;
-                                                    "
-                                                  ></span
-                                                  >#8a94a8, background color:
-                                                  <span
-                                                    class="
-                                                      fix-instruction-color-box--HXJ1A
-                                                    "
-                                                    style="
-                                                      background-color: #e7ecd8;
-                                                    "
-                                                  ></span
-                                                  >#e7ecd8, font size: 12.0pt
-                                                  (16px), font weight: normal).
-                                                  Expected contrast ratio of
-                                                  4.5:1
-                                                </span></span
-                                              ><span
-                                                ><ul
-                                                  ><li
-                                                    ><span>
-                                                      Use foreground color:
-                                                      <span
-                                                        class="
-                                                          fix-instruction-color-box--HXJ1A
-                                                        "
-                                                        style="
-                                                          background-color: #5e6572;
-                                                        "
-                                                      ></span
-                                                      >#5e6572 and the original
-                                                      background color:
-                                                      <span
-                                                        class="
-                                                          fix-instruction-color-box--HXJ1A
-                                                        "
-                                                        style="
-                                                          background-color: #e7ecd8;
-                                                        "
-                                                      ></span
-                                                      >#e7ecd8 to meet a
-                                                      contrast ratio of
-                                                      4.86:1</span
-                                                    ></li
-                                                  ></ul
-                                                ></span
-                                              ></span
                                             ><span
-                                              class="screen-reader-only--1uWLQ"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
-                                              color: #8a94a8, background color:
-                                              #e7ecd8, font size: 12.0pt (16px),
-                                              font weight: normal). Expected
-                                              contrast ratio of 4.5:1 Use
-                                              foreground color: #5e6572 and the
-                                              original background color: #e7ecd8
-                                              to meet a contrast ratio of
-                                              4.86:1.</span
+                                              color: </span
+                                            ><span
+                                              aria-hidden="true"
+                                              class="
+                                                fix-instruction-color-box--HXJ1A
+                                              "
+                                              style="background-color: #8a94a8"
+                                            ></span
+                                            ><span
+                                              >#8a94a8, background color: </span
+                                            ><span
+                                              aria-hidden="true"
+                                              class="
+                                                fix-instruction-color-box--HXJ1A
+                                              "
+                                              style="background-color: #e7ecd8"
+                                            ></span
+                                            ><span
+                                              >#e7ecd8, font size: 12.0pt
+                                              (16px), font weight: normal).
+                                              Expected contrast ratio of
+                                              4.5:1</span
+                                            ><ul
+                                              ><li
+                                                ><span>
+                                                  Use foreground color: </span
+                                                ><span
+                                                  aria-hidden="true"
+                                                  class="
+                                                    fix-instruction-color-box--HXJ1A
+                                                  "
+                                                  style="
+                                                    background-color: #5e6572;
+                                                  "
+                                                ></span
+                                                ><span
+                                                  >#5e6572 and the original
+                                                  background color: </span
+                                                ><span
+                                                  aria-hidden="true"
+                                                  class="
+                                                    fix-instruction-color-box--HXJ1A
+                                                  "
+                                                  style="
+                                                    background-color: #e7ecd8;
+                                                  "
+                                                ></span
+                                                ><span
+                                                  >#e7ecd8 to meet a contrast
+                                                  ratio of 4.86:1.</span
+                                                ></li
+                                              ></ul
                                             ></li
                                           ></ul
                                         ></div
@@ -2430,76 +2385,61 @@
                                             insights-fix-instruction-list--1vUZj
                                           "
                                           ><li
-                                            ><span aria-hidden="true"
-                                              ><span
-                                                ><span
-                                                  >Element has insufficient
-                                                  color contrast of 2.52
-                                                  (foreground color:
-                                                  <span
-                                                    class="
-                                                      fix-instruction-color-box--HXJ1A
-                                                    "
-                                                    style="
-                                                      background-color: #8a94a8;
-                                                    "
-                                                  ></span
-                                                  >#8a94a8, background color:
-                                                  <span
-                                                    class="
-                                                      fix-instruction-color-box--HXJ1A
-                                                    "
-                                                    style="
-                                                      background-color: #e7ecd8;
-                                                    "
-                                                  ></span
-                                                  >#e7ecd8, font size: 12.0pt
-                                                  (16px), font weight: normal).
-                                                  Expected contrast ratio of
-                                                  4.5:1
-                                                </span></span
-                                              ><span
-                                                ><ul
-                                                  ><li
-                                                    ><span>
-                                                      Use foreground color:
-                                                      <span
-                                                        class="
-                                                          fix-instruction-color-box--HXJ1A
-                                                        "
-                                                        style="
-                                                          background-color: #5e6572;
-                                                        "
-                                                      ></span
-                                                      >#5e6572 and the original
-                                                      background color:
-                                                      <span
-                                                        class="
-                                                          fix-instruction-color-box--HXJ1A
-                                                        "
-                                                        style="
-                                                          background-color: #e7ecd8;
-                                                        "
-                                                      ></span
-                                                      >#e7ecd8 to meet a
-                                                      contrast ratio of
-                                                      4.86:1</span
-                                                    ></li
-                                                  ></ul
-                                                ></span
-                                              ></span
                                             ><span
-                                              class="screen-reader-only--1uWLQ"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
-                                              color: #8a94a8, background color:
-                                              #e7ecd8, font size: 12.0pt (16px),
-                                              font weight: normal). Expected
-                                              contrast ratio of 4.5:1 Use
-                                              foreground color: #5e6572 and the
-                                              original background color: #e7ecd8
-                                              to meet a contrast ratio of
-                                              4.86:1.</span
+                                              color: </span
+                                            ><span
+                                              aria-hidden="true"
+                                              class="
+                                                fix-instruction-color-box--HXJ1A
+                                              "
+                                              style="background-color: #8a94a8"
+                                            ></span
+                                            ><span
+                                              >#8a94a8, background color: </span
+                                            ><span
+                                              aria-hidden="true"
+                                              class="
+                                                fix-instruction-color-box--HXJ1A
+                                              "
+                                              style="background-color: #e7ecd8"
+                                            ></span
+                                            ><span
+                                              >#e7ecd8, font size: 12.0pt
+                                              (16px), font weight: normal).
+                                              Expected contrast ratio of
+                                              4.5:1</span
+                                            ><ul
+                                              ><li
+                                                ><span>
+                                                  Use foreground color: </span
+                                                ><span
+                                                  aria-hidden="true"
+                                                  class="
+                                                    fix-instruction-color-box--HXJ1A
+                                                  "
+                                                  style="
+                                                    background-color: #5e6572;
+                                                  "
+                                                ></span
+                                                ><span
+                                                  >#5e6572 and the original
+                                                  background color: </span
+                                                ><span
+                                                  aria-hidden="true"
+                                                  class="
+                                                    fix-instruction-color-box--HXJ1A
+                                                  "
+                                                  style="
+                                                    background-color: #e7ecd8;
+                                                  "
+                                                ></span
+                                                ><span
+                                                  >#e7ecd8 to meet a contrast
+                                                  ratio of 4.86:1.</span
+                                                ></li
+                                              ></ul
                                             ></li
                                           ></ul
                                         ></div

--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -2091,59 +2091,85 @@
                                             insights-fix-instruction-list--1vUZj
                                           "
                                           ><li
+                                            ><span aria-hidden="true"
+                                              ><span
+                                                >Element has insufficient color
+                                                contrast of 2.52 (foreground
+                                                color: </span
+                                              ><span
+                                                aria-hidden="true"
+                                                class="
+                                                  fix-instruction-color-box--HXJ1A
+                                                "
+                                                style="
+                                                  background-color: #8a94a8;
+                                                "
+                                              ></span
+                                              ><span
+                                                >#8a94a8, background color: </span
+                                              ><span
+                                                aria-hidden="true"
+                                                class="
+                                                  fix-instruction-color-box--HXJ1A
+                                                "
+                                                style="
+                                                  background-color: #e7ecd8;
+                                                "
+                                              ></span
+                                              ><span
+                                                >#e7ecd8, font size: 12.0pt
+                                                (16px), font weight: normal).
+                                                Expected contrast ratio of
+                                                4.5:1</span
+                                              ></span
                                             ><span
+                                              class="screen-reader-only--1uWLQ"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
-                                              color: </span
-                                            ><span
-                                              aria-hidden="true"
-                                              class="
-                                                fix-instruction-color-box--HXJ1A
-                                              "
-                                              style="background-color: #8a94a8"
-                                            ></span
-                                            ><span
-                                              >#8a94a8, background color: </span
-                                            ><span
-                                              aria-hidden="true"
-                                              class="
-                                                fix-instruction-color-box--HXJ1A
-                                              "
-                                              style="background-color: #e7ecd8"
-                                            ></span
-                                            ><span
-                                              >#e7ecd8, font size: 12.0pt
-                                              (16px), font weight: normal).
-                                              Expected contrast ratio of
-                                              4.5:1</span
+                                              color: #8a94a8, background color:
+                                              #e7ecd8, font size: 12.0pt (16px),
+                                              font weight: normal). Expected
+                                              contrast ratio of 4.5:1</span
                                             ><ul
                                               ><li
-                                                ><span>
-                                                  Use foreground color: </span
+                                                ><span aria-hidden="true"
+                                                  ><span>
+                                                    Use foreground color: </span
+                                                  ><span
+                                                    aria-hidden="true"
+                                                    class="
+                                                      fix-instruction-color-box--HXJ1A
+                                                    "
+                                                    style="
+                                                      background-color: #5e6572;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#5e6572 and the original
+                                                    background color: </span
+                                                  ><span
+                                                    aria-hidden="true"
+                                                    class="
+                                                      fix-instruction-color-box--HXJ1A
+                                                    "
+                                                    style="
+                                                      background-color: #e7ecd8;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#e7ecd8 to meet a contrast
+                                                    ratio of 4.86:1.</span
+                                                  ></span
                                                 ><span
-                                                  aria-hidden="true"
                                                   class="
-                                                    fix-instruction-color-box--HXJ1A
+                                                    screen-reader-only--1uWLQ
                                                   "
-                                                  style="
-                                                    background-color: #5e6572;
-                                                  "
-                                                ></span
-                                                ><span
-                                                  >#5e6572 and the original
-                                                  background color: </span
-                                                ><span
-                                                  aria-hidden="true"
-                                                  class="
-                                                    fix-instruction-color-box--HXJ1A
-                                                  "
-                                                  style="
-                                                    background-color: #e7ecd8;
-                                                  "
-                                                ></span
-                                                ><span
-                                                  >#e7ecd8 to meet a contrast
-                                                  ratio of 4.86:1.</span
+                                                >
+                                                  Use foreground color: #5e6572
+                                                  and the original background
+                                                  color: #e7ecd8 to meet a
+                                                  contrast ratio of
+                                                  4.86:1.</span
                                                 ></li
                                               ></ul
                                             ></li
@@ -2189,59 +2215,85 @@
                                             insights-fix-instruction-list--1vUZj
                                           "
                                           ><li
+                                            ><span aria-hidden="true"
+                                              ><span
+                                                >Element has insufficient color
+                                                contrast of 2.52 (foreground
+                                                color: </span
+                                              ><span
+                                                aria-hidden="true"
+                                                class="
+                                                  fix-instruction-color-box--HXJ1A
+                                                "
+                                                style="
+                                                  background-color: #8a94a8;
+                                                "
+                                              ></span
+                                              ><span
+                                                >#8a94a8, background color: </span
+                                              ><span
+                                                aria-hidden="true"
+                                                class="
+                                                  fix-instruction-color-box--HXJ1A
+                                                "
+                                                style="
+                                                  background-color: #e7ecd8;
+                                                "
+                                              ></span
+                                              ><span
+                                                >#e7ecd8, font size: 12.0pt
+                                                (16px), font weight: normal).
+                                                Expected contrast ratio of
+                                                4.5:1</span
+                                              ></span
                                             ><span
+                                              class="screen-reader-only--1uWLQ"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
-                                              color: </span
-                                            ><span
-                                              aria-hidden="true"
-                                              class="
-                                                fix-instruction-color-box--HXJ1A
-                                              "
-                                              style="background-color: #8a94a8"
-                                            ></span
-                                            ><span
-                                              >#8a94a8, background color: </span
-                                            ><span
-                                              aria-hidden="true"
-                                              class="
-                                                fix-instruction-color-box--HXJ1A
-                                              "
-                                              style="background-color: #e7ecd8"
-                                            ></span
-                                            ><span
-                                              >#e7ecd8, font size: 12.0pt
-                                              (16px), font weight: normal).
-                                              Expected contrast ratio of
-                                              4.5:1</span
+                                              color: #8a94a8, background color:
+                                              #e7ecd8, font size: 12.0pt (16px),
+                                              font weight: normal). Expected
+                                              contrast ratio of 4.5:1</span
                                             ><ul
                                               ><li
-                                                ><span>
-                                                  Use foreground color: </span
+                                                ><span aria-hidden="true"
+                                                  ><span>
+                                                    Use foreground color: </span
+                                                  ><span
+                                                    aria-hidden="true"
+                                                    class="
+                                                      fix-instruction-color-box--HXJ1A
+                                                    "
+                                                    style="
+                                                      background-color: #5e6572;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#5e6572 and the original
+                                                    background color: </span
+                                                  ><span
+                                                    aria-hidden="true"
+                                                    class="
+                                                      fix-instruction-color-box--HXJ1A
+                                                    "
+                                                    style="
+                                                      background-color: #e7ecd8;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#e7ecd8 to meet a contrast
+                                                    ratio of 4.86:1.</span
+                                                  ></span
                                                 ><span
-                                                  aria-hidden="true"
                                                   class="
-                                                    fix-instruction-color-box--HXJ1A
+                                                    screen-reader-only--1uWLQ
                                                   "
-                                                  style="
-                                                    background-color: #5e6572;
-                                                  "
-                                                ></span
-                                                ><span
-                                                  >#5e6572 and the original
-                                                  background color: </span
-                                                ><span
-                                                  aria-hidden="true"
-                                                  class="
-                                                    fix-instruction-color-box--HXJ1A
-                                                  "
-                                                  style="
-                                                    background-color: #e7ecd8;
-                                                  "
-                                                ></span
-                                                ><span
-                                                  >#e7ecd8 to meet a contrast
-                                                  ratio of 4.86:1.</span
+                                                >
+                                                  Use foreground color: #5e6572
+                                                  and the original background
+                                                  color: #e7ecd8 to meet a
+                                                  contrast ratio of
+                                                  4.86:1.</span
                                                 ></li
                                               ></ul
                                             ></li
@@ -2287,59 +2339,85 @@
                                             insights-fix-instruction-list--1vUZj
                                           "
                                           ><li
+                                            ><span aria-hidden="true"
+                                              ><span
+                                                >Element has insufficient color
+                                                contrast of 2.52 (foreground
+                                                color: </span
+                                              ><span
+                                                aria-hidden="true"
+                                                class="
+                                                  fix-instruction-color-box--HXJ1A
+                                                "
+                                                style="
+                                                  background-color: #8a94a8;
+                                                "
+                                              ></span
+                                              ><span
+                                                >#8a94a8, background color: </span
+                                              ><span
+                                                aria-hidden="true"
+                                                class="
+                                                  fix-instruction-color-box--HXJ1A
+                                                "
+                                                style="
+                                                  background-color: #e7ecd8;
+                                                "
+                                              ></span
+                                              ><span
+                                                >#e7ecd8, font size: 12.0pt
+                                                (16px), font weight: normal).
+                                                Expected contrast ratio of
+                                                4.5:1</span
+                                              ></span
                                             ><span
+                                              class="screen-reader-only--1uWLQ"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
-                                              color: </span
-                                            ><span
-                                              aria-hidden="true"
-                                              class="
-                                                fix-instruction-color-box--HXJ1A
-                                              "
-                                              style="background-color: #8a94a8"
-                                            ></span
-                                            ><span
-                                              >#8a94a8, background color: </span
-                                            ><span
-                                              aria-hidden="true"
-                                              class="
-                                                fix-instruction-color-box--HXJ1A
-                                              "
-                                              style="background-color: #e7ecd8"
-                                            ></span
-                                            ><span
-                                              >#e7ecd8, font size: 12.0pt
-                                              (16px), font weight: normal).
-                                              Expected contrast ratio of
-                                              4.5:1</span
+                                              color: #8a94a8, background color:
+                                              #e7ecd8, font size: 12.0pt (16px),
+                                              font weight: normal). Expected
+                                              contrast ratio of 4.5:1</span
                                             ><ul
                                               ><li
-                                                ><span>
-                                                  Use foreground color: </span
+                                                ><span aria-hidden="true"
+                                                  ><span>
+                                                    Use foreground color: </span
+                                                  ><span
+                                                    aria-hidden="true"
+                                                    class="
+                                                      fix-instruction-color-box--HXJ1A
+                                                    "
+                                                    style="
+                                                      background-color: #5e6572;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#5e6572 and the original
+                                                    background color: </span
+                                                  ><span
+                                                    aria-hidden="true"
+                                                    class="
+                                                      fix-instruction-color-box--HXJ1A
+                                                    "
+                                                    style="
+                                                      background-color: #e7ecd8;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#e7ecd8 to meet a contrast
+                                                    ratio of 4.86:1.</span
+                                                  ></span
                                                 ><span
-                                                  aria-hidden="true"
                                                   class="
-                                                    fix-instruction-color-box--HXJ1A
+                                                    screen-reader-only--1uWLQ
                                                   "
-                                                  style="
-                                                    background-color: #5e6572;
-                                                  "
-                                                ></span
-                                                ><span
-                                                  >#5e6572 and the original
-                                                  background color: </span
-                                                ><span
-                                                  aria-hidden="true"
-                                                  class="
-                                                    fix-instruction-color-box--HXJ1A
-                                                  "
-                                                  style="
-                                                    background-color: #e7ecd8;
-                                                  "
-                                                ></span
-                                                ><span
-                                                  >#e7ecd8 to meet a contrast
-                                                  ratio of 4.86:1.</span
+                                                >
+                                                  Use foreground color: #5e6572
+                                                  and the original background
+                                                  color: #e7ecd8 to meet a
+                                                  contrast ratio of
+                                                  4.86:1.</span
                                                 ></li
                                               ></ul
                                             ></li
@@ -2385,59 +2463,85 @@
                                             insights-fix-instruction-list--1vUZj
                                           "
                                           ><li
+                                            ><span aria-hidden="true"
+                                              ><span
+                                                >Element has insufficient color
+                                                contrast of 2.52 (foreground
+                                                color: </span
+                                              ><span
+                                                aria-hidden="true"
+                                                class="
+                                                  fix-instruction-color-box--HXJ1A
+                                                "
+                                                style="
+                                                  background-color: #8a94a8;
+                                                "
+                                              ></span
+                                              ><span
+                                                >#8a94a8, background color: </span
+                                              ><span
+                                                aria-hidden="true"
+                                                class="
+                                                  fix-instruction-color-box--HXJ1A
+                                                "
+                                                style="
+                                                  background-color: #e7ecd8;
+                                                "
+                                              ></span
+                                              ><span
+                                                >#e7ecd8, font size: 12.0pt
+                                                (16px), font weight: normal).
+                                                Expected contrast ratio of
+                                                4.5:1</span
+                                              ></span
                                             ><span
+                                              class="screen-reader-only--1uWLQ"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
-                                              color: </span
-                                            ><span
-                                              aria-hidden="true"
-                                              class="
-                                                fix-instruction-color-box--HXJ1A
-                                              "
-                                              style="background-color: #8a94a8"
-                                            ></span
-                                            ><span
-                                              >#8a94a8, background color: </span
-                                            ><span
-                                              aria-hidden="true"
-                                              class="
-                                                fix-instruction-color-box--HXJ1A
-                                              "
-                                              style="background-color: #e7ecd8"
-                                            ></span
-                                            ><span
-                                              >#e7ecd8, font size: 12.0pt
-                                              (16px), font weight: normal).
-                                              Expected contrast ratio of
-                                              4.5:1</span
+                                              color: #8a94a8, background color:
+                                              #e7ecd8, font size: 12.0pt (16px),
+                                              font weight: normal). Expected
+                                              contrast ratio of 4.5:1</span
                                             ><ul
                                               ><li
-                                                ><span>
-                                                  Use foreground color: </span
+                                                ><span aria-hidden="true"
+                                                  ><span>
+                                                    Use foreground color: </span
+                                                  ><span
+                                                    aria-hidden="true"
+                                                    class="
+                                                      fix-instruction-color-box--HXJ1A
+                                                    "
+                                                    style="
+                                                      background-color: #5e6572;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#5e6572 and the original
+                                                    background color: </span
+                                                  ><span
+                                                    aria-hidden="true"
+                                                    class="
+                                                      fix-instruction-color-box--HXJ1A
+                                                    "
+                                                    style="
+                                                      background-color: #e7ecd8;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#e7ecd8 to meet a contrast
+                                                    ratio of 4.86:1.</span
+                                                  ></span
                                                 ><span
-                                                  aria-hidden="true"
                                                   class="
-                                                    fix-instruction-color-box--HXJ1A
+                                                    screen-reader-only--1uWLQ
                                                   "
-                                                  style="
-                                                    background-color: #5e6572;
-                                                  "
-                                                ></span
-                                                ><span
-                                                  >#5e6572 and the original
-                                                  background color: </span
-                                                ><span
-                                                  aria-hidden="true"
-                                                  class="
-                                                    fix-instruction-color-box--HXJ1A
-                                                  "
-                                                  style="
-                                                    background-color: #e7ecd8;
-                                                  "
-                                                ></span
-                                                ><span
-                                                  >#e7ecd8 to meet a contrast
-                                                  ratio of 4.86:1.</span
+                                                >
+                                                  Use foreground color: #5e6572
+                                                  and the original background
+                                                  color: #e7ecd8 to meet a
+                                                  contrast ratio of
+                                                  4.86:1.</span
                                                 ></li
                                               ></ul
                                             ></li

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -2394,64 +2394,90 @@
                                                 insights-fix-instruction-list--1vUZj
                                               "
                                               ><li
+                                                ><span aria-hidden="true"
+                                                  ><span
+                                                    >Element has insufficient
+                                                    color contrast of 2.52
+                                                    (foreground color: </span
+                                                  ><span
+                                                    aria-hidden="true"
+                                                    class="
+                                                      fix-instruction-color-box--HXJ1A
+                                                    "
+                                                    style="
+                                                      background-color: #8a94a8;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#8a94a8, background color: </span
+                                                  ><span
+                                                    aria-hidden="true"
+                                                    class="
+                                                      fix-instruction-color-box--HXJ1A
+                                                    "
+                                                    style="
+                                                      background-color: #e7ecd8;
+                                                    "
+                                                  ></span
+                                                  ><span
+                                                    >#e7ecd8, font size: 12.0pt
+                                                    (16px), font weight:
+                                                    normal). Expected contrast
+                                                    ratio of 4.5:1</span
+                                                  ></span
                                                 ><span
+                                                  class="
+                                                    screen-reader-only--1uWLQ
+                                                  "
                                                   >Element has insufficient
                                                   color contrast of 2.52
-                                                  (foreground color: </span
-                                                ><span
-                                                  aria-hidden="true"
-                                                  class="
-                                                    fix-instruction-color-box--HXJ1A
-                                                  "
-                                                  style="
-                                                    background-color: #8a94a8;
-                                                  "
-                                                ></span
-                                                ><span
-                                                  >#8a94a8, background color: </span
-                                                ><span
-                                                  aria-hidden="true"
-                                                  class="
-                                                    fix-instruction-color-box--HXJ1A
-                                                  "
-                                                  style="
-                                                    background-color: #e7ecd8;
-                                                  "
-                                                ></span
-                                                ><span
-                                                  >#e7ecd8, font size: 12.0pt
-                                                  (16px), font weight: normal).
-                                                  Expected contrast ratio of
-                                                  4.5:1</span
+                                                  (foreground color: #8a94a8,
+                                                  background color: #e7ecd8,
+                                                  font size: 12.0pt (16px), font
+                                                  weight: normal). Expected
+                                                  contrast ratio of 4.5:1</span
                                                 ><ul
                                                   ><li
-                                                    ><span>
-                                                      Use foreground color: </span
+                                                    ><span aria-hidden="true"
+                                                      ><span>
+                                                        Use foreground color: </span
+                                                      ><span
+                                                        aria-hidden="true"
+                                                        class="
+                                                          fix-instruction-color-box--HXJ1A
+                                                        "
+                                                        style="
+                                                          background-color: #5e6572;
+                                                        "
+                                                      ></span
+                                                      ><span
+                                                        >#5e6572 and the
+                                                        original background
+                                                        color: </span
+                                                      ><span
+                                                        aria-hidden="true"
+                                                        class="
+                                                          fix-instruction-color-box--HXJ1A
+                                                        "
+                                                        style="
+                                                          background-color: #e7ecd8;
+                                                        "
+                                                      ></span
+                                                      ><span
+                                                        >#e7ecd8 to meet a
+                                                        contrast ratio of
+                                                        4.86:1.</span
+                                                      ></span
                                                     ><span
-                                                      aria-hidden="true"
                                                       class="
-                                                        fix-instruction-color-box--HXJ1A
+                                                        screen-reader-only--1uWLQ
                                                       "
-                                                      style="
-                                                        background-color: #5e6572;
-                                                      "
-                                                    ></span
-                                                    ><span
-                                                      >#5e6572 and the original
-                                                      background color: </span
-                                                    ><span
-                                                      aria-hidden="true"
-                                                      class="
-                                                        fix-instruction-color-box--HXJ1A
-                                                      "
-                                                      style="
-                                                        background-color: #e7ecd8;
-                                                      "
-                                                    ></span
-                                                    ><span
-                                                      >#e7ecd8 to meet a
-                                                      contrast ratio of
-                                                      4.86:1.</span
+                                                    >
+                                                      Use foreground color:
+                                                      #5e6572 and the original
+                                                      background color: #e7ecd8
+                                                      to meet a contrast ratio
+                                                      of 4.86:1.</span
                                                     ></li
                                                   ></ul
                                                 ></li

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -2394,81 +2394,66 @@
                                                 insights-fix-instruction-list--1vUZj
                                               "
                                               ><li
-                                                ><span aria-hidden="true"
-                                                  ><span
-                                                    ><span
-                                                      >Element has insufficient
-                                                      color contrast of 2.52
-                                                      (foreground color:
-                                                      <span
-                                                        class="
-                                                          fix-instruction-color-box--HXJ1A
-                                                        "
-                                                        style="
-                                                          background-color: #8a94a8;
-                                                        "
-                                                      ></span
-                                                      >#8a94a8, background
-                                                      color:
-                                                      <span
-                                                        class="
-                                                          fix-instruction-color-box--HXJ1A
-                                                        "
-                                                        style="
-                                                          background-color: #e7ecd8;
-                                                        "
-                                                      ></span
-                                                      >#e7ecd8, font size:
-                                                      12.0pt (16px), font
-                                                      weight: normal). Expected
-                                                      contrast ratio of 4.5:1
-                                                    </span></span
-                                                  ><span
-                                                    ><ul
-                                                      ><li
-                                                        ><span>
-                                                          Use foreground color:
-                                                          <span
-                                                            class="
-                                                              fix-instruction-color-box--HXJ1A
-                                                            "
-                                                            style="
-                                                              background-color: #5e6572;
-                                                            "
-                                                          ></span
-                                                          >#5e6572 and the
-                                                          original background
-                                                          color:
-                                                          <span
-                                                            class="
-                                                              fix-instruction-color-box--HXJ1A
-                                                            "
-                                                            style="
-                                                              background-color: #e7ecd8;
-                                                            "
-                                                          ></span
-                                                          >#e7ecd8 to meet a
-                                                          contrast ratio of
-                                                          4.86:1</span
-                                                        ></li
-                                                      ></ul
-                                                    ></span
-                                                  ></span
                                                 ><span
-                                                  class="
-                                                    screen-reader-only--1uWLQ
-                                                  "
                                                   >Element has insufficient
                                                   color contrast of 2.52
-                                                  (foreground color: #8a94a8,
-                                                  background color: #e7ecd8,
-                                                  font size: 12.0pt (16px), font
-                                                  weight: normal). Expected
-                                                  contrast ratio of 4.5:1 Use
-                                                  foreground color: #5e6572 and
-                                                  the original background color:
-                                                  #e7ecd8 to meet a contrast
-                                                  ratio of 4.86:1.</span
+                                                  (foreground color: </span
+                                                ><span
+                                                  aria-hidden="true"
+                                                  class="
+                                                    fix-instruction-color-box--HXJ1A
+                                                  "
+                                                  style="
+                                                    background-color: #8a94a8;
+                                                  "
+                                                ></span
+                                                ><span
+                                                  >#8a94a8, background color: </span
+                                                ><span
+                                                  aria-hidden="true"
+                                                  class="
+                                                    fix-instruction-color-box--HXJ1A
+                                                  "
+                                                  style="
+                                                    background-color: #e7ecd8;
+                                                  "
+                                                ></span
+                                                ><span
+                                                  >#e7ecd8, font size: 12.0pt
+                                                  (16px), font weight: normal).
+                                                  Expected contrast ratio of
+                                                  4.5:1</span
+                                                ><ul
+                                                  ><li
+                                                    ><span>
+                                                      Use foreground color: </span
+                                                    ><span
+                                                      aria-hidden="true"
+                                                      class="
+                                                        fix-instruction-color-box--HXJ1A
+                                                      "
+                                                      style="
+                                                        background-color: #5e6572;
+                                                      "
+                                                    ></span
+                                                    ><span
+                                                      >#5e6572 and the original
+                                                      background color: </span
+                                                    ><span
+                                                      aria-hidden="true"
+                                                      class="
+                                                        fix-instruction-color-box--HXJ1A
+                                                      "
+                                                      style="
+                                                        background-color: #e7ecd8;
+                                                      "
+                                                    ></span
+                                                    ><span
+                                                      >#e7ecd8 to meet a
+                                                      contrast ratio of
+                                                      4.86:1.</span
+                                                    ></li
+                                                  ></ul
                                                 ></li
                                               ></ul
                                             ></div

--- a/src/common/components/fix-instruction-processor.tsx
+++ b/src/common/components/fix-instruction-processor.tsx
@@ -26,37 +26,45 @@ export class FixInstructionProcessor {
     );
 
     private readonly foregroundRecommendedColorText = 'Use foreground color: ';
+    // eslint-disable-next-line security/detect-non-literal-regexp
     private readonly foregroundRecommendedRegExp = new RegExp(
         `${this.foregroundRecommendedColorText}${this.colorValueMatcher}`,
         'i',
     );
     private readonly backgroundRecommendedColorText = 'Use background color: ';
+    // eslint-disable-next-line security/detect-non-literal-regexp
     private readonly backgroundRecommendedRegExp = new RegExp(
         `${this.backgroundRecommendedColorText}${this.colorValueMatcher}`,
         'i',
     );
 
     private readonly contrastRatioText = 'Expected contrast ratio of ';
+    // eslint-disable-next-line security/detect-non-literal-regexp
     private readonly contrastRatioRegExp = new RegExp(`${this.contrastRatioText}`, 'i');
     private readonly originalMiddleSentence = ' and the original foreground color: ';
 
-    private readonly recommendEndSentence = ' to meet a contrast ratio of #.##:1';
-
-    public process(fixInstruction: string, recommendation: RecommendColor): JSX.Element {
+    public process(fixInstruction: string, recommendColor: RecommendColor): JSX.Element {
         const matches = this.getColorMatches(fixInstruction);
 
+        let recommendationSentences: string[] = [];
         if (matches.length === 2 && fixInstruction != null) {
-            fixInstruction = this.getColorRecommendation(fixInstruction, matches, recommendation);
+            recommendationSentences = this.getColorRecommendations(
+                fixInstruction,
+                matches,
+                recommendColor,
+            );
         }
-        return this.splitFixInstruction(fixInstruction, matches);
+        return this.splitFixInstruction(fixInstruction, recommendationSentences, matches);
     }
 
-    private getColorRecommendation(
+    private getColorRecommendations(
         fixInstruction: string,
         matches: ColorMatch[],
-        recommendation: RecommendColor,
+        recommendColor: RecommendColor,
     ) {
+        const sentenceDivider = '. ';
         let contrastRatio: number = 4.5;
+
         const regularExpExpectation = this.contrastRatioRegExp.exec(fixInstruction);
         if (regularExpExpectation != null) {
             const indexContrast = regularExpExpectation.index;
@@ -66,16 +74,21 @@ export class FixInstructionProcessor {
             contrastRatio = parseFloat(contrastIndex.substring(0, contrastIndex.indexOf(':')));
         }
 
-        if (recommendation.sentence !== 'Color suggestion text') {
-            fixInstruction += recommendation.getRecommendColor(
-                matches[0].colorHexValue,
-                matches[1].colorHexValue,
-                contrastRatio,
-            );
-            this.getRecommendedColorMatches(fixInstruction, matches);
+        const recommendSentence = recommendColor.getRecommendColor(
+            matches[0].colorHexValue,
+            matches[1].colorHexValue,
+            contrastRatio,
+        );
+
+        const recommendationSentences = recommendSentence.split(sentenceDivider);
+
+        this.getRecommendedColorMatches(recommendationSentences[0], matches);
+        if (recommendationSentences.length === 1) {
+            return recommendationSentences;
         }
 
-        return fixInstruction;
+        this.getRecommendedColorMatches(recommendationSentences[1], matches);
+        return recommendationSentences;
     }
 
     private getColorMatches(fixInstruction: string): ColorMatch[] {
@@ -143,130 +156,80 @@ export class FixInstructionProcessor {
         };
     }
 
-    private splitFixInstruction(fixInstruction: string, matches: ColorMatch[]): JSX.Element {
-        const sortedMatches = matches.sort((a, b) => a.splitIndex - b.splitIndex);
-        if (sortedMatches.length === 0) {
+    private splitFixInstruction(
+        fixInstruction: string,
+        recommendationStrings: string[],
+        matches: ColorMatch[],
+    ): JSX.Element {
+        if (matches.length === 0) {
             return <>{fixInstruction}</>;
         }
 
-        const insertionIndex = 0;
-        const keyIndex = 0;
+        const recommendations: JSX.Element[][] = [];
+        const howToFixMatches = matches.slice(0, 2);
+        const recommendationMatches = matches.slice(2);
 
-        const result: JSX.Element[] = [];
-        if (matches.length >= 2) {
-            this.bulletAndColorBoxOutput(
-                sortedMatches,
-                fixInstruction,
-                insertionIndex,
-                result,
-                keyIndex,
+        const results = this.getInstructionWithBoxes(howToFixMatches, fixInstruction);
+
+        if (recommendationStrings.length === 0) {
+            return <>{results}</>;
+        }
+
+        const recommendationOne = this.getInstructionWithBoxes(
+            recommendationMatches.slice(0, 2),
+            recommendationStrings[0],
+        );
+
+        recommendations.push(recommendationOne);
+
+        if (recommendationStrings.length > 1) {
+            const recommendationTwo = this.getInstructionWithBoxes(
+                recommendationMatches.slice(2),
+                recommendationStrings[1],
             );
+            recommendations.push(recommendationTwo);
         }
 
-        return (
-            <>
-                <span aria-hidden="true">{result}</span>
-                <span className={styles.screenReaderOnly}>{fixInstruction}</span>
-            </>
+        this.addRecommendationsToResults(results, recommendations);
+
+        return <>{results}</>;
+    }
+
+    private addRecommendationsToResults(results: JSX.Element[], recommendations: JSX.Element[][]) {
+        results.push(
+            <ul key="recommendations-list">
+                {recommendations.map((rec, idx) => (
+                    <li key={`recommendation-${idx}`}>{rec}</li>
+                ))}
+            </ul>,
         );
     }
 
-    private bulletAndColorBoxOutput(
-        sortedMatches: ColorMatch[],
-        fixInstruction: string,
-        insertionIndex: number,
-        result: JSX.Element[],
-        keyIndex: number,
-    ) {
-        for (let i: number = 0; i < sortedMatches.length; i++) {
-            const match: ColorMatch = sortedMatches[i];
-            if (i === 0) {
-                insertionIndex = 0;
-            } else {
-                insertionIndex =
-                    match.splitIndex -
-                    this.foregroundRecommendedColorText.length -
-                    match.colorHexValue.length -
-                    1;
-                if (i > 2) {
-                    insertionIndex -= 3;
-                }
-            }
-            let colorEndIndex = match.splitIndex - match.colorHexValue.length;
-            const beforeColorBox = fixInstruction.substring(insertionIndex, colorEndIndex);
-            insertionIndex = colorEndIndex;
-            i++;
-            colorEndIndex = sortedMatches[i].splitIndex - match.colorHexValue.length;
-            const middleSubstring = fixInstruction.substring(insertionIndex, colorEndIndex);
-            insertionIndex = colorEndIndex;
-            let endSubstring = '';
-            if (i === 1) {
-                endSubstring = fixInstruction.substring(
-                    insertionIndex,
-                    fixInstruction.indexOf(this.contrastRatioText) +
-                        this.contrastRatioText.length +
-                        6,
-                );
-                result.push(
-                    <span key={`instruction-split-${keyIndex++}`}>
-                        {this.addBulletPoint(
-                            keyIndex,
-                            beforeColorBox,
-                            match,
-                            middleSubstring,
-                            sortedMatches,
-                            i,
-                            endSubstring,
-                        )}
-                    </span>,
-                );
-            } else {
-                colorEndIndex = sortedMatches[i].splitIndex + this.recommendEndSentence.length;
-                endSubstring = fixInstruction.substring(insertionIndex, colorEndIndex);
-                result.push(
-                    <span key={`instruction-split-${keyIndex++}`}>
-                        <ul key={`instruction-split-${keyIndex++}`}>
-                            <li key={`instruction-split-${keyIndex++}`}>
-                                {this.addBulletPoint(
-                                    keyIndex,
-                                    beforeColorBox,
-                                    match,
-                                    middleSubstring,
-                                    sortedMatches,
-                                    i,
-                                    endSubstring,
-                                )}
-                            </li>
-                        </ul>
-                    </span>,
-                );
-            }
-        }
-    }
+    private getInstructionWithBoxes(matches: ColorMatch[], fixInstruction: string) {
+        let insertionIndex = 0;
+        let keyIndex = 0;
+        const result: JSX.Element[] = [];
 
-    private addBulletPoint(
-        keyIndex: number,
-        beforeColorBox: string,
-        match: ColorMatch,
-        middleSubstring: string,
-        sortedMatches: ColorMatch[],
-        i: number,
-        endSubstring: string,
-    ): JSX.Element {
-        return (
-            <span key={`instruction-split-${keyIndex++}`}>
-                {beforeColorBox}
-                {this.createColorBox(match.colorHexValue, keyIndex++)}
-                {middleSubstring}
-                {this.createColorBox(sortedMatches[i].colorHexValue, keyIndex++)}
-                {endSubstring}
-            </span>
-        );
+        matches.forEach(match => {
+            const endIndex = match.splitIndex - match.colorHexValue.length;
+            const substring = fixInstruction.substring(insertionIndex, endIndex);
+
+            result.push(<span key={`instruction-split-${keyIndex++}`}>{substring}</span>);
+            result.push(this.createColorBox(match.colorHexValue, keyIndex++));
+
+            insertionIndex = endIndex;
+        });
+
+        const coda = fixInstruction.substr(insertionIndex);
+
+        result.push(<span key={`instruction-split-${keyIndex++}`}>{coda}</span>);
+        return result;
     }
 
     private createColorBox(colorHexValue: string, keyIndex: number): JSX.Element {
         return (
             <span
+                aria-hidden={true}
                 key={`instruction-split-${keyIndex}`}
                 className={styles.fixInstructionColorBox}
                 style={{ backgroundColor: colorHexValue }}

--- a/src/common/components/fix-instruction-processor.tsx
+++ b/src/common/components/fix-instruction-processor.tsx
@@ -165,17 +165,17 @@ export class FixInstructionProcessor {
             return <>{fixInstruction}</>;
         }
 
-        const recommendations: JSX.Element[][] = [];
+        const recommendations: JSX.Element[] = [];
         const howToFixMatches = matches.slice(0, 2);
         const recommendationMatches = matches.slice(2);
 
-        const results = this.getInstructionWithBoxes(howToFixMatches, fixInstruction);
+        const results = this.getInstructionWithAndWithoutBoxes(howToFixMatches, fixInstruction);
 
         if (recommendationStrings.length === 0) {
             return <>{results}</>;
         }
 
-        const recommendationOne = this.getInstructionWithBoxes(
+        const recommendationOne = this.getInstructionWithAndWithoutBoxes(
             recommendationMatches.slice(0, 2),
             recommendationStrings[0],
         );
@@ -183,25 +183,26 @@ export class FixInstructionProcessor {
         recommendations.push(recommendationOne);
 
         if (recommendationStrings.length > 1) {
-            const recommendationTwo = this.getInstructionWithBoxes(
+            const recommendationTwo = this.getInstructionWithAndWithoutBoxes(
                 recommendationMatches.slice(2),
                 recommendationStrings[1],
             );
             recommendations.push(recommendationTwo);
         }
 
-        this.addRecommendationsToResults(results, recommendations);
-
-        return <>{results}</>;
+        return this.addRecommendationsToResults(results, recommendations);
     }
 
-    private addRecommendationsToResults(results: JSX.Element[], recommendations: JSX.Element[][]) {
-        results.push(
-            <ul key="recommendations-list">
-                {recommendations.map((rec, idx) => (
-                    <li key={`recommendation-${idx}`}>{rec}</li>
-                ))}
-            </ul>,
+    private addRecommendationsToResults(results: JSX.Element, recommendations: JSX.Element[]) {
+        return (
+            <>
+                {results}
+                <ul key="recommendations-list">
+                    {recommendations.map((rec, idx) => (
+                        <li key={`recommendation-${idx}`}>{rec}</li>
+                    ))}
+                </ul>
+            </>
         );
     }
 
@@ -224,6 +225,18 @@ export class FixInstructionProcessor {
 
         result.push(<span key={`instruction-split-${keyIndex++}`}>{coda}</span>);
         return result;
+    }
+
+    private getInstructionWithAndWithoutBoxes(matches: ColorMatch[], fixInstruction: string) {
+        // this is necessary to ensure Narrator reads the instruction without pauses
+        return (
+            <>
+                <span aria-hidden="true">
+                    {this.getInstructionWithBoxes(matches, fixInstruction)}
+                </span>
+                <span className={styles.screenReaderOnly}>{fixInstruction}</span>
+            </>
+        );
     }
 
     private createColorBox(colorHexValue: string, keyIndex: number): JSX.Element {

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-fix-card-row.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-fix-card-row.test.tsx.snap
@@ -35,7 +35,6 @@ exports[`HowToFixWebCardRow renders 1`] = `
               "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
               "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
               "originalMiddleSentence": " and the original foreground color: ",
-              "recommendEndSentence": " to meet a contrast ratio of #.##:1",
             },
             "recommendColor": Object {},
           }
@@ -68,7 +67,6 @@ exports[`HowToFixWebCardRow renders 1`] = `
               "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
               "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
               "originalMiddleSentence": " and the original foreground color: ",
-              "recommendEndSentence": " to meet a contrast ratio of #.##:1",
             },
             "recommendColor": Object {},
           }

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
@@ -31,7 +31,6 @@ exports[`RulesWithInstances renders 1`] = `
             "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
             "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
             "originalMiddleSentence": " and the original foreground color: ",
-            "recommendEndSentence": " to meet a contrast ratio of #.##:1",
           }
         }
         rule={

--- a/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
@@ -2,100 +2,98 @@
 
 exports[`FixInstructionProcessor background and foreground on the message (mind the order) 1`] = `
 <React.Fragment>
-  <span
-    aria-hidden="true"
-  >
-    <span>
-      <span>
-        Element has insufficient color contrast of 2.52 (background color: 
-        <span
-          className="fixInstructionColorBox"
-          style={
-            Object {
-              "backgroundColor": "#8a94a8",
-            }
-          }
-        />
-        #8a94a8, foreground color: 
-        <span
-          className="fixInstructionColorBox"
-          style={
-            Object {
-              "backgroundColor": "#e7ecd8",
-            }
-          }
-        />
-        #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
-      </span>
-    </span>
+  <span>
+    Element has insufficient color contrast of 2.52 (background color: #8a94a8, foreground color: 
   </span>
   <span
-    className="screenReaderOnly"
-  >
-    Element has insufficient color contrast of 2.52 (background color: #8a94a8, foreground color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
-  </span>
-</React.Fragment>
-`;
-
-exports[`FixInstructionProcessor background color on the message 1`] = `
-<React.Fragment>
-  <span
-    aria-hidden="true"
+    aria-hidden={true}
+    className="fixInstructionColorBox"
+    style={
+      Object {
+        "backgroundColor": "#e7ecd8",
+      }
+    }
   />
-  <span
-    className="screenReaderOnly"
-  >
-    color contrast of 2.52 (background color: #8a94a8; nothing else to match here)
+  <span>
+    #8a94a8, foreground color: 
   </span>
+  <span
+    aria-hidden={true}
+    className="fixInstructionColorBox"
+    style={
+      Object {
+        "backgroundColor": "#8a94a8",
+      }
+    }
+  />
+  <span>
+    #8a94a8, foreground color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+  </span>
+  <ul>
+    <li>
+      <span>
+        test return value
+      </span>
+    </li>
+  </ul>
 </React.Fragment>
 `;
 
 exports[`FixInstructionProcessor foreground and background color on the message (mind the order) 1`] = `
 <React.Fragment>
+  <span>
+    Element has insufficient color contrast of 2.52 (foreground color: 
+  </span>
   <span
-    aria-hidden="true"
-  >
-    <span>
+    aria-hidden={true}
+    className="fixInstructionColorBox"
+    style={
+      Object {
+        "backgroundColor": "#8a94a8",
+      }
+    }
+  />
+  <span>
+    #8a94a8, background color: 
+  </span>
+  <span
+    aria-hidden={true}
+    className="fixInstructionColorBox"
+    style={
+      Object {
+        "backgroundColor": "#e7ecd8",
+      }
+    }
+  />
+  <span>
+    #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+  </span>
+  <ul>
+    <li>
       <span>
-        Element has insufficient color contrast of 2.52 (foreground color: 
-        <span
-          className="fixInstructionColorBox"
-          style={
-            Object {
-              "backgroundColor": "#8a94a8",
-            }
-          }
-        />
-        #8a94a8, background color: 
-        <span
-          className="fixInstructionColorBox"
-          style={
-            Object {
-              "backgroundColor": "#e7ecd8",
-            }
-          }
-        />
-        #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+        test return value
       </span>
-    </span>
-  </span>
-  <span
-    className="screenReaderOnly"
-  >
-    Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
-  </span>
+    </li>
+  </ul>
 </React.Fragment>
 `;
 
 exports[`FixInstructionProcessor foreground color on the message 1`] = `
 <React.Fragment>
+  <span>
+    color contrast of 2.52 (foreground color: 
+  </span>
   <span
-    aria-hidden="true"
+    aria-hidden={true}
+    className="fixInstructionColorBox"
+    style={
+      Object {
+        "backgroundColor": "#8a94a8",
+      }
+    }
   />
-  <span
-    className="screenReaderOnly"
-  >
-    color contrast of 2.52 (foreground color: #8a94a8; nothing else to match here)
+  <span>
+    #8a94a8; nothing else to match here)
   </span>
 </React.Fragment>
 `;
@@ -106,131 +104,197 @@ exports[`FixInstructionProcessor no background nor foreground on the message 1`]
 </React.Fragment>
 `;
 
-exports[`FixInstructionProcessor recommendColor non-stub 1`] = `
+exports[`FixInstructionProcessor recommendColor has one recommendation 1`] = `
 <React.Fragment>
+  <span>
+    Element has insufficient color contrast of 4.48 (foreground color: 
+  </span>
   <span
-    aria-hidden="true"
-  >
-    <span>
+    aria-hidden={true}
+    className="fixInstructionColorBox"
+    style={
+      Object {
+        "backgroundColor": "#fefefe",
+      }
+    }
+  />
+  <span>
+    #fefefe, background color: 
+  </span>
+  <span
+    aria-hidden={true}
+    className="fixInstructionColorBox"
+    style={
+      Object {
+        "backgroundColor": "#21809d",
+      }
+    }
+  />
+  <span>
+    #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1
+  </span>
+  <ul>
+    <li>
       <span>
-        Element has insufficient color contrast of 4.48 (foreground color: 
-        <span
-          className="fixInstructionColorBox"
-          style={
-            Object {
-              "backgroundColor": "#fefefe",
-            }
-          }
-        />
-        #fefefe, background color: 
-        <span
-          className="fixInstructionColorBox"
-          style={
-            Object {
-              "backgroundColor": "#21809d",
-            }
-          }
-        />
-        #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1U
+        Use foreground color: 
       </span>
-    </span>
-    <span>
-      <ul>
-        <li>
-          <span>
-            1Use foreground color: 
-            <span
-              className="fixInstructionColorBox"
-              style={
-                Object {
-                  "backgroundColor": "#ffffff",
-                }
-              }
-            />
-            #ffffff and the original background color: 
-            <span
-              className="fixInstructionColorBox"
-              style={
-                Object {
-                  "backgroundColor": "#21809d",
-                }
-              }
-            />
-            #21809d to meet a contrast ratio of 4.53:1
-          </span>
-        </li>
-      </ul>
-    </span>
-    <span>
-      <ul>
-        <li>
-          <span>
-             Or use background color: 
-            <span
-              className="fixInstructionColorBox"
-              style={
-                Object {
-                  "backgroundColor": "#1f7995",
-                }
-              }
-            />
-            #1f7995 and the original foreground color: 
-            <span
-              className="fixInstructionColorBox"
-              style={
-                Object {
-                  "backgroundColor": "#fcfcfc",
-                }
-              }
-            />
-            #fcfcfc to meet a contrast ratio of 4.84:1
-          </span>
-        </li>
-      </ul>
-    </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#ffffff",
+          }
+        }
+      />
+      <span>
+        #ffffff and the original background color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#21809d",
+          }
+        }
+      />
+      <span>
+        #21809d to meet a contrast ratio of 4.53:1
+      </span>
+    </li>
+    <li>
+      <span>
+        Or use background color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#1f7995",
+          }
+        }
+      />
+      <span>
+        #1f7995 and the original foreground color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#fcfcfc",
+          }
+        }
+      />
+      <span>
+        #fcfcfc to meet a contrast ratio of 4.84:1.
+      </span>
+    </li>
+  </ul>
+</React.Fragment>
+`;
+
+exports[`FixInstructionProcessor recommendColor has two recommendations 1`] = `
+<React.Fragment>
+  <span>
+    Element has insufficient color contrast of 4.48 (foreground color: 
   </span>
   <span
-    className="screenReaderOnly"
-  >
-    Element has insufficient color contrast of 4.48 (foreground color: #fefefe, background color: #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1Use foreground color: #ffffff and the original background color: #21809d to meet a contrast ratio of 4.53:1. Or use background color: #1f7995 and the original foreground color: #fcfcfc to meet a contrast ratio of 4.84:1.
+    aria-hidden={true}
+    className="fixInstructionColorBox"
+    style={
+      Object {
+        "backgroundColor": "#fefefe",
+      }
+    }
+  />
+  <span>
+    #fefefe, background color: 
   </span>
+  <span
+    aria-hidden={true}
+    className="fixInstructionColorBox"
+    style={
+      Object {
+        "backgroundColor": "#21809d",
+      }
+    }
+  />
+  <span>
+    #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1
+  </span>
+  <ul>
+    <li>
+      <span>
+        Use foreground color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#ffffff",
+          }
+        }
+      />
+      <span>
+        #ffffff and the original background color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#21809d",
+          }
+        }
+      />
+      <span>
+        #21809d to meet a contrast ratio of 4.53:1.
+      </span>
+    </li>
+  </ul>
 </React.Fragment>
 `;
 
 exports[`FixInstructionProcessor we assume only one instance of fore/background color, second instance will be ignored 1`] = `
 <React.Fragment>
+  <span>
+    first foreground color: 
+  </span>
   <span
-    aria-hidden="true"
-  >
-    <span>
+    aria-hidden={true}
+    className="fixInstructionColorBox"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  />
+  <span>
+    #ffffff, second foreground: #000000, first background color: 
+  </span>
+  <span
+    aria-hidden={true}
+    className="fixInstructionColorBox"
+    style={
+      Object {
+        "backgroundColor": "#AAAAAA",
+      }
+    }
+  />
+  <span>
+    #AAAAAA, second background color: #bbBBbb
+  </span>
+  <ul>
+    <li>
       <span>
-        first foreground color: 
-        <span
-          className="fixInstructionColorBox"
-          style={
-            Object {
-              "backgroundColor": "#ffffff",
-            }
-          }
-        />
-        #ffffff, second foreground: #000000, first background color: 
-        <span
-          className="fixInstructionColorBox"
-          style={
-            Object {
-              "backgroundColor": "#AAAAAA",
-            }
-          }
-        />
-         second foreground: #000000, first background color: 
+        test return value
       </span>
-    </span>
-  </span>
-  <span
-    className="screenReaderOnly"
-  >
-    first foreground color: #ffffff, second foreground: #000000, first background color: #AAAAAA, second background color: #bbBBbb
-  </span>
+    </li>
+  </ul>
 </React.Fragment>
 `;
 

--- a/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
@@ -2,38 +2,60 @@
 
 exports[`FixInstructionProcessor background and foreground on the message (mind the order) 1`] = `
 <React.Fragment>
-  <span>
-    Element has insufficient color contrast of 2.52 (background color: #8a94a8, foreground color: 
-  </span>
-  <span
-    aria-hidden={true}
-    className="fixInstructionColorBox"
-    style={
-      Object {
-        "backgroundColor": "#e7ecd8",
-      }
-    }
-  />
-  <span>
-    #8a94a8, foreground color: 
-  </span>
-  <span
-    aria-hidden={true}
-    className="fixInstructionColorBox"
-    style={
-      Object {
-        "backgroundColor": "#8a94a8",
-      }
-    }
-  />
-  <span>
-    #8a94a8, foreground color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
-  </span>
+  <React.Fragment>
+    <span
+      aria-hidden="true"
+    >
+      <span>
+        Element has insufficient color contrast of 2.52 (background color: #8a94a8, foreground color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#e7ecd8",
+          }
+        }
+      />
+      <span>
+        #8a94a8, foreground color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#8a94a8",
+          }
+        }
+      />
+      <span>
+        #8a94a8, foreground color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+      </span>
+    </span>
+    <span
+      className="screenReaderOnly"
+    >
+      Element has insufficient color contrast of 2.52 (background color: #8a94a8, foreground color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+    </span>
+  </React.Fragment>
   <ul>
     <li>
-      <span>
-        test return value
-      </span>
+      <React.Fragment>
+        <span
+          aria-hidden="true"
+        >
+          <span>
+            test return value
+          </span>
+        </span>
+        <span
+          className="screenReaderOnly"
+        >
+          test return value
+        </span>
+      </React.Fragment>
     </li>
   </ul>
 </React.Fragment>
@@ -41,38 +63,60 @@ exports[`FixInstructionProcessor background and foreground on the message (mind 
 
 exports[`FixInstructionProcessor foreground and background color on the message (mind the order) 1`] = `
 <React.Fragment>
-  <span>
-    Element has insufficient color contrast of 2.52 (foreground color: 
-  </span>
-  <span
-    aria-hidden={true}
-    className="fixInstructionColorBox"
-    style={
-      Object {
-        "backgroundColor": "#8a94a8",
-      }
-    }
-  />
-  <span>
-    #8a94a8, background color: 
-  </span>
-  <span
-    aria-hidden={true}
-    className="fixInstructionColorBox"
-    style={
-      Object {
-        "backgroundColor": "#e7ecd8",
-      }
-    }
-  />
-  <span>
-    #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
-  </span>
+  <React.Fragment>
+    <span
+      aria-hidden="true"
+    >
+      <span>
+        Element has insufficient color contrast of 2.52 (foreground color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#8a94a8",
+          }
+        }
+      />
+      <span>
+        #8a94a8, background color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#e7ecd8",
+          }
+        }
+      />
+      <span>
+        #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+      </span>
+    </span>
+    <span
+      className="screenReaderOnly"
+    >
+      Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+    </span>
+  </React.Fragment>
   <ul>
     <li>
-      <span>
-        test return value
-      </span>
+      <React.Fragment>
+        <span
+          aria-hidden="true"
+        >
+          <span>
+            test return value
+          </span>
+        </span>
+        <span
+          className="screenReaderOnly"
+        >
+          test return value
+        </span>
+      </React.Fragment>
     </li>
   </ul>
 </React.Fragment>
@@ -80,21 +124,32 @@ exports[`FixInstructionProcessor foreground and background color on the message 
 
 exports[`FixInstructionProcessor foreground color on the message 1`] = `
 <React.Fragment>
-  <span>
-    color contrast of 2.52 (foreground color: 
-  </span>
-  <span
-    aria-hidden={true}
-    className="fixInstructionColorBox"
-    style={
-      Object {
-        "backgroundColor": "#8a94a8",
-      }
-    }
-  />
-  <span>
-    #8a94a8; nothing else to match here)
-  </span>
+  <React.Fragment>
+    <span
+      aria-hidden="true"
+    >
+      <span>
+        color contrast of 2.52 (foreground color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#8a94a8",
+          }
+        }
+      />
+      <span>
+        #8a94a8; nothing else to match here)
+      </span>
+    </span>
+    <span
+      className="screenReaderOnly"
+    >
+      color contrast of 2.52 (foreground color: #8a94a8; nothing else to match here)
+    </span>
+  </React.Fragment>
 </React.Fragment>
 `;
 
@@ -106,49 +161,24 @@ exports[`FixInstructionProcessor no background nor foreground on the message 1`]
 
 exports[`FixInstructionProcessor recommendColor has one recommendation 1`] = `
 <React.Fragment>
-  <span>
-    Element has insufficient color contrast of 4.48 (foreground color: 
-  </span>
-  <span
-    aria-hidden={true}
-    className="fixInstructionColorBox"
-    style={
-      Object {
-        "backgroundColor": "#fefefe",
-      }
-    }
-  />
-  <span>
-    #fefefe, background color: 
-  </span>
-  <span
-    aria-hidden={true}
-    className="fixInstructionColorBox"
-    style={
-      Object {
-        "backgroundColor": "#21809d",
-      }
-    }
-  />
-  <span>
-    #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1
-  </span>
-  <ul>
-    <li>
+  <React.Fragment>
+    <span
+      aria-hidden="true"
+    >
       <span>
-        Use foreground color: 
+        Element has insufficient color contrast of 4.48 (foreground color: 
       </span>
       <span
         aria-hidden={true}
         className="fixInstructionColorBox"
         style={
           Object {
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fefefe",
           }
         }
       />
       <span>
-        #ffffff and the original background color: 
+        #fefefe, background color: 
       </span>
       <span
         aria-hidden={true}
@@ -160,37 +190,95 @@ exports[`FixInstructionProcessor recommendColor has one recommendation 1`] = `
         }
       />
       <span>
-        #21809d to meet a contrast ratio of 4.53:1
+        #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1
       </span>
+    </span>
+    <span
+      className="screenReaderOnly"
+    >
+      Element has insufficient color contrast of 4.48 (foreground color: #fefefe, background color: #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1
+    </span>
+  </React.Fragment>
+  <ul>
+    <li>
+      <React.Fragment>
+        <span
+          aria-hidden="true"
+        >
+          <span>
+            Use foreground color: 
+          </span>
+          <span
+            aria-hidden={true}
+            className="fixInstructionColorBox"
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+              }
+            }
+          />
+          <span>
+            #ffffff and the original background color: 
+          </span>
+          <span
+            aria-hidden={true}
+            className="fixInstructionColorBox"
+            style={
+              Object {
+                "backgroundColor": "#21809d",
+              }
+            }
+          />
+          <span>
+            #21809d to meet a contrast ratio of 4.53:1
+          </span>
+        </span>
+        <span
+          className="screenReaderOnly"
+        >
+          Use foreground color: #ffffff and the original background color: #21809d to meet a contrast ratio of 4.53:1
+        </span>
+      </React.Fragment>
     </li>
     <li>
-      <span>
-        Or use background color: 
-      </span>
-      <span
-        aria-hidden={true}
-        className="fixInstructionColorBox"
-        style={
-          Object {
-            "backgroundColor": "#1f7995",
-          }
-        }
-      />
-      <span>
-        #1f7995 and the original foreground color: 
-      </span>
-      <span
-        aria-hidden={true}
-        className="fixInstructionColorBox"
-        style={
-          Object {
-            "backgroundColor": "#fcfcfc",
-          }
-        }
-      />
-      <span>
-        #fcfcfc to meet a contrast ratio of 4.84:1.
-      </span>
+      <React.Fragment>
+        <span
+          aria-hidden="true"
+        >
+          <span>
+            Or use background color: 
+          </span>
+          <span
+            aria-hidden={true}
+            className="fixInstructionColorBox"
+            style={
+              Object {
+                "backgroundColor": "#1f7995",
+              }
+            }
+          />
+          <span>
+            #1f7995 and the original foreground color: 
+          </span>
+          <span
+            aria-hidden={true}
+            className="fixInstructionColorBox"
+            style={
+              Object {
+                "backgroundColor": "#fcfcfc",
+              }
+            }
+          />
+          <span>
+            #fcfcfc to meet a contrast ratio of 4.84:1.
+          </span>
+        </span>
+        <span
+          className="screenReaderOnly"
+        >
+          Or use background color: #1f7995 and the original foreground color: #fcfcfc to meet a contrast ratio of 4.84:1.
+        </span>
+      </React.Fragment>
     </li>
   </ul>
 </React.Fragment>
@@ -198,49 +286,24 @@ exports[`FixInstructionProcessor recommendColor has one recommendation 1`] = `
 
 exports[`FixInstructionProcessor recommendColor has two recommendations 1`] = `
 <React.Fragment>
-  <span>
-    Element has insufficient color contrast of 4.48 (foreground color: 
-  </span>
-  <span
-    aria-hidden={true}
-    className="fixInstructionColorBox"
-    style={
-      Object {
-        "backgroundColor": "#fefefe",
-      }
-    }
-  />
-  <span>
-    #fefefe, background color: 
-  </span>
-  <span
-    aria-hidden={true}
-    className="fixInstructionColorBox"
-    style={
-      Object {
-        "backgroundColor": "#21809d",
-      }
-    }
-  />
-  <span>
-    #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1
-  </span>
-  <ul>
-    <li>
+  <React.Fragment>
+    <span
+      aria-hidden="true"
+    >
       <span>
-        Use foreground color: 
+        Element has insufficient color contrast of 4.48 (foreground color: 
       </span>
       <span
         aria-hidden={true}
         className="fixInstructionColorBox"
         style={
           Object {
-            "backgroundColor": "#ffffff",
+            "backgroundColor": "#fefefe",
           }
         }
       />
       <span>
-        #ffffff and the original background color: 
+        #fefefe, background color: 
       </span>
       <span
         aria-hidden={true}
@@ -252,8 +315,55 @@ exports[`FixInstructionProcessor recommendColor has two recommendations 1`] = `
         }
       />
       <span>
-        #21809d to meet a contrast ratio of 4.53:1.
+        #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1
       </span>
+    </span>
+    <span
+      className="screenReaderOnly"
+    >
+      Element has insufficient color contrast of 4.48 (foreground color: #fefefe, background color: #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1
+    </span>
+  </React.Fragment>
+  <ul>
+    <li>
+      <React.Fragment>
+        <span
+          aria-hidden="true"
+        >
+          <span>
+            Use foreground color: 
+          </span>
+          <span
+            aria-hidden={true}
+            className="fixInstructionColorBox"
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+              }
+            }
+          />
+          <span>
+            #ffffff and the original background color: 
+          </span>
+          <span
+            aria-hidden={true}
+            className="fixInstructionColorBox"
+            style={
+              Object {
+                "backgroundColor": "#21809d",
+              }
+            }
+          />
+          <span>
+            #21809d to meet a contrast ratio of 4.53:1.
+          </span>
+        </span>
+        <span
+          className="screenReaderOnly"
+        >
+          Use foreground color: #ffffff and the original background color: #21809d to meet a contrast ratio of 4.53:1.
+        </span>
+      </React.Fragment>
     </li>
   </ul>
 </React.Fragment>
@@ -261,38 +371,60 @@ exports[`FixInstructionProcessor recommendColor has two recommendations 1`] = `
 
 exports[`FixInstructionProcessor we assume only one instance of fore/background color, second instance will be ignored 1`] = `
 <React.Fragment>
-  <span>
-    first foreground color: 
-  </span>
-  <span
-    aria-hidden={true}
-    className="fixInstructionColorBox"
-    style={
-      Object {
-        "backgroundColor": "#ffffff",
-      }
-    }
-  />
-  <span>
-    #ffffff, second foreground: #000000, first background color: 
-  </span>
-  <span
-    aria-hidden={true}
-    className="fixInstructionColorBox"
-    style={
-      Object {
-        "backgroundColor": "#AAAAAA",
-      }
-    }
-  />
-  <span>
-    #AAAAAA, second background color: #bbBBbb
-  </span>
+  <React.Fragment>
+    <span
+      aria-hidden="true"
+    >
+      <span>
+        first foreground color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#ffffff",
+          }
+        }
+      />
+      <span>
+        #ffffff, second foreground: #000000, first background color: 
+      </span>
+      <span
+        aria-hidden={true}
+        className="fixInstructionColorBox"
+        style={
+          Object {
+            "backgroundColor": "#AAAAAA",
+          }
+        }
+      />
+      <span>
+        #AAAAAA, second background color: #bbBBbb
+      </span>
+    </span>
+    <span
+      className="screenReaderOnly"
+    >
+      first foreground color: #ffffff, second foreground: #000000, first background color: #AAAAAA, second background color: #bbBBbb
+    </span>
+  </React.Fragment>
   <ul>
     <li>
-      <span>
-        test return value
-      </span>
+      <React.Fragment>
+        <span
+          aria-hidden="true"
+        >
+          <span>
+            test return value
+          </span>
+        </span>
+        <span
+          className="screenReaderOnly"
+        >
+          test return value
+        </span>
+      </React.Fragment>
     </li>
   </ul>
 </React.Fragment>

--- a/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
+++ b/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
@@ -6,37 +6,26 @@ import { Mock, Times } from 'typemoq';
 
 describe('FixInstructionProcessor', () => {
     let testSubject: FixInstructionProcessor;
-    let recommendationStub: RecommendColor;
+    const recommendColorMock = Mock.ofType(RecommendColor);
 
     beforeEach(() => {
+        recommendColorMock.reset();
         testSubject = new FixInstructionProcessor();
-        recommendationStub = {
-            sentence: 'Color suggestion text',
-        } as RecommendColor;
     });
 
     test('no background nor foreground on the message', () => {
         const fixInstruction =
             'there is nothing that will trigger the processor to change the fix instruction here';
 
-        const result = testSubject.process(fixInstruction, recommendationStub);
+        const result = testSubject.process(fixInstruction, recommendColorMock.object);
+
         expect(result).toMatchSnapshot();
     });
 
     test('foreground color on the message', () => {
         const fixInstruction =
             'color contrast of 2.52 (foreground color: #8a94a8; nothing else to match here)';
-
-        const result = testSubject.process(fixInstruction, recommendationStub);
-
-        expect(result).toMatchSnapshot();
-    });
-
-    test('background color on the message', () => {
-        const fixInstruction =
-            'color contrast of 2.52 (background color: #8a94a8; nothing else to match here)';
-
-        const result = testSubject.process(fixInstruction, recommendationStub);
+        const result = testSubject.process(fixInstruction, recommendColorMock.object);
 
         expect(result).toMatchSnapshot();
     });
@@ -44,54 +33,77 @@ describe('FixInstructionProcessor', () => {
     test('foreground and background color on the message (mind the order)', () => {
         const fixInstruction =
             'Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1';
-
-        const result = testSubject.process(fixInstruction, recommendationStub);
-
-        expect(result).toMatchSnapshot();
-    });
-
-    test('background and foreground on the message (mind the order)', () => {
-        const fixInstruction =
-            'Element has insufficient color contrast of 2.52 (background color: #8a94a8, foreground color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1';
-
-        const result = testSubject.process(fixInstruction, recommendationStub);
-
-        expect(result).toMatchSnapshot();
-    });
-
-    test('we assume only one instance of fore/background color, second instance will be ignored', () => {
-        const fixInstruction =
-            'first foreground color: #ffffff, second foreground: #000000, first background color: #AAAAAA, second background color: #bbBBbb';
-
-        const result = testSubject.process(fixInstruction, recommendationStub);
-
-        expect(result).toMatchSnapshot();
-    });
-
-    test('when we have nothing to process', () => {
-        const fixInstruction = 'nothing to process';
-
-        const result = testSubject.process(fixInstruction, recommendationStub);
-
-        expect(result).toMatchSnapshot();
-    });
-
-    test('recommendColor non-stub', () => {
-        const fixInstruction =
-            'Element has insufficient color contrast of 4.48 (foreground color: #fefefe, background color: #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1';
-
-        const getRecommendColorReturnValue =
-            'Use foreground color: #ffffff and the original background color: #21809d to meet a contrast ratio of 4.53:1. Or use background color: #1f7995 and the original foreground color: #fcfcfc to meet a contrast ratio of 4.84:1.';
-        const recommendColorMock = Mock.ofType(RecommendColor);
-
-        recommendColorMock
-            .setup(rc => rc.getRecommendColor('#fefefe', '#21809d', 4.5))
-            .returns(() => getRecommendColorReturnValue)
-            .verifiable(Times.once());
+        setupRecommendColorMock('#8a94a8', '#e7ecd8', 'test return value');
 
         const result = testSubject.process(fixInstruction, recommendColorMock.object);
 
         expect(result).toMatchSnapshot();
         recommendColorMock.verifyAll();
     });
+
+    test('background and foreground on the message (mind the order)', () => {
+        const fixInstruction =
+            'Element has insufficient color contrast of 2.52 (background color: #8a94a8, foreground color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1';
+        setupRecommendColorMock('#e7ecd8', '#8a94a8', 'test return value');
+
+        const result = testSubject.process(fixInstruction, recommendColorMock.object);
+
+        expect(result).toMatchSnapshot();
+        recommendColorMock.verifyAll();
+    });
+
+    test('we assume only one instance of fore/background color, second instance will be ignored', () => {
+        const fixInstruction =
+            'first foreground color: #ffffff, second foreground: #000000, first background color: #AAAAAA, second background color: #bbBBbb';
+        setupRecommendColorMock('#ffffff', '#AAAAAA', 'test return value');
+
+        const result = testSubject.process(fixInstruction, recommendColorMock.object);
+
+        expect(result).toMatchSnapshot();
+        recommendColorMock.verifyAll();
+    });
+
+    test('when we have nothing to process', () => {
+        const fixInstruction = 'nothing to process';
+
+        const result = testSubject.process(fixInstruction, recommendColorMock.object);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test('recommendColor has one recommendation', () => {
+        const fixInstruction =
+            'Element has insufficient color contrast of 4.48 (foreground color: #fefefe, background color: #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1';
+
+        const getRecommendColorReturnValue =
+            'Use foreground color: #ffffff and the original background color: #21809d to meet a contrast ratio of 4.53:1. Or use background color: #1f7995 and the original foreground color: #fcfcfc to meet a contrast ratio of 4.84:1.';
+
+        setupRecommendColorMock('#fefefe', '#21809d', getRecommendColorReturnValue);
+
+        const result = testSubject.process(fixInstruction, recommendColorMock.object);
+
+        expect(result).toMatchSnapshot();
+        recommendColorMock.verifyAll();
+    });
+
+    test('recommendColor has two recommendations', () => {
+        const fixInstruction =
+            'Element has insufficient color contrast of 4.48 (foreground color: #fefefe, background color: #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1';
+
+        const getRecommendColorReturnValue =
+            'Use foreground color: #ffffff and the original background color: #21809d to meet a contrast ratio of 4.53:1.';
+
+        setupRecommendColorMock('#fefefe', '#21809d', getRecommendColorReturnValue);
+
+        const result = testSubject.process(fixInstruction, recommendColorMock.object);
+
+        expect(result).toMatchSnapshot();
+        recommendColorMock.verifyAll();
+    });
+
+    const setupRecommendColorMock = (colorOne, colorTwo, returns) =>
+        recommendColorMock
+            .setup(rc => rc.getRecommendColor(colorOne, colorTwo, 4.5))
+            .returns(() => returns)
+            .verifiable(Times.once());
 });

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
@@ -71,7 +71,6 @@ exports[`ReportBody renders 1`] = `
         "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
         "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
         "originalMiddleSentence": " and the original foreground color: ",
-        "recommendEndSentence": " to meet a contrast ratio of #.##:1",
       }
     }
     getCollapsibleScript={[Function]}
@@ -229,7 +228,6 @@ exports[`ReportBody renders 1`] = `
           "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           "originalMiddleSentence": " and the original foreground color: ",
-          "recommendEndSentence": " to meet a contrast ratio of #.##:1",
         }
       }
       getCollapsibleScript={[Function]}
@@ -385,7 +383,6 @@ exports[`ReportBody renders 1`] = `
           "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           "originalMiddleSentence": " and the original foreground color: ",
-          "recommendEndSentence": " to meet a contrast ratio of #.##:1",
         }
       }
       getCollapsibleScript={[Function]}
@@ -541,7 +538,6 @@ exports[`ReportBody renders 1`] = `
           "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           "originalMiddleSentence": " and the original foreground color: ",
-          "recommendEndSentence": " to meet a contrast ratio of #.##:1",
         }
       }
       getCollapsibleScript={[Function]}
@@ -697,7 +693,6 @@ exports[`ReportBody renders 1`] = `
             "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
             "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
             "originalMiddleSentence": " and the original foreground color: ",
-            "recommendEndSentence": " to meet a contrast ratio of #.##:1",
           }
         }
         getCollapsibleScript={[Function]}
@@ -853,7 +848,6 @@ exports[`ReportBody renders 1`] = `
             "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
             "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
             "originalMiddleSentence": " and the original foreground color: ",
-            "recommendEndSentence": " to meet a contrast ratio of #.##:1",
           }
         }
         getCollapsibleScript={[Function]}
@@ -1009,7 +1003,6 @@ exports[`ReportBody renders 1`] = `
             "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
             "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
             "originalMiddleSentence": " and the original foreground color: ",
-            "recommendEndSentence": " to meet a contrast ratio of #.##:1",
           }
         }
         getCollapsibleScript={[Function]}
@@ -1168,7 +1161,6 @@ exports[`ReportBody renders 1`] = `
           "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           "originalMiddleSentence": " and the original foreground color: ",
-          "recommendEndSentence": " to meet a contrast ratio of #.##:1",
         }
       }
       getCollapsibleScript={[Function]}


### PR DESCRIPTION
#### Details
This PR updates the list structure of the color contrast suggestions added in FixInstructionProcessor. Previously, the list structure looked something like:
- \<ul>
  - \<li>
     - The original CC message
     - \<ul>
        - \<li>
           - The first CC suggestion
     - \<ul>
        - \<li>
           - The second CC suggestion

Now, it looks more like:
- \<ul>
  - \<li>
     - The original CC message
     - \<ul>
        - \<li>
           - The first CC suggestion
        - \<li>
           - The second CC suggestion

The change should have no visual impact, just AT impact. 
![image](https://user-images.githubusercontent.com/4615491/122616049-7dad6f00-d03e-11eb-8d8f-32a958aceb36.png)

##### Motivation
With the previous list structure, NVDA read,
>...list  with 1 items  •   Element has insufficient color contrast of 4.21 (foreground color: #0074d9, background color: #fff4c2, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1 Use foreground color: #006ece and the original background color: #fff4c2 to meet a contrast ratio of 4.60:1. Or use background color: #ffffcb and the original foreground color: #0074d9 to meet a contrast ratio of 4.54:1...

Now, NVDA reads:
> ...list  with 1 items  •   Element has insufficient color contrast of 4.21 (foreground color: #0074d9, background color: #fff4c2, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1 list  with 2 items  •   Use foreground color: #006ece and the original background color: #fff4c2 to meet a contrast ratio of 4.60:1•   Or use background color: #ffffcb and the original foreground color: #0074d9 to meet a contrast ratio of 4.54:1...


##### Context
The screenReaderOnly span alongside the aria-hidden span is necessary to ensure Narrator reads the instruction straight through. Without that, Narrator pauses every time it gets to a color box. The pattern was already in place; this PR simply expands upon its use.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
