### PR TITLE
fix: suppress failures on browser close for E2E tests

### DIFF
--- a/src/tests/end-to-end/common/browser.ts
+++ b/src/tests/end-to-end/common/browser.ts
@@ -26,6 +26,16 @@ export class Browser {
     }
 
     public async close(): Promise<void> {
+        try {
+            await this.unsafeClose();
+        } catch (e) {
+            console.log('Suppressing failure on browser close: ', e);
+        }
+    }
+
+    // Due to an update in Playwright, closing the browser like below causes transient issues
+    // in the E2E tests; notating this as unsafeClose until that issue is resolved.
+    private async unsafeClose(): Promise<void> {
         if (null == this.underlyingBrowserContext) {
             return;
         }


### PR DESCRIPTION
#### Details

This wraps the `close` method in the browser class with catch statement which will suppress failures.

##### Motivation

Seeing transient issues in our E2E due to recent playwright updates with this specific function.

##### Context

I chose this approach because it touches the least amount of files; I could create a new method called `closeSafely` but all signatures would need to change. Figured, renaming to unsafeClose for the function details with a comment would be a better approach.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
