### PR TITLE
fix: update mac folder zip command to use passed arguments for paths

### DIFF
--- a/pipeline/scripts/zip-mac-folder.js
+++ b/pipeline/scripts/zip-mac-folder.js
@@ -17,12 +17,14 @@ const parentDir = process.argv[2];
 const files = fs.readdirSync(parentDir);
 const existingDmg = files.find(f => path.extname(f) === '.dmg');
 const appName = path.basename(existingDmg, path.extname(existingDmg));
+const cmd = `${sevenBin.path7za}`;
+const args = ['a', `${appName}.zip`, '-r', 'mac'];
 
 console.log(`existingDmg: ${existingDmg}`);
 console.log(`appName: ${appName}`);
 console.log(`path to 7z: ${sevenBin.path7za}`);
 
-child_process.execSync(`${sevenBin.path7za} a "${appName}.zip" -r mac`, {
+child_process.execFileSync(cmd, args, {
     cwd: parentDir,
     stdio: 'inherit',
 });


### PR DESCRIPTION
#### Details

Update the shell command that zips the mac folder during release to use passed `args` instead of dynamically generating the entire command to be interpreted by the shell. 

##### Motivation

Identified by CodeQL, ruleID `js/shell-command-injection-from-environment`


##### Context

Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
