### PR TITLE
feat(google-rules-mvp): add atfaResults feature flag in unified

### DIFF
--- a/src/electron/common/unified-feature-flags.ts
+++ b/src/electron/common/unified-feature-flags.ts
@@ -49,8 +49,7 @@ export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
             id: UnifiedFeatureFlags.atfaResults,
             defaultValue: false,
             displayableName: 'Show ATFA results',
-            displayableDescription:
-                'Show the Accessibility Test Framework for Android results in Needs review',
+            displayableDescription: 'Show the Accessibility Test Framework for Android results',
             isPreviewFeature: false,
             forceDefault: false,
         },

--- a/src/electron/common/unified-feature-flags.ts
+++ b/src/electron/common/unified-feature-flags.ts
@@ -7,6 +7,7 @@ export class UnifiedFeatureFlags {
     public static readonly showAllFeatureFlags = 'showAllFeatureFlags';
     public static readonly exportReport = 'exportReport';
     public static readonly tabStops = 'tabStops';
+    public static readonly atfaResults = 'atfaResults';
 }
 
 export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
@@ -41,6 +42,15 @@ export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
             defaultValue: true,
             displayableName: 'Show Tab Stops test',
             displayableDescription: 'Show the Tab Stops test on the Left Nav',
+            isPreviewFeature: false,
+            forceDefault: false,
+        },
+        {
+            id: UnifiedFeatureFlags.atfaResults,
+            defaultValue: false,
+            displayableName: 'Show ATFA results',
+            displayableDescription:
+                'Show the Accessibility Test Framework for Android results in Needs review',
             isPreviewFeature: false,
             forceDefault: false,
         },

--- a/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
+++ b/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
@@ -24,6 +24,7 @@ describe('FeatureFlagsTest', () => {
             [UnifiedFeatureFlags.showAllFeatureFlags]: false,
             [UnifiedFeatureFlags.exportReport]: true,
             [UnifiedFeatureFlags.tabStops]: true,
+            [UnifiedFeatureFlags.atfaResults]: false,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Add feature flag for work on adding ATFAResults to Unified

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Address WI 1853272

##### Context

All the work for adding ATFAResults to Unified client will be done under a feature flag
<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: WI 1853272
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
