### PR TITLE
feat(download-report-json): add json report export schema to repo

### DIFF
--- a/docs/reports/json-export/json-export-schema.json
+++ b/docs/reports/json-export/json-export-schema.json
@@ -1,0 +1,121 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "url": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "date": {
+            "type": "string"
+        },
+        "comment": {
+            "type": "string"
+        },
+        "version": {
+            "type": "string"
+        },
+        "results": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "wcagNumber": {
+                        "type": "string"
+                    },
+                    "wcagName": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "requirementsFailed": {
+                        "type": "array",
+                        "items": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "requirementKey": {
+                                        "type": "string"
+                                    },
+                                    "requirementDescription": {
+                                        "type": "string"
+                                    },
+                                    "instances": {
+                                        "type": "array",
+                                        "items": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "path": {
+                                                        "type": "string"
+                                                    },
+                                                    "snippet": {
+                                                        "type": "string"
+                                                    },
+                                                    "comment": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "requirementKey",
+                                    "requirementDescription",
+                                    "instances"
+                                ]
+                            }
+                        ]
+                    },
+                    "requirementsPassed": {
+                        "type": "array",
+                        "items": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "requirementKey": {
+                                        "type": "string"
+                                    },
+                                    "requirementDescription": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["requirementKey", "requirementDescription"]
+                            }
+                        ]
+                    },
+                    "requirementsIncomplete": {
+                        "type": "array",
+                        "items": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "requirementKey": {
+                                        "type": "string"
+                                    },
+                                    "requirementDescription": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["requirementKey", "requirementDescription"]
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "wcagNumber",
+                    "wcagName",
+                    "status",
+                    "requirementsFailed",
+                    "requirementsPassed",
+                    "requirementsIncomplete"
+                ]
+            }
+        }
+    },
+    "required": ["url", "title", "date", "comment", "version", "results"]
+}


### PR DESCRIPTION
#### Details

This adds the JSON schema for the new JSON report export. This file will be pointed to from our docs.

##### Motivation

feature work


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
