### PR TITLE
fix: Add telemetry on save assessment

### DIFF
--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -141,6 +141,10 @@ export class AssessmentActionCreator {
             Messages.Visualizations.DetailsView.Select,
             this.onPivotChildSelected,
         );
+        this.interpreter.registerTypeToPayloadCallback(
+            AssessmentMessages.SaveAssessment,
+            this.onSaveAssessment,
+        );
     }
 
     private onContinuePreviousAssessment = (payload: BaseActionPayload, tabId: number): void => {
@@ -153,6 +157,11 @@ export class AssessmentActionCreator {
         const eventName = TelemetryEvents.LOAD_ASSESSMENT;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.LoadAssessment.invoke(payload);
+    };
+
+    private onSaveAssessment = (payload: BaseActionPayload): void => {
+        const eventName = TelemetryEvents.SAVE_ASSESSMENT;
+        this.telemetryEventHandler.publishTelemetry(eventName, payload);
     };
 
     private onPassUnmarkedInstances = (payload: ToggleActionPayload, tabId: number): void => {

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -35,6 +35,7 @@ export const EDIT_FAILURE_INSTANCE: string = 'editFailureInstance';
 export const PASS_UNMARKED_INSTANCES: string = 'passUnmarkedInstances';
 export const CONTINUE_PREVIOUS_ASSESSMENT: string = 'ContinuePreviousAssessment';
 export const LOAD_ASSESSMENT: string = 'loadAssessment';
+export const SAVE_ASSESSMENT: string = 'saveAssessment';
 export const ENABLE_VISUAL_HELPER: string = 'enableVisualHelper';
 export const UNDO_TEST_STATUS_CHANGE: string = 'undoTestStatusChange';
 export const UNDO_REQUIREMENT_STATUS_CHANGE: string = 'undoRequirementStatusChange';

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -729,6 +729,28 @@ describe('AssessmentActionCreatorTest', () => {
         updateSelectedPivotChildMock.verifyAll();
     });
 
+    it('handles SaveAssessment message', () => {
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.SaveAssessment,
+            telemetryOnlyPayload,
+            testTabId,
+        );
+
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            assessmentActionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        telemetryEventHandlerMock.verify(
+            handler =>
+                handler.publishTelemetry(TelemetryEvents.SAVE_ASSESSMENT, telemetryOnlyPayload),
+            Times.once(),
+        );
+    });
+
     function setupAssessmentActionsMock(
         actionName: keyof AssessmentActions,
         actionMock: IMock<Action<any>>,


### PR DESCRIPTION
#### Details

This PR adds telemetry for the "Save Assessment" button. 

##### Motivation

Addresses issue #4338 

##### Context

Before this PR, there was already an action message being sent out when the Save Assessment button was clicked, but no action creator was picking it up.  This made some sense, since clicking the button isn't intended to invoke one of our actions, but it left telemetry out, since our pattern is to publish telemetry in the same place where we invoke actions.  So, I added a callback to publish telemetry, and chose to put it in the assessment action creator.  It could have also fit in the action creator (since no action is invoked, there's no strong reason to put it in one action creator over the other, but I chose the assessment action creator since that's where the Load Assessment button is handled and the two feel like they belong together). 

Future work: I noticed the Load Assessment button is missing a unit test. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4338 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS

![1  save assessment telemetry works](https://user-images.githubusercontent.com/33770444/138524054-b6fb6b14-7bf9-4e50-92dd-5dbfde5b6748.gif)
Gif showing that telemetry now works for Save Assessment.  Console is open and feature flag to "log telemetry to console" is on.  So, when user starts an assessment and hits the Save Assessment button, the appropriate telemetry is visible in the console. 
