### PR TITLE
feat(google-rules-mvp): call Android Service API based on atfaResults feature flag

### DIFF
--- a/src/electron/platform/android/fetch-scan-results.ts
+++ b/src/electron/platform/android/fetch-scan-results.ts
@@ -1,15 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import axios from 'axios';
+import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import { AndroidScanResults } from './android-scan-results';
 
 export type ScanResultsFetcher = (port: number) => Promise<AndroidScanResults>;
 
 export type HttpGet = typeof axios.get;
 
-export const createScanResultsFetcher = (httpGet: HttpGet): ScanResultsFetcher => {
+export const createScanResultsFetcher = (
+    httpGet: HttpGet,
+    featureFlagStore: FeatureFlagStore,
+): ScanResultsFetcher => {
     return async (port: number) => {
-        const response = await httpGet(`http://localhost:${port}/AccessibilityInsights/result`);
+        const featureFlagStoreData = featureFlagStore.getState();
+        let resultsVersion = ''; // API for v1 results doesn't have an explicit version number
+        if (featureFlagStoreData[UnifiedFeatureFlags.atfaResults]) {
+            resultsVersion = '_v2';
+        }
+
+        const response = await httpGet(
+            `http://localhost:${port}/AccessibilityInsights/result${resultsVersion}`,
+        );
         return new AndroidScanResults(response.data);
     };
 };

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -310,7 +310,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
             tabStopsStore,
         ]);
 
-        const fetchScanResults = createScanResultsFetcher(axios.get);
+        const fetchScanResults = createScanResultsFetcher(axios.get, featureFlagStore);
 
         const featureFlagsController = new FeatureFlagsController(featureFlagStore, interpreter);
 

--- a/src/tests/unit/tests/electron/platform/android/fetch-scan-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/fetch-scan-results.test.ts
@@ -1,24 +1,32 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AxiosResponse } from 'axios';
+import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import { AndroidScanResults } from 'electron/platform/android/android-scan-results';
 import {
     createScanResultsFetcher,
     HttpGet,
     ScanResultsFetcher,
 } from 'electron/platform/android/fetch-scan-results';
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 
 describe('fetchScanResults', () => {
     let httpGetMock: IMock<HttpGet>;
-
+    let featureFlagStoreMock: IMock<FeatureFlagStore>;
     let testSubject: ScanResultsFetcher;
 
+    const storeDataStub: FeatureFlagStoreData = {
+        [UnifiedFeatureFlags.atfaResults]: false,
+    };
     const port = 10101;
 
     beforeEach(() => {
         httpGetMock = Mock.ofType<HttpGet>();
-        testSubject = createScanResultsFetcher(httpGetMock.object);
+        featureFlagStoreMock = Mock.ofType<FeatureFlagStore>();
+        featureFlagStoreMock.setup(store => store.getState()).returns(() => storeDataStub);
+        testSubject = createScanResultsFetcher(httpGetMock.object, featureFlagStoreMock.object);
     });
 
     it('returns a ScanResults instance', async () => {
@@ -50,5 +58,24 @@ describe('fetchScanResults', () => {
             .returns(() => Promise.reject(reason));
 
         await expect(testSubject(port)).rejects.toMatch(reason);
+    });
+
+    it.each([
+        ['enabled', true],
+        ['disabled', false],
+    ])('calls expected API when atfaResults feature flag is %s', async (testName, flag) => {
+        storeDataStub[UnifiedFeatureFlags.atfaResults] = flag;
+        const versionNumber = flag ? '_v2' : '';
+
+        httpGetMock
+            .setup(getter =>
+                getter(`http://localhost:${port}/AccessibilityInsights/result${versionNumber}`),
+            )
+            .returns(() => Promise.resolve({} as AxiosResponse<any>))
+            .verifiable(Times.once());
+
+        await testSubject(port);
+
+        httpGetMock.verifyAll();
     });
 });


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Updated fetch-scan-results.ts to determine which Accessibility Insights for Android Service API to call, based on the status of the atfaResults feature flag. 
* When the feature flag is enabled, it calls the v2 API.
* When the feature flag is disabled, it calls the original API (no version number).

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Partially addresses WI 1853273

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
This is a follow-up to #4394, which handled reading the axe results from both v1 and v2 results formats. This PR updates the ScanResultsFetcher to call either of the two APIs in the Android Service, depending on whether the atfaResults feature flag has been enabled or disabled. The Android Service returns the proper data (v1 or v2) based on the API that is called.
<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Partially addresses an existing issue: WI 1853273
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
