### PR TITLE
fix: spelling consistency of "grayscale"

### DIFF
--- a/src/ad-hoc-visualizations/color/visualization.tsx
+++ b/src/ad-hoc-visualizations/color/visualization.tsx
@@ -35,7 +35,7 @@ export const ColorAdHocVisualization: VisualizationConfiguration = {
     shouldShowExportReport: () => false,
     displayableData: {
         title: 'Color',
-        enableMessage: 'Changing color to greyscale...',
+        enableMessage: 'Changing color to grayscale...',
         toggleLabel: 'Show grayscale',
         linkToDetailsViewText: 'How to test color',
     },
@@ -46,7 +46,7 @@ export const ColorAdHocVisualization: VisualizationConfiguration = {
     getIdentifier: () => colorTestKey,
     visualizationInstanceProcessor: () => VisualizationInstanceProcessor.nullProcessor,
     getNotificationMessage: selectorMap => null,
-    getDrawer: provider => provider.createSingleTargetDrawer('insights-grey-scale-container'),
+    getDrawer: provider => provider.createSingleTargetDrawer('insights-gray-scale-container'),
     getSwitchToTargetTabOnScan: () => false,
     getInstanceIdentiferGenerator: () => generateUID,
     guidance,

--- a/src/assessments/color/test-steps/use-of-color.tsx
+++ b/src/assessments/color/test-steps/use-of-color.tsx
@@ -65,5 +65,5 @@ export const UseOfColor: Requirement = {
             }),
         ),
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
-    getDrawer: provider => provider.createSingleTargetDrawer('insights-grey-scale-container'),
+    getDrawer: provider => provider.createSingleTargetDrawer('insights-gray-scale-container'),
 };

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -7,7 +7,7 @@
     visibility: hidden !important;
 }
 
-.insights-grey-scale-container {
+.insights-gray-scale-container {
     filter: grayscale(100%) !important;
 }
 


### PR DESCRIPTION

#### Details

All docs/resources have the word "grayscale" spelled with an "a", but the visual toast notification in AI-web had it spelled using an "e".  For consistency, I have updated that visualization as well as a couple of variables in the code that had it spelled differently.

##### Motivation

Spelling consistency in our product.

##### Context

I looked into the docs and also the assessment instructions to see what spelling was most commonly used.  This visualization was the only public place in the repo that used the "e" spelling, so I changed it to match the rest.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
