### PR TITLE
feat(google-rules-mvp): Use latest HowToCheck text

### DIFF
--- a/src/common/components/cards/rich-resolution-content.tsx
+++ b/src/common/components/cards/rich-resolution-content.tsx
@@ -92,85 +92,60 @@ export const RichResolutionContent = NamedFC<RichResolutionContentProps>(
             case 'android/atfa/ClassNameCheck': {
                 return (
                     <span>
-                        Provide a <Markup.Code>className</Markup.Code> value within the element's{' '}
-                        <LinkComponent href="https://developer.android.com/reference/android/view/accessibility/AccessibilityNodeInfo.html">
-                            AccessibilityNodeInfo
+                        <LinkComponent href="https://developer.android.com/training/accessibility/testing.html#manual">
+                            Manually test
                         </LinkComponent>{' '}
-                        that:
-                        <ol>
-                            <li>Closely describes the element's function,</li>
-                            <li>
-                                Matches a class that extends{' '}
-                                <Markup.Code>android.view.View</Markup.Code>,
-                            </li>
-                            <li>Is provided with the Android SDK or support libraries, and</li>
-                            <li>Is as far down Android's class hierarchy as possible.</li>
-                        </ol>
-                        Note: Do not attempt to fix this issue by adding the class name to the
-                        object's <Markup.Code>ContentDescription</Markup.Code>, as that approach can
-                        cause some assistive technologies to announce the class twice.
+                        the control to verify that users receive sufficient information to
+                        understand the object's function.
                     </span>
                 );
             }
             case 'android/atfa/ClickableSpanCheck': {
                 return (
                     <span>
-                        <ul>
-                            <li>
-                                Implement the link using{' '}
-                                <LinkComponent href="https://developer.android.com/reference/android/text/style/URLSpan.html">
-                                    URLSpan
-                                </LinkComponent>{' '}
-                                or
-                                <LinkComponent href="https://developer.android.com/reference/android/text/util/Linkify.html">
-                                    Linkify
-                                </LinkComponent>
-                                .
-                            </li>
-                            <li>
-                                If you use <Markup.Code>URLSpan</Markup.Code>, provide a non-null
-                                absolute URL (such as{' '}
-                                <Markup.Code>https://example.com/page.html</Markup.Code>), not a
-                                relative URL (such as <Markup.Code>/page.html</Markup.Code>).
-                            </li>
-                        </ul>
+                        <LinkComponent href="https://developer.android.com/training/accessibility/testing.html#manual">
+                            Manually test
+                        </LinkComponent>{' '}
+                        the item containing the link and verify that the hyperlinked text is
+                        announced and appears in the “Links” section of Talkback’s Context Menu.
                     </span>
                 );
             }
             case 'android/atfa/DuplicateClickableBoundsCheck': {
                 return (
                     <span>
-                        When clickable <Markup.Code>Views</Markup.Code> are nested, implement click
-                        handling so that only one
-                        <Markup.Code>View</Markup.Code> handles clicks for any single action. <br />
-                        If a <Markup.Code>View</Markup.Code> that's clickable by default (such as a{' '}
-                        <Markup.Code>button</Markup.Code>) is not intended to be clickable, remove
-                        its <Markup.Code>OnClickListener</Markup.Code>, or set{' '}
-                        <Markup.Code>android:clickable="false"</Markup.Code>.
+                        Turn on{' '}
+                        <LinkComponent href="https://support.google.com/accessibility/android/answer/6301490">
+                            Switch Access for Android
+                        </LinkComponent>{' '}
+                        or use the{' '}
+                        <LinkComponent href="https://accessibilityinsights.io/docs/en/android/getstarted/fastpass/#complete-the-manual-test-for-tab-stops">
+                            TabStops feature
+                        </LinkComponent>{' '}
+                        to navigate through the elements in the application. If an element appears
+                        to be focused more than once, there may be multiple interactive elements
+                        occupying the same screen location.
                     </span>
                 );
             }
             case 'android/atfa/DuplicateSpeakableTextCheck': {
                 return (
                     <span>
-                        If clickable <Markup.Code>View</Markup.Code> objects perform the <i>same</i>{' '}
-                        function, they can have the same speakable text; no changes are needed.
+                        If clickable <Markup.Code>View</Markup.Code> objects have the <i>same</i>{' '}
+                        speakable text and perform the <i>same</i>
+                        function, they pass.
                         <br />
-                        If two or more clickable <Markup.Code>View</Markup.Code> objects perform{' '}
-                        <i>different</i> functions, give them unique speakable text.
+                        If clickable <Markup.Code>View</Markup.Code> objects have the <i>same</i>{' '}
+                        speakable text but perform <i>different</i> functions, they fail.
                     </span>
                 );
             }
             case 'android/atfa/LinkPurposeUnclearCheck': {
                 return (
                     <span>
-                        Describe the unique purpose of the link using any of the following:
-                        <ul>
-                            <li>Good: Programmatically related context, or</li>
-                            <li>Better: Accessible name and/or accessible description, or</li>
-                            <li>Best: Link text</li>
-                        </ul>
-                        Programmatically related context includes:
+                        Examine the link in the context of the app to verify that the link's unique
+                        purpose is described by the link together with its preceding page content,
+                        which includes:
                         <ul>
                             <li>
                                 Text in the same sentence, paragraph, list item, or table cell as
@@ -178,24 +153,8 @@ export const RichResolutionContent = NamedFC<RichResolutionContentProps>(
                             </li>
                             <li>Text in a parent list item</li>
                             <li>
-                                Text in a table header cell associated with the cell that contains
-                                the link
-                            </li>
-                        </ul>
-                        Writing tips:
-                        <ul>
-                            <li>
-                                If a link's destination is a document or web application, the name
-                                of the document or application is sufficient.
-                            </li>
-                            <li>
-                                Links with different destinations should have different
-                                descriptions; links with the same destination should have the same
-                                description.
-                            </li>
-                            <li>
-                                Programmatically related context is easier to understand when it
-                                precedes the link.
+                                Text in the table header cell that's associated with cell that
+                                contains the link
                             </li>
                         </ul>
                     </span>
@@ -204,27 +163,18 @@ export const RichResolutionContent = NamedFC<RichResolutionContentProps>(
             case 'android/atfa/RedundantDescriptionCheck': {
                 return (
                     <span>
-                        Don't include an element's role (type), state, or available actions in the
-                        following attributes: <Markup.Code>android:contentDescription</Markup.Code>,
-                        <Markup.Code>android:text</Markup.Code>,{' '}
-                        <Markup.Code>android:hint</Markup.Code>.
+                        Listen to TalkBack's announcement of the element to verify that the item's
+                        role (type), state, and/or available actions are announced only once.
                     </span>
                 );
             }
             case 'android/atfa/TraversalOrderCheck': {
                 return (
                     <span>
-                        Good: If the app's view hierarchy doesn't create a logical traversal order,
-                        use <Markup.Code>android:accessibilityTraversalBefore</Markup.Code> or
-                        <Markup.Code>android:accessibilityTraversalAfter</Markup.Code> attributes to
-                        create an order that makes sense to TalkBack users. Make sure that the
-                        attributes do not create any loops or traps that prevent the user from
-                        accessing all interactive elements.
-                        <br />
-                        Better: Restructure the view hierarchy to create a logical traversal order
-                        that does not require use of{' '}
-                        <Markup.Code>android:accessibilityTraversalBefore</Markup.Code> or
-                        <Markup.Code>android:accessibilityTraversalAfter</Markup.Code> attributes.
+                        Turn on Talkback. Swipe right to move accessibility focus forward through
+                        the elements on the screen, then swipe left to navigate backwards. Verify
+                        that focus moves through the elements in a logical, consistent order when
+                        navigating forwards or backwards.
                     </span>
                 );
             }
@@ -256,7 +206,18 @@ export const RichResolutionContent = NamedFC<RichResolutionContentProps>(
             case 'android/atfa/ImageContrastCheck': {
                 return (
                     <span>
-                        Make sure the meaningful elements in a graphic have a contrast ratio ≥ 3:1.
+                        Use{' '}
+                        <LinkComponent href="https://go.microsoft.com/fwlink/?linkid=2075365">
+                            Accessibility Insights for Windows
+                        </LinkComponent>{' '}
+                        (or the{' '}
+                        <LinkComponent href="https://developer.paciellogroup.com/resources/contrastanalyser/">
+                            Colour Contrast Analyser
+                        </LinkComponent>{' '}
+                        if you're testing on a Mac) to manually verify that the{' '}
+                        <Markup.Code>ImageView</Markup.Code> has sufficient contrast compared to the
+                        background. If the background is an image or gradient, test an area where
+                        the contrast appears to be the lowest.
                     </span>
                 );
             }

--- a/src/common/components/cards/rich-resolution-content.tsx
+++ b/src/common/components/cards/rich-resolution-content.tsx
@@ -132,8 +132,7 @@ export const RichResolutionContent = NamedFC<RichResolutionContentProps>(
                 return (
                     <span>
                         If clickable <Markup.Code>View</Markup.Code> objects have the <i>same</i>{' '}
-                        speakable text and perform the <i>same</i>
-                        function, they pass.
+                        speakable text and perform the <i>same</i> function, they pass.
                         <br />
                         If clickable <Markup.Code>View</Markup.Code> objects have the <i>same</i>{' '}
                         speakable text but perform <i>different</i> functions, they fail.

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/rich-resolution-content.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/rich-resolution-content.test.tsx.snap
@@ -177,7 +177,7 @@ exports[`RichResolutionContent renders static content with id=android/atfa/Dupli
   <i>
     same
   </i>
-  function, they pass.
+   function, they pass.
   <br />
   If clickable 
   <Code>

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/rich-resolution-content.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/rich-resolution-content.test.tsx.snap
@@ -118,117 +118,47 @@ exports[`RichResolutionContent renders static content with id=android/ImageViewN
 
 exports[`RichResolutionContent renders static content with id=android/atfa/ClassNameCheck 1`] = `
 <span>
-  Provide a 
-  <Code>
-    className
-  </Code>
-   value within the element's
-   
   <stubLinkComponent
-    href="https://developer.android.com/reference/android/view/accessibility/AccessibilityNodeInfo.html"
+    href="https://developer.android.com/training/accessibility/testing.html#manual"
   >
-    AccessibilityNodeInfo
+    Manually test
   </stubLinkComponent>
    
-  that:
-  <ol>
-    <li>
-      Closely describes the element's function,
-    </li>
-    <li>
-      Matches a class that extends
-       
-      <Code>
-        android.view.View
-      </Code>
-      ,
-    </li>
-    <li>
-      Is provided with the Android SDK or support libraries, and
-    </li>
-    <li>
-      Is as far down Android's class hierarchy as possible.
-    </li>
-  </ol>
-  Note: Do not attempt to fix this issue by adding the class name to the object's 
-  <Code>
-    ContentDescription
-  </Code>
-  , as that approach can cause some assistive technologies to announce the class twice.
+  the control to verify that users receive sufficient information to understand the object's function.
 </span>
 `;
 
 exports[`RichResolutionContent renders static content with id=android/atfa/ClickableSpanCheck 1`] = `
 <span>
-  <ul>
-    <li>
-      Implement the link using
-       
-      <stubLinkComponent
-        href="https://developer.android.com/reference/android/text/style/URLSpan.html"
-      >
-        URLSpan
-      </stubLinkComponent>
-       
-      or
-      <stubLinkComponent
-        href="https://developer.android.com/reference/android/text/util/Linkify.html"
-      >
-        Linkify
-      </stubLinkComponent>
-      .
-    </li>
-    <li>
-      If you use 
-      <Code>
-        URLSpan
-      </Code>
-      , provide a non-null absolute URL (such as
-       
-      <Code>
-        https://example.com/page.html
-      </Code>
-      ), not a relative URL (such as 
-      <Code>
-        /page.html
-      </Code>
-      ).
-    </li>
-  </ul>
+  <stubLinkComponent
+    href="https://developer.android.com/training/accessibility/testing.html#manual"
+  >
+    Manually test
+  </stubLinkComponent>
+   
+  the item containing the link and verify that the hyperlinked text is announced and appears in the “Links” section of Talkback’s Context Menu.
 </span>
 `;
 
 exports[`RichResolutionContent renders static content with id=android/atfa/DuplicateClickableBoundsCheck 1`] = `
 <span>
-  When clickable 
-  <Code>
-    Views
-  </Code>
-   are nested, implement click handling so that only one
-  <Code>
-    View
-  </Code>
-   handles clicks for any single action. 
-  <br />
-  If a 
-  <Code>
-    View
-  </Code>
-   that's clickable by default (such as a
+  Turn on
    
-  <Code>
-    button
-  </Code>
-  ) is not intended to be clickable, remove its 
-  <Code>
-    OnClickListener
-  </Code>
-  , or set
+  <stubLinkComponent
+    href="https://support.google.com/accessibility/android/answer/6301490"
+  >
+    Switch Access for Android
+  </stubLinkComponent>
    
-  <Code>
-    android:clickable="false"
-  </Code>
-  .
+  or use the
+   
+  <stubLinkComponent
+    href="https://accessibilityinsights.io/docs/en/android/getstarted/fastpass/#complete-the-manual-test-for-tab-stops"
+  >
+    TabStops feature
+  </stubLinkComponent>
+   
+  to navigate through the elements in the application. If an element appears to be focused more than once, there may be multiple interactive elements occupying the same screen location.
 </span>
 `;
 
@@ -238,47 +168,64 @@ exports[`RichResolutionContent renders static content with id=android/atfa/Dupli
   <Code>
     View
   </Code>
-   objects perform the 
+   objects have the 
   <i>
     same
   </i>
    
-  function, they can have the same speakable text; no changes are needed.
+  speakable text and perform the 
+  <i>
+    same
+  </i>
+  function, they pass.
   <br />
-  If two or more clickable 
+  If clickable 
   <Code>
     View
   </Code>
-   objects perform
+   objects have the 
+  <i>
+    same
+  </i>
    
+  speakable text but perform 
   <i>
     different
   </i>
-   functions, give them unique speakable text.
+   functions, they fail.
 </span>
 `;
 
 exports[`RichResolutionContent renders static content with id=android/atfa/ImageContrastCheck 1`] = `
 <span>
-  Make sure the meaningful elements in a graphic have a contrast ratio ≥ 3:1.
+  Use
+   
+  <stubLinkComponent
+    href="https://go.microsoft.com/fwlink/?linkid=2075365"
+  >
+    Accessibility Insights for Windows
+  </stubLinkComponent>
+   
+  (or the
+   
+  <stubLinkComponent
+    href="https://developer.paciellogroup.com/resources/contrastanalyser/"
+  >
+    Colour Contrast Analyser
+  </stubLinkComponent>
+   
+  if you're testing on a Mac) to manually verify that the
+   
+  <Code>
+    ImageView
+  </Code>
+   has sufficient contrast compared to the background. If the background is an image or gradient, test an area where the contrast appears to be the lowest.
 </span>
 `;
 
 exports[`RichResolutionContent renders static content with id=android/atfa/LinkPurposeUnclearCheck 1`] = `
 <span>
-  Describe the unique purpose of the link using any of the following:
-  <ul>
-    <li>
-      Good: Programmatically related context, or
-    </li>
-    <li>
-      Better: Accessible name and/or accessible description, or
-    </li>
-    <li>
-      Best: Link text
-    </li>
-  </ul>
-  Programmatically related context includes:
+  Examine the link in the context of the app to verify that the link's unique purpose is described by the link together with its preceding page content, which includes:
   <ul>
     <li>
       Text in the same sentence, paragraph, list item, or table cell as the link
@@ -287,19 +234,7 @@ exports[`RichResolutionContent renders static content with id=android/atfa/LinkP
       Text in a parent list item
     </li>
     <li>
-      Text in a table header cell associated with the cell that contains the link
-    </li>
-  </ul>
-  Writing tips:
-  <ul>
-    <li>
-      If a link's destination is a document or web application, the name of the document or application is sufficient.
-    </li>
-    <li>
-      Links with different destinations should have different descriptions; links with the same destination should have the same description.
-    </li>
-    <li>
-      Programmatically related context is easier to understand when it precedes the link.
+      Text in the table header cell that's associated with cell that contains the link
     </li>
   </ul>
 </span>
@@ -307,20 +242,7 @@ exports[`RichResolutionContent renders static content with id=android/atfa/LinkP
 
 exports[`RichResolutionContent renders static content with id=android/atfa/RedundantDescriptionCheck 1`] = `
 <span>
-  Don't include an element's role (type), state, or available actions in the following attributes: 
-  <Code>
-    android:contentDescription
-  </Code>
-  ,
-  <Code>
-    android:text
-  </Code>
-  ,
-   
-  <Code>
-    android:hint
-  </Code>
-  .
+  Listen to TalkBack's announcement of the element to verify that the item's role (type), state, and/or available actions are announced only once.
 </span>
 `;
 
@@ -363,26 +285,7 @@ exports[`RichResolutionContent renders static content with id=android/atfa/TextC
 
 exports[`RichResolutionContent renders static content with id=android/atfa/TraversalOrderCheck 1`] = `
 <span>
-  Good: If the app's view hierarchy doesn't create a logical traversal order, use 
-  <Code>
-    android:accessibilityTraversalBefore
-  </Code>
-   or
-  <Code>
-    android:accessibilityTraversalAfter
-  </Code>
-   attributes to create an order that makes sense to TalkBack users. Make sure that the attributes do not create any loops or traps that prevent the user from accessing all interactive elements.
-  <br />
-  Better: Restructure the view hierarchy to create a logical traversal order that does not require use of
-   
-  <Code>
-    android:accessibilityTraversalBefore
-  </Code>
-   or
-  <Code>
-    android:accessibilityTraversalAfter
-  </Code>
-   attributes.
+  Turn on Talkback. Swipe right to move accessibility focus forward through the elements on the screen, then swipe left to navigate backwards. Verify that focus moves through the elements in a logical, consistent order when navigating forwards or backwards.
 </span>
 `;
 


### PR DESCRIPTION
#### Details

Items in NeedsReview should use HowToCheck instructions instead of HowToFix instructions. Some of these instructions just settled today. 

##### Motivation

Part of MVP feature

##### Screenshots
These screenshots show what gets displayed in the UI. The results were synthesized by manually changing the returned rules to demonstrate all of the HowToCheck options, so please ignore the Class name, Content description, and Text options:

Rule | Screenshot
--- | ---
ClassNameCheck | ![image](https://user-images.githubusercontent.com/45672944/124046832-b0a11c80-d9c7-11eb-9b16-dcf528c82e47.png)
ClickableSpanCheck | ![image](https://user-images.githubusercontent.com/45672944/124046924-e0e8bb00-d9c7-11eb-98e4-0504eb9b6cf4.png)
DuplicateClickableBoundsCheck | ![image](https://user-images.githubusercontent.com/45672944/124046947-f65de500-d9c7-11eb-8e92-cb22a22a1133.png)
TextContrastCheck | ![image](https://user-images.githubusercontent.com/45672944/124046998-0bd30f00-d9c8-11eb-9241-889226079ba8.png)
DuplicateSpeakableTextCheck | ![image](https://user-images.githubusercontent.com/45672944/124047828-d0d1db00-d9c9-11eb-9680-9d001c5095e9.png)
LinkPurposeUnclearCheck | ![image](https://user-images.githubusercontent.com/45672944/124047089-3755f980-d9c8-11eb-8e60-2d9be024a517.png)
RedundantDescriptionCheck | ![image](https://user-images.githubusercontent.com/45672944/124047270-a3386200-d9c8-11eb-9dfe-d4c25394495e.png)
TraversalOrderCheck | ![image](https://user-images.githubusercontent.com/45672944/124047292-b77c5f00-d9c8-11eb-9734-24a1ab019237.png)
ImageContrastCheck | ![image](https://user-images.githubusercontent.com/45672944/124047320-cc58f280-d9c8-11eb-8b2b-678d6a662d00.png)



##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue:
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
