### PR TITLE
feat(tab-stops-details-view): Add AdhocTabStopsTestView component and feature flag

### DIFF
--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { NamedFC } from 'common/react/named-fc';
+import * as React from 'react';
+
+export interface AdhocTabStopsTestViewProps {}
+
+export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
+    'AdhocTabStopsTestView',
+    () => {
+        return <div></div>;
+    },
+);

--- a/src/DetailsView/components/test-view-container.tsx
+++ b/src/DetailsView/components/test-view-container.tsx
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 import { FailedInstancesSection } from 'common/components/cards/failed-instances-section';
 import { NeedsReviewInstancesSection } from 'common/components/cards/needs-review-instances-section';
+import { FlaggedComponent } from 'common/components/flagged-component';
+import { FeatureFlags } from 'common/feature-flags';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
+import { AdhocTabStopsTestView } from 'DetailsView/components/adhoc-tab-stops-test-view';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import * as React from 'react';
 
@@ -71,6 +74,15 @@ export const TestViewContainer = NamedFC<TestViewContainerProps>('TestViewContai
                 <AdhocIssuesTestView
                     instancesSection={NeedsReviewInstancesSection}
                     {...testViewProps}
+                />
+            );
+        case 'AdhocTabStops':
+            return (
+                <FlaggedComponent
+                    enableJSXElement={<AdhocTabStopsTestView {...testViewProps} />}
+                    disableJSXElement={<AdhocStaticTestView {...testViewProps} />}
+                    featureFlagStoreData={props.featureFlagStoreData}
+                    featureFlag={FeatureFlags.newTabStopsDetailsView}
                 />
             );
         case 'Assessment':

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -25,7 +25,7 @@ const tabStopVisualizationConfiguration: FocusAnalyzerConfiguration = {
 export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     key: tabStopsTestKey,
     testMode: TestMode.Adhoc,
-    testViewType: 'AdhocStatic',
+    testViewType: 'AdhocTabStops',
     testViewOverrides: {
         content: createHowToTest(2),
         guidance: extraGuidance,

--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -13,6 +13,7 @@ export class FeatureFlags {
     public static readonly manualInstanceDetails = 'manualInstanceDetails';
     public static readonly debugTools = 'debugTools';
     public static readonly exportReportOptions = 'exportReportOptions';
+    public static readonly newTabStopsDetailsView = 'newTabStopsDetailsView';
 }
 
 export interface FeatureFlagDetail {
@@ -95,6 +96,14 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
             displayableName: 'More export options',
             displayableDescription: 'Enables exporting reports to external services',
             isPreviewFeature: true,
+            forceDefault: false,
+        },
+        {
+            id: FeatureFlags.newTabStopsDetailsView,
+            defaultValue: false,
+            displayableName: 'New tab stops details view',
+            displayableDescription: 'show the new tabstops details view UI',
+            isPreviewFeature: false,
             forceDefault: false,
         },
     ];

--- a/src/common/types/test-view-type.ts
+++ b/src/common/types/test-view-type.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT License.
 import { ContentPageComponent } from 'views/content/content-page';
 
-export type TestViewType = 'AdhocStatic' | 'AdhocFailure' | 'AdhocNeedsReview' | 'Assessment';
+export type TestViewType =
+    | 'AdhocStatic'
+    | 'AdhocFailure'
+    | 'AdhocNeedsReview'
+    | 'AdhocTabStops'
+    | 'Assessment';
 export type TestViewOverrides = {
     content?: ContentPageComponent;
     guidance?: ContentPageComponent;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/test-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/test-view-container.test.tsx.snap
@@ -133,6 +133,100 @@ exports[`TestViewContainer for testViewType=AdhocStatic renders per snapshot wit
 />
 `;
 
+exports[`TestViewContainer for testViewType=AdhocTabStops renders per snapshot with no testViewOverrides 1`] = `
+<FlaggedComponent
+  disableJSXElement={
+    <AdhocStaticTestView
+      configuration={
+        Object {
+          "key": "configStub",
+          "testViewOverrides": undefined,
+          "testViewType": "AdhocTabStops",
+        }
+      }
+      selectedTest={-1}
+      someParentProp="parent-prop"
+      visualizationConfigurationFactory={
+        Object {
+          "getConfiguration": [Function],
+        }
+      }
+    />
+  }
+  enableJSXElement={
+    <AdhocTabStopsTestView
+      configuration={
+        Object {
+          "key": "configStub",
+          "testViewOverrides": undefined,
+          "testViewType": "AdhocTabStops",
+        }
+      }
+      selectedTest={-1}
+      someParentProp="parent-prop"
+      visualizationConfigurationFactory={
+        Object {
+          "getConfiguration": [Function],
+        }
+      }
+    />
+  }
+  featureFlag="newTabStopsDetailsView"
+/>
+`;
+
+exports[`TestViewContainer for testViewType=AdhocTabStops renders per snapshot with testViewOverrides 1`] = `
+<FlaggedComponent
+  disableJSXElement={
+    <AdhocStaticTestView
+      configuration={
+        Object {
+          "key": "configStub",
+          "testViewOverrides": Object {
+            "content": "stub content page component \\"content\\"",
+            "guidance": "stub content page component \\"guidance\\"",
+          },
+          "testViewType": "AdhocTabStops",
+        }
+      }
+      content="stub content page component \\"content\\""
+      guidance="stub content page component \\"guidance\\""
+      selectedTest={-1}
+      someParentProp="parent-prop"
+      visualizationConfigurationFactory={
+        Object {
+          "getConfiguration": [Function],
+        }
+      }
+    />
+  }
+  enableJSXElement={
+    <AdhocTabStopsTestView
+      configuration={
+        Object {
+          "key": "configStub",
+          "testViewOverrides": Object {
+            "content": "stub content page component \\"content\\"",
+            "guidance": "stub content page component \\"guidance\\"",
+          },
+          "testViewType": "AdhocTabStops",
+        }
+      }
+      content="stub content page component \\"content\\""
+      guidance="stub content page component \\"guidance\\""
+      selectedTest={-1}
+      someParentProp="parent-prop"
+      visualizationConfigurationFactory={
+        Object {
+          "getConfiguration": [Function],
+        }
+      }
+    />
+  }
+  featureFlag="newTabStopsDetailsView"
+/>
+`;
+
 exports[`TestViewContainer for testViewType=Assessment renders per snapshot with no testViewOverrides 1`] = `
 <AssessmentTestView
   configuration={

--- a/src/tests/unit/tests/DetailsView/components/test-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-view-container.test.tsx
@@ -13,48 +13,51 @@ import * as React from 'react';
 import { ContentPageComponent } from 'views/content/content-page';
 
 describe('TestViewContainer', () => {
-    describe.each(['AdhocStatic', 'AdhocFailure', 'AdhocNeedsReview', 'Assessment'])(
-        'for testViewType=%s',
-        (testViewType: TestViewType) => {
-            const selectedTest: VisualizationType = -1;
-            let configStub: VisualizationConfiguration;
-            let configFactoryStub: VisualizationConfigurationFactory;
-            let props: TestViewContainerProps;
-            beforeEach(() => {
-                configStub = {
-                    key: 'configStub',
-                    testViewType,
-                } as VisualizationConfiguration;
+    describe.each([
+        'AdhocStatic',
+        'AdhocFailure',
+        'AdhocNeedsReview',
+        'AdhocTabStops',
+        'Assessment',
+    ])('for testViewType=%s', (testViewType: TestViewType) => {
+        const selectedTest: VisualizationType = -1;
+        let configStub: VisualizationConfiguration;
+        let configFactoryStub: VisualizationConfigurationFactory;
+        let props: TestViewContainerProps;
+        beforeEach(() => {
+            configStub = {
+                key: 'configStub',
+                testViewType,
+            } as VisualizationConfiguration;
 
-                configFactoryStub = {
-                    getConfiguration: (visualizationType: VisualizationType) => configStub,
-                } as VisualizationConfigurationFactory;
+            configFactoryStub = {
+                getConfiguration: (visualizationType: VisualizationType) => configStub,
+            } as VisualizationConfigurationFactory;
 
-                props = {
-                    someParentProp: 'parent-prop',
-                    visualizationConfigurationFactory: configFactoryStub,
-                    selectedTest,
-                } as unknown as TestViewContainerProps;
-            });
+            props = {
+                someParentProp: 'parent-prop',
+                visualizationConfigurationFactory: configFactoryStub,
+                selectedTest,
+            } as unknown as TestViewContainerProps;
+        });
 
-            it('renders per snapshot with no testViewOverrides', () => {
-                configStub.testViewOverrides = undefined;
-                const rendered = shallow(<TestViewContainer {...props} />);
-                expect(rendered.getElement()).toMatchSnapshot();
-            });
+        it('renders per snapshot with no testViewOverrides', () => {
+            configStub.testViewOverrides = undefined;
+            const rendered = shallow(<TestViewContainer {...props} />);
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
 
-            it('renders per snapshot with testViewOverrides', () => {
-                configStub.testViewOverrides = {
-                    content: stubContentPageComponent('content'),
-                    guidance: stubContentPageComponent('guidance'),
-                };
-                const rendered = shallow(<TestViewContainer {...props} />);
-                expect(rendered.getElement()).toMatchSnapshot();
-            });
+        it('renders per snapshot with testViewOverrides', () => {
+            configStub.testViewOverrides = {
+                content: stubContentPageComponent('content'),
+                guidance: stubContentPageComponent('guidance'),
+            };
+            const rendered = shallow(<TestViewContainer {...props} />);
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
 
-            function stubContentPageComponent(identifier: string): ContentPageComponent {
-                return `stub content page component "${identifier}"` as unknown as ContentPageComponent;
-            }
-        },
-    );
+        function stubContentPageComponent(identifier: string): ContentPageComponent {
+            return `stub content page component "${identifier}"` as unknown as ContentPageComponent;
+        }
+    });
 });

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -25,6 +25,7 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.manualInstanceDetails]: false,
             [FeatureFlags.debugTools]: false,
             [FeatureFlags.exportReportOptions]: false,
+            [FeatureFlags.newTabStopsDetailsView]: false,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Details

This introduces the new AdhocTabStopsTestView and a feature flag for development purposes. 

##### Motivation

Feature Work

##### Context

Implementation of the new view will happen in future feature work. The feature flag will also be removed at the conclusion of feature work.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
