### PR TITLE
feat(google-rules-mvp): Enable ATFA results by default

### DIFF
--- a/src/electron/common/unified-feature-flags.ts
+++ b/src/electron/common/unified-feature-flags.ts
@@ -47,7 +47,7 @@ export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
         },
         {
             id: UnifiedFeatureFlags.atfaResults,
-            defaultValue: false,
+            defaultValue: true,
             displayableName: 'Show ATFA results',
             displayableDescription: 'Show the Accessibility Test Framework for Android results',
             isPreviewFeature: false,

--- a/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
+++ b/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
@@ -24,7 +24,7 @@ describe('FeatureFlagsTest', () => {
             [UnifiedFeatureFlags.showAllFeatureFlags]: false,
             [UnifiedFeatureFlags.exportReport]: true,
             [UnifiedFeatureFlags.tabStops]: true,
-            [UnifiedFeatureFlags.atfaResults]: false,
+            [UnifiedFeatureFlags.atfaResults]: true,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Details

Enable ATFA rules by default

##### Motivation

Feature requirement

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1853281](https://mseng.visualstudio.com/1ES/_workitems/edit/1853281)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
