### PR TITLE
chore: Update Docker node version to 14.17.2 (security fix) to unblock PR build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ FROM mcr.microsoft.com/playwright:v1.12.2-focal
 
 USER root
 
-# Downgrading from nodejs 16.3.0 to 14.17.1 is both for consistency with our other build
+# Downgrading from nodejs 16.3.0 to 14.17.2 is both for consistency with our other build
 # environments and a workaround for https://github.com/nodejs/node/issues/39019
 RUN apt-get update && apt-get install -y curl && \
   curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \
-  apt-get install -y --allow-downgrades nodejs=14.17.1* && \
+  apt-get install -y --allow-downgrades nodejs=14.17.2* && \
   rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g yarn@1.22.10


### PR DESCRIPTION
#### Details

Node 14.17.1 is no longer available for the docker installation. Bump to 14.17.2 (which contains 2 security patches)

##### Motivation

Unblock the PR buid

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
