### PR TITLE
fix: Specify stroke color for SVG's in HC modes

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -1041,6 +1041,7 @@
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
           fill: inherit !important;
+          stroke: ButtonText !important;
         }
       }
       button.kebab-menu-button--_mBMA:hover {
@@ -1077,6 +1078,11 @@
       }
       .foot--_yPbe .highlight-status--H08nj svg {
         fill: var(--secondary-text);
+      }
+      @media screen and (forced-colors: active) {
+        .foot--_yPbe .highlight-status--H08nj svg {
+          stroke: ButtonText !important;
+        }
       }
       .foot--_yPbe .highlight-status--H08nj label {
         color: var(--secondary-text);

--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -1040,7 +1040,7 @@
       }
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
-          fill: inherit !important;
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
@@ -1081,6 +1081,7 @@
       }
       @media screen and (forced-colors: active) {
         .foot--_yPbe .highlight-status--H08nj svg {
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -1041,6 +1041,7 @@
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
           fill: inherit !important;
+          stroke: ButtonText !important;
         }
       }
       button.kebab-menu-button--_mBMA:hover {
@@ -1077,6 +1078,11 @@
       }
       .foot--_yPbe .highlight-status--H08nj svg {
         fill: var(--secondary-text);
+      }
+      @media screen and (forced-colors: active) {
+        .foot--_yPbe .highlight-status--H08nj svg {
+          stroke: ButtonText !important;
+        }
       }
       .foot--_yPbe .highlight-status--H08nj label {
         color: var(--secondary-text);

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -1040,7 +1040,7 @@
       }
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
-          fill: inherit !important;
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
@@ -1081,6 +1081,7 @@
       }
       @media screen and (forced-colors: active) {
         .foot--_yPbe .highlight-status--H08nj svg {
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -1041,6 +1041,7 @@
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
           fill: inherit !important;
+          stroke: ButtonText !important;
         }
       }
       button.kebab-menu-button--_mBMA:hover {
@@ -1077,6 +1078,11 @@
       }
       .foot--_yPbe .highlight-status--H08nj svg {
         fill: var(--secondary-text);
+      }
+      @media screen and (forced-colors: active) {
+        .foot--_yPbe .highlight-status--H08nj svg {
+          stroke: ButtonText !important;
+        }
       }
       .foot--_yPbe .highlight-status--H08nj label {
         color: var(--secondary-text);

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -1040,7 +1040,7 @@
       }
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
-          fill: inherit !important;
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
@@ -1081,6 +1081,7 @@
       }
       @media screen and (forced-colors: active) {
         .foot--_yPbe .highlight-status--H08nj svg {
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -1041,6 +1041,7 @@
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
           fill: inherit !important;
+          stroke: ButtonText !important;
         }
       }
       button.kebab-menu-button--_mBMA:hover {
@@ -1077,6 +1078,11 @@
       }
       .foot--_yPbe .highlight-status--H08nj svg {
         fill: var(--secondary-text);
+      }
+      @media screen and (forced-colors: active) {
+        .foot--_yPbe .highlight-status--H08nj svg {
+          stroke: ButtonText !important;
+        }
       }
       .foot--_yPbe .highlight-status--H08nj label {
         color: var(--secondary-text);

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -1040,7 +1040,7 @@
       }
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
-          fill: inherit !important;
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
@@ -1081,6 +1081,7 @@
       }
       @media screen and (forced-colors: active) {
         .foot--_yPbe .highlight-status--H08nj svg {
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -1041,6 +1041,7 @@
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
           fill: inherit !important;
+          stroke: ButtonText !important;
         }
       }
       button.kebab-menu-button--_mBMA:hover {
@@ -1077,6 +1078,11 @@
       }
       .foot--_yPbe .highlight-status--H08nj svg {
         fill: var(--secondary-text);
+      }
+      @media screen and (forced-colors: active) {
+        .foot--_yPbe .highlight-status--H08nj svg {
+          stroke: ButtonText !important;
+        }
       }
       .foot--_yPbe .highlight-status--H08nj label {
         color: var(--secondary-text);

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -1040,7 +1040,7 @@
       }
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
-          fill: inherit !important;
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
@@ -1081,6 +1081,7 @@
       }
       @media screen and (forced-colors: active) {
         .foot--_yPbe .highlight-status--H08nj svg {
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -1041,6 +1041,7 @@
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
           fill: inherit !important;
+          stroke: ButtonText !important;
         }
       }
       button.kebab-menu-button--_mBMA:hover {
@@ -1077,6 +1078,11 @@
       }
       .foot--_yPbe .highlight-status--H08nj svg {
         fill: var(--secondary-text);
+      }
+      @media screen and (forced-colors: active) {
+        .foot--_yPbe .highlight-status--H08nj svg {
+          stroke: ButtonText !important;
+        }
       }
       .foot--_yPbe .highlight-status--H08nj label {
         color: var(--secondary-text);

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -1040,7 +1040,7 @@
       }
       @media screen and (forced-colors: active) {
         button.kebab-menu-button--_mBMA svg {
-          fill: inherit !important;
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
@@ -1081,6 +1081,7 @@
       }
       @media screen and (forced-colors: active) {
         .foot--_yPbe .highlight-status--H08nj svg {
+          fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }

--- a/src/common/components/cards/card-kebab-menu-button.scss
+++ b/src/common/components/cards/card-kebab-menu-button.scss
@@ -45,7 +45,7 @@ button.kebab-menu-button {
     svg {
         stroke: $primary-text;
         @media screen and (forced-colors: active) {
-            fill: inherit !important;
+            fill: ButtonFace !important;
             stroke: ButtonText !important;
         }
     }

--- a/src/common/components/cards/card-kebab-menu-button.scss
+++ b/src/common/components/cards/card-kebab-menu-button.scss
@@ -43,10 +43,11 @@ button.kebab-menu-button {
     background: transparent;
 
     svg {
+        stroke: $primary-text;
         @media screen and (forced-colors: active) {
             fill: inherit !important;
+            stroke: ButtonText !important;
         }
-        stroke: $primary-text;
     }
 
     &:hover {

--- a/src/common/components/cards/instance-details-footer.scss
+++ b/src/common/components/cards/instance-details-footer.scss
@@ -27,6 +27,7 @@
         svg {
             fill: $secondary-text;
             @media screen and (forced-colors: active) {
+                fill: ButtonFace !important;
                 stroke: ButtonText !important;
             }
         }

--- a/src/common/components/cards/instance-details-footer.scss
+++ b/src/common/components/cards/instance-details-footer.scss
@@ -26,6 +26,9 @@
 
         svg {
             fill: $secondary-text;
+            @media screen and (forced-colors: active) {
+                stroke: ButtonText !important;
+            }
         }
 
         label {


### PR DESCRIPTION
#### Details

Fix a couple of HC problems in card footer. Root problem is that we aren't specifying HC stroke and fill colors, so the browser is choosing unfortunate values on our behalf. Prior to this change, none of the SVG's on this page would be visible in any Windows HC modes.

##### Motivation

Addresses issue #4326 

##### Screenshots

HC Mode | Highlight Hidden | Highlight Visible | More Actions
--- | --- | --- | ---
None | ![image](https://user-images.githubusercontent.com/45672944/126401909-95f8b1f9-bdc2-4545-807e-bd3f2bdd56e5.png) | ![image](https://user-images.githubusercontent.com/45672944/126401932-28ba312e-599c-4495-929c-4b6fd56c0a19.png) | ![image](https://user-images.githubusercontent.com/45672944/126401957-81398068-7f03-4a7c-9e1a-e1adba18ff5b.png)
Extension HC mode | ![image](https://user-images.githubusercontent.com/45672944/126402937-fac4eb0f-8465-4575-b425-158bc799d6ed.png) | ![image](https://user-images.githubusercontent.com/45672944/126402903-7bae3dd4-5062-49d0-bbc7-3b66e7e15e32.png) | ![image](https://user-images.githubusercontent.com/45672944/126402968-aa44a3c7-0ff4-4d7b-b64b-fad8da98c979.png)
Windows HC 1 | ![image](https://user-images.githubusercontent.com/45672944/126401781-76ece9b1-9aab-49f7-9a70-11e68fb637e1.png) | ![image](https://user-images.githubusercontent.com/45672944/126401810-cd9e4d65-2fd0-437b-8076-6f74943c55f3.png) | ![image](https://user-images.githubusercontent.com/45672944/126401838-68d29eda-2a88-4cfb-8dc9-91facb8dc2bb.png)
Windows HC 2 | ![image](https://user-images.githubusercontent.com/45672944/126401385-cd0b8e3d-ea0a-442b-913c-c4bb26e54752.png) | ![image](https://user-images.githubusercontent.com/45672944/126401414-71edc791-071a-4728-86fa-99e3da6e3fc8.png) | ![image](https://user-images.githubusercontent.com/45672944/126401439-8031ac17-84b9-4151-b7dc-e93b899e052a.png)
Windows HC Black | ![image](https://user-images.githubusercontent.com/45672944/126401655-54341cc9-199d-4bbc-9d65-f6d3ff30527b.png) | ![image](https://user-images.githubusercontent.com/45672944/126401698-d51054c6-bdd0-4930-8bc0-db260b98a2c1.png) | ![image](https://user-images.githubusercontent.com/45672944/126401730-10d0392b-c369-4726-a974-3d92c34ff525.png)
Windows HC White | ![image](https://user-images.githubusercontent.com/45672944/126401489-1e8fb3ad-587c-42ca-b3d0-bf45321c26d0.png) | ![image](https://user-images.githubusercontent.com/45672944/126401521-5f13eed9-ec0d-4e66-90da-8ab30d4a1fcd.png) | ![image](https://user-images.githubusercontent.com/45672944/126402593-89ac8537-b23a-4acd-bcca-99e3ee28187b.png)


##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4326
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [css only] (UI changes only) Verified usability with NVDA/JAWS
