### PR TITLE
fix: Make table headers labels smaller, reword instructions

### DIFF
--- a/src/assessments/semantics/test-steps/headers-attribute.tsx
+++ b/src/assessments/semantics/test-steps/headers-attribute.tsx
@@ -3,7 +3,6 @@
 import { AnalyzerConfigurationFactory } from 'assessments/common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from 'assessments/common/assisted-test-record-your-results';
 import { onRenderSnippetColumn } from 'assessments/common/element-column-renderers';
-import { ReportInstanceField } from 'assessments/types/report-instance-field';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/semantics/headers-attribute';
@@ -36,8 +35,8 @@ const headersAttributeHowToTest: JSX.Element = (
             </li>
 
             <li>
-                If a table has <Markup.CodeTerm>headers</Markup.CodeTerm> attributes, verify that
-                they are coded correctly:
+                If a table has <Markup.CodeTerm>headers</Markup.CodeTerm> attributes, inspect the
+                page's HTML to verify that the header and data cells are coded correctly:
                 <ol>
                     <li>
                         Each header cell (<Markup.Tag tagName="th" /> element) must have an{' '}
@@ -52,8 +51,10 @@ const headersAttributeHowToTest: JSX.Element = (
                         reference all cells that function as headers for that data cell.
                     </li>
                 </ol>
-                Note: If a <Markup.CodeTerm>headers</Markup.CodeTerm> attribute references an
-                element that is missing or invalid, it will fail an automated check.
+                <Markup.Emphasis>
+                    Note: If a <Markup.CodeTerm>headers</Markup.CodeTerm> attribute references an
+                    element that is missing or invalid, it will fail an automated check.
+                </Markup.Emphasis>
             </li>
             <AssistedTestRecordYourResults />
         </ol>
@@ -80,7 +81,6 @@ export const HeadersAttribute: Requirement = {
         ),
     getDrawer: provider => provider.createTableHeaderAttributeDrawer(),
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
-    reportInstanceFields: [ReportInstanceField.fromSnippet('element', 'Element')],
     columnsConfig: [
         {
             key: 'element',

--- a/src/injected/visualization/table-headers-formatter.ts
+++ b/src/injected/visualization/table-headers-formatter.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { isEmpty } from 'lodash';
 import { DialogRenderer } from '../dialog-renderer';
 import { AssessmentVisualizationInstance } from '../frameCommunicators/html-element-axe-results-helper';
 import { FailureInstanceFormatter } from './failure-instance-formatter';
@@ -30,7 +29,7 @@ export class TableHeadersAttributeFormatter extends FailureInstanceFormatter {
             fontColor: '#FFFFFF',
         };
 
-        const text = isHeader ? this.getTextForHeader(element) : this.getTextForCell(element);
+        const text = isHeader ? 'th' : 'td';
 
         return {
             textBoxConfig: {
@@ -44,25 +43,5 @@ export class TableHeadersAttributeFormatter extends FailureInstanceFormatter {
             textAlign: 'right',
             failureBoxConfig: this.getFailureBoxConfig(data),
         };
-    }
-
-    private getTextForHeader(element: HTMLElement): string {
-        const idText = `id="${this.getAttribute(element, 'id')}"`;
-        const headersAttr = this.getAttribute(element, 'headers');
-        const headersText = headersAttr === null ? null : `headers="${headersAttr}"`;
-
-        return ['th', idText, headersText].filter(str => !isEmpty(str)).join(' ');
-    }
-
-    private getTextForCell(element: HTMLElement): string {
-        const headersAttr = this.getAttribute(element, 'headers');
-        const headersText = headersAttr === null ? null : `headers="${headersAttr}"`;
-
-        return ['td', headersText].filter(str => !isEmpty(str)).join(' ');
-    }
-
-    private getAttribute(element: HTMLElement, attrName: string): string {
-        const attr = element.attributes.getNamedItem(attrName);
-        return attr ? attr.textContent : null;
     }
 }

--- a/src/tests/unit/tests/injected/visualization/__snapshots__/table-headers-formatter.test.ts.snap
+++ b/src/tests/unit/tests/injected/visualization/__snapshots__/table-headers-formatter.test.ts.snap
@@ -10,7 +10,7 @@ Object {
   "textBoxConfig": Object {
     "background": "#6600CC",
     "fontColor": "#FFFFFF",
-    "text": "td headers=\\"headers\\"",
+    "text": "td",
   },
 }
 `;
@@ -25,7 +25,7 @@ Object {
   "textBoxConfig": Object {
     "background": "#6600CC",
     "fontColor": "#FFFFFF",
-    "text": "td headers=\\"headers\\"",
+    "text": "td",
   },
 }
 `;
@@ -40,7 +40,7 @@ Object {
   "textBoxConfig": Object {
     "background": "#0066CC",
     "fontColor": "#FFFFFF",
-    "text": "th id=\\"id\\" headers=\\"headers\\"",
+    "text": "th",
   },
 }
 `;
@@ -55,7 +55,7 @@ Object {
   "textBoxConfig": Object {
     "background": "#0066CC",
     "fontColor": "#FFFFFF",
-    "text": "th id=\\"id\\"",
+    "text": "th",
   },
 }
 `;


### PR DESCRIPTION
#### Details

This PR de-crowds the labeling in the target page. Now, only the text "th" or "td" is displayed by the visual helper. This makes the visual helper still useful with tightly-spaced data tables. This PR also removes the "element" line of this section of the report, since it was duplicating the exact information already listed under "snippet."

##### Motivation

Addresses issue #4027 

##### Context

Considered the suggestion to add all <th> elements to the instances list.  Modified the instructions instead, which achieves the same effect with less clutter on the page. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4027
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS

![overlap 1](https://user-images.githubusercontent.com/33770444/140428002-75bf7cfa-f267-4a5d-8bdc-39a758723414.jpg)
Image showing table with smaller labels highlighting two of the table elements; labels are all fully legible and at most, cover the element they are labeling, not the surrounding elements any more.  

![overlap 2](https://user-images.githubusercontent.com/33770444/140428010-7d0be62f-3720-4586-b4e7-4a8ff28aa8c4.jpg)
Image showing same story as previous image, but with three table elements highlighted. 

![all on](https://user-images.githubusercontent.com/33770444/140428017-134c3610-5893-41d9-828a-fee21ff81a51.jpg)
Image with visual helper turned on for all elements in table; all labels are individually visible.  

![report](https://user-images.githubusercontent.com/33770444/140428025-86547906-130b-46b3-93b7-fc1cfaed2f73.jpg)
Image showing the report, now with only "Path" and "Snippet" underneath the Semantics heading. (No "Element" with the same information as "Snippet" anymore.)

![image](https://user-images.githubusercontent.com/33770444/140429835-d5412308-816c-43f2-b0d5-3531dee9cb06.png)
Screenshot of the updated "How to test" guidance with differences (instruction number two, and italics used for the note) highlighted.