### PR TITLE
feat(tab-stops-details-view): Add failed instances section

### DIFF
--- a/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
+++ b/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
@@ -7,6 +7,8 @@ import {
     RemoveTabStopInstancePayload,
     UpdateTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
+    ResetTabStopRequirementStatusPayload,
+    ToggleTabStopRequirementExpandPayload,
 } from 'background/actions/action-payloads';
 import { DevToolActionMessageCreator } from 'common/message-creators/dev-tool-action-message-creator';
 import { Messages } from 'common/messages';
@@ -82,5 +84,31 @@ export class TabStopRequirementActionMessageCreator extends DevToolActionMessage
         });
     }
 
-    public undoStatusForRequirement(_: TabStopRequirementId): void {}
+    public resetStatusForRequirement(requirementId: TabStopRequirementId): void {
+        const telemetry = this.telemetryFactory.forTabStopRequirement(requirementId);
+
+        const payload: ResetTabStopRequirementStatusPayload = {
+            requirementId,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: messages.ResetTabStopsRequirementStatus,
+            payload,
+        });
+    }
+
+    public toggleTabStopRequirementExpand = (
+        requirementId: TabStopRequirementId,
+        event: React.SyntheticEvent,
+    ) => {
+        const payload: ToggleTabStopRequirementExpandPayload = {
+            requirementId,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Visualizations.TabStops.RequirementExpansionToggled,
+            payload,
+        });
+    };
 }

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -1,19 +1,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ResultSectionDeps } from 'common/components/cards/result-section';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { NamedFC } from 'common/react/named-fc';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationType } from 'common/types/visualization-type';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { RequirementInstructions } from 'DetailsView/components/requirement-instructions';
 import * as styles from 'DetailsView/components/static-content-common.scss';
+import { TabStopsFailedInstanceSection } from 'DetailsView/components/tab-stops-failed-instance-section';
 import { createFastPassProviderWithFeatureFlags } from 'fast-pass/fast-pass-provider';
 import * as React from 'react';
 import * as Markup from '../../assessments/markup';
 
+export type AdhocTabStopsTestViewDeps = ResultSectionDeps & {
+    tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
+};
+
 export interface AdhocTabStopsTestViewProps {
+    deps: AdhocTabStopsTestViewDeps;
     configuration: VisualizationConfiguration;
     featureFlagStoreData: FeatureFlagStoreData;
+    visualizationScanResultData: VisualizationScanResultData;
     selectedTest: VisualizationType;
 }
 
@@ -66,6 +76,7 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                 </h1>
                 {description}
                 <RequirementInstructions howToTest={howToTest} />
+                <TabStopsFailedInstanceSection {...props} />
             </div>
         );
     },

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ResultSectionDeps } from 'common/components/cards/result-section';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { NamedFC } from 'common/react/named-fc';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -10,12 +9,15 @@ import { VisualizationType } from 'common/types/visualization-type';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { RequirementInstructions } from 'DetailsView/components/requirement-instructions';
 import * as styles from 'DetailsView/components/static-content-common.scss';
-import { TabStopsFailedInstanceSection } from 'DetailsView/components/tab-stops-failed-instance-section';
+import {
+    TabStopsFailedInstanceSection,
+    TabStopsFailedInstanceSectionDeps,
+} from 'DetailsView/components/tab-stops-failed-instance-section';
 import { createFastPassProviderWithFeatureFlags } from 'fast-pass/fast-pass-provider';
 import * as React from 'react';
 import * as Markup from '../../assessments/markup';
 
-export type AdhocTabStopsTestViewDeps = ResultSectionDeps & {
+export type AdhocTabStopsTestViewDeps = TabStopsFailedInstanceSectionDeps & {
     tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
 };
 
@@ -76,7 +78,10 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                 </h1>
                 {description}
                 <RequirementInstructions howToTest={howToTest} />
-                <TabStopsFailedInstanceSection {...props} />
+                <TabStopsFailedInstanceSection
+                    deps={props.deps}
+                    visualizationScanResultData={props.visualizationScanResultData}
+                />
             </div>
         );
     },

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -6,7 +6,6 @@ import { NamedFC } from 'common/react/named-fc';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationType } from 'common/types/visualization-type';
-import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { RequirementInstructions } from 'DetailsView/components/requirement-instructions';
 import * as styles from 'DetailsView/components/static-content-common.scss';
 import {
@@ -17,9 +16,7 @@ import { createFastPassProviderWithFeatureFlags } from 'fast-pass/fast-pass-prov
 import * as React from 'react';
 import * as Markup from '../../assessments/markup';
 
-export type AdhocTabStopsTestViewDeps = TabStopsFailedInstanceSectionDeps & {
-    tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
-};
+export type AdhocTabStopsTestViewDeps = TabStopsFailedInstanceSectionDeps;
 
 export interface AdhocTabStopsTestViewProps {
     deps: AdhocTabStopsTestViewDeps;

--- a/src/DetailsView/components/tab-stops-failed-instance-section.scss
+++ b/src/DetailsView/components/tab-stops-failed-instance-section.scss
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.tab-stops-failure-instance-section {
+    padding-bottom: 58px;
+
+    .title-container {
+        .collapsible-control::before {
+            position: relative;
+            bottom: 2px;
+        }
+    }
+
+    > h2 {
+        margin: 0px;
+        font-size: 17px;
+        line-height: 24px;
+    }
+}

--- a/src/DetailsView/components/tab-stops-failed-instance-section.tsx
+++ b/src/DetailsView/components/tab-stops-failed-instance-section.tsx
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { css } from '@uifabric/utilities';
+import { CollapsibleComponentCardsDeps } from 'common/components/cards/collapsible-component-cards';
+import { ResultSectionTitle } from 'common/components/cards/result-section-title';
+import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
+import { AdhocTabStopsTestViewDeps } from 'DetailsView/components/adhoc-tab-stops-test-view';
+import { requirements } from 'DetailsView/components/tab-stops/requirements';
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
+import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
+import {
+    TabStopsRequirementsWithInstances,
+    TabStopsRequirementsWithInstancesDeps,
+} from 'DetailsView/tab-stops-requirements-with-instances';
+import * as React from 'react';
+import * as styles from './tab-stops-failed-instance-section.scss';
+
+export type TabStopsFailedInstanceSectionDeps = AdhocTabStopsTestViewDeps &
+    CollapsibleComponentCardsDeps &
+    TabStopsRequirementsWithInstancesDeps;
+
+export interface TabStopsFailedInstanceSectionProps {
+    deps: TabStopsFailedInstanceSectionDeps;
+    visualizationScanResultData: VisualizationScanResultData;
+}
+
+export const tabStopsFailedInstanceSectionAutomationId = 'tab-stops-failure-instance-section';
+
+export class TabStopsFailedInstanceSection extends React.Component<TabStopsFailedInstanceSectionProps> {
+    private getTabStopRequirementsResults = (): TabStopsRequirementResult[] => {
+        const results = [];
+        const storeData = this.props.visualizationScanResultData;
+        for (const [requirementId, data] of Object.entries(storeData.tabStops.requirements)) {
+            if (data.status === 'fail') {
+                results.push({
+                    id: requirementId,
+                    name: requirements[requirementId].name,
+                    description: requirements[requirementId].description,
+                    instances: data.instances,
+                    isExpanded: data.isExpanded,
+                });
+            }
+        }
+        return results;
+    };
+
+    public render(): JSX.Element {
+        const results = this.getTabStopRequirementsResults();
+
+        if (results.length === 0) {
+            return null;
+        }
+
+        return (
+            <div
+                className={css(null, styles.tabStopsFailureInstanceSection)}
+                data-automation-id={tabStopsFailedInstanceSectionAutomationId}
+            >
+                <h2>
+                    <ResultSectionTitle
+                        title="Failed instances"
+                        badgeCount={TabStopsFailedCounter.getTotalFailed(results)}
+                        outcomeType="fail"
+                        titleSize="title"
+                    />
+                </h2>
+                <TabStopsRequirementsWithInstances
+                    results={results}
+                    headingLevel={3}
+                    outcomeType="fail"
+                    {...this.props}
+                />
+            </div>
+        );
+    }
+}

--- a/src/DetailsView/components/tab-stops-failed-instance-section.tsx
+++ b/src/DetailsView/components/tab-stops-failed-instance-section.tsx
@@ -5,6 +5,7 @@ import { ResultSectionTitle } from 'common/components/cards/result-section-title
 import { NamedFC } from 'common/react/named-fc';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { requirements } from 'DetailsView/components/tab-stops/requirements';
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import {
     TabStopsRequirementsWithInstances,
     TabStopsRequirementsWithInstancesDeps,
@@ -12,7 +13,9 @@ import {
 import * as React from 'react';
 import * as styles from './tab-stops-failed-instance-section.scss';
 
-export type TabStopsFailedInstanceSectionDeps = TabStopsRequirementsWithInstancesDeps;
+export type TabStopsFailedInstanceSectionDeps = TabStopsRequirementsWithInstancesDeps & {
+    tabStopsFailedCounter: TabStopsFailedCounter;
+};
 
 export interface TabStopsFailedInstanceSectionProps {
     deps: TabStopsFailedInstanceSectionDeps;

--- a/src/DetailsView/components/tab-stops-failed-instance-section.tsx
+++ b/src/DetailsView/components/tab-stops-failed-instance-section.tsx
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { css } from '@uifabric/utilities';
-import { CollapsibleComponentCardsDeps } from 'common/components/cards/collapsible-component-cards';
 import { ResultSectionTitle } from 'common/components/cards/result-section-title';
+import { NamedFC } from 'common/react/named-fc';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
-import { AdhocTabStopsTestViewDeps } from 'DetailsView/components/adhoc-tab-stops-test-view';
 import { requirements } from 'DetailsView/components/tab-stops/requirements';
-import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
-import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 import {
     TabStopsRequirementsWithInstances,
     TabStopsRequirementsWithInstancesDeps,
@@ -16,9 +12,7 @@ import {
 import * as React from 'react';
 import * as styles from './tab-stops-failed-instance-section.scss';
 
-export type TabStopsFailedInstanceSectionDeps = AdhocTabStopsTestViewDeps &
-    CollapsibleComponentCardsDeps &
-    TabStopsRequirementsWithInstancesDeps;
+export type TabStopsFailedInstanceSectionDeps = TabStopsRequirementsWithInstancesDeps;
 
 export interface TabStopsFailedInstanceSectionProps {
     deps: TabStopsFailedInstanceSectionDeps;
@@ -27,26 +21,24 @@ export interface TabStopsFailedInstanceSectionProps {
 
 export const tabStopsFailedInstanceSectionAutomationId = 'tab-stops-failure-instance-section';
 
-export class TabStopsFailedInstanceSection extends React.Component<TabStopsFailedInstanceSectionProps> {
-    private getTabStopRequirementsResults = (): TabStopsRequirementResult[] => {
+export const TabStopsFailedInstanceSection = NamedFC<TabStopsFailedInstanceSectionProps>(
+    'TabStopsFailedInstanceSection',
+    props => {
         const results = [];
-        const storeData = this.props.visualizationScanResultData;
+        const storeData = props.visualizationScanResultData;
         for (const [requirementId, data] of Object.entries(storeData.tabStops.requirements)) {
-            if (data.status === 'fail') {
-                results.push({
-                    id: requirementId,
-                    name: requirements[requirementId].name,
-                    description: requirements[requirementId].description,
-                    instances: data.instances,
-                    isExpanded: data.isExpanded,
-                });
+            if (data.status !== 'fail') {
+                continue;
             }
-        }
-        return results;
-    };
 
-    public render(): JSX.Element {
-        const results = this.getTabStopRequirementsResults();
+            results.push({
+                id: requirementId,
+                name: requirements[requirementId].name,
+                description: requirements[requirementId].description,
+                instances: data.instances,
+                isExpanded: data.isExpanded,
+            });
+        }
 
         if (results.length === 0) {
             return null;
@@ -54,13 +46,13 @@ export class TabStopsFailedInstanceSection extends React.Component<TabStopsFaile
 
         return (
             <div
-                className={css(null, styles.tabStopsFailureInstanceSection)}
+                className={styles.tabStopsFailureInstanceSection}
                 data-automation-id={tabStopsFailedInstanceSectionAutomationId}
             >
                 <h2>
                     <ResultSectionTitle
                         title="Failed instances"
-                        badgeCount={TabStopsFailedCounter.getTotalFailed(results)}
+                        badgeCount={props.deps.tabStopsFailedCounter.getTotalFailed(results)}
                         outcomeType="fail"
                         titleSize="title"
                     />
@@ -68,10 +60,9 @@ export class TabStopsFailedInstanceSection extends React.Component<TabStopsFaile
                 <TabStopsRequirementsWithInstances
                     results={results}
                     headingLevel={3}
-                    outcomeType="fail"
-                    {...this.props}
+                    deps={props.deps}
                 />
             </div>
         );
-    }
-}
+    },
+);

--- a/src/DetailsView/components/tab-stops/tab-stops-requirements-table.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-requirements-table.tsx
@@ -48,7 +48,7 @@ export const TabStopsRequirementsTable = NamedFC<TabStopsRequirementsTableProps>
                         <TabStopsChoiceGroup
                             status={props.requirementState[item.id].status}
                             onUndoClicked={_ =>
-                                tabStopsRequirementActionMessageCreator.undoStatusForRequirement(
+                                tabStopsRequirementActionMessageCreator.resetStatusForRequirement(
                                     item.id,
                                 )
                             }

--- a/src/DetailsView/components/test-view-container.tsx
+++ b/src/DetailsView/components/test-view-container.tsx
@@ -6,7 +6,10 @@ import { FlaggedComponent } from 'common/components/flagged-component';
 import { FeatureFlags } from 'common/feature-flags';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
-import { AdhocTabStopsTestView } from 'DetailsView/components/adhoc-tab-stops-test-view';
+import {
+    AdhocTabStopsTestView,
+    AdhocTabStopsTestViewDeps,
+} from 'DetailsView/components/adhoc-tab-stops-test-view';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import * as React from 'react';
 
@@ -34,7 +37,8 @@ import { TestViewDeps } from './test-view';
 export type TestViewContainerDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
 } & TestViewDeps &
-    OverviewContainerDeps;
+    OverviewContainerDeps &
+    AdhocTabStopsTestViewDeps;
 
 export interface TestViewContainerProps {
     deps: TestViewContainerDeps;

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -36,6 +36,7 @@ import { LoadAssessmentHelper } from 'DetailsView/components/load-assessment-hel
 import { NoContentAvailableViewDeps } from 'DetailsView/components/no-content-available/no-content-available-view';
 import { AllUrlsPermissionHandler } from 'DetailsView/handlers/allurls-permission-handler';
 import { NoContentAvailableViewRenderer } from 'DetailsView/no-content-available-view-renderer';
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import { NullStoreActionMessageCreator } from 'electron/adapters/null-store-action-message-creator';
 import { loadTheme, setFocusVisibility } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
@@ -445,6 +446,8 @@ if (tabId != null) {
                 loadAssessmentDataValidator,
             );
 
+            const tabStopsFailedCounter = new TabStopsFailedCounter();
+
             const deps: DetailsViewContainerDeps = {
                 textContent,
                 fixInstructionProcessor,
@@ -523,6 +526,7 @@ if (tabId != null) {
                 navLinkRenderer,
                 getNarrowModeThresholds: getNarrowModeThresholdsForWeb,
                 tabStopRequirementActionMessageCreator,
+                tabStopsFailedCounter,
             };
 
             const renderer = new DetailsViewRenderer(

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -28,6 +28,7 @@ import { CardSelectionStoreData } from 'common/types/store-data/card-selection-s
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { toolName } from 'content/strings/application';
 import { textContent } from 'content/strings/text-content';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { AssessmentViewUpdateHandler } from 'DetailsView/components/assessment-view-update-handler';
 import { NavLinkRenderer } from 'DetailsView/components/left-nav/nav-link-renderer';
 import { LoadAssessmentDataValidator } from 'DetailsView/components/load-assessment-data-validator';
@@ -232,6 +233,12 @@ if (tabId != null) {
                 tab.id,
                 logger,
             );
+
+            const tabStopRequirementActionMessageCreator =
+                new TabStopRequirementActionMessageCreator(
+                    telemetryFactory,
+                    actionMessageDispatcher,
+                );
 
             const detailsViewActionMessageCreator = new DetailsViewActionMessageCreator(
                 telemetryFactory,
@@ -515,6 +522,7 @@ if (tabId != null) {
                 assessmentViewUpdateHandler,
                 navLinkRenderer,
                 getNarrowModeThresholds: getNarrowModeThresholdsForWeb,
+                tabStopRequirementActionMessageCreator,
             };
 
             const renderer = new DetailsViewRenderer(

--- a/src/DetailsView/tab-stops-failed-counter.ts
+++ b/src/DetailsView/tab-stops-failed-counter.ts
@@ -3,22 +3,19 @@
 
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 
-const getFailedByRequirementId = (
-    results: TabStopsRequirementResult[],
-    requirementId: string,
-): number => {
-    return results.reduce((total, result) => {
-        return result.id === requirementId ? total + result.instances.length : total;
-    }, 0);
-};
+export class TabStopsFailedCounter {
+    public getFailedByRequirementId = (
+        results: TabStopsRequirementResult[],
+        requirementId: string,
+    ): number => {
+        return results.reduce((total, result) => {
+            return result.id === requirementId ? total + result.instances.length : total;
+        }, 0);
+    };
 
-const getTotalFailed = (results: TabStopsRequirementResult[]): number => {
-    return results.reduce((total, result) => {
-        return total + result.instances.length;
-    }, 0);
-};
-
-export const TabStopsFailedCounter = {
-    getFailedByRequirementId,
-    getTotalFailed,
-};
+    public getTotalFailed = (results: TabStopsRequirementResult[]): number => {
+        return results.reduce((total, result) => {
+            return total + result.instances.length;
+        }, 0);
+    };
+}

--- a/src/DetailsView/tab-stops-failed-counter.ts
+++ b/src/DetailsView/tab-stops-failed-counter.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
+
+const getFailedByRequirementId = (
+    results: TabStopsRequirementResult[],
+    requirementId: string,
+): number => {
+    return results.reduce((total, result) => {
+        return result.id === requirementId ? total + result.instances.length : total;
+    }, 0);
+};
+
+const getTotalFailed = (results: TabStopsRequirementResult[]): number => {
+    return results.reduce((total, result) => {
+        return total + result.instances.length;
+    }, 0);
+};
+
+export const TabStopsFailedCounter = {
+    getFailedByRequirementId,
+    getTotalFailed,
+};

--- a/src/DetailsView/tab-stops-minimal-requirement-header.scss
+++ b/src/DetailsView/tab-stops-minimal-requirement-header.scss
@@ -5,9 +5,7 @@
 
 .requirement-detail {
     font-size: 14px;
-
     padding: 16px 8px;
-
     display: flex;
     align-items: baseline;
     text-align: left;
@@ -19,7 +17,7 @@
 }
 
 .requirement-detail-description {
-    color: $secondary-text !important;
+    color: $secondary-text;
     word-break: break-all;
 }
 
@@ -30,7 +28,7 @@
 
     a {
         font-family: $semiBoldFontFamily;
-        color: $primary-text !important;
+        color: $primary-text;
     }
 }
 

--- a/src/DetailsView/tab-stops-minimal-requirement-header.scss
+++ b/src/DetailsView/tab-stops-minimal-requirement-header.scss
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../common/styles/colors.scss';
+@import '../common/styles/fonts.scss';
+
+.requirement-detail {
+    font-size: 14px;
+
+    padding: 16px 8px;
+
+    display: flex;
+    align-items: baseline;
+    text-align: left;
+
+    :global(.outcome-chip) {
+        vertical-align: middle;
+        margin-bottom: 2px;
+    }
+}
+
+.requirement-detail-description {
+    color: $secondary-text !important;
+    word-break: break-all;
+}
+
+.requirement-details-id {
+    font-family: $semiBoldFontFamily;
+    color: $primary-text;
+    word-break: break-all;
+
+    a {
+        font-family: $semiBoldFontFamily;
+        color: $primary-text !important;
+    }
+}
+
+.outcome-chip-container {
+    min-width: 50px;
+}

--- a/src/DetailsView/tab-stops-minimal-requirement-header.tsx
+++ b/src/DetailsView/tab-stops-minimal-requirement-header.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
+import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
+import * as React from 'react';
+import { OutcomeChip } from 'reports/components/outcome-chip';
+import { outcomeChipContainer } from 'reports/components/report-sections/minimal-rule-header.scss';
+
+export type TabStopsMinimalRequirementHeaderProps = {
+    requirement: TabStopsRequirementResult;
+};
+
+export const TabStopsMinimalRequirementHeader = NamedFC<TabStopsMinimalRequirementHeaderProps>(
+    'TabStopsMinimalRequirementHeader',
+    props => {
+        const { requirement } = props;
+
+        const renderCountBadge = () => {
+            const count = TabStopsFailedCounter.getFailedByRequirementId(
+                [requirement],
+                requirement.id,
+            );
+
+            return (
+                <span aria-hidden="true">
+                    <OutcomeChip count={count} outcomeType={'fail'} />
+                </span>
+            );
+        };
+
+        const renderRuleName = () => <span className="rule-details-id">{requirement.name}</span>;
+
+        const renderDescription = () => (
+            <span className="rule-details-description">{requirement.description}</span>
+        );
+
+        return (
+            <span className="rule-detail">
+                <span className={outcomeChipContainer}>{renderCountBadge()}</span>
+                <span>
+                    {renderRuleName()}: {renderDescription()}
+                </span>
+            </span>
+        );
+    },
+);

--- a/src/DetailsView/tab-stops-minimal-requirement-header.tsx
+++ b/src/DetailsView/tab-stops-minimal-requirement-header.tsx
@@ -5,9 +5,14 @@ import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 import * as React from 'react';
 import { OutcomeChip } from 'reports/components/outcome-chip';
-import { outcomeChipContainer } from 'reports/components/report-sections/minimal-rule-header.scss';
+import * as styles from '../DetailsView/tab-stops-minimal-requirement-header.scss';
+
+export interface TabStopsMinimalRequirementHeaderDeps {
+    tabStopsFailedCounter: TabStopsFailedCounter;
+}
 
 export type TabStopsMinimalRequirementHeaderProps = {
+    deps: TabStopsMinimalRequirementHeaderDeps;
     requirement: TabStopsRequirementResult;
 };
 
@@ -17,7 +22,7 @@ export const TabStopsMinimalRequirementHeader = NamedFC<TabStopsMinimalRequireme
         const { requirement } = props;
 
         const renderCountBadge = () => {
-            const count = TabStopsFailedCounter.getFailedByRequirementId(
+            const count = props.deps.tabStopsFailedCounter.getFailedByRequirementId(
                 [requirement],
                 requirement.id,
             );
@@ -29,15 +34,17 @@ export const TabStopsMinimalRequirementHeader = NamedFC<TabStopsMinimalRequireme
             );
         };
 
-        const renderRuleName = () => <span className="rule-details-id">{requirement.name}</span>;
+        const renderRuleName = () => (
+            <span className={styles.requirementDetailsId}>{requirement.name}</span>
+        );
 
         const renderDescription = () => (
-            <span className="rule-details-description">{requirement.description}</span>
+            <span className={styles.requirementDetailDescription}>{requirement.description}</span>
         );
 
         return (
-            <span className="rule-detail">
-                <span className={outcomeChipContainer}>{renderCountBadge()}</span>
+            <span className={styles.requirementDetail}>
+                <span className={styles.outcomeChipContainer}>{renderCountBadge()}</span>
                 <span>
                     {renderRuleName()}: {renderDescription()}
                 </span>

--- a/src/DetailsView/tab-stops-requirement-instances-collapsible-content.scss
+++ b/src/DetailsView/tab-stops-requirement-instances-collapsible-content.scss
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../common/styles/colors.scss';
+@import '../common/styles/common.scss';
+
+.failure-instance-panel {
+    .observed-failure-textfield {
+        padding-bottom: 12px;
+    }
+    :global(.header-text) {
+        font-size: 21px;
+    }
+}
+
+.failure-instance-snippet-empty-body {
+    margin: 8px 0px 24px 0px;
+    color: $secondary-text;
+}
+
+.failure-instance-snippet-title {
+    margin: 24px 0px 8px 0px;
+    color: $primary-text;
+}
+
+.failure-instance-selector-note {
+    color: $secondary-text;
+    margin: 8px 0px 8px 0px;
+}
+
+.failure-instance-snippet-filled-body {
+    margin: 8px 0px 24px 0px;
+    padding: 12px 16px 12px 16px;
+    max-height: 200px;
+    color: $primary-text;
+    background-color: $neutral-4;
+    overflow-y: scroll;
+    word-wrap: break-word;
+}
+
+.failure-instance-snippet-error {
+    margin: 9px 0px 50px 9px;
+    color: $secondary-text;
+    display: flex;
+    flex-direction: row;
+}
+
+.failure-instance-snippet-error-icon {
+    color: $negative-outcome;
+    padding: 3px 8px;
+}
+
+.edit-button {
+    font-size: 16px !important;
+    line-height: 24px !important;
+    color: $neutral-100 !important;
+    @media screen and (forced-colors: active) {
+        color: inherit !important;
+    }
+}
+
+.remove-button {
+    margin-left: 12px;
+    font-size: 16px;
+    line-height: 24px;
+    color: $negative-outcome;
+    @media screen and (forced-colors: active) {
+        color: inherit;
+    }
+}

--- a/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
+++ b/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
@@ -17,6 +17,8 @@ import * as styles from './tab-stops-requirement-instances-collapsible-content.s
 
 export type TabStopsRequirementInstancesCollapsibleContentProps = {
     instances: TabStopsRequirementResultInstance[];
+    onEditButtonClicked: (requirementId: string) => void;
+    onRemoveButtonClicked: (requirementId: string) => void;
 };
 export const TabStopsRequirementInstancesCollapsibleContent =
     NamedFC<TabStopsRequirementInstancesCollapsibleContentProps>(
@@ -40,10 +42,16 @@ export const TabStopsRequirementInstancesCollapsibleContent =
             ): JSX.Element => {
                 return (
                     <>
-                        <Link className={styles.editButton} onClick={() => {}}>
+                        <Link
+                            className={styles.editButton}
+                            onClick={() => props.onEditButtonClicked(instance.id)}
+                        >
                             <Icon iconName="edit" ariaLabel={'edit instance'} />
                         </Link>
-                        <Link className={styles.removeButton} onClick={() => {}}>
+                        <Link
+                            className={styles.removeButton}
+                            onClick={() => props.onRemoveButtonClicked(instance.id)}
+                        >
                             <Icon iconName="delete" ariaLabel={'delete instance'} />
                         </Link>
                     </>

--- a/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
+++ b/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { AssessmentInstanceDetailsColumn } from 'DetailsView/components/assessment-instance-details-column';
+import { TabStopsRequirementResultInstance } from 'DetailsView/tab-stops-requirement-result';
+import {
+    CheckboxVisibility,
+    ColumnActionsMode,
+    ConstrainMode,
+    DetailsList,
+    IColumn,
+    Icon,
+    Link,
+} from 'office-ui-fabric-react';
+import * as React from 'react';
+import * as styles from './tab-stops-requirement-instances-collapsible-content.scss';
+
+export type TabStopsRequirementInstancesCollapsibleContentProps = {
+    instances: TabStopsRequirementResultInstance[];
+};
+export const TabStopsRequirementInstancesCollapsibleContent =
+    NamedFC<TabStopsRequirementInstancesCollapsibleContentProps>(
+        'TabStopsRequirementInstancesCollapsibleContent',
+        props => {
+            const onRenderCapturedInstanceDetailsColumn = (
+                instance: TabStopsRequirementResultInstance,
+            ): JSX.Element => {
+                return (
+                    <AssessmentInstanceDetailsColumn
+                        background={'#767676'}
+                        textContent={instance.description}
+                        headerText={'Comment:'}
+                        tooltipId={instance.id}
+                    />
+                );
+            };
+
+            const onRenderCapturedInstanceIconsColumn = (
+                instance: TabStopsRequirementResultInstance,
+            ): JSX.Element => {
+                return (
+                    <>
+                        <Link className={styles.editButton} onClick={() => {}}>
+                            <Icon iconName="edit" ariaLabel={'edit instance'} />
+                        </Link>
+                        <Link className={styles.removeButton} onClick={() => {}}>
+                            <Icon iconName="delete" ariaLabel={'delete instance'} />
+                        </Link>
+                    </>
+                );
+            };
+
+            const columns: IColumn[] = [
+                {
+                    key: 'failureDescription',
+                    name: 'Failure description',
+                    fieldName: 'description',
+                    minWidth: 200,
+                    maxWidth: 400,
+                    isResizable: true,
+                    onRender: onRenderCapturedInstanceDetailsColumn,
+                    columnActionsMode: ColumnActionsMode.disabled,
+                },
+                {
+                    key: 'instanceActionButtons',
+                    name: 'instance actions',
+                    isIconOnly: true,
+                    fieldName: 'instanceActionButtons',
+                    minWidth: 100,
+                    maxWidth: 100,
+                    isResizable: false,
+                    onRender: onRenderCapturedInstanceIconsColumn,
+                    columnActionsMode: ColumnActionsMode.disabled,
+                },
+            ];
+
+            return (
+                <DetailsList
+                    items={props.instances}
+                    columns={columns}
+                    checkboxVisibility={CheckboxVisibility.hidden}
+                    constrainMode={ConstrainMode.horizontalConstrained}
+                    onRenderDetailsHeader={() => null}
+                />
+            );
+        },
+    );

--- a/src/DetailsView/tab-stops-requirement-result.ts
+++ b/src/DetailsView/tab-stops-requirement-result.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
+
+export interface TabStopsRequirementResultInstance {
+    id: string;
+    description: string;
+}
+export interface TabStopsRequirementResult {
+    id: TabStopRequirementId;
+    description: string;
+    name: string;
+    instances: TabStopsRequirementResultInstance[];
+    isExpanded: boolean;
+}

--- a/src/DetailsView/tab-stops-requirements-with-instances.scss
+++ b/src/DetailsView/tab-stops-requirements-with-instances.scss
@@ -6,10 +6,6 @@
 .collapsible-requirement-details-group {
     box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
 
-    :global(.requirement-detail) {
-        box-shadow: unset;
-    }
-
     &:global(:not(.collapsed)) {
         box-shadow: unset;
     }

--- a/src/DetailsView/tab-stops-requirements-with-instances.scss
+++ b/src/DetailsView/tab-stops-requirements-with-instances.scss
@@ -3,43 +3,10 @@
 @import '../common/styles/colors.scss';
 @import '../common/styles/fonts.scss';
 
-.rule-details-group {
-    :global(.rule-detail) {
-        font-size: 14px;
-
-        padding: 16px 8px;
-
-        display: flex;
-        align-items: baseline;
-        text-align: left;
-
-        :global(.outcome-chip) {
-            vertical-align: middle;
-            margin-bottom: 2px;
-        }
-
-        :global(.rule-details-id) {
-            font-family: $semiBoldFontFamily;
-            color: $primary-text;
-            word-break: break-all;
-
-            a {
-                font-family: $semiBoldFontFamily;
-                color: $primary-text !important;
-            }
-        }
-
-        :global(.rule-detail-description) {
-            color: $secondary-text !important;
-            word-break: break-all;
-        }
-    }
-}
-
-.collapsible-rule-details-group {
+.collapsible-requirement-details-group {
     box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
 
-    :global(.rule-detail) {
+    :global(.requirement-detail) {
         box-shadow: unset;
     }
 

--- a/src/DetailsView/tab-stops-requirements-with-instances.scss
+++ b/src/DetailsView/tab-stops-requirements-with-instances.scss
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../common/styles/colors.scss';
+@import '../common/styles/fonts.scss';
+
+.rule-details-group {
+    :global(.rule-detail) {
+        font-size: 14px;
+
+        padding: 16px 8px;
+
+        display: flex;
+        align-items: baseline;
+        text-align: left;
+
+        :global(.outcome-chip) {
+            vertical-align: middle;
+            margin-bottom: 2px;
+        }
+
+        :global(.rule-details-id) {
+            font-family: $semiBoldFontFamily;
+            color: $primary-text;
+            word-break: break-all;
+
+            a {
+                font-family: $semiBoldFontFamily;
+                color: $primary-text !important;
+            }
+        }
+
+        :global(.rule-detail-description) {
+            color: $secondary-text !important;
+            word-break: break-all;
+        }
+    }
+}
+
+.collapsible-rule-details-group {
+    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+
+    :global(.rule-detail) {
+        box-shadow: unset;
+    }
+
+    &:global(:not(.collapsed)) {
+        box-shadow: unset;
+    }
+}

--- a/src/DetailsView/tab-stops-requirements-with-instances.tsx
+++ b/src/DetailsView/tab-stops-requirements-with-instances.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    CollapsibleComponentCardsDeps,
+    CollapsibleComponentCardsProps,
+} from 'common/components/cards/collapsible-component-cards';
+import { NamedFC } from 'common/react/named-fc';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
+import { TabStopsMinimalRequirementHeader } from 'DetailsView/tab-stops-minimal-requirement-header';
+import { TabStopsRequirementInstancesCollapsibleContent } from 'DetailsView/tab-stops-requirement-instances-collapsible-content';
+import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
+import * as React from 'react';
+import { outcomeTypeSemantics } from 'reports/components/outcome-type';
+
+import * as styles from './tab-stops-requirements-with-instances.scss';
+
+export const resultsGroupAutomationId = 'tab-stops-results-group';
+
+export type TabStopsRequirementsWithInstancesDeps = CollapsibleComponentCardsDeps & {
+    collapsibleControl: (props: CollapsibleComponentCardsProps) => JSX.Element;
+    tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
+};
+
+export type TabStopsRequirementsWithInstancesProps = {
+    deps: TabStopsRequirementsWithInstancesDeps;
+    results: TabStopsRequirementResult[];
+    headingLevel: number;
+};
+
+export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWithInstancesProps>(
+    'TabStopsRequirementsWithInstances',
+    ({ results, deps, headingLevel }) => {
+        const getCollapsibleComponentProps = (
+            result: TabStopsRequirementResult,
+            idx: number,
+            buttonAriaLabel: string,
+        ) => {
+            return {
+                id: result.id,
+                key: `summary-details-${idx + 1}`,
+                header: <TabStopsMinimalRequirementHeader key={result.id} requirement={result} />,
+                content: (
+                    <TabStopsRequirementInstancesCollapsibleContent
+                        key={`${result.id}-requirement-group`}
+                        instances={result.instances}
+                    />
+                ),
+                containerAutomationId: resultsGroupAutomationId,
+                containerClassName: styles.collapsibleRuleDetailsGroup,
+                buttonAriaLabel: buttonAriaLabel,
+                headingLevel,
+                deps: deps,
+                onExpandToggle: (event: React.MouseEvent<HTMLDivElement>) => {
+                    deps.tabStopRequirementActionMessageCreator.toggleTabStopRequirementExpand(
+                        result.id,
+                        event,
+                    );
+                },
+                isExpanded: result.isExpanded,
+            };
+        };
+
+        return (
+            <div className={styles.ruleDetailsGroup}>
+                {results.map((requirement, idx) => {
+                    const { pastTense } = outcomeTypeSemantics.fail;
+                    const count = TabStopsFailedCounter.getFailedByRequirementId(
+                        results,
+                        requirement.id,
+                    );
+                    const buttonAriaLabel = `${requirement.id} ${count} ${pastTense} ${requirement.description}`;
+                    const CollapsibleComponent = deps.collapsibleControl(
+                        getCollapsibleComponentProps(requirement, idx, buttonAriaLabel),
+                    );
+                    return CollapsibleComponent;
+                })}
+            </div>
+        );
+    },
+);

--- a/src/DetailsView/tab-stops-requirements-with-instances.tsx
+++ b/src/DetailsView/tab-stops-requirements-with-instances.tsx
@@ -32,6 +32,13 @@ export type TabStopsRequirementsWithInstancesProps = {
 export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWithInstancesProps>(
     'TabStopsRequirementsWithInstances',
     ({ results, deps, headingLevel }) => {
+        const onInstanceRemoveButtonClicked = (requirementId: string) => {
+            console.log('remove ' + requirementId);
+        };
+        const onInstanceEditButtonClicked = (requirementId: string) => {
+            console.log('edit ' + requirementId);
+        };
+
         const getCollapsibleComponentProps = (
             result: TabStopsRequirementResult,
             idx: number,
@@ -51,6 +58,8 @@ export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWit
                     <TabStopsRequirementInstancesCollapsibleContent
                         key={`${result.id}-requirement-group`}
                         instances={result.instances}
+                        onEditButtonClicked={onInstanceEditButtonClicked}
+                        onRemoveButtonClicked={onInstanceRemoveButtonClicked}
                     />
                 ),
                 containerAutomationId: resultsGroupAutomationId,

--- a/src/DetailsView/tab-stops-requirements-with-instances.tsx
+++ b/src/DetailsView/tab-stops-requirements-with-instances.tsx
@@ -20,6 +20,7 @@ export const resultsGroupAutomationId = 'tab-stops-results-group';
 export type TabStopsRequirementsWithInstancesDeps = CollapsibleComponentCardsDeps & {
     collapsibleControl: (props: CollapsibleComponentCardsProps) => JSX.Element;
     tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
+    tabStopsFailedCounter: TabStopsFailedCounter;
 };
 
 export type TabStopsRequirementsWithInstancesProps = {
@@ -39,7 +40,13 @@ export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWit
             return {
                 id: result.id,
                 key: `summary-details-${idx + 1}`,
-                header: <TabStopsMinimalRequirementHeader key={result.id} requirement={result} />,
+                header: (
+                    <TabStopsMinimalRequirementHeader
+                        deps={deps}
+                        key={result.id}
+                        requirement={result}
+                    />
+                ),
                 content: (
                     <TabStopsRequirementInstancesCollapsibleContent
                         key={`${result.id}-requirement-group`}
@@ -47,7 +54,7 @@ export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWit
                     />
                 ),
                 containerAutomationId: resultsGroupAutomationId,
-                containerClassName: styles.collapsibleRuleDetailsGroup,
+                containerClassName: styles.collapsibleRequirementDetailsGroup,
                 buttonAriaLabel: buttonAriaLabel,
                 headingLevel,
                 deps: deps,
@@ -62,10 +69,10 @@ export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWit
         };
 
         return (
-            <div className={styles.ruleDetailsGroup}>
+            <div>
                 {results.map((requirement, idx) => {
                     const { pastTense } = outcomeTypeSemantics.fail;
-                    const count = TabStopsFailedCounter.getFailedByRequirementId(
+                    const count = deps.tabStopsFailedCounter.getFailedByRequirementId(
                         results,
                         requirement.id,
                     );

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -131,12 +131,19 @@ export interface AddTabbedElementPayload extends BaseActionPayload {
     tabbedElements: TabStopEvent[];
 }
 
-export interface UpdateTabStopRequirementStatusPayload extends BaseActionPayload {
-    status: TabStopRequirementStatus;
+export interface ResetTabStopRequirementStatusPayload extends BaseActionPayload {
     requirementId: TabStopRequirementId;
+}
+export interface UpdateTabStopRequirementStatusPayload
+    extends ResetTabStopRequirementStatusPayload {
+    status: TabStopRequirementStatus;
 }
 export interface RemoveTabStopInstancePayload extends BaseActionPayload {
     id: string;
+    requirementId: TabStopRequirementId;
+}
+
+export interface ToggleTabStopRequirementExpandPayload extends BaseActionPayload {
     requirementId: TabStopRequirementId;
 }
 export interface AddTabStopInstancePayload extends BaseActionPayload {

--- a/src/background/actions/tab-stop-requirement-action-creator.ts
+++ b/src/background/actions/tab-stop-requirement-action-creator.ts
@@ -7,6 +7,8 @@ import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import {
     AddTabStopInstancePayload,
     RemoveTabStopInstancePayload,
+    ResetTabStopRequirementStatusPayload,
+    ToggleTabStopRequirementExpandPayload,
     UpdateTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
 } from './action-payloads';
@@ -26,6 +28,11 @@ export class TabStopRequirementActionCreator {
         );
 
         this.interpreter.registerTypeToPayloadCallback(
+            Messages.Visualizations.TabStops.ResetTabStopsRequirementStatus,
+            this.onResetTabStopsRequirementStatus,
+        );
+
+        this.interpreter.registerTypeToPayloadCallback(
             Messages.Visualizations.TabStops.AddTabStopInstance,
             this.onAddTabStopInstance,
         );
@@ -39,6 +46,11 @@ export class TabStopRequirementActionCreator {
             Messages.Visualizations.TabStops.RemoveTabStopInstance,
             this.onRemoveTabStopInstance,
         );
+
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.Visualizations.TabStops.RequirementExpansionToggled,
+            this.onRequirementExpansionToggled,
+        );
     }
 
     private onUpdateTabStopsRequirementStatus = (
@@ -47,6 +59,16 @@ export class TabStopRequirementActionCreator {
         this.tabStopRequirementActions.updateTabStopsRequirementStatus.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.UPDATE_TABSTOPS_REQUIREMENT_STATUS,
+            payload,
+        );
+    };
+
+    private onResetTabStopsRequirementStatus = (
+        payload: ResetTabStopRequirementStatusPayload,
+    ): void => {
+        this.tabStopRequirementActions.resetTabStopRequirementStatus.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(
+            TelemetryEvents.RESET_TABSTOPS_REQUIREMENT_STATUS,
             payload,
         );
     };
@@ -73,5 +95,11 @@ export class TabStopRequirementActionCreator {
             TelemetryEvents.REMOVE_TABSTOPS_REQUIREMENT_INSTANCE,
             payload,
         );
+    };
+
+    private onRequirementExpansionToggled = (
+        payload: ToggleTabStopRequirementExpandPayload,
+    ): void => {
+        this.tabStopRequirementActions.toggleTabStopRequirementExpand.invoke(payload);
     };
 }

--- a/src/background/actions/tab-stop-requirement-actions.ts
+++ b/src/background/actions/tab-stop-requirement-actions.ts
@@ -6,6 +6,8 @@ import { Action } from 'common/flux/action';
 import {
     AddTabStopInstancePayload,
     RemoveTabStopInstancePayload,
+    ResetTabStopRequirementStatusPayload,
+    ToggleTabStopRequirementExpandPayload,
     UpdateTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
 } from './action-payloads';
@@ -17,4 +19,8 @@ export class TabStopRequirementActions {
     public readonly addTabStopInstance = new Action<AddTabStopInstancePayload>();
     public readonly updateTabStopInstance = new Action<UpdateTabStopInstancePayload>();
     public readonly removeTabStopInstance = new Action<RemoveTabStopInstancePayload>();
+    public readonly resetTabStopRequirementStatus =
+        new Action<ResetTabStopRequirementStatusPayload>();
+    public readonly toggleTabStopRequirementExpand =
+        new Action<ToggleTabStopRequirementExpandPayload>();
 }

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -14,6 +14,7 @@ export const ADD_TABSTOPS_REQUIREMENT_INSTANCE: string = 'AddTabStopsRequirement
 export const REMOVE_TABSTOPS_REQUIREMENT_INSTANCE: string = 'RemoveTabStopsRequirementInstance';
 export const UPDATE_TABSTOPS_REQUIREMENT_INSTANCE: string = 'UpdateTabStopsRequirementInstance';
 export const UPDATE_TABSTOPS_REQUIREMENT_STATUS: string = 'UpdateTabStopsRequirementStatus';
+export const RESET_TABSTOPS_REQUIREMENT_STATUS: string = 'ResetTabStopsRequirmentStatus';
 export const COLOR_TOGGLE: string = 'ColorToggled';
 export const HEADINGS_TOGGLE: string = 'HeadingsToggled';
 export const SHORTCUT_MODIFIED: string = 'ShortcutModified';

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -20,9 +20,11 @@ export const Messages = {
             RecordingCompleted: `${messagePrefix}/visualization/tab-stops/completed`,
             TerminateScan: `${messagePrefix}/visualization/tab-stops/terminated`,
             UpdateTabStopsRequirementStatus: `${messagePrefix}/visualization/tab-stops/requirement-updated`,
+            ResetTabStopsRequirementStatus: `${messagePrefix}/visualization/tab-stops/requirement-reset`,
             AddTabStopInstance: `${messagePrefix}/visualization/tab-stops/instance-added`,
             UpdateTabStopInstance: `${messagePrefix}/visualization/tab-stops/instance-updated`,
             RemoveTabStopInstance: `${messagePrefix}/visualization/tab-stops/instance-removed`,
+            RequirementExpansionToggled: `${messagePrefix}/visualization/tab-stops/toggleTabStopRequirementExpand`,
         },
         Issues: {
             UpdateFocusedInstance: `${messagePrefix}/visualization/issues/targets/focused/update`,

--- a/src/common/types/store-data/visualization-scan-result-data.ts
+++ b/src/common/types/store-data/visualization-scan-result-data.ts
@@ -17,7 +17,13 @@ export interface TabbedElementData extends TabStopEvent {
     propertyBag?: TabOrderPropertyBag;
 }
 
-export type TabStopRequirementStatus = 'pass' | 'fail' | 'unknown';
+export enum TabStopRequirementStatuses {
+    pass = 'pass',
+    fail = 'fail',
+    unknown = 'unknown',
+}
+
+export type TabStopRequirementStatus = keyof typeof TabStopRequirementStatuses;
 
 export type TabStopRequirementState = {
     [requirementId: string]: {
@@ -26,6 +32,7 @@ export type TabStopRequirementState = {
             description: string;
             id: string;
         }[];
+        isExpanded: boolean;
     };
 };
 

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -167,22 +167,27 @@ exports[`DetailsViewBody render render 1`] = `
             "requirements": Object {
               "focus-indicator": Object {
                 "instances": Array [],
+                "isExpanded": false,
                 "status": "unknown",
               },
               "input-focus": Object {
                 "instances": Array [],
+                "isExpanded": false,
                 "status": "unknown",
               },
               "keyboard-navigation": Object {
                 "instances": Array [],
+                "isExpanded": false,
                 "status": "unknown",
               },
               "keyboard-traps": Object {
                 "instances": Array [],
+                "isExpanded": false,
                 "status": "unknown",
               },
               "tab-order": Object {
                 "instances": Array [],
+                "isExpanded": false,
                 "status": "unknown",
               },
             },
@@ -483,22 +488,27 @@ exports[`DetailsViewBody render render 1`] = `
               "requirements": Object {
                 "focus-indicator": Object {
                   "instances": Array [],
+                  "isExpanded": false,
                   "status": "unknown",
                 },
                 "input-focus": Object {
                   "instances": Array [],
+                  "isExpanded": false,
                   "status": "unknown",
                 },
                 "keyboard-navigation": Object {
                   "instances": Array [],
+                  "isExpanded": false,
                   "status": "unknown",
                 },
                 "keyboard-traps": Object {
                   "instances": Array [],
+                  "isExpanded": false,
                   "status": "unknown",
                 },
                 "tab-order": Object {
                   "instances": Array [],
+                  "isExpanded": false,
                   "status": "unknown",
                 },
               },
@@ -806,22 +816,27 @@ exports[`DetailsViewBody render render 1`] = `
                   "requirements": Object {
                     "focus-indicator": Object {
                       "instances": Array [],
+                      "isExpanded": false,
                       "status": "unknown",
                     },
                     "input-focus": Object {
                       "instances": Array [],
+                      "isExpanded": false,
                       "status": "unknown",
                     },
                     "keyboard-navigation": Object {
                       "instances": Array [],
+                      "isExpanded": false,
                       "status": "unknown",
                     },
                     "keyboard-traps": Object {
                       "instances": Array [],
+                      "isExpanded": false,
                       "status": "unknown",
                     },
                     "tab-order": Object {
                       "instances": Array [],
+                      "isExpanded": false,
                       "status": "unknown",
                     },
                   },

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -288,22 +288,27 @@ exports[` render renders normally 1`] = `
           "requirements": Object {
             "focus-indicator": Object {
               "instances": Array [],
+              "isExpanded": false,
               "status": "unknown",
             },
             "input-focus": Object {
               "instances": Array [],
+              "isExpanded": false,
               "status": "unknown",
             },
             "keyboard-navigation": Object {
               "instances": Array [],
+              "isExpanded": false,
               "status": "unknown",
             },
             "keyboard-traps": Object {
               "instances": Array [],
+              "isExpanded": false,
               "status": "unknown",
             },
             "tab-order": Object {
               "instances": Array [],
+              "isExpanded": false,
               "status": "unknown",
             },
           },

--- a/src/tests/unit/tests/DetailsView/actions/tab-stop-requirement-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/tab-stop-requirement-action-message-creator.test.ts
@@ -7,8 +7,10 @@ import {
     UpdateTabStopRequirementStatusPayload,
     UpdateTabStopInstancePayload,
     RemoveTabStopInstancePayload,
+    ToggleTabStopRequirementExpandPayload,
 } from 'background/actions/action-payloads';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
+import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
 import {
     TelemetryEventSource,
@@ -171,6 +173,30 @@ describe('TabStopRequirementActionMessageCreatorTest', () => {
             requirementInstance.requirementId,
             requirementInstance.id,
         );
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+
+        telemetryFactoryMock.verifyAll();
+    });
+
+    test('toggleRabStopRequirementExpand', () => {
+        const requirementInstance: ToggleTabStopRequirementExpandPayload = {
+            requirementId: 'input-focus',
+        };
+
+        const eventStub = {} as React.SyntheticEvent;
+
+        const expectedMessage = {
+            messageType: Messages.Visualizations.TabStops.RequirementExpansionToggled,
+            payload: {
+                ...requirementInstance,
+            },
+        };
+
+        testSubject.toggleTabStopRequirementExpand(requirementInstance.requirementId, eventStub);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -44,13 +44,6 @@ exports[`AdhocTabStopsTestView renders with content 1`] = `
     }
   />
   <TabStopsFailedInstanceSection
-    configuration={
-      Object {
-        "displayableData": Object {
-          "title": "test title",
-        },
-      }
-    }
     deps={Object {}}
     visualizationScanResultData={Object {}}
   />

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -43,5 +43,16 @@ exports[`AdhocTabStopsTestView renders with content 1`] = `
       </ol>
     }
   />
+  <TabStopsFailedInstanceSection
+    configuration={
+      Object {
+        "displayableData": Object {
+          "title": "test title",
+        },
+      }
+    }
+    deps={Object {}}
+    visualizationScanResultData={Object {}}
+  />
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-failed-instance-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-failed-instance-section.test.tsx.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TabStopsFailedInstanceSection does not render when no results are failing 1`] = `null`;
+
+exports[`TabStopsFailedInstanceSection renders with failing results 1`] = `
+<div
+  className="tabStopsFailureInstanceSection"
+  data-automation-id="tab-stops-failure-instance-section"
+>
+  <h2>
+    <ResultSectionTitle
+      badgeCount={2}
+      outcomeType="fail"
+      title="Failed instances"
+      titleSize="title"
+    />
+  </h2>
+  <TabStopsRequirementsWithInstances
+    deps={Object {}}
+    headingLevel={3}
+    outcomeType="fail"
+    results={
+      Array [
+        Object {
+          "description": "All interactive elements can be reached using the Tab and arrow keys. ",
+          "id": "keyboard-navigation",
+          "instances": Array [
+            Object {
+              "description": "test desc 1",
+              "id": "test-id-1",
+            },
+          ],
+          "isExpanded": false,
+          "name": "Keyboard navigation",
+        },
+        Object {
+          "description": "There are no interactive elements that “trap” input focus and prevent navigating away.",
+          "id": "keyboard-traps",
+          "instances": Array [
+            Object {
+              "description": "test desc 2",
+              "id": "test-id-2",
+            },
+          ],
+          "isExpanded": false,
+          "name": "Keyboard traps",
+        },
+      ]
+    }
+    visualizationScanResultData={
+      Object {
+        "tabStops": Object {
+          "requirements": Object {
+            "keyboard-navigation": Object {
+              "instances": Array [
+                Object {
+                  "description": "test desc 1",
+                  "id": "test-id-1",
+                },
+              ],
+              "isExpanded": false,
+              "status": "fail",
+            },
+            "keyboard-traps": Object {
+              "instances": Array [
+                Object {
+                  "description": "test desc 2",
+                  "id": "test-id-2",
+                },
+              ],
+              "isExpanded": false,
+              "status": "fail",
+            },
+          },
+        },
+      }
+    }
+  />
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-failed-instance-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-failed-instance-section.test.tsx.snap
@@ -9,16 +9,22 @@ exports[`TabStopsFailedInstanceSection renders with failing results 1`] = `
 >
   <h2>
     <ResultSectionTitle
-      badgeCount={2}
       outcomeType="fail"
       title="Failed instances"
       titleSize="title"
     />
   </h2>
   <TabStopsRequirementsWithInstances
-    deps={Object {}}
+    deps={
+      Object {
+        "tabStopsFailedCounter": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "getFailedByRequirementId": [Function],
+          "getTotalFailed": [Function],
+        },
+      }
+    }
     headingLevel={3}
-    outcomeType="fail"
     results={
       Array [
         Object {
@@ -46,34 +52,6 @@ exports[`TabStopsFailedInstanceSection renders with failing results 1`] = `
           "name": "Keyboard traps",
         },
       ]
-    }
-    visualizationScanResultData={
-      Object {
-        "tabStops": Object {
-          "requirements": Object {
-            "keyboard-navigation": Object {
-              "instances": Array [
-                Object {
-                  "description": "test desc 1",
-                  "id": "test-id-1",
-                },
-              ],
-              "isExpanded": false,
-              "status": "fail",
-            },
-            "keyboard-traps": Object {
-              "instances": Array [
-                Object {
-                  "description": "test desc 2",
-                  "id": "test-id-2",
-                },
-              ],
-              "isExpanded": false,
-              "status": "fail",
-            },
-          },
-        },
-      }
     }
   />
 </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-failed-instance-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-failed-instance-section.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`TabStopsFailedInstanceSection renders with failing results 1`] = `
 >
   <h2>
     <ResultSectionTitle
+      badgeCount={10}
       outcomeType="fail"
       title="Failed instances"
       titleSize="title"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-minimal-requirement-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-minimal-requirement-header.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`TabStopsMinimalRequirementHeader renders 1`] = `
       aria-hidden="true"
     >
       <OutcomeChip
+        count={2}
         outcomeType="fail"
       />
     </span>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-minimal-requirement-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-minimal-requirement-header.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TabStopsMinimalRequirementHeader renders 1`] = `
 <span
-  className="rule-detail"
+  className="requirementDetail"
 >
   <span
     className="outcomeChipContainer"
@@ -11,20 +11,19 @@ exports[`TabStopsMinimalRequirementHeader renders 1`] = `
       aria-hidden="true"
     >
       <OutcomeChip
-        count={1}
         outcomeType="fail"
       />
     </span>
   </span>
   <span>
     <span
-      className="rule-details-id"
+      className="requirementDetailsId"
     >
       test requirement name
     </span>
     : 
     <span
-      className="rule-details-description"
+      className="requirementDetailDescription"
     >
       test requirement description
     </span>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-minimal-requirement-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-minimal-requirement-header.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TabStopsMinimalRequirementHeader renders 1`] = `
+<span
+  className="rule-detail"
+>
+  <span
+    className="outcomeChipContainer"
+  >
+    <span
+      aria-hidden="true"
+    >
+      <OutcomeChip
+        count={1}
+        outcomeType="fail"
+      />
+    </span>
+  </span>
+  <span>
+    <span
+      className="rule-details-id"
+    >
+      test requirement name
+    </span>
+    : 
+    <span
+      className="rule-details-description"
+    >
+      test requirement description
+    </span>
+  </span>
+</span>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
@@ -40,3 +40,44 @@ exports[`TabStopsRequirementInstancesCollapsibleContent renders 1`] = `
   onRenderDetailsHeader={[Function]}
 />
 `;
+
+exports[`TabStopsRequirementInstancesCollapsibleContent renders captured instance details column 1`] = `
+<AssessmentInstanceDetailsColumn
+  background="#767676"
+  headerText="Comment:"
+  textContent="test requirement description"
+  tooltipId="test-requirement-id"
+/>
+`;
+
+exports[`TabStopsRequirementInstancesCollapsibleContent renders captured instance icons column 1`] = `
+<React.Fragment>
+  <StyledLinkBase
+    className="editButton"
+    onClick={[Function]}
+  >
+    <StyledIconBase
+      ariaLabel="edit instance"
+      iconName="edit"
+    />
+  </StyledLinkBase>
+  <StyledLinkBase
+    className="removeButton"
+    onClick={[Function]}
+  >
+    <StyledIconBase
+      ariaLabel="delete instance"
+      iconName="delete"
+    />
+  </StyledLinkBase>
+</React.Fragment>
+`;
+
+exports[`TabStopsRequirementInstancesCollapsibleContent renders captured instances column 1`] = `
+<AssessmentInstanceDetailsColumn
+  background="#767676"
+  headerText="Comment:"
+  textContent="test requirement description"
+  tooltipId="test-requirement-id"
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TabStopsRequirementInstancesCollapsibleContent renders 1`] = `
+<StyledWithViewportComponent
+  checkboxVisibility={2}
+  columns={
+    Array [
+      Object {
+        "columnActionsMode": 0,
+        "fieldName": "description",
+        "isResizable": true,
+        "key": "failureDescription",
+        "maxWidth": 400,
+        "minWidth": 200,
+        "name": "Failure description",
+        "onRender": [Function],
+      },
+      Object {
+        "columnActionsMode": 0,
+        "fieldName": "instanceActionButtons",
+        "isIconOnly": true,
+        "isResizable": false,
+        "key": "instanceActionButtons",
+        "maxWidth": 100,
+        "minWidth": 100,
+        "name": "instance actions",
+        "onRender": [Function],
+      },
+    ]
+  }
+  constrainMode={1}
+  items={
+    Array [
+      Object {
+        "description": "test-description",
+        "id": "test-id",
+      },
+    ]
+  }
+  onRenderDetailsHeader={[Function]}
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
@@ -72,12 +72,3 @@ exports[`TabStopsRequirementInstancesCollapsibleContent renders captured instanc
   </StyledLinkBase>
 </React.Fragment>
 `;
-
-exports[`TabStopsRequirementInstancesCollapsibleContent renders captured instances column 1`] = `
-<AssessmentInstanceDetailsColumn
-  background="#767676"
-  headerText="Comment:"
-  textContent="test requirement description"
-  tooltipId="test-requirement-id"
-/>
-`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`TabStopsRequirementInstancesCollapsibleContent renders 1`] = `
     Array [
       Object {
         "description": "test-description",
-        "id": "test-id",
+        "id": "test-requirement-id",
       },
     ]
   }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TabStopsRequirementsWithInstances renders 1`] = `
+<div
+  className="ruleDetailsGroup"
+>
+  <CollapsibleControlStub
+    buttonAriaLabel="keyboard-navigation 1 Failed test requirement description 1"
+    containerAutomationId="tab-stops-results-group"
+    containerClassName="collapsibleRuleDetailsGroup"
+    content={
+      <TabStopsRequirementInstancesCollapsibleContent
+        instances={
+          Array [
+            Object {
+              "description": "test desc 1",
+              "id": "test-id-1",
+            },
+          ]
+        }
+      />
+    }
+    deps={
+      Object {
+        "collapsibleControl": [Function],
+      }
+    }
+    header={
+      <TabStopsMinimalRequirementHeader
+        requirement={
+          Object {
+            "description": "test requirement description 1",
+            "id": "keyboard-navigation",
+            "instances": Array [
+              Object {
+                "description": "test desc 1",
+                "id": "test-id-1",
+              },
+            ],
+            "isExpanded": false,
+            "name": "test requirement name 1",
+          }
+        }
+      />
+    }
+    headingLevel={3}
+    id="keyboard-navigation"
+    isExpanded={false}
+    onExpandToggle={[Function]}
+  />
+  <CollapsibleControlStub
+    buttonAriaLabel="keybaord-traps 1 Failed test requirement description 2"
+    containerAutomationId="tab-stops-results-group"
+    containerClassName="collapsibleRuleDetailsGroup"
+    content={
+      <TabStopsRequirementInstancesCollapsibleContent
+        instances={
+          Array [
+            Object {
+              "description": "test desc 2",
+              "id": "test-id-2",
+            },
+          ]
+        }
+      />
+    }
+    deps={
+      Object {
+        "collapsibleControl": [Function],
+      }
+    }
+    header={
+      <TabStopsMinimalRequirementHeader
+        requirement={
+          Object {
+            "description": "test requirement description 2",
+            "id": "keybaord-traps",
+            "instances": Array [
+              Object {
+                "description": "test desc 2",
+                "id": "test-id-2",
+              },
+            ],
+            "isExpanded": false,
+            "name": "test requirement name 2",
+          }
+        }
+      />
+    }
+    headingLevel={3}
+    id="keybaord-traps"
+    isExpanded={false}
+    onExpandToggle={[Function]}
+  />
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
@@ -1,13 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TabStopsRequirementsWithInstances renders 1`] = `
-<div
-  className="ruleDetailsGroup"
->
+<div>
   <CollapsibleControlStub
-    buttonAriaLabel="keyboard-navigation 1 Failed test requirement description 1"
+    buttonAriaLabel="keyboard-navigation undefined Failed test requirement description 1"
     containerAutomationId="tab-stops-results-group"
-    containerClassName="collapsibleRuleDetailsGroup"
+    containerClassName="collapsibleRequirementDetailsGroup"
     content={
       <TabStopsRequirementInstancesCollapsibleContent
         instances={
@@ -23,10 +21,25 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
     deps={
       Object {
         "collapsibleControl": [Function],
+        "tabStopsFailedCounter": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "getFailedByRequirementId": [Function],
+          "getTotalFailed": [Function],
+        },
       }
     }
     header={
       <TabStopsMinimalRequirementHeader
+        deps={
+          Object {
+            "collapsibleControl": [Function],
+            "tabStopsFailedCounter": proxy {
+              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "getFailedByRequirementId": [Function],
+              "getTotalFailed": [Function],
+            },
+          }
+        }
         requirement={
           Object {
             "description": "test requirement description 1",
@@ -49,9 +62,9 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
     onExpandToggle={[Function]}
   />
   <CollapsibleControlStub
-    buttonAriaLabel="keybaord-traps 1 Failed test requirement description 2"
+    buttonAriaLabel="keybaord-traps undefined Failed test requirement description 2"
     containerAutomationId="tab-stops-results-group"
-    containerClassName="collapsibleRuleDetailsGroup"
+    containerClassName="collapsibleRequirementDetailsGroup"
     content={
       <TabStopsRequirementInstancesCollapsibleContent
         instances={
@@ -67,10 +80,25 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
     deps={
       Object {
         "collapsibleControl": [Function],
+        "tabStopsFailedCounter": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "getFailedByRequirementId": [Function],
+          "getTotalFailed": [Function],
+        },
       }
     }
     header={
       <TabStopsMinimalRequirementHeader
+        deps={
+          Object {
+            "collapsibleControl": [Function],
+            "tabStopsFailedCounter": proxy {
+              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "getFailedByRequirementId": [Function],
+              "getTotalFailed": [Function],
+            },
+          }
+        }
         requirement={
           Object {
             "description": "test requirement description 2",

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
@@ -16,6 +16,8 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
             },
           ]
         }
+        onEditButtonClicked={[Function]}
+        onRemoveButtonClicked={[Function]}
       />
     }
     deps={
@@ -75,6 +77,8 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
             },
           ]
         }
+        onEditButtonClicked={[Function]}
+        onRemoveButtonClicked={[Function]}
       />
     }
     deps={

--- a/src/tests/unit/tests/DetailsView/components/adhoc-tab-stops-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/adhoc-tab-stops-test-view.test.tsx
@@ -2,20 +2,26 @@
 // Licensed under the MIT License.
 
 import { DisplayableVisualizationTypeData } from 'common/types/displayable-visualization-type-data';
+import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import {
     AdhocTabStopsTestView,
+    AdhocTabStopsTestViewDeps,
     AdhocTabStopsTestViewProps,
 } from 'DetailsView/components/adhoc-tab-stops-test-view';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('AdhocTabStopsTestView', () => {
+    const visualizationScanResultDataStub = {} as VisualizationScanResultData;
+
     const props = {
         configuration: {
             displayableData: {
                 title: 'test title',
             } as DisplayableVisualizationTypeData,
         },
+        visualizationScanResultData: visualizationScanResultDataStub,
+        deps: {} as AdhocTabStopsTestViewDeps,
     } as AdhocTabStopsTestViewProps;
 
     it('renders with content', () => {

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-counter.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-counter.test.ts
@@ -7,6 +7,7 @@ import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-res
 // Licensed under the MIT License.
 describe('TabStopsFailedCounter', () => {
     let results = [] as TabStopsRequirementResult[];
+    const testSubject = new TabStopsFailedCounter();
 
     beforeEach(() => {
         results = [
@@ -16,14 +17,14 @@ describe('TabStopsFailedCounter', () => {
 
     test('getTotalFailed returns zero when there are no instances', () => {
         results = [];
-        expect(TabStopsFailedCounter.getTotalFailed(results)).toBe(0);
+        expect(testSubject.getTotalFailed(results)).toBe(0);
     });
 
     test('getTotalFailed returns one result when a single failed instance is passed', () => {
         results = [
             { instances: [{ id: 'test-id-1', description: 'test desc 1' }] },
         ] as TabStopsRequirementResult[];
-        expect(TabStopsFailedCounter.getTotalFailed(results)).toBe(1);
+        expect(testSubject.getTotalFailed(results)).toBe(1);
     });
 
     test('getTotalFailed counts all instances from all requirements', () => {
@@ -40,7 +41,7 @@ describe('TabStopsFailedCounter', () => {
                 ],
             },
         ] as TabStopsRequirementResult[];
-        expect(TabStopsFailedCounter.getTotalFailed(results)).toBe(3);
+        expect(testSubject.getTotalFailed(results)).toBe(3);
     });
 
     test('getFailedByRequirementId returns zero when requirementId does not exist', () => {
@@ -50,7 +51,7 @@ describe('TabStopsFailedCounter', () => {
                 instances: [{ id: 'test-id-1', description: 'test desc 1' }],
             },
         ] as TabStopsRequirementResult[];
-        expect(TabStopsFailedCounter.getFailedByRequirementId(results, 'non-existent-id')).toBe(0);
+        expect(testSubject.getFailedByRequirementId(results, 'non-existent-id')).toBe(0);
     });
 
     test('getFailedByRequirementId returns correct number of instances for requirement', () => {
@@ -67,6 +68,6 @@ describe('TabStopsFailedCounter', () => {
                 ],
             },
         ] as TabStopsRequirementResult[];
-        expect(TabStopsFailedCounter.getFailedByRequirementId(results, 'input-focus')).toBe(2);
+        expect(testSubject.getFailedByRequirementId(results, 'input-focus')).toBe(2);
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-counter.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-counter.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
+import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
+
+// Licensed under the MIT License.
+describe('TabStopsFailedCounter', () => {
+    let results = [] as TabStopsRequirementResult[];
+
+    beforeEach(() => {
+        results = [
+            { instances: [{ id: 'test-id-1', description: 'test desc 1' }] },
+        ] as TabStopsRequirementResult[];
+    });
+
+    test('getTotalFailed returns zero when there are no instances', () => {
+        results = [];
+        expect(TabStopsFailedCounter.getTotalFailed(results)).toBe(0);
+    });
+
+    test('getTotalFailed returns one result when a single failed instance is passed', () => {
+        results = [
+            { instances: [{ id: 'test-id-1', description: 'test desc 1' }] },
+        ] as TabStopsRequirementResult[];
+        expect(TabStopsFailedCounter.getTotalFailed(results)).toBe(1);
+    });
+
+    test('getTotalFailed counts all instances from all requirements', () => {
+        results = [
+            {
+                id: 'keyboard-navigation',
+                instances: [{ id: 'test-id-1', description: 'test desc 1' }],
+            },
+            {
+                id: 'input-focus',
+                instances: [
+                    { id: 'test-id-2', description: 'test desc 2' },
+                    { id: 'test-id-3', description: 'test desc 3' },
+                ],
+            },
+        ] as TabStopsRequirementResult[];
+        expect(TabStopsFailedCounter.getTotalFailed(results)).toBe(3);
+    });
+
+    test('getFailedByRequirementId returns zero when requirementId does not exist', () => {
+        results = [
+            {
+                id: 'keyboard-navigation',
+                instances: [{ id: 'test-id-1', description: 'test desc 1' }],
+            },
+        ] as TabStopsRequirementResult[];
+        expect(TabStopsFailedCounter.getFailedByRequirementId(results, 'non-existent-id')).toBe(0);
+    });
+
+    test('getFailedByRequirementId returns correct number of instances for requirement', () => {
+        results = [
+            {
+                id: 'keyboard-navigation',
+                instances: [{ id: 'test-id-1', description: 'test desc 1' }],
+            },
+            {
+                id: 'input-focus',
+                instances: [
+                    { id: 'test-id-2', description: 'test desc 2' },
+                    { id: 'test-id-3', description: 'test desc 3' },
+                ],
+            },
+        ] as TabStopsRequirementResult[];
+        expect(TabStopsFailedCounter.getFailedByRequirementId(results, 'input-focus')).toBe(2);
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-counter.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-counter.test.ts
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
@@ -5,20 +5,35 @@ import { VisualizationScanResultData } from 'common/types/store-data/visualizati
 import {
     TabStopsFailedInstanceSection,
     TabStopsFailedInstanceSectionDeps,
+    TabStopsFailedInstanceSectionProps,
 } from 'DetailsView/components/tab-stops-failed-instance-section';
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { IMock, Mock } from 'typemoq';
 
 describe('TabStopsFailedInstanceSection', () => {
-    const depsStub = {} as TabStopsFailedInstanceSectionDeps;
+    let tabStopsFailedCounterMock: IMock<TabStopsFailedCounter>;
+
     const visualizationScanResultDataStub = {
         tabStops: { requirements: {} },
     } as VisualizationScanResultData;
 
-    const props = {
-        deps: depsStub,
-        visualizationScanResultData: visualizationScanResultDataStub,
-    };
+    let props = {} as TabStopsFailedInstanceSectionProps;
+    let depsStub = {} as TabStopsFailedInstanceSectionDeps;
+
+    beforeAll(() => {
+        tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
+
+        depsStub = {
+            tabStopsFailedCounter: tabStopsFailedCounterMock.object,
+        } as TabStopsFailedInstanceSectionDeps;
+
+        props = {
+            deps: depsStub,
+            visualizationScanResultData: visualizationScanResultDataStub,
+        };
+    });
 
     beforeEach(() => {
         props.visualizationScanResultData.tabStops.requirements = {
@@ -36,7 +51,12 @@ describe('TabStopsFailedInstanceSection', () => {
     });
 
     it('renders with failing results', () => {
-        const wrapper = shallow(<TabStopsFailedInstanceSection {...props} />);
+        const wrapper = shallow(
+            <TabStopsFailedInstanceSection
+                deps={depsStub}
+                visualizationScanResultData={visualizationScanResultDataStub}
+            />,
+        );
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 
@@ -47,7 +67,12 @@ describe('TabStopsFailedInstanceSection', () => {
             requirementsStub[requirementId].instances = [];
         }
 
-        const wrapper = shallow(<TabStopsFailedInstanceSection {...props} />);
+        const wrapper = shallow(
+            <TabStopsFailedInstanceSection
+                deps={depsStub}
+                visualizationScanResultData={visualizationScanResultDataStub}
+            />,
+        );
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
+import {
+    TabStopsFailedInstanceSection,
+    TabStopsFailedInstanceSectionDeps,
+} from 'DetailsView/components/tab-stops-failed-instance-section';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('TabStopsFailedInstanceSection', () => {
+    const depsStub = {} as TabStopsFailedInstanceSectionDeps;
+    const visualizationScanResultDataStub = {
+        tabStops: { requirements: {} },
+    } as VisualizationScanResultData;
+
+    const props = {
+        deps: depsStub,
+        visualizationScanResultData: visualizationScanResultDataStub,
+    };
+
+    beforeEach(() => {
+        props.visualizationScanResultData.tabStops.requirements = {
+            'keyboard-navigation': {
+                status: 'fail',
+                instances: [{ id: 'test-id-1', description: 'test desc 1' }],
+                isExpanded: false,
+            },
+            'keyboard-traps': {
+                status: 'fail',
+                instances: [{ id: 'test-id-2', description: 'test desc 2' }],
+                isExpanded: false,
+            },
+        };
+    });
+
+    it('renders with failing results', () => {
+        const wrapper = shallow(<TabStopsFailedInstanceSection {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    it('does not render when no results are failing', () => {
+        const requirementsStub = props.visualizationScanResultData.tabStops.requirements;
+        for (const requirementId of Object.keys(requirementsStub)) {
+            requirementsStub[requirementId].status = 'pass';
+            requirementsStub[requirementId].instances = [];
+        }
+
+        const wrapper = shallow(<TabStopsFailedInstanceSection {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
@@ -10,7 +10,7 @@ import {
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, Mock } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('TabStopsFailedInstanceSection', () => {
     let tabStopsFailedCounterMock: IMock<TabStopsFailedCounter>;
@@ -19,23 +19,20 @@ describe('TabStopsFailedInstanceSection', () => {
         tabStops: { requirements: {} },
     } as VisualizationScanResultData;
 
-    let props = {} as TabStopsFailedInstanceSectionProps;
-    let depsStub = {} as TabStopsFailedInstanceSectionDeps;
+    let props: TabStopsFailedInstanceSectionProps;
+    let deps: TabStopsFailedInstanceSectionDeps;
 
-    beforeAll(() => {
+    beforeEach(() => {
         tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
 
-        depsStub = {
+        deps = {
             tabStopsFailedCounter: tabStopsFailedCounterMock.object,
         } as TabStopsFailedInstanceSectionDeps;
 
         props = {
-            deps: depsStub,
+            deps: deps,
             visualizationScanResultData: visualizationScanResultDataStub,
         };
-    });
-
-    beforeEach(() => {
         props.visualizationScanResultData.tabStops.requirements = {
             'keyboard-navigation': {
                 status: 'fail',
@@ -51,13 +48,19 @@ describe('TabStopsFailedInstanceSection', () => {
     });
 
     it('renders with failing results', () => {
+        tabStopsFailedCounterMock
+            .setup(tsf => tsf.getTotalFailed(It.isAny()))
+            .returns(() => 10)
+            .verifiable(Times.once());
+
         const wrapper = shallow(
             <TabStopsFailedInstanceSection
-                deps={depsStub}
+                deps={deps}
                 visualizationScanResultData={visualizationScanResultDataStub}
             />,
         );
         expect(wrapper.getElement()).toMatchSnapshot();
+        tabStopsFailedCounterMock.verifyAll();
     });
 
     it('does not render when no results are failing', () => {
@@ -67,12 +70,18 @@ describe('TabStopsFailedInstanceSection', () => {
             requirementsStub[requirementId].instances = [];
         }
 
+        tabStopsFailedCounterMock
+            .setup(tsf => tsf.getTotalFailed(It.isAny()))
+            .returns(() => 10)
+            .verifiable(Times.never());
+
         const wrapper = shallow(
             <TabStopsFailedInstanceSection
-                deps={depsStub}
+                deps={deps}
                 visualizationScanResultData={visualizationScanResultDataStub}
             />,
         );
         expect(wrapper.getElement()).toMatchSnapshot();
+        tabStopsFailedCounterMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
@@ -72,7 +72,6 @@ describe('TabStopsFailedInstanceSection', () => {
 
         tabStopsFailedCounterMock
             .setup(tsf => tsf.getTotalFailed(It.isAny()))
-            .returns(() => 10)
             .verifiable(Times.never());
 
         const wrapper = shallow(

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-minimal-requirement-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-minimal-requirement-header.test.tsx
@@ -1,15 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import {
     TabStopsMinimalRequirementHeader,
+    TabStopsMinimalRequirementHeaderDeps,
     TabStopsMinimalRequirementHeaderProps,
 } from 'DetailsView/tab-stops-minimal-requirement-header';
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { IMock, Mock } from 'typemoq';
 
 describe('TabStopsMinimalRequirementHeader', () => {
+    let tabStopsFailedCounterMock: IMock<TabStopsFailedCounter>;
+
     const requirement = {
         id: 'keyboard-navigation',
         description: 'test requirement description',
@@ -18,8 +23,19 @@ describe('TabStopsMinimalRequirementHeader', () => {
         isExpanded: false,
     } as TabStopsRequirementResult;
 
+    let deps = {} as TabStopsMinimalRequirementHeaderDeps;
+
+    beforeAll(() => {
+        tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
+
+        deps = {
+            tabStopsFailedCounter: tabStopsFailedCounterMock.object,
+        } as TabStopsMinimalRequirementHeaderDeps;
+    });
+
     it('renders', () => {
         const props: TabStopsMinimalRequirementHeaderProps = {
+            deps,
             requirement,
         };
         const wrapped = shallow(<TabStopsMinimalRequirementHeader {...props} />);

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-minimal-requirement-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-minimal-requirement-header.test.tsx
@@ -10,7 +10,7 @@ import {
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, Mock } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('TabStopsMinimalRequirementHeader', () => {
     let tabStopsFailedCounterMock: IMock<TabStopsFailedCounter>;
@@ -23,9 +23,9 @@ describe('TabStopsMinimalRequirementHeader', () => {
         isExpanded: false,
     } as TabStopsRequirementResult;
 
-    let deps = {} as TabStopsMinimalRequirementHeaderDeps;
+    let deps: TabStopsMinimalRequirementHeaderDeps;
 
-    beforeAll(() => {
+    beforeEach(() => {
         tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
 
         deps = {
@@ -38,7 +38,14 @@ describe('TabStopsMinimalRequirementHeader', () => {
             deps,
             requirement,
         };
+
+        tabStopsFailedCounterMock
+            .setup(tsf => tsf.getFailedByRequirementId(It.isAny(), It.isAnyString()))
+            .returns(() => 2)
+            .verifiable(Times.once());
+
         const wrapped = shallow(<TabStopsMinimalRequirementHeader {...props} />);
         expect(wrapped.getElement()).toMatchSnapshot();
+        tabStopsFailedCounterMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-minimal-requirement-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-minimal-requirement-header.test.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    TabStopsMinimalRequirementHeader,
+    TabStopsMinimalRequirementHeaderProps,
+} from 'DetailsView/tab-stops-minimal-requirement-header';
+import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('TabStopsMinimalRequirementHeader', () => {
+    const requirement = {
+        id: 'keyboard-navigation',
+        description: 'test requirement description',
+        name: 'test requirement name',
+        instances: [{ id: 'test-id', description: 'test description' }],
+        isExpanded: false,
+    } as TabStopsRequirementResult;
+
+    it('renders', () => {
+        const props: TabStopsMinimalRequirementHeaderProps = {
+            requirement,
+        };
+        const wrapped = shallow(<TabStopsMinimalRequirementHeader {...props} />);
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 import { TabStopsRequirementInstancesCollapsibleContent } from 'DetailsView/tab-stops-requirement-instances-collapsible-content';
 import { shallow } from 'enzyme';

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
@@ -2,16 +2,48 @@
 // Licensed under the MIT License.
 
 import { TabStopsRequirementInstancesCollapsibleContent } from 'DetailsView/tab-stops-requirement-instances-collapsible-content';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
+import { IMock, Mock, Times } from 'typemoq';
 
-// Licensed under the MIT License.
 describe('TabStopsRequirementInstancesCollapsibleContent', () => {
-    const props = {
-        instances: [{ id: 'test-id', description: 'test-description' }],
-    };
+    let onEditButtonClickedMock: IMock<(requirementId: string) => void>;
+    let onRemoveButtonClickedMock: IMock<(requirementId: string) => void>;
+    let props;
+
+    beforeEach(() => {
+        onEditButtonClickedMock = Mock.ofType<(requirementId: string) => void>();
+        onRemoveButtonClickedMock = Mock.ofType<(requirementId: string) => void>();
+
+        props = {
+            instances: [{ id: 'test-requirement-id', description: 'test-description' }],
+            onEditButtonClicked: onEditButtonClickedMock.object,
+            onRemoveButtonClicked: onRemoveButtonClickedMock.object,
+        };
+    });
+
     it('renders', () => {
         const wrapper = shallow(<TabStopsRequirementInstancesCollapsibleContent {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('click events pass through as expected', () => {
+        onEditButtonClickedMock.setup(ebc => ebc('test-requirement-id')).verifiable(Times.once());
+        onRemoveButtonClickedMock.setup(rbc => rbc('test-requirement-id')).verifiable(Times.once());
+        const testSubject = mount(
+            <TabStopsRequirementInstancesCollapsibleContent
+                instances={props.instances}
+                onEditButtonClicked={onEditButtonClickedMock.object}
+                onRemoveButtonClicked={onRemoveButtonClickedMock.object}
+            />,
+        );
+        testSubject
+            .find(Link)
+            .find('button')
+            .forEach(wrapper => wrapper.simulate('click'));
+
+        onEditButtonClickedMock.verifyAll();
+        onRemoveButtonClickedMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+import { TabStopsRequirementInstancesCollapsibleContent } from 'DetailsView/tab-stops-requirement-instances-collapsible-content';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+// Licensed under the MIT License.
+describe('TabStopsRequirementInstancesCollapsibleContent', () => {
+    const props = {
+        instances: [{ id: 'test-id', description: 'test-description' }],
+    };
+    it('renders', () => {
+        const wrapper = shallow(<TabStopsRequirementInstancesCollapsibleContent {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
@@ -1,16 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { TabStopsRequirementInstancesCollapsibleContent } from 'DetailsView/tab-stops-requirement-instances-collapsible-content';
+import {
+    TabStopsRequirementInstancesCollapsibleContent,
+    TabStopsRequirementInstancesCollapsibleContentProps,
+} from 'DetailsView/tab-stops-requirement-instances-collapsible-content';
+import { TabStopsRequirementResultInstance } from 'DetailsView/tab-stops-requirement-result';
 import { mount, shallow } from 'enzyme';
-import { Link } from 'office-ui-fabric-react';
+import { DetailsList, Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
 describe('TabStopsRequirementInstancesCollapsibleContent', () => {
     let onEditButtonClickedMock: IMock<(requirementId: string) => void>;
     let onRemoveButtonClickedMock: IMock<(requirementId: string) => void>;
-    let props;
+    let props: TabStopsRequirementInstancesCollapsibleContentProps;
+    let requirementResultInstanceStub: TabStopsRequirementResultInstance;
 
     beforeEach(() => {
         onEditButtonClickedMock = Mock.ofType<(requirementId: string) => void>();
@@ -21,11 +26,28 @@ describe('TabStopsRequirementInstancesCollapsibleContent', () => {
             onEditButtonClicked: onEditButtonClickedMock.object,
             onRemoveButtonClicked: onRemoveButtonClickedMock.object,
         };
+
+        requirementResultInstanceStub = {
+            id: 'test-requirement-id',
+            description: 'test requirement description',
+        };
     });
 
     it('renders', () => {
         const wrapper = shallow(<TabStopsRequirementInstancesCollapsibleContent {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('renders captured instance details column', () => {
+        const testSubject = shallow(<TabStopsRequirementInstancesCollapsibleContent {...props} />);
+        const columns = testSubject.find(DetailsList).props().columns;
+        expect(columns[0].onRender(requirementResultInstanceStub)).toMatchSnapshot();
+    });
+
+    test('renders captured instance icons column', () => {
+        const testSubject = shallow(<TabStopsRequirementInstancesCollapsibleContent {...props} />);
+        const columns = testSubject.find(DetailsList).props().columns;
+        expect(columns[1].onRender(requirementResultInstanceStub)).toMatchSnapshot();
     });
 
     test('click events pass through as expected', () => {

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-requirements-with-instances.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-requirements-with-instances.test.tsx
@@ -3,6 +3,7 @@
 
 import { CollapsibleComponentCardsProps } from 'common/components/cards/collapsible-component-cards';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 import {
     TabStopsRequirementsWithInstances,
@@ -11,17 +12,24 @@ import {
 } from 'DetailsView/tab-stops-requirements-with-instances';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { IMock, Mock } from 'typemoq';
 
 describe('TabStopsRequirementsWithInstances', () => {
+    let tabStopsFailedCounterMock: IMock<TabStopsFailedCounter>;
     const CollapsibleControlStub = getCollapsibleControlStub();
-    const depsStub = {
-        collapsibleControl: (props: CollapsibleComponentCardsProps) => (
-            <CollapsibleControlStub {...props} />
-        ),
-    } as TabStopsRequirementsWithInstancesDeps;
+    let depsStub = {} as TabStopsRequirementsWithInstancesDeps;
     let props = {} as TabStopsRequirementsWithInstancesProps;
 
     beforeEach(() => {
+        tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
+
+        depsStub = {
+            collapsibleControl: (props: CollapsibleComponentCardsProps) => (
+                <CollapsibleControlStub {...props} />
+            ),
+            tabStopsFailedCounter: tabStopsFailedCounterMock.object,
+        } as TabStopsRequirementsWithInstancesDeps;
+
         props = {
             deps: depsStub,
             headingLevel: 3,

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-requirements-with-instances.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-requirements-with-instances.test.tsx
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { CollapsibleComponentCardsProps } from 'common/components/cards/collapsible-component-cards';
+import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
+import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
+import {
+    TabStopsRequirementsWithInstances,
+    TabStopsRequirementsWithInstancesDeps,
+    TabStopsRequirementsWithInstancesProps,
+} from 'DetailsView/tab-stops-requirements-with-instances';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('TabStopsRequirementsWithInstances', () => {
+    const CollapsibleControlStub = getCollapsibleControlStub();
+    const depsStub = {
+        collapsibleControl: (props: CollapsibleComponentCardsProps) => (
+            <CollapsibleControlStub {...props} />
+        ),
+    } as TabStopsRequirementsWithInstancesDeps;
+    let props = {} as TabStopsRequirementsWithInstancesProps;
+
+    beforeEach(() => {
+        props = {
+            deps: depsStub,
+            headingLevel: 3,
+            results: [
+                {
+                    id: 'keyboard-navigation',
+                    description: 'test requirement description 1',
+                    name: 'test requirement name 1',
+                    instances: [{ id: 'test-id-1', description: 'test desc 1' }],
+                    isExpanded: false,
+                },
+                {
+                    id: 'keybaord-traps',
+                    description: 'test requirement description 2',
+                    name: 'test requirement name 2',
+                    instances: [{ id: 'test-id-2', description: 'test desc 2' }],
+                    isExpanded: false,
+                },
+            ] as TabStopsRequirementResult[],
+        } as TabStopsRequirementsWithInstancesProps;
+    });
+
+    it('renders', () => {
+        const wrapped = shallow(<TabStopsRequirementsWithInstances {...props} />);
+
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+
+    function getCollapsibleControlStub(): ReactFCWithDisplayName<CollapsibleComponentCardsProps> {
+        return NamedFC<CollapsibleComponentCardsProps>('CollapsibleControlStub', _ => null);
+    }
+});

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-requirements-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-requirements-table.test.tsx
@@ -79,7 +79,7 @@ describe('TabStopsRequirementsTable', () => {
         renderedProps.onAddFailureInstanceClicked(eventStub);
 
         tabStopsRequirementActionMessageCreatorMock.verify(
-            m => m.undoStatusForRequirement(actualRequirement.id),
+            m => m.resetStatusForRequirement(actualRequirement.id),
             Times.once(),
         );
         tabStopsRequirementActionMessageCreatorMock.verify(

--- a/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
@@ -5,6 +5,8 @@ import {
     UpdateTabStopInstancePayload,
     RemoveTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
+    ResetTabStopRequirementStatusPayload,
+    ToggleTabStopRequirementExpandPayload,
 } from 'background/actions/action-payloads';
 import { TabStopRequirementActionCreator } from 'background/actions/tab-stop-requirement-action-creator';
 import { TabStopRequirementActions } from 'background/actions/tab-stop-requirement-actions';
@@ -57,6 +59,39 @@ describe('TabStopRequirementActionCreator', () => {
             handler =>
                 handler.publishTelemetry(
                     TelemetryEvents.UPDATE_TABSTOPS_REQUIREMENT_STATUS,
+                    payload,
+                ),
+            Times.once(),
+        );
+    });
+
+    test('registerCallback for reset tab stops requirement status', () => {
+        const actionName = 'resetTabStopRequirementStatus';
+        const payload: ResetTabStopRequirementStatusPayload = {
+            requirementId: requirementId,
+        };
+
+        const resetTabStopRequirementStatusMock = createActionMock(payload);
+
+        const actionsMock = createActionsMock(actionName, resetTabStopRequirementStatusMock.object);
+        const interpreterMock = createInterpreterMock(
+            Messages.Visualizations.TabStops.ResetTabStopsRequirementStatus,
+            payload,
+        );
+
+        const testSubject = new TabStopRequirementActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        resetTabStopRequirementStatusMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler =>
+                handler.publishTelemetry(
+                    TelemetryEvents.RESET_TABSTOPS_REQUIREMENT_STATUS,
                     payload,
                 ),
             Times.once(),
@@ -135,6 +170,31 @@ describe('TabStopRequirementActionCreator', () => {
                 ),
             Times.once(),
         );
+    });
+
+    test('registerCallback for on requirement expansion toggled', () => {
+        const actionName = 'toggleTabStopRequirementExpand';
+        const payload: ToggleTabStopRequirementExpandPayload = {
+            requirementId: requirementId,
+        };
+
+        const onRequirementExpansionToggledMock = createActionMock(payload);
+
+        const actionsMock = createActionsMock(actionName, onRequirementExpansionToggledMock.object);
+        const interpreterMock = createInterpreterMock(
+            Messages.Visualizations.TabStops.RequirementExpansionToggled,
+            payload,
+        );
+
+        const testSubject = new TabStopRequirementActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        onRequirementExpansionToggledMock.verifyAll();
     });
 
     test('registerCallback for remove tab stops requirement instance', () => {

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -418,6 +418,7 @@ describe('VisualizationScanResultStoreTest', () => {
             'keyboard-navigation': {
                 status: 'pass',
                 instances: [],
+                isExpanded: false,
             },
         };
 
@@ -442,6 +443,7 @@ describe('VisualizationScanResultStoreTest', () => {
             'keyboard-navigation': {
                 status: 'unknown',
                 instances: [{ description: 'test1', id: 'abc' }],
+                isExpanded: false,
             },
         };
 
@@ -468,6 +470,7 @@ describe('VisualizationScanResultStoreTest', () => {
                     { description: 'test1', id: 'abc' },
                     { description: 'test3', id: 'xyz' },
                 ],
+                isExpanded: false,
             },
         };
 
@@ -501,6 +504,7 @@ describe('VisualizationScanResultStoreTest', () => {
                     { description: 'test1', id: 'abc' },
                     { description: 'test3', id: 'xyz' },
                 ],
+                isExpanded: false,
             },
         };
 

--- a/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
@@ -4,7 +4,6 @@ import {
     CardsCollapsibleControl,
     CollapsibleComponentCardsProps,
 } from 'common/components/cards/collapsible-component-cards';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { shallow } from 'enzyme';
 import { forOwn } from 'lodash';
 import * as React from 'react';
@@ -15,7 +14,6 @@ import { SetFocusVisibility } from 'types/set-focus-visibility';
 describe('CollapsibleComponentCardsTest', () => {
     const eventStubFactory = new EventStubFactory();
 
-    let cardSelectionMessageCreatorMock: IMock<CardSelectionMessageCreator>;
     let setFocusVisibilityMock: IMock<SetFocusVisibility>;
     let onExpandToggleMock: IMock<(event: React.MouseEvent<HTMLDivElement>) => void>;
     let clickEventMock: IMock<React.MouseEvent<HTMLDivElement>>;
@@ -36,7 +34,6 @@ describe('CollapsibleComponentCardsTest', () => {
     beforeEach(() => {
         onExpandToggleMock = Mock.ofType<(event: React.MouseEvent<HTMLDivElement>) => void>();
         clickEventMock = Mock.ofType<React.MouseEvent<HTMLDivElement>>();
-        cardSelectionMessageCreatorMock = Mock.ofType(CardSelectionMessageCreator);
         setFocusVisibilityMock = Mock.ofType<SetFocusVisibility>();
         partialProps.deps = {
             setFocusVisibility: setFocusVisibilityMock.object,
@@ -59,7 +56,7 @@ describe('CollapsibleComponentCardsTest', () => {
                 const control = CardsCollapsibleControl(props);
                 const result = shallow(control);
                 expect(result.getElement()).toMatchSnapshot();
-                cardSelectionMessageCreatorMock.verifyAll();
+                onExpandToggleMock.verifyAll();
             });
         });
     });
@@ -80,7 +77,7 @@ describe('CollapsibleComponentCardsTest', () => {
         button.simulate('click', clickEventMock.object);
         expect(result.getElement()).toMatchSnapshot('collapsed');
 
-        cardSelectionMessageCreatorMock.verifyAll();
+        onExpandToggleMock.verifyAll();
     });
 
     describe('set focus visibility when expanding/collapsing', () => {


### PR DESCRIPTION
#### Details

This adds the failed instances section to the new tab stops details view. It renders only when a failed instance is added, and defaults to collapsed state.

![Screenshot 2021-11-03 100952](https://user-images.githubusercontent.com/13286385/140170941-7f994946-ae36-4560-b88d-be1facfe21c3.png)

##### Motivation

Feature work

##### Context

The actions from within the collapsible content (edit/delete) will be wired up in a future PR. We also decided to save the expanded/collapsed state for consistency with assessment and reports.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
