### PR TITLE
fix: Fix cancel button in inspect dialog in HC modes (2nd attempt)

### DIFF
--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -65,14 +65,11 @@
         max-width: 25%;
         user-select: text;
         min-width: 520px;
-        svg {
+        svg path {
             @media screen and (forced-colors: active) {
-                fill: inherit !important;
-            }
-        }
-        path {
-            @media screen and (forced-colors: active) {
-                fill: inherit !important;
+                forced-color-adjust: none !important;
+                stroke: ButtonText !important;
+                fill: ButtonText !important;
             }
         }
     }
@@ -125,7 +122,7 @@
             fill: $neutral-100 !important;
             fill-opacity: 0.9 !important;
 
-            @media screen and (forced-colors) {
+            @media screen and (forced-colors: active) {
                 fill: inherit !important;
             }
         }
@@ -135,7 +132,7 @@
     .insights-dialog-main-override .copy-issue-details-button,
     .insights-dialog-main-override .insights-dialog-button-inspect {
         svg path {
-            @media screen and (forced-colors) {
+            @media screen and (forced-colors: active) {
                 forced-color-adjust: none !important;
                 stroke: ButtonText !important;
                 fill: ButtonFace !important;
@@ -178,12 +175,6 @@
             font-size: 21px !important;
             font-weight: $fontWeightSemiBold !important;
             letter-spacing: -0.02em !important;
-            svg {
-                @media screen and (forced-colors: active) {
-                    fill: ButtonFace !important;
-                    stroke: ButtonText !important;
-                }
-            }
         }
 
         .insights-dialog-section-title {


### PR DESCRIPTION
#### Details

This is a reworking of #4509, which failed to fix #4281. My best theory is that I had some file caching issue when testing #4509 locally. #4509 scoped SVG's in forced-color mode to the inspect dialog title bar; this expands it to all of the SVG's inside the inspect dialog. It might be possible to optimize out some override steps.

##### Motivation

Address #4281 

##### Screenshots

Screenshots include the entire inspect dialog, to minimize the risk of unintended side effects

HC Mode | Dialog
--- | ---
None | ![image](https://user-images.githubusercontent.com/45672944/127412205-440fc0a1-1b56-4188-8546-e63699886782.png)
App in HC | ![image](https://user-images.githubusercontent.com/45672944/127412248-cff79ea0-6a36-4fc3-bffc-d4bb101b39f5.png)
OS in HC 1 | ![image](https://user-images.githubusercontent.com/45672944/127411931-658065d8-4571-4e4f-b0fe-793a07f46daa.png)
OS in HC 2 | ![image](https://user-images.githubusercontent.com/45672944/127411967-97b66c2f-4b19-4150-ae2f-7aef5dcbccc7.png)
OS in HC Black | ![image](https://user-images.githubusercontent.com/45672944/127412018-196b03ed-15b9-48bb-90d2-d5cb4a994527.png)
OS in HC White | ![image](https://user-images.githubusercontent.com/45672944/127412051-d2def812-4ea7-450e-a404-318043b3e53f.png)


##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4281 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [css only] (UI changes only) Verified usability with NVDA/JAWS
