### PR TITLE
feat(tab-stops-details-view): create tab stops view store, actions, and controller

### DIFF
--- a/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
+++ b/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
 import { FailureInstanceData } from 'common/types/failure-instance-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import { Icon, Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './assessment-instance-edit-and-remove-control.scss';
-import {
-    CapturedInstanceActionType,
-    FailureInstancePanelControl,
-} from './failure-instance-panel-control';
+import { FailureInstancePanelControl } from './failure-instance-panel-control';
 
 export interface AssessmentInstanceEditAndRemoveControlProps {
     test: VisualizationType;

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -3,17 +3,20 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { FlaggedComponent } from 'common/components/flagged-component';
 import { FeatureFlags } from 'common/feature-flags';
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
 import { FailureInstanceData } from 'common/types/failure-instance-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import { clone, isEqual } from 'lodash';
-import { ActionButton } from 'office-ui-fabric-react';
-import { Icon } from 'office-ui-fabric-react';
-import { ILabelStyles } from 'office-ui-fabric-react';
-import { Link } from 'office-ui-fabric-react';
-import { ITextFieldStyles, TextField } from 'office-ui-fabric-react';
+import {
+    ActionButton,
+    Icon,
+    ILabelStyles,
+    ITextFieldStyles,
+    Link,
+    TextField,
+} from 'office-ui-fabric-react';
 import * as React from 'react';
-
 import { ActionAndCancelButtonsComponent } from './action-and-cancel-buttons-component';
 import { FailureInstancePanelDetails } from './failure-instance-panel-details';
 import * as styles from './failure-instance-panel.scss';
@@ -36,11 +39,6 @@ export interface FailureInstancePanelControlProps {
 export interface FailureInstancePanelControlState {
     isPanelOpen: boolean;
     currentInstance: FailureInstanceData;
-}
-
-export enum CapturedInstanceActionType {
-    EDIT,
-    CREATE,
 }
 
 export class FailureInstancePanelControl extends React.Component<

--- a/src/DetailsView/components/manual-test-step-view.tsx
+++ b/src/DetailsView/components/manual-test-step-view.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
 import { FailureInstanceData } from 'common/types/failure-instance-data';
 import { ManualTestStatus } from 'common/types/manual-test-status';
 import { ManualTestStepResult } from 'common/types/store-data/assessment-result-data';
@@ -11,10 +12,7 @@ import { CheckboxVisibility, ConstrainMode, DetailsList } from 'office-ui-fabric
 import * as React from 'react';
 import { DictionaryStringTo } from 'types/common-types';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
-import {
-    CapturedInstanceActionType,
-    FailureInstancePanelControl,
-} from './failure-instance-panel-control';
+import { FailureInstancePanelControl } from './failure-instance-panel-control';
 import { TestStatusChoiceGroup } from './test-status-choice-group';
 
 export interface ManualTestStepViewProps {

--- a/src/DetailsView/components/tab-stops/tab-stops-test-view-controller.ts
+++ b/src/DetailsView/components/tab-stops/tab-stops-test-view-controller.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    EditExistingFailureInstancePayload,
+    TabStopsViewActions,
+} from 'DetailsView/components/tab-stops/tab-stops-view-actions';
+
+export class TabStopsTestViewController {
+    constructor(private actions: TabStopsViewActions) {}
+
+    public createNewFailureInstancePanel: (payload: string) => void = payload =>
+        this.actions.createNewFailureInstancePanel.invoke(payload);
+
+    public editExistingFailureInstance: (payload: EditExistingFailureInstancePayload) => void =
+        payload => this.actions.editExistingFailureInstance.invoke(payload);
+
+    public dismissPanel = () => this.actions.dismissPanel.invoke();
+
+    public updateDescription: (payload: string) => void = payload =>
+        this.actions.updateDescription.invoke(payload);
+}

--- a/src/DetailsView/components/tab-stops/tab-stops-view-actions.ts
+++ b/src/DetailsView/components/tab-stops/tab-stops-view-actions.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Action } from 'common/flux/action';
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
+
+export interface EditExistingFailureInstancePayload {
+    instanceId: string;
+    requirementId: TabStopRequirementId;
+}
+
+export class TabStopsViewActions {
+    public readonly createNewFailureInstancePanel = new Action<string>();
+    public readonly editExistingFailureInstance = new Action<EditExistingFailureInstancePayload>();
+    public readonly dismissPanel = new Action<void>();
+    public readonly updateDescription = new Action<string>();
+}

--- a/src/DetailsView/components/tab-stops/tab-stops-view-store-data.ts
+++ b/src/DetailsView/components/tab-stops/tab-stops-view-store-data.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
+
+export interface FailureInstanceState {
+    isPanelOpen: boolean | null;
+    selectedRequirementId: TabStopRequirementId | null;
+    selectedInstanceId: string | null;
+    description: string | null;
+    actionType: CapturedInstanceActionType;
+}
+
+export interface TabStopsViewStoreData {
+    failureInstanceState: FailureInstanceState;
+}

--- a/src/DetailsView/components/tab-stops/tab-stops-view-store.ts
+++ b/src/DetailsView/components/tab-stops/tab-stops-view-store.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BaseStoreImpl } from 'background/stores/base-store-impl';
+import { StoreNames } from 'common/stores/store-names';
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
+import {
+    EditExistingFailureInstancePayload,
+    TabStopsViewActions,
+} from 'DetailsView/components/tab-stops/tab-stops-view-actions';
+import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
+
+export class TabStopsViewStore extends BaseStoreImpl<TabStopsViewStoreData> {
+    public constructor(private tabStopsViewActions: TabStopsViewActions) {
+        super(StoreNames.TabStopsViewStore);
+    }
+
+    public getDefaultState(): TabStopsViewStoreData {
+        const defaultState: TabStopsViewStoreData = {
+            failureInstanceState: {
+                isPanelOpen: false,
+                description: null,
+                selectedInstanceId: null,
+                selectedRequirementId: null,
+                actionType: CapturedInstanceActionType.CREATE,
+            },
+        };
+
+        return defaultState;
+    }
+
+    public addActionListeners(): void {
+        this.tabStopsViewActions.createNewFailureInstancePanel.addListener(
+            this.onCreateNewFailureInstancePanel,
+        );
+        this.tabStopsViewActions.editExistingFailureInstance.addListener(
+            this.onEditExistingFailureInstance,
+        );
+        this.tabStopsViewActions.updateDescription.addListener(this.onUpdateDescription);
+        this.tabStopsViewActions.dismissPanel.addListener(this.onDismissPanel);
+    }
+
+    private onCreateNewFailureInstancePanel = (requirementId: TabStopRequirementId) => {
+        this.state.failureInstanceState.isPanelOpen = true;
+        this.state.failureInstanceState.selectedRequirementId = requirementId;
+        this.state.failureInstanceState.actionType = CapturedInstanceActionType.CREATE;
+        this.emitChanged();
+    };
+
+    private onEditExistingFailureInstance = (payload: EditExistingFailureInstancePayload) => {
+        this.state.failureInstanceState.isPanelOpen = true;
+        this.state.failureInstanceState.selectedRequirementId = payload.requirementId;
+        this.state.failureInstanceState.selectedInstanceId = payload.instanceId;
+        this.state.failureInstanceState.actionType = CapturedInstanceActionType.EDIT;
+        this.emitChanged();
+    };
+
+    private onDismissPanel = () => {
+        this.state.failureInstanceState = this.getDefaultState().failureInstanceState;
+        this.emitChanged();
+    };
+
+    private onUpdateDescription = (description: string) => {
+        this.state.failureInstanceState.description = description;
+        this.emitChanged();
+    };
+}

--- a/src/common/stores/store-names.ts
+++ b/src/common/stores/store-names.ts
@@ -26,4 +26,5 @@ export enum StoreNames {
     ContentPanelStore,
     DeviceConnectionStore,
     TabStopsStore,
+    TabStopsViewStore,
 }

--- a/src/common/types/captured-instance-action-type.tsx
+++ b/src/common/types/captured-instance-action-type.tsx
@@ -1,0 +1,4 @@
+export enum CapturedInstanceActionType {
+    EDIT = 'EDIT',
+    CREATE = 'CREATE',
+}

--- a/src/common/types/captured-instance-action-type.tsx
+++ b/src/common/types/captured-instance-action-type.tsx
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 export enum CapturedInstanceActionType {
     EDIT = 'EDIT',
     CREATE = 'CREATE',

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
@@ -1,20 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as styles from 'DetailsView/components/assessment-instance-edit-and-remove-control.scss';
-import { Icon, Link } from 'office-ui-fabric-react';
-import * as React from 'react';
-import { Mock, Times } from 'typemoq';
-import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
 import {
     AssessmentInstanceEditAndRemoveControl,
     AssessmentInstanceEditAndRemoveControlProps,
-} from '../../../../../DetailsView/components/assessment-instance-edit-and-remove-control';
-import {
-    CapturedInstanceActionType,
-    FailureInstancePanelControl,
-} from '../../../../../DetailsView/components/failure-instance-panel-control';
-import { CreateTestAssessmentProvider } from '../../../common/test-assessment-provider';
+} from 'DetailsView/components/assessment-instance-edit-and-remove-control';
+import * as styles from 'DetailsView/components/assessment-instance-edit-and-remove-control.scss';
+import { FailureInstancePanelControl } from 'DetailsView/components/failure-instance-panel-control';
+import { Icon, Link } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { CreateTestAssessmentProvider } from 'tests/unit/common/test-assessment-provider';
+import { Mock, Times } from 'typemoq';
 
 describe('AssessmentInstanceRemoveButton', () => {
     const featureFlagStoreData = {} as FeatureFlagStoreData;

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -1,23 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
-import { shallow } from 'enzyme';
-import { ActionButton } from 'office-ui-fabric-react';
-import { TextField } from 'office-ui-fabric-react';
-import * as React from 'react';
-import { IMock, Mock, Times } from 'typemoq';
-
-import { FlaggedComponent } from '../../../../../common/components/flagged-component';
-import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { ActionAndCancelButtonsComponent } from '../../../../../DetailsView/components/action-and-cancel-buttons-component';
+import { FlaggedComponent } from 'common/components/flagged-component';
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import { ActionAndCancelButtonsComponent } from 'DetailsView/components/action-and-cancel-buttons-component';
 import {
-    CapturedInstanceActionType,
     FailureInstancePanelControl,
     FailureInstancePanelControlProps,
-} from '../../../../../DetailsView/components/failure-instance-panel-control';
-import { FailureInstancePanelDetailsProps } from '../../../../../DetailsView/components/failure-instance-panel-details';
-import { GenericPanel } from '../../../../../DetailsView/components/generic-panel';
+} from 'DetailsView/components/failure-instance-panel-control';
+import { FailureInstancePanelDetailsProps } from 'DetailsView/components/failure-instance-panel-details';
+import { GenericPanel } from 'DetailsView/components/generic-panel';
+import { shallow } from 'enzyme';
+import { ActionButton, TextField } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { IMock, Mock, Times } from 'typemoq';
 
 describe('FailureInstancePanelControlTest', () => {
     let addPathForValidationMock: IMock<(path) => void>;

--- a/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
@@ -1,24 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CheckboxVisibility, ConstrainMode, DetailsList } from 'office-ui-fabric-react';
-import * as React from 'react';
-import { Mock } from 'typemoq';
-
-import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
-import { ManualTestStepResult } from '../../../../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
-import {
-    CapturedInstanceActionType,
-    FailureInstancePanelControl,
-} from '../../../../../DetailsView/components/failure-instance-panel-control';
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
+import { ManualTestStatus } from 'common/types/manual-test-status';
+import { ManualTestStepResult } from 'common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import { FailureInstancePanelControl } from 'DetailsView/components/failure-instance-panel-control';
 import {
     ManualTestStepView,
     ManualTestStepViewProps,
-} from '../../../../../DetailsView/components/manual-test-step-view';
-import { TestStatusChoiceGroup } from '../../../../../DetailsView/components/test-status-choice-group';
-import { AssessmentInstanceTableHandler } from '../../../../../DetailsView/handlers/assessment-instance-table-handler';
-import { CreateTestAssessmentProvider } from '../../../common/test-assessment-provider';
+} from 'DetailsView/components/manual-test-step-view';
+import { TestStatusChoiceGroup } from 'DetailsView/components/test-status-choice-group';
+import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
+import { CheckboxVisibility, ConstrainMode, DetailsList } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { CreateTestAssessmentProvider } from 'tests/unit/common/test-assessment-provider';
+import { Mock } from 'typemoq';
 
 describe('ManualTestStepView', () => {
     const featureFlagStoreData = {} as FeatureFlagStoreData;

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-test-view-controller.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-test-view-controller.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Action } from 'common/flux/action';
+import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
+import {
+    EditExistingFailureInstancePayload,
+    TabStopsViewActions,
+} from 'DetailsView/components/tab-stops/tab-stops-view-actions';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
+describe('TabStopsTestViewController', () => {
+    let testSubject: TabStopsTestViewController;
+    let tabStopActionsMock: IMock<TabStopsViewActions>;
+
+    test('createNewFailureInstancePanel', () => {
+        const payload = 'some string';
+        tabStopActionsMock = createActionsMock('createNewFailureInstancePanel');
+        testSubject = new TabStopsTestViewController(tabStopActionsMock.object);
+
+        testSubject.createNewFailureInstancePanel(payload);
+
+        tabStopActionsMock.verify(
+            m => m.createNewFailureInstancePanel.invoke(payload),
+            Times.once(),
+        );
+    });
+
+    test('updateDescription', () => {
+        const payload = 'some string';
+        tabStopActionsMock = createActionsMock('updateDescription');
+        testSubject = new TabStopsTestViewController(tabStopActionsMock.object);
+
+        testSubject.updateDescription(payload);
+
+        tabStopActionsMock.verify(m => m.updateDescription.invoke(payload), Times.once());
+    });
+
+    test('dismissPanel', () => {
+        tabStopActionsMock = createActionsMock('dismissPanel');
+        testSubject = new TabStopsTestViewController(tabStopActionsMock.object);
+
+        testSubject.dismissPanel();
+
+        tabStopActionsMock.verify(m => m.dismissPanel.invoke(), Times.once());
+    });
+
+    test('editExistingFailureInstance', () => {
+        const payload = {} as EditExistingFailureInstancePayload;
+        tabStopActionsMock = createActionsMock('editExistingFailureInstance');
+        testSubject = new TabStopsTestViewController(tabStopActionsMock.object);
+
+        testSubject.editExistingFailureInstance(payload);
+
+        tabStopActionsMock.verify(m => m.editExistingFailureInstance.invoke(payload), Times.once());
+    });
+
+    function createActionsMock(actionName: keyof TabStopsViewActions): IMock<TabStopsViewActions> {
+        const actionMock = createActionMock();
+
+        const actionsMock = Mock.ofType(TabStopsViewActions, MockBehavior.Loose);
+        actionsMock.setup(a => a[actionName as string]).returns(() => actionMock.object);
+
+        return actionsMock;
+    }
+
+    function createActionMock(): IMock<Action<unknown>> {
+        const actionMock = Mock.ofType(Action);
+
+        actionMock
+            .setup(a => a.addListener(It.is(param => param instanceof Function)))
+            .callback(listener => (this.listener = listener));
+
+        return actionMock;
+    }
+});

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-view-store.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-view-store.test.ts
@@ -90,10 +90,6 @@ describe(TabStopsViewStore, () => {
             .testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onCreateNewFailureInstancePanel', () => {});
-
-    test('onCreateNewFailureInstancePanel', () => {});
-
     function getDefaultState(): TabStopsViewStoreData {
         return createStoreWithNullParams(TabStopsViewStore).getDefaultState();
     }

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-view-store.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-view-store.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { StoreNames } from 'common/stores/store-names';
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
+import {
+    TabStopsViewActions,
+    EditExistingFailureInstancePayload,
+} from 'DetailsView/components/tab-stops/tab-stops-view-actions';
+import { TabStopsViewStore } from 'DetailsView/components/tab-stops/tab-stops-view-store';
+import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
+import { createStoreWithNullParams, StoreTester } from 'tests/unit/common/store-tester';
+
+describe(TabStopsViewStore, () => {
+    test('constructor  no side effects', () => {
+        const testObject = createStoreWithNullParams(TabStopsViewStore);
+        expect(testObject).toBeDefined();
+    });
+
+    test('getId', () => {
+        const testObject = createStoreWithNullParams(TabStopsViewStore);
+        expect(testObject.getId()).toEqual(StoreNames[StoreNames.TabStopsViewStore]);
+    });
+
+    test('getDefaultState', () => {
+        const testObject = createStoreWithNullParams(TabStopsViewStore);
+        const expected: TabStopsViewStoreData = {
+            failureInstanceState: {
+                isPanelOpen: false,
+                description: null,
+                selectedInstanceId: null,
+                selectedRequirementId: null,
+                actionType: CapturedInstanceActionType.CREATE,
+            },
+        };
+        expect(testObject.getDefaultState()).toEqual(expected);
+    });
+
+    test('onDismissPanel', () => {
+        const initialState = getDefaultState();
+        initialState.failureInstanceState = {
+            isPanelOpen: true,
+            description: 'some description',
+            selectedInstanceId: 'some instance id',
+            selectedRequirementId: 'focus-indicator',
+            actionType: CapturedInstanceActionType.EDIT,
+        };
+        const finalState = getDefaultState();
+        createStoreForTabStopsViewActions('dismissPanel')
+            .withActionParam(null)
+            .testListenerToBeCalledOnce(initialState, finalState);
+    });
+
+    test('onUpdateDescription', () => {
+        const expectedDescription = 'some description';
+        const initialState = getDefaultState();
+        const finalState = getDefaultState();
+        finalState.failureInstanceState.description = expectedDescription;
+        createStoreForTabStopsViewActions('updateDescription')
+            .withActionParam(expectedDescription)
+            .testListenerToBeCalledOnce(initialState, finalState);
+    });
+
+    test('onCreateNewFailureInstancePanel', () => {
+        const requirementId = 'focus-indicator';
+        const initialState = getDefaultState();
+        const finalState = getDefaultState();
+        finalState.failureInstanceState.selectedRequirementId = requirementId;
+        finalState.failureInstanceState.isPanelOpen = true;
+        createStoreForTabStopsViewActions('createNewFailureInstancePanel')
+            .withActionParam(requirementId)
+            .testListenerToBeCalledOnce(initialState, finalState);
+    });
+
+    test('onEditExistingFailureInstance', () => {
+        const requirementId = 'focus-indicator';
+        const someInstanceId = 'some instance id';
+        const initialState = getDefaultState();
+        const finalState = getDefaultState();
+        finalState.failureInstanceState.selectedRequirementId = requirementId;
+        finalState.failureInstanceState.selectedInstanceId = someInstanceId;
+        finalState.failureInstanceState.isPanelOpen = true;
+        finalState.failureInstanceState.actionType = CapturedInstanceActionType.EDIT;
+        const payload: EditExistingFailureInstancePayload = {
+            instanceId: someInstanceId,
+            requirementId,
+        };
+        createStoreForTabStopsViewActions('editExistingFailureInstance')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, finalState);
+    });
+
+    test('onCreateNewFailureInstancePanel', () => {});
+
+    test('onCreateNewFailureInstancePanel', () => {});
+
+    function getDefaultState(): TabStopsViewStoreData {
+        return createStoreWithNullParams(TabStopsViewStore).getDefaultState();
+    }
+
+    function createStoreForTabStopsViewActions(
+        actionName: keyof TabStopsViewActions,
+    ): StoreTester<TabStopsViewStoreData, TabStopsViewActions> {
+        const factory = (actions: TabStopsViewActions) => new TabStopsViewStore(actions);
+
+        return new StoreTester(TabStopsViewActions, actionName, factory);
+    }
+});


### PR DESCRIPTION
#### Details

Creates a store to be used in details view to manage state of the tab stops view.

##### Motivation

feature work.

##### Context

This is a new approach to a kind of problem where we usually have stateful components that pass state-management functions down to children. This would be complicated and messy in this case (although possible) since there are multiple places that the failed instance panel could open from (not included in this PR).

In this case, we create a store that only exists in details view and thus our components can be simpler and not do any state management themselves.

The controller is a more palatable approach than interacting with actions directly (don't want to create confusion with our usage of action-message-creators).

The usage of this in UI components will be in a future PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
