### PR TITLE
chore: Use Node 14.17.1 to unblock PR build

### DIFF
--- a/pipeline/install-node-prerequisites.yaml
+++ b/pipeline/install-node-prerequisites.yaml
@@ -3,8 +3,8 @@
 steps:
     - task: NodeTool@0
       inputs:
-          versionSpec: '14.15.0'
-      displayName: use node 14.15.0
+          versionSpec: '14.17.1'
+      displayName: use node 14.17.1
       timeoutInMinutes: 2
 
     - script: npm install yarn@1.22.10 -g


### PR DESCRIPTION
#### Details

Use Node version 14.17.1 in the e2e pipelines

##### Motivation

Attempt to unblock the e2e_web_linux job, which recently reports failure because of a node version mismatch.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
