### PR TITLE
feat(tab-stops-details-view): add accessibility check e2e test for new tabstops details view

### DIFF
--- a/src/tests/end-to-end/tests/details-view/tabstops.test.ts
+++ b/src/tests/end-to-end/tests/details-view/tabstops.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { FeatureFlags } from 'common/feature-flags';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
+import { BackgroundPage } from 'tests/end-to-end/common/page-controllers/background-page';
+import { Browser } from '../../common/browser';
+import { launchBrowser } from '../../common/browser-factory';
+import { DetailsViewPage } from '../../common/page-controllers/details-view-page';
+import { TargetPage } from '../../common/page-controllers/target-page';
+import { scanForAccessibilityIssues } from '../../common/scan-for-accessibility-issues';
+
+const tabStopsNavDataAutomationId: string = getAutomationIdSelector('TabStops');
+
+describe('Details View -> FastPass -> TabStops', () => {
+    let browser: Browser;
+    let targetPage: TargetPage;
+    let detailsViewPage: DetailsViewPage;
+    let backgroundPage: BackgroundPage;
+
+    beforeAll(async () => {
+        browser = await launchBrowser({ suppressFirstTimeDialog: true });
+        targetPage = await browser.newTargetPage();
+        await browser.newPopupPage(targetPage); // Required for the details view to register as having permissions/being open
+        detailsViewPage = await openTabStopsPage(browser, targetPage);
+        backgroundPage = await browser.backgroundPage();
+        await backgroundPage.enableFeatureFlag(FeatureFlags.newTabStopsDetailsView);
+    });
+
+    afterAll(async () => {
+        await browser?.close();
+    });
+
+    it.each([true, false])(
+        'should pass accessibility validation with highContrastMode=%s',
+        async highContrastMode => {
+            await browser.setHighContrastMode(highContrastMode);
+            await detailsViewPage.waitForHighContrastMode(highContrastMode);
+
+            const results = await scanForAccessibilityIssues(detailsViewPage, '*');
+            expect(results).toHaveLength(0);
+        },
+    );
+});
+
+async function openTabStopsPage(
+    browser: Browser,
+    targetPage: TargetPage,
+): Promise<DetailsViewPage> {
+    const detailsViewPage = await browser.newDetailsViewPage(targetPage);
+    await detailsViewPage.switchToFastPass();
+    await detailsViewPage.waitForSelector(tabStopsNavDataAutomationId);
+    await detailsViewPage.clickSelector(tabStopsNavDataAutomationId);
+
+    return detailsViewPage;
+}


### PR DESCRIPTION
#### Details

Adds an E2E test that checks the accessibility of the new tabstops details view.

##### Motivation

Feature work

##### Context

Additional E2E tests will be added later in the feature. We've decided to put this into place early to have continuous accessibility checks while we build the new interface.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
