### PR TITLE
docs: add instructions for running Unified app with modified Android Service

### DIFF
--- a/docs/building-unified.md
+++ b/docs/building-unified.md
@@ -41,7 +41,7 @@ See guidance [here](../src/tests/miscellaneous/mock-adb/README.md).
 
 If you _do_ need to work with an actual Android device/VM, you'll want to install [Android Studio](https://developer.android.com/studio/) and use it to connect to a device and/or start an emulator. The Unified app will automatically detect and install the [Accessibility Insights for Android Service](https://github.com/microsoft/accessibility-insights-for-android-service) onto your device; see [Getting Started with Accessibility Insights for Android](https://accessibilityinsights.io/docs/en/android/getstarted/setup#getting-started-with-accessibility-insights-for-android) for more info on how to prepare a device/emulator with the Accessibility Insights for Android Service.
 
-Note: If you want to use a modified version of Accessibility Insights for Android Service, follow the [Manual installation](https://accessibilityinsights.io/docs/en/android/getstarted/setup/#manual-installation) steps and update [hasRequiredServiceVersion](https://github.com/microsoft/accessibility-insights-web/blob/18a2317856addd6e4398d9c63c000cf0d04665e1/src/electron/platform/android/setup/android-service-configurator.ts#L58) to return true for your scenario. **Do not push this change.**
+Note: If you want to use a modified version of Accessibility Insights for Android Service, follow the [Manual installation](https://accessibilityinsights.io/docs/en/android/getstarted/setup/#manual-installation) steps. Then, make a [small modification to the Unified app](https://github.com/microsoft/accessibility-insights-web/pull/4395) to bypass the Android Service version check.  **Do not push this change.**
 
 ```sh
 # You can leave off the with:mock-service-for-android if

--- a/docs/building-unified.md
+++ b/docs/building-unified.md
@@ -39,7 +39,9 @@ See guidance [here](../src/tests/miscellaneous/mock-adb/README.md).
 
 #### Connecting to a real device/emulator
 
-If you _do_ need to work with an actual Android device/VM, you'll want to install [Android Studio](https://developer.android.com/studio/) and use it to connect to a device and/or start an emulator. You'll need to install the [Accessibility Insights for Android Service](https://github.com/microsoft/accessibility-insights-for-android-service) beforehand; see [Getting Started with Accessibility Insights for Android](https://accessibilityinsights.io/docs/en/android/getstarted/setup#getting-started-with-accessibility-insights-for-android) for instructions on how to prepare a device/emulator with the Accessibility Insights for Android Service (follow its steps up until "Install the Accessibility Insights for Android app").
+If you _do_ need to work with an actual Android device/VM, you'll want to install [Android Studio](https://developer.android.com/studio/) and use it to connect to a device and/or start an emulator. The Unified app will automatically detect and install the [Accessibility Insights for Android Service](https://github.com/microsoft/accessibility-insights-for-android-service) onto your device; see [Getting Started with Accessibility Insights for Android](https://accessibilityinsights.io/docs/en/android/getstarted/setup#getting-started-with-accessibility-insights-for-android) for more info on how to prepare a device/emulator with the Accessibility Insights for Android Service.
+
+Note: If you want to use a modified version of Accessibility Insights for Android Service, follow the [Manual installation](https://accessibilityinsights.io/docs/en/android/getstarted/setup/#manual-installation) steps and update [hasRequiredServiceVersion](https://github.com/microsoft/accessibility-insights-web/blob/18a2317856addd6e4398d9c63c000cf0d04665e1/src/electron/platform/android/setup/android-service-configurator.ts#L58) to return true for your scenario. **Do not push this change.**
 
 ```sh
 # You can leave off the with:mock-service-for-android if


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
* Minor updates to outdated text/references to Getting Started doc
* Added instructions for how to run dev version of Unified app with a modified version of [Accessibility Insights for Android Service](https://github.com/microsoft/accessibility-insights-for-android-service)

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
It was not immediately clear how to develop on the Unified app when working with a different or modified version of the Android Service.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
