### PR TITLE
chore: remove dependency on q

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
         "luxon": "^1.27.0",
         "office-ui-fabric-react": "7.98.0",
         "portfinder": "^1.0.28",
-        "q": "1.5.1",
         "react": "^16.14.0",
         "react-copy-to-clipboard": "^5.0.3",
         "react-dom": "^16.14.0",

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -6,7 +6,6 @@ import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-
 import { BaseStore } from '../../common/base-store';
 import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
 import { ScopingStoreData } from '../../common/types/store-data/scoping-store-data';
-import { WindowUtils } from '../../common/window-utils';
 import { ScannerUtils } from '../scanner-utils';
 import { TabStopsListener } from '../tab-stops-listener';
 import {
@@ -106,7 +105,6 @@ export class AnalyzerProvider {
         return new TabStopsAnalyzer(
             config,
             this.tabStopsListener,
-            new WindowUtils(),
             this.sendMessageDelegate,
             this.scanIncompleteWarningDetector,
             this.logger,

--- a/src/injected/analyzers/base-analyzer.ts
+++ b/src/injected/analyzers/base-analyzer.ts
@@ -5,7 +5,6 @@ import { Message } from 'common/message';
 import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
 import { VisualizationType } from 'common/types/visualization-type';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
-import * as Q from 'q';
 
 import { Analyzer, AnalyzerConfiguration, ScanCompletedPayload } from './analyzer';
 
@@ -32,8 +31,8 @@ export class BaseAnalyzer implements Analyzer {
 
     public teardown(): void {}
 
-    protected getResults = (): Q.Promise<AxeAnalyzerResult> => {
-        return Q(this.emptyResults);
+    protected getResults = (): Promise<AxeAnalyzerResult> => {
+        return Promise.resolve(this.emptyResults);
     };
 
     protected onResolve = (analyzerResult: AxeAnalyzerResult): void => {

--- a/src/tests/unit/common/debounce-faker.ts
+++ b/src/tests/unit/common/debounce-faker.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import type { DebouncedFunc } from 'lodash';
+
+export type DebounceCallRecord<T extends (...args: any[]) => any> = {
+    args: Parameters<T>;
+};
+
+// Intended for use in tests of components that rely on lodash.debounce.
+//
+// A test can set up a new DebounceFaker() instance and pass theDebounceFaker.debounce in place
+// of lodash.debounce to a dependency, and then use theDebounceFaker's properties to track
+// details of the call to debounce and/or invoke theDebounceFaker's flush/cancel methods to control
+// the timings of when debouncing triggers.
+//
+// Note that the faked version of debounce will *not* automatically invoke its callback after
+// the usual delay; a test must *explicitly* invoke theDebounceFaker.flush() when it is ready
+// for any debounced calls to run.
+export class DebounceFaker<T extends (...args: any[]) => any> {
+    public used = false;
+    public cancelled = false;
+    public pendingCall: DebounceCallRecord<T> | null = null;
+    public delay: number;
+    public callback: T;
+
+    public cancel = () => {
+        this.cancelled = true;
+        this.pendingCall = null;
+    };
+    public flush = (): ReturnType<T> | undefined => {
+        if (this.pendingCall != null) {
+            const args = this.pendingCall.args;
+            this.pendingCall = null;
+            return this.callback(...args);
+        }
+        return undefined;
+    };
+    public debounce = (callback: T, delay: number, options?: {}): DebouncedFunc<T> => {
+        if (this.used) {
+            throw new Error('A given DebounceFaker can only be used once');
+        }
+        if (options != null) {
+            throw new Error('Custom debounce options not implemented');
+        }
+        this.used = true;
+        this.delay = delay;
+        this.callback = callback;
+
+        const output = (...args: Parameters<T>): ReturnType<T> | undefined => {
+            if (!this.cancelled) {
+                this.pendingCall = { args };
+            }
+            return undefined;
+        };
+        output.cancel = this.cancel;
+        output.flush = this.flush;
+        return output;
+    };
+}

--- a/src/tests/unit/stubs/q-stub.ts
+++ b/src/tests/unit/stubs/q-stub.ts
@@ -1,9 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-export class QStub {
-    public defer(): void {}
-
-    public allSettled(): void {}
-
-    public timeout(): void {}
-}

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -7,7 +7,6 @@ import { IMock, Mock } from 'typemoq';
 
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { WindowUtils } from '../../../../../common/window-utils';
 import {
     AnalyzerConfiguration,
     FocusAnalyzerConfiguration,
@@ -143,7 +142,6 @@ describe('AnalyzerProviderTests', () => {
         const analyzer = testObject.createFocusTrackingAnalyzer(config);
         const openAnalyzer = analyzer as any;
         expect(analyzer).toBeInstanceOf(BaseAnalyzer);
-        expect(openAnalyzer.windowUtils).toBeInstanceOf(WindowUtils);
         expect(openAnalyzer.tabStopsListener).toEqual(tabStopsListener.object);
         expect(openAnalyzer.config).toEqual(config);
         expect(openAnalyzer.sendMessage).toEqual(sendMessageMock.object);

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -482,6 +482,7 @@
         "./src/tests/unit/common/assessment-data-builder.ts",
         "./src/tests/unit/common/assessment-store-tester.ts",
         "./src/tests/unit/common/base-data-builder.ts",
+        "./src/tests/unit/common/debounce-faker.ts",
         "./src/tests/unit/common/event-stub-factory.ts",
         "./src/tests/unit/common/fail-test-on-error-logger.ts",
         "./src/tests/unit/common/html-collection-of-builder.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10281,7 +10281,7 @@ puppeteer-core@^5.1.0:
     unbzip2-stream "^1.3.3"
     ws "^7.2.3"
 
-q@1.5.1, q@^1.5.1, q@~1.5.0:
+q@^1.5.1, q@~1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=


### PR DESCRIPTION
#### Details

`q` is a library that provides a standalone implementation of Promises. We've been gradually switching from it to native Promises for some time now. This PR finishes that work and removes the dependency on `q`.

Most of the interesting dependencies on Q were removed as part of #4155. The remaining interesting dependency was in `tab-stops-analyzer`, which used `Q.Promise`'s `progress()` callback in a way which isn't supported by native promises.

The only actual callback passed to the progress callback was the tab stops analyzer's own `onProgress` handler, which then calls out to `window.setTimeout` to implement some custom debouncing logic. This PR ripped out the `onProgress` implementation based on Q and replaced it with a more direct use of callbacks. While I was having to redo some of the test infrastructure anyway, I went ahead and replaced the custom debounce implementation with `lodash.debounce`; this required writing a `DebounceFaker` test helper to test with, but simplified the implementation substantially, which I think is a good tradeoff.

##### Motivation

Reduce unnecessary dependencies

##### Context

No user visible changes. I verified manually that paths through the tab-stops-analyzer (tab stops in adhoc, fastpass, assessment), rule-analyzer (individual assessment visualizers), and batched-analyzer (fastpass/assessment automated checks) seemed to have unchanged behavior.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
