### PR TITLE
fix: change resize text display resolution

### DIFF
--- a/src/assessments/adaptable-content/test-steps/resize-text.tsx
+++ b/src/assessments/adaptable-content/test-steps/resize-text.tsx
@@ -32,7 +32,7 @@ const resizeTextHowToTest: JSX.Element = (
                 <Markup.Term>System</Markup.Term> {'>'} <Markup.Term>Display</Markup.Term> {'>'}{' '}
                 <Markup.Term>Scale and layout</Markup.Term> to
                 <ol>
-                    <li>Set the resolution to 1920x1080, and</li>
+                    <li>Set the resolution to 1280 pixels wide, and</li>
                     <li>Set scaling to 100%.</li>
                 </ol>
             </li>


### PR DESCRIPTION
#### Details

This fix updates the display resolution sizes in the instructions for Adaptable Content > Resize Text. 

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context
![image](https://user-images.githubusercontent.com/18401275/142060263-e0b5b6a6-4413-4dd6-b4fe-44be7cd6c490.png)
Outdated display resolution text.

![image](https://user-images.githubusercontent.com/18401275/142059460-b26c6f5c-3b53-4819-a168-da0e4e52b08c.png)
Updated text, changed for testing consistency.

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4884
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
