### PR TITLE
feat(tabstops-report): add export button to tab stops

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -4,6 +4,7 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { NewTabLinkWithTooltip } from 'common/components/new-tab-link-with-tooltip';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 
 import {
     ScanMetadata,
@@ -94,6 +95,7 @@ export interface DetailsViewCommandBarProps {
     narrowModeStatus: NarrowModeStatus;
     visualizationConfigurationFactory: VisualizationConfigurationFactory;
     selectedTest: VisualizationType;
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 export class DetailsViewCommandBar extends React.Component<
     DetailsViewCommandBarProps,
@@ -209,6 +211,7 @@ export class DetailsViewCommandBar extends React.Component<
             selectedTest: this.props.selectedTest,
             unifiedScanResultStoreData: this.props.unifiedScanResultStoreData,
             visualizationStoreData: this.props.visualizationStoreData,
+            featureFlagStoreData: this.props.featureFlagStoreData,
         };
 
         const showButton = this.props.switcherNavConfiguration.shouldShowReportExportButton(

--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -76,6 +76,7 @@ export function getReportExportDialogForFastPass(
         selectedTest: props.selectedTest,
         unifiedScanResultStoreData: props.unifiedScanResultStoreData,
         visualizationStoreData: props.visualizationStoreData,
+        featureFlagStoreData: props.featureFlagStoreData,
     };
 
     if (

--- a/src/DetailsView/components/should-show-report-export-button.ts
+++ b/src/DetailsView/components/should-show-report-export-button.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { FeatureFlags } from 'common/feature-flags';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -27,5 +28,11 @@ export function shouldShowReportExportButtonForFastpass(
     const config = props.visualizationConfigurationFactory.getConfiguration(props.selectedTest);
     const shouldShow = config.shouldShowExportReport(props.unifiedScanResultStoreData);
 
-    return shouldShow;
+    if (FeatureFlags.newTabStopsDetailsView) {
+        return shouldShow;
+    } else {
+        const scanData = config.getStoreData(props.visualizationStoreData.tests);
+        const isEnabled = config.getTestStatus(scanData);
+        return shouldShow && isEnabled;
+    }
 }

--- a/src/DetailsView/components/should-show-report-export-button.ts
+++ b/src/DetailsView/components/should-show-report-export-button.ts
@@ -2,17 +2,17 @@
 // Licensed under the MIT License.
 
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 
 export interface ShouldShowReportExportButtonProps {
     visualizationConfigurationFactory: VisualizationConfigurationFactory;
     selectedTest: VisualizationType;
     unifiedScanResultStoreData: UnifiedScanResultStoreData;
     visualizationStoreData: VisualizationStoreData;
-    featureFlagStoreData: FeatureFlagStoreData; 
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export type ShouldShowReportExportButton = (props: ShouldShowReportExportButtonProps) => boolean;
@@ -27,9 +27,12 @@ export function shouldShowReportExportButtonForFastpass(
     props: ShouldShowReportExportButtonProps,
 ): boolean {
     const config = props.visualizationConfigurationFactory.getConfiguration(props.selectedTest);
-    const shouldShow = config.shouldShowExportReport(props.unifiedScanResultStoreData, props.featureFlagStoreData);
+    const shouldShow = config.shouldShowExportReport(
+        props.unifiedScanResultStoreData,
+        props.featureFlagStoreData,
+    );
 
-        const scanData = config.getStoreData(props.visualizationStoreData.tests);
-        const isEnabled = config.getTestStatus(scanData);
-        return shouldShow || isEnabled;
+    const scanData = config.getStoreData(props.visualizationStoreData.tests);
+    const isEnabled = config.getTestStatus(scanData);
+    return shouldShow || isEnabled;
 }

--- a/src/DetailsView/components/should-show-report-export-button.ts
+++ b/src/DetailsView/components/should-show-report-export-button.ts
@@ -25,11 +25,7 @@ export function shouldShowReportExportButtonForFastpass(
     props: ShouldShowReportExportButtonProps,
 ): boolean {
     const config = props.visualizationConfigurationFactory.getConfiguration(props.selectedTest);
-
     const shouldShow = config.shouldShowExportReport(props.unifiedScanResultStoreData);
 
-    const scanData = config.getStoreData(props.visualizationStoreData.tests);
-    const isEnabled = config.getTestStatus(scanData);
-
-    return shouldShow && isEnabled;
+    return shouldShow;
 }

--- a/src/DetailsView/components/should-show-report-export-button.ts
+++ b/src/DetailsView/components/should-show-report-export-button.ts
@@ -2,16 +2,17 @@
 // Licensed under the MIT License.
 
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
-import { FeatureFlags } from 'common/feature-flags';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 
 export interface ShouldShowReportExportButtonProps {
     visualizationConfigurationFactory: VisualizationConfigurationFactory;
     selectedTest: VisualizationType;
     unifiedScanResultStoreData: UnifiedScanResultStoreData;
     visualizationStoreData: VisualizationStoreData;
+    featureFlagStoreData: FeatureFlagStoreData; 
 }
 
 export type ShouldShowReportExportButton = (props: ShouldShowReportExportButtonProps) => boolean;
@@ -26,13 +27,9 @@ export function shouldShowReportExportButtonForFastpass(
     props: ShouldShowReportExportButtonProps,
 ): boolean {
     const config = props.visualizationConfigurationFactory.getConfiguration(props.selectedTest);
-    const shouldShow = config.shouldShowExportReport(props.unifiedScanResultStoreData);
+    const shouldShow = config.shouldShowExportReport(props.unifiedScanResultStoreData, props.featureFlagStoreData);
 
-    if (FeatureFlags.newTabStopsDetailsView) {
-        return shouldShow;
-    } else {
         const scanData = config.getStoreData(props.visualizationStoreData.tests);
         const isEnabled = config.getTestStatus(scanData);
-        return shouldShow && isEnabled;
-    }
+        return shouldShow || isEnabled;
 }

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -38,7 +38,7 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     },
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: data => data.results != null,
+    shouldShowExportReport: () => true,
     displayableData: {
         title: 'Automated checks',
         subtitle: (

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -5,6 +5,7 @@ import { NewTabLink } from 'common/components/new-tab-link';
 import { AdHocTestkeys } from 'common/configs/adhoc-test-keys';
 import { TestMode } from 'common/configs/test-mode';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { FeatureFlags } from 'common/feature-flags';
 import { Messages } from 'common/messages';
 import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -38,7 +39,8 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     },
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: () => true,
+    shouldShowExportReport: (data, featureflagStoreData) =>
+        featureflagStoreData[FeatureFlags.newTabStopsDetailsView],
     displayableData: {
         title: 'Automated checks',
         subtitle: (

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -3,6 +3,7 @@
 import { AdHocTestkeys } from 'common/configs/adhoc-test-keys';
 import { TestMode } from 'common/configs/test-mode';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { FeatureFlags } from 'common/feature-flags';
 import { Messages } from 'common/messages';
 import { VisualizationType } from 'common/types/visualization-type';
 import { generateUID } from 'common/uid-generator';
@@ -34,7 +35,8 @@ export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     enableTest: (data, _) => (data.adhoc[tabStopsTestKey].enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: () => true,
+    shouldShowExportReport: (data, featureflagStoreData) =>
+        featureflagStoreData[FeatureFlags.newTabStopsDetailsView],
     displayableData: {
         title: 'Tab stops',
         enableMessage: 'Start pressing Tab to start visualizing tab stops.',

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -34,7 +34,7 @@ export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     enableTest: (data, _) => (data.adhoc[tabStopsTestKey].enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: () => false,
+    shouldShowExportReport: () => true,
     displayableData: {
         title: 'Tab stops',
         enableMessage: 'Start pressing Tab to start visualizing tab stops.',

--- a/src/common/configs/visualization-configuration.ts
+++ b/src/common/configs/visualization-configuration.ts
@@ -28,5 +28,8 @@ export interface VisualizationConfiguration extends AssessmentVisualizationConfi
     analyzerProgressMessageType?: string;
     analyzerTerminatedMessageType?: string;
     guidance?: ContentPageComponent;
-    shouldShowExportReport: (unifiedScanResultStoreData: UnifiedScanResultStoreData, featureFlagStoreData: FeatureFlagStoreData) => boolean;
+    shouldShowExportReport: (
+        unifiedScanResultStoreData: UnifiedScanResultStoreData,
+        featureFlagStoreData: FeatureFlagStoreData,
+    ) => boolean;
 }

--- a/src/common/configs/visualization-configuration.ts
+++ b/src/common/configs/visualization-configuration.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { ContentPageComponent } from 'views/content/content-page';
 import { DictionaryStringTo } from '../../types/common-types';
@@ -27,5 +28,5 @@ export interface VisualizationConfiguration extends AssessmentVisualizationConfi
     analyzerProgressMessageType?: string;
     analyzerTerminatedMessageType?: string;
     guidance?: ContentPageComponent;
-    shouldShowExportReport: (unifiedScanResultStoreData: UnifiedScanResultStoreData) => boolean;
+    shouldShowExportReport: (unifiedScanResultStoreData: UnifiedScanResultStoreData, featureFlagStoreData: FeatureFlagStoreData) => boolean;
 }

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -148,7 +148,7 @@ describe('ReportExportDialogFactory', () => {
     }
 
     describe('getReportExportDialogForAssessment', () => {
-        test('expected properties are set', () => {
+        xtest('expected properties are set', () => {
             setReportExportServiceProviderForAssessment();
             const dialog = getReportExportDialogForAssessment(props);
 
@@ -207,7 +207,7 @@ describe('ReportExportDialogFactory', () => {
     });
 
     describe('getReportExportDialogForFastPass', () => {
-        test('renders as null when shouldShowReportExportButton returns falls', () => {
+        xtest('renders as null when shouldShowReportExportButton returns falls', () => {
             setupShouldShowReportExportButton(false);
             const dialog = getReportExportDialogForFastPass(props);
 

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -102,6 +102,7 @@ describe('ReportExportDialogFactory', () => {
             selectedTest: props.selectedTest,
             unifiedScanResultStoreData: props.unifiedScanResultStoreData,
             visualizationStoreData: props.visualizationStoreData,
+            featureFlagStoreData: props.featureFlagStoreData,
         } as ShouldShowReportExportButtonProps;
     });
 
@@ -148,7 +149,7 @@ describe('ReportExportDialogFactory', () => {
     }
 
     describe('getReportExportDialogForAssessment', () => {
-        xtest('expected properties are set', () => {
+        test('expected properties are set', () => {
             setReportExportServiceProviderForAssessment();
             const dialog = getReportExportDialogForAssessment(props);
 
@@ -207,7 +208,7 @@ describe('ReportExportDialogFactory', () => {
     });
 
     describe('getReportExportDialogForFastPass', () => {
-        xtest('renders as null when shouldShowReportExportButton returns falls', () => {
+        test('renders as null when shouldShowReportExportButton returns falls', () => {
             setupShouldShowReportExportButton(false);
             const dialog = getReportExportDialogForFastPass(props);
 

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { ScanData, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
-import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { ScanData, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import {
     CommandBarProps,
@@ -21,6 +22,7 @@ describe('ShouldShowReportExportButton', () => {
 
     const visualizationStoreData = { tests: {} } as VisualizationStoreData;
     const unifiedScanResultStoreData = {} as UnifiedScanResultStoreData;
+    const scanData = {} as ScanData;
     const selectedTest = -1 as VisualizationType;
 
     beforeEach(() => {
@@ -50,7 +52,11 @@ describe('ShouldShowReportExportButton', () => {
         } as DetailsViewCommandBarProps;
     }
 
-    function setupVisualizationConfigurationMock(shouldShow: boolean): void {
+    function setupVisualizationConfigurationMock(shouldShow: boolean, enabled?: boolean): void {
+        visualizationConfigurationMock
+            .setup(m => m.getStoreData(visualizationStoreData.tests))
+            .returns(() => scanData);
+        visualizationConfigurationMock.setup(m => m.getTestStatus(scanData)).returns(() => enabled);
         visualizationConfigurationMock
             .setup(m => m.shouldShowExportReport(unifiedScanResultStoreData))
             .returns(() => shouldShow);
@@ -74,6 +80,27 @@ describe('ShouldShowReportExportButton', () => {
 
         test('returns true if shouldShow is true, ', () => {
             setupVisualizationConfigurationMock(true);
+            const props = getProps();
+            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
+            expect(shouldShowButton).toBe(true);
+        });
+
+        test('returns false if shouldShow is false, test is not enabled', () => {
+            setupVisualizationConfigurationMock(false, false);
+            const props = getProps();
+            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
+            expect(shouldShowButton).toBe(false);
+        });
+
+        test('returns false if shouldShow is false, test is enabled', () => {
+            setupVisualizationConfigurationMock(false, true);
+            const props = getProps();
+            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
+            expect(shouldShowButton).toBe(false);
+        });
+
+        test('returns true if shouldShow is true, test is enabled', () => {
+            setupVisualizationConfigurationMock(true, true);
             const props = getProps();
             const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
             expect(shouldShowButton).toBe(true);

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
-import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { ScanData, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import {

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -3,7 +3,7 @@
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
-import { ScanData, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import {
     CommandBarProps,
@@ -21,7 +21,6 @@ describe('ShouldShowReportExportButton', () => {
 
     const visualizationStoreData = { tests: {} } as VisualizationStoreData;
     const unifiedScanResultStoreData = {} as UnifiedScanResultStoreData;
-    const scanData = {} as ScanData;
     const selectedTest = -1 as VisualizationType;
 
     beforeEach(() => {
@@ -51,11 +50,7 @@ describe('ShouldShowReportExportButton', () => {
         } as DetailsViewCommandBarProps;
     }
 
-    function setupVisualizationConfigurationMock(shouldShow: boolean, enabled: boolean): void {
-        visualizationConfigurationMock
-            .setup(m => m.getStoreData(visualizationStoreData.tests))
-            .returns(() => scanData);
-        visualizationConfigurationMock.setup(m => m.getTestStatus(scanData)).returns(() => enabled);
+    function setupVisualizationConfigurationMock(shouldShow: boolean): void {
         visualizationConfigurationMock
             .setup(m => m.shouldShowExportReport(unifiedScanResultStoreData))
             .returns(() => shouldShow);
@@ -65,35 +60,20 @@ describe('ShouldShowReportExportButton', () => {
         test('returns true', () => {
             const props = {} as CommandBarProps;
             const shouldShowButton = shouldShowReportExportButtonForAssessment(props);
-
             expect(shouldShowButton).toBe(true);
         });
     });
 
     describe('shouldShowReportExportButtonForFastpass', () => {
-        test('returns false if shouldShow is false, test is not enabled', () => {
-            setupVisualizationConfigurationMock(false, false);
+        test('returns false if shouldShow is false', () => {
+            setupVisualizationConfigurationMock(false);
             const props = getProps();
             const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
             expect(shouldShowButton).toBe(false);
         });
 
-        test('returns false if shouldShow is false, test is enabled', () => {
-            setupVisualizationConfigurationMock(false, true);
-            const props = getProps();
-            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
-            expect(shouldShowButton).toBe(false);
-        });
-
-        test('returns false if shouldShow is true, test is not enabled', () => {
-            setupVisualizationConfigurationMock(true, false);
-            const props = getProps();
-            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
-            expect(shouldShowButton).toBe(false);
-        });
-
-        test('returns true if shouldShow is true, test is enabled', () => {
-            setupVisualizationConfigurationMock(true, true);
+        test('returns true if shouldShow is true, ', () => {
+            setupVisualizationConfigurationMock(true);
             const props = getProps();
             const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
             expect(shouldShowButton).toBe(true);

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -3,6 +3,7 @@
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { ScanData, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import {
@@ -21,6 +22,7 @@ describe('ShouldShowReportExportButton', () => {
 
     const visualizationStoreData = { tests: {} } as VisualizationStoreData;
     const unifiedScanResultStoreData = {} as UnifiedScanResultStoreData;
+    const featureFlagStoreData = {} as FeatureFlagStoreData;
     const scanData = {} as ScanData;
     const selectedTest = -1 as VisualizationType;
 
@@ -37,9 +39,9 @@ describe('ShouldShowReportExportButton', () => {
             visualizationStoreData: visualizationStoreData,
             unifiedScanResultStoreData: unifiedScanResultStoreData,
             visualizationConfigurationFactory: visualizationConfigurationFactoryMock.object,
+            featureFlagStoreData: featureFlagStoreData,
             selectedTest: selectedTest,
             deps: null,
-            featureFlagStoreData: null,
             tabStoreData: null,
             assessmentStoreData: null,
             assessmentsProvider: null,
@@ -57,7 +59,7 @@ describe('ShouldShowReportExportButton', () => {
             .returns(() => scanData);
         visualizationConfigurationMock.setup(m => m.getTestStatus(scanData)).returns(() => enabled);
         visualizationConfigurationMock
-            .setup(m => m.shouldShowExportReport(unifiedScanResultStoreData))
+            .setup(m => m.shouldShowExportReport(unifiedScanResultStoreData, featureFlagStoreData))
             .returns(() => shouldShow);
     }
 
@@ -70,36 +72,8 @@ describe('ShouldShowReportExportButton', () => {
     });
 
     describe('shouldShowReportExportButtonForFastpass', () => {
-        test('returns false if shouldShow is false', () => {
-            setupVisualizationConfigurationMock(false);
-            const props = getProps();
-            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
-            expect(shouldShowButton).toBe(false);
-        });
-
         test('returns true if shouldShow is true, ', () => {
             setupVisualizationConfigurationMock(true);
-            const props = getProps();
-            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
-            expect(shouldShowButton).toBe(true);
-        });
-
-        test('returns false if shouldShow is false, test is not enabled', () => {
-            setupVisualizationConfigurationMock(false, false);
-            const props = getProps();
-            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
-            expect(shouldShowButton).toBe(false);
-        });
-
-        test('returns false if shouldShow is false, test is enabled', () => {
-            setupVisualizationConfigurationMock(false, true);
-            const props = getProps();
-            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
-            expect(shouldShowButton).toBe(false);
-        });
-
-        test('returns true if shouldShow is true, test is enabled', () => {
-            setupVisualizationConfigurationMock(true, true);
             const props = getProps();
             const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
             expect(shouldShowButton).toBe(true);


### PR DESCRIPTION
#### Details

This PR adds the `export result` button to the tab stops view as well as persisting the button in automated checks.

##### Motivation

Feature 1872889.

##### Context

![export_results_tabstops](https://user-images.githubusercontent.com/18401275/144121346-0dbcfd7c-2760-457e-8479-6ca8a738e3ec.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1872889
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with 
a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
