### PR TITLE
feat(tabstops-report) add NeedsReviewScanResultStore and NeedsReviewCardSelectionStore

### DIFF
--- a/src/background/actions/action-hub.ts
+++ b/src/background/actions/action-hub.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
 import { InjectionActions } from 'background/actions/injection-actions';
+import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
+import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
 import { SidePanelActions } from 'background/actions/side-panel-actions';
 import { TabStopRequirementActions } from 'background/actions/tab-stop-requirement-actions';
 import { TabActions } from '../actions/tab-actions';
@@ -32,6 +34,8 @@ export class ActionHub {
     public cardSelectionActions: CardSelectionActions;
     public injectionActions: InjectionActions;
     public sidePanelActions: SidePanelActions;
+    public needsReviewScanResultActions: NeedsReviewScanResultActions;
+    public needsReviewCardSelectionActions: NeedsReviewCardSelectionActions;
 
     constructor() {
         this.visualizationActions = new VisualizationActions();
@@ -49,5 +53,7 @@ export class ActionHub {
         this.cardSelectionActions = new CardSelectionActions();
         this.injectionActions = new InjectionActions();
         this.sidePanelActions = new SidePanelActions();
+        this.needsReviewScanResultActions = new NeedsReviewScanResultActions();
+        this.needsReviewCardSelectionActions = new NeedsReviewCardSelectionActions();
     }
 }

--- a/src/background/actions/needs-review-card-selection-action-creator.ts
+++ b/src/background/actions/needs-review-card-selection-action-creator.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
+import { StoreNames } from 'common/stores/store-names';
+
+import * as TelemetryEvents from '../../common/extension-telemetry-events';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { Interpreter } from '../interpreter';
+import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
+import {
+    BaseActionPayload,
+    CardSelectionPayload,
+    RuleExpandCollapsePayload,
+} from './action-payloads';
+
+export class NeedsReviewCardSelectionActionCreator {
+    constructor(
+        private readonly interpreter: Interpreter,
+        private readonly needsReviewCardSelectionActions: NeedsReviewCardSelectionActions,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+    ) {}
+
+    public registerCallbacks(): void {
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.NeedsReviewCardSelection.CardSelectionToggled,
+            this.onNeedsReviewCardSelectionToggle,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.NeedsReviewCardSelection.RuleExpansionToggled,
+            this.onRuleExpansionToggle,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            getStoreStateMessage(StoreNames.NeedsReviewCardSelectionStore),
+            this.onGetCurrentState,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.NeedsReviewCardSelection.ToggleVisualHelper,
+            this.onToggleVisualHelper,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.NeedsReviewCardSelection.ExpandAllRules,
+            this.onExpandAllRules,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.NeedsReviewCardSelection.CollapseAllRules,
+            this.onCollapseAllRules,
+        );
+    }
+
+    private onGetCurrentState = (): void => {
+        this.needsReviewCardSelectionActions.getCurrentState.invoke(null);
+    };
+
+    private onNeedsReviewCardSelectionToggle = (payload: CardSelectionPayload): void => {
+        this.needsReviewCardSelectionActions.toggleCardSelection.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(
+            TelemetryEvents.CARD_SELECTION_TOGGLED,
+            payload,
+        );
+    };
+
+    private onRuleExpansionToggle = (payload: RuleExpandCollapsePayload): void => {
+        this.needsReviewCardSelectionActions.toggleRuleExpandCollapse.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(
+            TelemetryEvents.RULE_EXPANSION_TOGGLED,
+            payload,
+        );
+    };
+
+    private onToggleVisualHelper = (payload: BaseActionPayload): void => {
+        this.needsReviewCardSelectionActions.toggleVisualHelper.invoke(null);
+        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.VISUAL_HELPER_TOGGLED, payload);
+    };
+
+    private onCollapseAllRules = (payload: BaseActionPayload): void => {
+        this.needsReviewCardSelectionActions.collapseAllRules.invoke(null);
+        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_COLLAPSED, payload);
+    };
+
+    private onExpandAllRules = (payload: BaseActionPayload): void => {
+        this.needsReviewCardSelectionActions.expandAllRules.invoke(null);
+        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_EXPANDED, payload);
+    };
+}

--- a/src/background/actions/needs-review-card-selection-actions.ts
+++ b/src/background/actions/needs-review-card-selection-actions.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Action } from 'common/flux/action';
+import { CardSelectionPayload, RuleExpandCollapsePayload } from './action-payloads';
+
+export class NeedsReviewCardSelectionActions {
+    public readonly getCurrentState = new Action();
+    public readonly navigateToNewCardsView = new Action();
+    public readonly toggleRuleExpandCollapse = new Action<RuleExpandCollapsePayload>();
+    public readonly toggleCardSelection = new Action<CardSelectionPayload>();
+    public readonly collapseAllRules = new Action();
+    public readonly expandAllRules = new Action();
+    public readonly toggleVisualHelper = new Action();
+    public readonly resetFocusedIdentifier = new Action();
+}

--- a/src/background/actions/needs-review-scan-result-action-creator.ts
+++ b/src/background/actions/needs-review-scan-result-action-creator.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { SCAN_INCOMPLETE_WARNINGS } from 'common/extension-telemetry-events';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { NotificationCreator } from 'common/notification-creator';
+import { StoreNames } from 'common/stores/store-names';
+import { Interpreter } from '../interpreter';
+import { UnifiedScanCompletedPayload } from './action-payloads';
+
+export class NeedsReviewScanResultActionCreator {
+    constructor(
+        private readonly interpreter: Interpreter,
+        private readonly needsReviewScanResultActions: NeedsReviewScanResultActions,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly notificationCreator: NotificationCreator,
+    ) {}
+
+    public registerCallbacks(): void {
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.NeedsReviewScan.ScanCompleted,
+            this.onScanCompleted,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            getStoreStateMessage(StoreNames.NeedsReviewScanResultStore),
+            this.onGetScanCurrentState,
+        );
+    }
+
+    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
+        this.needsReviewScanResultActions.scanCompleted.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(SCAN_INCOMPLETE_WARNINGS, payload);
+        this.notificationCreator.createNotification(payload.notificationText);
+    };
+
+    private onGetScanCurrentState = (): void => {
+        this.needsReviewScanResultActions.getCurrentState.invoke(null);
+    };
+}

--- a/src/background/actions/needs-review-scan-result-actions.ts
+++ b/src/background/actions/needs-review-scan-result-actions.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
+import { Action } from 'common/flux/action';
+import { UnifiedScanCompletedPayload } from './action-payloads';
+
+export class NeedsReviewScanResultActions extends UnifiedScanResultActions {
+    public readonly scanCompleted = new Action<UnifiedScanCompletedPayload>();
+    public readonly getCurrentState = new Action();
+    public readonly startScan = new Action();
+}

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
 import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
-import {
-    NeedsReviewCardSelectionStoreData,
-    RuleExpandCollapseData,
-} from 'common/types/store-data/needs-review-card-selection-store-data';
+import { RuleExpandCollapseData } from 'common/types/store-data/card-selection-store-data';
+import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
 import { forOwn, isEmpty } from 'lodash';
 import { StoreNames } from '../../common/stores/store-names';
 import {
@@ -12,29 +11,36 @@ import {
     RuleExpandCollapsePayload,
     UnifiedScanCompletedPayload,
 } from '../actions/action-payloads';
-import { CardSelectionActions } from '../actions/card-selection-actions';
 import { BaseStoreImpl } from './base-store-impl';
 
 export class NeedsReviewCardSelectionStore extends BaseStoreImpl<NeedsReviewCardSelectionStoreData> {
     constructor(
-        private readonly cardSelectionActions: CardSelectionActions,
+        private readonly needsReviewCardSelectionActions: NeedsReviewCardSelectionActions,
         private readonly needsReviewScanResultActions: NeedsReviewScanResultActions,
     ) {
         super(StoreNames.NeedsReviewCardSelectionStore);
     }
 
     protected addActionListeners(): void {
-        this.cardSelectionActions.toggleRuleExpandCollapse.addListener(
+        this.needsReviewCardSelectionActions.toggleRuleExpandCollapse.addListener(
             this.toggleRuleExpandCollapse,
         );
-        this.cardSelectionActions.toggleCardSelection.addListener(this.toggleCardSelection);
-        this.cardSelectionActions.collapseAllRules.addListener(this.collapseAllRules);
-        this.cardSelectionActions.expandAllRules.addListener(this.expandAllRules);
-        this.cardSelectionActions.toggleVisualHelper.addListener(this.toggleVisualHelper);
-        this.cardSelectionActions.getCurrentState.addListener(this.onGetCurrentState);
+        this.needsReviewCardSelectionActions.toggleCardSelection.addListener(
+            this.toggleCardSelection,
+        );
+        this.needsReviewCardSelectionActions.collapseAllRules.addListener(this.collapseAllRules);
+        this.needsReviewCardSelectionActions.expandAllRules.addListener(this.expandAllRules);
+        this.needsReviewCardSelectionActions.toggleVisualHelper.addListener(
+            this.toggleVisualHelper,
+        );
+        this.needsReviewCardSelectionActions.getCurrentState.addListener(this.onGetCurrentState);
         this.needsReviewScanResultActions.scanCompleted.addListener(this.onScanCompleted);
-        this.cardSelectionActions.resetFocusedIdentifier.addListener(this.onResetFocusedIdentifier);
-        this.cardSelectionActions.navigateToNewCardsView.addListener(this.onNavigateToNewCardsView);
+        this.needsReviewCardSelectionActions.resetFocusedIdentifier.addListener(
+            this.onResetFocusedIdentifier,
+        );
+        this.needsReviewCardSelectionActions.navigateToNewCardsView.addListener(
+            this.onNavigateToNewCardsView,
+        );
     }
 
     public getDefaultState(): NeedsReviewCardSelectionStoreData {

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
+import {
+    NeedsReviewCardSelectionStoreData,
+    RuleExpandCollapseData,
+} from 'common/types/store-data/needs-review-card-selection-store-data';
+import { forOwn, isEmpty } from 'lodash';
+import { StoreNames } from '../../common/stores/store-names';
+import {
+    CardSelectionPayload,
+    RuleExpandCollapsePayload,
+    UnifiedScanCompletedPayload,
+} from '../actions/action-payloads';
+import { CardSelectionActions } from '../actions/card-selection-actions';
+import { BaseStoreImpl } from './base-store-impl';
+
+export class NeedsReviewCardSelectionStore extends BaseStoreImpl<NeedsReviewCardSelectionStoreData> {
+    constructor(
+        private readonly cardSelectionActions: CardSelectionActions,
+        private readonly needsReviewScanResultActions: NeedsReviewScanResultActions,
+    ) {
+        super(StoreNames.NeedsReviewCardSelectionStore);
+    }
+
+    protected addActionListeners(): void {
+        this.cardSelectionActions.toggleRuleExpandCollapse.addListener(
+            this.toggleRuleExpandCollapse,
+        );
+        this.cardSelectionActions.toggleCardSelection.addListener(this.toggleCardSelection);
+        this.cardSelectionActions.collapseAllRules.addListener(this.collapseAllRules);
+        this.cardSelectionActions.expandAllRules.addListener(this.expandAllRules);
+        this.cardSelectionActions.toggleVisualHelper.addListener(this.toggleVisualHelper);
+        this.cardSelectionActions.getCurrentState.addListener(this.onGetCurrentState);
+        this.needsReviewScanResultActions.scanCompleted.addListener(this.onScanCompleted);
+        this.cardSelectionActions.resetFocusedIdentifier.addListener(this.onResetFocusedIdentifier);
+        this.cardSelectionActions.navigateToNewCardsView.addListener(this.onNavigateToNewCardsView);
+    }
+
+    public getDefaultState(): NeedsReviewCardSelectionStoreData {
+        const defaultValue: NeedsReviewCardSelectionStoreData = {
+            rules: {},
+            visualHelperEnabled: false,
+            focusedResultUid: null,
+        };
+
+        return defaultValue;
+    }
+
+    private deselectAllCardsInRule = (rule: RuleExpandCollapseData): void => {
+        if (!rule) {
+            return;
+        }
+
+        forOwn(rule.cards, (isSelected, resultInstanceUid, cards) => {
+            cards[resultInstanceUid] = false;
+        });
+    };
+
+    private deselectAllCards = (): void => {
+        forOwn(this.state.rules, rule => {
+            this.deselectAllCardsInRule(rule);
+        });
+    };
+
+    private toggleRuleExpandCollapse = (payload: RuleExpandCollapsePayload): void => {
+        if (!payload || !this.state.rules[payload.ruleId]) {
+            return;
+        }
+
+        const rule = this.state.rules[payload.ruleId];
+
+        rule.isExpanded = !rule.isExpanded;
+
+        if (!rule.isExpanded) {
+            this.deselectAllCardsInRule(rule);
+        }
+
+        this.emitChanged();
+    };
+
+    private toggleCardSelection = (payload: CardSelectionPayload): void => {
+        if (
+            !payload ||
+            !this.state.rules[payload.ruleId] ||
+            this.state.rules[payload.ruleId].cards[payload.resultInstanceUid] === undefined
+        ) {
+            return;
+        }
+
+        const rule = this.state.rules[payload.ruleId];
+        const isSelected = !rule.cards[payload.resultInstanceUid];
+        rule.cards[payload.resultInstanceUid] = isSelected;
+
+        // whenever a card is selected, the visual helper is enabled
+        if (isSelected) {
+            this.state.visualHelperEnabled = true;
+            this.state.focusedResultUid = payload.resultInstanceUid;
+        }
+
+        this.emitChanged();
+    };
+
+    private collapseAllRules = (): void => {
+        forOwn(this.state.rules, rule => {
+            rule.isExpanded = false;
+            this.deselectAllCardsInRule(rule);
+        });
+
+        this.emitChanged();
+    };
+
+    private expandAllRules = (): void => {
+        forOwn(this.state.rules, rule => {
+            rule.isExpanded = true;
+        });
+
+        this.emitChanged();
+    };
+
+    private toggleVisualHelper = (): void => {
+        this.state.visualHelperEnabled = !this.state.visualHelperEnabled;
+
+        if (!this.state.visualHelperEnabled) {
+            this.deselectAllCards();
+        }
+
+        this.emitChanged();
+    };
+
+    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
+        this.state = this.getDefaultState();
+
+        if (!payload) {
+            return;
+        }
+
+        payload.scanResult.forEach(result => {
+            if (result.status !== 'fail' && result.status !== 'unknown') {
+                return;
+            }
+
+            if (this.state.rules[result.ruleId] === undefined) {
+                this.state.rules[result.ruleId] = {
+                    isExpanded: false,
+                    cards: {},
+                };
+            }
+
+            this.state.rules[result.ruleId].cards[result.uid] = false;
+        });
+
+        this.state.visualHelperEnabled = true;
+
+        this.emitChanged();
+    };
+
+    private onResetFocusedIdentifier = (): void => {
+        this.state.focusedResultUid = null;
+        this.emitChanged();
+    };
+
+    private onNavigateToNewCardsView = (): void => {
+        this.state.focusedResultUid = null;
+        for (const ruleId in this.state.rules) {
+            this.state.rules[ruleId].isExpanded = false;
+            for (const resultId in this.state.rules[ruleId].cards) {
+                this.state.rules[ruleId].cards[resultId] = false;
+            }
+        }
+        this.state.visualHelperEnabled = !isEmpty(this.state.rules);
+        this.emitChanged();
+    };
+}

--- a/src/background/stores/needs-review-scan-result-store.ts
+++ b/src/background/stores/needs-review-scan-result-store.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import { StoreNames } from '../../common/stores/store-names';
+import { UnifiedScanCompletedPayload } from '../actions/action-payloads';
+import { UnifiedScanResultActions } from '../actions/unified-scan-result-actions';
+import { BaseStoreImpl } from './base-store-impl';
+
+export class NeedsReviewScanResultStore extends BaseStoreImpl<NeedsReviewScanResultStoreData> {
+    constructor(private readonly unifiedScanResultActions: UnifiedScanResultActions) {
+        super(StoreNames.NeedsReviewScanResultStore);
+    }
+
+    public getDefaultState(): NeedsReviewScanResultStoreData {
+        const defaultValue: NeedsReviewScanResultStoreData = {
+            results: null,
+            rules: null,
+            toolInfo: null,
+            targetAppInfo: null,
+            timestamp: null,
+            scanIncompleteWarnings: null,
+            screenshotData: null,
+            platformInfo: null,
+        };
+
+        return defaultValue;
+    }
+
+    protected addActionListeners(): void {
+        this.unifiedScanResultActions.getCurrentState.addListener(this.onGetCurrentState);
+        this.unifiedScanResultActions.scanCompleted.addListener(this.onScanCompleted);
+        this.unifiedScanResultActions.startScan.addListener(this.onScanStarted);
+    }
+
+    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
+        this.state.results = payload.scanResult;
+        this.state.rules = payload.rules;
+        this.state.toolInfo = payload.toolInfo;
+        this.state.targetAppInfo = payload.targetAppInfo;
+        this.state.timestamp = payload.timestamp;
+        this.state.scanIncompleteWarnings = payload.scanIncompleteWarnings;
+        this.state.screenshotData = payload.screenshotData;
+        this.state.platformInfo = payload.platformInfo;
+        this.emitChanged();
+    };
+
+    private onScanStarted = (test: VisualizationType): void => {
+        if (test === VisualizationType.TabStops) {
+            return;
+        }
+        this.state = this.getDefaultState();
+        this.emitChanged();
+    };
+}

--- a/src/background/stores/needs-review-scan-result-store.ts
+++ b/src/background/stores/needs-review-scan-result-store.ts
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
 import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
-import { VisualizationType } from 'common/types/visualization-type';
 import { StoreNames } from '../../common/stores/store-names';
 import { UnifiedScanCompletedPayload } from '../actions/action-payloads';
-import { UnifiedScanResultActions } from '../actions/unified-scan-result-actions';
 import { BaseStoreImpl } from './base-store-impl';
 
 export class NeedsReviewScanResultStore extends BaseStoreImpl<NeedsReviewScanResultStoreData> {
-    constructor(private readonly unifiedScanResultActions: UnifiedScanResultActions) {
+    constructor(private readonly needsReviewScanResultActions: NeedsReviewScanResultActions) {
         super(StoreNames.NeedsReviewScanResultStore);
     }
 
@@ -28,9 +27,9 @@ export class NeedsReviewScanResultStore extends BaseStoreImpl<NeedsReviewScanRes
     }
 
     protected addActionListeners(): void {
-        this.unifiedScanResultActions.getCurrentState.addListener(this.onGetCurrentState);
-        this.unifiedScanResultActions.scanCompleted.addListener(this.onScanCompleted);
-        this.unifiedScanResultActions.startScan.addListener(this.onScanStarted);
+        this.needsReviewScanResultActions.getCurrentState.addListener(this.onGetCurrentState);
+        this.needsReviewScanResultActions.scanCompleted.addListener(this.onScanCompleted);
+        this.needsReviewScanResultActions.startScan.addListener(this.onScanStarted);
     }
 
     private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
@@ -45,10 +44,7 @@ export class NeedsReviewScanResultStore extends BaseStoreImpl<NeedsReviewScanRes
         this.emitChanged();
     };
 
-    private onScanStarted = (test: VisualizationType): void => {
-        if (test === VisualizationType.TabStops) {
-            return;
-        }
+    private onScanStarted = (): void => {
         this.state = this.getDefaultState();
         this.emitChanged();
     };

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CardSelectionStore } from 'background/stores/card-selection-store';
-
+import { NeedsReviewCardSelectionStore } from 'background/stores/needs-review-card-selection-store';
+import { NeedsReviewScanResultStore } from 'background/stores/needs-review-scan-result-store';
 import { BaseStore } from '../../common/base-store';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { StoreType } from '../../common/types/store-type';
@@ -27,6 +28,8 @@ export class TabContextStoreHub implements StoreHub {
     public pathSnippetStore: PathSnippetStore;
     public unifiedScanResultStore: UnifiedScanResultStore;
     public cardSelectionStore: CardSelectionStore;
+    public needsReviewCardSelectionStore: NeedsReviewCardSelectionStore;
+    public needsReviewScanResultStore: NeedsReviewScanResultStore;
 
     constructor(
         actionHub: ActionHub,
@@ -77,6 +80,17 @@ export class TabContextStoreHub implements StoreHub {
             actionHub.scanResultActions,
         );
         this.cardSelectionStore.initialize();
+
+        this.needsReviewScanResultStore = new NeedsReviewScanResultStore(
+            actionHub.needsReviewScanResultActions,
+        );
+        this.needsReviewScanResultStore.initialize();
+
+        this.needsReviewCardSelectionStore = new NeedsReviewCardSelectionStore(
+            actionHub.needsReviewCardSelectionActions,
+            actionHub.needsReviewScanResultActions,
+        );
+        this.needsReviewCardSelectionStore.initialize();
     }
 
     public getAllStores(): BaseStore<any>[] {
@@ -90,6 +104,8 @@ export class TabContextStoreHub implements StoreHub {
             this.pathSnippetStore,
             this.unifiedScanResultStore,
             this.cardSelectionStore,
+            this.needsReviewScanResultStore,
+            this.needsReviewCardSelectionStore,
         ].filter(store => store != null);
     }
 

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NeedsReviewCardSelectionActionCreator } from 'background/actions/needs-review-card-selection-action-creator';
+import { NeedsReviewScanResultActionCreator } from 'background/actions/needs-review-scan-result-action-creator';
 import { TabStopRequirementActionCreator } from 'background/actions/tab-stop-requirement-action-creator';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
@@ -126,6 +128,12 @@ export class TabContextFactory {
             this.telemetryEventHandler,
             this.notificationCreator,
         );
+        const needsReviewScanResultActionCreator = new NeedsReviewScanResultActionCreator(
+            interpreter,
+            actionsHub.needsReviewScanResultActions,
+            this.telemetryEventHandler,
+            this.notificationCreator,
+        );
         const contentActionCreator = new ContentActionCreator(
             interpreter,
             actionsHub.contentActions,
@@ -135,6 +143,11 @@ export class TabContextFactory {
         const cardSelectionActionCreator = new CardSelectionActionCreator(
             interpreter,
             actionsHub.cardSelectionActions,
+            this.telemetryEventHandler,
+        );
+        const needsReviewCardSelectionActionCreator = new NeedsReviewCardSelectionActionCreator(
+            interpreter,
+            actionsHub.needsReviewCardSelectionActions,
             this.telemetryEventHandler,
         );
         const injectionActionCreator = new InjectionActionCreator(
@@ -162,7 +175,9 @@ export class TabContextFactory {
         tabStopRequirementActionCreator.registerCallbacks();
         popupActionCreator.registerCallbacks();
         contentActionCreator.registerCallbacks();
+        needsReviewCardSelectionActionCreator.registerCallbacks();
         scanResultActionCreator.registerCallbacks();
+        needsReviewScanResultActionCreator.registerCallbacks();
         cardSelectionActionCreator.registerCallbacks();
         injectionActionCreator.registerCallbacks();
 

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -164,6 +164,9 @@ export const Messages = {
         ScanCompleted: `${messagePrefix}/unifiedScan/scanCompleted`,
     },
 
+    NeedsReviewScan: {
+        ScanCompleted: `${messagePrefix}/needsReviewScan/scanCompleted`,
+    },
     CardSelection: {
         CardSelectionToggled: `${messagePrefix}/cardSelection/cardSelectionToggled`,
         RuleExpansionToggled: `${messagePrefix}/cardSelection/ruleExpansionToggled`,
@@ -171,6 +174,14 @@ export const Messages = {
         ExpandAllRules: `${messagePrefix}/cardSelection/expandAllRules`,
         ToggleVisualHelper: `${messagePrefix}/cardSelection/toggleVisualHelper`,
         NavigateToNewCardsView: `${messagePrefix}/cardSelection/navigateToNewCardsView`,
+    },
+    NeedsReviewCardSelection: {
+        CardSelectionToggled: `${messagePrefix}/needsReviewCardSelection/cardSelectionToggled`,
+        RuleExpansionToggled: `${messagePrefix}/needsReviewCardSelection/ruleExpansionToggled`,
+        CollapseAllRules: `${messagePrefix}/needsReviewCardSelection/collapseAllRules`,
+        ExpandAllRules: `${messagePrefix}/needsReviewCardSelection/expandAllRules`,
+        ToggleVisualHelper: `${messagePrefix}/needsReviewCardSelection/toggleVisualHelper`,
+        NavigateToNewCardsView: `${messagePrefix}/needsReviewCardSelection/navigateToNewCardsView`,
     },
 
     PermissionsState: {

--- a/src/common/stores/store-names.ts
+++ b/src/common/stores/store-names.ts
@@ -27,4 +27,6 @@ export enum StoreNames {
     DeviceConnectionStore,
     TabStopsStore,
     TabStopsViewStore,
+    NeedsReviewScanResultStore,
+    NeedsReviewCardSelectionStore,
 }

--- a/src/common/types/store-data/needs-review-card-selection-store-data.ts
+++ b/src/common/types/store-data/needs-review-card-selection-store-data.ts
@@ -1,19 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export type NeedsReviewCardSelectionData = { [resultInstanceUid: string]: boolean };
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 
-export interface RuleExpandCollapseData {
-    isExpanded: boolean;
-    cards: NeedsReviewCardSelectionData;
-}
-
-export interface RuleExpandCollapseDataDictionary {
-    [ruleId: string]: RuleExpandCollapseData;
-}
-
-export interface NeedsReviewCardSelectionStoreData {
-    rules: RuleExpandCollapseDataDictionary;
-    visualHelperEnabled: boolean;
-    focusedResultUid: string | null;
-}
+export type NeedsReviewCardSelectionStoreData = CardSelectionStoreData;

--- a/src/common/types/store-data/needs-review-card-selection-store-data.ts
+++ b/src/common/types/store-data/needs-review-card-selection-store-data.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type NeedsReviewCardSelectionData = { [resultInstanceUid: string]: boolean };
+
+export interface RuleExpandCollapseData {
+    isExpanded: boolean;
+    cards: NeedsReviewCardSelectionData;
+}
+
+export interface RuleExpandCollapseDataDictionary {
+    [ruleId: string]: RuleExpandCollapseData;
+}
+
+export interface NeedsReviewCardSelectionStoreData {
+    rules: RuleExpandCollapseDataDictionary;
+    visualHelperEnabled: boolean;
+    focusedResultUid: string | null;
+}

--- a/src/common/types/store-data/needs-review-scan-result-data.ts
+++ b/src/common/types/store-data/needs-review-scan-result-data.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import {
+    PlatformData,
+    ScreenshotData,
+    TargetAppData,
+    ToolData,
+    UnifiedResult,
+    UnifiedRule,
+} from 'common/types/store-data/unified-data-interface';
+
+export interface NeedsReviewScanResultStoreData {
+    results: UnifiedResult[];
+    rules: UnifiedRule[];
+    platformInfo?: PlatformData;
+    toolInfo?: ToolData;
+    targetAppInfo?: TargetAppData;
+    timestamp?: string;
+    scanIncompleteWarnings?: ScanIncompleteWarningId[];
+    screenshotData?: ScreenshotData;
+}

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -8,6 +8,8 @@ import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unav
 import { createDefaultLogger } from 'common/logging/default-logger';
 import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
+import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
 import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -25,7 +27,6 @@ import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-
 import { TargetPageVisualizationUpdater } from 'injected/target-page-visualization-updater';
 import { visualizationNeedsUpdate } from 'injected/visualization-needs-update';
 import { VisualizationStateChangeHandler } from 'injected/visualization-state-change-handler';
-
 import { AxeInfo } from '../common/axe-info';
 import { InspectConfigurationFactory } from '../common/configs/inspect-configuration-factory';
 import { DateProvider } from '../common/date-provider';
@@ -91,6 +92,8 @@ export class MainWindowInitializer extends WindowInitializer {
     private pathSnippetStoreProxy: StoreProxy<PathSnippetStoreData>;
     private unifiedScanResultStoreProxy: StoreProxy<UnifiedScanResultStoreData>;
     private cardSelectionStoreProxy: StoreProxy<CardSelectionStoreData>;
+    private needsReviewScanResultStoreProxy: StoreProxy<NeedsReviewScanResultStoreData>;
+    private needsReviewCardSelectionStoreProxy: StoreProxy<NeedsReviewCardSelectionStoreData>;
     private permissionsStateStoreProxy: StoreProxy<PermissionsStateStoreData>;
 
     public async initialize(): Promise<void> {
@@ -145,6 +148,14 @@ export class MainWindowInitializer extends WindowInitializer {
             StoreNames[StoreNames.CardSelectionStore],
             this.browserAdapter,
         );
+        this.needsReviewScanResultStoreProxy = new StoreProxy<NeedsReviewScanResultStoreData>(
+            StoreNames[StoreNames.NeedsReviewScanResultStore],
+            this.browserAdapter,
+        );
+        this.needsReviewCardSelectionStoreProxy = new StoreProxy<NeedsReviewCardSelectionStoreData>(
+            StoreNames[StoreNames.NeedsReviewCardSelectionStore],
+            this.browserAdapter,
+        );
         this.permissionsStateStoreProxy = new StoreProxy<PermissionsStateStoreData>(
             StoreNames[StoreNames.PermissionsStateStore],
             this.browserAdapter,
@@ -175,6 +186,8 @@ export class MainWindowInitializer extends WindowInitializer {
             this.pathSnippetStoreProxy,
             this.unifiedScanResultStoreProxy,
             this.cardSelectionStoreProxy,
+            this.needsReviewScanResultStoreProxy,
+            this.needsReviewCardSelectionStoreProxy,
             this.permissionsStateStoreProxy,
         ]);
         storeActionMessageCreator.getAllStates();
@@ -238,6 +251,8 @@ export class MainWindowInitializer extends WindowInitializer {
             this.userConfigStoreProxy,
             this.unifiedScanResultStoreProxy,
             this.cardSelectionStoreProxy,
+            this.needsReviewScanResultStoreProxy,
+            this.needsReviewCardSelectionStoreProxy,
             this.permissionsStateStoreProxy,
         ]);
 

--- a/src/tests/unit/tests/background/actions/action-hub.test.ts
+++ b/src/tests/unit/tests/background/actions/action-hub.test.ts
@@ -6,6 +6,8 @@ import { ContentActions } from 'background/actions/content-actions';
 import { DevToolActions } from 'background/actions/dev-tools-actions';
 import { InjectionActions } from 'background/actions/injection-actions';
 import { InspectActions } from 'background/actions/inspect-actions';
+import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
+import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
 import { ScopingActions } from 'background/actions/scoping-actions';
 import { SidePanelActions } from 'background/actions/side-panel-actions';
 import { TabActions } from 'background/actions/tab-actions';
@@ -39,4 +41,6 @@ function runTypeAsserts(hub: ActionHub): void {
     expect(hub.contentActions).toBeInstanceOf(ContentActions);
     expect(hub.injectionActions).toBeInstanceOf(InjectionActions);
     expect(hub.sidePanelActions).toBeInstanceOf(SidePanelActions);
+    expect(hub.needsReviewScanResultActions).toBeInstanceOf(NeedsReviewScanResultActions);
+    expect(hub.needsReviewCardSelectionActions).toBeInstanceOf(NeedsReviewCardSelectionActions);
 }

--- a/src/tests/unit/tests/background/actions/needs-review-card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/needs-review-card-selection-action-creator.test.ts
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    BaseActionPayload,
+    CardSelectionPayload,
+    RuleExpandCollapsePayload,
+} from 'background/actions/action-payloads';
+import { NeedsReviewCardSelectionActionCreator } from 'background/actions/needs-review-card-selection-action-creator';
+import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import * as TelemetryEvents from 'common/extension-telemetry-events';
+import { Messages } from 'common/messages';
+import { IMock, Mock, Times } from 'typemoq';
+
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
+
+describe('NeedsReviewCardSelectionActionCreator', () => {
+    const tabId = -2;
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+
+    beforeEach(() => {
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+    });
+
+    it('handles card selection toggle', () => {
+        const payload: CardSelectionPayload = {
+            resultInstanceUid: 'test-instance-uuid',
+            ruleId: 'test-rule-id',
+        };
+        const toggleNeedsReviewCardSelectionMock = createActionMock(payload);
+        const actionsMock = createActionsMock(
+            'toggleCardSelection',
+            toggleNeedsReviewCardSelectionMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            Messages.NeedsReviewCardSelection.CardSelectionToggled,
+            payload,
+            tabId,
+        );
+
+        const testSubject = new NeedsReviewCardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        toggleNeedsReviewCardSelectionMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.CARD_SELECTION_TOGGLED, payload),
+            Times.once(),
+        );
+    });
+
+    test('onRuleExpansionToggle', () => {
+        const payload: RuleExpandCollapsePayload = {
+            ruleId: 'test-rule-id',
+        };
+        const ruleExpansionToggleMock = createActionMock(payload);
+        const actionsMock = createActionsMock(
+            'toggleRuleExpandCollapse',
+            ruleExpansionToggleMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            Messages.NeedsReviewCardSelection.RuleExpansionToggled,
+            payload,
+            tabId,
+        );
+
+        const testSubject = new NeedsReviewCardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        ruleExpansionToggleMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.RULE_EXPANSION_TOGGLED, payload),
+            Times.once(),
+        );
+    });
+
+    test('onToggleVisualHelper', () => {
+        const payloadStub: BaseActionPayload = {};
+        const toggleVisualHelperMock = createActionMock(null);
+        const actionsMock = createActionsMock('toggleVisualHelper', toggleVisualHelperMock.object);
+        const interpreterMock = createInterpreterMock(
+            Messages.NeedsReviewCardSelection.ToggleVisualHelper,
+            payloadStub,
+            tabId,
+        );
+
+        const testSubject = new NeedsReviewCardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        toggleVisualHelperMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.VISUAL_HELPER_TOGGLED, payloadStub),
+            Times.once(),
+        );
+    });
+
+    test('onCollapseAllRules', () => {
+        const payloadStub: BaseActionPayload = {};
+        const collapseAllRulesActionMock = createActionMock(null);
+        const actionsMock = createActionsMock(
+            'collapseAllRules',
+            collapseAllRulesActionMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            Messages.NeedsReviewCardSelection.CollapseAllRules,
+            payloadStub,
+            tabId,
+        );
+
+        const testSubject = new NeedsReviewCardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        collapseAllRulesActionMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.ALL_RULES_COLLAPSED, payloadStub),
+            Times.once(),
+        );
+    });
+
+    test('onExpandAllRules', () => {
+        const payloadStub: BaseActionPayload = {};
+        const expandAllRulesActionMock = createActionMock(null);
+        const actionsMock = createActionsMock('expandAllRules', expandAllRulesActionMock.object);
+        const interpreterMock = createInterpreterMock(
+            Messages.NeedsReviewCardSelection.ExpandAllRules,
+            payloadStub,
+            tabId,
+        );
+
+        const testSubject = new NeedsReviewCardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        expandAllRulesActionMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.ALL_RULES_EXPANDED, payloadStub),
+            Times.once(),
+        );
+    });
+
+    function createActionsMock<ActionName extends keyof NeedsReviewCardSelectionActions>(
+        actionName: ActionName,
+        action: NeedsReviewCardSelectionActions[ActionName],
+    ): IMock<NeedsReviewCardSelectionActions> {
+        const actionsMock = Mock.ofType<NeedsReviewCardSelectionActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
+    }
+});

--- a/src/tests/unit/tests/background/actions/needs-review-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/needs-review-scan-result-action-creator.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
+import { NeedsReviewScanResultActionCreator } from 'background/actions/needs-review-scan-result-action-creator';
+import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import {
+    SCAN_INCOMPLETE_WARNINGS,
+    ScanIncompleteWarningsTelemetryData,
+} from 'common/extension-telemetry-events';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { NotificationCreator } from 'common/notification-creator';
+import { StoreNames } from 'common/stores/store-names';
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
+import { IMock, Mock, Times } from 'typemoq';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
+
+describe('NeedsReviewScanResultActionCreator', () => {
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let notificationCreatorMock: IMock<NotificationCreator>;
+
+    beforeEach(() => {
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        notificationCreatorMock = Mock.ofType<NotificationCreator>();
+    });
+
+    it('should handle ScanCompleted message', () => {
+        const scanIncompleteWarnings = ['test-warning-id' as ScanIncompleteWarningId];
+        const telemetry = {
+            scanIncompleteWarnings,
+        } as ScanIncompleteWarningsTelemetryData;
+        const payload: UnifiedScanCompletedPayload = {
+            scanResult: [],
+            rules: [],
+            toolInfo: {} as ToolData,
+            targetAppInfo: { name: 'app name' },
+            timestamp: 'timestamp',
+            scanIncompleteWarnings,
+            telemetry,
+        };
+
+        const scanCompletedMock = createActionMock(payload);
+        const actionsMock = createActionsMock('scanCompleted', scanCompletedMock.object);
+        const interpreterMock = createInterpreterMock(
+            Messages.NeedsReviewScan.ScanCompleted,
+            payload,
+        );
+
+        const testSubject = new NeedsReviewScanResultActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+            notificationCreatorMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        scanCompletedMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(SCAN_INCOMPLETE_WARNINGS, payload),
+            Times.once(),
+        );
+        notificationCreatorMock.verify(
+            handler => handler.createNotification(payload.notificationText),
+            Times.once(),
+        );
+    });
+
+    it('should handle GetState message', () => {
+        const payload = null;
+
+        const getCurrentStateMock = createActionMock<null>(payload);
+        const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
+        const interpreterMock = createInterpreterMock(
+            getStoreStateMessage(StoreNames.NeedsReviewScanResultStore),
+            payload,
+        );
+
+        const testSubject = new NeedsReviewScanResultActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+            notificationCreatorMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        getCurrentStateMock.verifyAll();
+    });
+
+    function createActionsMock<ActionName extends keyof NeedsReviewScanResultActions>(
+        actionName: ActionName,
+        action: NeedsReviewScanResultActions[ActionName],
+    ): IMock<NeedsReviewScanResultActions> {
+        const actionsMock = Mock.ofType<NeedsReviewScanResultActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
+    }
+});

--- a/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
@@ -1,0 +1,388 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
+import { NeedsReviewCardSelectionStore } from 'background/stores/needs-review-card-selection-store';
+import {
+    NeedsReviewCardSelectionStoreData,
+    RuleExpandCollapseData,
+} from 'common/types/store-data/needs-review-card-selection-store-data';
+import { cloneDeep, forOwn } from 'lodash';
+
+import {
+    BaseActionPayload,
+    CardSelectionPayload,
+    RuleExpandCollapsePayload,
+    UnifiedScanCompletedPayload,
+} from '../../../../../background/actions/action-payloads';
+import { UnifiedScanResultActions } from '../../../../../background/actions/unified-scan-result-actions';
+import { StoreNames } from '../../../../../common/stores/store-names';
+import { UnifiedResult } from '../../../../../common/types/store-data/unified-data-interface';
+import { createStoreWithNullParams, StoreTester } from '../../../common/store-tester';
+
+describe('NeedsReviewCardSelectionStore Test', () => {
+    test('constructor has no side effects', () => {
+        const testObject = createStoreWithNullParams(NeedsReviewCardSelectionStore);
+        expect(testObject).toBeDefined();
+    });
+
+    test('getId', () => {
+        const testObject = createStoreWithNullParams(NeedsReviewCardSelectionStore);
+
+        expect(testObject.getId()).toEqual(StoreNames[StoreNames.NeedsReviewCardSelectionStore]);
+    });
+
+    test('check defaultState is as expected', () => {
+        const defaultState = getDefaultState();
+
+        expect(defaultState.rules).toBeDefined();
+    });
+
+    it.each`
+        result
+        ${'fail'}
+        ${'unknown'}
+    `('onScanCompleted', ({ result }) => {
+        const initialState = getDefaultState();
+
+        const payload: UnifiedScanCompletedPayload = {
+            scanResult: [
+                {
+                    ruleId: 'sampleRuleId',
+                    uid: 'sampleUid1',
+                    status: result,
+                } as UnifiedResult,
+                {
+                    ruleId: 'sampleRuleId',
+                    uid: 'sampleUid2',
+                    status: result,
+                } as UnifiedResult,
+            ],
+            rules: [],
+        } as UnifiedScanCompletedPayload;
+
+        const expectedState: NeedsReviewCardSelectionStoreData = {
+            rules: {
+                sampleRuleId: {
+                    isExpanded: false,
+                    cards: {
+                        sampleUid1: false,
+                        sampleUid2: false,
+                    },
+                },
+            },
+            focusedResultUid: null,
+            visualHelperEnabled: true,
+        };
+
+        createStoreForUnifiedScanResultActions('scanCompleted')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    function getDefaultState(): NeedsReviewCardSelectionStoreData {
+        return createStoreWithNullParams(NeedsReviewCardSelectionStore).getDefaultState();
+    }
+
+    function createStoreForUnifiedScanResultActions(
+        actionName: keyof UnifiedScanResultActions,
+    ): StoreTester<NeedsReviewCardSelectionStoreData, UnifiedScanResultActions> {
+        const factory = (actions: UnifiedScanResultActions) =>
+            new NeedsReviewCardSelectionStore(new NeedsReviewCardSelectionActions(), actions);
+
+        return new StoreTester(UnifiedScanResultActions, actionName, factory);
+    }
+});
+
+describe('NeedsReviewCardSelectionStore Test', () => {
+    let initialState: NeedsReviewCardSelectionStoreData = null;
+    let expectedState: NeedsReviewCardSelectionStoreData = null;
+
+    beforeEach(() => {
+        const defaultState: NeedsReviewCardSelectionStoreData = {
+            rules: {
+                sampleRuleId1: {
+                    isExpanded: false,
+                    cards: {
+                        sampleUid1: false,
+                        sampleUid2: false,
+                    },
+                },
+                sampleRuleId2: {
+                    isExpanded: false,
+                    cards: {
+                        sampleUid1: false,
+                        sampleUid2: false,
+                    },
+                },
+            },
+            visualHelperEnabled: false,
+            focusedResultUid: null,
+        };
+
+        initialState = cloneDeep(defaultState);
+        expectedState = cloneDeep(defaultState);
+    });
+
+    test('ToggleRuleExpandCollapse expanded', () => {
+        const payload: RuleExpandCollapsePayload = {
+            ruleId: 'sampleRuleId1',
+        };
+
+        expectedState.rules['sampleRuleId1'].isExpanded = true;
+
+        createStoreForNeedsReviewCardSelectionActions('toggleRuleExpandCollapse')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('onResetFocusedIdentifier', () => {
+        const payload: BaseActionPayload = {};
+
+        initialState.focusedResultUid = 'some uid';
+
+        createStoreForNeedsReviewCardSelectionActions('resetFocusedIdentifier')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('ToggleRuleExpandCollapse collapsed', () => {
+        const payload: RuleExpandCollapsePayload = {
+            ruleId: 'sampleRuleId1',
+        };
+
+        initialState.rules['sampleRuleId1'].isExpanded = true;
+        initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+
+        createStoreForNeedsReviewCardSelectionActions('toggleRuleExpandCollapse')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('ToggleRuleExpandCollapse invalid rule', () => {
+        const payload: RuleExpandCollapsePayload = {
+            ruleId: 'invalid-rule-id',
+        };
+
+        createStoreForNeedsReviewCardSelectionActions('toggleRuleExpandCollapse')
+            .withActionParam(payload)
+            .testListenerToNeverBeCalled(initialState, expectedState);
+    });
+
+    test('ToggleRuleExpandCollapse no payload', () => {
+        createStoreForNeedsReviewCardSelectionActions('toggleRuleExpandCollapse')
+            .withActionParam(null)
+            .testListenerToNeverBeCalled(initialState, expectedState);
+    });
+
+    test('ToggleRuleExpandCollapse invalid payload', () => {
+        const payload: RuleExpandCollapsePayload = {
+            ruleId: null,
+        };
+
+        createStoreForNeedsReviewCardSelectionActions('toggleRuleExpandCollapse')
+            .withActionParam(payload)
+            .testListenerToNeverBeCalled(initialState, expectedState);
+    });
+
+    test('toggleCardSelection selected', () => {
+        const payload: CardSelectionPayload = {
+            ruleId: 'sampleRuleId1',
+            resultInstanceUid: 'sampleUid1',
+        };
+
+        expectedState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+        expectedState.focusedResultUid = 'sampleUid1';
+        expectedState.visualHelperEnabled = true;
+
+        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('toggleCardSelection unselected', () => {
+        const payload: CardSelectionPayload = {
+            ruleId: 'sampleRuleId1',
+            resultInstanceUid: 'sampleUid1',
+        };
+
+        initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+
+        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('toggleCardSelection invalid rule', () => {
+        const payload: CardSelectionPayload = {
+            ruleId: 'invalid-rule-id',
+            resultInstanceUid: 'sampleUid1',
+        };
+
+        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
+            .withActionParam(payload)
+            .testListenerToNeverBeCalled(initialState, expectedState);
+    });
+
+    test('toggleCardSelection invalid card', () => {
+        const payload: CardSelectionPayload = {
+            ruleId: 'sampleRuleId1',
+            resultInstanceUid: 'invalid-uid',
+        };
+
+        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
+            .withActionParam(payload)
+            .testListenerToNeverBeCalled(initialState, expectedState);
+    });
+
+    test('toggleCardSelection  no payload', () => {
+        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
+            .withActionParam(null)
+            .testListenerToNeverBeCalled(initialState, expectedState);
+    });
+
+    test('ToggleRuleExpandCollapse invalid payload', () => {
+        const payload: CardSelectionPayload = {} as CardSelectionPayload;
+
+        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
+            .withActionParam(payload)
+            .testListenerToNeverBeCalled(initialState, expectedState);
+    });
+
+    test('CollapseAllRules', () => {
+        expandRuleSelectCards(initialState.rules['sampleRuleId1']);
+        expandRuleSelectCards(initialState.rules['sampleRuleId2']);
+
+        createStoreForNeedsReviewCardSelectionActions(
+            'collapseAllRules',
+        ).testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('expandAllRules', () => {
+        initialState.rules['sampleRuleId1'].isExpanded = true;
+        initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+
+        expectedState.rules['sampleRuleId1'].isExpanded = true;
+        expectedState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+        expectedState.rules['sampleRuleId2'].isExpanded = true;
+
+        createStoreForNeedsReviewCardSelectionActions('expandAllRules').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
+    });
+
+    test('toggleVisualHelper on - no card selection or rule expansion changes', () => {
+        initialState.rules['sampleRuleId1'].isExpanded = true;
+        initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+
+        expectedState = cloneDeep(initialState);
+        expectedState.visualHelperEnabled = true;
+
+        createStoreForNeedsReviewCardSelectionActions(
+            'toggleVisualHelper',
+        ).testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('toggleVisualHelper off - cards deselected, no rule expansion changes', () => {
+        initialState.rules['sampleRuleId1'].isExpanded = true;
+        initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+        initialState.visualHelperEnabled = true;
+
+        expectedState.rules['sampleRuleId1'].isExpanded = true;
+
+        createStoreForNeedsReviewCardSelectionActions(
+            'toggleVisualHelper',
+        ).testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    describe('navigateToNewCardsView', () => {
+        beforeEach(() => {
+            expectedState.visualHelperEnabled = true;
+        });
+
+        it('should reset the focused element', () => {
+            initialState.focusedResultUid = 'sampleUid1';
+            expectedState.focusedResultUid = null;
+
+            createStoreForNeedsReviewCardSelectionActions(
+                'navigateToNewCardsView',
+            ).testListenerToBeCalledOnce(initialState, expectedState);
+        });
+
+        it('should keep all rules/cards/results but set them to collapsed/unselected', () => {
+            initialState.rules = {
+                sampleRuleId1: {
+                    isExpanded: true,
+                    cards: {
+                        sampleUid1: true,
+                        sampleUid2: false,
+                    },
+                },
+                sampleRuleId2: {
+                    isExpanded: false,
+                    cards: {
+                        sampleUid1: false,
+                        sampleUid2: false,
+                    },
+                },
+            };
+            expectedState.rules = {
+                sampleRuleId1: {
+                    isExpanded: false,
+                    cards: {
+                        sampleUid1: false,
+                        sampleUid2: false,
+                    },
+                },
+                sampleRuleId2: {
+                    isExpanded: false,
+                    cards: {
+                        sampleUid1: false,
+                        sampleUid2: false,
+                    },
+                },
+            };
+
+            createStoreForNeedsReviewCardSelectionActions(
+                'navigateToNewCardsView',
+            ).testListenerToBeCalledOnce(initialState, expectedState);
+        });
+
+        it('should set the visualHelperToggle to enabled if there are any rules', () => {
+            initialState.visualHelperEnabled = false;
+            expectedState.visualHelperEnabled = true;
+
+            createStoreForNeedsReviewCardSelectionActions(
+                'navigateToNewCardsView',
+            ).testListenerToBeCalledOnce(initialState, expectedState);
+        });
+
+        it('should set the visualHelperToggle to disabled if there are no rules', () => {
+            initialState.rules = {};
+            initialState.visualHelperEnabled = true;
+            expectedState.rules = {};
+            expectedState.visualHelperEnabled = false;
+
+            createStoreForNeedsReviewCardSelectionActions(
+                'navigateToNewCardsView',
+            ).testListenerToBeCalledOnce(initialState, expectedState);
+        });
+    });
+
+    function expandRuleSelectCards(rule: RuleExpandCollapseData): void {
+        rule.isExpanded = true;
+
+        forOwn(rule.cards, (value, card, cards) => {
+            cards[card] = true;
+        });
+    }
+
+    function createStoreForNeedsReviewCardSelectionActions(
+        actionName: keyof NeedsReviewCardSelectionActions,
+    ): StoreTester<NeedsReviewCardSelectionStoreData, NeedsReviewCardSelectionActions> {
+        const factory = (actions: NeedsReviewCardSelectionActions) =>
+            new NeedsReviewCardSelectionStore(actions, new UnifiedScanResultActions());
+
+        return new StoreTester(NeedsReviewCardSelectionActions, actionName, factory);
+    }
+});

--- a/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
+import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
 import { NeedsReviewCardSelectionStore } from 'background/stores/needs-review-card-selection-store';
-import {
-    NeedsReviewCardSelectionStoreData,
-    RuleExpandCollapseData,
-} from 'common/types/store-data/needs-review-card-selection-store-data';
+import { RuleExpandCollapseData } from 'common/types/store-data/card-selection-store-data';
+import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
 import { cloneDeep, forOwn } from 'lodash';
 
 import {
@@ -14,7 +13,6 @@ import {
     RuleExpandCollapsePayload,
     UnifiedScanCompletedPayload,
 } from '../../../../../background/actions/action-payloads';
-import { UnifiedScanResultActions } from '../../../../../background/actions/unified-scan-result-actions';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import { UnifiedResult } from '../../../../../common/types/store-data/unified-data-interface';
 import { createStoreWithNullParams, StoreTester } from '../../../common/store-tester';
@@ -74,7 +72,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
             visualHelperEnabled: true,
         };
 
-        createStoreForUnifiedScanResultActions('scanCompleted')
+        createStoreForNeedsReviewScanResultActions('scanCompleted')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
@@ -83,13 +81,13 @@ describe('NeedsReviewCardSelectionStore Test', () => {
         return createStoreWithNullParams(NeedsReviewCardSelectionStore).getDefaultState();
     }
 
-    function createStoreForUnifiedScanResultActions(
-        actionName: keyof UnifiedScanResultActions,
-    ): StoreTester<NeedsReviewCardSelectionStoreData, UnifiedScanResultActions> {
-        const factory = (actions: UnifiedScanResultActions) =>
+    function createStoreForNeedsReviewScanResultActions(
+        actionName: keyof NeedsReviewScanResultActions,
+    ): StoreTester<NeedsReviewCardSelectionStoreData, NeedsReviewScanResultActions> {
+        const factory = (actions: NeedsReviewScanResultActions) =>
             new NeedsReviewCardSelectionStore(new NeedsReviewCardSelectionActions(), actions);
 
-        return new StoreTester(UnifiedScanResultActions, actionName, factory);
+        return new StoreTester(NeedsReviewScanResultActions, actionName, factory);
     }
 });
 
@@ -381,7 +379,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
         actionName: keyof NeedsReviewCardSelectionActions,
     ): StoreTester<NeedsReviewCardSelectionStoreData, NeedsReviewCardSelectionActions> {
         const factory = (actions: NeedsReviewCardSelectionActions) =>
-            new NeedsReviewCardSelectionStore(actions, new UnifiedScanResultActions());
+            new NeedsReviewCardSelectionStore(actions, new NeedsReviewScanResultActions());
 
         return new StoreTester(NeedsReviewCardSelectionActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
+import { NeedsReviewScanResultStore } from 'background/stores/needs-review-scan-result-store';
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
+import { UnifiedScanCompletedPayload } from '../../../../../background/actions/action-payloads';
+import { StoreNames } from '../../../../../common/stores/store-names';
+import { createStoreWithNullParams, StoreTester } from '../../../common/store-tester';
+import { TargetAppData } from './../../../../../common/types/store-data/unified-data-interface';
+
+describe('NeedsReviewScanResultStore Test', () => {
+    test('constructor has no side effects', () => {
+        const testObject = createStoreWithNullParams(NeedsReviewScanResultStore);
+        expect(testObject).toBeDefined();
+    });
+
+    test('getId', () => {
+        const testObject = createStoreWithNullParams(NeedsReviewScanResultStore);
+
+        expect(testObject.getId()).toEqual(StoreNames[StoreNames.NeedsReviewScanResultStore]);
+    });
+
+    test('check defaultState is empty', () => {
+        const defaultState = getDefaultState();
+
+        expect(defaultState.results).toBeNull();
+        expect(defaultState.rules).toBeNull();
+        expect(defaultState.toolInfo).toBeNull();
+        expect(defaultState.scanIncompleteWarnings).toBeNull();
+        expect(defaultState.screenshotData).toBeNull();
+        expect(defaultState.platformInfo).toBeNull();
+    });
+
+    test('onGetCurrentState', () => {
+        const initialState = getDefaultState();
+        const finalState = getDefaultState();
+
+        createStoreForNeedsReviewScanResultActions('getCurrentState').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
+    });
+
+    test('onScanCompleted', () => {
+        const initialState = getDefaultState();
+        const targetAppInfo: TargetAppData = { name: 'app name' };
+        const payload: UnifiedScanCompletedPayload = {
+            scanResult: [
+                {
+                    uid: 'test-uid',
+                },
+            ],
+            rules: [
+                {
+                    id: 'test-rule-id',
+                },
+            ],
+            toolInfo: {
+                scanEngineProperties: {
+                    name: 'test-scan-engine-name',
+                },
+            },
+            timestamp: 'timestamp',
+            scanIncompleteWarnings: ['some-incomplete-warning-id' as ScanIncompleteWarningId],
+            screenshotData: {
+                base64PngData: 'testScreenshotText',
+            },
+            targetAppInfo,
+            platformInfo: {
+                deviceName: 'test-device-name',
+            },
+        } as UnifiedScanCompletedPayload;
+
+        const expectedState: NeedsReviewScanResultStoreData = {
+            rules: payload.rules,
+            results: payload.scanResult,
+            toolInfo: payload.toolInfo,
+            targetAppInfo,
+            timestamp: payload.timestamp,
+            scanIncompleteWarnings: payload.scanIncompleteWarnings,
+            screenshotData: payload.screenshotData,
+            platformInfo: payload.platformInfo,
+        };
+
+        createStoreForNeedsReviewScanResultActions('scanCompleted')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('onScanStarted', () => {
+        const initialState = getDefaultState();
+        const finalState = getDefaultState();
+
+        createStoreForNeedsReviewScanResultActions('startScan').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
+    });
+
+    function getDefaultState(): NeedsReviewScanResultStoreData {
+        return createStoreWithNullParams(NeedsReviewScanResultStore).getDefaultState();
+    }
+
+    function createStoreForNeedsReviewScanResultActions(
+        actionName: keyof NeedsReviewScanResultActions,
+    ): StoreTester<NeedsReviewScanResultStoreData, NeedsReviewScanResultActions> {
+        const factory = (actions: NeedsReviewScanResultActions) =>
+            new NeedsReviewScanResultStore(actions);
+
+        return new StoreTester(NeedsReviewScanResultActions, actionName, factory);
+    }
+});

--- a/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
@@ -11,7 +11,7 @@ describe('TabContextStoreHubTest', () => {
     });
 
     it('verify getAllStores', () => {
-        expect(testSubject.getAllStores().length).toBe(9);
+        expect(testSubject.getAllStores().length).toBe(11);
     });
 
     it('verify store type', () => {

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -68,6 +68,8 @@ describe('TabContextFactoryTest', () => {
             StoreNames.PathSnippetStore,
             StoreNames.UnifiedScanResultStore,
             StoreNames.CardSelectionStore,
+            StoreNames.NeedsReviewCardSelectionStore,
+            StoreNames.NeedsReviewScanResultStore,
         ];
 
         storeNames.forEach(storeName => {

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -6,6 +6,8 @@ import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { DetailsViewStore } from 'background/stores/details-view-store';
 import { DevToolStore } from 'background/stores/dev-tools-store';
 import { InspectStore } from 'background/stores/inspect-store';
+import { NeedsReviewCardSelectionStore } from 'background/stores/needs-review-card-selection-store';
+import { NeedsReviewScanResultStore } from 'background/stores/needs-review-scan-result-store';
 import { TabStore } from 'background/stores/tab-store';
 import { VisualizationScanResultStore } from 'background/stores/visualization-scan-result-store';
 import { VisualizationStore } from 'background/stores/visualization-store';
@@ -144,6 +146,12 @@ describe('TabContextFactoryTest', () => {
         expect(tabContext.stores.inspectStore).toBeInstanceOf(InspectStore);
         expect(tabContext.stores.unifiedScanResultStore).toBeInstanceOf(UnifiedScanResultStore);
         expect(tabContext.stores.cardSelectionStore).toBeInstanceOf(CardSelectionStore);
+        expect(tabContext.stores.needsReviewCardSelectionStore).toBeInstanceOf(
+            NeedsReviewCardSelectionStore,
+        );
+        expect(tabContext.stores.needsReviewScanResultStore).toBeInstanceOf(
+            NeedsReviewScanResultStore,
+        );
 
         broadcastMock.verifyAll();
     });


### PR DESCRIPTION
#### Details

This adds two stores, NeedsReviewScanResultStore and NeedsReviewCardSelectionStore. These will be used to independently store information for Needs Review, rather than reusing the UnifiedScanResultStore and CardSelectionStore that is being shared with Automated Checks.

##### Motivation

Feature work, we need this data persistence to be separate to enable the report to always be able to export Automated Checks data, without it being overwritten by Needs Review data.

##### Context

There is a lot of context that went into this decision. We considered going the route of turning the existing UnifiedScanResultStore into a dictionary with keys for each test type. We also considered having multiple instances of the UnifiedScanResultStore. Due to a number of technical and time constraints, we decided ultimately that our best option was the break these stores into separate stores for automated checks and needs review.  The UnifiedScanResultStore will likely eventually be renamed the AutomatedChecksScanResultStore but I'm leaving it for now.

These stores are partially wired up but will be fully wired up in a later PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
