### PR TITLE
chore: add report package e2e test documentation

### DIFF
--- a/docs/building-web.md
+++ b/docs/building-web.md
@@ -117,6 +117,15 @@ yarn test:e2e -u
 
 # Run from the context of the docker container our Linux CI builds use (requires Docker to be installed)
 yarn test:e2e:docker
+
+# Run tests for the report package
+yarn test:report:e2e
+
+# -u updates snapshots for the report package
+# Windows: 
+yarn test:report:e2e -- -- -- -u
+#Linux and Mac:
+yarn test:report:e2e -- -- -u
 ```
 
 Generally, if a Pull Request doesn't touch any E2E tests, you don't have to run them yourself; the automated Pull Request build will do it for you.


### PR DESCRIPTION
#### Details

Update documentation to include details for how to run report package e2e tests. 

##### Motivation

There currently isn't documentation on how to run the report package e2e tests. Also the way you have to update report package e2e snapshots is odd and not intuitive. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
