### PR TITLE
fix: Add aria label to chevron on next requirement button, so next is read aloud

### DIFF
--- a/src/DetailsView/components/next-requirement-button.tsx
+++ b/src/DetailsView/components/next-requirement-button.tsx
@@ -40,7 +40,7 @@ export const NextRequirementButton = NamedFC<NextRequirementButtonProps>(
                 onClick={selectNextRequirement}
             >
                 <span>
-                    <Icon iconName="ChevronRight" />
+                    <Icon iconName="ChevronRight" ariaLabel={'next'} />
                 </span>
             </DefaultButton>
         );

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/next-requirement-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/next-requirement-button.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`NextRequirementButton renders 1`] = `
 >
   <span>
     <StyledIconBase
+      ariaLabel="next"
       iconName="ChevronRight"
     />
   </span>


### PR DESCRIPTION
#### Details

This PR adds an aria label to the chevron icon on the next requirement button.  This adds the word "next" to what screen readers say aloud when describing the next requirement button. For example, screen readers now say "xyz next button" instead of "xyz button." This allows users who use a screen reader to become apprised of the same information as visual users; the word "next" provides the same indication as the chevron visually does. 
 
##### Motivation

Addresses issue #4811 

##### Context

Adding the aria label to the chevron was preferable over adding an aria label to the button itself because of varying NVDA behavior.  If the aria label was on the button, upon clicking the button, NVDA would then read aloud the aria label of the new next requirement button that was loaded on the following page.  JAWS, however, would not.  Before this change, neither screen reader would read the newly loaded button's label aloud.  Putting the label on the chevron made it so that neither NVDA nor JAWS read the newly loaded button aloud, which is consistent with current expectations, and still fixed the bug as intended. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4811
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
