### PR TITLE
feat(download-report-json): Only show to JSON export option in assessment

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -28,7 +28,10 @@ import {
 } from 'DetailsView/components/load-assessment-dialog';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { ReportExportButton } from 'DetailsView/components/report-export-button';
-import { ReportExportDialogFactoryProps } from 'DetailsView/components/report-export-dialog-factory';
+import {
+    ReportExportDialogFactoryDeps,
+    ReportExportDialogFactoryProps,
+} from 'DetailsView/components/report-export-dialog-factory';
 import {
     SaveAssessmentButtonFactoryDeps,
     SaveAssessmentButtonFactoryProps,
@@ -59,7 +62,8 @@ export type DetailsViewCommandBarDeps = {
     SaveAssessmentButtonFactoryDeps &
     LoadAssessmentButtonDeps &
     StartOverFactoryDeps &
-    LoadAssessmentDialogDeps;
+    LoadAssessmentDialogDeps &
+    ReportExportDialogFactoryDeps;
 
 export type CommandBarProps = DetailsViewCommandBarProps;
 

--- a/src/DetailsView/components/export-dialog-with-local-state.tsx
+++ b/src/DetailsView/components/export-dialog-with-local-state.tsx
@@ -3,6 +3,7 @@
 import { ReportExportFormat } from 'common/extension-telemetry-events';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import * as React from 'react';
+import { ReportExportService } from 'report-export/types/report-export-service';
 import { ReportGenerator } from 'reports/report-generator';
 import { ExportDialog, ExportDialogDeps } from './export-dialog';
 
@@ -22,6 +23,7 @@ export interface ExportDialogWithLocalStateProps {
     featureFlagStoreData: FeatureFlagStoreData;
     dismissExportDialog: () => void;
     afterDialogDismissed: () => void;
+    reportExportServices: ReportExportService[];
 }
 
 interface ExportDialogWithLocalStateState {
@@ -71,6 +73,7 @@ export class ExportDialogWithLocalState extends React.Component<
                 onExportClick={this.generateHtml}
                 featureFlagStoreData={featureFlagStoreData}
                 afterDismissed={this.props.afterDialogDismissed}
+                reportExportServices={this.props.reportExportServices}
             />
         );
     }

--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -5,8 +5,10 @@ import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store
 import { ExportDropdown } from 'DetailsView/components/export-dropdown';
 import { Dialog, DialogFooter, DialogType, PrimaryButton, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
-import { ReportExportServiceKey } from 'report-export/types/report-export-service';
+import {
+    ReportExportService,
+    ReportExportServiceKey,
+} from 'report-export/types/report-export-service';
 import { ReportExportFormat } from '../../common/extension-telemetry-events';
 import { FileURLProvider } from '../../common/file-url-provider';
 import { NamedFC } from '../../common/react/named-fc';
@@ -25,12 +27,12 @@ export interface ExportDialogProps {
     onExportClick: () => void;
     featureFlagStoreData: FeatureFlagStoreData;
     afterDismissed?: () => void;
+    reportExportServices: ReportExportService[];
 }
 
 export interface ExportDialogDeps {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
     fileURLProvider: FileURLProvider;
-    reportExportServiceProvider: ReportExportServiceProvider;
 }
 
 export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => {
@@ -61,10 +63,14 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
     };
 
     const fileURL = props.deps.fileURLProvider.provideURL([props.html], 'text/html');
-    const exportService = props.deps.reportExportServiceProvider.forKey(serviceKey);
+    const exportService = props.reportExportServices.find(s => s.key === serviceKey);
     const ExportForm = exportService ? exportService.exportForm : null;
-    const exportToCodepen = props.featureFlagStoreData[FeatureFlags.exportReportOptions];
-    const exportToJSON = props.featureFlagStoreData[FeatureFlags.exportReportJSON];
+    const exportToCodepen =
+        props.featureFlagStoreData[FeatureFlags.exportReportOptions] &&
+        props.reportExportServices.some(s => s.key === 'codepen');
+    const exportToJSON =
+        props.featureFlagStoreData[FeatureFlags.exportReportJSON] &&
+        props.reportExportServices.some(s => s.key === 'json');
 
     const getSingleExportToHtmlButton = () => {
         return (
@@ -89,7 +95,7 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
                     featureFlagStoreData={props.featureFlagStoreData}
                     html={props.html}
                     onExportLinkClick={onExportLinkClick}
-                    reportExportServiceProvider={props.deps.reportExportServiceProvider}
+                    reportExportServices={props.reportExportServices}
                 />
                 {ExportForm && (
                     <ExportForm

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -4,6 +4,7 @@ import { InsightsCommandButton } from 'common/components/controls/insights-comma
 import { ReportExportFormat } from 'common/extension-telemetry-events';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import * as React from 'react';
+import { ReportExportService } from 'report-export/types/report-export-service';
 import { ReportGenerator } from 'reports/report-generator';
 
 import { ExportDialog, ExportDialogDeps } from './export-dialog';
@@ -22,6 +23,7 @@ export interface ReportExportComponentProps {
     getExportDescription: () => string;
     featureFlagStoreData: FeatureFlagStoreData;
     onDialogDismiss?: () => void;
+    reportExportServices: ReportExportService[];
 }
 
 export interface ReportExportComponentState {
@@ -102,6 +104,7 @@ export class ReportExportComponent extends React.Component<
                     onExportClick={this.generateHtml}
                     featureFlagStoreData={this.props.featureFlagStoreData}
                     afterDismissed={this.props.onDialogDismiss}
+                    reportExportServices={this.props.reportExportServices}
                 />
             </>
         );

--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -8,6 +8,11 @@ import {
 } from 'DetailsView/components/export-dialog-with-local-state';
 import { ShouldShowReportExportButtonProps } from 'DetailsView/components/should-show-report-export-button';
 import * as React from 'react';
+import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
+
+export type ReportExportDialogFactoryDeps = {
+    reportExportServiceProvider: ReportExportServiceProvider;
+};
 
 export type ReportExportDialogFactoryProps = CommandBarProps & {
     isOpen: boolean;
@@ -50,6 +55,7 @@ export function getReportExportDialogForAssessment(
         isOpen,
         dismissExportDialog,
         afterDialogDismissed,
+        reportExportServices: deps.reportExportServiceProvider.servicesForAssessment(),
     };
     return <ExportDialogWithLocalState {...dialogProps} />;
 }
@@ -92,6 +98,7 @@ export function getReportExportDialogForFastPass(
         isOpen,
         dismissExportDialog,
         afterDialogDismissed,
+        reportExportServices: deps.reportExportServiceProvider.servicesForFastPass(),
     };
 
     return <ExportDialogWithLocalState {...dialogProps} />;

--- a/src/electron/views/results/components/reflow-command-bar.tsx
+++ b/src/electron/views/results/components/reflow-command-bar.tsx
@@ -21,6 +21,7 @@ import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { ContentPageInfo } from 'electron/types/content-page-info';
 import { css, IButton } from 'office-ui-fabric-react';
 import * as React from 'react';
+import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
 import { ReportGenerator } from 'reports/report-generator';
 import * as styles from './reflow-command-bar.scss';
 
@@ -29,6 +30,7 @@ export type ReflowCommandBarDeps = {
     dropdownClickHandler: DropdownClickHandler;
     reportGenerator: ReportGenerator;
     tabStopsActionCreator: TabStopsActionCreator;
+    reportExportServiceProvider: ReportExportServiceProvider;
 } & ReportExportComponentDeps;
 
 export interface ReflowCommandBarProps {
@@ -81,6 +83,7 @@ export const ReflowCommandBar = NamedFC<ReflowCommandBarProps>('ReflowCommandBar
                     dropdownMenuButtonRef.dismissMenu();
                     dropdownMenuButtonRef.focus();
                 }}
+                reportExportServices={deps.reportExportServiceProvider.servicesForFastPass()}
             />
         );
     }

--- a/src/report-export/report-export-service-provider.ts
+++ b/src/report-export/report-export-service-provider.ts
@@ -8,11 +8,13 @@ import {
 export class ReportExportServiceProvider {
     constructor(private readonly services: ReportExportService[]) {}
 
-    public all(): ReportExportService[] {
-        return this.services;
+    public servicesForFastPass(): ReportExportService[] {
+        const keysForFastpass: ReportExportServiceKey[] = ['html', 'codepen'];
+        return this.services.filter(s => keysForFastpass.includes(s.key));
     }
 
-    public forKey(key: ReportExportServiceKey): ReportExportService | undefined {
-        return this.services.find(service => service.key === key);
+    public servicesForAssessment(): ReportExportService[] {
+        const keysForAssessment: ReportExportServiceKey[] = ['html', 'json', 'codepen'];
+        return this.services.filter(s => keysForAssessment.includes(s.key));
     }
 }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog-with-local-state.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog-with-local-state.test.tsx.snap
@@ -26,6 +26,14 @@ exports[`ExportDialogWithLocalState clicking export on the dialog should trigger
   onDescriptionChange={[Function]}
   onExportClick={[Function]}
   reportExportFormat="Assessment"
+  reportExportServices={
+    Array [
+      Object {
+        "generateMenuItem": null,
+        "key": "html",
+      },
+    ]
+  }
 />
 `;
 
@@ -55,6 +63,14 @@ exports[`ExportDialogWithLocalState edit text field: test content with special c
   onDescriptionChange={[Function]}
   onExportClick={[Function]}
   reportExportFormat="Assessment"
+  reportExportServices={
+    Array [
+      Object {
+        "generateMenuItem": null,
+        "key": "html",
+      },
+    ]
+  }
 />
 `;
 
@@ -84,6 +100,14 @@ exports[`ExportDialogWithLocalState on dialog opened 1`] = `
   onDescriptionChange={[Function]}
   onExportClick={[Function]}
   reportExportFormat="Assessment"
+  reportExportServices={
+    Array [
+      Object {
+        "generateMenuItem": null,
+        "key": "html",
+      },
+    ]
+  }
 />
 `;
 
@@ -113,6 +137,14 @@ exports[`ExportDialogWithLocalState render with dialog closed 1`] = `
   onDescriptionChange={[Function]}
   onExportClick={[Function]}
   reportExportFormat="Assessment"
+  reportExportServices={
+    Array [
+      Object {
+        "generateMenuItem": null,
+        "key": "html",
+      },
+    ]
+  }
 />
 `;
 
@@ -142,5 +174,13 @@ exports[`ExportDialogWithLocalState render with dialog open 1`] = `
   onDescriptionChange={[Function]}
   onExportClick={[Function]}
   reportExportFormat="Assessment"
+  reportExportServices={
+    Array [
+      Object {
+        "generateMenuItem": null,
+        "key": "html",
+      },
+    ]
+  }
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
@@ -37,18 +37,7 @@ exports[`ExportDialog renders with export dropdown 1`] = `
                         var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
                         _this._interceptor.intercept(methodInvocation);
                         return methodInvocation.returnValue;
-                    }] { provideURL: [Function (anonymous)], [Symbol(Symbol.toStringTag)]: [Function: bound toString] }} featureFlagStoreData={{...}} html=\\"fake html\\" onExportLinkClick={[Function: onExportLinkClick]} reportExportServiceProvider={[Function: function () {
-                        var args = [];
-                        for (var _i = 0; _i < arguments.length; _i++) {
-                            args[_i] = arguments[_i];
-                        }
-                        _this._interceptor.removeInvocation(invocation_1);
-                        var method = new MethodInfo(target, p);
-                        var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
-                        _this._interceptor.intercept(methodInvocation);
-                        return methodInvocation.returnValue;
-                    }] { forKey: [Function (anonymous)], [Symbol(Symbol.toStringTag)]: [Function: bound toString] }} />
-    <CodePenExportForm fileName=\\"THE REPORT FILE NAME\\" description=\\"description\\" html=\\"fake html\\" onSubmit={[Function: onSubmit]} />
+                    }] { provideURL: [Function (anonymous)], [Symbol(Symbol.toStringTag)]: [Function: bound toString] }} featureFlagStoreData={{...}} html=\\"fake html\\" onExportLinkClick={[Function: onExportLinkClick]} reportExportServices={{...}} />
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>"
 `;
@@ -131,4 +120,15 @@ exports[`ExportDialog renders with open true 1`] = `
     </CustomizedPrimaryButton>
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>
+`;
+
+exports[`ExportDialog renders without export dropdown due to lack of service 1`] = `
+"<StyledWithResponsiveMode hidden={false} onDismiss={[Function: onDismiss]} dialogContentProps={{...}} modalProps={{...}}>
+  <StyledTextFieldBase multiline={true} autoFocus={true} rows={8} resizable={false} onChange={[Function: onDescriptionChange]} value=\\"description\\" ariaLabel=\\"Provide result description\\" />
+  <StyledDialogFooterBase>
+    <CustomizedPrimaryButton onClick={[Function: onClick]} download=\\"THE REPORT FILE NAME\\" href=\\"fake-url\\">
+      Export
+    </CustomizedPrimaryButton>
+  </StyledDialogFooterBase>
+</StyledWithResponsiveMode>"
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dropdown.test.tsx.snap
@@ -41,6 +41,41 @@ exports[`ExportDropdown handles click to show menu with feature flags 1`] = `
 </div>
 `;
 
+exports[`ExportDropdown handles click to show menu with feature flags but missing json 1`] = `
+<div>
+  <CustomizedPrimaryButton
+    ariaLabel="export options menu"
+    menuIconProps={
+      Object {
+        "iconName": "ChevronDown",
+      }
+    }
+    onClick={[Function]}
+    text="Export"
+  />
+  <StyledWithResponsiveMode
+    items={
+      Array [
+        Object {
+          "download": "A file name",
+          "href": "a file url",
+          "key": "html",
+          "onClick": [Function],
+        },
+        Object {
+          "download": undefined,
+          "href": undefined,
+          "key": "codepen",
+          "onClick": [Function],
+        },
+      ]
+    }
+    onDismiss={[Function]}
+    target="test target"
+  />
+</div>
+`;
+
 exports[`ExportDropdown handles click to show menu without feature flags 1`] = `
 <div>
   <CustomizedPrimaryButton

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
@@ -38,6 +38,14 @@ exports[`ReportExportComponentTest render 1`] = `
     onDescriptionChange={[Function]}
     onExportClick={[Function]}
     reportExportFormat="Assessment"
+    reportExportServices={
+      Array [
+        Object {
+          "generateMenuItem": null,
+          "key": "html",
+        },
+      ]
+    }
   />
 </React.Fragment>
 `;
@@ -79,6 +87,14 @@ exports[`ReportExportComponentTest user interactions click export button: dialog
     onDescriptionChange={[Function]}
     onExportClick={[Function]}
     reportExportFormat="Assessment"
+    reportExportServices={
+      Array [
+        Object {
+          "generateMenuItem": null,
+          "key": "html",
+        },
+      ]
+    }
   />
 </React.Fragment>
 `;
@@ -120,6 +136,14 @@ exports[`ReportExportComponentTest user interactions dismiss dialog: dialog shou
     onDescriptionChange={[Function]}
     onExportClick={[Function]}
     reportExportFormat="Assessment"
+    reportExportServices={
+      Array [
+        Object {
+          "generateMenuItem": null,
+          "key": "html",
+        },
+      ]
+    }
   />
 </React.Fragment>
 `;
@@ -162,6 +186,14 @@ exports[`ReportExportComponentTest user interactions edit text field: test conte
     onDescriptionChange={[Function]}
     onExportClick={[Function]}
     reportExportFormat="Assessment"
+    reportExportServices={
+      Array [
+        Object {
+          "generateMenuItem": null,
+          "key": "html",
+        },
+      ]
+    }
   />
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
@@ -36,6 +36,10 @@ exports[`ReportExportDialogFactory getReportExportDialogForAssessment expected p
       },
       "getCurrentDate": [Function],
       "getDateFromTimestamp": [Function],
+      "reportExportServiceProvider": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "services": undefined,
+      },
       "reportGenerator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
         "assessmentReportHtmlGenerator": undefined,
@@ -51,6 +55,22 @@ exports[`ReportExportDialogFactory getReportExportDialogForAssessment expected p
   isOpen={true}
   pageTitle="command-bar-test-tab-title"
   reportExportFormat="Assessment"
+  reportExportServices={
+    Array [
+      Object {
+        "generateMenuItem": null,
+        "key": "html",
+      },
+      Object {
+        "generateMenuItem": null,
+        "key": "json",
+      },
+      Object {
+        "generateMenuItem": null,
+        "key": "codepen",
+      },
+    ]
+  }
   scanDate={2021-02-07T05:02:00.000Z}
   updatePersistedDescription={[Function]}
 />
@@ -92,6 +112,10 @@ exports[`ReportExportDialogFactory getReportExportDialogForFastPass expected pro
       },
       "getCurrentDate": [Function],
       "getDateFromTimestamp": [Function],
+      "reportExportServiceProvider": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "services": undefined,
+      },
       "reportGenerator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
         "assessmentReportHtmlGenerator": undefined,
@@ -107,6 +131,18 @@ exports[`ReportExportDialogFactory getReportExportDialogForFastPass expected pro
   isOpen={true}
   pageTitle="command-bar-test-tab-title"
   reportExportFormat="AutomatedChecks"
+  reportExportServices={
+    Array [
+      Object {
+        "generateMenuItem": null,
+        "key": "html",
+      },
+      Object {
+        "generateMenuItem": null,
+        "key": "codepen",
+      },
+    ]
+  }
   scanDate={2019-03-12T09:00:00.000Z}
   updatePersistedDescription={[Function]}
 />

--- a/src/tests/unit/tests/DetailsView/components/export-dialog-with-local-state.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog-with-local-state.test.tsx
@@ -7,6 +7,7 @@ import {
 } from 'DetailsView/components/export-dialog-with-local-state';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { ReportExportService } from 'report-export/types/report-export-service';
 import { ReportGenerator } from 'reports/report-generator';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { ExportDialog } from '../../../../../DetailsView/components/export-dialog';
@@ -26,6 +27,9 @@ describe('ExportDialogWithLocalState', () => {
     const pageTitle = 'test title';
     const reportExportFormat = 'Assessment';
     const exportName = 'export name';
+    const reportExportServicesStub: ReportExportService[] = [
+        { key: 'html', generateMenuItem: null },
+    ];
 
     beforeEach(() => {
         reportGeneratorMock = Mock.ofType(ReportGenerator);
@@ -51,6 +55,7 @@ describe('ExportDialogWithLocalState', () => {
             isOpen: true,
             dismissExportDialog: dismissDialogMock.object,
             afterDialogDismissed: afterDialogDismissedMock.object,
+            reportExportServices: reportExportServicesStub,
         };
     });
 

--- a/src/tests/unit/tests/DetailsView/components/export-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dropdown.test.tsx
@@ -7,17 +7,15 @@ import { ExportDropdown, ExportDropdownProps } from 'DetailsView/components/expo
 import { shallow } from 'enzyme';
 import { ContextualMenu, PrimaryButton } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
 import { CodePenReportExportService } from 'report-export/services/code-pen-report-export-service';
 import {
     ReportExportService,
     ReportExportServiceKey,
 } from 'report-export/types/report-export-service';
-import { It, Mock, Times } from 'typemoq';
+import { Mock } from 'typemoq';
 
 describe('ExportDropdown', () => {
     const fileProviderMock = Mock.ofType<FileURLProvider>();
-    const reportExportServiceProvider = Mock.ofType<ReportExportServiceProvider>();
     const event = {
         currentTarget: 'test target',
     } as React.MouseEvent<any>;
@@ -40,16 +38,19 @@ describe('ExportDropdown', () => {
         };
     };
 
+    const makeReportExportServicesForKeys = (keys: ReportExportServiceKey[]) => {
+        return keys.map(key => makeReportExportServiceStub(key));
+    };
+
     beforeEach(() => {
         props = {
             onExportLinkClick: null,
-            reportExportServiceProvider: reportExportServiceProvider.object,
+            reportExportServices: null,
             fileName: 'A file name',
             html: '<some html>',
             fileURLProvider: fileProviderMock.object,
             featureFlagStoreData: {},
         };
-        reportExportServiceProvider.reset();
         fileProviderMock
             .setup(f => f.provideURL(['<some html>'], 'text/html'))
             .returns(() => 'a file url');
@@ -62,31 +63,34 @@ describe('ExportDropdown', () => {
     });
 
     it('handles click to show menu without feature flags', () => {
-        reportExportServiceProvider
-            .setup(p => p.forKey('html'))
-            .returns(key => makeReportExportServiceStub(key))
-            .verifiable(Times.once());
+        props.reportExportServices = makeReportExportServicesForKeys(['html']);
 
         const rendered = shallow(<ExportDropdown {...props} />);
         rendered.find(PrimaryButton).simulate('click', event);
 
         expect(rendered.getElement()).toMatchSnapshot();
-        reportExportServiceProvider.verifyAll();
     });
 
     it('handles click to show menu with feature flags', () => {
         props.featureFlagStoreData[FeatureFlags.exportReportOptions] = true;
         props.featureFlagStoreData[FeatureFlags.exportReportJSON] = true;
-        reportExportServiceProvider
-            .setup(p => p.forKey(It.isAny()))
-            .returns(key => makeReportExportServiceStub(key))
-            .verifiable(Times.exactly(3));
+        props.reportExportServices = makeReportExportServicesForKeys(['html', 'json', 'codepen']);
 
         const rendered = shallow(<ExportDropdown {...props} />);
         rendered.find(PrimaryButton).simulate('click', event);
 
         expect(rendered.getElement()).toMatchSnapshot();
-        reportExportServiceProvider.verifyAll();
+    });
+
+    it('handles click to show menu with feature flags but missing json', () => {
+        props.featureFlagStoreData[FeatureFlags.exportReportOptions] = true;
+        props.featureFlagStoreData[FeatureFlags.exportReportJSON] = true;
+        props.reportExportServices = makeReportExportServicesForKeys(['html', 'codepen']);
+
+        const rendered = shallow(<ExportDropdown {...props} />);
+        rendered.find(PrimaryButton).simulate('click', event);
+
+        expect(rendered.getElement()).toMatchSnapshot();
     });
 
     it('handles click on menu item', () => {
@@ -95,10 +99,7 @@ describe('ExportDropdown', () => {
             wasClicked = true;
         };
         props.onExportLinkClick = onClick;
-        reportExportServiceProvider
-            .setup(p => p.forKey('html'))
-            .returns(key => makeReportExportServiceStub(key))
-            .verifiable(Times.once());
+        props.reportExportServices = makeReportExportServicesForKeys(['html']);
 
         const rendered = shallow(<ExportDropdown {...props} />);
         rendered.find(PrimaryButton).simulate('click', event);
@@ -109,13 +110,10 @@ describe('ExportDropdown', () => {
             .onClick();
 
         expect(wasClicked).toBeTruthy();
-        reportExportServiceProvider.verifyAll();
     });
 
     it('should dismiss the contextMenu', () => {
-        reportExportServiceProvider
-            .setup(p => p.forKey('html'))
-            .returns(key => makeReportExportServiceStub(key));
+        props.reportExportServices = makeReportExportServicesForKeys(['html']);
 
         const rendered = shallow(<ExportDropdown {...props} />);
         rendered.find(PrimaryButton).simulate('click', event);

--- a/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
@@ -3,6 +3,7 @@
 import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { ReportExportService } from 'report-export/types/report-export-service';
 import { ReportGenerator } from 'reports/report-generator';
 import { IMock, It, Mock, Times } from 'typemoq';
 
@@ -20,6 +21,9 @@ describe('ReportExportComponentTest', () => {
     let htmlGeneratorMock: IMock<(description: string) => string>;
     let updateDescriptionMock: IMock<(value: string) => void>;
     let getDescriptionMock: IMock<() => string>;
+    const reportExportServicesStub: ReportExportService[] = [
+        { key: 'html', generateMenuItem: null },
+    ];
 
     beforeEach(() => {
         reportGeneratorMock = Mock.ofType(ReportGenerator);
@@ -41,6 +45,7 @@ describe('ReportExportComponentTest', () => {
                 'test-feature-flag': true,
             },
             onDialogDismiss: () => null,
+            reportExportServices: reportExportServicesStub,
         };
     });
 

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -21,6 +21,7 @@ import {
     ShouldShowReportExportButton,
     ShouldShowReportExportButtonProps,
 } from 'DetailsView/components/should-show-report-export-button';
+import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
 import { ReportGenerator } from 'reports/report-generator';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
@@ -48,6 +49,7 @@ describe('ReportExportDialogFactory', () => {
     let afterDialogDismissedMock: IMock<() => void>;
     let props: ReportExportDialogFactoryProps;
     let shouldShowReportExportButtonProps: ShouldShowReportExportButtonProps;
+    let reportExportServiceProviderMock: IMock<ReportExportServiceProvider>;
 
     beforeEach(() => {
         featureFlagStoreData = {};
@@ -66,6 +68,7 @@ describe('ReportExportDialogFactory', () => {
         } as ScanMetadata;
         assessmentsProviderMock = Mock.ofType<AssessmentsProvider>(undefined, MockBehavior.Loose);
         reportGeneratorMock = Mock.ofType(ReportGenerator, MockBehavior.Loose);
+        reportExportServiceProviderMock = Mock.ofType(ReportExportServiceProvider);
         dismissExportDialogMock = Mock.ofInstance(() => null);
         afterDialogDismissedMock = Mock.ofInstance(() => null);
         shouldShowReportExportButtonMock = Mock.ofInstance(() => true);
@@ -75,6 +78,7 @@ describe('ReportExportDialogFactory', () => {
             getCurrentDate: () => currentDate,
             reportGenerator: reportGeneratorMock.object,
             getDateFromTimestamp: value => scanCompleteDate,
+            reportExportServiceProvider: reportExportServiceProviderMock.object,
         } as DetailsViewCommandBarDeps;
         const switcherNavConfiguration = {
             shouldShowReportExportButton: shouldShowReportExportButtonMock.object,
@@ -116,6 +120,27 @@ describe('ReportExportDialogFactory', () => {
             .verifiable(Times.once());
     }
 
+    function setReportExportServiceProviderForAssessment(): void {
+        reportExportServiceProviderMock
+            .setup(r => r.servicesForAssessment())
+            .returns(() => [
+                { key: 'html', generateMenuItem: null },
+                { key: 'json', generateMenuItem: null },
+                { key: 'codepen', generateMenuItem: null },
+            ])
+            .verifiable(Times.once());
+    }
+
+    function setReportExportServiceProviderForFastPass(): void {
+        reportExportServiceProviderMock
+            .setup(r => r.servicesForFastPass())
+            .returns(() => [
+                { key: 'html', generateMenuItem: null },
+                { key: 'codepen', generateMenuItem: null },
+            ])
+            .verifiable(Times.once());
+    }
+
     function setupShouldShowReportExportButton(showReportExportButton: boolean): void {
         shouldShowReportExportButtonMock
             .setup(s => s(shouldShowReportExportButtonProps))
@@ -124,12 +149,14 @@ describe('ReportExportDialogFactory', () => {
 
     describe('getReportExportDialogForAssessment', () => {
         test('expected properties are set', () => {
+            setReportExportServiceProviderForAssessment();
             const dialog = getReportExportDialogForAssessment(props);
 
             expect(dialog).toMatchSnapshot();
 
             reportGeneratorMock.verifyAll();
             detailsViewActionMessageCreatorMock.verifyAll();
+            reportExportServiceProviderMock.verifyAll();
         });
 
         test('htmlGenerator calls reportGenerator', () => {
@@ -188,9 +215,13 @@ describe('ReportExportDialogFactory', () => {
         });
 
         test('expected properties are set', () => {
+            setReportExportServiceProviderForFastPass();
             setupShouldShowReportExportButton(true);
+
             const dialog = getReportExportDialogForFastPass(props);
+
             expect(dialog).toMatchSnapshot();
+            reportExportServiceProviderMock.verifyAll();
         });
 
         test('htmlGenerator calls reportGenerator', () => {

--- a/src/tests/unit/tests/electron/views/results/components/__snapshots__/reflow-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/results/components/__snapshots__/reflow-command-bar.test.tsx.snap
@@ -33,6 +33,10 @@ exports[`ReflowCommandBar reflow behavior isCommandBarCollapsed is true: export 
 <ReportExportComponent
   deps={
     Object {
+      "reportExportServiceProvider": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "services": undefined,
+      },
       "reportGenerator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
         "assessmentReportHtmlGenerator": undefined,
@@ -52,6 +56,18 @@ exports[`ReflowCommandBar reflow behavior isCommandBarCollapsed is true: export 
   onDialogDismiss={[Function]}
   pageTitle="scan target name"
   reportExportFormat="AutomatedChecks"
+  reportExportServices={
+    Array [
+      Object {
+        "generateMenuItem": null,
+        "key": "html",
+      },
+      Object {
+        "generateMenuItem": null,
+        "key": "codepen",
+      },
+    ]
+  }
   scanDate={1970-01-01T00:00:00.000Z}
   updatePersistedDescription={[Function]}
 />
@@ -76,6 +92,10 @@ exports[`ReflowCommandBar reflow behavior isHeaderAndNavCollapsed is true 1`] = 
           <ReportExportComponent
             deps={
               Object {
+                "reportExportServiceProvider": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "services": undefined,
+                },
                 "reportGenerator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "assessmentReportHtmlGenerator": undefined,
@@ -95,6 +115,18 @@ exports[`ReflowCommandBar reflow behavior isHeaderAndNavCollapsed is true 1`] = 
             onDialogDismiss={[Function]}
             pageTitle="scan target name"
             reportExportFormat="AutomatedChecks"
+            reportExportServices={
+              Array [
+                Object {
+                  "generateMenuItem": null,
+                  "key": "html",
+                },
+                Object {
+                  "generateMenuItem": null,
+                  "key": "codepen",
+                },
+              ]
+            }
             scanDate={1970-01-01T00:00:00.000Z}
             updatePersistedDescription={[Function]}
           />
@@ -240,6 +272,10 @@ exports[`ReflowCommandBar renders with start over button disabled 1`] = `
           <ReportExportComponent
             deps={
               Object {
+                "reportExportServiceProvider": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "services": undefined,
+                },
                 "reportGenerator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "assessmentReportHtmlGenerator": undefined,
@@ -259,6 +295,18 @@ exports[`ReflowCommandBar renders with start over button disabled 1`] = `
             onDialogDismiss={[Function]}
             pageTitle="scan target name"
             reportExportFormat="AutomatedChecks"
+            reportExportServices={
+              Array [
+                Object {
+                  "generateMenuItem": null,
+                  "key": "html",
+                },
+                Object {
+                  "generateMenuItem": null,
+                  "key": "codepen",
+                },
+              ]
+            }
             updatePersistedDescription={[Function]}
           />
         }

--- a/src/tests/unit/tests/electron/views/results/components/reflow-command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/components/reflow-command-bar.test.tsx
@@ -18,6 +18,7 @@ import { mount, shallow } from 'enzyme';
 import { isMatch } from 'lodash';
 import { IButton } from 'office-ui-fabric-react';
 import * as React from 'react';
+import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
 import { ReportGenerator } from 'reports/report-generator';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
@@ -31,6 +32,7 @@ describe('ReflowCommandBar', () => {
     let scanDateStub: Date;
     let narrowModeStatusStub: NarrowModeStatus;
     let props: ReflowCommandBarProps;
+    let reportExportServiceProviderMock: IMock<ReportExportServiceProvider>;
 
     beforeEach(() => {
         featureFlagStoreDataStub = {
@@ -53,11 +55,13 @@ describe('ReflowCommandBar', () => {
         };
         scanDateStub = new Date(0);
         reportGeneratorMock = Mock.ofType(ReportGenerator);
-
+        reportExportServiceProviderMock = Mock.ofType(ReportExportServiceProvider);
+        setReportExportServiceProviderForFastPass();
         props = {
             deps: {
                 scanActionCreator: null,
                 reportGenerator: reportGeneratorMock.object,
+                reportExportServiceProvider: reportExportServiceProviderMock.object,
             } as ReflowCommandBarDeps,
             scanStoreData: {} as ScanStoreData,
             cardsViewData: cardsViewDataStub,
@@ -78,6 +82,16 @@ describe('ReflowCommandBar', () => {
         };
     });
 
+    function setReportExportServiceProviderForFastPass(): void {
+        reportExportServiceProviderMock
+            .setup(r => r.servicesForFastPass())
+            .returns(() => [
+                { key: 'html', generateMenuItem: null },
+                { key: 'codepen', generateMenuItem: null },
+            ])
+            .verifiable(Times.once());
+    }
+
     describe('renders', () => {
         it('with start over button disabled', () => {
             props.currentContentPageInfo.startOverButtonSettings = _ => {
@@ -90,6 +104,7 @@ describe('ReflowCommandBar', () => {
             const rendered = shallow(<ReflowCommandBar {...props} />);
 
             expect(rendered.getElement()).toMatchSnapshot();
+            reportExportServiceProviderMock.verifyAll();
         });
 
         it('does not create report export when scan metadata is null', () => {

--- a/src/tests/unit/tests/report-export/report-export-service-provider.test.tsx
+++ b/src/tests/unit/tests/report-export/report-export-service-provider.test.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
+import { ReportExportService } from 'report-export/types/report-export-service';
+
+describe('ReportExportServiceProvider', () => {
+    const reportExportServices: ReportExportService[] = [
+        { key: 'html', generateMenuItem: null },
+        { key: 'codepen', generateMenuItem: null },
+        { key: 'json', generateMenuItem: null },
+    ];
+    let reportExportServiceProvider: ReportExportServiceProvider;
+
+    beforeAll(() => {
+        reportExportServiceProvider = new ReportExportServiceProvider(reportExportServices);
+    });
+
+    test('returns correct services for fastpass', () => {
+        const expectedServices = [
+            { key: 'html', generateMenuItem: null },
+            { key: 'codepen', generateMenuItem: null },
+        ];
+
+        const services = reportExportServiceProvider.servicesForFastPass();
+
+        expect(services).toEqual(expectedServices);
+    });
+
+    test('returns correct services for assessment', () => {
+        const expectedServices = [
+            { key: 'html', generateMenuItem: null },
+            { key: 'codepen', generateMenuItem: null },
+            { key: 'json', generateMenuItem: null },
+        ];
+
+        const services = reportExportServiceProvider.servicesForAssessment();
+
+        expect(services).toEqual(expectedServices);
+    });
+});


### PR DESCRIPTION
#### Details
This PR follows up on #4754 to only show the new to JSON export option in assessment, not fastpass. To accomplish this, `ExportDropdown` was refactored to expect a list of currently applicable `ReportExportServices` rather than a `ReportExportServiceProvider`. `ReportExportServiceProvider` was updated to provide lists of `ReportExportServices` for FastPass and Assessment. Props/deps were updated such that `ReportExportServiceProvider` is now passed down only until the point at which `ExportDialog` diverges for FastPass and Assessment (specifically in `ReportExportDialogFactory` for web and `ReportExportComponent` for unified). At this point, it is used to generate the appropriate list of `ReportExportServices`, which is then passed through until it is used in `ExportDialog` and `ExportDropdown`.

##### Motivation
To JSON is only an export option for assessment.

##### Context
- The to JSON option still doesn't do anything
- Some slight refactoring was done in `ExportDialog` to ensure that a dropdown with only one option isn't displayed in fastpass if the export JSON feature flag is enabled and export to codepen feature flag is not

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
