### PR TITLE
fix: Show dialog cancel buttons in system HC modes

### DIFF
--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -178,6 +178,12 @@
             font-size: 21px !important;
             font-weight: $fontWeightSemiBold !important;
             letter-spacing: -0.02em !important;
+            svg {
+                @media screen and (forced-colors: active) {
+                    fill: ButtonFace !important;
+                    stroke: ButtonText !important;
+                }
+            }
         }
 
         .insights-dialog-section-title {


### PR DESCRIPTION
#### Details

Specify HC overrides of SVG color in dialog title bar, so that the dialog's close button gets displayed correctly in system HC modes.

##### Motivation

Addresses #4281 

##### Screenshots
HC Mode | Dialog Caption
--- | ---
None | ![image](https://user-images.githubusercontent.com/45672944/126408906-ec0cfacd-06c5-43a2-82b3-a4e97b722d9c.png)
HC 1 | ![image](https://user-images.githubusercontent.com/45672944/126408866-7fcd0caa-d554-4ae5-9428-61dc5119b351.png)
HC 2 | ![image](https://user-images.githubusercontent.com/45672944/126408834-68577eac-7d06-4786-a89a-7b253696c292.png)
HC Black | ![image](https://user-images.githubusercontent.com/45672944/126408786-a94e4611-53af-4328-9867-65ce32e77d54.png)
HC White | ![image](https://user-images.githubusercontent.com/45672944/126408806-6e18953b-cdcd-4503-bbd7-cd5fc48f39f7.png)
Extension HC | ![image](https://user-images.githubusercontent.com/45672944/126408989-3d04a7b9-9747-49c5-a2a1-ff999ccd2ddb.png)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4281 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [css only] (UI changes only) Verified usability with NVDA/JAWS
