### PR TITLE
chore: remove @types/q

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
         "@types/lodash": "^4.14.170",
         "@types/luxon": "^1.27.0",
         "@types/node": "^14.17.5",
-        "@types/q": "^1.5.4",
         "@types/react": "^16.14.11",
         "@types/react-copy-to-clipboard": "^5.0.0",
         "@types/react-dom": "^16.9.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,11 +2200,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/q@^1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
-  integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
-
 "@types/react-copy-to-clipboard@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@types/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.0.tgz#38b035ca0c28334d3e0efaf3f319b81eea9690cd"


### PR DESCRIPTION
#### Details

#4447 removed our dependency on `q` but missed the corresponding dependency on `@types/q`. This drops the obsolete types package.

##### Motivation

Remove unnecessary dependency

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
