### PR TITLE
feat(download-report-json): Modify export telemetry to include export service

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -34,6 +34,7 @@ import { ManualTestStatus } from 'common/types/manual-test-status';
 import { VersionedAssessmentData } from 'common/types/versioned-assessment-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import * as React from 'react';
+import { ReportExportServiceKey } from 'report-export/types/report-export-service';
 import { DetailsViewRightContentPanelType } from '../components/left-nav/details-view-right-content-panel-type';
 
 const messages = Messages.Visualizations;
@@ -104,12 +105,12 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
 
     public exportResultsClicked(
         reportExportFormat: ReportExportFormat,
-        exportedHtml: string,
+        selectedServiceKey: ReportExportServiceKey,
         event: React.MouseEvent<HTMLElement>,
     ): void {
-        const telemetryData = this.telemetryFactory.forExportedHtml(
+        const telemetryData = this.telemetryFactory.forExportedResults(
             reportExportFormat,
-            exportedHtml,
+            selectedServiceKey,
             event,
             TelemetryEvents.TelemetryEventSource.DetailsView,
         );

--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -50,7 +50,7 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
         props.onDescriptionChange(props.description);
         detailsViewActionMessageCreator.exportResultsClicked(
             props.reportExportFormat,
-            props.html,
+            selectedServiceKey,
             event,
         );
         setServiceKey(selectedServiceKey);

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import { ReportExportServiceKey } from 'report-export/types/report-export-service';
 import { SingleElementSelector } from './types/store-data/scoping-store-data';
 
 export const POPUP_INITIALIZED: string = 'PopupInitialized';
@@ -112,7 +113,7 @@ export type FeatureFlagToggleTelemetryData = {
 
 export type ExportResultsTelemetryData = {
     exportResultsType: string;
-    exportResultsData: number;
+    exportResultsService: ReportExportServiceKey;
 } & BaseTelemetryData;
 
 export type DetailsViewOpenTelemetryData = {

--- a/src/common/telemetry-data-factory.ts
+++ b/src/common/telemetry-data-factory.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
+import { ReportExportServiceKey } from 'report-export/types/report-export-service';
 
 import { DictionaryStringTo } from '../types/common-types';
 import {
@@ -81,16 +82,16 @@ export class TelemetryDataFactory {
         };
     }
 
-    public forExportedHtml(
+    public forExportedResults(
         reportExportFormat: ReportExportFormat,
-        html: string,
+        selectedServiceKey: ReportExportServiceKey,
         event: SupportedMouseEvent,
         source: TelemetryEventSource,
     ): ExportResultsTelemetryData {
         return {
             ...this.withTriggeredByAndSource(event, source),
             exportResultsType: reportExportFormat,
-            exportResultsData: html.length,
+            exportResultsService: selectedServiceKey,
         };
     }
 

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -1041,13 +1041,13 @@ describe('DetailsViewActionMessageCreatorTest', () => {
     });
 
     test('exportResultsClicked', () => {
-        const html = 'html content';
+        const serviceKey = 'html';
         const event = eventStubFactory.createMouseClickEvent() as any;
 
         const telemetry: ExportResultsTelemetryData = {
             source: TelemetryEventSource.DetailsView,
             triggeredBy: 'mouseclick',
-            exportResultsData: 12,
+            exportResultsService: 'html',
             exportResultsType: 'export result type',
         };
 
@@ -1055,16 +1055,16 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         telemetryFactoryMock
             .setup(tf =>
-                tf.forExportedHtml(
+                tf.forExportedResults(
                     exportResultsType,
-                    html,
+                    serviceKey,
                     event,
                     TelemetryEventSource.DetailsView,
                 ),
             )
             .returns(() => telemetry);
 
-        testSubject.exportResultsClicked(exportResultsType, html, event);
+        testSubject.exportResultsClicked(exportResultsType, serviceKey, event);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.sendTelemetry(EXPORT_RESULTS, telemetry),

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -86,7 +86,7 @@ describe('ExportDialog', () => {
             props.featureFlagStoreData[FeatureFlags.exportReportOptions] = true;
             props.featureFlagStoreData[FeatureFlags.exportReportJSON] = true;
             detailsViewActionMessageCreatorMock
-                .setup(a => a.exportResultsClicked(props.reportExportFormat, props.html, eventStub))
+                .setup(a => a.exportResultsClicked(props.reportExportFormat, 'html', eventStub))
                 .verifiable(Times.once());
 
             props.isOpen = true;
@@ -113,7 +113,7 @@ describe('ExportDialog', () => {
             ] as ReportExportService[];
 
             detailsViewActionMessageCreatorMock
-                .setup(a => a.exportResultsClicked(props.reportExportFormat, props.html, eventStub))
+                .setup(a => a.exportResultsClicked(props.reportExportFormat, 'html', eventStub))
                 .verifiable(Times.once());
 
             props.isOpen = true;
@@ -174,7 +174,7 @@ describe('ExportDialog', () => {
             onExportClickMock.setup(getter => getter()).verifiable(Times.once());
 
             detailsViewActionMessageCreatorMock
-                .setup(a => a.exportResultsClicked(props.reportExportFormat, props.html, eventStub))
+                .setup(a => a.exportResultsClicked(props.reportExportFormat, 'html', eventStub))
                 .verifiable(Times.once());
 
             const wrapper = shallow(<ExportDialog {...props} />);

--- a/src/tests/unit/tests/common/telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/common/telemetry-data-factory.test.ts
@@ -601,21 +601,21 @@ describe('TelemetryDataFactoryTest', () => {
         expect(JSON.parse(actual.failedRuleResults)).toEqual(failedRuleResultsStub);
     });
 
-    test('forExportedHtml by keypress', () => {
-        const exportedHtml = 'some html string';
+    test('forExportedResults by keypress', () => {
+        const serviceKey = 'html';
         const event = keypressEvent;
         const exportResultsType = 'Assessment';
 
-        const result = testObject.forExportedHtml(
+        const result = testObject.forExportedResults(
             exportResultsType,
-            exportedHtml,
+            serviceKey,
             event,
             testSource,
         );
 
         const expected: ExportResultsTelemetryData = {
             exportResultsType: exportResultsType,
-            exportResultsData: exportedHtml.length,
+            exportResultsService: serviceKey,
             triggeredBy: 'keypress',
             source: testSource,
         };
@@ -623,21 +623,21 @@ describe('TelemetryDataFactoryTest', () => {
         expect(result).toEqual(expected);
     });
 
-    test('forExportedHtml by mouseclick', () => {
-        const exportedHtml = 'some html string1';
+    test('forExportedResults by mouseclick', () => {
+        const serviceKey = 'html';
         const event = mouseClickEvent;
         const exportResultsType = 'AutomatedChecks';
 
-        const result = testObject.forExportedHtml(
+        const result = testObject.forExportedResults(
             exportResultsType,
-            exportedHtml,
+            serviceKey,
             event,
             testSource,
         );
 
         const expected: ExportResultsTelemetryData = {
             exportResultsType: exportResultsType,
-            exportResultsData: exportedHtml.length,
+            exportResultsService: serviceKey,
             triggeredBy: 'mouseclick',
             source: testSource,
         };


### PR DESCRIPTION
#### Details
This PR updates the telemetry logged on report export click in two ways:
1. `exportResultsService` is added to the event with potential values of `html`, `json`, and `codepen`
2. `exportResultsData` is removed from the event (read more in Context)

##### Motivation
Telemetry updates for the json export feature

##### Context
In theory, `exportResultsData` was recording the length of the downloaded html string. In reality, it had a bug which caused it to record the length of the _previously downloaded_ html string from that session, which was usually 0. This PR fixes that bug by removing the value entirely (per discussion with @ferBonnin, we don't need that data).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
