### PR TITLE
feat(tab-stops-details-view): fit and finish of UI

### DIFF
--- a/src/DetailsView/components/adhoc-tab-stops-test-view.scss
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.scss
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+@import '../../common/styles/fonts.scss';
+
+.requirement-table-title {
+    @include text-style-title-s;
+    margin-bottom: unset;
+}
+
+.visual-helper-toggle {
+    display: flex;
+    align-items: center;
+    word-wrap: break-word;
+    margin: unset;
+
+    label {
+        @include text-style-body-m;
+        margin-right: 8px;
+        font-weight: 600;
+    }
+}
+
+h2.requirement-how-to-test-header {
+    @include text-style-title-s;
+}

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { VisualizationToggle } from 'common/components/visualization-toggle';
+import * as toggleStyles from 'common/components/cards/visual-helper-toggle.scss';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { NamedFC } from 'common/react/named-fc';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -28,6 +28,7 @@ import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stop
 import { TargetPageChangedView } from 'DetailsView/components/target-page-changed-view';
 import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { createFastPassProviderWithFeatureFlags } from 'fast-pass/fast-pass-provider';
+import { Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ContentLink, ContentLinkDeps } from 'views/content/content-link';
 import { ContentReference } from 'views/content/content-page';
@@ -120,14 +121,13 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                     {` ${stepsText} `}
                     <ContentLink deps={props.deps} reference={props.guidance} iconName="info" />
                 </h1>
-                <VisualizationToggle
-                    checked={scanData.enabled}
-                    onClick={clickHandler}
-                    label={displayableData.toggleLabel}
-                    className={styles.detailsViewToggle}
-                    visualizationName={displayableData.title}
-                />
                 {description}
+                <Toggle
+                    onClick={clickHandler}
+                    label="Visual helper"
+                    checked={scanData.enabled}
+                    className={toggleStyles.visualHelperToggle}
+                />
                 <RequirementInstructions howToTest={howToTest} />
                 <TabStopsRequirementsTable deps={props.deps} requirementState={requirementState} />
                 <TabStopsFailedInstanceSection

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as toggleStyles from 'common/components/cards/visual-helper-toggle.scss';
+import { CollapsibleComponent } from 'common/components/collapsible-component';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { NamedFC } from 'common/react/named-fc';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -10,8 +10,9 @@ import { VisualizationScanResultData } from 'common/types/store-data/visualizati
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
-import { RequirementInstructions } from 'DetailsView/components/requirement-instructions';
-import * as styles from 'DetailsView/components/static-content-common.scss';
+import * as styles from 'DetailsView/components/adhoc-tab-stops-test-view.scss';
+import * as requirementInstructionStyles from 'DetailsView/components/requirement-instructions.scss';
+import * as commonStyles from 'DetailsView/components/static-content-common.scss';
 import {
     TabStopsFailedInstanceSection,
     TabStopsFailedInstanceSectionDeps,
@@ -115,7 +116,7 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
         }
 
         return (
-            <div className={styles.staticContentInDetailsView}>
+            <div className={commonStyles.staticContentInDetailsView}>
                 <h1>
                     {displayableData.title}
                     {` ${stepsText} `}
@@ -126,9 +127,14 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                     onClick={clickHandler}
                     label="Visual helper"
                     checked={scanData.enabled}
-                    className={toggleStyles.visualHelperToggle}
+                    className={styles.visualHelperToggle}
                 />
-                <RequirementInstructions howToTest={howToTest} />
+                <CollapsibleComponent
+                    header={<h2 className={styles.requirementHowToTestHeader}>How to test</h2>}
+                    content={howToTest}
+                    contentClassName={requirementInstructionStyles.requirementInstructions}
+                />
+                <h2 className={styles.requirementTableTitle}>Record your results</h2>
                 <TabStopsRequirementsTable deps={props.deps} requirementState={requirementState} />
                 <TabStopsFailedInstanceSection
                     deps={props.deps}

--- a/src/DetailsView/components/static-content-common.scss
+++ b/src/DetailsView/components/static-content-common.scss
@@ -4,9 +4,9 @@
 @import '../../common/styles/common.scss';
 
 .static-content-in-details-view {
-    margin-top: $fastPassRightPanelMarginTop;
-    margin-right: $fastPassRightPanelMarginRight;
-    margin-left: $fastPassRightPanelMarginLeft;
+    padding-top: $fastPassRightPanelMarginTop;
+    padding-right: $fastPassRightPanelMarginRight;
+    padding-left: $fastPassRightPanelMarginLeft;
     margin-bottom: auto;
     ol {
         -webkit-padding-start: 16px;
@@ -17,6 +17,8 @@
     i {
         font-size: 16px;
     }
+    background-color: $neutral-2;
+    height: 100%;
 }
 
 .details-view-toggle {

--- a/src/DetailsView/components/tab-stops/tab-stops-requirement-table.scss
+++ b/src/DetailsView/components/tab-stops/tab-stops-requirement-table.scss
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+@import '../../../common/styles/common.scss';
+
 .requirement-column {
     font-size: 14px;
 }
@@ -12,4 +14,8 @@
 
 .requirement-name {
     font-weight: 600;
+}
+
+.requirement-table * {
+    background-color: $neutral-2;
 }

--- a/src/DetailsView/components/tab-stops/tab-stops-requirements-table.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-requirements-table.tsx
@@ -70,6 +70,13 @@ export const TabStopsRequirementsTable = NamedFC<TabStopsRequirementsTableProps>
             },
         ];
 
-        return <DetailsList items={requirementsList} columns={columns} checkboxVisibility={2} />;
+        return (
+            <DetailsList
+                className={styles.requirementTable}
+                items={requirementsList}
+                columns={columns}
+                checkboxVisibility={2}
+            />
+        );
     },
 );

--- a/src/DetailsView/tab-stops-requirement-instances-collapsible-content.scss
+++ b/src/DetailsView/tab-stops-requirement-instances-collapsible-content.scss
@@ -3,52 +3,6 @@
 @import '../common/styles/colors.scss';
 @import '../common/styles/common.scss';
 
-.failure-instance-panel {
-    .observed-failure-textfield {
-        padding-bottom: 12px;
-    }
-    :global(.header-text) {
-        font-size: 21px;
-    }
-}
-
-.failure-instance-snippet-empty-body {
-    margin: 8px 0px 24px 0px;
-    color: $secondary-text;
-}
-
-.failure-instance-snippet-title {
-    margin: 24px 0px 8px 0px;
-    color: $primary-text;
-}
-
-.failure-instance-selector-note {
-    color: $secondary-text;
-    margin: 8px 0px 8px 0px;
-}
-
-.failure-instance-snippet-filled-body {
-    margin: 8px 0px 24px 0px;
-    padding: 12px 16px 12px 16px;
-    max-height: 200px;
-    color: $primary-text;
-    background-color: $neutral-4;
-    overflow-y: scroll;
-    word-wrap: break-word;
-}
-
-.failure-instance-snippet-error {
-    margin: 9px 0px 50px 9px;
-    color: $secondary-text;
-    display: flex;
-    flex-direction: row;
-}
-
-.failure-instance-snippet-error-icon {
-    color: $negative-outcome;
-    padding: 3px 8px;
-}
-
 .edit-button {
     font-size: 16px !important;
     line-height: 24px !important;
@@ -66,4 +20,8 @@
     @media screen and (forced-colors: active) {
         color: inherit;
     }
+}
+
+.failed-instances-details * {
+    background-color: $neutral-2;
 }

--- a/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
+++ b/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
@@ -103,6 +103,7 @@ export const TabStopsRequirementInstancesCollapsibleContent =
                     checkboxVisibility={CheckboxVisibility.hidden}
                     constrainMode={ConstrainMode.horizontalConstrained}
                     onRenderDetailsHeader={() => null}
+                    className={styles.failedInstancesDetails}
                 />
             );
         },

--- a/src/common/components/collapsible-component.scss
+++ b/src/common/components/collapsible-component.scss
@@ -14,7 +14,6 @@ span.collapsible-title {
     border: none;
     outline: none;
     line-height: 0.25px;
-    background-color: $neutral-0;
     display: flex;
     justify-content: flex-start;
     align-items: center;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -13,18 +13,17 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
       reference="stub-guidance"
     />
   </h1>
-  <VisualizationToggle
-    checked={true}
-    className="detailsViewToggle"
-    label="test toggle label"
-    onClick={[Function]}
-    visualizationName="test title"
-  />
   <p>
     <Emphasis>
       Note: this test requires you to use a keyboard and to visually identify interactive elements.
     </Emphasis>
   </p>
+  <StyledToggleBase
+    checked={true}
+    className="visualHelperToggle"
+    label="Visual helper"
+    onClick={[Function]}
+  />
   <RequirementInstructions
     howToTest={
       <ol>
@@ -89,18 +88,17 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
       iconName="info"
     />
   </h1>
-  <VisualizationToggle
-    checked={true}
-    className="detailsViewToggle"
-    label="test toggle label"
-    onClick={[Function]}
-    visualizationName="test title"
-  />
   <p>
     <Emphasis>
       Note: this test requires you to use a keyboard and to visually identify interactive elements.
     </Emphasis>
   </p>
+  <StyledToggleBase
+    checked={true}
+    className="visualHelperToggle"
+    label="Visual helper"
+    onClick={[Function]}
+  />
   <RequirementInstructions
     howToTest={
       <ol>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -24,8 +24,8 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
     label="Visual helper"
     onClick={[Function]}
   />
-  <RequirementInstructions
-    howToTest={
+  <CollapsibleComponent
+    content={
       <ol>
         <li>
           Locate the visual helper on the target page, it will highlight element in focus with an empty circle.
@@ -53,7 +53,20 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
         </li>
       </ol>
     }
+    contentClassName="requirementInstructions"
+    header={
+      <h2
+        className="requirementHowToTestHeader"
+      >
+        How to test
+      </h2>
+    }
   />
+  <h2
+    className="requirementTableTitle"
+  >
+    Record your results
+  </h2>
   <TabStopsRequirementsTable
     deps="stub-deps"
   />
@@ -99,8 +112,8 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
     label="Visual helper"
     onClick={[Function]}
   />
-  <RequirementInstructions
-    howToTest={
+  <CollapsibleComponent
+    content={
       <ol>
         <li>
           Locate the visual helper on the target page, it will highlight element in focus with an empty circle.
@@ -128,7 +141,20 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
         </li>
       </ol>
     }
+    contentClassName="requirementInstructions"
+    header={
+      <h2
+        className="requirementHowToTestHeader"
+      >
+        How to test
+      </h2>
+    }
   />
+  <h2
+    className="requirementTableTitle"
+  >
+    Record your results
+  </h2>
   <TabStopsRequirementsTable
     deps="stub-deps"
   />

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirement-instances-collapsible-content.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`TabStopsRequirementInstancesCollapsibleContent renders 1`] = `
 <StyledWithViewportComponent
   checkboxVisibility={2}
+  className="failedInstancesDetails"
   columns={
     Array [
       Object {

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-requirements-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-requirements-table.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`TabStopsRequirementsTable renders result column 1`] = `
 exports[`TabStopsRequirementsTable renders table 1`] = `
 <StyledWithViewportComponent
   checkboxVisibility={2}
+  className="requirementTable"
   columns={
     Array [
       Object {


### PR DESCRIPTION
#### Details

fit and finish for the new tab stops details view.

##### Motivation

feature work.

##### Context

Left is before and right is after changes for the screen grab below.

![image](https://user-images.githubusercontent.com/32555133/142142475-ce2086e0-127b-463b-894d-b5d3bb4934f6.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
