### PR TITLE
chore: Stop ignoring new versions of electron-builder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -93,8 +93,3 @@ updates:
   - dependency-name: "@types/react-dom"
     versions:
     - ">=17.0.0"
-    # electron-builder 22.10.5 broke our signed Mac builds. Temporarily
-    # pausing updates until we have a fix.
-  - dependency-name: electron-builder
-    versions:
-    - ">22.9.1"


### PR DESCRIPTION
#### Details
This PR removes electron-builder from the dependabot ignore list.

##### Motivation
Now that issue #4290 has been addressed, we want to keep electron-builder up to date.

##### Context
PR #4284 downgraded electron-builder and paused future upgrades. Now that PR #4421 has fixed the underlying issue, we're fine to keep current with electron-builder again. 

[Example successful signed build with electron-builder 22.11.7](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=24021&view=results).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4290
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
