### PR TITLE
fix: Remove avoiding scan when test already enabled

### DIFF
--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -181,18 +181,14 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
 
         const configuration = this.visualizationConfigurationFactory.getConfiguration(payload.test);
         this.disableAssessmentVisualizationsWithoutEmitting();
-        const scanData = configuration.getStoreData(this.state.tests);
 
         const step = (payload as AssessmentToggleActionPayload).requirement;
-        const alreadyEnabled = configuration.getTestStatus(scanData, step);
-        if (!alreadyEnabled) {
-            if (!skipScanning) {
-                this.state.scanning = configuration.getIdentifier(step);
-            }
-
-            this.state.injectingRequested = true;
-            configuration.enableTest(this.state.tests, payload);
+        if (!skipScanning) {
+            this.state.scanning = configuration.getIdentifier(step);
         }
+
+        this.state.injectingRequested = true;
+        configuration.enableTest(this.state.tests, payload);
         this.emitChanged();
     }
 

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -244,25 +244,33 @@ describe('VisualizationStoreTest ', () => {
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onEnableHeadings when headings is disable', () => {
-        const actionName = 'enableVisualization';
-        const dataBuilder = new VisualizationStoreDataBuilder();
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.Headings,
-        };
+    describe('onEnableHeadings with headings already enabled or disabled', () => {
+        test.each`
+            initialDataBuilder
+            ${new VisualizationStoreDataBuilder().withHeadingsEnable()}
+            ${new VisualizationStoreDataBuilder()}
+        `(
+            'case enabled = $initialDataBuilder.data.tests.adhoc.headings.enabled',
+            ({ initialDataBuilder }) => {
+                const actionName = 'enableVisualization';
+                const payload: ToggleActionPayload = {
+                    test: VisualizationType.Headings,
+                };
 
-        const initialState = dataBuilder.build();
-        const expectedState = dataBuilder
-            .withHeadingsEnable()
-            .with('scanning', 'headings')
-            .with('selectedAdhocDetailsView', VisualizationType.Issues)
-            .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
-            .with('injectingRequested', true)
-            .build();
+                const initialState = initialDataBuilder.build();
+                const expectedState = new VisualizationStoreDataBuilder()
+                    .withHeadingsEnable()
+                    .with('scanning', 'headings')
+                    .with('selectedAdhocDetailsView', VisualizationType.Issues)
+                    .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
+                    .with('injectingRequested', true)
+                    .build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+                createStoreTesterForVisualizationActions(actionName)
+                    .withActionParam(payload)
+                    .testListenerToBeCalledOnce(initialState, expectedState);
+            },
+        );
     });
 
     test('onEnableHeadingsAssessment without scan', () => {
@@ -279,21 +287,6 @@ describe('VisualizationStoreTest ', () => {
             .with('selectedAdhocDetailsView', VisualizationType.Issues)
             .with('injectingRequested', true)
             .build();
-
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
-    });
-
-    test('onEnableHeadings when headings is already enable', () => {
-        const actionName = 'enableVisualization';
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.Headings,
-        };
-
-        const initialState = new VisualizationStoreDataBuilder().withHeadingsEnable().build();
-
-        const expectedState = new VisualizationStoreDataBuilder().withHeadingsEnable().build();
 
         createStoreTesterForVisualizationActions(actionName)
             .withActionParam(payload)
@@ -415,37 +408,32 @@ describe('VisualizationStoreTest ', () => {
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onEnableTabStops when TabStops is disable', () => {
-        const actionName = 'enableVisualization';
-        const dataBuilder = new VisualizationStoreDataBuilder();
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.TabStops,
-        };
-        const initialState = dataBuilder.build();
-        const expectedState = dataBuilder
-            .withTabStopsEnable()
-            .with('injectingRequested', true)
-            .with('scanning', 'tabStops')
-            .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
-            .build();
+    describe('onEnableTabStops with TabStops already enabled or disabled', () => {
+        test.each`
+            initialDataBuilder
+            ${new VisualizationStoreDataBuilder().withTabStopsEnable()}
+            ${new VisualizationStoreDataBuilder()}
+        `(
+            'case enabled = $initialDataBuilder.data.tests.adhoc.tabStops.enabled',
+            ({ initialDataBuilder }) => {
+                const actionName = 'enableVisualization';
+                const payload: ToggleActionPayload = {
+                    test: VisualizationType.TabStops,
+                };
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
-    });
+                const initialState = initialDataBuilder.build();
+                const expectedState = new VisualizationStoreDataBuilder()
+                    .withTabStopsEnable()
+                    .with('injectingRequested', true)
+                    .with('scanning', 'tabStops')
+                    .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
+                    .build();
 
-    test('onEnableTabStops when TabStops is already enable', () => {
-        const actionName = 'enableVisualization';
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.TabStops,
-        };
-        const initialState = new VisualizationStoreDataBuilder().withTabStopsEnable().build();
-
-        const expectedState = new VisualizationStoreDataBuilder().withTabStopsEnable().build();
-
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+                createStoreTesterForVisualizationActions(actionName)
+                    .withActionParam(payload)
+                    .testListenerToBeCalledOnce(initialState, expectedState);
+            },
+        );
     });
 
     test('OnDisableTabStops when TabStops is enable', () => {
@@ -497,36 +485,32 @@ describe('VisualizationStoreTest ', () => {
             .testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('onEnableLandmarks when landmarks is disable', () => {
-        const actionName = 'enableVisualization';
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.Landmarks,
-        };
-        const initialState = new VisualizationStoreDataBuilder().build();
-        const expectedState = new VisualizationStoreDataBuilder()
-            .withLandmarksEnable()
-            .with('scanning', 'landmarks')
-            .with('injectingRequested', true)
-            .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
-            .build();
+    describe('onEnableLandmarks with landmarks already enabled or disabled', () => {
+        test.each`
+            initialDataBuilder
+            ${new VisualizationStoreDataBuilder().withLandmarksEnable()}
+            ${new VisualizationStoreDataBuilder()}
+        `(
+            'case enabled = $initialDataBuilder.data.tests.adhoc.landmarks.enabled',
+            ({ initialDataBuilder }) => {
+                const actionName = 'enableVisualization';
+                const payload: ToggleActionPayload = {
+                    test: VisualizationType.Landmarks,
+                };
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
-    });
+                const initialState = initialDataBuilder.build();
+                const expectedState = new VisualizationStoreDataBuilder()
+                    .withLandmarksEnable()
+                    .with('scanning', 'landmarks')
+                    .with('injectingRequested', true)
+                    .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
+                    .build();
 
-    test('onEnableLandmarks when landmarks is already enable', () => {
-        const actionName = 'enableVisualization';
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.Landmarks,
-        };
-        const initialState = new VisualizationStoreDataBuilder().withLandmarksEnable().build();
-
-        const expectedState = new VisualizationStoreDataBuilder().withLandmarksEnable().build();
-
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+                createStoreTesterForVisualizationActions(actionName)
+                    .withActionParam(payload)
+                    .testListenerToBeCalledOnce(initialState, expectedState);
+            },
+        );
     });
 
     test('onDisableLandmarks when landmarks is enable', () => {
@@ -557,40 +541,33 @@ describe('VisualizationStoreTest ', () => {
             .testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('onEnableIssues when issues is disable', () => {
-        const actionName = 'enableVisualization';
+    describe('onEnableIssues with issues already enabled or disabled', () => {
+        test.each`
+            initialDataBuilder
+            ${new VisualizationStoreDataBuilder().withIssuesEnable()}
+            ${new VisualizationStoreDataBuilder()}
+        `(
+            'case enabled = $initialDataBuilder.data.tests.adhoc.issues.enabled',
+            ({ initialDataBuilder }) => {
+                const actionName = 'enableVisualization';
+                const payload: ToggleActionPayload = {
+                    test: VisualizationType.Issues,
+                };
 
-        const initialState = new VisualizationStoreDataBuilder().build();
+                const initialState = initialDataBuilder.build();
+                const expectedState = new VisualizationStoreDataBuilder()
+                    .withIssuesEnable()
+                    .with('scanning', 'issues')
+                    .with('injectingRequested', true)
+                    .with('selectedAdhocDetailsView', VisualizationType.Issues)
+                    .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
+                    .build();
 
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.Issues,
-        };
-
-        const expectedState = new VisualizationStoreDataBuilder()
-            .withIssuesEnable()
-            .with('scanning', 'issues')
-            .with('injectingRequested', true)
-            .with('selectedAdhocDetailsView', VisualizationType.Issues)
-            .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
-            .build();
-
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
-    });
-
-    test('onEnableIssues when issues is already enable', () => {
-        const actionName = 'enableVisualization';
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.Issues,
-        };
-        const initialState = new VisualizationStoreDataBuilder().withIssuesEnable().build();
-
-        const expectedState = new VisualizationStoreDataBuilder().withIssuesEnable().build();
-
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+                createStoreTesterForVisualizationActions(actionName)
+                    .withActionParam(payload)
+                    .testListenerToBeCalledOnce(initialState, expectedState);
+            },
+        );
     });
 
     test('onDisableIssues when issues is enable', () => {


### PR DESCRIPTION
#### Details

This PR removes the behavior where if a test is already enabled, we avoid re-triggering a scan for that test when prompted.  This was causing the bug described in issue #3258 , where re-starting Fastpass from the popup cleared the details view, and clicking "List View and Filtering" from the ad hoc panel after already toggling "on" a scan cleared the details view.  Intended behavior in both of those cases is to re-trigger a scan and populate the details view with the results.  

##### Motivation

Addresses issue #3258

##### Context

A main part of this bug fix was ensuring that this seemingly straightforward fix did not have any negative implications or side effects for other parts of the extension.  Console logs were used to smoke test for differences between the current code in main and the extension after these changes.  It appears that removing this "avoid if already enabled" check does not cause any excessive re-scanning in assessments or for the ad-hoc tests. Removing this check fixes the bug.  

After this change, the same result is now expected when a test is enabled, whether that same test was previously enabled or not.  So, I refactored the relevant unit tests (one for a previously-enabled test, one for a previously-disabled test) into one test that handles both cases, so that it is more apparent to future devs that the expected result is the same, regardless of starting state. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3258
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS

![0  fastpass rescan works](https://user-images.githubusercontent.com/33770444/138377311-10955c84-52db-469d-a74c-e5f29713d8a5.gif)
Gif showing how clicking fastpass from the popup works the first time, and now also re-scans and populates the details view when clicked a subsequent time.  In the gif, after the first fastpass click, the user fixes an issue in the DOM.  When the user then clicks fastpass again, this change is reflected in the target page visualization and in the details view, showing that a new scan was triggered.  

![0  adhoc list view button works](https://user-images.githubusercontent.com/33770444/138377534-775b1726-c566-4420-90ae-9ce7eba9415a.gif)
Gif showing how clicking the "List View and Filtering" button in the ad hoc pop up panel now no longer clears the details view, but now triggers a scan and populates the details view with those results. 

