### PR TITLE
feat(tab-stops-details-view): add static tabstops content 

### DIFF
--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -48,7 +48,7 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                         </li>
                         <li>
                             Use the arrow keys to navigate between the focusable elements within a
-                            composite control.=
+                            composite control.
                         </li>
                     </ol>
                 </li>
@@ -56,24 +56,14 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
         );
 
         const selectedTest = props.selectedTest;
-
-        const stepsText = (): string => {
-            const fastPassProvider = createFastPassProviderWithFeatureFlags(
-                props.featureFlagStoreData,
-            );
-            return fastPassProvider.getStepsText(selectedTest);
-        };
-
-        const givenProps = {
-            title: displayableData.title,
-            stepsText: stepsText(),
-        };
+        const fastPassProvider = createFastPassProviderWithFeatureFlags(props.featureFlagStoreData);
+        const stepsText = fastPassProvider.getStepsText(selectedTest);
 
         return (
             <div className={styles.staticContentInDetailsView}>
                 <h1>
-                    {givenProps.title}
-                    {` ${givenProps.stepsText} `}
+                    {displayableData.title}
+                    {` ${stepsText} `}
                 </h1>
                 {description}
                 <RequirementInstructions howToTest={howToTest} />

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -1,18 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { NamedFC } from 'common/react/named-fc';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
 import { RequirementInstructions } from 'DetailsView/components/requirement-instructions';
 import * as styles from 'DetailsView/components/static-content-common.scss';
+import { createFastPassProviderWithFeatureFlags } from 'fast-pass/fast-pass-provider';
 import * as React from 'react';
 import * as Markup from '../../assessments/markup';
 
-export interface AdhocTabStopsTestViewProps {}
+export interface AdhocTabStopsTestViewProps {
+    configuration: VisualizationConfiguration;
+    featureFlagStoreData: FeatureFlagStoreData;
+    selectedTest: VisualizationType;
+}
 
 export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
     'AdhocTabStopsTestView',
     props => {
-        const title = <h1>Tab stops Step 2 of 3</h1>;
+        const displayableData = props.configuration.displayableData;
 
         const description = (
             <p>
@@ -40,16 +48,33 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                         </li>
                         <li>
                             Use the arrow keys to navigate between the focusable elements within a
-                            composite control.
+                            composite control.=
                         </li>
                     </ol>
                 </li>
             </ol>
         );
 
+        const selectedTest = props.selectedTest;
+
+        const stepsText = (): string => {
+            const fastPassProvider = createFastPassProviderWithFeatureFlags(
+                props.featureFlagStoreData,
+            );
+            return fastPassProvider.getStepsText(selectedTest);
+        };
+
+        const givenProps = {
+            title: displayableData.title,
+            stepsText: stepsText(),
+        };
+
         return (
             <div className={styles.staticContentInDetailsView}>
-                {title}
+                <h1>
+                    {givenProps.title}
+                    {` ${givenProps.stepsText} `}
+                </h1>
                 {description}
                 <RequirementInstructions howToTest={howToTest} />
             </div>

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -3,31 +3,52 @@
 
 import { NamedFC } from 'common/react/named-fc';
 import { RequirementInstructions } from 'DetailsView/components/requirement-instructions';
+import * as Markup from '../../assessments/markup';
+import * as styles from 'DetailsView/components/static-content-common.scss';
 import * as React from 'react';
 
 export interface AdhocTabStopsTestViewProps {}
 
-const howToTest: JSX.Element = (
-    <ol>
-        <li>
-            Locate the visual helper on the target page, it will highlight element in focus with an
-            empty circle.
-        </li>
-        <li>
-            Use your keyboard to move input focus through all the interactive elements in the page:
-            <ol>
-                <li>Use Tab and Shift+Tab to navigate between standalone controls. </li>
-                <li>
-                    Use the arrow keys to navigate between the focusable elements within a composite
-                    control.
-                </li>
-            </ol>
-        </li>
-    </ol>
-);
 export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
     'AdhocTabStopsTestView',
-    () => {
-        return <RequirementInstructions howToTest={howToTest} />;
+    props => {
+        const title = <h1>Tab stops Step 2 of 3</h1>;
+
+        const description = (
+            <p>
+                <Markup.Emphasis>
+                    Note: this test requires you to use a keyboard and to visually identify
+                    interactive elements.
+                </Markup.Emphasis>
+            </p>
+        );
+
+        const howToTest: JSX.Element = (
+            <ol>
+                <li>
+                    Locate the visual helper on the target page, it will highlight element in focus
+                    with an empty circle.
+                </li>
+                <li>
+                    Use your keyboard to move input focus through all the interactive elements in
+                    the page:
+                    <ol>
+                        <li>Use Tab and Shift+Tab to navigate between standalone controls. </li>
+                        <li>
+                            Use the arrow keys to navigate between the focusable elements within a
+                            composite control.
+                        </li>
+                    </ol>
+                </li>
+            </ol>
+        );
+
+        return (
+            <div className={styles.staticContentInDetailsView}>
+                {title}
+                {description}
+                <RequirementInstructions howToTest={howToTest} />
+            </div>
+        );
     },
 );

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -3,9 +3,9 @@
 
 import { NamedFC } from 'common/react/named-fc';
 import { RequirementInstructions } from 'DetailsView/components/requirement-instructions';
-import * as Markup from '../../assessments/markup';
 import * as styles from 'DetailsView/components/static-content-common.scss';
 import * as React from 'react';
+import * as Markup from '../../assessments/markup';
 
 export interface AdhocTabStopsTestViewProps {}
 
@@ -33,7 +33,11 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                     Use your keyboard to move input focus through all the interactive elements in
                     the page:
                     <ol>
-                        <li>Use Tab and Shift+Tab to navigate between standalone controls. </li>
+                        <li>
+                            Use <Markup.Term>Tab</Markup.Term> and{' '}
+                            <Markup.Term>Shift+Tab</Markup.Term> to navigate between standalone
+                            controls.{' '}
+                        </li>
                         <li>
                             Use the arrow keys to navigate between the focusable elements within a
                             composite control.

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -20,8 +20,6 @@ export interface AdhocTabStopsTestViewProps {
 export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
     'AdhocTabStopsTestView',
     props => {
-        const displayableData = props.configuration.displayableData;
-
         const description = (
             <p>
                 <Markup.Emphasis>
@@ -56,6 +54,7 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
         );
 
         const selectedTest = props.selectedTest;
+        const displayableData = props.configuration.displayableData;
         const fastPassProvider = createFastPassProviderWithFeatureFlags(props.featureFlagStoreData);
         const stepsText = fastPassProvider.getStepsText(selectedTest);
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -5,7 +5,8 @@ exports[`AdhocTabStopsTestView renders with content 1`] = `
   className="staticContentInDetailsView"
 >
   <h1>
-    Tab stops Step 2 of 3
+    test title
+     Step 0 of 3 
   </h1>
   <p>
     <Emphasis>
@@ -35,7 +36,7 @@ exports[`AdhocTabStopsTestView renders with content 1`] = `
                
             </li>
             <li>
-              Use the arrow keys to navigate between the focusable elements within a composite control.
+              Use the arrow keys to navigate between the focusable elements within a composite control.=
             </li>
           </ol>
         </li>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -1,24 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AdhocTabStopsTestView renders with content 1`] = `
-<RequirementInstructions
-  howToTest={
-    <ol>
-      <li>
-        Locate the visual helper on the target page, it will highlight element in focus with an empty circle.
-      </li>
-      <li>
-        Use your keyboard to move input focus through all the interactive elements in the page:
-        <ol>
-          <li>
-            Use Tab and Shift+Tab to navigate between standalone controls. 
-          </li>
-          <li>
-            Use the arrow keys to navigate between the focusable elements within a composite control.
-          </li>
-        </ol>
-      </li>
-    </ol>
-  }
-/>
+<div
+  className="staticContentInDetailsView"
+>
+  <h1>
+    Tab stops Step 2 of 3
+  </h1>
+  <p>
+    <Emphasis>
+      Note: this test requires you to use a keyboard and to visually identify interactive elements.
+    </Emphasis>
+  </p>
+  <RequirementInstructions
+    howToTest={
+      <ol>
+        <li>
+          Locate the visual helper on the target page, it will highlight element in focus with an empty circle.
+        </li>
+        <li>
+          Use your keyboard to move input focus through all the interactive elements in the page:
+          <ol>
+            <li>
+              Use 
+              <Term>
+                Tab
+              </Term>
+               and
+               
+              <Term>
+                Shift+Tab
+              </Term>
+               to navigate between standalone controls.
+               
+            </li>
+            <li>
+              Use the arrow keys to navigate between the focusable elements within a composite control.
+            </li>
+          </ol>
+        </li>
+      </ol>
+    }
+  />
+</div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`AdhocTabStopsTestView renders with content 1`] = `
                
             </li>
             <li>
-              Use the arrow keys to navigate between the focusable elements within a composite control.=
+              Use the arrow keys to navigate between the focusable elements within a composite control.
             </li>
           </ol>
         </li>

--- a/src/tests/unit/tests/DetailsView/components/adhoc-tab-stops-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/adhoc-tab-stops-test-view.test.tsx
@@ -1,13 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AdhocTabStopsTestView } from 'DetailsView/components/adhoc-tab-stops-test-view';
+import { DisplayableVisualizationTypeData } from 'common/types/displayable-visualization-type-data';
+import {
+    AdhocTabStopsTestView,
+    AdhocTabStopsTestViewProps,
+} from 'DetailsView/components/adhoc-tab-stops-test-view';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('AdhocTabStopsTestView', () => {
+    const props = {
+        configuration: {
+            displayableData: {
+                title: 'test title',
+            } as DisplayableVisualizationTypeData,
+        },
+    } as AdhocTabStopsTestViewProps;
+
     it('renders with content', () => {
-        const rendered = shallow(<AdhocTabStopsTestView />);
+        const rendered = shallow(<AdhocTabStopsTestView {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Details

This adds additional static content to the Adhoc Tabstop. Visual helper toggle will be added in a later PR.

![image](https://user-images.githubusercontent.com/18401275/139298671-de59f1a8-8b72-4077-86ab-9a2e797caf53.png)


#### Pull request checklist
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
