### PR TITLE
feat(google-rules-mvp): Pick up latest version of Android service

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
         "webpack-node-externals": "^3.0.0"
     },
     "dependencies": {
-        "accessibility-insights-for-android-service-bin": "1.3.1",
+        "accessibility-insights-for-android-service-bin": "1.4.0",
         "ajv": "^8.6.0",
         "android-device-list": "^1.2.7",
         "appium-adb": "^8.12.3",

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/mock-adb.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/mock-adb.test.ts.snap
@@ -51,7 +51,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -133,7 +133,7 @@ Success
   },
   "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-2 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -215,7 +215,7 @@ Success
   },
   "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s emulator-3 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -320,7 +320,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -427,7 +427,7 @@ Success
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "delayMs": 5000,
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "delayMs": 5000,
@@ -540,7 +540,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -622,7 +622,7 @@ Success
   },
   "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-2 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -704,7 +704,7 @@ Success
   },
   "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s emulator-3 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -809,7 +809,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -916,7 +916,7 @@ Success
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "delayMs": 5000,
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "delayMs": 5000,
@@ -1019,7 +1019,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1097,7 +1097,7 @@ Success
   },
   "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-2 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1175,7 +1175,7 @@ Success
   },
   "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s emulator-3 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1274,7 +1274,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1376,7 +1376,7 @@ Success
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "delayMs": 5000,
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "delayMs": 5000,
@@ -1483,7 +1483,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1562,7 +1562,7 @@ Success
   },
   "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-2 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1641,7 +1641,7 @@ Success
   },
   "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s emulator-3 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1743,7 +1743,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -1846,7 +1846,7 @@ Success
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "delayMs": 5000,
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "delayMs": 5000,
@@ -1959,7 +1959,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -2041,7 +2041,7 @@ Success
   },
   "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-2 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -2123,7 +2123,7 @@ Success
   },
   "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s emulator-3 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -2228,7 +2228,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -2335,7 +2335,7 @@ Success
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "delayMs": 5000,
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "delayMs": 5000,
@@ -2447,7 +2447,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -2529,7 +2529,7 @@ Success
   },
   "-s device-2 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-2 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -2611,7 +2611,7 @@ Success
   },
   "-s emulator-3 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s emulator-3 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -2716,7 +2716,7 @@ Success
   },
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "stdout": "10",
@@ -2822,7 +2822,7 @@ Success
   "-s device-1 shell dumpsys package com.microsoft.accessibilityinsightsforandroidservice": Object {
     "delayMs": 5000,
     "stdout": "    versionCode=102000 minSdk=24 targetSdk=28
-    versionName=1.3.1",
+    versionName=1.4.0",
   },
   "-s device-1 shell getprop ro.build.version.release": Object {
     "delayMs": 5000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2674,10 +2674,10 @@ accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
-accessibility-insights-for-android-service-bin@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/accessibility-insights-for-android-service-bin/-/accessibility-insights-for-android-service-bin-1.3.1.tgz#4e19b3beed821ec9229eb56365eb6a3f623f9b95"
-  integrity sha512-pTq5+wkWVOUIhZdHri4mHLpaPZsVxAnHYny6y6JxeehfMWvrGj2ZZo7nvfPp9LLx3PHf7DQfUw0NzPLmaLK3eA==
+accessibility-insights-for-android-service-bin@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/accessibility-insights-for-android-service-bin/-/accessibility-insights-for-android-service-bin-1.4.0.tgz#fb1b6ec2995be09fd70242559fccf8487069c10c"
+  integrity sha512-oXbluaGEOjAH+VnPwg7sArtiqq9refMCXSfdiiWrOIx2mH4chvRKDDL2+wI8xqH01ChXDaTZRvFk3/IYdK9wVA==
 
 acorn-globals@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
#### Details

This incorporates version 1.4.0 of the Android service into the Unified client. As long as the `atfaResults` feature flag is false, the client will continue to receive and display the same results as before.

##### Motivation

Feature requirement

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
I'm not really sure if we want to lock this version, since the releases are infrequent and tightly controlled. I kept the existing pattern for now...

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1858555](https://mseng.visualstudio.com/1ES/_workitems/edit/1858555)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
