### PR TITLE
chore: Pin docker to nodejs version 14.* instead of 14.17.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ FROM mcr.microsoft.com/playwright:v1.12.2-focal
 
 USER root
 
-# Downgrading from nodejs 16.3.0 to 14.17.2 is both for consistency with our other build
+# Downgrading from nodejs 16.3.0 to 14.* is both for consistency with our other build
 # environments and a workaround for https://github.com/nodejs/node/issues/39019
 RUN apt-get update && apt-get install -y curl && \
   curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \
-  apt-get install -y --allow-downgrades nodejs=14.17.2* && \
+  apt-get install -y --allow-downgrades nodejs=14.* && \
   rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g yarn@1.22.10


### PR DESCRIPTION
#### Details

Letting Docker use any version of nodejs created a breaking change in nodejs 16.3.0, but pinning to 14.17.1 broke the build pipeline when 14.17.1 was deprecated and replaced by 14.17.2. This PR represents a "middle ground" option--we pin the major version at 14, but let the minor and patch versions float.

##### Motivation

(Hopefully) make the build pipeline more resilient to new releases of nodejs

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
Local docker image sets up successfully with this change.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
