### PR TITLE
fix: link-in-text-block accessibility issue

### DIFF
--- a/src/DetailsView/components/generic-toggle.scss
+++ b/src/DetailsView/components/generic-toggle.scss
@@ -23,6 +23,6 @@
     }
 
     .toggle-description {
-        color: $secondary-text;
+        color: $primary-text;
     }
 }

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -68,7 +68,7 @@ div.insights-dialog-main-override.telemetry-permission-dialog {
 
     .telemetry-checkbox-section {
         font-size: 12px;
-        color: $secondary-text;
+        color: $primary-text;
         padding-top: 10px;
     }
 


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Change text colors from `secondary-text` to `primary-text` to meet the minimum contrast ratio of 3:1 when links are found in text blocks. Using `primary-text` provides a contrast ratio of 3.345:1 between the surrounding text and link text colors.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Fixes #4928 

##### Context

Changed the text color for descriptions of `GenericToggle`. This additionally affects the description text in "Enable high contrast" under the settings panel, as well as any descriptions for the toggles under preview features. I decided to go with this, rather than selectively changing the text in the areas with accessibility issues, so the UI looks more consistent (same text color for toggle descriptions throughout) and prevents similar accessibility issues in the future.

Screenshots of changes in affected areas:
| Before changes  | After changes |
|-------------------|----------------|
| ![settings-panel-before](https://user-images.githubusercontent.com/48259897/143331861-551e6477-e2ba-4ef7-bd7a-a0f7c756250b.png) | ![settings-panel-after](https://user-images.githubusercontent.com/48259897/143332010-d5c4df4d-e7be-4881-9b33-45b3d11bedec.png) |
| ![telemetry-dialog-before](https://user-images.githubusercontent.com/48259897/143332045-c1ce732c-4210-4968-9003-1933a77fde79.png) | ![telemetry-dialog-after](https://user-images.githubusercontent.com/48259897/143332050-2c6a2520-dc82-4268-8715-c3a73ae0efda.png) |
| ![preview-features-before](https://user-images.githubusercontent.com/48259897/143332031-90d6e49d-b5d7-4fc6-b036-a42102c72cac.png) | ![preview-features-after](https://user-images.githubusercontent.com/48259897/143332040-ed2e32cb-34c6-4859-a7d5-fc7ca4f16935.png) |

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4928
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
