### PR TITLE
chore: fix codeql GitHub Action failures in dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ name: CI
 
 on:
   push:
+    branches: main
   pull_request:
   schedule:
     - cron: '0 19 * * 0'


### PR DESCRIPTION
#### Details

This updates the trigger configuration for our new GitHub Actions CI/PR build to avoid double-triggering for pushes to PRs that originate from in-upstream branches.

##### Motivation

The main impact of this is that we'll stop double-triggering PR builds for each push to a dependabot PR. This will also fix the spurious failures in the codeql job on some Dependabot PRs ([example](https://github.com/microsoft/accessibility-insights-web/pull/4419/checks?check_run_id=2945121676))

##### Context

The two alternatives I considered were what this PR does (`push: { branches: main }`) vs `push: { branches-ignore: dependabot/* }`.

Both solve the issue with the spurious dependabot PR codeql failures.

The differences are:
* The latter would still involve double-triggering the PR build for any PRs whose base branch is pushed to upstream, rather than a fork. The former would not double-trigger PR builds for such PRs.
* The former will not trigger CI builds for non-main upstream branches unless a (possibly-draft) PR is created from that branch. The latter would run CI builds for such a branch even if there is no open PR that uses it as a base.

Besides dependabot, we don't generally use in-repo branches. I think the main cases where we do are usually for testing release infrastructure changes (where we need to use in-repo branches for our release pipelines to allow secrets to be passed to testing builds). I don't think the difference is too big a deal either way since those cases generally use draft PRs anyway once they're ready to test/review, so I went with the option that uses fewer build resources. If we ever need to use a long-lived feature/release branch for some reason, we'd want to add it to the branches list.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
