### PR TITLE
feat(tab-stop-details-view): add tab stop requirement interfaces

### DIFF
--- a/src/common/types/store-data/visualization-scan-result-data.ts
+++ b/src/common/types/store-data/visualization-scan-result-data.ts
@@ -17,6 +17,17 @@ export interface TabbedElementData extends TabStopEvent {
     propertyBag?: TabOrderPropertyBag;
 }
 
+export type TabStopRequirementStatus = 'pass' | 'fail' | 'unknown';
+
+export type TabStopRequirementState = {
+    [requirementId: string]: {
+        status: TabStopRequirementStatus;
+        instances: {
+            description: string;
+        }[];
+    };
+};
+
 interface TabStopsScanResultData {
     tabbedElements: TabbedElementData[];
 }

--- a/src/types/tab-stop-requirement-info.ts
+++ b/src/types/tab-stop-requirement-info.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export type TabStopRequirementId =
+    | 'keyboard-navigation'
+    | 'keyboard-traps'
+    | 'focus-indicator'
+    | 'tab-order'
+    | 'input-focus';
+
+export type TabStopRequirementInfo = {
+    [requirementId in TabStopRequirementId]: {
+        name: string;
+        description: string;
+    };
+};


### PR DESCRIPTION
#### Details

Adds interfaces that will be used for tab stops details view.

##### Motivation

Feature work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
