### PR TITLE
feat(tab-stops-details-view): E2E tests to add, edit, and remove a failure instance

### DIFF
--- a/src/DetailsView/components/action-and-cancel-buttons-component.tsx
+++ b/src/DetailsView/components/action-and-cancel-buttons-component.tsx
@@ -13,6 +13,7 @@ export interface ActionAndCancelButtonsComponentProps {
     primaryButtonOnClick: (ev) => void;
     cancelButtonOnClick: (ev) => void;
     primaryButtonHref?: string;
+    primaryButtonDataAutomationId?: string;
 }
 
 export class ActionAndCancelButtonsComponent extends React.Component<ActionAndCancelButtonsComponentProps> {
@@ -24,6 +25,7 @@ export class ActionAndCancelButtonsComponent extends React.Component<ActionAndCa
                 </div>
                 <div className={styles.actionCancelButtonCol}>
                     <DefaultButton
+                        data-automation-id={this.props.primaryButtonDataAutomationId}
                         primary={true}
                         text={this.props.primaryButtonText}
                         onClick={this.props.primaryButtonOnClick}

--- a/src/DetailsView/components/tab-stops/failed-instance-panel.tsx
+++ b/src/DetailsView/components/tab-stops/failed-instance-panel.tsx
@@ -17,6 +17,9 @@ export interface FailedInstancePanelProps {
     onDismiss: () => void;
 }
 
+export const addFailedInstanceTextAreaAutomationId: string = 'addFailedInstanceTextArea';
+export const primaryAddFailedInstanceButtonAutomationId: string = 'primaryAddFailedInstanceButton';
+
 export class FailedInstancePanel extends React.Component<FailedInstancePanelProps> {
     public render(): JSX.Element {
         const panelProps: GenericPanelProps = {
@@ -31,6 +34,7 @@ export class FailedInstancePanel extends React.Component<FailedInstancePanelProp
         return (
             <GenericPanel {...panelProps}>
                 <TextField
+                    data-automation-id={addFailedInstanceTextAreaAutomationId}
                     className={styles.observedFailureTextfield}
                     label="Comment"
                     multiline={true}
@@ -50,6 +54,7 @@ export class FailedInstancePanel extends React.Component<FailedInstancePanelProp
             <div>
                 <ActionAndCancelButtonsComponent
                     isHidden={false}
+                    primaryButtonDataAutomationId={primaryAddFailedInstanceButtonAutomationId}
                     primaryButtonDisabled={this.props.instanceDescription === null}
                     primaryButtonText={this.props.confirmButtonText}
                     primaryButtonOnClick={() => {

--- a/src/DetailsView/components/tab-stops/tab-stops-choice-group.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-choice-group.tsx
@@ -17,6 +17,9 @@ export interface TabStopsChoiceGroupsProps {
     onAddFailureInstanceClicked: (ev: SupportedMouseEvent) => void;
 }
 
+export const addTabStopsFailureInstanceAutomationId = 'addTabStopsFailureInstance';
+export const tabStopsPassFailChoiceGroupAutomationId = 'tabStopsPassFailChoiceGroup';
+
 export interface ITabStopsChoiceGroup extends IChoiceGroupOption {
     key: InstanceResultStatus;
 }
@@ -29,6 +32,7 @@ export class TabStopsChoiceGroup extends React.Component<TabStopsChoiceGroupsPro
             <>
                 <div className={styles.tabStopsChoiceGroup}>
                     <ChoiceGroup
+                        data-automation-id={tabStopsPassFailChoiceGroupAutomationId}
                         className={this.props.status}
                         onChange={this.onChange}
                         componentRef={this.setComponentRef}
@@ -65,6 +69,7 @@ export class TabStopsChoiceGroup extends React.Component<TabStopsChoiceGroupsPro
                     <>
                         {this.getUndoButton()}
                         <Link
+                            data-automation-id={addTabStopsFailureInstanceAutomationId}
                             className={styles.undoButton}
                             onClick={this.props.onAddFailureInstanceClicked}
                         >

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { collapsibleButtonAutomationId } from 'common/components/cards/collapsible-component-cards';
 import { resultSectionAutomationId } from 'common/components/cards/result-section';
 import { ruleDetailsGroupAutomationId } from 'common/components/cards/rules-with-instances';
 import { instanceTableTextContentAutomationId } from 'DetailsView/components/assessment-instance-details-column';
@@ -15,6 +16,11 @@ import { overviewContainerAutomationId } from 'DetailsView/components/overview-c
 import { overviewHeadingAutomationId } from 'DetailsView/components/overview-content/overview-heading';
 import { reportExportButtonAutomationId } from 'DetailsView/components/report-export-button';
 import { startOverAutomationId } from 'DetailsView/components/start-over-component-factory';
+import { tabStopsFailedInstanceSectionAutomationId } from 'DetailsView/components/tab-stops-failed-instance-section';
+import {
+    addFailedInstanceTextAreaAutomationId,
+    primaryAddFailedInstanceButtonAutomationId,
+} from 'DetailsView/components/tab-stops/failed-instance-panel';
 import {
     addTabStopsFailureInstanceAutomationId,
     tabStopsPassFailChoiceGroupAutomationId,
@@ -87,6 +93,15 @@ export const tabStopsSelectors = {
     tabStopsFailRadioButton:
         getAutomationIdSelector(tabStopsPassFailChoiceGroupAutomationId) +
         ' > div > div >div:nth-child(2)',
+    addFailedInstanceTextArea: getAutomationIdSelector(addFailedInstanceTextAreaAutomationId),
+    primaryAddFailedInstanceButton: getAutomationIdSelector(
+        primaryAddFailedInstanceButtonAutomationId,
+    ),
+    failedInstancesSection: getAutomationIdSelector(tabStopsFailedInstanceSectionAutomationId),
+    collapsibleComponentExpandToggleButton: getAutomationIdSelector(collapsibleButtonAutomationId),
+    instanceTableTextContent: getAutomationIdSelector(instanceTableTextContentAutomationId),
+    instanceEditButton: '[data-automation-key="instanceActionButtons"] button:nth-child(1)',
+    instanceRemoveButton: '[data-automation-key="instanceActionButtons"] button:nth-child(2)',
 };
 
 export const overviewSelectors = {

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -81,10 +81,12 @@ export const fastPassAutomatedChecksSelectors = {
 };
 
 export const tabStopsSelectors = {
+    navDataAutomationId: getAutomationIdSelector('TabStops'),
     addFailureInstanceButton: getAutomationIdSelector(addTabStopsFailureInstanceAutomationId),
     tabStopsPassFailChoiceGroup: getAutomationIdSelector(tabStopsPassFailChoiceGroupAutomationId),
     tabStopsFailRadioButton:
-        getAutomationIdSelector(tabStopsPassFailChoiceGroupAutomationId) + ' [aria-label="Fail"]',
+        getAutomationIdSelector(tabStopsPassFailChoiceGroupAutomationId) +
+        ' > div > div >div:nth-child(2)',
 };
 
 export const overviewSelectors = {

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -15,6 +15,10 @@ import { overviewContainerAutomationId } from 'DetailsView/components/overview-c
 import { overviewHeadingAutomationId } from 'DetailsView/components/overview-content/overview-heading';
 import { reportExportButtonAutomationId } from 'DetailsView/components/report-export-button';
 import { startOverAutomationId } from 'DetailsView/components/start-over-component-factory';
+import {
+    addTabStopsFailureInstanceAutomationId,
+    tabStopsPassFailChoiceGroupAutomationId,
+} from 'DetailsView/components/tab-stops/tab-stops-choice-group';
 import { reportExportAsHtmlAutomationId } from 'report-export/services/html-report-export-service';
 import { reportExportAsJsonAutomationId } from 'report-export/services/json-report-export-service';
 import { testSummaryStatusAutomationId } from 'reports/components/assessment-summary-details';
@@ -74,6 +78,13 @@ export const fastPassAutomatedChecksSelectors = {
     cardsRuleId: getAutomationIdSelector(cardsRuleIdAutomationId),
     failureCount: getAutomationIdSelector(failureCountAutomationId),
     iframeWarning: getAutomationIdSelector(IframeWarningContainerAutomationId),
+};
+
+export const tabStopsSelectors = {
+    addFailureInstanceButton: getAutomationIdSelector(addTabStopsFailureInstanceAutomationId),
+    tabStopsPassFailChoiceGroup: getAutomationIdSelector(tabStopsPassFailChoiceGroupAutomationId),
+    tabStopsFailRadioButton:
+        getAutomationIdSelector(tabStopsPassFailChoiceGroupAutomationId) + ' [aria-label="Fail"]',
 };
 
 export const overviewSelectors = {

--- a/src/tests/end-to-end/tests/details-view/tabstops.test.ts
+++ b/src/tests/end-to-end/tests/details-view/tabstops.test.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FeatureFlags } from 'common/feature-flags';
+import { formatPageElementForSnapshot } from 'tests/common/element-snapshot-formatter';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
+import {
+    detailsViewSelectors,
+    tabStopsSelectors,
+} from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
 import { BackgroundPage } from 'tests/end-to-end/common/page-controllers/background-page';
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
@@ -27,7 +32,7 @@ describe('Details View -> FastPass -> TabStops', () => {
     });
 
     afterAll(async () => {
-        await browser?.close();
+        // await browser?.close();
     });
 
     it.each([true, false])(
@@ -40,6 +45,12 @@ describe('Details View -> FastPass -> TabStops', () => {
             expect(results).toHaveLength(0);
         },
     );
+
+    it('Shows proper options when failing a requirement', async () => {
+        await detailsViewPage.waitForSelector(tabStopsSelectors.tabStopsFailRadioButton);
+        await detailsViewPage.clickSelector(tabStopsSelectors.tabStopsFailRadioButton);
+        //should click the fail button but doesn't seem to be working currently
+    });
 });
 
 async function openTabStopsPage(

--- a/src/tests/end-to-end/tests/details-view/tabstops.test.ts
+++ b/src/tests/end-to-end/tests/details-view/tabstops.test.ts
@@ -1,20 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FeatureFlags } from 'common/feature-flags';
-import { formatPageElementForSnapshot } from 'tests/common/element-snapshot-formatter';
-import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
-import {
-    detailsViewSelectors,
-    tabStopsSelectors,
-} from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
+import { tabStopsSelectors } from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
 import { BackgroundPage } from 'tests/end-to-end/common/page-controllers/background-page';
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
 import { DetailsViewPage } from '../../common/page-controllers/details-view-page';
 import { TargetPage } from '../../common/page-controllers/target-page';
 import { scanForAccessibilityIssues } from '../../common/scan-for-accessibility-issues';
-
-const tabStopsNavDataAutomationId: string = getAutomationIdSelector('TabStops');
 
 describe('Details View -> FastPass -> TabStops', () => {
     let browser: Browser;
@@ -47,9 +40,11 @@ describe('Details View -> FastPass -> TabStops', () => {
     );
 
     it('Shows proper options when failing a requirement', async () => {
+        console.log(tabStopsSelectors.tabStopsFailRadioButton);
         await detailsViewPage.waitForSelector(tabStopsSelectors.tabStopsFailRadioButton);
         await detailsViewPage.clickSelector(tabStopsSelectors.tabStopsFailRadioButton);
-        //should click the fail button but doesn't seem to be working currently
+        await detailsViewPage.waitForSelector(tabStopsSelectors.addFailureInstanceButton);
+        await detailsViewPage.clickSelector(tabStopsSelectors.addFailureInstanceButton);
     });
 });
 
@@ -59,8 +54,8 @@ async function openTabStopsPage(
 ): Promise<DetailsViewPage> {
     const detailsViewPage = await browser.newDetailsViewPage(targetPage);
     await detailsViewPage.switchToFastPass();
-    await detailsViewPage.waitForSelector(tabStopsNavDataAutomationId);
-    await detailsViewPage.clickSelector(tabStopsNavDataAutomationId);
+    await detailsViewPage.waitForSelector(tabStopsSelectors.navDataAutomationId);
+    await detailsViewPage.clickSelector(tabStopsSelectors.navDataAutomationId);
 
     return detailsViewPage;
 }

--- a/src/tests/end-to-end/tests/details-view/tabstops.test.ts
+++ b/src/tests/end-to-end/tests/details-view/tabstops.test.ts
@@ -19,13 +19,13 @@ describe('Details View -> FastPass -> TabStops', () => {
         browser = await launchBrowser({ suppressFirstTimeDialog: true });
         targetPage = await browser.newTargetPage();
         await browser.newPopupPage(targetPage); // Required for the details view to register as having permissions/being open
-        detailsViewPage = await openTabStopsPage(browser, targetPage);
         backgroundPage = await browser.backgroundPage();
         await backgroundPage.enableFeatureFlag(FeatureFlags.newTabStopsDetailsView);
+        detailsViewPage = await openTabStopsPage(browser, targetPage);
     });
 
     afterAll(async () => {
-        // await browser?.close();
+        await browser?.close();
     });
 
     it.each([true, false])(
@@ -39,12 +39,59 @@ describe('Details View -> FastPass -> TabStops', () => {
         },
     );
 
-    it('Shows proper options when failing a requirement', async () => {
-        console.log(tabStopsSelectors.tabStopsFailRadioButton);
+    test('Add, Edit, and Remove a failure instance', async () => {
+        const initialFailureInstanceText = 'this is a test failure instance';
+        const editedFailureInstanceText = 'this is an edited failure instance';
+
+        //click "Fail" radio
         await detailsViewPage.waitForSelector(tabStopsSelectors.tabStopsFailRadioButton);
         await detailsViewPage.clickSelector(tabStopsSelectors.tabStopsFailRadioButton);
+
+        //click "+" button
         await detailsViewPage.waitForSelector(tabStopsSelectors.addFailureInstanceButton);
         await detailsViewPage.clickSelector(tabStopsSelectors.addFailureInstanceButton);
+
+        //add text to TextArea in failed instances panel
+        const addFailureTextArea = await detailsViewPage.waitForSelector(
+            tabStopsSelectors.addFailedInstanceTextArea,
+        );
+        await addFailureTextArea.fill(initialFailureInstanceText);
+
+        //click add button
+        await detailsViewPage.clickSelector(tabStopsSelectors.primaryAddFailedInstanceButton);
+
+        //check for failed instances section
+        await detailsViewPage.waitForSelector(tabStopsSelectors.failedInstancesSection);
+
+        // expand collapsible content to reveal failed instance
+        await detailsViewPage.clickSelector(
+            tabStopsSelectors.collapsibleComponentExpandToggleButton,
+        );
+
+        //get text of failed instance and check it's as expected
+        const textContentElement = await detailsViewPage.waitForSelector(
+            tabStopsSelectors.instanceTableTextContent,
+        );
+        const textContent = await textContentElement.textContent();
+        expect(textContent).toBe(initialFailureInstanceText);
+
+        //click edit button
+        await detailsViewPage.clickSelector(tabStopsSelectors.instanceEditButton);
+
+        //edit text and save
+        const editFailureTextArea = await detailsViewPage.waitForSelector(
+            tabStopsSelectors.addFailedInstanceTextArea,
+        );
+        await editFailureTextArea.fill(editedFailureInstanceText);
+        await detailsViewPage.clickSelector(tabStopsSelectors.primaryAddFailedInstanceButton);
+
+        //check that failure instance section shows newly edited text
+        const editedTextContent = await textContentElement.textContent();
+        expect(editedTextContent).toBe(editedFailureInstanceText);
+
+        //click remove button, ensure failed instance section disappears
+        await detailsViewPage.clickSelector(tabStopsSelectors.instanceRemoveButton);
+        await detailsViewPage.waitForSelectorToDisappear(tabStopsSelectors.failedInstancesSection);
     });
 });
 

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/failed-instance-panel.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/failed-instance-panel.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`FailedInstancePanel primary button disabled without description 1`] = `
 >
   <StyledTextFieldBase
     className="observedFailureTextfield"
+    data-automation-id="addFailedInstanceTextArea"
     label="Comment"
     multiline={true}
     onChange={[Function]}
@@ -23,6 +24,7 @@ exports[`FailedInstancePanel primary button disabled without description 1`] = `
     <ActionAndCancelButtonsComponent
       cancelButtonOnClick={[Function]}
       isHidden={false}
+      primaryButtonDataAutomationId="primaryAddFailedInstanceButton"
       primaryButtonDisabled={true}
       primaryButtonOnClick={[Function]}
       primaryButtonText="some confirm text"
@@ -42,6 +44,7 @@ exports[`FailedInstancePanel renders 1`] = `
 >
   <StyledTextFieldBase
     className="observedFailureTextfield"
+    data-automation-id="addFailedInstanceTextArea"
     label="Comment"
     multiline={true}
     onChange={[Function]}
@@ -54,6 +57,7 @@ exports[`FailedInstancePanel renders 1`] = `
     <ActionAndCancelButtonsComponent
       cancelButtonOnClick={[Function]}
       isHidden={false}
+      primaryButtonDataAutomationId="primaryAddFailedInstanceButton"
       primaryButtonDisabled={false}
       primaryButtonOnClick={[Function]}
       primaryButtonText="some confirm text"

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-choice-group.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-choice-group.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`TabStopsChoiceGroup render with fail status 1`] = `
     <StyledChoiceGroupBase
       className="fail"
       componentRef={[Function]}
+      data-automation-id="tabStopsPassFailChoiceGroup"
       onChange={[Function]}
       options={
         Array [
@@ -46,6 +47,7 @@ exports[`TabStopsChoiceGroup render with fail status 1`] = `
       </StyledLinkBase>
       <StyledLinkBase
         className="undoButton"
+        data-automation-id="addTabStopsFailureInstance"
         onClick={[Function]}
       >
         <StyledIconBase
@@ -66,6 +68,7 @@ exports[`TabStopsChoiceGroup render with pass status 1`] = `
     <StyledChoiceGroupBase
       className="pass"
       componentRef={[Function]}
+      data-automation-id="tabStopsPassFailChoiceGroup"
       onChange={[Function]}
       options={
         Array [
@@ -109,6 +112,7 @@ exports[`TabStopsChoiceGroup render with unknown status 1`] = `
     <StyledChoiceGroupBase
       className="unknown"
       componentRef={[Function]}
+      data-automation-id="tabStopsPassFailChoiceGroup"
       onChange={[Function]}
       options={
         Array [


### PR DESCRIPTION
#### Details

This adds an E2E test to add, edit, and remove a failure instance in tab stops.

##### Motivation

Feature work

##### Context

I considered breaking the single test into multiple tests. I decided to leave it as one large test because the flow made sense and reduced the need for a lot of duplicate (and very slow) setup steps. As such it first adds, then edits, then removes the same failure instance within a single test.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
