### PR TITLE
chore: Temporarily use es2017 to release the report package

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -6073,11 +6073,11 @@
                 continue;
               }
               button.addEventListener("click", function () {
-                var ref;
+                var _a;
                 const content =
-                  (ref = button.parentElement) === null || ref === void 0
+                  (_a = button.parentElement) === null || _a === void 0
                     ? void 0
-                    : ref.nextElementSibling;
+                    : _a.nextElementSibling;
                 if (content == null) {
                   throw Error(
                     `Expected button element's parent to have a next sibling`

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -3803,11 +3803,11 @@
                 continue;
               }
               button.addEventListener("click", function () {
-                var ref;
+                var _a;
                 const content =
-                  (ref = button.parentElement) === null || ref === void 0
+                  (_a = button.parentElement) === null || _a === void 0
                     ? void 0
-                    : ref.nextElementSibling;
+                    : _a.nextElementSibling;
                 if (content == null) {
                   throw Error(
                     `Expected button element's parent to have a next sibling`

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -2866,11 +2866,11 @@
                 continue;
               }
               button.addEventListener("click", function () {
-                var ref;
+                var _a;
                 const content =
-                  (ref = button.parentElement) === null || ref === void 0
+                  (_a = button.parentElement) === null || _a === void 0
                     ? void 0
-                    : ref.nextElementSibling;
+                    : _a.nextElementSibling;
                 if (content == null) {
                   throw Error(
                     `Expected button element's parent to have a next sibling`

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -2850,11 +2850,11 @@
                 continue;
               }
               button.addEventListener("click", function () {
-                var ref;
+                var _a;
                 const content =
-                  (ref = button.parentElement) === null || ref === void 0
+                  (_a = button.parentElement) === null || _a === void 0
                     ? void 0
-                    : ref.nextElementSibling;
+                    : _a.nextElementSibling;
                 if (content == null) {
                   throw Error(
                     `Expected button element's parent to have a next sibling`

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -2166,11 +2166,11 @@
                 continue;
               }
               button.addEventListener("click", function () {
-                var ref;
+                var _a;
                 const content =
-                  (ref = button.parentElement) === null || ref === void 0
+                  (_a = button.parentElement) === null || _a === void 0
                     ? void 0
-                    : ref.nextElementSibling;
+                    : _a.nextElementSibling;
                 if (content == null) {
                   throw Error(
                     `Expected button element's parent to have a next sibling`

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -2133,11 +2133,11 @@
                 continue;
               }
               button.addEventListener("click", function () {
-                var ref;
+                var _a;
                 const content =
-                  (ref = button.parentElement) === null || ref === void 0
+                  (_a = button.parentElement) === null || _a === void 0
                     ? void 0
-                    : ref.nextElementSibling;
+                    : _a.nextElementSibling;
                 if (content == null) {
                   throw Error(
                     `Expected button element's parent to have a next sibling`

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -2074,11 +2074,11 @@
                 continue;
               }
               button.addEventListener("click", function () {
-                var ref;
+                var _a;
                 const content =
-                  (ref = button.parentElement) === null || ref === void 0
+                  (_a = button.parentElement) === null || _a === void 0
                     ? void 0
-                    : ref.nextElementSibling;
+                    : _a.nextElementSibling;
                 if (content == null) {
                   throw Error(
                     `Expected button element's parent to have a next sibling`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2020",
-        "module": "es2020",
-        "lib": ["es2020", "dom", "scripthost"],
+        "target": "es2017",
+        "module": "amd",
+        "lib": ["es2017", "dom", "scripthost"],
         "outDir": "./dist/",
         "rootDir": "./",
         "baseUrl": "./src",
+        "typeRoots": ["node_modules/@types"],
         "strictNullChecks": false,
         "noUnusedLocals": true
     },


### PR DESCRIPTION
#### Details

As described in #4621, we need to temporarily switch to es2017 to release the report package in a format that the service can consume. This PR does just that, and I've confirmed that `packages\report\drop\index.js` contains no instances of `?.`. We'll revert this change once the report package has been released.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
