### PR TITLE
feat(tab-stops-details-view): add TargetPageChangedView to AdhocTabStopsTestView

### DIFF
--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -5,9 +5,11 @@ import { VisualizationToggle } from 'common/components/visualization-toggle';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { NamedFC } from 'common/react/named-fc';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { RequirementInstructions } from 'DetailsView/components/requirement-instructions';
 import * as styles from 'DetailsView/components/static-content-common.scss';
 import {
@@ -18,6 +20,7 @@ import {
     TabStopsRequirementsTable,
     TabStopsRequirementsTableDeps,
 } from 'DetailsView/components/tab-stops/tab-stops-requirements-table';
+import { TargetPageChangedView } from 'DetailsView/components/target-page-changed-view';
 import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { createFastPassProviderWithFeatureFlags } from 'fast-pass/fast-pass-provider';
 import * as React from 'react';
@@ -25,12 +28,15 @@ import { ContentLink, ContentLinkDeps } from 'views/content/content-link';
 import { ContentReference } from 'views/content/content-page';
 import * as Markup from '../../assessments/markup';
 
-export type AdhocTabStopsTestViewDeps = TabStopsRequirementsTableDeps &
+export type AdhocTabStopsTestViewDeps = {
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+} & TabStopsRequirementsTableDeps &
     TabStopsFailedInstanceSectionDeps &
     ContentLinkDeps;
 
 export interface AdhocTabStopsTestViewProps {
     deps: AdhocTabStopsTestViewDeps;
+    tabStoreData: Pick<TabStoreData, 'isChanged'>;
     configuration: VisualizationConfiguration;
     featureFlagStoreData: FeatureFlagStoreData;
     visualizationStoreData: VisualizationStoreData;
@@ -95,6 +101,19 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
             //TODO: fill this in
             console.log(requirementId);
         };
+
+        if (props.tabStoreData.isChanged) {
+            return (
+                <TargetPageChangedView
+                    displayableData={displayableData}
+                    visualizationType={selectedTest}
+                    toggleClickHandler={clickHandler}
+                    featureFlagStoreData={props.featureFlagStoreData}
+                    detailsViewActionMessageCreator={props.deps.detailsViewActionMessageCreator}
+                />
+            );
+        }
+
         return (
             <div className={styles.staticContentInDetailsView}>
                 <h1>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -146,3 +146,18 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
   />
 </div>
 `;
+
+exports[`AdhocTabStopsTestView render should return target page changed view as tab is changed 1`] = `
+<TargetPageChangedView
+  detailsViewActionMessageCreator={[Function]}
+  displayableData={
+    Object {
+      "title": "test title",
+      "toggleLabel": "test toggle label",
+    }
+  }
+  featureFlagStoreData={Object {}}
+  toggleClickHandler={[Function]}
+  visualizationType={-1}
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/components/adhoc-tab-stops-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/adhoc-tab-stops-test-view.test.tsx
@@ -86,8 +86,21 @@ describe('AdhocTabStopsTestView', () => {
             ['no guidance', null],
         ];
 
+        it('should return target page changed view as tab is changed', () => {
+            props.tabStoreData = {
+                isChanged: true,
+            };
+
+            const wrapper = shallow(<AdhocTabStopsTestView {...props} />);
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
+
         it.each(scenarios)('handles %s', (_, guidance) => {
             props.deps = 'stub-deps' as unknown as AdhocTabStopsTestViewDeps;
+
+            props.tabStoreData = {
+                isChanged: false,
+            };
 
             if (guidance) {
                 props.guidance = guidance;


### PR DESCRIPTION
#### Details

This shows the target page changed view when the target page is navigated away from. This brings the AdhocTabStopsTestView to parity with the other adhoc test views.

##### Motivation

feature work

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
