### PR TITLE
fix: update Dockerfile so it can access nodesource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,13 @@ FROM mcr.microsoft.com/playwright:v1.15.0-focal AS setup
 
 USER root
 
+# We need to update certificates before we can successfully update and install node
+# This is a workaround for https://github.com/nodesource/distributions/issues/1266 
 # Downgrading from nodejs 16.3.0 to 14.* is both for consistency with our other build
 # environments and a workaround for https://github.com/nodejs/node/issues/39019
-RUN apt-get update && apt-get install -y curl && \
+RUN apt-get update ; apt-get install ca-certificates \
+    && apt-get update \
+    && apt-get install -y curl && \
   curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \
   apt-get install -y --allow-downgrades nodejs=14.* && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION

#### Details

This is a workaround for `deb.nodesource` certificates being expired on Linux machines.  This updates the certs on the machine before installing other dependencies.

##### Motivation

workaround for https://github.com/nodesource/distributions/issues/1266 so our linux builds will run successfully


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
