### PR TITLE
feat(download-json-report): Don't clear export description on dropdown open

### DIFF
--- a/src/DetailsView/components/export-dialog-with-local-state.tsx
+++ b/src/DetailsView/components/export-dialog-with-local-state.tsx
@@ -70,7 +70,6 @@ export class ExportDialogWithLocalState extends React.Component<
     private generateExports = () => {
         this.generateJson();
         this.generateHtml();
-        this.setState({ exportDescription: '' });
     };
 
     public render(): JSX.Element {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog-with-local-state.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog-with-local-state.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`ExportDialogWithLocalState clicking export on the dialog triggers gener
       },
     }
   }
-  description=""
+  description="test content with special characters: <> $ \\" \` '"
   featureFlagStoreData={
     Object {
       "test-feature-flag": true,


### PR DESCRIPTION
#### Details
Currently, opening the export dropdown clears the user's description in the export dialog. If they then download an export, the description will be there. If they don't download at that moment, the description is lost. This PR updates the behavior to be in line with current production behavior wherein the user's description is not cleared until they start a new assessment. 

Before:

![before](https://user-images.githubusercontent.com/4615491/136467890-f2c9e62a-253c-4d17-ba18-4bcb880645a7.gif)


After:

![after](https://user-images.githubusercontent.com/4615491/136467899-12d99191-711b-4953-89b4-6405b19e6964.gif)


##### Motivation
Fixes unwanted behavior

##### Context
I considered clearing the description on dialog close, but that would not line up with production behavior.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
