### PR TITLE
chore(test): fix inaccurate line/source info in test output

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -9,5 +9,6 @@
         "type": "commonjs",
         "noInterop": true
     },
-    "env": {}
+    "env": {},
+    "sourceMaps": "inline"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
             "name": "Debug current test file in VSCode",
             "type": "node",
             "request": "launch",
+            "cwd": "${workspaceFolder}",
             "runtimeArgs": [
                 "--inspect-brk",
                 "${workspaceRoot}/node_modules/jest/bin/jest.js",
@@ -71,6 +72,7 @@
             "name": "Debug null:find",
             "type": "node",
             "request": "launch",
+            "cwd": "${workspaceFolder}",
             "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/tools/strict-null-checks/find.js"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",


### PR DESCRIPTION
#### Details

`swc` omits source map information by default, which meant that our test output was giving wrong information whenever Jest wanted to emit a stack or a source snippet for debugging purposes, and also meant that VS Code had trouble with interpreting breakpoints accurately.

This PR enables inline source maps in our `.swcrc`. This has a substantial negative impact on test runtime (on my machine, it bumps the time for a full `yarn test` from 3m05s to 4m15s), but I think being able to debug failures accurately is more important and this doesn't impact PR build time - even chunked, both the unified and web e2e tests are still long poles in comparison).

I also included a minor fix to `.vscode/launch.json` to explicitly specify a `cwd` property in node/launch configs. Previously, if your VS Code integrated terminal settings involve a non-standard cwd (like mine did), those launch tasks wouldn't work because they assume they're being run from the workspace root; this change should be a noop for folks without customized terminal settings.

##### Motivation

Enables accurate debugging of test failures.

Example of a MockException failure in url-validator (reviewer note: if you're trying this locally, you'll need `yarn test -- -- --clearCache` in between changes to `.swcrc`:

**Before:**

note that the line number at the bottom of the stack, `src/tests/unit/tests/common/url-validator.test.ts:72:28`, is misreported (the whole file is only 67 lines long), and that there is no code snippet:

```
> yarn test -- -- --collectCoverage=false -- url-valid
yarn run v1.22.10
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
$ cross-env --max-old-space-size=16384  jest --projects src/tests/unit --collectCoverage=false -- url-valid
 FAIL   unit tests  src/tests/unit/tests/common/url-validator.test.ts
  UrlValidatorTest
    × isSupportedUrl: file (5 ms)

  ● UrlValidatorTest › isSupportedUrl: file

    MockException: expected invocation of Function() at least 2 times, invoked 1 times
     Configured setups:
     Function(), at least 2 times

     Performed invocations:
     Function()



      at MockException.Exception [as constructor] (node_modules/typemoq/dist/Error/Error/Error/Exception.ts:3:9)
      at new MockException (node_modules/typemoq/dist/Error/Error/Error/MockException.ts:20:9)
      at InterceptorExecute.Object.<anonymous>.InterceptorExecute.throwVerifyCallCountException (node_modules/typemoq/dist/InterceptorExecute.ts:75:17)
      at InterceptorExecute.Object.<anonymous>.InterceptorExecute.verifyCallCount (node_modules/typemoq/dist/InterceptorExecute.ts:64:18)
      at InterceptorExecute.Object.<anonymous>.InterceptorExecute.verify (node_modules/typemoq/dist/InterceptorExecute.ts:51:18)
      at DynamicMock.Object.<anonymous>.MockBase.verifyAll (node_modules/typemoq/dist/MockBase.ts:61:31)
      at Object.<anonymous> (src/tests/unit/tests/common/url-validator.test.ts:72:28)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 13 passed, 14 total
Snapshots:   0 total
Time:        3.098 s
Ran all test suites matching /url-valid/i.
```

**After:**

note line number `src/tests/unit/tests/common/url-validator.test.ts:51:28` is correct and code snippet is present

```
> yarn test -- -- --collectCoverage=false -- url-valid
yarn run v1.22.10
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
$ cross-env --max-old-space-size=16384  jest --projects src/tests/unit --collectCoverage=false -- url-valid
 FAIL   unit tests  src/tests/unit/tests/common/url-validator.test.ts
  UrlValidatorTest
    × isSupportedUrl: file (4 ms)

  ● UrlValidatorTest › isSupportedUrl: file

    MockException: expected invocation of Function() at least 2 times, invoked 1 times
     Configured setups:
     Function(), at least 2 times

     Performed invocations:
     Function()

      49 |         expect(isSupported).toBe(true);
      50 |
    > 51 |         browserAdapterMock.verifyAll();
         |                            ^
      52 |     });
      53 |
      54 |     test('isFileUrl, but have no access, so isNotSupportedUrl', async () => {

      at MockException.Exception [as constructor] (node_modules/typemoq/dist/Error/Error/Error/Exception.ts:3:9)
      at new MockException (node_modules/typemoq/dist/Error/Error/Error/MockException.ts:20:9)
      at InterceptorExecute.Object.<anonymous>.InterceptorExecute.throwVerifyCallCountException (node_modules/typemoq/dist/InterceptorExecute.ts:75:17)
      at InterceptorExecute.Object.<anonymous>.InterceptorExecute.verifyCallCount (node_modules/typemoq/dist/InterceptorExecute.ts:64:18)
      at InterceptorExecute.Object.<anonymous>.InterceptorExecute.verify (node_modules/typemoq/dist/InterceptorExecute.ts:51:18)
      at DynamicMock.Object.<anonymous>.MockBase.verifyAll (node_modules/typemoq/dist/MockBase.ts:61:31)
      at Object.<anonymous> (src/tests/unit/tests/common/url-validator.test.ts:51:28)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 13 passed, 14 total
Snapshots:   0 total
Time:        3.798 s, estimated 11 s
Ran all test suites matching /url-valid/i.
```

##### Context

I tested and compared the performance of using babel-jest. swc with inline source maps is still a little faster than babel-jest (4m15s vs 5m05s on my machine), but enabling the source maps from swc definitely brings the two more in line timing wise.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
