### PR TITLE
feat(tab-stops-details-view): wiring up failed instance panel

### DIFF
--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -17,9 +17,14 @@ import {
     TabStopsFailedInstanceSectionDeps,
 } from 'DetailsView/components/tab-stops-failed-instance-section';
 import {
+    TabStopsFailedInstancePanel,
+    TabStopsFailedInstancePanelDeps,
+} from 'DetailsView/components/tab-stops/tab-stops-failed-instance-panel';
+import {
     TabStopsRequirementsTable,
     TabStopsRequirementsTableDeps,
 } from 'DetailsView/components/tab-stops/tab-stops-requirements-table';
+import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 import { TargetPageChangedView } from 'DetailsView/components/target-page-changed-view';
 import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { createFastPassProviderWithFeatureFlags } from 'fast-pass/fast-pass-provider';
@@ -31,6 +36,7 @@ import * as Markup from '../../assessments/markup';
 export type AdhocTabStopsTestViewDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
 } & TabStopsRequirementsTableDeps &
+    TabStopsFailedInstancePanelDeps &
     TabStopsFailedInstanceSectionDeps &
     ContentLinkDeps;
 
@@ -44,6 +50,7 @@ export interface AdhocTabStopsTestViewProps {
     selectedTest: VisualizationType;
     clickHandlerFactory: DetailsViewToggleClickHandlerFactory;
     guidance?: ContentReference;
+    tabStopsViewStoreData: TabStopsViewStoreData;
 }
 
 export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
@@ -86,10 +93,6 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
         const displayableData = props.configuration.displayableData;
         const fastPassProvider = createFastPassProviderWithFeatureFlags(props.featureFlagStoreData);
         const stepsText = fastPassProvider.getStepsText(selectedTest);
-        const tabStopsRequirementTableDeps = {
-            tabStopsRequirementActionMessageCreator:
-                props.deps.tabStopsRequirementActionMessageCreator,
-        };
         const requirementState = props.visualizationScanResultData.tabStops.requirements;
 
         const scanData = props.configuration.getStoreData(props.visualizationStoreData.tests);
@@ -97,10 +100,6 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
             selectedTest,
             !scanData.enabled,
         );
-        const addFailureInstanceForRequirement = (requirementId: string): void => {
-            //TODO: fill this in
-            console.log(requirementId);
-        };
 
         if (props.tabStoreData.isChanged) {
             return (
@@ -130,14 +129,15 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                 />
                 {description}
                 <RequirementInstructions howToTest={howToTest} />
-                <TabStopsRequirementsTable
-                    deps={tabStopsRequirementTableDeps}
-                    requirementState={requirementState}
-                    addFailureInstanceForRequirement={addFailureInstanceForRequirement}
-                />
+                <TabStopsRequirementsTable deps={props.deps} requirementState={requirementState} />
                 <TabStopsFailedInstanceSection
                     deps={props.deps}
                     visualizationScanResultData={props.visualizationScanResultData}
+                />
+                <TabStopsFailedInstancePanel
+                    deps={props.deps}
+                    failureInstanceState={props.tabStopsViewStoreData.failureInstanceState}
+                    requirementState={requirementState}
                 />
             </div>
         );

--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -106,6 +106,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
             <DetailsViewBody
                 deps={deps}
                 tabStoreData={storeState.tabStoreData}
+                tabStopsViewStoreData={storeState.tabStopsViewStoreData}
                 assessmentStoreData={storeState.assessmentStoreData}
                 pathSnippetStoreData={storeState.pathSnippetStoreData}
                 featureFlagStoreData={storeState.featureFlagStoreData}

--- a/src/DetailsView/components/tab-stops/tab-stops-requirements-table.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-requirements-table.tsx
@@ -7,24 +7,25 @@ import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-
 import { requirementsList } from 'DetailsView/components/tab-stops/requirements';
 import { TabStopsChoiceGroup } from 'DetailsView/components/tab-stops/tab-stops-choice-group';
 import * as styles from 'DetailsView/components/tab-stops/tab-stops-requirement-table.scss';
+import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
 import { DetailsList, IColumn } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export interface TabStopsRequirementsTableProps {
     deps: TabStopsRequirementsTableDeps;
     requirementState: TabStopRequirementState;
-    addFailureInstanceForRequirement: (requirementId: string) => void;
 }
 
 export type TabStopsRequirementsTableDeps = {
-    tabStopsRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
+    tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
+    tabStopsTestViewController: TabStopsTestViewController;
 };
 
 export const TabStopsRequirementsTable = NamedFC<TabStopsRequirementsTableProps>(
     'TabStopsRequirementsTable',
     props => {
-        const { deps, addFailureInstanceForRequirement } = props;
-        const { tabStopsRequirementActionMessageCreator } = deps;
+        const { deps } = props;
+        const { tabStopRequirementActionMessageCreator } = deps;
         const columns: IColumn[] = [
             {
                 name: 'Requirement',
@@ -48,18 +49,20 @@ export const TabStopsRequirementsTable = NamedFC<TabStopsRequirementsTableProps>
                         <TabStopsChoiceGroup
                             status={props.requirementState[item.id].status}
                             onUndoClicked={_ =>
-                                tabStopsRequirementActionMessageCreator.resetStatusForRequirement(
+                                tabStopRequirementActionMessageCreator.resetStatusForRequirement(
                                     item.id,
                                 )
                             }
                             onGroupChoiceChange={(_, status) =>
-                                tabStopsRequirementActionMessageCreator.updateTabStopRequirementStatus(
+                                tabStopRequirementActionMessageCreator.updateTabStopRequirementStatus(
                                     item.id,
                                     status,
                                 )
                             }
                             onAddFailureInstanceClicked={_ =>
-                                addFailureInstanceForRequirement(item.id)
+                                deps.tabStopsTestViewController.createNewFailureInstancePanel(
+                                    item.id,
+                                )
                             }
                         />
                     );

--- a/src/DetailsView/components/test-view-container.tsx
+++ b/src/DetailsView/components/test-view-container.tsx
@@ -11,6 +11,7 @@ import {
     AdhocTabStopsTestViewDeps,
 } from 'DetailsView/components/adhoc-tab-stops-test-view';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
+import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 import * as React from 'react';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { NamedFC } from '../../common/react/named-fc';
@@ -24,7 +25,6 @@ import { VisualizationScanResultData } from '../../common/types/store-data/visua
 import { VisualizationStoreData } from '../../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
-import { TabStopRequirementActionMessageCreator } from '../actions/tab-stop-requirement-action-message-creator';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
 import { DetailsViewToggleClickHandlerFactory } from '../handlers/details-view-toggle-click-handler-factory';
 import { AdhocIssuesTestView } from './adhoc-issues-test-view';
@@ -36,7 +36,6 @@ import { TestViewDeps } from './test-view';
 
 export type TestViewContainerDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-    tabStopsRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
 } & TestViewDeps &
     OverviewContainerDeps &
     AdhocTabStopsTestViewDeps;
@@ -44,6 +43,7 @@ export type TestViewContainerDeps = {
 export interface TestViewContainerProps {
     deps: TestViewContainerDeps;
     tabStoreData: TabStoreData;
+    tabStopsViewStoreData: TabStopsViewStoreData;
     assessmentStoreData: AssessmentStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
     pathSnippetStoreData: PathSnippetStoreData;

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -11,6 +11,7 @@ import {
 import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { FluentSideNav, FluentSideNavDeps } from 'DetailsView/components/left-nav/fluent-side-nav';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
+import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 import * as styles from 'DetailsView/details-view-body.scss';
 import * as React from 'react';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -44,6 +45,7 @@ export type DetailsViewBodyDeps = DetailsViewContentDeps &
 export interface DetailsViewBodyProps {
     deps: DetailsViewBodyDeps;
     tabStoreData: TabStoreData;
+    tabStopsViewStoreData: TabStopsViewStoreData;
     assessmentStoreData: AssessmentStoreData;
     pathSnippetStoreData: PathSnippetStoreData;
     featureFlagStoreData: FeatureFlagStoreData;

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -9,6 +9,7 @@ import {
     NarrowModeDetector,
     NarrowModeDetectorDeps,
 } from 'DetailsView/components/narrow-mode-detector';
+import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ThemeDeps } from '../common/components/theme';
@@ -92,6 +93,7 @@ export interface DetailsViewContainerState {
     selectedDetailsRightPanelConfiguration: DetailsRightPanelConfiguration;
     cardSelectionStoreData: CardSelectionStoreData;
     permissionsStateStoreData: PermissionsStateStoreData;
+    tabStopsViewStoreData: TabStopsViewStoreData;
 }
 
 export class DetailsViewContainer extends React.Component<DetailsViewContainerProps> {

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -34,6 +34,10 @@ import { NavLinkRenderer } from 'DetailsView/components/left-nav/nav-link-render
 import { LoadAssessmentDataValidator } from 'DetailsView/components/load-assessment-data-validator';
 import { LoadAssessmentHelper } from 'DetailsView/components/load-assessment-helper';
 import { NoContentAvailableViewDeps } from 'DetailsView/components/no-content-available/no-content-available-view';
+import { requirements } from 'DetailsView/components/tab-stops/requirements';
+import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
+import { TabStopsViewActions } from 'DetailsView/components/tab-stops/tab-stops-view-actions';
+import { TabStopsViewStore } from 'DetailsView/components/tab-stops/tab-stops-view-store';
 import { AllUrlsPermissionHandler } from 'DetailsView/handlers/allurls-permission-handler';
 import { NoContentAvailableViewRenderer } from 'DetailsView/no-content-available-view-renderer';
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
@@ -213,6 +217,11 @@ if (tabId != null) {
                 tab.id,
             );
 
+            const tabStopsViewActions = new TabStopsViewActions();
+            const tabStopsTestViewController = new TabStopsTestViewController(tabStopsViewActions);
+            const tabStopsViewStore = new TabStopsViewStore(tabStopsViewActions);
+            tabStopsViewStore.initialize();
+
             const storesHub = new BaseClientStoresHub<DetailsViewContainerState>([
                 detailsViewStore,
                 featureFlagStore,
@@ -226,6 +235,7 @@ if (tabId != null) {
                 scopingStore,
                 userConfigStore,
                 cardSelectionStore,
+                tabStopsViewStore,
             ]);
 
             const logger = createDefaultLogger();
@@ -245,12 +255,6 @@ if (tabId != null) {
                 telemetryFactory,
                 actionMessageDispatcher,
             );
-
-            const tabStopsRequirementActionMessageCreator =
-                new TabStopRequirementActionMessageCreator(
-                    telemetryFactory,
-                    actionMessageDispatcher,
-                );
 
             const scopingActionMessageCreator = new ScopingActionMessageCreator(
                 telemetryFactory,
@@ -466,7 +470,7 @@ if (tabId != null) {
                 contentProvider: contentPages,
                 contentActionMessageCreator,
                 detailsViewActionMessageCreator,
-                tabStopsRequirementActionMessageCreator,
+                tabStopRequirementActionMessageCreator,
                 assessmentsProvider: Assessments,
                 actionInitiators,
                 assessmentDefaultMessageGenerator: assessmentDefaultMessageGenerator,
@@ -533,8 +537,9 @@ if (tabId != null) {
                 assessmentViewUpdateHandler,
                 navLinkRenderer,
                 getNarrowModeThresholds: getNarrowModeThresholdsForWeb,
-                tabStopRequirementActionMessageCreator,
+                tabStopRequirements: requirements,
                 tabStopsFailedCounter,
+                tabStopsTestViewController,
             };
 
             const renderer = new DetailsViewRenderer(

--- a/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
+++ b/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
@@ -19,7 +19,11 @@ import * as styles from './tab-stops-requirement-instances-collapsible-content.s
 export type TabStopsRequirementInstancesCollapsibleContentProps = {
     requirementId: TabStopRequirementId;
     instances: TabStopsRequirementResultInstance[];
-    onEditButtonClicked: (instanceId: string) => void;
+    onEditButtonClicked: (
+        requirementId: TabStopRequirementId,
+        instanceId: string,
+        description: string,
+    ) => void;
     onRemoveButtonClicked: (requirementId: TabStopRequirementId, instanceId: string) => void;
 };
 export const TabStopsRequirementInstancesCollapsibleContent =
@@ -46,7 +50,13 @@ export const TabStopsRequirementInstancesCollapsibleContent =
                     <>
                         <Link
                             className={styles.editButton}
-                            onClick={() => props.onEditButtonClicked(instance.id)}
+                            onClick={() =>
+                                props.onEditButtonClicked(
+                                    props.requirementId,
+                                    instance.id,
+                                    instance.description,
+                                )
+                            }
                         >
                             <Icon iconName="edit" ariaLabel={'edit instance'} />
                         </Link>

--- a/src/DetailsView/tab-stops-requirements-with-instances.tsx
+++ b/src/DetailsView/tab-stops-requirements-with-instances.tsx
@@ -6,6 +6,7 @@ import {
 } from 'common/components/cards/collapsible-component-cards';
 import { NamedFC } from 'common/react/named-fc';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
+import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import { TabStopsMinimalRequirementHeader } from 'DetailsView/tab-stops-minimal-requirement-header';
 import { TabStopsRequirementInstancesCollapsibleContent } from 'DetailsView/tab-stops-requirement-instances-collapsible-content';
@@ -13,7 +14,6 @@ import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-res
 import * as React from 'react';
 import { outcomeTypeSemantics } from 'reports/components/outcome-type';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
-
 import * as styles from './tab-stops-requirements-with-instances.scss';
 
 export const resultsGroupAutomationId = 'tab-stops-results-group';
@@ -22,6 +22,7 @@ export type TabStopsRequirementsWithInstancesDeps = CollapsibleComponentCardsDep
     collapsibleControl: (props: CollapsibleComponentCardsProps) => JSX.Element;
     tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
     tabStopsFailedCounter: TabStopsFailedCounter;
+    tabStopsTestViewController: TabStopsTestViewController;
 };
 
 export type TabStopsRequirementsWithInstancesProps = {
@@ -42,8 +43,16 @@ export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWit
                 instanceId,
             );
         };
-        const onInstanceEditButtonClicked = (requirementId: string) => {
-            console.log('edit ' + requirementId);
+        const onInstanceEditButtonClicked = (
+            requirementId: TabStopRequirementId,
+            instanceId: string,
+            description: string,
+        ) => {
+            deps.tabStopsTestViewController.editExistingFailureInstance({
+                instanceId,
+                requirementId,
+                description,
+            });
         };
 
         const getCollapsibleComponentProps = (

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -124,6 +124,11 @@ exports[`DetailsViewBody render render 1`] = `
           "StartOverComponentFactory": Object {},
         }
       }
+      tabStopsViewStoreData={
+        Object {
+          "failureInstanceState": Object {},
+        }
+      }
       tabStoreData={
         Object {
           "id": null,
@@ -443,6 +448,11 @@ exports[`DetailsViewBody render render 1`] = `
             "LeftNav": [Function],
             "ReportExportDialogFactory": [Function],
             "StartOverComponentFactory": Object {},
+          }
+        }
+        tabStopsViewStoreData={
+          Object {
+            "failureInstanceState": Object {},
           }
         }
         tabStoreData={
@@ -771,6 +781,11 @@ exports[`DetailsViewBody render render 1`] = `
                 "LeftNav": [Function],
                 "ReportExportDialogFactory": [Function],
                 "StartOverComponentFactory": Object {},
+              }
+            }
+            tabStopsViewStoreData={
+              Object {
+                "failureInstanceState": Object {},
               }
             }
             tabStoreData={

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -213,6 +213,17 @@ exports[` render renders normally 1`] = `
         "getSelectedDetailsView": [Function],
       }
     }
+    tabStopsViewStoreData={
+      Object {
+        "failureInstanceState": Object {
+          "actionType": "CREATE",
+          "description": null,
+          "isPanelOpen": false,
+          "selectedInstanceId": null,
+          "selectedRequirementId": null,
+        },
+      }
+    }
     tabStoreData={
       Object {
         "id": 1,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -56,18 +56,21 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
     }
   />
   <TabStopsRequirementsTable
-    addFailureInstanceForRequirement={[Function]}
-    deps={
-      Object {
-        "tabStopsRequirementActionMessageCreator": undefined,
-      }
-    }
+    deps="stub-deps"
   />
   <TabStopsFailedInstanceSection
     deps="stub-deps"
     visualizationScanResultData={
       Object {
         "tabStops": Object {},
+      }
+    }
+  />
+  <TabStopsFailedInstancePanel
+    deps="stub-deps"
+    failureInstanceState={
+      Object {
+        "actionType": "CREATE",
       }
     }
   />
@@ -129,18 +132,21 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
     }
   />
   <TabStopsRequirementsTable
-    addFailureInstanceForRequirement={[Function]}
-    deps={
-      Object {
-        "tabStopsRequirementActionMessageCreator": undefined,
-      }
-    }
+    deps="stub-deps"
   />
   <TabStopsFailedInstanceSection
     deps="stub-deps"
     visualizationScanResultData={
       Object {
         "tabStops": Object {},
+      }
+    }
+  />
+  <TabStopsFailedInstancePanel
+    deps="stub-deps"
+    failureInstanceState={
+      Object {
+        "actionType": "CREATE",
       }
     }
   />

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
@@ -37,6 +37,14 @@ exports[`TabStopsRequirementsWithInstances renders when instance count > 0 1`] =
           "getFailedByRequirementId": [Function],
           "getTotalFailed": [Function],
         },
+        "tabStopsTestViewController": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "createNewFailureInstancePanel": [Function],
+          "dismissPanel": [Function],
+          "editExistingFailureInstance": [Function],
+          "updateDescription": [Function],
+        },
       }
     }
     header={
@@ -54,6 +62,14 @@ exports[`TabStopsRequirementsWithInstances renders when instance count > 0 1`] =
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
               "getFailedByRequirementId": [Function],
               "getTotalFailed": [Function],
+            },
+            "tabStopsTestViewController": proxy {
+              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "actions": undefined,
+              "createNewFailureInstancePanel": [Function],
+              "dismissPanel": [Function],
+              "editExistingFailureInstance": [Function],
+              "updateDescription": [Function],
             },
           }
         }
@@ -111,6 +127,14 @@ exports[`TabStopsRequirementsWithInstances renders when instance count > 0 1`] =
           "getFailedByRequirementId": [Function],
           "getTotalFailed": [Function],
         },
+        "tabStopsTestViewController": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "actions": undefined,
+          "createNewFailureInstancePanel": [Function],
+          "dismissPanel": [Function],
+          "editExistingFailureInstance": [Function],
+          "updateDescription": [Function],
+        },
       }
     }
     header={
@@ -128,6 +152,14 @@ exports[`TabStopsRequirementsWithInstances renders when instance count > 0 1`] =
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
               "getFailedByRequirementId": [Function],
               "getTotalFailed": [Function],
+            },
+            "tabStopsTestViewController": proxy {
+              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "actions": undefined,
+              "createNewFailureInstancePanel": [Function],
+              "dismissPanel": [Function],
+              "editExistingFailureInstance": [Function],
+              "updateDescription": [Function],
             },
           }
         }

--- a/src/tests/unit/tests/DetailsView/components/adhoc-tab-stops-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/adhoc-tab-stops-test-view.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
 import { DisplayableVisualizationTypeData } from 'common/types/displayable-visualization-type-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
@@ -16,13 +17,12 @@ import {
     AdhocTabStopsTestViewDeps,
     AdhocTabStopsTestViewProps,
 } from 'DetailsView/components/adhoc-tab-stops-test-view';
+import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 import { ContentReference } from 'views/content/content-page';
-import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
-import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 
 describe('AdhocTabStopsTestView', () => {
     let props: AdhocTabStopsTestViewProps;

--- a/src/tests/unit/tests/DetailsView/components/adhoc-tab-stops-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/adhoc-tab-stops-test-view.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { DisplayableVisualizationTypeData } from 'common/types/displayable-visualization-type-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
@@ -20,6 +21,8 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 import { ContentReference } from 'views/content/content-page';
+import { CapturedInstanceActionType } from 'common/types/captured-instance-action-type';
+import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 
 describe('AdhocTabStopsTestView', () => {
     let props: AdhocTabStopsTestViewProps;
@@ -32,7 +35,6 @@ describe('AdhocTabStopsTestView', () => {
     let selectedTest: VisualizationType;
     let featureFlagStoreDataStub: FeatureFlagStoreData;
     let visualizationScanResultData: VisualizationScanResultData;
-
     beforeEach(() => {
         getStoreDataMock = Mock.ofInstance(() => null, MockBehavior.Strict);
         clickHandlerFactoryMock = Mock.ofType(
@@ -55,17 +57,23 @@ describe('AdhocTabStopsTestView', () => {
         visualizationScanResultData = { tabStops: {} } as VisualizationScanResultData;
 
         props = {
+            deps: Mock.ofType<AdhocTabStopsTestViewDeps>().object,
             configuration: {
                 getStoreData: getStoreDataMock.object,
                 displayableData: displayableDataStub,
-            },
+            } as VisualizationConfiguration,
             clickHandlerFactory: clickHandlerFactoryMock.object,
             visualizationStoreData: visualizationStoreDataStub,
             selectedTest,
             featureFlagStoreData: featureFlagStoreDataStub,
             visualizationScanResultData,
-            deps: Mock.ofType<AdhocTabStopsTestViewDeps>().object,
-        } as AdhocTabStopsTestViewProps;
+            tabStoreData: null,
+            tabStopsViewStoreData: {
+                failureInstanceState: {
+                    actionType: CapturedInstanceActionType.CREATE,
+                },
+            } as TabStopsViewStoreData,
+        };
 
         getStoreDataMock
             .setup(gsdm => gsdm(visualizationStoreDataStub.tests))

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-requirement-instances-collapsible-content.test.tsx
@@ -13,7 +13,9 @@ import { IMock, Mock, Times } from 'typemoq';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 
 describe('TabStopsRequirementInstancesCollapsibleContent', () => {
-    let onEditButtonClickedMock: IMock<(instanceId: string) => void>;
+    let onEditButtonClickedMock: IMock<
+        (requirementId: TabStopRequirementId, instanceId: string, description: string) => void
+    >;
     let onRemoveButtonClickedMock: IMock<
         (requirementId: TabStopRequirementId, instanceId: string) => void
     >;
@@ -21,7 +23,14 @@ describe('TabStopsRequirementInstancesCollapsibleContent', () => {
     let requirementResultInstanceStub: TabStopsRequirementResultInstance;
 
     beforeEach(() => {
-        onEditButtonClickedMock = Mock.ofType<(instanceId: string) => void>();
+        onEditButtonClickedMock =
+            Mock.ofType<
+                (
+                    requirementId: TabStopRequirementId,
+                    instanceId: string,
+                    description: string,
+                ) => void
+            >();
         onRemoveButtonClickedMock =
             Mock.ofType<(requirementId: TabStopRequirementId, instanceId: string) => void>();
 
@@ -56,7 +65,9 @@ describe('TabStopsRequirementInstancesCollapsibleContent', () => {
     });
 
     test('click events pass through as expected', () => {
-        onEditButtonClickedMock.setup(ebc => ebc('test-instance-id')).verifiable(Times.once());
+        onEditButtonClickedMock
+            .setup(ebc => ebc('keyboard-navigation', 'test-instance-id', 'test-description'))
+            .verifiable(Times.once());
         onRemoveButtonClickedMock
             .setup(rbc => rbc(props.requirementId, 'test-instance-id'))
             .verifiable(Times.once());

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-requirements-with-instances.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-requirements-with-instances.test.tsx
@@ -4,6 +4,7 @@
 import { CollapsibleComponentCardsProps } from 'common/components/cards/collapsible-component-cards';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
+import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 import {
@@ -14,25 +15,29 @@ import {
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 
 describe('TabStopsRequirementsWithInstances', () => {
     let tabStopsFailedCounterMock: IMock<TabStopsFailedCounter>;
     let tabStopsRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
+    let tabStopsTestViewControllerMock: IMock<TabStopsTestViewController>;
     const CollapsibleControlStub = getCollapsibleControlStub();
-    let depsStub = {} as TabStopsRequirementsWithInstancesDeps;
-    let props = {} as TabStopsRequirementsWithInstancesProps;
+    let depsStub: TabStopsRequirementsWithInstancesDeps;
+    let props: TabStopsRequirementsWithInstancesProps;
 
     beforeEach(() => {
         tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
         tabStopsRequirementActionMessageCreatorMock = Mock.ofType(
             TabStopRequirementActionMessageCreator,
         );
+        tabStopsTestViewControllerMock = Mock.ofType(TabStopsTestViewController);
 
         depsStub = {
             collapsibleControl: (props: CollapsibleComponentCardsProps) => (
                 <CollapsibleControlStub {...props} />
             ),
             tabStopsFailedCounter: tabStopsFailedCounterMock.object,
+            tabStopsTestViewController: tabStopsTestViewControllerMock.object,
             tabStopRequirementActionMessageCreator:
                 tabStopsRequirementActionMessageCreatorMock.object,
         } as TabStopsRequirementsWithInstancesDeps;
@@ -85,6 +90,29 @@ describe('TabStopsRequirementsWithInstances', () => {
         wrapper.find(CollapsibleControlStub).first().props().content.props.onRemoveButtonClicked();
 
         tabStopsRequirementActionMessageCreatorMock.verifyAll();
+    });
+
+    test('onInstanceEditButtonClicked', () => {
+        const instanceId = 'some instance id';
+        const requirementId: TabStopRequirementId = 'keyboard-navigation';
+        const description = 'some description';
+        const expectedPayload = {
+            instanceId,
+            requirementId,
+            description,
+        };
+        const wrapper = shallow(<TabStopsRequirementsWithInstances {...props} />);
+
+        wrapper
+            .find(CollapsibleControlStub)
+            .first()
+            .props()
+            .content.props.onEditButtonClicked(requirementId, instanceId, description);
+
+        tabStopsTestViewControllerMock.verify(
+            m => m.editExistingFailureInstance(It.isValue(expectedPayload)),
+            Times.once(),
+        );
     });
 
     function getCollapsibleControlStub(): ReactFCWithDisplayName<CollapsibleComponentCardsProps> {

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-requirements-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-requirements-table.test.tsx
@@ -10,6 +10,7 @@ import {
     TabStopsRequirementsTable,
     TabStopsRequirementsTableProps,
 } from 'DetailsView/components/tab-stops/tab-stops-requirements-table';
+import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
 import { shallow } from 'enzyme';
 import { DetailsList } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -22,23 +23,23 @@ describe('TabStopsRequirementsTable', () => {
     let props: TabStopsRequirementsTableProps;
     let requirementState: TabStopRequirementState;
     let tabStopsRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
-    let addFailureInstanceForRequirementMock: IMock<(requirementId: string) => void>;
     let requirementContentStub: {
         id: string;
     } & TabStopRequirementContent;
+    let tabStopsTestViewControllerMock: IMock<TabStopsTestViewController>;
 
     beforeEach(() => {
-        addFailureInstanceForRequirementMock = Mock.ofType<(requirementId: string) => void>();
+        tabStopsTestViewControllerMock = Mock.ofType<TabStopsTestViewController>();
         tabStopsRequirementActionMessageCreatorMock =
             Mock.ofType<TabStopRequirementActionMessageCreator>();
         requirementState = new VisualizationScanResultStoreDataBuilder().build().tabStops
             .requirements;
         props = {
             deps: {
-                tabStopsRequirementActionMessageCreator:
+                tabStopRequirementActionMessageCreator:
                     tabStopsRequirementActionMessageCreatorMock.object,
+                tabStopsTestViewController: tabStopsTestViewControllerMock.object,
             },
-            addFailureInstanceForRequirement: addFailureInstanceForRequirementMock.object,
             requirementState: requirementState,
         };
         requirementContentStub = {
@@ -86,6 +87,9 @@ describe('TabStopsRequirementsTable', () => {
             m => m.updateTabStopRequirementStatus(actualRequirement.id, 'fail'),
             Times.once(),
         );
-        addFailureInstanceForRequirementMock.verify(m => m(actualRequirement.id), Times.once());
+        tabStopsTestViewControllerMock.verify(
+            m => m.createNewFailureInstancePanel(actualRequirement.id),
+            Times.once(),
+        );
     });
 });

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -8,9 +8,9 @@ import {
 } from 'DetailsView/components/details-view-command-bar';
 import { FluentSideNav } from 'DetailsView/components/left-nav/fluent-side-nav';
 import { StartOverComponentFactory } from 'DetailsView/components/start-over-component-factory';
+import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-
 import { IMock, Mock } from 'typemoq';
 import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
 import { NamedFC, ReactFCWithDisplayName } from '../../../../common/react/named-fc';
@@ -37,7 +37,6 @@ import { TabStoreDataBuilder } from '../../common/tab-store-data-builder';
 import { VisualizationScanResultStoreDataBuilder } from '../../common/visualization-scan-result-store-data-builder';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 import { exampleUnifiedStatusResults } from '../common/components/cards/sample-view-model-data';
-import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 
 describe('DetailsViewBody', () => {
     let selectedTest: VisualizationType;

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -37,6 +37,7 @@ import { TabStoreDataBuilder } from '../../common/tab-store-data-builder';
 import { VisualizationScanResultStoreDataBuilder } from '../../common/visualization-scan-result-store-data-builder';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 import { exampleUnifiedStatusResults } from '../common/components/cards/sample-view-model-data';
+import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 
 describe('DetailsViewBody', () => {
     let selectedTest: VisualizationType;
@@ -102,6 +103,7 @@ describe('DetailsViewBody', () => {
                 tabStoreData: new TabStoreDataBuilder().build(),
                 visualizationStoreData: new VisualizationStoreDataBuilder().build(),
                 visualizationScanResultData: new VisualizationScanResultStoreDataBuilder().build(),
+                tabStopsViewStoreData: { failureInstanceState: {} } as TabStopsViewStoreData,
                 featureFlagStoreData: {} as FeatureFlagStoreData,
                 selectedTest: selectedTest,
                 visualizationConfigurationFactory: configFactoryStub,

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -271,6 +271,7 @@ describe(DetailsViewContent, () => {
                         userConfigurationStoreData: storeMocks.userConfigurationStoreData,
                         unifiedScanResultStoreData: storeMocks.unifiedScanResultStoreData,
                         cardSelectionStoreData: storeMocks.cardSelectionStoreData,
+                        tabStopsViewStoreData: storeMocks.tabStopsViewStoreData,
                     }
                 );
             });
@@ -331,6 +332,7 @@ describe(DetailsViewContent, () => {
             selectedDetailsRightPanelConfiguration: rightPanel,
             cardSelectionStoreData: storeMocks.cardSelectionStoreData,
             permissionsStateStoreData: storeMocks.permissionsStateStoreData,
+            tabStopsViewStoreData: storeMocks.tabStopsViewStoreData,
         };
     }
 });

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -17,8 +17,8 @@ import { TabStore } from 'background/stores/tab-store';
 import { VisualizationScanResultStore } from 'background/stores/visualization-scan-result-store';
 import { VisualizationStore } from 'background/stores/visualization-store';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { TabStopsViewStore } from 'DetailsView/components/tab-stops/tab-stops-view-store';
 import { It, Mock, MockBehavior } from 'typemoq';
-
 import { PermissionsStateStore } from '../../../../background/stores/global/permissions-state-store';
 import { UnifiedScanResultStore } from '../../../../background/stores/unified-scan-result-store';
 import { FeatureFlags } from '../../../../common/feature-flags';
@@ -58,6 +58,7 @@ export class StoreMocks {
     public launchPanelStateStoreMock = Mock.ofType(LaunchPanelStore, MockBehavior.Strict);
     public unifiedScanResultStoreMock = Mock.ofType(UnifiedScanResultStore, MockBehavior.Strict);
     public permissionsStateStoreMock = Mock.ofType(PermissionsStateStore, MockBehavior.Strict);
+    public tabStopsViewStoreMock = Mock.ofType(TabStopsViewStore, MockBehavior.Strict);
 
     public visualizationStoreData = new VisualizationStoreDataBuilder().build();
     public visualizationScanResultsStoreData =
@@ -89,7 +90,7 @@ export class StoreMocks {
     };
     public assessmentStoreData: AssessmentStoreData;
     public permissionsStateStoreData = new PermissionsStateStore(null).getDefaultState();
-
+    public tabStopsViewStoreData = new TabStopsViewStore(null).getDefaultState();
     public cardSelectionStoreData = new CardSelectionStore(null, null).getDefaultState();
 
     constructor() {


### PR DESCRIPTION
#### Details

Wires up the tab stops failed instance panel.

##### Motivation

Feature work.

##### Context

This uses the work in my previous two PRs and actually uses them.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
