### PR TITLE
feat(google-rules-mvp): Correct incorrect field names

### DIFF
--- a/src/electron/platform/android/atfa-data-types.ts
+++ b/src/electron/platform/android/atfa-data-types.ts
@@ -27,7 +27,7 @@ export interface ViewHierarchyElement {
 export interface AccessibilityHierarchyCheckResult {
     'AccessibilityHierarchyCheckResult.element': ViewHierarchyElement;
     'AccessibilityHierarchyCheckResult.resultId': number;
-    'AccessibilityHierarchyCheckResult.checkClass': string;
-    'AccessibilityHierarchyCheckResult.type': string; // TODO: make an enum?
+    'AccessibilityCheckResult.checkClass': string;
+    'AccessibilityCheckResult.type': string; // TODO: make an enum?
     'AccessibilityHierarchyCheckResult.metadata'?: any;
 }

--- a/src/electron/platform/android/atfa-scan-results-to-unified-results.ts
+++ b/src/electron/platform/android/atfa-scan-results-to-unified-results.ts
@@ -36,7 +36,7 @@ export function convertAtfaScanResultsToUnifiedResults(
                 atfaResult['AccessibilityHierarchyCheckResult.element'];
             if (viewElement) {
                 const ruleInformation: RuleInformation = ruleInformationProvider.getRuleInformation(
-                    atfaResult['AccessibilityHierarchyCheckResult.checkClass'],
+                    atfaResult['AccessibilityCheckResult.checkClass'],
                 );
 
                 if (ruleInformation) {
@@ -65,7 +65,7 @@ function createUnifiedResult(
     const ruleResult: RuleResultsData = {
         axeViewId: `atfa-${viewElement['ViewHierarchyElement.id']}`,
         ruleId: ruleInformation.ruleId,
-        status: atfaResult['AccessibilityHierarchyCheckResult.type'],
+        status: atfaResult['AccessibilityCheckResult.type'],
         props: atfaResult['AccessibilityHierarchyCheckResult.metadata'],
     };
     return {
@@ -98,7 +98,7 @@ function getRawString(spannableString?: SpannableString): string | null {
 }
 
 function includeBasedOnResultType(atfaResult: AccessibilityHierarchyCheckResult): boolean {
-    const resultType: string | null = atfaResult['AccessibilityHierarchyCheckResult.type'] ?? null;
+    const resultType: string | null = atfaResult['AccessibilityCheckResult.type'] ?? null;
 
     return includedResults.includes(resultType);
 }

--- a/src/electron/platform/android/atfa-scan-results-to-unified-rules.ts
+++ b/src/electron/platform/android/atfa-scan-results-to-unified-rules.ts
@@ -25,7 +25,7 @@ export function convertAtfaScanResultsToUnifiedRules(
     const ruleIds: Set<string> = new Set();
 
     for (const atfaResult of scanResults.atfaResults) {
-        const ruleId: string = atfaResult['AccessibilityHierarchyCheckResult.checkClass'];
+        const ruleId: string = atfaResult['AccessibilityCheckResult.checkClass'];
         if (!ruleIds.has(ruleId)) {
             const ruleInformation = ruleInformationProvider.getRuleInformation(ruleId);
 

--- a/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
@@ -193,8 +193,8 @@ export function buildAtfaResult(
     const result = {};
     result['AccessibilityHierarchyCheckResult.element'] = element;
     result['AccessibilityHierarchyCheckResult.resultId'] = resultId;
-    result['AccessibilityHierarchyCheckResult.checkClass'] = checkClass;
-    result['AccessibilityHierarchyCheckResult.type'] = type;
+    result['AccessibilityCheckResult.checkClass'] = checkClass;
+    result['AccessibilityCheckResult.type'] = type;
     if (metadata) {
         result['AccessibilityHierarchyCheckResult.metadata'] = metadata;
     }


### PR DESCRIPTION
#### Details

#4406 added new fields for ATFA rules, but 2 of those fields were incorrect. The mistakes were

Field | Incorrect value | Correct value
--- | --- | ---
checkClass (identifies test) | `AccessibilityHierarchyCheckResult.checkClass` | `AccessibilityCheckResult.checkClass`
type (identifies test status) | `AccessibilityHierarchyCheckResult.type` | `AccessibilityCheckResult.type`

Here's a result from the service, redacted to just the fields that we use--the checkClass and type are at the very end of the object:

```
    {
      "AccessibilityHierarchyCheckResult.element": {
        "ViewHierarchyElement.accessibilityClassName": "android.widget.TextView",
        "ViewHierarchyElement.boundsInScreen": {
          "Rect.bottom": 505,
          "Rect.left": 439,
          "Rect.right": 641,
          "Rect.top": 252
        },
        "ViewHierarchyElement.className": "android.widget.TextView",
        "ViewHierarchyElement.contentDescription": {
          "SpannableString.rawString": "Camera",
          "SpannableString.spans": []
        },
        "ViewHierarchyElement.id": 4,
        "ViewHierarchyElement.text": {
          "SpannableString.rawString": "Camera",
          "SpannableString.spans": []
        },
      },
      "AccessibilityHierarchyCheckResult.metadata": {
        }
      },
      "AccessibilityHierarchyCheckResult.resultId": 12,
      "AccessibilityCheckResult.checkClass": "TextContrastCheck",
      "AccessibilityCheckResult.type": "WARNING"
    },
```

I've confirmed with service data that we are able to obtain results using this change.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing isssue
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
