### PR TITLE
feat(download-report-json): Introduce ExportDropdown with toJSON option and use it in ExportDialog

### DIFF
--- a/src/DetailsView/components/export-dropdown.tsx
+++ b/src/DetailsView/components/export-dropdown.tsx
@@ -71,17 +71,18 @@ export class ExportDropdown extends React.Component<ExportDropdownProps, ExportD
             reportExportServiceProvider,
             onExportLinkClick,
             html,
+            fileName,
             fileURLProvider,
         } = this.props;
 
         const exportToCodepen = featureFlagStoreData[FeatureFlags.exportReportOptions];
         const exportToJSON = featureFlagStoreData[FeatureFlags.exportReportJSON];
-        const fileURL = fileURLProvider.provideURL([this.props.html], 'text/html');
+        const fileURL = fileURLProvider.provideURL([html], 'text/html');
 
         const items: IContextualMenuItem[] = [
             reportExportServiceProvider
                 .forKey('html')
-                .generateMenuItem(onExportLinkClick, fileURL, html),
+                .generateMenuItem(onExportLinkClick, fileURL, fileName),
         ];
 
         if (exportToJSON) {

--- a/src/DetailsView/components/export-dropdown.tsx
+++ b/src/DetailsView/components/export-dropdown.tsx
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FeatureFlags } from 'common/feature-flags';
+import { FileURLProvider } from 'common/file-url-provider';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { ContextualMenu, IContextualMenuItem, IPoint, PrimaryButton } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
+import { ReportExportServiceKey } from 'report-export/types/report-export-service';
+
+export interface ExportDropdownState {
+    isContextMenuVisible: boolean;
+    target?: HTMLElement | string | MouseEvent | IPoint | null;
+}
+
+export interface ExportDropdownProps {
+    onExportLinkClick: (
+        event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+        selectedServiceKey: ReportExportServiceKey,
+    ) => void;
+    reportExportServiceProvider: ReportExportServiceProvider;
+    fileName: string;
+    html: string;
+    fileURLProvider: FileURLProvider;
+    featureFlagStoreData: FeatureFlagStoreData;
+}
+
+export class ExportDropdown extends React.Component<ExportDropdownProps, ExportDropdownState> {
+    constructor(props: ExportDropdownProps) {
+        super(props);
+
+        this.state = {
+            isContextMenuVisible: false,
+        };
+    }
+
+    public render(): JSX.Element {
+        return (
+            <div>
+                <PrimaryButton
+                    text="Export"
+                    ariaLabel="export options menu"
+                    onClick={this.openDropdown}
+                    menuIconProps={{
+                        iconName: 'ChevronDown',
+                    }}
+                />
+                {this.renderContextMenu()}
+            </div>
+        );
+    }
+
+    private renderContextMenu(): JSX.Element {
+        if (!this.state.isContextMenuVisible) {
+            return null;
+        }
+
+        return (
+            <ContextualMenu
+                target={this.state.target}
+                onDismiss={() => this.dismissDropdown()}
+                items={this.getMenuItems()}
+            />
+        );
+    }
+
+    private getMenuItems(): IContextualMenuItem[] {
+        const {
+            featureFlagStoreData,
+            reportExportServiceProvider,
+            onExportLinkClick,
+            html,
+            fileURLProvider,
+        } = this.props;
+
+        const exportToCodepen = featureFlagStoreData[FeatureFlags.exportReportOptions];
+        const exportToJSON = featureFlagStoreData[FeatureFlags.exportReportJSON];
+        const fileURL = fileURLProvider.provideURL([this.props.html], 'text/html');
+
+        const items: IContextualMenuItem[] = [
+            reportExportServiceProvider
+                .forKey('html')
+                .generateMenuItem(onExportLinkClick, fileURL, html),
+        ];
+
+        if (exportToJSON) {
+            items.push(
+                reportExportServiceProvider.forKey('json').generateMenuItem(onExportLinkClick),
+            );
+        }
+
+        if (exportToCodepen) {
+            items.push(
+                reportExportServiceProvider.forKey('codepen').generateMenuItem(onExportLinkClick),
+            );
+        }
+
+        return items;
+    }
+
+    private openDropdown = (event): void => {
+        this.setState({ target: event.currentTarget, isContextMenuVisible: true });
+    };
+
+    private dismissDropdown(): void {
+        this.setState({ target: null, isContextMenuVisible: false });
+    }
+}

--- a/src/report-export/report-export-service-provider-impl.ts
+++ b/src/report-export/report-export-service-provider-impl.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT License.
 import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
 import { CodePenReportExportService } from 'report-export/services/code-pen-report-export-service';
+import { HtmlReportExportService } from 'report-export/services/html-report-export-service';
+import { JsonReportExportService } from 'report-export/services/json-report-export-service';
 
 export const ReportExportServiceProviderImpl = new ReportExportServiceProvider([
+    HtmlReportExportService,
+    JsonReportExportService,
     CodePenReportExportService,
 ]);

--- a/src/report-export/services/code-pen-report-export-service.tsx
+++ b/src/report-export/services/code-pen-report-export-service.tsx
@@ -52,6 +52,14 @@ class CodePenExportForm extends React.Component<ReportExportFormProps> {
 
 export const CodePenReportExportService: ReportExportService = {
     key: codePenReportExportServiceKey,
-    displayName: 'CodePen',
     exportForm: CodePenExportForm,
+    generateMenuItem: (onMenuItemClick, _, __) => {
+        return {
+            key: codePenReportExportServiceKey,
+            name: 'to CodePen',
+            onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+                onMenuItemClick(e, codePenReportExportServiceKey);
+            },
+        };
+    },
 };

--- a/src/report-export/services/html-report-export-service.ts
+++ b/src/report-export/services/html-report-export-service.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    ReportExportService,
+    ReportExportServiceKey,
+} from 'report-export/types/report-export-service';
+
+const htmlReportExportServiceKey: ReportExportServiceKey = 'html';
+
+export const HtmlReportExportService: ReportExportService = {
+    key: htmlReportExportServiceKey,
+    generateMenuItem: (onMenuItemClick, href, download) => {
+        return {
+            key: htmlReportExportServiceKey,
+            name: 'as HTML',
+            onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+                onMenuItemClick(e, htmlReportExportServiceKey);
+            },
+            href,
+            download,
+        };
+    },
+};

--- a/src/report-export/services/json-report-export-service.ts
+++ b/src/report-export/services/json-report-export-service.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    ReportExportService,
+    ReportExportServiceKey,
+} from 'report-export/types/report-export-service';
+
+const jsonReportExportServiceKey: ReportExportServiceKey = 'json';
+
+export const JsonReportExportService: ReportExportService = {
+    key: jsonReportExportServiceKey,
+    displayName: 'JSON',
+    generateMenuItem: (onMenuItemClick, _, __) => {
+        return {
+            key: jsonReportExportServiceKey,
+            name: 'as JSON',
+            onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+                onMenuItemClick(e, jsonReportExportServiceKey);
+            },
+        };
+    },
+};

--- a/src/report-export/types/report-export-service.ts
+++ b/src/report-export/types/report-export-service.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export type ReportExportServiceKey = 'download' | 'codepen';
+import { IContextualMenuItem } from 'office-ui-fabric-react';
+
+export type ReportExportServiceKey = 'html' | 'codepen' | 'json';
 
 export type ReportExportFormProps = ReportExportProps & { onSubmit: () => void };
 
@@ -13,6 +15,13 @@ export type ReportExportProps = {
 
 export type ReportExportService = {
     key: ReportExportServiceKey;
-    displayName: string;
-    exportForm: React.ComponentType<ReportExportFormProps>;
+    generateMenuItem: (
+        onMenuItemClick: (
+            event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+            selectedServiceKey: ReportExportServiceKey,
+        ) => void,
+        href?: string,
+        download?: string,
+    ) => IContextualMenuItem;
+    exportForm?: React.ComponentType<ReportExportFormProps>;
 };

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
@@ -23,6 +23,36 @@ exports[`ExportDialog renders with CodePen export form 1`] = `
 </form>
 `;
 
+exports[`ExportDialog renders with export dropdown 1`] = `
+"<StyledWithResponsiveMode hidden={false} onDismiss={[Function: onDismiss]} dialogContentProps={{...}} modalProps={{...}}>
+  <StyledTextFieldBase multiline={true} autoFocus={true} rows={8} resizable={false} onChange={[Function: onDescriptionChange]} value=\\"description\\" ariaLabel=\\"Provide result description\\" />
+  <StyledDialogFooterBase>
+    <ExportDropdown fileName=\\"THE REPORT FILE NAME\\" fileURLProvider={[Function: function () {
+                        var args = [];
+                        for (var _i = 0; _i < arguments.length; _i++) {
+                            args[_i] = arguments[_i];
+                        }
+                        _this._interceptor.removeInvocation(invocation_1);
+                        var method = new MethodInfo(target, p);
+                        var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                        _this._interceptor.intercept(methodInvocation);
+                        return methodInvocation.returnValue;
+                    }] { provideURL: [Function (anonymous)], [Symbol(Symbol.toStringTag)]: [Function: bound toString] }} featureFlagStoreData={{...}} html=\\"fake html\\" onExportLinkClick={[Function: onExportLinkClick]} reportExportServiceProvider={[Function: function () {
+                        var args = [];
+                        for (var _i = 0; _i < arguments.length; _i++) {
+                            args[_i] = arguments[_i];
+                        }
+                        _this._interceptor.removeInvocation(invocation_1);
+                        var method = new MethodInfo(target, p);
+                        var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                        _this._interceptor.intercept(methodInvocation);
+                        return methodInvocation.returnValue;
+                    }] { forKey: [Function (anonymous)], [Symbol(Symbol.toStringTag)]: [Function: bound toString] }} />
+    <CodePenExportForm fileName=\\"THE REPORT FILE NAME\\" description=\\"description\\" html=\\"fake html\\" onSubmit={[Function: onSubmit]} />
+  </StyledDialogFooterBase>
+</StyledWithResponsiveMode>"
+`;
+
 exports[`ExportDialog renders with open false 1`] = `
 <StyledWithResponsiveMode
   dialogContentProps={
@@ -52,43 +82,13 @@ exports[`ExportDialog renders with open false 1`] = `
     value="description"
   />
   <StyledDialogFooterBase>
-    <FlaggedComponent
-      disableJSXElement={
-        <CustomizedPrimaryButton
-          download="THE REPORT FILE NAME"
-          href="fake-url"
-          onClick={[Function]}
-        >
-          Export
-        </CustomizedPrimaryButton>
-      }
-      enableJSXElement={
-        <React.Fragment>
-          <CustomizedPrimaryButton
-            aria-roledescription="split button"
-            download="THE REPORT FILE NAME"
-            href="fake-url"
-            menuProps={
-              Object {
-                "items": Array [
-                  Object {
-                    "key": "codepen",
-                    "onClick": [Function],
-                    "text": "CodePen",
-                  },
-                ],
-              }
-            }
-            onClick={[Function]}
-            split={true}
-            splitButtonAriaLabel="Export HTML to any of these format options"
-            text="Export"
-          />
-        </React.Fragment>
-      }
-      featureFlag="exportReportOptions"
-      featureFlagStoreData={Object {}}
-    />
+    <CustomizedPrimaryButton
+      download="THE REPORT FILE NAME"
+      href="fake-url"
+      onClick={[Function]}
+    >
+      Export
+    </CustomizedPrimaryButton>
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>
 `;
@@ -122,43 +122,13 @@ exports[`ExportDialog renders with open true 1`] = `
     value="description"
   />
   <StyledDialogFooterBase>
-    <FlaggedComponent
-      disableJSXElement={
-        <CustomizedPrimaryButton
-          download="THE REPORT FILE NAME"
-          href="fake-url"
-          onClick={[Function]}
-        >
-          Export
-        </CustomizedPrimaryButton>
-      }
-      enableJSXElement={
-        <React.Fragment>
-          <CustomizedPrimaryButton
-            aria-roledescription="split button"
-            download="THE REPORT FILE NAME"
-            href="fake-url"
-            menuProps={
-              Object {
-                "items": Array [
-                  Object {
-                    "key": "codepen",
-                    "onClick": [Function],
-                    "text": "CodePen",
-                  },
-                ],
-              }
-            }
-            onClick={[Function]}
-            split={true}
-            splitButtonAriaLabel="Export HTML to any of these format options"
-            text="Export"
-          />
-        </React.Fragment>
-      }
-      featureFlag="exportReportOptions"
-      featureFlagStoreData={Object {}}
-    />
+    <CustomizedPrimaryButton
+      download="THE REPORT FILE NAME"
+      href="fake-url"
+      onClick={[Function]}
+    >
+      Export
+    </CustomizedPrimaryButton>
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dropdown.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ExportDropdown handles click to show menu with feature flags 1`] = `
     items={
       Array [
         Object {
-          "download": "<some html>",
+          "download": "A file name",
           "href": "a file url",
           "key": "html",
           "onClick": [Function],
@@ -57,7 +57,7 @@ exports[`ExportDropdown handles click to show menu without feature flags 1`] = `
     items={
       Array [
         Object {
-          "download": "<some html>",
+          "download": "A file name",
           "href": "a file url",
           "key": "html",
           "onClick": [Function],

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dropdown.test.tsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExportDropdown handles click to show menu with feature flags 1`] = `
+<div>
+  <CustomizedPrimaryButton
+    ariaLabel="export options menu"
+    menuIconProps={
+      Object {
+        "iconName": "ChevronDown",
+      }
+    }
+    onClick={[Function]}
+    text="Export"
+  />
+  <StyledWithResponsiveMode
+    items={
+      Array [
+        Object {
+          "download": "<some html>",
+          "href": "a file url",
+          "key": "html",
+          "onClick": [Function],
+        },
+        Object {
+          "download": undefined,
+          "href": undefined,
+          "key": "json",
+          "onClick": [Function],
+        },
+        Object {
+          "download": undefined,
+          "href": undefined,
+          "key": "codepen",
+          "onClick": [Function],
+        },
+      ]
+    }
+    onDismiss={[Function]}
+    target="test target"
+  />
+</div>
+`;
+
+exports[`ExportDropdown handles click to show menu without feature flags 1`] = `
+<div>
+  <CustomizedPrimaryButton
+    ariaLabel="export options menu"
+    menuIconProps={
+      Object {
+        "iconName": "ChevronDown",
+      }
+    }
+    onClick={[Function]}
+    text="Export"
+  />
+  <StyledWithResponsiveMode
+    items={
+      Array [
+        Object {
+          "download": "<some html>",
+          "href": "a file url",
+          "key": "html",
+          "onClick": [Function],
+        },
+      ]
+    }
+    onDismiss={[Function]}
+    target="test target"
+  />
+</div>
+`;
+
+exports[`ExportDropdown renders without menu items 1`] = `
+<div>
+  <CustomizedPrimaryButton
+    ariaLabel="export options menu"
+    menuIconProps={
+      Object {
+        "iconName": "ChevronDown",
+      }
+    }
+    onClick={[Function]}
+    text="Export"
+  />
+</div>
+`;
+
+exports[`ExportDropdown should dismiss the contextMenu 1`] = `
+<div>
+  <CustomizedPrimaryButton
+    ariaLabel="export options menu"
+    menuIconProps={
+      Object {
+        "iconName": "ChevronDown",
+      }
+    }
+    onClick={[Function]}
+    text="Export"
+  />
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FlaggedComponent } from 'common/components/flagged-component';
 import { FeatureFlags } from 'common/feature-flags';
 import { shallow } from 'enzyme';
 import { Dialog, PrimaryButton, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
 import { CodePenReportExportService } from 'report-export/services/code-pen-report-export-service';
+import { ReportExportService } from 'report-export/types/report-export-service';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
 import { FileURLProvider } from '../../../../../common/file-url-provider';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
@@ -27,6 +27,11 @@ describe('ExportDialog', () => {
     const eventStub = 'event stub' as any;
     const onExportClickMock = Mock.ofInstance(() => {});
     const afterDismissedMock = Mock.ofInstance(() => null);
+    const reportExportServiceStub = {
+        key: 'html',
+        generateMenuItem: () => null,
+        exportForm: CodePenReportExportService.exportForm,
+    } as ReportExportService;
     let props: ExportDialogProps;
 
     beforeEach(() => {
@@ -67,14 +72,30 @@ describe('ExportDialog', () => {
                 .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
                 .returns(() => 'fake-url')
                 .verifiable(Times.once());
-            reportExportServiceProvider
-                .setup(a => a.all())
-                .returns(() => [CodePenReportExportService])
-                .verifiable(Times.once());
             const wrapper = shallow(<ExportDialog {...props} />);
             expect(wrapper.getElement()).toMatchSnapshot();
 
-            reportExportServiceProvider.verifyAll();
+            fileProviderMock.verifyAll();
+        });
+
+        it('with export dropdown', () => {
+            props.featureFlagStoreData[FeatureFlags.exportReportOptions] = true;
+            props.featureFlagStoreData[FeatureFlags.exportReportJSON] = true;
+            detailsViewActionMessageCreatorMock
+                .setup(a => a.exportResultsClicked(props.reportExportFormat, props.html, eventStub))
+                .verifiable(Times.once());
+            reportExportServiceProvider
+                .setup(p => p.forKey(It.isAny()))
+                .returns(() => reportExportServiceStub);
+            props.isOpen = true;
+            fileProviderMock
+                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
+                .returns(() => 'fake-url')
+                .verifiable(Times.once());
+            const wrapper = shallow(<ExportDialog {...props} />);
+            const elem = wrapper.debug();
+            expect(elem).toMatchSnapshot();
+
             fileProviderMock.verifyAll();
         });
 
@@ -100,15 +121,10 @@ describe('ExportDialog', () => {
                 .returns(() => 'fake-url')
                 .verifiable(Times.once());
             onExportClickMock.setup(getter => getter()).verifiable(Times.never());
-            reportExportServiceProvider
-                .setup(a => a.all())
-                .returns(() => [CodePenReportExportService])
-                .verifiable(Times.once());
             const wrapper = shallow(<ExportDialog {...props} />);
 
             wrapper.find(Dialog).prop('onDismiss')();
 
-            reportExportServiceProvider.verifyAll();
             fileProviderMock.verifyAll();
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();
@@ -133,61 +149,12 @@ describe('ExportDialog', () => {
                 .setup(a => a.exportResultsClicked(props.reportExportFormat, props.html, eventStub))
                 .verifiable(Times.once());
 
-            reportExportServiceProvider
-                .setup(a => a.all())
-                .returns(() => [CodePenReportExportService])
-                .verifiable(Times.exactly(2));
-
             const wrapper = shallow(<ExportDialog {...props} />);
 
-            const flaggedComponent = wrapper.find(FlaggedComponent);
+            const flaggedComponent = wrapper.find(PrimaryButton);
 
-            flaggedComponent.dive().find(PrimaryButton).simulate('click', eventStub);
+            flaggedComponent.simulate('click', eventStub);
 
-            reportExportServiceProvider.verifyAll();
-            fileProviderMock.verifyAll();
-            onCloseMock.verifyAll();
-            onDescriptionChangeMock.verifyAll();
-            detailsViewActionMessageCreatorMock.verifyAll();
-            onExportClickMock.verifyAll();
-        });
-
-        it('handles click on export to CodePen button', () => {
-            const unchangedDescription = 'description';
-            onDescriptionChangeMock
-                .setup(dc => dc(It.isValue(unchangedDescription)))
-                .verifiable(Times.once());
-
-            onCloseMock.setup(oc => oc()).verifiable(Times.once());
-            fileProviderMock
-                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
-                .returns(() => 'fake-url')
-                .verifiable(Times.exactly(2));
-            onExportClickMock.setup(getter => getter()).verifiable(Times.once());
-
-            detailsViewActionMessageCreatorMock
-                .setup(a => a.exportResultsClicked(props.reportExportFormat, props.html, eventStub))
-                .verifiable(Times.once());
-
-            reportExportServiceProvider
-                .setup(a => a.all())
-                .returns(() => [CodePenReportExportService])
-                .verifiable(Times.exactly(2));
-
-            props.featureFlagStoreData[FeatureFlags.exportReportOptions] = true;
-
-            const wrapper = shallow(<ExportDialog {...props} />);
-
-            const flaggedComponent = wrapper.find(FlaggedComponent);
-
-            flaggedComponent
-                .dive()
-                .find(PrimaryButton)
-                .props()
-                .menuProps.items.find(({ key }) => key === CodePenReportExportService.key)
-                .onClick(eventStub);
-
-            reportExportServiceProvider.verifyAll();
             fileProviderMock.verifyAll();
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();
@@ -205,17 +172,12 @@ describe('ExportDialog', () => {
             onDescriptionChangeMock
                 .setup(handler => handler(It.isValue(changedDescription)))
                 .verifiable(Times.once());
-            reportExportServiceProvider
-                .setup(a => a.all())
-                .returns(() => [CodePenReportExportService])
-                .verifiable(Times.once());
 
             const wrapper = shallow(<ExportDialog {...props} />);
 
             const textField = wrapper.find(TextField);
             textField.simulate('change', eventStub, changedDescription);
 
-            reportExportServiceProvider.verifyAll();
             fileProviderMock.verifyAll();
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();

--- a/src/tests/unit/tests/DetailsView/components/export-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dropdown.test.tsx
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FeatureFlags } from 'common/feature-flags';
+import { FileURLProvider } from 'common/file-url-provider';
+import { ExportDropdown, ExportDropdownProps } from 'DetailsView/components/export-dropdown';
+import { shallow } from 'enzyme';
+import { ContextualMenu, PrimaryButton } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
+import { CodePenReportExportService } from 'report-export/services/code-pen-report-export-service';
+import {
+    ReportExportService,
+    ReportExportServiceKey,
+} from 'report-export/types/report-export-service';
+import { It, Mock, Times } from 'typemoq';
+
+describe('ExportDropdown', () => {
+    const fileProviderMock = Mock.ofType<FileURLProvider>();
+    const reportExportServiceProvider = Mock.ofType<ReportExportServiceProvider>();
+    const event = {
+        currentTarget: 'test target',
+    } as React.MouseEvent<any>;
+    let props: ExportDropdownProps;
+
+    const makeReportExportServiceStub = (key: ReportExportServiceKey): ReportExportService => {
+        return {
+            key: key,
+            generateMenuItem: (onItemClick, href?, download?) => {
+                return {
+                    key: key,
+                    onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+                        onItemClick(e, key);
+                    },
+                    href: href,
+                    download: download,
+                };
+            },
+            exportForm: CodePenReportExportService.exportForm,
+        };
+    };
+
+    beforeEach(() => {
+        props = {
+            onExportLinkClick: null,
+            reportExportServiceProvider: reportExportServiceProvider.object,
+            fileName: 'A file name',
+            html: '<some html>',
+            fileURLProvider: fileProviderMock.object,
+            featureFlagStoreData: {},
+        };
+        reportExportServiceProvider.reset();
+        fileProviderMock
+            .setup(f => f.provideURL(['<some html>'], 'text/html'))
+            .returns(() => 'a file url');
+    });
+
+    it('renders without menu items', () => {
+        const rendered = shallow(<ExportDropdown {...props} />);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('handles click to show menu without feature flags', () => {
+        reportExportServiceProvider
+            .setup(p => p.forKey('html'))
+            .returns(key => makeReportExportServiceStub(key))
+            .verifiable(Times.once());
+
+        const rendered = shallow(<ExportDropdown {...props} />);
+        rendered.find(PrimaryButton).simulate('click', event);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+        reportExportServiceProvider.verifyAll();
+    });
+
+    it('handles click to show menu with feature flags', () => {
+        props.featureFlagStoreData[FeatureFlags.exportReportOptions] = true;
+        props.featureFlagStoreData[FeatureFlags.exportReportJSON] = true;
+        reportExportServiceProvider
+            .setup(p => p.forKey(It.isAny()))
+            .returns(key => makeReportExportServiceStub(key))
+            .verifiable(Times.exactly(3));
+
+        const rendered = shallow(<ExportDropdown {...props} />);
+        rendered.find(PrimaryButton).simulate('click', event);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+        reportExportServiceProvider.verifyAll();
+    });
+
+    it('handles click on menu item', () => {
+        let wasClicked = false;
+        const onClick = () => {
+            wasClicked = true;
+        };
+        props.onExportLinkClick = onClick;
+        reportExportServiceProvider
+            .setup(p => p.forKey('html'))
+            .returns(key => makeReportExportServiceStub(key))
+            .verifiable(Times.once());
+
+        const rendered = shallow(<ExportDropdown {...props} />);
+        rendered.find(PrimaryButton).simulate('click', event);
+        rendered
+            .find(ContextualMenu)
+            .prop('items')
+            .find(elem => elem.key === 'html')
+            .onClick();
+
+        expect(wasClicked).toBeTruthy();
+        reportExportServiceProvider.verifyAll();
+    });
+
+    it('should dismiss the contextMenu', () => {
+        reportExportServiceProvider
+            .setup(p => p.forKey('html'))
+            .returns(key => makeReportExportServiceStub(key));
+
+        const rendered = shallow(<ExportDropdown {...props} />);
+        rendered.find(PrimaryButton).simulate('click', event);
+        rendered.find(ContextualMenu).prop('onDismiss')();
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Details
In order to add the export to JSON option, this PR introduces `ExportDropdown` and uses it in the `ExportDialog`. When multiple export options are available, `ExportDropdown` replaces the ordinary Export button and provides a menu with a list of export options on click. Some other notes:
- To address an accessibility concern, `ExportDropdown` replaces the split button in the current export to Codepen preview feature
- `ExportDropdown` is modelled after `StartOverDropdown`
- `ReportExportService` is refactored to apply to all forms of exporting--HTML, Codepen, and now JSON--rather than just Codepen. As such, `HtmlReportExportService` and `JsonReportExportService` are introduced and `CodepenReportExportService` is updated
- The "to JSON" option does not yet do anything
- All uses of the dropdown are currently behind feature flags

Screenshot with relevant feature flags enabled:
![image](https://user-images.githubusercontent.com/4615491/135504281-c6e5d0f4-75bc-4636-b5a8-ec737335a45e.png)

Screenshot without feature flags (same as prod):
![image](https://user-images.githubusercontent.com/4615491/135504603-3d95584d-0bf6-452a-ba22-a95706fe319a.png)

##### Motivation
Necessary for feature

##### Context
- I considered leaving `ReportExportService` as-is, but that wouldn't work well because the JSON export option is more similar to the HTML export option than it is to Codepen
-  A future PR will remove the to JSON option from the Automated Checks export dropdown
- A future PR will make the to JSON option download JSON

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
