### PR TITLE
fix: downgrade Playwright to more stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
         "mini-css-extract-plugin": "1.6.1",
         "npm-run-all": "^4.1.5",
         "pkg": "^5.3.0",
-        "playwright": "^1.12.2",
+        "playwright": "1.11.1",
         "preprocess": "^3.2.0",
         "prettier": "^2.3.1",
         "regenerator-runtime": "^0.13.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9886,10 +9886,10 @@ pkg@^5.3.0:
     stream-meter "^1.0.4"
     tslib "2.1.0"
 
-playwright@^1.12.2:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.12.2.tgz#a484447177b061dd76247734fe65d77e3fb139fa"
-  integrity sha512-tSZGeILY70T4imhCMCsvzhoaDm9baosIG5fQncSWprpjVc/X4yYdBQCLBMvOi98H50hvu9fhgy2hpsgFKCsUaw==
+playwright@1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.11.1.tgz#c5f2946db5195bd099a57ce4e188c01057876cff"
+  integrity sha512-UuMrYuvzttbJXUD7sTVcQBsGRojelGepvuQPD+QtVm/n5zyKvkiUErU/DGRXfX8VDZRdQ5D6qVqZndrydC2b4w==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"
@@ -9903,7 +9903,7 @@ playwright@^1.12.2:
     proxy-from-env "^1.1.0"
     rimraf "^3.0.2"
     stack-utils "^2.0.3"
-    ws "^7.4.6"
+    ws "^7.3.1"
     yazl "^2.5.1"
 
 plist@^3.0.1:
@@ -13028,10 +13028,15 @@ write-pkg@^4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
-ws@^7.2.3, ws@^7.4.5, ws@^7.4.6:
+ws@^7.2.3, ws@^7.4.5:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@^7.3.1:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
+  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
#### Details

This downgrades Playwright to 1.11.1 where we see significantly fewer transient E2E failures.

##### Motivation

Seeing lots of transient e2e failures after playwright was updated.

##### Context

Note: obviously doesn't fix the problem that may be occurring with Playwright. Investigation on the issue showed that our clean-up tasks for e2e tests (closing the browser) may be the culprit and wrapping that with error handling resolved the issue. Further investigation may be required to raise an issue on Playwright.

To get the e2e reliability runs, this will reference another PR (#4418) where I made these same changes with another negligible change to cause that pipeline to run. It is important to note that this doesn't fix all transient issues in our E2Es but only ones that pertain to "browserContext.close" issues that were coming up.

Here are e2e runs for the versions in question:
1. Original (1.11.1): https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=23043&view=results
2. Main branch (1.12.2): https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=23041&view=results
3. Most up-to-date version of Playwright (1.12.3): https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=23040&view=results

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
