### PR TITLE
feat(google-rules-mvp): Hide axe color contrast when ATFA rules are enabled

### DIFF
--- a/src/electron/platform/android/atfa-scan-results-to-unified-results.ts
+++ b/src/electron/platform/android/atfa-scan-results-to-unified-results.ts
@@ -35,7 +35,7 @@ export function convertAtfaScanResultsToUnifiedResults(
             const viewElement: ViewHierarchyElement =
                 atfaResult['AccessibilityHierarchyCheckResult.element'];
             if (viewElement) {
-                const ruleInformation: RuleInformation = ruleInformationProvider.getRuleInformation(
+                const ruleInformation = ruleInformationProvider.getRuleInformation(
                     atfaResult['AccessibilityCheckResult.checkClass'],
                 );
 

--- a/src/electron/platform/android/axe-scan-results-to-unified-results.ts
+++ b/src/electron/platform/android/axe-scan-results-to-unified-results.ts
@@ -26,9 +26,7 @@ export function convertAxeScanResultsToUnifiedResults(
     const unifiedResults: UnifiedResult[] = [];
 
     for (const ruleResult of scanResults.ruleResults) {
-        const ruleInformation: RuleInformation = ruleInformationProvider.getRuleInformation(
-            ruleResult.ruleId,
-        );
+        const ruleInformation = ruleInformationProvider.getRuleInformation(ruleResult.ruleId);
 
         if (ruleInformation) {
             unifiedResults.push(

--- a/src/electron/platform/android/rule-information-provider-type.ts
+++ b/src/electron/platform/android/rule-information-provider-type.ts
@@ -4,5 +4,5 @@
 import { RuleInformation } from './rule-information';
 
 export interface RuleInformationProviderType {
-    getRuleInformation(ruleId: string): RuleInformation;
+    getRuleInformation(ruleId: string): RuleInformation | null;
 }

--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -271,7 +271,7 @@ export class RuleInformationProvider {
         }
     };
 
-    public getRuleInformation(ruleId: string): RuleInformation {
+    public getRuleInformation(ruleId: string): RuleInformation | null {
         if (this.isRuleDisabledByAtfaResultsFeatureFlag(ruleId)) {
             return null;
         }

--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import {
     InstanceResultStatus,
     UnifiedResolution,
 } from 'common/types/store-data/unified-data-interface';
 import { link } from 'content/link';
+import { UnifiedFeatureFlags } from 'electron/common/unified-feature-flags';
 import { DictionaryStringTo } from 'types/common-types';
 
 import { RuleResultsData } from './android-scan-results';
@@ -12,8 +15,9 @@ import { RuleInformation } from './rule-information';
 
 export class RuleInformationProvider {
     private supportedRules: DictionaryStringTo<RuleInformation>;
+    private readonly rulesToDisableWithAtfaResults: string[];
     private readonly ruleLinkBaseUrl = 'https://accessibilityinsights.io/info-examples/android';
-    constructor() {
+    constructor(readonly featureFlagStore: FeatureFlagStore) {
         this.supportedRules = {
             ColorContrast: new RuleInformation(
                 'ColorContrast',
@@ -216,6 +220,8 @@ export class RuleInformationProvider {
                 this.getStandardResultStatus,
             ),
         };
+
+        this.rulesToDisableWithAtfaResults = ['ColorContrast'];
     }
 
     private getTouchSizeUnifiedResolution = (
@@ -266,8 +272,22 @@ export class RuleInformationProvider {
     };
 
     public getRuleInformation(ruleId: string): RuleInformation {
+        if (this.isRuleDisabledByAtfaResultsFeatureFlag(ruleId)) {
+            return null;
+        }
+
         const ruleInfo = this.supportedRules[ruleId];
         return ruleInfo || null;
+    }
+
+    private isRuleDisabledByAtfaResultsFeatureFlag(ruleId: string): boolean {
+        const featureFlagStoreData: FeatureFlagStoreData = this.featureFlagStore.getState();
+
+        if (featureFlagStoreData[UnifiedFeatureFlags.atfaResults]) {
+            return this.rulesToDisableWithAtfaResults.includes(ruleId);
+        }
+
+        return false;
     }
 
     private floorTo3Decimal(num: number): number {

--- a/src/electron/platform/android/unified-result-builder.ts
+++ b/src/electron/platform/android/unified-result-builder.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
+import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
 import { generateUID, UUIDGenerator } from 'common/uid-generator';
 import { ToolDataDelegate } from 'electron/common/application-properties-provider';
@@ -58,12 +59,13 @@ export const createBuilder =
 export const createDefaultBuilder = (
     getToolData: ToolDataDelegate,
     friendlyNameProvider: AndroidFriendlyDeviceNameProvider,
+    featureFlagsStore: FeatureFlagStore,
 ) => {
     return createBuilder(
         convertAllScanResultsToUnifiedResults,
         convertAllScanResultsToUnifiedRules,
         convertScanResultsToPlatformData,
-        new RuleInformationProvider(),
+        new RuleInformationProvider(featureFlagsStore),
         generateUID,
         getToolData,
         friendlyNameProvider,

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -437,7 +437,11 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch)
             'axe-android',
         );
 
-        const unifiedResultsBuilder = createDefaultBuilder(getToolData, friendlyDeviceNameProvider);
+        const unifiedResultsBuilder = createDefaultBuilder(
+            getToolData,
+            friendlyDeviceNameProvider,
+            featureFlagStore,
+        );
         const scanController = new ScanController(
             scanActions,
             unifiedScanResultActions,

--- a/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
@@ -263,7 +263,7 @@ describe('RuleInformationProvider', () => {
 
     it.each([
         ['available when ATFA flag is disabled', false],
-        ['not available when ATFA flag is enabled', false],
+        ['not available when ATFA flag is enabled', true],
     ])('Axe ColorContrast rule is %s', async (testName, flag) => {
         const atfaEnabledStore: FeatureFlagStoreData = {
             [UnifiedFeatureFlags.atfaResults]: flag,


### PR DESCRIPTION
#### Details

Exclude Axe ColorContrast rules from NeedsReview tab if ATFA rules are enabled, as ATFA has its own color contrast rule that we believe to be less noisy. Also includes some strict null checks that were necessary to get `yarn fastpass` to work as expected. These are called out individually in the review.

##### Motivation

Requirement from the spec

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: https://mseng.visualstudio.com/1ES/_workitems/edit/1856549
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
