### PR TITLE
feat(tab-stops-details-view): fix failure instance panel displaying header when it shouldn't

### DIFF
--- a/src/DetailsView/components/tab-stops-failed-instance-section.tsx
+++ b/src/DetailsView/components/tab-stops-failed-instance-section.tsx
@@ -43,7 +43,10 @@ export const TabStopsFailedInstanceSection = NamedFC<TabStopsFailedInstanceSecti
             });
         }
 
-        if (results.length === 0) {
+        const totalFailedInstancesCount: number =
+            props.deps.tabStopsFailedCounter.getTotalFailed(results);
+
+        if (totalFailedInstancesCount === 0) {
             return null;
         }
 
@@ -55,7 +58,7 @@ export const TabStopsFailedInstanceSection = NamedFC<TabStopsFailedInstanceSecti
                 <h2>
                     <ResultSectionTitle
                         title="Failed instances"
-                        badgeCount={props.deps.tabStopsFailedCounter.getTotalFailed(results)}
+                        badgeCount={totalFailedInstancesCount}
                         outcomeType="fail"
                         titleSize="title"
                     />

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-failed-instance-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-failed-instance-section.test.tsx.snap
@@ -2,8 +2,6 @@
 
 exports[`TabStopsFailedInstanceSection does not render when no results are failing 1`] = `null`;
 
-exports[`TabStopsFailedInstanceSection does not render when results are failing but there are no failed instances 1`] = `null`;
-
 exports[`TabStopsFailedInstanceSection renders with failing results 1`] = `
 <div
   className="tabStopsFailureInstanceSection"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-failed-instance-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-failed-instance-section.test.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`TabStopsFailedInstanceSection does not render when no results are failing 1`] = `null`;
 
+exports[`TabStopsFailedInstanceSection does not render when results are failing but there are no failed instances 1`] = `null`;
+
 exports[`TabStopsFailedInstanceSection renders with failing results 1`] = `
 <div
   className="tabStopsFailureInstanceSection"

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
@@ -84,20 +84,4 @@ describe('TabStopsFailedInstanceSection', () => {
         expect(wrapper.getElement()).toMatchSnapshot();
         tabStopsFailedCounterMock.verifyAll();
     });
-
-    it('does not render when results are failing but there are no failed instances', () => {
-        tabStopsFailedCounterMock
-            .setup(tsf => tsf.getTotalFailed(It.isAny()))
-            .returns(() => 0)
-            .verifiable(Times.once());
-
-        const wrapper = shallow(
-            <TabStopsFailedInstanceSection
-                deps={deps}
-                visualizationScanResultData={visualizationScanResultDataStub}
-            />,
-        );
-        expect(wrapper.getElement()).toMatchSnapshot();
-        tabStopsFailedCounterMock.verifyAll();
-    });
 });

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
@@ -72,7 +72,24 @@ describe('TabStopsFailedInstanceSection', () => {
 
         tabStopsFailedCounterMock
             .setup(tsf => tsf.getTotalFailed(It.isAny()))
-            .verifiable(Times.never());
+            .returns(() => 0)
+            .verifiable(Times.once());
+
+        const wrapper = shallow(
+            <TabStopsFailedInstanceSection
+                deps={deps}
+                visualizationScanResultData={visualizationScanResultDataStub}
+            />,
+        );
+        expect(wrapper.getElement()).toMatchSnapshot();
+        tabStopsFailedCounterMock.verifyAll();
+    });
+
+    it('does not render when results are failing but there are no failed instances', () => {
+        tabStopsFailedCounterMock
+            .setup(tsf => tsf.getTotalFailed(It.isAny()))
+            .returns(() => 0)
+            .verifiable(Times.once());
 
         const wrapper = shallow(
             <TabStopsFailedInstanceSection


### PR DESCRIPTION
#### Details

This fixes an issue that was causing the failure instance panel to show up when a requirement was failed but no instances were added.

##### Motivation

feature work

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
