### PR TITLE
fix: Use aria-label on NavLinkButton to improve Orca reading behavior

### DIFF
--- a/src/DetailsView/components/nav-link-button.tsx
+++ b/src/DetailsView/components/nav-link-button.tsx
@@ -12,11 +12,13 @@ export interface NavLinkButtonProps extends INavButtonProps {
 
 export const NavLinkButton = NamedFC<NavLinkButtonProps>('NavLinkButton', props => {
     const link = props.link;
+    const ariaLabel = buildAriaLabel(link, props);
+
     return (
         <Link
             data-automation-id={link.key}
             aria-expanded={link.isExpanded}
-            aria-current={props['aria-current']}
+            aria-label={ariaLabel}
             title={link.title || link.name}
             onClick={e => link.onClickNavLink(e, link)}
             className={css(styles.navLinkButton, props.className)}
@@ -26,3 +28,13 @@ export const NavLinkButton = NamedFC<NavLinkButtonProps>('NavLinkButton', props 
         </Link>
     );
 });
+
+// This is a workaround to simulate the aria-current property because Orca (Ubuntu's SR) ignores it
+const buildAriaLabel = (
+    link: BaseLeftNavLink,
+    props: React.PropsWithChildren<NavLinkButtonProps>,
+) => {
+    let ariaLabel = link.title || link.name;
+    ariaLabel += props['aria-current'] ? ' (current page)' : '';
+    return ariaLabel;
+};

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/nav-link-button.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`NavLinkButton renders as button element 1`] = `
 <StyledLinkBase
   aria-expanded={true}
+  aria-label="some title"
   className="navLinkButton some class name"
   onClick={[Function]}
   title="some title"
@@ -12,8 +13,19 @@ exports[`NavLinkButton renders as button element 1`] = `
 exports[`NavLinkButton renders with href set 1`] = `
 <StyledLinkBase
   aria-expanded={true}
+  aria-label="some title"
   className="navLinkButton some class name"
   href="#"
+  onClick={[Function]}
+  title="some title"
+/>
+`;
+
+exports[`NavLinkButton renders with the proper aria-label 1`] = `
+<StyledLinkBase
+  aria-expanded={true}
+  aria-label="some title (current page)"
+  className="navLinkButton some class name"
   onClick={[Function]}
   title="some title"
 />
@@ -22,6 +34,7 @@ exports[`NavLinkButton renders with href set 1`] = `
 exports[`NavLinkButton renders with using name instead of title 1`] = `
 <StyledLinkBase
   aria-expanded={true}
+  aria-label="some title"
   className="navLinkButton some class name"
   onClick={[Function]}
   title="some title"

--- a/src/tests/unit/tests/DetailsView/components/nav-link-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/nav-link-button.test.tsx
@@ -43,4 +43,10 @@ describe('NavLinkButton', () => {
         const testSubject = shallow(<NavLinkButton {...props} />);
         expect(testSubject.getElement()).toMatchSnapshot();
     });
+
+    test('renders with the proper aria-label', () => {
+        props['aria-current'] = 'page';
+        const testSubject = shallow(<NavLinkButton {...props} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Details
Currently, we set aria-current="page" on the left nav bar button for the currently selected page. This is right and proper. Unfortunately, the Orca screen reader ignores this setting in both the Web and Android products. To improve the user's experience, this PR replaces the use of aria-current with an aria-label to simulate the proper reading behavior. 

##### Motivation
Addresses accessibility bug in Linux.

##### Context
I considered leaving the aria-current value as-is, but that results in a double reading of current page from non-Orca screen readers.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: ADO 1886192
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
