### PR TITLE
fix: Adjust styling so text is visible at high zoom level

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -39,6 +39,12 @@ body {
     flex-direction: column;
     height: 100%;
 
+    .ms-DetailsRow {
+        .property-bag-div {
+            white-space: normal;
+        }
+    }
+
     .ms-DetailsRow,
     .ms-GroupHeader {
         user-select: text;

--- a/src/DetailsView/components/assessment-instance-details-column.scss
+++ b/src/DetailsView/components/assessment-instance-details-column.scss
@@ -37,7 +37,7 @@
 }
 .assessment-instance-textContent {
     overflow: hidden;
-    white-space: nowrap;
+    white-space: normal;
     text-overflow: ellipsis;
     color: $secondary-text;
     @media screen and (forced-colors: active) {


### PR DESCRIPTION
#### Details

This PR adds the white-space: normal style to information displayed in the details view in tables during an assessment.  This makes it so that at a high zoom level, instead of being truncated with "..." like before, information in a table cell that extends past one line will now wrap and continue in the same cell on the next line.  This makes that content visible to users who are using a high zoom level. 

##### Motivation

Addresses ADO Trusted Tester bug #1883866.

##### Context

Assessment test steps that render instances in a table either do so through generating an AssessmentInstanceDetailsColumn or by using the PropertyBagColumnRendererFactory.  So, styling here needed to be updated in two spots to account for the two different places we generate content. 


![image](https://user-images.githubusercontent.com/33770444/141521655-ea8813a6-f67f-4bfe-adfc-6a429caae82f.png)
Pic above: The issue mentioned in the trusted tester bug, with a long header instance being truncated and no way to reveal the entire sentence


![image](https://user-images.githubusercontent.com/33770444/141521686-89b42d0a-d228-48f8-a069-c54e0b9fa857.png)
Pic above: The issue mentioned in the trusted tester bug, now resolved with word wrap, so the instance in the table is taller and the entire sentence is visible. 


![image](https://user-images.githubusercontent.com/33770444/141521935-63ec03e3-00ae-4703-8a4c-ad3ee0383d0f.png)
Pic above: The same issue, but in a table for the images test, whose instances are rendered via a different method than for headings. Instead of being truncated with ellipses, the text is simply truncated at the edge of the table cell


![image](https://user-images.githubusercontent.com/33770444/141524645-ec1b7f76-9bf1-4a24-ac79-2e45a4462a51.png)
Pic above: The same issue, but in a table for the images test, now resolved in the same manner (word wrap)


![image](https://user-images.githubusercontent.com/33770444/141524957-d36975b4-2e64-4713-9a39-cdad435d3ea2.png)
Pic above: The issue affecting manually added instance failures


![image](https://user-images.githubusercontent.com/33770444/141524979-0cd48b62-a7fb-4bdf-a0ec-ff51e3dc219e.png)
Pic above: The issue, now resolved, no longer affecting manually added instance failures. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Trusted Tester bug
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
