### PR TITLE
feat(download-report-json): wire up JSON download to export dialog

### DIFF
--- a/src/DetailsView/components/export-dialog-with-local-state.tsx
+++ b/src/DetailsView/components/export-dialog-with-local-state.tsx
@@ -18,6 +18,7 @@ export interface ExportDialogWithLocalStateProps {
     pageTitle: string;
     scanDate: Date;
     htmlGenerator: (descriptionPlaceholder: string) => string;
+    jsonGenerator: (descriptionPlaceholder: string) => string;
     updatePersistedDescription: (value: string) => void;
     getExportDescription: () => string;
     featureFlagStoreData: FeatureFlagStoreData;
@@ -27,9 +28,11 @@ export interface ExportDialogWithLocalStateProps {
 }
 
 interface ExportDialogWithLocalStateState {
-    exportName: string;
+    htmlExportName: string;
+    htmlExportData: string;
+    jsonExportName: string;
+    jsonExportData: string;
     exportDescription: string;
-    exportData: string;
 }
 
 export class ExportDialogWithLocalState extends React.Component<
@@ -39,8 +42,10 @@ export class ExportDialogWithLocalState extends React.Component<
     constructor(props) {
         super(props);
         this.state = {
-            exportName: '',
-            exportData: '',
+            htmlExportName: '',
+            htmlExportData: '',
+            jsonExportName: '',
+            jsonExportData: '',
             exportDescription: '',
         };
     }
@@ -52,9 +57,20 @@ export class ExportDialogWithLocalState extends React.Component<
 
     private generateHtml = () => {
         this.setState((prevState, prevProps) => ({
-            exportData: prevProps.htmlGenerator(prevState.exportDescription),
-            exportDescription: '',
+            htmlExportData: prevProps.htmlGenerator(prevState.exportDescription),
         }));
+    };
+
+    private generateJson = () => {
+        this.setState((prevState, prevProps) => ({
+            jsonExportData: prevProps.jsonGenerator(prevState.exportDescription),
+        }));
+    };
+
+    private generateExports = () => {
+        this.generateJson();
+        this.generateHtml();
+        this.setState({ exportDescription: '' });
     };
 
     public render(): JSX.Element {
@@ -64,13 +80,15 @@ export class ExportDialogWithLocalState extends React.Component<
             <ExportDialog
                 deps={deps}
                 isOpen={isOpen}
-                fileName={this.state.exportName}
+                htmlFileName={this.state.htmlExportName}
+                jsonFileName={this.state.jsonExportName}
                 description={this.state.exportDescription}
-                html={this.state.exportData}
+                htmlExportData={this.state.htmlExportData}
+                jsonExportData={this.state.jsonExportData}
                 onClose={this.props.dismissExportDialog}
                 onDescriptionChange={this.onExportDescriptionChange}
                 reportExportFormat={reportExportFormat}
-                onExportClick={this.generateHtml}
+                generateExports={this.generateExports}
                 featureFlagStoreData={featureFlagStoreData}
                 afterDismissed={this.props.afterDialogDismissed}
                 reportExportServices={this.props.reportExportServices}
@@ -78,9 +96,14 @@ export class ExportDialogWithLocalState extends React.Component<
         );
     }
 
-    private generateReportName(): string {
+    private generateReportName(fileExtension: string): string {
         const { deps, scanDate, reportExportFormat, pageTitle } = this.props;
-        return deps.reportGenerator.generateName(reportExportFormat, scanDate, pageTitle);
+        return deps.reportGenerator.generateName(
+            reportExportFormat,
+            scanDate,
+            pageTitle,
+            fileExtension,
+        );
     }
 
     private dialogWasOpened(prev: ExportDialogWithLocalStateProps): boolean {
@@ -90,7 +113,8 @@ export class ExportDialogWithLocalState extends React.Component<
     private onDialogOpened(): void {
         this.setState((_, props) => ({
             exportDescription: props.getExportDescription(),
-            exportName: this.generateReportName(),
+            htmlExportName: this.generateReportName('.html'),
+            jsonExportName: this.generateReportName('.json'),
         }));
     }
 

--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -18,13 +18,15 @@ import * as styles from './export-dialog.scss';
 export interface ExportDialogProps {
     deps: ExportDialogDeps;
     isOpen: boolean;
-    fileName: string;
+    htmlFileName: string;
+    jsonFileName: string;
     description: string;
-    html: string;
+    htmlExportData: string;
+    jsonExportData: string;
     onClose: () => void;
     onDescriptionChange: (value: string) => void;
     reportExportFormat: ReportExportFormat;
-    onExportClick: () => void;
+    generateExports: () => void;
     featureFlagStoreData: FeatureFlagStoreData;
     afterDismissed?: () => void;
     reportExportServices: ReportExportService[];
@@ -50,11 +52,10 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
         props.onDescriptionChange(props.description);
         detailsViewActionMessageCreator.exportResultsClicked(
             props.reportExportFormat,
-            props.html,
+            selectedServiceKey,
             event,
         );
         setServiceKey(selectedServiceKey);
-        props.onExportClick();
         props.onClose();
     };
 
@@ -62,7 +63,7 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
         props.onDescriptionChange(value);
     };
 
-    const fileURL = props.deps.fileURLProvider.provideURL([props.html], 'text/html');
+    const htmlFileUrl = props.deps.fileURLProvider.provideURL([props.htmlExportData], 'text/html');
     const exportService = props.reportExportServices.find(s => s.key === serviceKey);
     const ExportForm = exportService ? exportService.exportForm : null;
     const exportToCodepen =
@@ -75,11 +76,12 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
     const getSingleExportToHtmlButton = () => {
         return (
             <PrimaryButton
-                onClick={event =>
-                    onExportLinkClick(event as React.MouseEvent<HTMLAnchorElement>, 'html')
-                }
-                download={props.fileName}
-                href={fileURL}
+                onClick={event => {
+                    props.generateExports();
+                    onExportLinkClick(event as React.MouseEvent<HTMLAnchorElement>, 'html');
+                }}
+                download={props.htmlFileName}
+                href={htmlFileUrl}
             >
                 Export
             </PrimaryButton>
@@ -90,18 +92,23 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
         return (
             <>
                 <ExportDropdown
-                    fileName={props.fileName}
+                    htmlFileName={props.htmlFileName}
+                    jsonFileName={props.jsonFileName}
                     fileURLProvider={props.deps.fileURLProvider}
                     featureFlagStoreData={props.featureFlagStoreData}
-                    html={props.html}
+                    htmlExportData={props.htmlExportData}
+                    jsonExportData={props.jsonExportData}
+                    generateExports={props.generateExports}
                     onExportLinkClick={onExportLinkClick}
                     reportExportServices={props.reportExportServices}
                 />
                 {ExportForm && (
                     <ExportForm
-                        fileName={props.fileName}
+                        htmlFileName={props.htmlFileName}
+                        jsonFileName={props.jsonFileName}
                         description={props.description}
-                        html={props.html}
+                        htmlExportData={props.htmlExportData}
+                        jsonExportData={props.jsonExportData}
                         onSubmit={() => {
                             setServiceKey(null);
                         }}

--- a/src/DetailsView/components/export-dropdown.tsx
+++ b/src/DetailsView/components/export-dropdown.tsx
@@ -21,9 +21,12 @@ export interface ExportDropdownProps {
         event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
         selectedServiceKey: ReportExportServiceKey,
     ) => void;
+    generateExports: () => void;
     reportExportServices: ReportExportService[];
-    fileName: string;
-    html: string;
+    htmlFileName: string;
+    jsonFileName: string;
+    htmlExportData: string;
+    jsonExportData: string;
     fileURLProvider: FileURLProvider;
     featureFlagStoreData: FeatureFlagStoreData;
 }
@@ -68,17 +71,25 @@ export class ExportDropdown extends React.Component<ExportDropdownProps, ExportD
     }
 
     private getMenuItems(): IContextualMenuItem[] {
-        const { featureFlagStoreData, html, fileName, fileURLProvider } = this.props;
+        const {
+            featureFlagStoreData,
+            htmlExportData,
+            jsonExportData,
+            htmlFileName,
+            jsonFileName,
+            fileURLProvider,
+        } = this.props;
 
         const exportToCodepen = featureFlagStoreData[FeatureFlags.exportReportOptions];
         const exportToJSON = featureFlagStoreData[FeatureFlags.exportReportJSON];
-        const fileURL = fileURLProvider.provideURL([html], 'text/html');
+        const htmlFileUrl = fileURLProvider.provideURL([htmlExportData], 'text/html');
+        const jsonFileUrl = fileURLProvider.provideURL([jsonExportData], 'application/json');
 
         const items: IContextualMenuItem[] = [];
-        this.tryAddMenuItemForKey('html', items, fileURL, fileName);
+        this.tryAddMenuItemForKey('html', items, htmlFileUrl, htmlFileName);
 
         if (exportToJSON) {
-            this.tryAddMenuItemForKey('json', items);
+            this.tryAddMenuItemForKey('json', items, jsonFileUrl, jsonFileName);
         }
 
         if (exportToCodepen) {
@@ -104,6 +115,7 @@ export class ExportDropdown extends React.Component<ExportDropdownProps, ExportD
     }
 
     private openDropdown = (event): void => {
+        this.props.generateExports();
         this.setState({ target: event.currentTarget, isContextMenuVisible: true });
     };
 

--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -41,7 +41,15 @@ export function getReportExportDialogForAssessment(
         pageTitle: scanMetadata.targetAppInfo.name,
         scanDate: props.deps.getCurrentDate(),
         htmlGenerator: description =>
-            reportGenerator.generateAssessmentReport(
+            reportGenerator.generateAssessmentHTMLReport(
+                assessmentStoreData,
+                assessmentsProvider,
+                featureFlagStoreData,
+                scanMetadata.targetAppInfo,
+                description,
+            ),
+        jsonGenerator: description =>
+            reportGenerator.generateAssessmentJsonExport(
                 assessmentStoreData,
                 assessmentsProvider,
                 featureFlagStoreData,
@@ -92,6 +100,7 @@ export function getReportExportDialogForFastPass(
                 description,
                 props.scanMetadata,
             ),
+        jsonGenerator: () => null,
         updatePersistedDescription: () => null,
         getExportDescription: () => '',
         featureFlagStoreData: props.featureFlagStoreData,

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -39,6 +39,7 @@ import { NullStoreActionMessageCreator } from 'electron/adapters/null-store-acti
 import { loadTheme, setFocusVisibility } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
 import { ReportExportServiceProviderImpl } from 'report-export/report-export-service-provider-impl';
+import { AssessmentJsonExportGenerator } from 'reports/assessment-json-export-generator';
 import { AssessmentReportHtmlGenerator } from 'reports/assessment-report-html-generator';
 import { AssessmentReportModelBuilderFactory } from 'reports/assessment-report-model-builder-factory';
 import { AutomatedChecksReportSectionFactory } from 'reports/components/report-sections/automated-checks-report-section-factory';
@@ -343,14 +344,23 @@ if (tabId != null) {
                 globalization,
             };
 
+            const assessmentReportModelBuilderFactory = new AssessmentReportModelBuilderFactory();
+
             const assessmentReportHtmlGenerator = new AssessmentReportHtmlGenerator(
                 assessmentReportHtmlGeneratorDeps,
                 reactStaticRenderer,
-                new AssessmentReportModelBuilderFactory(),
+                assessmentReportModelBuilderFactory,
                 DateProvider.getCurrentDate,
                 extensionVersion,
                 axeVersion,
                 browserSpec,
+                assessmentDefaultMessageGenerator,
+            );
+
+            const assessmentJsonExportGenerator = new AssessmentJsonExportGenerator(
+                assessmentReportModelBuilderFactory,
+                DateProvider.getCurrentDate,
+                extensionVersion,
                 assessmentDefaultMessageGenerator,
             );
 
@@ -388,6 +398,7 @@ if (tabId != null) {
                 reportNameGenerator,
                 reportHtmlGenerator,
                 assessmentReportHtmlGenerator,
+                assessmentJsonExportGenerator,
             );
 
             const assessmentDataFormatter = new AssessmentDataFormatter();

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -536,6 +536,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
             new UnifiedReportNameGenerator(),
             reportHtmlGenerator,
             null,
+            null,
         );
 
         const startTesting = () => {

--- a/src/electron/views/results/components/reflow-command-bar.tsx
+++ b/src/electron/views/results/components/reflow-command-bar.tsx
@@ -76,6 +76,7 @@ export const ReflowCommandBar = NamedFC<ReflowCommandBarProps>('ReflowCommandBar
                         scanMetadata,
                     )
                 }
+                jsonGenerator={() => null}
                 updatePersistedDescription={() => null}
                 getExportDescription={() => ''}
                 featureFlagStoreData={featureFlagStoreData}

--- a/src/report-export/services/code-pen-report-export-service.tsx
+++ b/src/report-export/services/code-pen-report-export-service.tsx
@@ -38,9 +38,9 @@ class CodePenExportForm extends React.Component<ReportExportFormProps> {
                     name="data"
                     type="hidden"
                     value={JSON.stringify({
-                        title: this.props.fileName,
+                        title: this.props.htmlFileName,
                         description: this.props.description,
-                        html: this.props.html,
+                        html: this.props.htmlExportData,
                         editors: '100', // collapse CSS and JS editors
                     })}
                 />

--- a/src/report-export/services/json-report-export-service.ts
+++ b/src/report-export/services/json-report-export-service.ts
@@ -10,13 +10,15 @@ const jsonReportExportServiceKey: ReportExportServiceKey = 'json';
 export const JsonReportExportService: ReportExportService = {
     key: jsonReportExportServiceKey,
     displayName: 'JSON',
-    generateMenuItem: (onMenuItemClick, _, __) => {
+    generateMenuItem: (onMenuItemClick, href, download) => {
         return {
             key: jsonReportExportServiceKey,
             name: 'as JSON',
             onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
                 onMenuItemClick(e, jsonReportExportServiceKey);
             },
+            href,
+            download,
         };
     },
 };

--- a/src/report-export/types/report-export-service.ts
+++ b/src/report-export/types/report-export-service.ts
@@ -8,8 +8,10 @@ export type ReportExportServiceKey = 'html' | 'codepen' | 'json';
 export type ReportExportFormProps = ReportExportProps & { onSubmit: () => void };
 
 export type ReportExportProps = {
-    html: string;
-    fileName: string;
+    htmlExportData: string;
+    htmlFileName: string;
+    jsonFileName: string;
+    jsonExportData: string;
     description: string;
 };
 

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -5,6 +5,7 @@ import { AssessmentStoreData } from 'common/types/store-data/assessment-result-d
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { ScanMetadata, TargetAppData } from 'common/types/store-data/unified-data-interface';
+import { AssessmentJsonExportGenerator } from 'reports/assessment-json-export-generator';
 import { AssessmentReportHtmlGenerator } from './assessment-report-html-generator';
 import { ReportHtmlGenerator } from './report-html-generator';
 import { ReportNameGenerator } from './report-name-generator';
@@ -14,10 +15,16 @@ export class ReportGenerator {
         private reportNameGenerator: ReportNameGenerator,
         private reportHtmlGenerator: ReportHtmlGenerator,
         private assessmentReportHtmlGenerator: AssessmentReportHtmlGenerator,
+        private assessmentJsonExportGenerator: AssessmentJsonExportGenerator,
     ) {}
 
-    public generateName(baseName: string, scanDate: Date, pageTitle: string): string {
-        return this.reportNameGenerator.generateName(baseName, scanDate, pageTitle);
+    public generateName(
+        baseName: string,
+        scanDate: Date,
+        pageTitle: string,
+        fileExtension: string,
+    ): string {
+        return this.reportNameGenerator.generateName(baseName, scanDate, pageTitle, fileExtension);
     }
 
     public generateFastPassAutomatedChecksReport(
@@ -28,7 +35,7 @@ export class ReportGenerator {
         return this.reportHtmlGenerator.generateHtml(description, cardsViewData, scanMetadata);
     }
 
-    public generateAssessmentReport(
+    public generateAssessmentHTMLReport(
         assessmentStoreData: AssessmentStoreData,
         assessmentsProvider: AssessmentsProvider,
         featureFlagStoreData: FeatureFlagStoreData,
@@ -36,6 +43,22 @@ export class ReportGenerator {
         description: string,
     ): string {
         return this.assessmentReportHtmlGenerator.generateHtml(
+            assessmentStoreData,
+            assessmentsProvider,
+            featureFlagStoreData,
+            targetAppInfo,
+            description,
+        );
+    }
+
+    public generateAssessmentJsonExport(
+        assessmentStoreData: AssessmentStoreData,
+        assessmentsProvider: AssessmentsProvider,
+        featureFlagStoreData: FeatureFlagStoreData,
+        targetAppInfo: TargetAppData,
+        description: string,
+    ): string {
+        return this.assessmentJsonExportGenerator.generateJson(
             assessmentStoreData,
             assessmentsProvider,
             featureFlagStoreData,

--- a/src/reports/report-name-generator.ts
+++ b/src/reports/report-name-generator.ts
@@ -3,20 +3,30 @@
 import { FileNameBuilder } from 'common/filename-builder';
 
 export interface ReportNameGenerator {
-    generateName(baseName: string, scanDate: Date, pageTitle: string): string;
+    generateName(
+        baseName: string,
+        scanDate: Date,
+        pageTitle: string,
+        fileExtension: string,
+    ): string;
 }
 
 export class WebReportNameGenerator implements ReportNameGenerator {
     constructor(private readonly fileNameBuilder: FileNameBuilder = new FileNameBuilder()) {}
 
-    public generateName(baseName: string, scanDate: Date, pageTitle: string): string {
+    public generateName(
+        baseName: string,
+        scanDate: Date,
+        pageTitle: string,
+        fileExtension: string,
+    ): string {
         return (
             baseName +
             '_' +
             this.fileNameBuilder.getDateSegment(scanDate) +
             '_' +
             this.fileNameBuilder.getTitleSegment(pageTitle) +
-            '.html'
+            fileExtension
         );
     }
 }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog-with-local-state.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog-with-local-state.test.tsx.snap
@@ -1,12 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ExportDialogWithLocalState clicking export on the dialog should trigger generateHtml with the current exportDescription 1`] = `
+exports[`ExportDialogWithLocalState clicking export on the dialog triggers generateExports, generates json and html with the current exportDescription 1`] = `
 <ExportDialog
   afterDismissed={[Function]}
   deps={
     Object {
       "reportGenerator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "assessmentJsonExportGenerator": undefined,
         "assessmentReportHtmlGenerator": undefined,
         "reportHtmlGenerator": undefined,
         "reportNameGenerator": undefined,
@@ -19,12 +20,14 @@ exports[`ExportDialogWithLocalState clicking export on the dialog should trigger
       "test-feature-flag": true,
     }
   }
-  fileName=""
-  html="test html"
+  generateExports={[Function]}
+  htmlExportData="test html"
+  htmlFileName=""
   isOpen={true}
+  jsonExportData="test json"
+  jsonFileName=""
   onClose={[Function]}
   onDescriptionChange={[Function]}
-  onExportClick={[Function]}
   reportExportFormat="Assessment"
   reportExportServices={
     Array [
@@ -44,6 +47,7 @@ exports[`ExportDialogWithLocalState edit text field: test content with special c
     Object {
       "reportGenerator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "assessmentJsonExportGenerator": undefined,
         "assessmentReportHtmlGenerator": undefined,
         "reportHtmlGenerator": undefined,
         "reportNameGenerator": undefined,
@@ -56,12 +60,14 @@ exports[`ExportDialogWithLocalState edit text field: test content with special c
       "test-feature-flag": true,
     }
   }
-  fileName=""
-  html=""
+  generateExports={[Function]}
+  htmlExportData=""
+  htmlFileName=""
   isOpen={true}
+  jsonExportData=""
+  jsonFileName=""
   onClose={[Function]}
   onDescriptionChange={[Function]}
-  onExportClick={[Function]}
   reportExportFormat="Assessment"
   reportExportServices={
     Array [
@@ -81,6 +87,7 @@ exports[`ExportDialogWithLocalState on dialog opened 1`] = `
     Object {
       "reportGenerator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "assessmentJsonExportGenerator": undefined,
         "assessmentReportHtmlGenerator": undefined,
         "reportHtmlGenerator": undefined,
         "reportNameGenerator": undefined,
@@ -93,12 +100,13 @@ exports[`ExportDialogWithLocalState on dialog opened 1`] = `
       "test-feature-flag": true,
     }
   }
-  fileName="export name"
-  html=""
+  generateExports={[Function]}
+  htmlExportData=""
+  htmlFileName="export name"
   isOpen={true}
+  jsonExportData=""
   onClose={[Function]}
   onDescriptionChange={[Function]}
-  onExportClick={[Function]}
   reportExportFormat="Assessment"
   reportExportServices={
     Array [
@@ -118,6 +126,7 @@ exports[`ExportDialogWithLocalState render with dialog closed 1`] = `
     Object {
       "reportGenerator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "assessmentJsonExportGenerator": undefined,
         "assessmentReportHtmlGenerator": undefined,
         "reportHtmlGenerator": undefined,
         "reportNameGenerator": undefined,
@@ -130,12 +139,14 @@ exports[`ExportDialogWithLocalState render with dialog closed 1`] = `
       "test-feature-flag": true,
     }
   }
-  fileName=""
-  html=""
+  generateExports={[Function]}
+  htmlExportData=""
+  htmlFileName=""
   isOpen={false}
+  jsonExportData=""
+  jsonFileName=""
   onClose={[Function]}
   onDescriptionChange={[Function]}
-  onExportClick={[Function]}
   reportExportFormat="Assessment"
   reportExportServices={
     Array [
@@ -155,6 +166,7 @@ exports[`ExportDialogWithLocalState render with dialog open 1`] = `
     Object {
       "reportGenerator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "assessmentJsonExportGenerator": undefined,
         "assessmentReportHtmlGenerator": undefined,
         "reportHtmlGenerator": undefined,
         "reportNameGenerator": undefined,
@@ -167,12 +179,14 @@ exports[`ExportDialogWithLocalState render with dialog open 1`] = `
       "test-feature-flag": true,
     }
   }
-  fileName=""
-  html=""
+  generateExports={[Function]}
+  htmlExportData=""
+  htmlFileName=""
   isOpen={true}
+  jsonExportData=""
+  jsonFileName=""
   onClose={[Function]}
   onDescriptionChange={[Function]}
-  onExportClick={[Function]}
   reportExportFormat="Assessment"
   reportExportServices={
     Array [

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`ExportDialog renders with export dropdown 1`] = `
 "<StyledWithResponsiveMode hidden={false} onDismiss={[Function: onDismiss]} dialogContentProps={{...}} modalProps={{...}}>
   <StyledTextFieldBase multiline={true} autoFocus={true} rows={8} resizable={false} onChange={[Function: onDescriptionChange]} value=\\"description\\" ariaLabel=\\"Provide result description\\" />
   <StyledDialogFooterBase>
-    <ExportDropdown fileName=\\"THE REPORT FILE NAME\\" fileURLProvider={[Function: function () {
+    <ExportDropdown htmlFileName=\\"THE REPORT FILE NAME\\" jsonFileName=\\"JSON file name\\" fileURLProvider={[Function: function () {
                         var args = [];
                         for (var _i = 0; _i < arguments.length; _i++) {
                             args[_i] = arguments[_i];
@@ -37,7 +37,7 @@ exports[`ExportDialog renders with export dropdown 1`] = `
                         var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
                         _this._interceptor.intercept(methodInvocation);
                         return methodInvocation.returnValue;
-                    }] { provideURL: [Function (anonymous)], [Symbol(Symbol.toStringTag)]: [Function: bound toString] }} featureFlagStoreData={{...}} html=\\"fake html\\" onExportLinkClick={[Function: onExportLinkClick]} reportExportServices={{...}} />
+                    }] { provideURL: [Function (anonymous)], [Symbol(Symbol.toStringTag)]: [Function: bound toString] }} featureFlagStoreData={{...}} htmlExportData=\\"fake html\\" jsonExportData=\\"fake json\\" generateExports={[Function: proxy]} onExportLinkClick={[Function: onExportLinkClick]} reportExportServices={{...}} />
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>"
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dropdown.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`ExportDropdown handles click to show menu with feature flags 1`] = `
           "onClick": [Function],
         },
         Object {
-          "download": undefined,
+          "download": "json file name",
           "href": undefined,
           "key": "json",
           "onClick": [Function],

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
@@ -179,6 +179,7 @@ exports[`IssuesTableTest not scanning, issuesEnabled is true 1`] = `
           "getDateFromTimestamp": [Function],
           "reportGenerator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "assessmentJsonExportGenerator": undefined,
             "assessmentReportHtmlGenerator": undefined,
             "reportHtmlGenerator": undefined,
             "reportNameGenerator": undefined,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`ReportExportComponentTest render 1`] = `
       Object {
         "reportGenerator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "assessmentJsonExportGenerator": undefined,
           "assessmentReportHtmlGenerator": undefined,
           "reportHtmlGenerator": undefined,
           "reportNameGenerator": undefined,
@@ -31,12 +32,14 @@ exports[`ReportExportComponentTest render 1`] = `
         "test-feature-flag": true,
       }
     }
-    fileName=""
-    html=""
+    generateExports={[Function]}
+    htmlExportData=""
+    htmlFileName=""
     isOpen={false}
+    jsonExportData=""
+    jsonFileName=""
     onClose={[Function]}
     onDescriptionChange={[Function]}
-    onExportClick={[Function]}
     reportExportFormat="Assessment"
     reportExportServices={
       Array [
@@ -69,6 +72,7 @@ exports[`ReportExportComponentTest user interactions click export button: dialog
       Object {
         "reportGenerator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "assessmentJsonExportGenerator": undefined,
           "assessmentReportHtmlGenerator": undefined,
           "reportHtmlGenerator": undefined,
           "reportNameGenerator": undefined,
@@ -81,11 +85,65 @@ exports[`ReportExportComponentTest user interactions click export button: dialog
         "test-feature-flag": true,
       }
     }
-    html=""
+    generateExports={[Function]}
+    htmlExportData=""
     isOpen={true}
+    jsonExportData=""
     onClose={[Function]}
     onDescriptionChange={[Function]}
-    onExportClick={[Function]}
+    reportExportFormat="Assessment"
+    reportExportServices={
+      Array [
+        Object {
+          "generateMenuItem": null,
+          "key": "html",
+        },
+      ]
+    }
+  />
+</React.Fragment>
+`;
+
+exports[`ReportExportComponentTest user interactions clicking export on the dialog should trigger generateExports with the current exportDescription 1`] = `
+<React.Fragment>
+  <InsightsCommandButton
+    data-automation-id="export-report-command-bar-button"
+    iconProps={
+      Object {
+        "iconName": "Export",
+      }
+    }
+    onClick={[Function]}
+  >
+    Export result
+  </InsightsCommandButton>
+  <ExportDialog
+    afterDismissed={[Function]}
+    deps={
+      Object {
+        "reportGenerator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "assessmentJsonExportGenerator": undefined,
+          "assessmentReportHtmlGenerator": undefined,
+          "reportHtmlGenerator": undefined,
+          "reportNameGenerator": undefined,
+        },
+      }
+    }
+    description=""
+    featureFlagStoreData={
+      Object {
+        "test-feature-flag": true,
+      }
+    }
+    generateExports={[Function]}
+    htmlExportData="test html"
+    htmlFileName=""
+    isOpen={false}
+    jsonExportData="test json"
+    jsonFileName=""
+    onClose={[Function]}
+    onDescriptionChange={[Function]}
     reportExportFormat="Assessment"
     reportExportServices={
       Array [
@@ -118,6 +176,7 @@ exports[`ReportExportComponentTest user interactions dismiss dialog: dialog shou
       Object {
         "reportGenerator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "assessmentJsonExportGenerator": undefined,
           "assessmentReportHtmlGenerator": undefined,
           "reportHtmlGenerator": undefined,
           "reportNameGenerator": undefined,
@@ -130,11 +189,12 @@ exports[`ReportExportComponentTest user interactions dismiss dialog: dialog shou
         "test-feature-flag": true,
       }
     }
-    html=""
+    generateExports={[Function]}
+    htmlExportData=""
     isOpen={false}
+    jsonExportData=""
     onClose={[Function]}
     onDescriptionChange={[Function]}
-    onExportClick={[Function]}
     reportExportFormat="Assessment"
     reportExportServices={
       Array [
@@ -167,6 +227,7 @@ exports[`ReportExportComponentTest user interactions edit text field: test conte
       Object {
         "reportGenerator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "assessmentJsonExportGenerator": undefined,
           "assessmentReportHtmlGenerator": undefined,
           "reportHtmlGenerator": undefined,
           "reportNameGenerator": undefined,
@@ -179,12 +240,14 @@ exports[`ReportExportComponentTest user interactions edit text field: test conte
         "test-feature-flag": true,
       }
     }
-    fileName=""
-    html=""
+    generateExports={[Function]}
+    htmlExportData=""
+    htmlFileName=""
     isOpen={false}
+    jsonExportData=""
+    jsonFileName=""
     onClose={[Function]}
     onDescriptionChange={[Function]}
-    onExportClick={[Function]}
     reportExportFormat="Assessment"
     reportExportServices={
       Array [

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`ReportExportDialogFactory getReportExportDialogForAssessment expected p
       },
       "reportGenerator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "assessmentJsonExportGenerator": undefined,
         "assessmentReportHtmlGenerator": undefined,
         "reportHtmlGenerator": undefined,
         "reportNameGenerator": undefined,
@@ -53,6 +54,7 @@ exports[`ReportExportDialogFactory getReportExportDialogForAssessment expected p
   getExportDescription={[Function]}
   htmlGenerator={[Function]}
   isOpen={true}
+  jsonGenerator={[Function]}
   pageTitle="command-bar-test-tab-title"
   reportExportFormat="Assessment"
   reportExportServices={
@@ -118,6 +120,7 @@ exports[`ReportExportDialogFactory getReportExportDialogForFastPass expected pro
       },
       "reportGenerator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "assessmentJsonExportGenerator": undefined,
         "assessmentReportHtmlGenerator": undefined,
         "reportHtmlGenerator": undefined,
         "reportNameGenerator": undefined,
@@ -129,6 +132,7 @@ exports[`ReportExportDialogFactory getReportExportDialogForFastPass expected pro
   getExportDescription={[Function]}
   htmlGenerator={[Function]}
   isOpen={true}
+  jsonGenerator={[Function]}
   pageTitle="command-bar-test-tab-title"
   reportExportFormat="AutomatedChecks"
   reportExportServices={

--- a/src/tests/unit/tests/DetailsView/components/export-dialog-with-local-state.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog-with-local-state.test.tsx
@@ -17,6 +17,7 @@ describe('ExportDialogWithLocalState', () => {
     let props: ExportDialogWithLocalStateProps;
     let reportGeneratorMock: IMock<ReportGenerator>;
     let htmlGeneratorMock: IMock<(description: string) => string>;
+    let jsonGeneratorMock: IMock<(description: string) => string>;
     let updateDescriptionMock: IMock<(value: string) => void>;
     let getDescriptionMock: IMock<() => string>;
     let dismissDialogMock: IMock<() => void>;
@@ -25,6 +26,7 @@ describe('ExportDialogWithLocalState', () => {
     const exportDescription = 'export description';
     const scanDate = new Date(2019, 5, 28);
     const pageTitle = 'test title';
+    const fileExtension = '.html';
     const reportExportFormat = 'Assessment';
     const exportName = 'export name';
     const reportExportServicesStub: ReportExportService[] = [
@@ -37,6 +39,7 @@ describe('ExportDialogWithLocalState', () => {
             reportGenerator: reportGeneratorMock.object,
         } as ExportDialogWithLocalStateDeps;
         htmlGeneratorMock = Mock.ofInstance(description => null);
+        jsonGeneratorMock = Mock.ofInstance(description => null);
         updateDescriptionMock = Mock.ofInstance(value => null);
         getDescriptionMock = Mock.ofInstance(() => null);
         dismissDialogMock = Mock.ofInstance(() => null);
@@ -47,6 +50,7 @@ describe('ExportDialogWithLocalState', () => {
             pageTitle,
             scanDate,
             htmlGenerator: htmlGeneratorMock.object,
+            jsonGenerator: jsonGeneratorMock.object,
             updatePersistedDescription: updateDescriptionMock.object,
             getExportDescription: getDescriptionMock.object,
             featureFlagStoreData: {
@@ -96,7 +100,7 @@ describe('ExportDialogWithLocalState', () => {
             isOpen: false,
         };
         reportGeneratorMock
-            .setup(r => r.generateName(reportExportFormat, scanDate, pageTitle))
+            .setup(r => r.generateName(reportExportFormat, scanDate, pageTitle, fileExtension))
             .returns(() => exportName);
         getDescriptionMock.setup(g => g()).returns(() => exportDescription);
 
@@ -128,7 +132,7 @@ describe('ExportDialogWithLocalState', () => {
         updateDescriptionMock.verifyAll();
     });
 
-    test('clicking export on the dialog should trigger generateHtml with the current exportDescription', () => {
+    test('clicking export on the dialog triggers generateExports, generates json and html with the current exportDescription', () => {
         const wrapper = shallow(<ExportDialogWithLocalState {...props} />);
         wrapper.setState({ exportDescription: testContentWithSpecials });
 
@@ -137,12 +141,18 @@ describe('ExportDialogWithLocalState', () => {
             .returns(() => 'test html')
             .verifiable(Times.once());
 
+        jsonGeneratorMock
+            .setup(jgm => jgm(testContentWithSpecials))
+            .returns(() => 'test json')
+            .verifiable(Times.once());
+
         const dialog = wrapper.find(ExportDialog);
 
-        dialog.props().onExportClick();
+        dialog.props().generateExports();
 
         expect(wrapper.getElement()).toMatchSnapshot();
 
         htmlGeneratorMock.verifyAll();
+        jsonGeneratorMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -23,7 +23,7 @@ describe('ExportDialog', () => {
     );
     const fileProviderMock = Mock.ofType<FileURLProvider>();
     const eventStub = 'event stub' as any;
-    const onExportClickMock = Mock.ofInstance(() => {});
+    const generateExportsMock = Mock.ofInstance(() => {});
     const afterDismissedMock = Mock.ofInstance(() => null);
     const reportExportServicesStub = [
         {
@@ -43,7 +43,7 @@ describe('ExportDialog', () => {
         onCloseMock.reset();
         onDescriptionChangeMock.reset();
         detailsViewActionMessageCreatorMock.reset();
-        onExportClickMock.reset();
+        generateExportsMock.reset();
         fileProviderMock.reset();
 
         const deps = {
@@ -54,13 +54,15 @@ describe('ExportDialog', () => {
         props = {
             deps,
             isOpen: false,
-            html: 'fake html',
-            fileName: 'THE REPORT FILE NAME',
+            htmlExportData: 'fake html',
+            htmlFileName: 'THE REPORT FILE NAME',
+            jsonFileName: 'JSON file name',
+            jsonExportData: 'fake json',
             description: 'description',
+            generateExports: generateExportsMock.object,
             onClose: onCloseMock.object,
             onDescriptionChange: onDescriptionChangeMock.object,
             reportExportFormat: 'Assessment',
-            onExportClick: onExportClickMock.object,
             featureFlagStoreData: {},
             afterDismissed: afterDismissedMock.object,
             reportExportServices: reportExportServicesStub,
@@ -86,7 +88,7 @@ describe('ExportDialog', () => {
             props.featureFlagStoreData[FeatureFlags.exportReportOptions] = true;
             props.featureFlagStoreData[FeatureFlags.exportReportJSON] = true;
             detailsViewActionMessageCreatorMock
-                .setup(a => a.exportResultsClicked(props.reportExportFormat, props.html, eventStub))
+                .setup(a => a.exportResultsClicked(props.reportExportFormat, 'html', eventStub))
                 .verifiable(Times.once());
 
             props.isOpen = true;
@@ -113,7 +115,7 @@ describe('ExportDialog', () => {
             ] as ReportExportService[];
 
             detailsViewActionMessageCreatorMock
-                .setup(a => a.exportResultsClicked(props.reportExportFormat, props.html, eventStub))
+                .setup(a => a.exportResultsClicked(props.reportExportFormat, 'html', eventStub))
                 .verifiable(Times.once());
 
             props.isOpen = true;
@@ -129,8 +131,10 @@ describe('ExportDialog', () => {
 
         it('with CodePen export form', () => {
             const formProps = {
-                html: props.html,
-                fileName: props.fileName,
+                htmlExportData: props.htmlExportData,
+                htmlFileName: props.htmlFileName,
+                jsonFileName: props.jsonFileName,
+                jsonExportData: props.jsonExportData,
                 description: props.description,
                 onSubmit: jest.fn(),
             };
@@ -148,7 +152,7 @@ describe('ExportDialog', () => {
                 .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
                 .returns(() => 'fake-url')
                 .verifiable(Times.once());
-            onExportClickMock.setup(getter => getter()).verifiable(Times.never());
+            generateExportsMock.setup(getter => getter()).verifiable(Times.never());
             const wrapper = shallow(<ExportDialog {...props} />);
 
             wrapper.find(Dialog).prop('onDismiss')();
@@ -157,7 +161,7 @@ describe('ExportDialog', () => {
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();
             detailsViewActionMessageCreatorMock.verifyAll();
-            onExportClickMock.verifyAll();
+            generateExportsMock.verifyAll();
         });
 
         it('handles click on export button', () => {
@@ -171,10 +175,10 @@ describe('ExportDialog', () => {
                 .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
                 .returns(() => 'fake-url')
                 .verifiable(Times.exactly(2));
-            onExportClickMock.setup(getter => getter()).verifiable(Times.once());
+            generateExportsMock.setup(getter => getter()).verifiable(Times.once());
 
             detailsViewActionMessageCreatorMock
-                .setup(a => a.exportResultsClicked(props.reportExportFormat, props.html, eventStub))
+                .setup(a => a.exportResultsClicked(props.reportExportFormat, 'html', eventStub))
                 .verifiable(Times.once());
 
             const wrapper = shallow(<ExportDialog {...props} />);
@@ -187,7 +191,7 @@ describe('ExportDialog', () => {
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();
             detailsViewActionMessageCreatorMock.verifyAll();
-            onExportClickMock.verifyAll();
+            generateExportsMock.verifyAll();
         });
 
         it('handles text changes for the description', () => {
@@ -210,7 +214,7 @@ describe('ExportDialog', () => {
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();
             detailsViewActionMessageCreatorMock.verifyAll();
-            onExportClickMock.verifyAll();
+            generateExportsMock.verifyAll();
         });
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/export-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dropdown.test.tsx
@@ -16,6 +16,7 @@ import { Mock } from 'typemoq';
 
 describe('ExportDropdown', () => {
     const fileProviderMock = Mock.ofType<FileURLProvider>();
+    const generateExportsMock = Mock.ofType<() => void>();
     const event = {
         currentTarget: 'test target',
     } as React.MouseEvent<any>;
@@ -46,8 +47,11 @@ describe('ExportDropdown', () => {
         props = {
             onExportLinkClick: null,
             reportExportServices: null,
-            fileName: 'A file name',
-            html: '<some html>',
+            htmlFileName: 'A file name',
+            jsonFileName: 'json file name',
+            htmlExportData: '<some html>',
+            jsonExportData: '{}',
+            generateExports: generateExportsMock.object,
             fileURLProvider: fileProviderMock.object,
             featureFlagStoreData: {},
         };

--- a/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
@@ -19,6 +19,7 @@ describe('ReportExportComponentTest', () => {
     let props: ReportExportComponentProps;
     let reportGeneratorMock: IMock<ReportGenerator>;
     let htmlGeneratorMock: IMock<(description: string) => string>;
+    let jsonGeneratorMock: IMock<(description: string) => string>;
     let updateDescriptionMock: IMock<(value: string) => void>;
     let getDescriptionMock: IMock<() => string>;
     const reportExportServicesStub: ReportExportService[] = [
@@ -31,6 +32,7 @@ describe('ReportExportComponentTest', () => {
             reportGenerator: reportGeneratorMock.object,
         } as ReportExportComponentDeps;
         htmlGeneratorMock = Mock.ofInstance(description => null);
+        jsonGeneratorMock = Mock.ofInstance(description => null);
         updateDescriptionMock = Mock.ofInstance(value => null);
         getDescriptionMock = Mock.ofInstance(() => '');
         props = {
@@ -38,6 +40,7 @@ describe('ReportExportComponentTest', () => {
             reportExportFormat: 'Assessment',
             pageTitle: 'test title',
             scanDate: new Date(2019, 5, 28),
+            jsonGenerator: jsonGeneratorMock.object,
             htmlGenerator: htmlGeneratorMock.object,
             updatePersistedDescription: updateDescriptionMock.object,
             getExportDescription: getDescriptionMock.object,
@@ -61,7 +64,12 @@ describe('ReportExportComponentTest', () => {
 
             reportGeneratorMock
                 .setup(rgm =>
-                    rgm.generateName(props.reportExportFormat, props.scanDate, props.pageTitle),
+                    rgm.generateName(
+                        props.reportExportFormat,
+                        props.scanDate,
+                        props.pageTitle,
+                        '.html',
+                    ),
                 )
                 .verifiable(Times.once());
             getDescriptionMock
@@ -94,7 +102,12 @@ describe('ReportExportComponentTest', () => {
             const wrapper = shallow(<ReportExportComponent {...props} />);
             reportGeneratorMock
                 .setup(rgm =>
-                    rgm.generateName(props.reportExportFormat, props.scanDate, props.pageTitle),
+                    rgm.generateName(
+                        props.reportExportFormat,
+                        props.scanDate,
+                        props.pageTitle,
+                        '.html',
+                    ),
                 )
                 .verifiable(Times.once());
             getDescriptionMock
@@ -136,7 +149,7 @@ describe('ReportExportComponentTest', () => {
             updateDescriptionMock.verifyAll();
         });
 
-        test('clicking export on the dialog should trigger generateHtml with the current exportDescription', () => {
+        test('clicking export on the dialog should trigger generateExports with the current exportDescription', () => {
             const wrapper = shallow(<ReportExportComponent {...props} />);
             wrapper.setState({ exportDescription: testContentWithSpecials });
 
@@ -145,11 +158,19 @@ describe('ReportExportComponentTest', () => {
                 .returns(() => 'test html')
                 .verifiable(Times.once());
 
+            jsonGeneratorMock
+                .setup(jgm => jgm(testContentWithSpecials))
+                .returns(() => 'test json')
+                .verifiable(Times.once());
+
             const dialog = wrapper.find(ExportDialog);
 
-            dialog.props().onExportClick();
+            dialog.props().generateExports();
+
+            expect(wrapper.getElement()).toMatchSnapshot();
 
             htmlGeneratorMock.verifyAll();
+            jsonGeneratorMock.verifyAll();
         });
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -108,7 +108,7 @@ describe('ReportExportDialogFactory', () => {
     function setAssessmentReportGenerator(): void {
         reportGeneratorMock
             .setup(reportGenerator =>
-                reportGenerator.generateAssessmentReport(
+                reportGenerator.generateAssessmentHTMLReport(
                     assessmentStoreData,
                     assessmentsProviderMock.object,
                     featureFlagStoreData,

--- a/src/tests/unit/tests/electron/views/results/components/__snapshots__/reflow-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/results/components/__snapshots__/reflow-command-bar.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`ReflowCommandBar reflow behavior isCommandBarCollapsed is true: export 
       },
       "reportGenerator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "assessmentJsonExportGenerator": undefined,
         "assessmentReportHtmlGenerator": undefined,
         "reportHtmlGenerator": undefined,
         "reportNameGenerator": undefined,
@@ -53,6 +54,7 @@ exports[`ReflowCommandBar reflow behavior isCommandBarCollapsed is true: export 
   }
   getExportDescription={[Function]}
   htmlGenerator={[Function]}
+  jsonGenerator={[Function]}
   onDialogDismiss={[Function]}
   pageTitle="scan target name"
   reportExportFormat="AutomatedChecks"
@@ -98,6 +100,7 @@ exports[`ReflowCommandBar reflow behavior isHeaderAndNavCollapsed is true 1`] = 
                 },
                 "reportGenerator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "assessmentJsonExportGenerator": undefined,
                   "assessmentReportHtmlGenerator": undefined,
                   "reportHtmlGenerator": undefined,
                   "reportNameGenerator": undefined,
@@ -112,6 +115,7 @@ exports[`ReflowCommandBar reflow behavior isHeaderAndNavCollapsed is true 1`] = 
             }
             getExportDescription={[Function]}
             htmlGenerator={[Function]}
+            jsonGenerator={[Function]}
             onDialogDismiss={[Function]}
             pageTitle="scan target name"
             reportExportFormat="AutomatedChecks"
@@ -278,6 +282,7 @@ exports[`ReflowCommandBar renders with start over button disabled 1`] = `
                 },
                 "reportGenerator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "assessmentJsonExportGenerator": undefined,
                   "assessmentReportHtmlGenerator": undefined,
                   "reportHtmlGenerator": undefined,
                   "reportNameGenerator": undefined,
@@ -292,6 +297,7 @@ exports[`ReflowCommandBar renders with start over button disabled 1`] = `
             }
             getExportDescription={[Function]}
             htmlGenerator={[Function]}
+            jsonGenerator={[Function]}
             onDialogDismiss={[Function]}
             pageTitle="scan target name"
             reportExportFormat="AutomatedChecks"

--- a/src/tests/unit/tests/report-export/__snapshots__/code-pen-report-export-service.test.tsx.snap
+++ b/src/tests/unit/tests/report-export/__snapshots__/code-pen-report-export-service.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`CodePenReportExportService exportForm renders 1`] = `
   <input
     name="data"
     type="hidden"
-    value="{\\"title\\":\\"test-filename\\",\\"description\\":\\"test-description\\",\\"html\\":\\"test-html\\",\\"editors\\":\\"100\\"}"
+    value="{\\"title\\":\\"test-html-filename\\",\\"description\\":\\"test-description\\",\\"html\\":\\"test-html\\",\\"editors\\":\\"100\\"}"
   />
   <button
     type="submit"

--- a/src/tests/unit/tests/report-export/code-pen-report-export-service.test.tsx
+++ b/src/tests/unit/tests/report-export/code-pen-report-export-service.test.tsx
@@ -14,8 +14,10 @@ describe('CodePenReportExportService', () => {
         beforeEach(() => {
             props = {
                 description: 'test-description',
-                fileName: 'test-filename',
-                html: 'test-html',
+                htmlFileName: 'test-html-filename',
+                jsonFileName: 'test-json-filename',
+                htmlExportData: 'test-html',
+                jsonExportData: 'test-json',
                 onSubmit: null,
             };
         });

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -4,6 +4,7 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-interface';
+import { AssessmentJsonExportGenerator } from 'reports/assessment-json-export-generator';
 import { AssessmentReportHtmlGenerator } from 'reports/assessment-report-html-generator';
 import { ReportGenerator } from 'reports/report-generator';
 import { ReportHtmlGenerator } from 'reports/report-html-generator';
@@ -16,6 +17,7 @@ describe('ReportGenerator', () => {
     const date = new Date(2018, 2, 12, 15, 46);
     const title = 'title';
     const url = 'http://url/';
+    const fileExtension = '.html';
     const description = 'description';
     const cardsViewDataStub = {
         cards: exampleUnifiedStatusResults,
@@ -37,12 +39,17 @@ describe('ReportGenerator', () => {
     let dataBuilderMock: IMock<ReportHtmlGenerator>;
     let nameBuilderMock: IMock<ReportNameGenerator>;
     let assessmentReportHtmlGeneratorMock: IMock<AssessmentReportHtmlGenerator>;
+    let assessmentJsonExportGeneratorMock: IMock<AssessmentJsonExportGenerator>;
 
     beforeEach(() => {
         nameBuilderMock = Mock.ofType<ReportNameGenerator>(undefined, MockBehavior.Strict);
         dataBuilderMock = Mock.ofType<ReportHtmlGenerator>(undefined, MockBehavior.Strict);
         assessmentReportHtmlGeneratorMock = Mock.ofType(
             AssessmentReportHtmlGenerator,
+            MockBehavior.Strict,
+        );
+        assessmentJsonExportGeneratorMock = Mock.ofType(
+            AssessmentJsonExportGenerator,
             MockBehavior.Strict,
         );
     });
@@ -58,6 +65,7 @@ describe('ReportGenerator', () => {
             nameBuilderMock.object,
             dataBuilderMock.object,
             assessmentReportHtmlGeneratorMock.object,
+            assessmentJsonExportGeneratorMock.object,
         );
         const actual = testObject.generateFastPassAutomatedChecksReport(
             cardsViewDataStub,
@@ -91,8 +99,9 @@ describe('ReportGenerator', () => {
             nameBuilderMock.object,
             dataBuilderMock.object,
             assessmentReportHtmlGeneratorMock.object,
+            assessmentJsonExportGeneratorMock.object,
         );
-        const actual = testObject.generateAssessmentReport(
+        const actual = testObject.generateAssessmentHTMLReport(
             assessmentStoreData,
             assessmentsProvider,
             featureFlagStoreData,
@@ -107,7 +116,12 @@ describe('ReportGenerator', () => {
     test('generateName', () => {
         nameBuilderMock
             .setup(builder =>
-                builder.generateName('InsightsScan', It.isValue(date), It.isValue(title)),
+                builder.generateName(
+                    'InsightsScan',
+                    It.isValue(date),
+                    It.isValue(title),
+                    It.isValue(fileExtension),
+                ),
             )
             .returns(() => 'returned-name')
             .verifiable(Times.once());
@@ -116,8 +130,9 @@ describe('ReportGenerator', () => {
             nameBuilderMock.object,
             dataBuilderMock.object,
             assessmentReportHtmlGeneratorMock.object,
+            assessmentJsonExportGeneratorMock.object,
         );
-        const actual = testObject.generateName('InsightsScan', date, title);
+        const actual = testObject.generateName('InsightsScan', date, title, fileExtension);
 
         const expected = 'returned-name';
         expect(actual).toEqual(expected);

--- a/src/tests/unit/tests/reports/report-name-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-name-generator.test.ts
@@ -8,6 +8,7 @@ describe('WebReportNameGenerator', () => {
     const theBase = 'BASE';
     const theTitle = 'Title';
     const theDate = new Date();
+    const theExtension = '.html';
 
     const dateSegment = 'date segment';
     const titleSegment = 'title segment';
@@ -27,9 +28,9 @@ describe('WebReportNameGenerator', () => {
     });
 
     it('generateName', () => {
-        const actual = testObject.generateName(theBase, theDate, theTitle);
+        const actual = testObject.generateName(theBase, theDate, theTitle, theExtension);
 
-        const expected = `${theBase}_${dateSegment}_${titleSegment}.html`;
+        const expected = `${theBase}_${dateSegment}_${titleSegment}${theExtension}`;
         expect(actual).toEqual(expected);
 
         fileNameBuilderMock.verifyAll();


### PR DESCRIPTION
#### Details

This PR wires up the JSON export download with the export dialog.

##### Motivation

Feature work

##### Context

Previously, generating exports was done when the actual menu item was clicked. This was causing a race condition that caused the exports to not always be completely generated when the download link was clicked, resulting in an empty export. To address this I moved the generation of the exports to when the dropdown is clicked, which has resolved the issue.

I also considered refactoring the export-dialog-with-local-state.tsx to use the report-export-component.tsx. There is a fair bit of duplicated code in the two components. I decided to leave it in its current separated state but may keep it in mind for something that could be addressed during slack time.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
