### PR TITLE
feat(tab-stops-details-view): start over removes data from scan result store

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -343,6 +343,7 @@ export class ActionCreator {
     private onRescanVisualization = (payload: RescanVisualizationPayload) => {
         this.visualizationActions.disableVisualization.invoke(payload.test);
         this.visualizationActions.enableVisualization.invoke(payload);
+        this.visualizationActions.rescanVisualization.invoke(payload.test);
         this.unifiedScanResultActions.startScan.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.RESCAN_VISUALIZATION, payload);
     };

--- a/src/background/actions/visualization-actions.ts
+++ b/src/background/actions/visualization-actions.ts
@@ -13,6 +13,7 @@ export class VisualizationActions {
     public readonly enableVisualizationWithoutScan = new Action<ToggleActionPayload>();
     public readonly disableVisualization = new Action<VisualizationType>();
     public readonly disableAssessmentVisualizations = new Action<void>();
+    public readonly rescanVisualization = new Action<VisualizationType>();
 
     public readonly updateFocusedInstance = new Action<string[]>();
 

--- a/src/background/actions/visualization-scan-result-actions.ts
+++ b/src/background/actions/visualization-scan-result-actions.ts
@@ -7,7 +7,6 @@ import { AddTabbedElementPayload } from './action-payloads';
 export class VisualizationScanResultActions {
     public readonly scanCompleted = new Action<ScanCompletedPayload<any>>();
     public readonly getCurrentState = new Action();
-    public readonly disableIssues = new Action();
     public readonly addTabbedElement = new Action<AddTabbedElementPayload>();
     public readonly disableTabStop = new Action();
 }

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -44,7 +44,9 @@ export class TabContextStoreHub implements StoreHub {
             actionHub.visualizationScanResultActions,
             actionHub.tabActions,
             actionHub.tabStopRequirementActions,
+            actionHub.visualizationActions,
             generateUID,
+            visualizationConfigurationFactory,
         );
         this.visualizationScanResultStore.initialize();
 

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -107,6 +107,10 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
     };
 
     private onRescanVisualization = (type: VisualizationType) => {
+        this.resetDataForVisualization(type);
+    };
+
+    private resetDataForVisualization = (type: VisualizationType) => {
         const config = this.visualizationConfigurationFactory.getConfiguration(type);
         const testKey = config.key;
         if (this.state[testKey] == null) {

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -77,7 +77,7 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
     }
 
     protected addActionListeners(): void {
-        this.visualizationActions.disableVisualization.addListener(this.onDisableVisualization);
+        this.visualizationActions.rescanVisualization.addListener(this.onRescanVisualization);
         this.visualizationScanResultActions.scanCompleted.addListener(this.onScanCompleted);
         this.visualizationScanResultActions.getCurrentState.addListener(this.onGetCurrentState);
         this.visualizationScanResultActions.addTabbedElement.addListener(this.onAddTabbedElement);
@@ -106,7 +106,7 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         this.emitChanged();
     };
 
-    private onDisableVisualization = (type: VisualizationType) => {
+    private onRescanVisualization = (type: VisualizationType) => {
         const config = this.visualizationConfigurationFactory.getConfiguration(type);
         const testKey = config.key;
         if (this.state[testKey] == null) {

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -2,12 +2,16 @@
 // Licensed under the MIT License.
 
 import { TabStopRequirementActions } from 'background/actions/tab-stop-requirement-actions';
+import { VisualizationActions } from 'background/actions/visualization-actions';
+import { AdHocTestkeys } from 'common/configs/adhoc-test-keys';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { StoreNames } from 'common/stores/store-names';
 import {
-    VisualizationScanResultData,
     TabStopRequirementStatuses,
+    VisualizationScanResultData,
 } from 'common/types/store-data/visualization-scan-result-data';
 import { TabStopEvent } from 'common/types/tab-stop-event';
+import { VisualizationType } from 'common/types/visualization-type';
 import { ScanCompletedPayload } from 'injected/analyzers/analyzer';
 import { DecoratedAxeNodeResult, HtmlElementAxeResults } from 'injected/scanner-utils';
 import { forOwn, map } from 'lodash';
@@ -26,23 +30,15 @@ import { TabActions } from '../actions/tab-actions';
 import { VisualizationScanResultActions } from '../actions/visualization-scan-result-actions';
 import { BaseStoreImpl } from './base-store-impl';
 export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationScanResultData> {
-    private visualizationScanResultsActions: VisualizationScanResultActions;
-    private tabActions: TabActions;
-    private tabStopRequirementActions: TabStopRequirementActions;
-    private generateUID: () => string;
-
     constructor(
-        visualizationScanResultActions: VisualizationScanResultActions,
-        tabActions: TabActions,
-        tabStopRequirementActions: TabStopRequirementActions,
-        generateUID: () => string,
+        private visualizationScanResultActions: VisualizationScanResultActions,
+        private tabActions: TabActions,
+        private tabStopRequirementActions: TabStopRequirementActions,
+        private visualizationActions: VisualizationActions,
+        private generateUID: () => string,
+        private visualizationConfigurationFactory: VisualizationConfigurationFactory,
     ) {
         super(StoreNames.VisualizationScanResultStore);
-
-        this.visualizationScanResultsActions = visualizationScanResultActions;
-        this.tabActions = tabActions;
-        this.tabStopRequirementActions = tabStopRequirementActions;
-        this.generateUID = generateUID;
     }
 
     public getDefaultState(): VisualizationScanResultData {
@@ -55,13 +51,19 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
             };
         }
         const state: Partial<VisualizationScanResultData> = {
-            tabStops: {
+            [AdHocTestkeys.TabStops]: {
                 tabbedElements: null,
                 requirements,
             },
         };
 
-        const keys = ['issues', 'landmarks', 'headings', 'color', 'needsReview'];
+        const keys: AdHocTestkeys[] = [
+            AdHocTestkeys.Issues,
+            AdHocTestkeys.Landmarks,
+            AdHocTestkeys.Headings,
+            AdHocTestkeys.Color,
+            AdHocTestkeys.NeedsReview,
+        ];
 
         keys.forEach(key => {
             state[key] = {
@@ -75,11 +77,11 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
     }
 
     protected addActionListeners(): void {
-        this.visualizationScanResultsActions.scanCompleted.addListener(this.onScanCompleted);
-        this.visualizationScanResultsActions.getCurrentState.addListener(this.onGetCurrentState);
-        this.visualizationScanResultsActions.disableIssues.addListener(this.onIssuesDisabled);
-        this.visualizationScanResultsActions.addTabbedElement.addListener(this.onAddTabbedElement);
-        this.visualizationScanResultsActions.disableTabStop.addListener(this.onTabStopsDisabled);
+        this.visualizationActions.disableVisualization.addListener(this.onDisableVisualization);
+        this.visualizationScanResultActions.scanCompleted.addListener(this.onScanCompleted);
+        this.visualizationScanResultActions.getCurrentState.addListener(this.onGetCurrentState);
+        this.visualizationScanResultActions.addTabbedElement.addListener(this.onAddTabbedElement);
+        this.visualizationScanResultActions.disableTabStop.addListener(this.onTabStopsDisabled);
         this.tabStopRequirementActions.updateTabStopsRequirementStatus.addListener(
             this.onUpdateTabStopRequirementStatus,
         );
@@ -101,6 +103,17 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
 
     private onTabStopsDisabled = (): void => {
         this.state.tabStops.tabbedElements = null;
+        this.emitChanged();
+    };
+
+    private onDisableVisualization = (type: VisualizationType) => {
+        const config = this.visualizationConfigurationFactory.getConfiguration(type);
+        const testKey = config.key;
+        if (this.state[testKey] == null) {
+            return;
+        }
+
+        this.state[testKey] = this.getDefaultState()[testKey];
         this.emitChanged();
     };
 
@@ -200,11 +213,6 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         this.state[payload.key].fullAxeResultsMap = selectorMap;
         this.state[payload.key].scanResult = result;
 
-        this.emitChanged();
-    };
-
-    private onIssuesDisabled = (): void => {
-        this.state.issues.scanResult = null;
         this.emitChanged();
     };
 

--- a/src/common/types/store-data/visualization-scan-result-data.ts
+++ b/src/common/types/store-data/visualization-scan-result-data.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AdHocTestkeys } from 'common/configs/adhoc-test-keys';
 import { TabStopEvent } from 'common/types/tab-stop-event';
 import { DecoratedAxeNodeResult, HtmlElementAxeResults } from 'injected/scanner-utils';
 import { TabOrderPropertyBag } from 'injected/tab-order-property-bag';
@@ -42,9 +43,9 @@ interface TabStopsScanResultData {
 }
 
 export interface VisualizationScanResultData {
-    issues: IssuesScanResultData;
-    landmarks: IssuesScanResultData;
-    headings: IssuesScanResultData;
-    color: IssuesScanResultData;
-    tabStops: TabStopsScanResultData;
+    [AdHocTestkeys.Issues]: IssuesScanResultData;
+    [AdHocTestkeys.Landmarks]: IssuesScanResultData;
+    [AdHocTestkeys.Headings]: IssuesScanResultData;
+    [AdHocTestkeys.Color]: IssuesScanResultData;
+    [AdHocTestkeys.TabStops]: TabStopsScanResultData;
 }

--- a/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
@@ -16,7 +16,9 @@ export class VisualizationScanResultStoreDataBuilder extends BaseDataBuilder<Vis
             null,
             null,
             null,
+            null,
             generateUID,
+            null,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -738,6 +738,7 @@ describe('ActionCreatorTest', () => {
         const disableActionName = 'disableVisualization';
         const enableActionName = 'enableVisualization';
         const startScanActionName = 'startScan';
+        const rescanVisualization = 'rescanVisualization';
 
         const validator = new ActionCreatorValidator()
             .setupRegistrationCallback(Messages.Visualizations.Common.RescanVisualization, [
@@ -745,9 +746,11 @@ describe('ActionCreatorTest', () => {
                 tabId,
             ])
             .setupActionOnVisualizationActions(disableActionName)
+            .setupActionOnVisualizationActions(rescanVisualization)
             .setupActionOnVisualizationActions(enableActionName)
             .setupActionOnUnifiedScanResultActions(startScanActionName)
             .setupVisualizationActionWithInvokeParameter(disableActionName, payload.test)
+            .setupVisualizationActionWithInvokeParameter(rescanVisualization, payload.test)
             .setupVisualizationActionWithInvokeParameter(enableActionName, payload)
             .setupUnifiedScanResultActionWithInvokeParameter(startScanActionName, null)
             .setupTelemetrySend(TelemetryEvents.RESCAN_VISUALIZATION, payload, tabId);

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -84,7 +84,7 @@ describe('VisualizationScanResultStoreTest', () => {
         ).testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onVisualizationDisabled: for test that has state', () => {
+    test('onRescanVisualization: for test that has state', () => {
         const tabEvents: TabbedElementData[] = [
             {
                 target: ['selector'],
@@ -109,12 +109,12 @@ describe('VisualizationScanResultStoreTest', () => {
             .setup(m => m.getConfiguration(visualizationTypeStub))
             .returns(() => configStub);
 
-        createStoreTesterForVisualizationActions('disableVisualization')
+        createStoreTesterForVisualizationActions('rescanVisualization')
             .withActionParam(visualizationTypeStub)
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onVisualizationDisabled: for test that does not have state', () => {
+    test('onRescanVisualizationv: for test that does not have state', () => {
         const tabEvents: TabbedElementData[] = [
             {
                 target: ['selector'],
@@ -137,7 +137,7 @@ describe('VisualizationScanResultStoreTest', () => {
             .setup(m => m.getConfiguration(visualizationTypeStub))
             .returns(() => configStub);
 
-        createStoreTesterForVisualizationActions('disableVisualization')
+        createStoreTesterForVisualizationActions('rescanVisualization')
             .withActionParam(visualizationTypeStub)
             .testListenerToNeverBeCalled(initialState, initialState);
     });

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -9,8 +9,13 @@ import {
 } from 'background/actions/action-payloads';
 import { TabActions } from 'background/actions/tab-actions';
 import { TabStopRequirementActions } from 'background/actions/tab-stop-requirement-actions';
+import { VisualizationActions } from 'background/actions/visualization-actions';
 import { VisualizationScanResultActions } from 'background/actions/visualization-scan-result-actions';
 import { VisualizationScanResultStore } from 'background/stores/visualization-scan-result-store';
+import { AdHocTestkeys } from 'common/configs/adhoc-test-keys';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { IMock, Mock } from 'typemoq';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import {
     TabbedElementData,
@@ -23,8 +28,15 @@ import { ScanResults } from '../../../../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../../../../types/common-types';
 import { createStoreWithNullParams, StoreTester } from '../../../common/store-tester';
 import { VisualizationScanResultStoreDataBuilder } from '../../../common/visualization-scan-result-store-data-builder';
+
 const generateUIDStub = () => 'abc';
 describe('VisualizationScanResultStoreTest', () => {
+    let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
+
+    beforeEach(() => {
+        visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
+    });
+
     test('constructor, no side effects', () => {
         const testObject = createStoreWithNullParams(VisualizationScanResultStore);
 
@@ -49,119 +61,6 @@ describe('VisualizationScanResultStoreTest', () => {
         );
     });
 
-    test('onIssuesDisabled', () => {
-        const expectedViolations: AxeRule[] = [
-            {
-                id: 'test id',
-                description: 'test description',
-                nodes: [
-                    {
-                        any: [],
-                        none: [],
-                        all: [],
-                        html: '',
-                        target: ['target1'],
-                    },
-                    {
-                        any: [],
-                        none: [],
-                        all: [],
-                        html: '',
-                        target: ['target2'],
-                    },
-                ],
-            },
-        ];
-
-        const expectedFullIdToResultMap = {
-            id1: {
-                all: [],
-                any: [],
-                failureSummary: 'failureSummary',
-                html: 'html',
-                none: [],
-                ruleId: 'test id',
-                status: false,
-                selector: 'target1',
-                id: 'id1',
-            },
-            id2: {
-                all: [],
-                any: [],
-                failureSummary: 'failureSummary',
-                html: 'html',
-                none: [],
-                ruleId: 'test id',
-                status: false,
-                selector: 'target2',
-                id: 'id2',
-            },
-        };
-
-        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
-            target1: {
-                target: ['target1'],
-                ruleResults: {
-                    'test id': {
-                        any: [],
-                        all: [],
-                        none: [],
-                        status: false,
-                        ruleId: 'test id',
-                        selector: 'target1',
-                        html: 'html',
-                        failureSummary: 'failureSummary',
-                        help: 'help1',
-                        id: 'id1',
-                        guidanceLinks: [],
-                        helpUrl: 'help1',
-                    },
-                },
-            },
-            target2: {
-                target: ['target2'],
-                ruleResults: {
-                    'test id': {
-                        any: [],
-                        all: [],
-                        none: [],
-                        status: false,
-                        ruleId: 'test id',
-                        selector: 'target2',
-                        html: 'html',
-                        failureSummary: 'failureSummary',
-                        help: 'help2',
-                        id: 'id2',
-                        guidanceLinks: [],
-                        helpUrl: 'help2',
-                    },
-                },
-            },
-        };
-
-        const scanResult: ScanResults = {
-            passes: [],
-            violations: expectedViolations,
-        } as ScanResults;
-
-        const visualizationType = VisualizationType.Issues;
-
-        const initialState = new VisualizationScanResultStoreDataBuilder()
-            .withSelectorMap(visualizationType, selectorMap)
-            .withFullIdToRuleResultMapForIssues(expectedFullIdToResultMap)
-            .withScanResult(visualizationType, scanResult)
-            .build();
-
-        const expectedState = new VisualizationScanResultStoreDataBuilder()
-            .withSelectorMap(visualizationType, selectorMap)
-            .withFullIdToRuleResultMapForIssues(expectedFullIdToResultMap)
-            .build();
-
-        createStoreTesterForVisualizationScanResultActions(
-            'disableIssues',
-        ).testListenerToBeCalledOnce(initialState, expectedState);
-    });
-
     test('onTabStopDisabled', () => {
         const tabEvents: TabbedElementData[] = [
             {
@@ -183,6 +82,64 @@ describe('VisualizationScanResultStoreTest', () => {
         createStoreTesterForVisualizationScanResultActions(
             'disableTabStop',
         ).testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('onVisualizationDisabled: for test that has state', () => {
+        const tabEvents: TabbedElementData[] = [
+            {
+                target: ['selector'],
+                timestamp: 1,
+                html: 'test',
+                tabOrder: 1,
+            },
+        ];
+        const testKey = AdHocTestkeys.TabStops;
+        const visualizationTypeStub = -2;
+        const configStub: VisualizationConfiguration = {
+            key: testKey,
+        } as VisualizationConfiguration;
+
+        const initialState = new VisualizationScanResultStoreDataBuilder()
+            .withTabStopsTabbedElements(tabEvents)
+            .build();
+
+        const expectedState = new VisualizationScanResultStoreDataBuilder().build();
+
+        visualizationConfigurationFactoryMock
+            .setup(m => m.getConfiguration(visualizationTypeStub))
+            .returns(() => configStub);
+
+        createStoreTesterForVisualizationActions('disableVisualization')
+            .withActionParam(visualizationTypeStub)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('onVisualizationDisabled: for test that does not have state', () => {
+        const tabEvents: TabbedElementData[] = [
+            {
+                target: ['selector'],
+                timestamp: 1,
+                html: 'test',
+                tabOrder: 1,
+            },
+        ];
+        const testKey = 'some test key';
+        const visualizationTypeStub = -2;
+        const configStub: VisualizationConfiguration = {
+            key: testKey,
+        } as VisualizationConfiguration;
+
+        const initialState = new VisualizationScanResultStoreDataBuilder()
+            .withTabStopsTabbedElements(tabEvents)
+            .build();
+
+        visualizationConfigurationFactoryMock
+            .setup(m => m.getConfiguration(visualizationTypeStub))
+            .returns(() => configStub);
+
+        createStoreTesterForVisualizationActions('disableVisualization')
+            .withActionParam(visualizationTypeStub)
+            .testListenerToNeverBeCalled(initialState, initialState);
     });
 
     test('onScanCompleted', () => {
@@ -532,7 +489,9 @@ describe('VisualizationScanResultStoreTest', () => {
                 actions,
                 new TabActions(),
                 new TabStopRequirementActions(),
+                new VisualizationActions(),
                 generateUIDStub,
+                visualizationConfigurationFactoryMock.object,
             );
 
         return new StoreTester(VisualizationScanResultActions, actionName, factory);
@@ -546,7 +505,9 @@ describe('VisualizationScanResultStoreTest', () => {
                 new VisualizationScanResultActions(),
                 actions,
                 new TabStopRequirementActions(),
+                new VisualizationActions(),
                 generateUIDStub,
+                visualizationConfigurationFactoryMock.object,
             );
 
         return new StoreTester(TabActions, actionName, factory);
@@ -560,9 +521,27 @@ describe('VisualizationScanResultStoreTest', () => {
                 new VisualizationScanResultActions(),
                 new TabActions(),
                 actions,
+                new VisualizationActions(),
                 generateUIDStub,
+                visualizationConfigurationFactoryMock.object,
             );
 
         return new StoreTester(TabStopRequirementActions, actionName, factory);
+    }
+
+    function createStoreTesterForVisualizationActions(
+        actionName: keyof VisualizationActions,
+    ): StoreTester<VisualizationScanResultData, VisualizationActions> {
+        const factory = (actions: VisualizationActions) =>
+            new VisualizationScanResultStore(
+                new VisualizationScanResultActions(),
+                new TabActions(),
+                new TabStopRequirementActions(),
+                actions,
+                generateUIDStub,
+                visualizationConfigurationFactoryMock.object,
+            );
+
+        return new StoreTester(VisualizationActions, actionName, factory);
     }
 });


### PR DESCRIPTION
#### Detail
This will cause data to be removed when a test in fastpass is started over.

##### Motivation

Feature work.
##### Context

Did some smoke testing for a bunch of tests to ensure this doesn't break anything.

Also included is removing an action is not being used.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
