### PR TITLE
chore: fix CI build artifact names from chunked jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: ${{ always() }}
       with:
-        name: e2e-web-tests-${{ matrix.chunk-index }}-results
+        name: e2e-web-tests-${{ strategy.job-index }}-results
         path: test-results/e2e/junit-e2e.xml
       timeout-minutes: 3
 
@@ -210,7 +210,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
-        name: e2e-web-tests-${{ matrix.chunk-index }}-debug-logs
+        name: e2e-web-tests-${{ strategy.job-index }}-debug-logs
         path: |
           test-results/e2e/chrome-logs
           test-results/e2e/failure-screenshots
@@ -266,7 +266,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: ${{ always() }}
       with:
-        name: e2e-unified-tests-${{ matrix.chunk-index }}-results
+        name: e2e-unified-tests-${{ strategy.job-index }}-results
         path: test-results/electron
       timeout-minutes: 3
 


### PR DESCRIPTION
#### Details

The artifact names our GitHub Actions CI builds were using for uploads in the chunked e2e jobs were using an outdated value for the chunk index as part of the name, so in practice, they were showing up with names like `e2e-unified-tests--results.zip` instead of the intended `e2e-unified-tests-1-results.zip`.

This has the particularly nasty side effect that only one of the chunks' logs/results actually got uploaded at all, since each chunk gets the same name.

This PR fixes them to be consistent with how the job titles are formed.

##### Motivation

Be able to get results from each chunk of e2e tests

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
