### PR TITLE
feat(tab-stops-details-view): added failed instance panel

### DIFF
--- a/src/DetailsView/components/tab-stops/failed-instance-panel.tsx
+++ b/src/DetailsView/components/tab-stops/failed-instance-panel.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ActionAndCancelButtonsComponent } from 'DetailsView/components/action-and-cancel-buttons-component';
+import { GenericPanel, GenericPanelProps } from 'DetailsView/components/generic-panel';
+import { TextField } from 'office-ui-fabric-react';
+import * as React from 'react';
+import * as styles from '../failure-instance-panel.scss';
+
+export interface FailedInstancePanelProps {
+    isOpen: boolean;
+    instanceDescription: string;
+    headerText: string;
+    confirmButtonText: string;
+    onConfirm: () => void;
+    onChange: (event: React.SyntheticEvent, description: string) => void;
+    onDismiss: () => void;
+}
+
+export class FailedInstancePanel extends React.Component<FailedInstancePanelProps> {
+    public render(): JSX.Element {
+        const panelProps: GenericPanelProps = {
+            isOpen: this.props.isOpen,
+            className: styles.failureInstancePanel,
+            onDismiss: this.props.onDismiss,
+            headerText: this.props.headerText,
+            hasCloseButton: true,
+            closeButtonAriaLabel: 'Close failure instance panel',
+        };
+
+        return (
+            <GenericPanel {...panelProps}>
+                <TextField
+                    className={styles.observedFailureTextfield}
+                    label="Comment"
+                    multiline={true}
+                    rows={8}
+                    value={this.props.instanceDescription}
+                    onChange={this.props.onChange}
+                    resizable={false}
+                    placeholder="Comment"
+                />
+                {this.getActionCancelButtons()}
+            </GenericPanel>
+        );
+    }
+
+    private getActionCancelButtons = (): JSX.Element => {
+        return (
+            <div>
+                <ActionAndCancelButtonsComponent
+                    isHidden={false}
+                    primaryButtonDisabled={this.props.instanceDescription === null}
+                    primaryButtonText={this.props.confirmButtonText}
+                    primaryButtonOnClick={() => {
+                        this.props.onConfirm();
+                        this.props.onDismiss();
+                    }}
+                    cancelButtonOnClick={this.props.onDismiss}
+                />
+            </div>
+        );
+    };
+}

--- a/src/DetailsView/components/tab-stops/tab-stops-failed-instance-panel.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-failed-instance-panel.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { NamedFC } from 'common/react/named-fc';
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
+import {
+    FailedInstancePanel,
+    FailedInstancePanelProps,
+} from 'DetailsView/components/tab-stops/failed-instance-panel';
+import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
+import { FailureInstanceState } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
+import * as React from 'react';
+import { TabStopRequirementInfo } from 'types/tab-stop-requirement-info';
+
+export type TabStopsFailedInstancePanelDeps = {
+    tabStopRequirements: TabStopRequirementInfo;
+    tabStopsTestViewController: TabStopsTestViewController;
+    tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
+};
+
+export interface TabStopsFailedInstancePanelProps {
+    deps: TabStopsFailedInstancePanelDeps;
+    failureInstanceState: FailureInstanceState;
+}
+
+export const TabStopsFailedInstancePanel = NamedFC<TabStopsFailedInstancePanelProps>(
+    'TabStopsFailedInstancePanel',
+    props => {
+        const { deps, failureInstanceState } = props;
+        const {
+            tabStopRequirements,
+            tabStopsTestViewController,
+            tabStopRequirementActionMessageCreator,
+        } = deps;
+
+        if (failureInstanceState.selectedRequirementId === null) {
+            return null;
+        }
+
+        let failureInstanceProps: FailedInstancePanelProps = {
+            headerText: `Add a failed instance for ${
+                tabStopRequirements[failureInstanceState.selectedRequirementId].name
+            }`,
+            isOpen: failureInstanceState.isPanelOpen,
+            instanceDescription: failureInstanceState.description,
+            confirmButtonText: 'Add failed instance',
+            onConfirm: () => {
+                tabStopRequirementActionMessageCreator.addTabStopInstance(
+                    failureInstanceState.selectedRequirementId,
+                    failureInstanceState.description,
+                );
+            },
+            onChange: (_, description) => {
+                deps.tabStopsTestViewController.updateDescription(description);
+            },
+            onDismiss: tabStopsTestViewController.dismissPanel,
+        };
+
+        if (failureInstanceState.actionType === CapturedInstanceActionType.EDIT) {
+            failureInstanceProps = {
+                ...failureInstanceProps,
+                headerText: `Edit failed instance for ${
+                    tabStopRequirements[failureInstanceState.selectedRequirementId].name
+                }`,
+                onConfirm: () => {
+                    tabStopRequirementActionMessageCreator.updateTabStopInstance(
+                        failureInstanceState.selectedRequirementId,
+                        failureInstanceState.selectedInstanceId,
+                        failureInstanceState.description,
+                    );
+                },
+                confirmButtonText: 'Save',
+            };
+        }
+
+        return <FailedInstancePanel {...failureInstanceProps} />;
+    },
+);

--- a/src/DetailsView/components/tab-stops/tab-stops-view-actions.ts
+++ b/src/DetailsView/components/tab-stops/tab-stops-view-actions.ts
@@ -7,6 +7,7 @@ import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 export interface EditExistingFailureInstancePayload {
     instanceId: string;
     requirementId: TabStopRequirementId;
+    description: string;
 }
 
 export class TabStopsViewActions {

--- a/src/DetailsView/components/tab-stops/tab-stops-view-store.ts
+++ b/src/DetailsView/components/tab-stops/tab-stops-view-store.ts
@@ -42,6 +42,7 @@ export class TabStopsViewStore extends BaseStoreImpl<TabStopsViewStoreData> {
     }
 
     private onCreateNewFailureInstancePanel = (requirementId: TabStopRequirementId) => {
+        this.state.failureInstanceState = this.getDefaultState().failureInstanceState;
         this.state.failureInstanceState.isPanelOpen = true;
         this.state.failureInstanceState.selectedRequirementId = requirementId;
         this.state.failureInstanceState.actionType = CapturedInstanceActionType.CREATE;
@@ -52,12 +53,13 @@ export class TabStopsViewStore extends BaseStoreImpl<TabStopsViewStoreData> {
         this.state.failureInstanceState.isPanelOpen = true;
         this.state.failureInstanceState.selectedRequirementId = payload.requirementId;
         this.state.failureInstanceState.selectedInstanceId = payload.instanceId;
+        this.state.failureInstanceState.description = payload.description;
         this.state.failureInstanceState.actionType = CapturedInstanceActionType.EDIT;
         this.emitChanged();
     };
 
     private onDismissPanel = () => {
-        this.state.failureInstanceState = this.getDefaultState().failureInstanceState;
+        this.state.failureInstanceState.isPanelOpen = false;
         this.emitChanged();
     };
 

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/failed-instance-panel.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/failed-instance-panel.test.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FailedInstancePanel primary button disabled without description 1`] = `
+<GenericPanel
+  className="failureInstancePanel"
+  closeButtonAriaLabel="Close failure instance panel"
+  hasCloseButton={true}
+  headerText="some header"
+  isOpen={true}
+  onDismiss={[Function]}
+>
+  <StyledTextFieldBase
+    className="observedFailureTextfield"
+    label="Comment"
+    multiline={true}
+    onChange={[Function]}
+    placeholder="Comment"
+    resizable={false}
+    rows={8}
+    value={null}
+  />
+  <div>
+    <ActionAndCancelButtonsComponent
+      cancelButtonOnClick={[Function]}
+      isHidden={false}
+      primaryButtonDisabled={true}
+      primaryButtonOnClick={[Function]}
+      primaryButtonText="some confirm text"
+    />
+  </div>
+</GenericPanel>
+`;
+
+exports[`FailedInstancePanel renders 1`] = `
+<GenericPanel
+  className="failureInstancePanel"
+  closeButtonAriaLabel="Close failure instance panel"
+  hasCloseButton={true}
+  headerText="some header"
+  isOpen={true}
+  onDismiss={[Function]}
+>
+  <StyledTextFieldBase
+    className="observedFailureTextfield"
+    label="Comment"
+    multiline={true}
+    onChange={[Function]}
+    placeholder="Comment"
+    resizable={false}
+    rows={8}
+    value="some description"
+  />
+  <div>
+    <ActionAndCancelButtonsComponent
+      cancelButtonOnClick={[Function]}
+      isHidden={false}
+      primaryButtonDisabled={false}
+      primaryButtonOnClick={[Function]}
+      primaryButtonText="some confirm text"
+    />
+  </div>
+</GenericPanel>
+`;

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-failed-instance-panel.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-failed-instance-panel.test.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TabStopsFailedInstancePanel render with failure instance action type CREATE 1`] = `
+<FailedInstancePanel
+  confirmButtonText="Add failed instance"
+  headerText="Add a failed instance for some name for requirement"
+  instanceDescription="some description"
+  isOpen={true}
+  onChange={[Function]}
+  onConfirm={[Function]}
+  onDismiss={[Function]}
+/>
+`;
+
+exports[`TabStopsFailedInstancePanel render with failure instance action type EDIT 1`] = `
+<FailedInstancePanel
+  confirmButtonText="Save"
+  headerText="Edit failed instance for some name for requirement"
+  instanceDescription="some description"
+  isOpen={true}
+  onChange={[Function]}
+  onConfirm={[Function]}
+  onDismiss={[Function]}
+/>
+`;
+
+exports[`TabStopsFailedInstancePanel render with no selected requirement id 1`] = `null`;

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/failed-instance-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/failed-instance-panel.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ActionAndCancelButtonsComponent } from 'DetailsView/components/action-and-cancel-buttons-component';
+import { GenericPanel } from 'DetailsView/components/generic-panel';
+import {
+    FailedInstancePanel,
+    FailedInstancePanelProps,
+} from 'DetailsView/components/tab-stops/failed-instance-panel';
+import { shallow } from 'enzyme';
+import { TextField } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { IMock, Mock, Times } from 'typemoq';
+
+describe('FailedInstancePanel', () => {
+    let props: FailedInstancePanelProps;
+    let onConfirmMock: IMock<() => void>;
+    let onChangeMock: IMock<(_: React.SyntheticEvent, d: string) => void>;
+    let onDismissMock: IMock<() => void>;
+
+    beforeEach(() => {
+        onConfirmMock = Mock.ofInstance(() => null);
+        onChangeMock = Mock.ofInstance((_, d) => null);
+        onDismissMock = Mock.ofInstance(() => null);
+        props = {
+            isOpen: true,
+            instanceDescription: 'some description',
+            headerText: 'some header',
+            confirmButtonText: 'some confirm text',
+            onChange: onChangeMock.object,
+            onConfirm: onConfirmMock.object,
+            onDismiss: onDismissMock.object,
+        };
+    });
+
+    test('renders', () => {
+        const testSubject = shallow(<FailedInstancePanel {...props} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    test('verify button behaviors', () => {
+        const testSubject = shallow(<FailedInstancePanel {...props} />);
+        const actionCancelButtonProps = testSubject.find(ActionAndCancelButtonsComponent).props();
+        const panelProps = testSubject.find(GenericPanel).props();
+        const descriptionTextFieldProps = testSubject.find(TextField).props();
+
+        actionCancelButtonProps.primaryButtonOnClick(null);
+
+        onConfirmMock.verify(m => m(), Times.once());
+        expect(actionCancelButtonProps.cancelButtonOnClick).toEqual(onDismissMock.object);
+        expect(panelProps.onDismiss).toEqual(onDismissMock.object);
+        expect(descriptionTextFieldProps.onChange).toEqual(onChangeMock.object);
+    });
+
+    test('primary button disabled without description', () => {
+        props.instanceDescription = null;
+        const testSubject = shallow(<FailedInstancePanel {...props} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-failed-instance-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-failed-instance-panel.test.tsx
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
+import { FailedInstancePanel } from 'DetailsView/components/tab-stops/failed-instance-panel';
+import {
+    TabStopsFailedInstancePanel,
+    TabStopsFailedInstancePanelDeps,
+    TabStopsFailedInstancePanelProps,
+} from 'DetailsView/components/tab-stops/tab-stops-failed-instance-panel';
+import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
+import { FailureInstanceState } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { IMock, Mock, Times } from 'typemoq';
+import { TabStopRequirementId, TabStopRequirementInfo } from 'types/tab-stop-requirement-info';
+
+describe('TabStopsFailedInstancePanel', () => {
+    let props: TabStopsFailedInstancePanelProps;
+    let tabStopRequirementsStub: TabStopRequirementInfo;
+    let tabStopsTestViewControllerMock: IMock<TabStopsTestViewController>;
+    let tabStopRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
+    let failureState: FailureInstanceState;
+
+    beforeEach(() => {
+        const requirementId: TabStopRequirementId = 'focus-indicator';
+        tabStopRequirementsStub = {
+            [requirementId]: {
+                name: 'some name for requirement',
+            },
+        } as TabStopRequirementInfo;
+        tabStopsTestViewControllerMock = Mock.ofType<TabStopsTestViewController>();
+        tabStopRequirementActionMessageCreatorMock =
+            Mock.ofType<TabStopRequirementActionMessageCreator>();
+        failureState = {
+            isPanelOpen: true,
+            selectedRequirementId: requirementId,
+            selectedInstanceId: 'some instance id',
+            description: 'some description',
+            actionType: CapturedInstanceActionType.CREATE,
+        };
+        props = {
+            deps: {
+                tabStopRequirements: tabStopRequirementsStub,
+                tabStopsTestViewController: tabStopsTestViewControllerMock.object,
+                tabStopRequirementActionMessageCreator:
+                    tabStopRequirementActionMessageCreatorMock.object,
+            } as TabStopsFailedInstancePanelDeps,
+            failureInstanceState: failureState,
+        };
+    });
+
+    test('render with no selected requirement id', () => {
+        props.failureInstanceState.selectedRequirementId = null;
+        const testSubject = shallow(<TabStopsFailedInstancePanel {...props} />);
+
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    test('render with failure instance action type CREATE', () => {
+        const description = 'description';
+
+        const testSubject = shallow(<TabStopsFailedInstancePanel {...props} />);
+        const panelProps = testSubject.find(FailedInstancePanel).props();
+        panelProps.onConfirm();
+        panelProps.onChange(null, description);
+        panelProps.onDismiss();
+
+        expect(testSubject.getElement()).toMatchSnapshot();
+        tabStopsTestViewControllerMock.verify(m => m.dismissPanel(), Times.once());
+        tabStopsTestViewControllerMock.verify(m => m.updateDescription(description), Times.once());
+        tabStopRequirementActionMessageCreatorMock.verify(
+            m => m.addTabStopInstance(failureState.selectedRequirementId, failureState.description),
+            Times.once(),
+        );
+    });
+
+    test('render with failure instance action type EDIT', () => {
+        const description = 'description';
+        props.failureInstanceState.actionType = CapturedInstanceActionType.EDIT;
+        const testSubject = shallow(<TabStopsFailedInstancePanel {...props} />);
+        const panelProps = testSubject.find(FailedInstancePanel).props();
+        panelProps.onConfirm();
+        panelProps.onChange(null, description);
+        panelProps.onDismiss();
+
+        expect(testSubject.getElement()).toMatchSnapshot();
+        tabStopsTestViewControllerMock.verify(m => m.dismissPanel(), Times.once());
+        tabStopsTestViewControllerMock.verify(m => m.updateDescription(description), Times.once());
+        tabStopRequirementActionMessageCreatorMock.verify(
+            m =>
+                m.updateTabStopInstance(
+                    failureState.selectedRequirementId,
+                    failureState.selectedInstanceId,
+                    failureState.description,
+                ),
+            Times.once(),
+        );
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-view-store.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-view-store.test.ts
@@ -38,13 +38,7 @@ describe(TabStopsViewStore, () => {
 
     test('onDismissPanel', () => {
         const initialState = getDefaultState();
-        initialState.failureInstanceState = {
-            isPanelOpen: true,
-            description: 'some description',
-            selectedInstanceId: 'some instance id',
-            selectedRequirementId: 'focus-indicator',
-            actionType: CapturedInstanceActionType.EDIT,
-        };
+        initialState.failureInstanceState.isPanelOpen = true;
         const finalState = getDefaultState();
         createStoreForTabStopsViewActions('dismissPanel')
             .withActionParam(null)
@@ -74,16 +68,21 @@ describe(TabStopsViewStore, () => {
 
     test('onEditExistingFailureInstance', () => {
         const requirementId = 'focus-indicator';
+        const expectedDescription = 'some description';
         const someInstanceId = 'some instance id';
         const initialState = getDefaultState();
         const finalState = getDefaultState();
-        finalState.failureInstanceState.selectedRequirementId = requirementId;
-        finalState.failureInstanceState.selectedInstanceId = someInstanceId;
-        finalState.failureInstanceState.isPanelOpen = true;
-        finalState.failureInstanceState.actionType = CapturedInstanceActionType.EDIT;
+        finalState.failureInstanceState = {
+            selectedInstanceId: someInstanceId,
+            selectedRequirementId: requirementId,
+            isPanelOpen: true,
+            description: expectedDescription,
+            actionType: CapturedInstanceActionType.EDIT,
+        };
         const payload: EditExistingFailureInstancePayload = {
             instanceId: someInstanceId,
             requirementId,
+            description: expectedDescription,
         };
         createStoreForTabStopsViewActions('editExistingFailureInstance')
             .withActionParam(payload)


### PR DESCRIPTION
#### Details

Creates the failed instance panel for tab stops view.
##### Motivation
Feature work

##### Context

Does not include wiring this up (future PR). Screen caps below of what it looks like when wired up.

![image](https://user-images.githubusercontent.com/32555133/141604908-eeb6e1fe-ea9f-4f56-bd40-af0061a2e2e5.png)

![image](https://user-images.githubusercontent.com/32555133/141604925-7f1316ed-e64a-4117-8bbf-0f6690d7c560.png)



#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
