### PR TITLE
feat(tab-stops-details-view): Wire up remove instance button

### DIFF
--- a/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
+++ b/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
@@ -13,12 +13,14 @@ import {
     Link,
 } from 'office-ui-fabric-react';
 import * as React from 'react';
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 import * as styles from './tab-stops-requirement-instances-collapsible-content.scss';
 
 export type TabStopsRequirementInstancesCollapsibleContentProps = {
+    requirementId: TabStopRequirementId;
     instances: TabStopsRequirementResultInstance[];
-    onEditButtonClicked: (requirementId: string) => void;
-    onRemoveButtonClicked: (requirementId: string) => void;
+    onEditButtonClicked: (instanceId: string) => void;
+    onRemoveButtonClicked: (requirementId: TabStopRequirementId, instanceId: string) => void;
 };
 export const TabStopsRequirementInstancesCollapsibleContent =
     NamedFC<TabStopsRequirementInstancesCollapsibleContentProps>(
@@ -50,7 +52,9 @@ export const TabStopsRequirementInstancesCollapsibleContent =
                         </Link>
                         <Link
                             className={styles.removeButton}
-                            onClick={() => props.onRemoveButtonClicked(instance.id)}
+                            onClick={() =>
+                                props.onRemoveButtonClicked(props.requirementId, instance.id)
+                            }
                         >
                             <Icon iconName="delete" ariaLabel={'delete instance'} />
                         </Link>

--- a/src/DetailsView/tab-stops-requirements-with-instances.tsx
+++ b/src/DetailsView/tab-stops-requirements-with-instances.tsx
@@ -93,13 +93,16 @@ export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWit
                         results,
                         requirement.id,
                     );
+
+                    if (count === 0) {
+                        return null;
+                    }
+
                     const buttonAriaLabel = `${requirement.id} ${count} ${pastTense} ${requirement.description}`;
                     const CollapsibleComponent = deps.collapsibleControl(
                         getCollapsibleComponentProps(requirement, idx, buttonAriaLabel),
                     );
-                    if (count === 0) {
-                        return null;
-                    }
+
                     return CollapsibleComponent;
                 })}
             </div>

--- a/src/DetailsView/tab-stops-requirements-with-instances.tsx
+++ b/src/DetailsView/tab-stops-requirements-with-instances.tsx
@@ -12,6 +12,7 @@ import { TabStopsRequirementInstancesCollapsibleContent } from 'DetailsView/tab-
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 import * as React from 'react';
 import { outcomeTypeSemantics } from 'reports/components/outcome-type';
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 
 import * as styles from './tab-stops-requirements-with-instances.scss';
 
@@ -32,8 +33,14 @@ export type TabStopsRequirementsWithInstancesProps = {
 export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWithInstancesProps>(
     'TabStopsRequirementsWithInstances',
     ({ results, deps, headingLevel }) => {
-        const onInstanceRemoveButtonClicked = (requirementId: string) => {
-            console.log('remove ' + requirementId);
+        const onInstanceRemoveButtonClicked = (
+            requirementId: TabStopRequirementId,
+            instanceId: string,
+        ) => {
+            deps.tabStopRequirementActionMessageCreator.removeTabStopInstance(
+                requirementId,
+                instanceId,
+            );
         };
         const onInstanceEditButtonClicked = (requirementId: string) => {
             console.log('edit ' + requirementId);
@@ -57,6 +64,7 @@ export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWit
                 content: (
                     <TabStopsRequirementInstancesCollapsibleContent
                         key={`${result.id}-requirement-group`}
+                        requirementId={result.id}
                         instances={result.instances}
                         onEditButtonClicked={onInstanceEditButtonClicked}
                         onRemoveButtonClicked={onInstanceRemoveButtonClicked}
@@ -89,6 +97,9 @@ export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWit
                     const CollapsibleComponent = deps.collapsibleControl(
                         getCollapsibleComponentProps(requirement, idx, buttonAriaLabel),
                     );
+                    if (count === 0) {
+                        return null;
+                    }
                     return CollapsibleComponent;
                 })}
             </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`TabStopsRequirementInstancesCollapsibleContent renders 1`] = `
     Array [
       Object {
         "description": "test-description",
-        "id": "test-requirement-id",
+        "id": "test-instance-id",
       },
     ]
   }
@@ -46,7 +46,7 @@ exports[`TabStopsRequirementInstancesCollapsibleContent renders captured instanc
   background="#767676"
   headerText="Comment:"
   textContent="test requirement description"
-  tooltipId="test-requirement-id"
+  tooltipId="test-instance-id"
 />
 `;
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TabStopsRequirementsWithInstances renders 1`] = `
+exports[`TabStopsRequirementsWithInstances renders empty div when instance count === 0 1`] = `<div />`;
+
+exports[`TabStopsRequirementsWithInstances renders when instance count > 0 1`] = `
 <div>
   <CollapsibleControlStub
-    buttonAriaLabel="keyboard-navigation undefined Failed test requirement description 1"
+    buttonAriaLabel="keyboard-navigation 2 Failed test requirement description 1"
     containerAutomationId="tab-stops-results-group"
     containerClassName="collapsibleRequirementDetailsGroup"
     content={
@@ -18,11 +20,18 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
         }
         onEditButtonClicked={[Function]}
         onRemoveButtonClicked={[Function]}
+        requirementId="keyboard-navigation"
       />
     }
     deps={
       Object {
         "collapsibleControl": [Function],
+        "tabStopRequirementActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "telemetryFactory": undefined,
+          "toggleTabStopRequirementExpand": [Function],
+        },
         "tabStopsFailedCounter": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "getFailedByRequirementId": [Function],
@@ -35,6 +44,12 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
         deps={
           Object {
             "collapsibleControl": [Function],
+            "tabStopRequirementActionMessageCreator": proxy {
+              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "dispatcher": undefined,
+              "telemetryFactory": undefined,
+              "toggleTabStopRequirementExpand": [Function],
+            },
             "tabStopsFailedCounter": proxy {
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
               "getFailedByRequirementId": [Function],
@@ -64,7 +79,7 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
     onExpandToggle={[Function]}
   />
   <CollapsibleControlStub
-    buttonAriaLabel="keybaord-traps undefined Failed test requirement description 2"
+    buttonAriaLabel="keyboard-traps 2 Failed test requirement description 2"
     containerAutomationId="tab-stops-results-group"
     containerClassName="collapsibleRequirementDetailsGroup"
     content={
@@ -79,11 +94,18 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
         }
         onEditButtonClicked={[Function]}
         onRemoveButtonClicked={[Function]}
+        requirementId="keyboard-traps"
       />
     }
     deps={
       Object {
         "collapsibleControl": [Function],
+        "tabStopRequirementActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "telemetryFactory": undefined,
+          "toggleTabStopRequirementExpand": [Function],
+        },
         "tabStopsFailedCounter": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "getFailedByRequirementId": [Function],
@@ -96,6 +118,12 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
         deps={
           Object {
             "collapsibleControl": [Function],
+            "tabStopRequirementActionMessageCreator": proxy {
+              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "dispatcher": undefined,
+              "telemetryFactory": undefined,
+              "toggleTabStopRequirementExpand": [Function],
+            },
             "tabStopsFailedCounter": proxy {
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
               "getFailedByRequirementId": [Function],
@@ -106,7 +134,7 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
         requirement={
           Object {
             "description": "test requirement description 2",
-            "id": "keybaord-traps",
+            "id": "keyboard-traps",
             "instances": Array [
               Object {
                 "description": "test desc 2",
@@ -120,7 +148,7 @@ exports[`TabStopsRequirementsWithInstances renders 1`] = `
       />
     }
     headingLevel={3}
-    id="keybaord-traps"
+    id="keyboard-traps"
     isExpanded={false}
     onExpandToggle={[Function]}
   />

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
@@ -10,25 +10,30 @@ import { mount, shallow } from 'enzyme';
 import { DetailsList, Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 
 describe('TabStopsRequirementInstancesCollapsibleContent', () => {
-    let onEditButtonClickedMock: IMock<(requirementId: string) => void>;
-    let onRemoveButtonClickedMock: IMock<(requirementId: string) => void>;
+    let onEditButtonClickedMock: IMock<(instanceId: string) => void>;
+    let onRemoveButtonClickedMock: IMock<
+        (requirementId: TabStopRequirementId, instanceId: string) => void
+    >;
     let props: TabStopsRequirementInstancesCollapsibleContentProps;
     let requirementResultInstanceStub: TabStopsRequirementResultInstance;
 
     beforeEach(() => {
-        onEditButtonClickedMock = Mock.ofType<(requirementId: string) => void>();
-        onRemoveButtonClickedMock = Mock.ofType<(requirementId: string) => void>();
+        onEditButtonClickedMock = Mock.ofType<(instanceId: string) => void>();
+        onRemoveButtonClickedMock =
+            Mock.ofType<(requirementId: TabStopRequirementId, instanceId: string) => void>();
 
         props = {
-            instances: [{ id: 'test-requirement-id', description: 'test-description' }],
+            requirementId: 'keyboard-navigation',
+            instances: [{ id: 'test-instance-id', description: 'test-description' }],
             onEditButtonClicked: onEditButtonClickedMock.object,
             onRemoveButtonClicked: onRemoveButtonClickedMock.object,
         };
 
         requirementResultInstanceStub = {
-            id: 'test-requirement-id',
+            id: 'test-instance-id',
             description: 'test requirement description',
         };
     });
@@ -51,10 +56,13 @@ describe('TabStopsRequirementInstancesCollapsibleContent', () => {
     });
 
     test('click events pass through as expected', () => {
-        onEditButtonClickedMock.setup(ebc => ebc('test-requirement-id')).verifiable(Times.once());
-        onRemoveButtonClickedMock.setup(rbc => rbc('test-requirement-id')).verifiable(Times.once());
+        onEditButtonClickedMock.setup(ebc => ebc('test-instance-id')).verifiable(Times.once());
+        onRemoveButtonClickedMock
+            .setup(rbc => rbc(props.requirementId, 'test-instance-id'))
+            .verifiable(Times.once());
         const testSubject = mount(
             <TabStopsRequirementInstancesCollapsibleContent
+                requirementId={props.requirementId}
                 instances={props.instances}
                 onEditButtonClicked={onEditButtonClickedMock.object}
                 onRemoveButtonClicked={onRemoveButtonClickedMock.object}

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-requirements-with-instances.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-requirements-with-instances.test.tsx
@@ -3,6 +3,7 @@
 
 import { CollapsibleComponentCardsProps } from 'common/components/cards/collapsible-component-cards';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 import {
@@ -12,22 +13,28 @@ import {
 } from 'DetailsView/tab-stops-requirements-with-instances';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, Mock } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('TabStopsRequirementsWithInstances', () => {
     let tabStopsFailedCounterMock: IMock<TabStopsFailedCounter>;
+    let tabStopsRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
     const CollapsibleControlStub = getCollapsibleControlStub();
     let depsStub = {} as TabStopsRequirementsWithInstancesDeps;
     let props = {} as TabStopsRequirementsWithInstancesProps;
 
     beforeEach(() => {
         tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
+        tabStopsRequirementActionMessageCreatorMock = Mock.ofType(
+            TabStopRequirementActionMessageCreator,
+        );
 
         depsStub = {
             collapsibleControl: (props: CollapsibleComponentCardsProps) => (
                 <CollapsibleControlStub {...props} />
             ),
             tabStopsFailedCounter: tabStopsFailedCounterMock.object,
+            tabStopRequirementActionMessageCreator:
+                tabStopsRequirementActionMessageCreatorMock.object,
         } as TabStopsRequirementsWithInstancesDeps;
 
         props = {
@@ -42,7 +49,7 @@ describe('TabStopsRequirementsWithInstances', () => {
                     isExpanded: false,
                 },
                 {
-                    id: 'keybaord-traps',
+                    id: 'keyboard-traps',
                     description: 'test requirement description 2',
                     name: 'test requirement name 2',
                     instances: [{ id: 'test-id-2', description: 'test desc 2' }],
@@ -52,10 +59,32 @@ describe('TabStopsRequirementsWithInstances', () => {
         } as TabStopsRequirementsWithInstancesProps;
     });
 
-    it('renders', () => {
-        const wrapped = shallow(<TabStopsRequirementsWithInstances {...props} />);
+    it('renders when instance count > 0', () => {
+        tabStopsFailedCounterMock
+            .setup(m => m.getFailedByRequirementId(It.isAny(), It.isAny()))
+            .returns(() => 2);
+        const wrapper = shallow(<TabStopsRequirementsWithInstances {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
 
-        expect(wrapped.getElement()).toMatchSnapshot();
+    it('renders empty div when instance count === 0', () => {
+        tabStopsFailedCounterMock
+            .setup(m => m.getFailedByRequirementId(It.isAny(), It.isAny()))
+            .returns(() => 0);
+        const wrapper = shallow(<TabStopsRequirementsWithInstances {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('onRemoveInstanceButtonClicked', () => {
+        tabStopsRequirementActionMessageCreatorMock
+            .setup(m => m.removeTabStopInstance(It.isAny(), It.isAny()))
+            .verifiable(Times.once());
+
+        const wrapper = shallow(<TabStopsRequirementsWithInstances {...props} />);
+
+        wrapper.find(CollapsibleControlStub).first().props().content.props.onRemoveButtonClicked();
+
+        tabStopsRequirementActionMessageCreatorMock.verifyAll();
     });
 
     function getCollapsibleControlStub(): ReactFCWithDisplayName<CollapsibleComponentCardsProps> {


### PR DESCRIPTION
#### Details

This wires up the remove instance icon to the store. It also ensure that if no failure instances exist for a requirement that the requirement doesn't render.

##### Motivation

Feature work

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
