### PR TITLE
feat(tabstops-report): Separate Needs Review and Automated Checks into relevant stores

### DIFF
--- a/src/DetailsView/components/adhoc-issues-test-view.tsx
+++ b/src/DetailsView/components/adhoc-issues-test-view.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { CommonInstancesSectionProps } from 'common/components/cards/common-instances-section-props';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -37,6 +38,7 @@ export type AdhocIssuesTestViewProps = {
     userConfigurationStoreData: UserConfigurationStoreData;
     scanMetadata: ScanMetadata;
     cardsViewData: CardsViewModel;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
     instancesSection: ReactFCWithDisplayName<CommonInstancesSectionProps>;
 };
 

--- a/src/DetailsView/components/details-list-issues-view.tsx
+++ b/src/DetailsView/components/details-list-issues-view.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { CommonInstancesSectionProps } from 'common/components/cards/common-instances-section-props';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -25,6 +26,7 @@ export interface DetailsListIssuesViewProps {
     cardsViewData: CardsViewModel;
     instancesSection: ReactFCWithDisplayName<CommonInstancesSectionProps>;
     selectedTest: VisualizationType;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
 }
 
 export const DetailsListIssuesView = NamedFC<DetailsListIssuesViewProps>(
@@ -56,6 +58,7 @@ export const DetailsListIssuesView = NamedFC<DetailsListIssuesViewProps>(
                 cardsViewData={props.cardsViewData}
                 instancesSection={props.instancesSection}
                 visualizationStoreData={props.visualizationStoreData}
+                cardSelectionMessageCreator={props.cardSelectionMessageCreator}
             />
         );
     },

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -6,10 +6,7 @@ import { VisualizationConfigurationFactory } from 'common/configs/visualization-
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 
-import {
-    ScanMetadata,
-    UnifiedScanResultStoreData,
-} from 'common/types/store-data/unified-data-interface';
+import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VersionedAssessmentData } from 'common/types/versioned-assessment-data';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -88,8 +85,8 @@ export interface DetailsViewCommandBarProps {
     assessmentsProvider: AssessmentsProvider;
     rightPanelConfiguration: DetailsRightPanelConfiguration;
     visualizationStoreData: VisualizationStoreData;
-    unifiedScanResultStoreData: UnifiedScanResultStoreData;
-    cardsViewData: CardsViewModel;
+    automatedChecksCardsViewData: CardsViewModel;
+    needsReviewCardsViewData: CardsViewModel;
     switcherNavConfiguration: DetailsViewSwitcherNavConfiguration;
     scanMetadata: ScanMetadata;
     narrowModeStatus: NarrowModeStatus;
@@ -209,7 +206,6 @@ export class DetailsViewCommandBar extends React.Component<
         const shouldShowReportExportButtonProps: ShouldShowReportExportButtonProps = {
             visualizationConfigurationFactory: this.props.visualizationConfigurationFactory,
             selectedTest: this.props.selectedTest,
-            unifiedScanResultStoreData: this.props.unifiedScanResultStoreData,
             visualizationStoreData: this.props.visualizationStoreData,
             featureFlagStoreData: this.props.featureFlagStoreData,
         };

--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -75,12 +75,22 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
         const selectedTest =
             selectedDetailsViewSwitcherNavConfiguration.getSelectedDetailsView(storeState);
 
-        const cardsViewData = props.deps.getCardViewData(
+        const automatedChecksCardsViewData = props.deps.getCardViewData(
             props.storeState.unifiedScanResultStoreData.rules,
             props.storeState.unifiedScanResultStoreData.results,
             props.deps.getCardSelectionViewData(
                 props.storeState.cardSelectionStoreData,
                 props.storeState.unifiedScanResultStoreData,
+                props.deps.isResultHighlightUnavailable,
+            ),
+        );
+
+        const needsReviewCardsViewData = props.deps.getCardViewData(
+            props.storeState.needsReviewScanResultStoreData.rules,
+            props.storeState.needsReviewScanResultStoreData.results,
+            props.deps.getCardSelectionViewData(
+                props.storeState.needsReviewCardSelectionStoreData,
+                props.storeState.needsReviewScanResultStoreData,
                 props.deps.isResultHighlightUnavailable,
             ),
         );
@@ -123,8 +133,8 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                 rightPanelConfiguration={selectedDetailsRightPanelConfiguration}
                 switcherNavConfiguration={selectedDetailsViewSwitcherNavConfiguration}
                 userConfigurationStoreData={storeState.userConfigurationStoreData}
-                cardsViewData={cardsViewData}
-                cardSelectionStoreData={storeState.cardSelectionStoreData}
+                automatedChecksCardsViewData={automatedChecksCardsViewData}
+                needsReviewCardsViewData={needsReviewCardsViewData}
                 scanIncompleteWarnings={
                     storeState.unifiedScanResultStoreData.scanIncompleteWarnings
                 }

--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -142,7 +142,6 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                 isSideNavOpen={props.isSideNavOpen}
                 setSideNavOpen={props.setSideNavOpen}
                 narrowModeStatus={props.narrowModeStatus}
-                unifiedScanResultStoreData={storeState.unifiedScanResultStoreData}
             />
         );
     };

--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -5,6 +5,7 @@ import {
     CommonInstancesSectionProps,
 } from 'common/components/cards/common-instances-section-props';
 import { ScanningSpinner } from 'common/components/scanning-spinner/scanning-spinner';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ReactFCWithDisplayName } from 'common/react/named-fc';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -35,6 +36,7 @@ export interface IssuesTableProps {
     scanMetadata: ScanMetadata;
     cardsViewData: CardsViewModel;
     instancesSection: ReactFCWithDisplayName<CommonInstancesSectionProps>;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
     visualizationStoreData: VisualizationStoreData;
 }
 
@@ -99,6 +101,7 @@ export class IssuesTable extends React.Component<IssuesTableProps> {
                 userConfigurationStoreData={this.props.userConfigurationStoreData}
                 scanMetadata={this.props.scanMetadata}
                 shouldAlertFailuresCount={true}
+                cardSelectionMessageCreator={this.props.cardSelectionMessageCreator}
             />
         );
     }

--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -75,7 +75,6 @@ export function getReportExportDialogForFastPass(
     const shouldShowReportExportButtonProps: ShouldShowReportExportButtonProps = {
         visualizationConfigurationFactory: props.visualizationConfigurationFactory,
         selectedTest: props.selectedTest,
-        unifiedScanResultStoreData: props.unifiedScanResultStoreData,
         visualizationStoreData: props.visualizationStoreData,
         featureFlagStoreData: props.featureFlagStoreData,
     };
@@ -94,7 +93,7 @@ export function getReportExportDialogForFastPass(
         reportGenerator.generateFastPassHtmlReport(
             {
                 results: {
-                    automatedChecks: props.cardsViewData,
+                    automatedChecks: props.automatedChecksCardsViewData,
                     tabStops: null,
                 },
                 description,

--- a/src/DetailsView/components/should-show-report-export-button.ts
+++ b/src/DetailsView/components/should-show-report-export-button.ts
@@ -3,14 +3,12 @@
 
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 
 export interface ShouldShowReportExportButtonProps {
     visualizationConfigurationFactory: VisualizationConfigurationFactory;
     selectedTest: VisualizationType;
-    unifiedScanResultStoreData: UnifiedScanResultStoreData;
     visualizationStoreData: VisualizationStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
 }
@@ -27,10 +25,7 @@ export function shouldShowReportExportButtonForFastpass(
     props: ShouldShowReportExportButtonProps,
 ): boolean {
     const config = props.visualizationConfigurationFactory.getConfiguration(props.selectedTest);
-    const shouldShow = config.shouldShowExportReport(
-        props.unifiedScanResultStoreData,
-        props.featureFlagStoreData,
-    );
+    const shouldShow = config.shouldShowExportReport(props.featureFlagStoreData);
 
     const scanData = config.getStoreData(props.visualizationStoreData.tests);
     const isEnabled = config.getTestStatus(scanData);

--- a/src/DetailsView/components/test-view-container.tsx
+++ b/src/DetailsView/components/test-view-container.tsx
@@ -4,6 +4,8 @@ import { FailedInstancesSection } from 'common/components/cards/failed-instances
 import { NeedsReviewInstancesSection } from 'common/components/cards/needs-review-instances-section';
 import { FlaggedComponent } from 'common/components/flagged-component';
 import { FeatureFlags } from 'common/feature-flags';
+import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
+import { NeedsReviewCardSelectionMessageCreator } from 'common/message-creators/needs-review-card-selection-message-creator';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import {
@@ -36,6 +38,8 @@ import { TestViewDeps } from './test-view';
 
 export type TestViewContainerDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+    automatedChecksCardSelectionMessageCreator: AutomatedChecksCardSelectionMessageCreator;
+    needsReviewCardSelectionMessageCreator: NeedsReviewCardSelectionMessageCreator;
 } & TestViewDeps &
     OverviewContainerDeps &
     AdhocTabStopsTestViewDeps;
@@ -56,7 +60,8 @@ export interface TestViewContainerProps {
     issuesTableHandler: IssuesTableHandler;
     userConfigurationStoreData: UserConfigurationStoreData;
     scanMetadata: ScanMetadata;
-    cardsViewData: CardsViewModel;
+    automatedChecksCardsViewData: CardsViewModel;
+    needsReviewCardsViewData: CardsViewModel;
     switcherNavConfiguration: DetailsViewSwitcherNavConfiguration;
     scanIncompleteWarnings: ScanIncompleteWarningId[];
 }
@@ -66,16 +71,26 @@ export const TestViewContainer = NamedFC<TestViewContainerProps>('TestViewContai
         props.selectedTest,
     );
     const testViewProps = { configuration, ...configuration.testViewOverrides, ...props };
+
     switch (configuration.testViewType) {
         case 'AdhocStatic':
             return <AdhocStaticTestView {...testViewProps} />;
         case 'AdhocFailure':
             return (
-                <AdhocIssuesTestView instancesSection={FailedInstancesSection} {...testViewProps} />
+                <AdhocIssuesTestView
+                    instancesSection={FailedInstancesSection}
+                    cardSelectionMessageCreator={
+                        props.deps.automatedChecksCardSelectionMessageCreator
+                    }
+                    cardsViewData={props.automatedChecksCardsViewData}
+                    {...testViewProps}
+                />
             );
         case 'AdhocNeedsReview':
             return (
                 <AdhocIssuesTestView
+                    cardsViewData={props.needsReviewCardsViewData}
+                    cardSelectionMessageCreator={props.deps.needsReviewCardSelectionMessageCreator}
                     instancesSection={NeedsReviewInstancesSection}
                     {...testViewProps}
                 />

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -4,10 +4,7 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import classNames from 'classnames';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
-import {
-    ScanMetadata,
-    UnifiedScanResultStoreData,
-} from 'common/types/store-data/unified-data-interface';
+import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { FluentSideNav, FluentSideNavDeps } from 'DetailsView/components/left-nav/fluent-side-nav';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
@@ -69,7 +66,6 @@ export interface DetailsViewBodyProps {
     isSideNavOpen: boolean;
     setSideNavOpen: (isOpen: boolean, event?: React.MouseEvent<any>) => void;
     narrowModeStatus: NarrowModeStatus;
-    unifiedScanResultStoreData: UnifiedScanResultStoreData;
 }
 
 export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -62,7 +62,8 @@ export interface DetailsViewBodyProps {
     rightPanelConfiguration: DetailsRightPanelConfiguration;
     switcherNavConfiguration: DetailsViewSwitcherNavConfiguration;
     userConfigurationStoreData: UserConfigurationStoreData;
-    cardsViewData: CardsViewModel;
+    automatedChecksCardsViewData: CardsViewModel;
+    needsReviewCardsViewData: CardsViewModel;
     scanIncompleteWarnings: ScanIncompleteWarningId[];
     scanMetadata: ScanMetadata;
     isSideNavOpen: boolean;

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -4,6 +4,8 @@ import { Header, HeaderProps } from 'common/components/header';
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
+import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
 import { DetailsViewContentWithLocalState } from 'DetailsView/components/details-view-content-with-local-state';
 import {
     NarrowModeDetector,
@@ -83,6 +85,9 @@ export interface DetailsViewContainerState {
     tabStoreData: TabStoreData;
     visualizationScanResultStoreData: VisualizationScanResultData;
     unifiedScanResultStoreData: UnifiedScanResultStoreData;
+    cardSelectionStoreData: CardSelectionStoreData;
+    needsReviewScanResultStoreData: NeedsReviewScanResultStoreData;
+    needsReviewCardSelectionStoreData: NeedsReviewCardSelectionStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
     detailsViewStoreData: DetailsViewStoreData;
     assessmentStoreData: AssessmentStoreData;
@@ -91,7 +96,6 @@ export interface DetailsViewContainerState {
     userConfigurationStoreData: UserConfigurationStoreData;
     selectedDetailsView: VisualizationType;
     selectedDetailsRightPanelConfiguration: DetailsRightPanelConfiguration;
-    cardSelectionStoreData: CardSelectionStoreData;
     permissionsStateStoreData: PermissionsStateStoreData;
     tabStopsViewStoreData: TabStopsViewStoreData;
 }

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -22,10 +22,13 @@ import { Globalization } from 'common/globalization';
 import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unavailable';
 import { createDefaultLogger } from 'common/logging/default-logger';
 import { Logger } from 'common/logging/logger';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
+import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
+import { NeedsReviewCardSelectionMessageCreator } from 'common/message-creators/needs-review-card-selection-message-creator';
 import { getNarrowModeThresholdsForWeb } from 'common/narrow-mode-thresholds';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
+import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
 import { toolName } from 'content/strings/application';
 import { textContent } from 'content/strings/text-content';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
@@ -182,6 +185,21 @@ if (tabId != null) {
                 browserAdapter,
                 tab.id,
             );
+            const cardSelectionStore = new StoreProxy<CardSelectionStoreData>(
+                StoreNames[StoreNames.CardSelectionStore],
+                browserAdapter,
+                tab.id,
+            );
+            const needsReviewScanResultStore = new StoreProxy<NeedsReviewScanResultStoreData>(
+                StoreNames[StoreNames.NeedsReviewScanResultStore],
+                browserAdapter,
+                tab.id,
+            );
+            const needsReviewCardSelectionStore = new StoreProxy<NeedsReviewCardSelectionStoreData>(
+                StoreNames[StoreNames.NeedsReviewCardSelectionStore],
+                browserAdapter,
+                tab.id,
+            );
             const pathSnippetStore = new StoreProxy<PathSnippetStoreData>(
                 StoreNames[StoreNames.PathSnippetStore],
                 browserAdapter,
@@ -212,11 +230,6 @@ if (tabId != null) {
                 browserAdapter,
                 tab.id,
             );
-            const cardSelectionStore = new StoreProxy<CardSelectionStoreData>(
-                StoreNames[StoreNames.CardSelectionStore],
-                browserAdapter,
-                tab.id,
-            );
 
             const tabStopsViewActions = new TabStopsViewActions();
             const tabStopsTestViewController = new TabStopsTestViewController(tabStopsViewActions);
@@ -230,12 +243,14 @@ if (tabId != null) {
                 tabStore,
                 visualizationScanResultStore,
                 unifiedScanResultStore,
+                cardSelectionStore,
+                needsReviewScanResultStore,
+                needsReviewCardSelectionStore,
                 visualizationStore,
                 assessmentStore,
                 pathSnippetStore,
                 scopingStore,
                 userConfigStore,
-                cardSelectionStore,
                 tabStopsViewStore,
             ]);
 
@@ -417,11 +432,20 @@ if (tabId != null) {
                 createIssueDetailsBuilder(PlainTextFormatter),
             );
 
-            const cardSelectionMessageCreator = new CardSelectionMessageCreator(
-                actionMessageDispatcher,
-                telemetryFactory,
-                TelemetryEventSource.DetailsView,
-            );
+            const automatedChecksCardSelectionMessageCreator =
+                new AutomatedChecksCardSelectionMessageCreator(
+                    actionMessageDispatcher,
+                    telemetryFactory,
+                    TelemetryEventSource.DetailsView,
+                );
+
+            const needsReviewCardSelectionMessageCreator =
+                new NeedsReviewCardSelectionMessageCreator(
+                    actionMessageDispatcher,
+                    telemetryFactory,
+                    TelemetryEventSource.DetailsView,
+                );
+
             const windowUtils = new WindowUtils();
 
             const fileURLProvider = new FileURLProvider(windowUtils, provideBlob);
@@ -529,7 +553,8 @@ if (tabId != null) {
                 collapsibleControl: CardsCollapsibleControl,
                 cardInteractionSupport: allCardInteractionsSupported,
                 navigatorUtils: navigatorUtils,
-                cardSelectionMessageCreator,
+                automatedChecksCardSelectionMessageCreator,
+                needsReviewCardSelectionMessageCreator,
                 getCardSelectionViewData: getCardSelectionViewData,
                 cardsVisualizationModifierButtons: ExpandCollapseVisualHelperModifierButtons,
                 allUrlsPermissionHandler: new AllUrlsPermissionHandler(

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -39,7 +39,7 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     },
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: (data, featureflagStoreData) =>
+    shouldShowExportReport: featureflagStoreData =>
         featureflagStoreData[FeatureFlags.newTabStopsDetailsView],
     displayableData: {
         title: 'Automated checks',

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -35,7 +35,7 @@ export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     enableTest: (data, _) => (data.adhoc[tabStopsTestKey].enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: (data, featureflagStoreData) =>
+    shouldShowExportReport: featureflagStoreData =>
         featureflagStoreData[FeatureFlags.newTabStopsDetailsView],
     displayableData: {
         title: 'Tab stops',

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
+import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
 import { SidePanelActions } from 'background/actions/side-panel-actions';
 import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
 import { TestMode } from 'common/configs/test-mode';
@@ -46,6 +47,7 @@ export class ActionCreator {
     };
     private inspectActions: InspectActions;
     private cardSelectionActions: CardSelectionActions;
+    private needsReviewCardSelectionActions: NeedsReviewCardSelectionActions;
     private unifiedScanResultActions: UnifiedScanResultActions;
     private sidePanelActions: SidePanelActions;
 
@@ -63,6 +65,7 @@ export class ActionCreator {
         this.visualizationScanResultActions = actionHub.visualizationScanResultActions;
         this.inspectActions = actionHub.inspectActions;
         this.cardSelectionActions = actionHub.cardSelectionActions;
+        this.needsReviewCardSelectionActions = actionHub.needsReviewCardSelectionActions;
         this.unifiedScanResultActions = actionHub.scanResultActions;
         this.sidePanelActions = actionHub.sidePanelActions;
     }
@@ -270,6 +273,7 @@ export class ActionCreator {
     private onScrollRequested = (): void => {
         this.visualizationActions.scrollRequested.invoke(null);
         this.cardSelectionActions.resetFocusedIdentifier.invoke(null);
+        this.needsReviewCardSelectionActions.resetFocusedIdentifier.invoke(null);
     };
 
     private onDetailsViewOpen = async (

--- a/src/common/components/cards/common-instances-section-props.ts
+++ b/src/common/components/cards/common-instances-section-props.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { CardsViewModel } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
@@ -12,4 +13,5 @@ export type CommonInstancesSectionProps = {
     userConfigurationStoreData: UserConfigurationStoreData;
     scanMetadata: ScanMetadata;
     shouldAlertFailuresCount?: boolean;
+    cardSelectionMessageCreator?: CardSelectionMessageCreator;
 };

--- a/src/common/components/cards/expand-collapse-all-button.tsx
+++ b/src/common/components/cards/expand-collapse-all-button.tsx
@@ -6,27 +6,23 @@ import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './expand-collapse-all-button.scss';
 
-export type ExpandCollapseAllButtonDeps = {
-    cardSelectionMessageCreator: CardSelectionMessageCreator;
-};
-
 export type ExpandCollapseAllButtonProps = {
-    deps: ExpandCollapseAllButtonDeps;
     allCardsCollapsed: boolean;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
 };
 
 export const ExpandCollapseAllButton = NamedFC<ExpandCollapseAllButtonProps>(
     'ExpandCollapseAllButton',
     props => {
-        const { deps, allCardsCollapsed } = props;
+        const { allCardsCollapsed, cardSelectionMessageCreator } = props;
 
-        let expandCollapseAllButtonHandler = deps.cardSelectionMessageCreator.collapseAllRules;
+        let expandCollapseAllButtonHandler = cardSelectionMessageCreator.collapseAllRules;
         let buttonText = 'Collapse all';
         let iconName = 'ChevronDown';
         let ariaLabel: string | undefined = undefined;
 
         if (allCardsCollapsed) {
-            expandCollapseAllButtonHandler = deps.cardSelectionMessageCreator.expandAllRules;
+            expandCollapseAllButtonHandler = cardSelectionMessageCreator.expandAllRules;
             buttonText = 'Expand all';
             iconName = 'ChevronRight';
             ariaLabel = 'Expand all rules to show failed instances.';

--- a/src/common/components/cards/failed-instances-section.tsx
+++ b/src/common/components/cards/failed-instances-section.tsx
@@ -15,6 +15,7 @@ export const FailedInstancesSection = NamedFC<CommonInstancesSectionProps>(
         userConfigurationStoreData,
         scanMetadata,
         shouldAlertFailuresCount,
+        cardSelectionMessageCreator,
     }) => {
         if (cardsViewData == null || cardsViewData.cards == null) {
             return null;
@@ -39,6 +40,7 @@ export const FailedInstancesSection = NamedFC<CommonInstancesSectionProps>(
                 allCardsCollapsed={cardsViewData.allCardsCollapsed}
                 outcomeCounter={OutcomeCounter.countByCards}
                 headingLevel={3}
+                cardSelectionMessageCreator={cardSelectionMessageCreator}
             />
         );
     },

--- a/src/common/components/cards/instance-details-group.tsx
+++ b/src/common/components/cards/instance-details-group.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
@@ -25,12 +26,19 @@ export type InstanceDetailsGroupProps = {
     rule: CardRuleResult;
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
 };
 
 export const InstanceDetailsGroup = NamedFC<InstanceDetailsGroupProps>(
     'InstanceDetailsGroup',
     props => {
-        const { deps, rule, userConfigurationStoreData, targetAppInfo } = props;
+        const {
+            deps,
+            rule,
+            userConfigurationStoreData,
+            targetAppInfo,
+            cardSelectionMessageCreator,
+        } = props;
         const { nodes } = rule;
         const unifiedRule: UnifiedRule = {
             id: rule.id,
@@ -55,6 +63,7 @@ export const InstanceDetailsGroup = NamedFC<InstanceDetailsGroupProps>(
                             userConfigurationStoreData={userConfigurationStoreData}
                             rule={unifiedRule}
                             targetAppInfo={targetAppInfo}
+                            cardSelectionMessageCreator={cardSelectionMessageCreator}
                         />
                     </li>
                 ))}

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import classNames from 'classnames';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC } from 'common/react/named-fc';
 import { CardResult } from 'common/types/store-data/card-view-model';
 import { forOwn, isEmpty } from 'lodash';
@@ -19,7 +20,6 @@ import {
     CardRowDeps,
     PropertyConfiguration,
 } from '../../../common/configs/unified-result-property-configurations';
-import { CardSelectionMessageCreator } from '../../../common/message-creators/card-selection-message-creator';
 import {
     StoredInstancePropertyBag,
     TargetAppData,
@@ -32,7 +32,6 @@ export const instanceCardAutomationId = 'instance-card';
 
 export type InstanceDetailsDeps = {
     getPropertyConfigById: (id: string) => PropertyConfiguration;
-    cardSelectionMessageCreator: CardSelectionMessageCreator;
 } & CardRowDeps &
     InstanceDetailsFooterDeps;
 
@@ -43,10 +42,18 @@ export type InstanceDetailsProps = {
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
     rule: UnifiedRule;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
 };
 
 export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', props => {
-    const { result, deps, userConfigurationStoreData, rule, targetAppInfo } = props;
+    const {
+        result,
+        deps,
+        userConfigurationStoreData,
+        rule,
+        targetAppInfo,
+        cardSelectionMessageCreator,
+    } = props;
     const [cardFocused, setCardFocus] = React.useState(false);
 
     const isHighlightSupported: boolean = deps.cardInteractionSupport.supportsHighlighting;
@@ -65,7 +72,7 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
 
     const toggleSelectHandler = (event: React.SyntheticEvent): void => {
         event.stopPropagation();
-        deps.cardSelectionMessageCreator.toggleCardSelection(result.ruleId, result.uid, event);
+        cardSelectionMessageCreator.toggleCardSelection(result.ruleId, result.uid, event);
     };
 
     const hiddenButton = React.useRef(null);

--- a/src/common/components/cards/needs-review-instances-section.tsx
+++ b/src/common/components/cards/needs-review-instances-section.tsx
@@ -15,6 +15,7 @@ export const NeedsReviewInstancesSection = NamedFC<CommonInstancesSectionProps>(
         userConfigurationStoreData,
         scanMetadata,
         shouldAlertFailuresCount,
+        cardSelectionMessageCreator,
     }) => {
         if (cardsViewData == null || cardsViewData.cards == null) {
             return null;
@@ -39,6 +40,7 @@ export const NeedsReviewInstancesSection = NamedFC<CommonInstancesSectionProps>(
                 allCardsCollapsed={cardsViewData.allCardsCollapsed}
                 outcomeCounter={OutcomeCounter.countByCards}
                 headingLevel={3}
+                cardSelectionMessageCreator={cardSelectionMessageCreator}
             />
         );
     },

--- a/src/common/components/cards/result-section-content.tsx
+++ b/src/common/components/cards/result-section-content.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { CardsVisualizationModifierButtons } from 'common/components/cards/cards-visualization-modifier-buttons';
 import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { OutcomeCounter } from 'reports/components/outcome-counter';
@@ -32,6 +33,7 @@ export type ResultSectionContentProps = {
     allCardsCollapsed: boolean;
     outcomeCounter: OutcomeCounter;
     headingLevel: number;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
 };
 
 export const ResultSectionContent = NamedFC<ResultSectionContentProps>(
@@ -50,7 +52,6 @@ export const ResultSectionContent = NamedFC<ResultSectionContentProps>(
         if (results.length === 0) {
             return <NoFailedInstancesCongrats outcomeType={outcomeType} deps={props.deps} />;
         }
-
         return (
             <>
                 <deps.cardsVisualizationModifierButtons {...props} />
@@ -63,6 +64,7 @@ export const ResultSectionContent = NamedFC<ResultSectionContentProps>(
                     targetAppInfo={targetAppInfo}
                     outcomeCounter={outcomeCounter}
                     headingLevel={headingLevel}
+                    cardSelectionMessageCreator={props.cardSelectionMessageCreator}
                 />
             </>
         );

--- a/src/common/components/cards/rule-content.tsx
+++ b/src/common/components/cards/rule-content.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
@@ -16,6 +17,7 @@ export type RuleContentProps = {
     rule: CardRuleResult;
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
 };
 
 export const RuleContent = NamedFC<RuleContentProps>('RuleContent', props => {

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -23,7 +23,6 @@ export const ruleGroupAutomationId = 'cards-rule-group';
 export type RulesWithInstancesDeps = RuleContentDeps &
     CollapsibleComponentCardsDeps & {
         collapsibleControl: (props: CollapsibleComponentCardsProps) => JSX.Element;
-        cardSelectionMessageCreator: CardSelectionMessageCreator;
     };
 
 export type RulesWithInstancesProps = {
@@ -35,6 +34,7 @@ export type RulesWithInstancesProps = {
     targetAppInfo: TargetAppData;
     outcomeCounter: OutcomeCounter;
     headingLevel: number;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
 };
 
 export const ruleDetailsGroupAutomationId = 'rule-details-group';
@@ -50,6 +50,7 @@ export const RulesWithInstances = NamedFC<RulesWithInstancesProps>(
         targetAppInfo,
         outcomeCounter,
         headingLevel,
+        cardSelectionMessageCreator,
     }) => {
         const getCollapsibleComponentProps = (
             rule: CardRuleResult,
@@ -75,6 +76,7 @@ export const RulesWithInstances = NamedFC<RulesWithInstancesProps>(
                         fixInstructionProcessor={fixInstructionProcessor}
                         userConfigurationStoreData={userConfigurationStoreData}
                         targetAppInfo={targetAppInfo}
+                        cardSelectionMessageCreator={cardSelectionMessageCreator}
                     />
                 ),
                 containerAutomationId: ruleGroupAutomationId,
@@ -83,7 +85,7 @@ export const RulesWithInstances = NamedFC<RulesWithInstancesProps>(
                 headingLevel,
                 deps: deps,
                 onExpandToggle: (event: React.MouseEvent<HTMLDivElement>) => {
-                    deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(rule.id, event);
+                    cardSelectionMessageCreator.toggleRuleExpandCollapse(rule.id, event);
                 },
                 isExpanded: rule.isExpanded,
             };

--- a/src/common/components/cards/visual-helper-toggle.tsx
+++ b/src/common/components/cards/visual-helper-toggle.tsx
@@ -6,20 +6,16 @@ import { css, Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './visual-helper-toggle.scss';
 
-export type VisualHelperToggleDeps = {
-    cardSelectionMessageCreator: CardSelectionMessageCreator;
-};
-
 export type VisualHelperToggleProps = {
-    deps: VisualHelperToggleDeps;
     visualHelperEnabled: boolean;
     className?: string;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
 };
 
 export const VisualHelperToggle = NamedFC<VisualHelperToggleProps>('VisualHelperToggle', props => {
     return (
         <Toggle
-            onClick={props.deps.cardSelectionMessageCreator.toggleVisualHelper}
+            onClick={props.cardSelectionMessageCreator.toggleVisualHelper}
             label="Visual helper"
             checked={props.visualHelperEnabled}
             className={css(styles.visualHelperToggle, props.className)}

--- a/src/common/configs/visualization-configuration.ts
+++ b/src/common/configs/visualization-configuration.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { ContentPageComponent } from 'views/content/content-page';
 import { DictionaryStringTo } from '../../types/common-types';
 import { DisplayableVisualizationTypeData } from '../types/displayable-visualization-type-data';
@@ -28,8 +27,5 @@ export interface VisualizationConfiguration extends AssessmentVisualizationConfi
     analyzerProgressMessageType?: string;
     analyzerTerminatedMessageType?: string;
     guidance?: ContentPageComponent;
-    shouldShowExportReport: (
-        unifiedScanResultStoreData: UnifiedScanResultStoreData,
-        featureFlagStoreData: FeatureFlagStoreData,
-    ) => boolean;
+    shouldShowExportReport: (featureFlagStoreData: FeatureFlagStoreData) => boolean;
 }

--- a/src/common/message-creators/automated-checks-card-selection-message-creator.ts
+++ b/src/common/message-creators/automated-checks-card-selection-message-creator.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    BaseActionPayload,
+    CardSelectionPayload,
+    RuleExpandCollapsePayload,
+} from 'background/actions/action-payloads';
+import { TelemetryEventSource } from 'common/extension-telemetry-events';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
+import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
+import { Messages } from 'common/messages';
+import { SupportedMouseEvent, TelemetryDataFactory } from 'common/telemetry-data-factory';
+
+export class AutomatedChecksCardSelectionMessageCreator implements CardSelectionMessageCreator {
+    constructor(
+        private readonly dispatcher: ActionMessageDispatcher,
+        private readonly telemetryFactory: TelemetryDataFactory,
+        private readonly source: TelemetryEventSource,
+    ) {}
+
+    public toggleCardSelection = (
+        ruleId: string,
+        resultInstanceUid: string,
+        event: React.SyntheticEvent,
+    ) => {
+        const payload: CardSelectionPayload = {
+            resultInstanceUid,
+            ruleId,
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.CardSelection.CardSelectionToggled,
+            payload,
+        });
+    };
+
+    public toggleRuleExpandCollapse = (ruleId: string, event: React.SyntheticEvent) => {
+        const payload: RuleExpandCollapsePayload = {
+            ruleId,
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.CardSelection.RuleExpansionToggled,
+            payload,
+        });
+    };
+
+    public collapseAllRules = (event: SupportedMouseEvent) => {
+        const payload: BaseActionPayload = {
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.CardSelection.CollapseAllRules,
+            payload,
+        });
+    };
+
+    public expandAllRules = (event: SupportedMouseEvent) => {
+        const payload: BaseActionPayload = {
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.CardSelection.ExpandAllRules,
+            payload,
+        });
+    };
+
+    public toggleVisualHelper = (event: SupportedMouseEvent) => {
+        const payload: BaseActionPayload = {
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.CardSelection.ToggleVisualHelper,
+            payload,
+        });
+    };
+}

--- a/src/common/message-creators/card-selection-message-creator.ts
+++ b/src/common/message-creators/card-selection-message-creator.ts
@@ -1,81 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import {
-    BaseActionPayload,
-    CardSelectionPayload,
-    RuleExpandCollapsePayload,
-} from 'background/actions/action-payloads';
-import { TelemetryEventSource } from 'common/extension-telemetry-events';
-import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
-import { Messages } from 'common/messages';
-import { SupportedMouseEvent, TelemetryDataFactory } from 'common/telemetry-data-factory';
 
-export class CardSelectionMessageCreator {
-    constructor(
-        private readonly dispatcher: ActionMessageDispatcher,
-        private readonly telemetryFactory: TelemetryDataFactory,
-        private readonly source: TelemetryEventSource,
-    ) {}
+import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 
-    public toggleCardSelection = (
+export interface CardSelectionMessageCreator {
+    toggleCardSelection: (
         ruleId: string,
         resultInstanceUid: string,
         event: React.SyntheticEvent,
-    ) => {
-        const payload: CardSelectionPayload = {
-            resultInstanceUid,
-            ruleId,
-            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.CardSelection.CardSelectionToggled,
-            payload,
-        });
-    };
-
-    public toggleRuleExpandCollapse = (ruleId: string, event: React.SyntheticEvent) => {
-        const payload: RuleExpandCollapsePayload = {
-            ruleId,
-            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.CardSelection.RuleExpansionToggled,
-            payload,
-        });
-    };
-
-    public collapseAllRules = (event: SupportedMouseEvent) => {
-        const payload: BaseActionPayload = {
-            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.CardSelection.CollapseAllRules,
-            payload,
-        });
-    };
-
-    public expandAllRules = (event: SupportedMouseEvent) => {
-        const payload: BaseActionPayload = {
-            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.CardSelection.ExpandAllRules,
-            payload,
-        });
-    };
-
-    public toggleVisualHelper = (event: SupportedMouseEvent) => {
-        const payload: BaseActionPayload = {
-            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.CardSelection.ToggleVisualHelper,
-            payload,
-        });
-    };
+    ) => void;
+    toggleRuleExpandCollapse: (ruleId: string, event: React.SyntheticEvent) => void;
+    collapseAllRules: (event: SupportedMouseEvent) => void;
+    expandAllRules: (event: SupportedMouseEvent) => void;
+    toggleVisualHelper: (event: SupportedMouseEvent) => void;
 }

--- a/src/common/message-creators/needs-review-card-selection-message-creator.ts
+++ b/src/common/message-creators/needs-review-card-selection-message-creator.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    BaseActionPayload,
+    CardSelectionPayload,
+    RuleExpandCollapsePayload,
+} from 'background/actions/action-payloads';
+import { TelemetryEventSource } from 'common/extension-telemetry-events';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
+import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
+import { Messages } from 'common/messages';
+import { SupportedMouseEvent, TelemetryDataFactory } from 'common/telemetry-data-factory';
+
+export class NeedsReviewCardSelectionMessageCreator implements CardSelectionMessageCreator {
+    constructor(
+        private readonly dispatcher: ActionMessageDispatcher,
+        private readonly telemetryFactory: TelemetryDataFactory,
+        private readonly source: TelemetryEventSource,
+    ) {}
+
+    public toggleCardSelection = (
+        ruleId: string,
+        resultInstanceUid: string,
+        event: React.SyntheticEvent,
+    ) => {
+        const payload: CardSelectionPayload = {
+            resultInstanceUid,
+            ruleId,
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.NeedsReviewCardSelection.CardSelectionToggled,
+            payload,
+        });
+    };
+
+    public toggleRuleExpandCollapse = (ruleId: string, event: React.SyntheticEvent) => {
+        const payload: RuleExpandCollapsePayload = {
+            ruleId,
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.NeedsReviewCardSelection.RuleExpansionToggled,
+            payload,
+        });
+    };
+
+    public collapseAllRules = (event: SupportedMouseEvent) => {
+        const payload: BaseActionPayload = {
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.NeedsReviewCardSelection.CollapseAllRules,
+            payload,
+        });
+    };
+
+    public expandAllRules = (event: SupportedMouseEvent) => {
+        const payload: BaseActionPayload = {
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.NeedsReviewCardSelection.ExpandAllRules,
+            payload,
+        });
+    };
+
+    public toggleVisualHelper = (event: SupportedMouseEvent) => {
+        const payload: BaseActionPayload = {
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.NeedsReviewCardSelection.ToggleVisualHelper,
+            payload,
+        });
+    };
+}

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -40,7 +40,7 @@ import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { isResultHighlightUnavailableUnified } from 'common/is-result-highlight-unavailable';
 import { createDefaultLogger } from 'common/logging/default-logger';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
+import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
 import { DropdownActionMessageCreator } from 'common/message-creators/dropdown-action-message-creator';
 import { IssueFilingActionMessageCreator } from 'common/message-creators/issue-filing-action-message-creator';
 import { UserConfigMessageCreator } from 'common/message-creators/user-config-message-creator';
@@ -397,11 +397,12 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
         );
         detailsViewActionCreator.registerCallback();
 
-        const cardSelectionMessageCreator = new CardSelectionMessageCreator(
-            dispatcher,
-            telemetryDataFactory,
-            TelemetryEventSource.ElectronResultsView,
-        );
+        const automatedChecksCardSelectionMessageCreator =
+            new AutomatedChecksCardSelectionMessageCreator(
+                dispatcher,
+                telemetryDataFactory,
+                TelemetryEventSource.ElectronResultsView,
+            );
 
         const windowFrameListener = new WindowFrameListener(
             windowStateActionCreator,
@@ -500,7 +501,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
             getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks,
 
             userConfigMessageCreator: userConfigMessageCreator,
-            cardSelectionMessageCreator,
+            cardSelectionMessageCreator: automatedChecksCardSelectionMessageCreator,
 
             detailsViewActionMessageCreator,
             issueFilingActionMessageCreator: issueFilingActionMessageCreator,

--- a/src/electron/views/results/test-view.tsx
+++ b/src/electron/views/results/test-view.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { ResultSectionContentDeps } from 'common/components/cards/result-section-content';
 import { ScanningSpinner } from 'common/components/scanning-spinner/scanning-spinner';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC } from 'common/react/named-fc';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
@@ -11,7 +12,9 @@ import { ContentPageInfo } from 'electron/types/content-page-info';
 import { HeaderSection } from 'electron/views/results/components/header-section';
 import * as React from 'react';
 
-export type TestViewDeps = ResultSectionContentDeps;
+export type TestViewDeps = ResultSectionContentDeps & {
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
+};
 export type TestViewProps = {
     deps: TestViewDeps;
     scanStatus: ScanStatus;
@@ -58,6 +61,7 @@ export const TestView = NamedFC<TestViewProps>('TestView', props => {
                 shouldAlertFailuresCount={true}
                 cardsViewData={cardsViewData}
                 tabStopsEnabled={props.tabStopsEnabled}
+                cardSelectionMessageCreator={deps.cardSelectionMessageCreator}
             />
         </div>
     );

--- a/src/injected/analyzers/unified-result-sender.ts
+++ b/src/injected/analyzers/unified-result-sender.ts
@@ -33,26 +33,36 @@ export class UnifiedResultSender {
     ) {}
 
     public sendAutomatedChecksResults: PostResolveCallback = (axeResults: AxeAnalyzerResult) => {
-        this.sendResults(
+        const payload = this.preparePayload(
             axeResults.originalResult,
             this.convertScanResultsToUnifiedResults.automatedChecksConversion,
             this.notificationTextCreator.automatedChecksText,
         );
+
+        this.sendMessage({
+            messageType: Messages.UnifiedScan.ScanCompleted,
+            payload,
+        });
     };
 
     public sendNeedsReviewResults: PostResolveCallback = (axeResults: AxeAnalyzerResult) => {
-        this.sendResults(
+        const payload = this.preparePayload(
             this.filterNeedsReviewResults(axeResults.originalResult),
             this.convertScanResultsToUnifiedResults.needsReviewConversion,
             this.notificationTextCreator.needsReviewText,
         );
+
+        this.sendMessage({
+            messageType: Messages.NeedsReviewScan.ScanCompleted,
+            payload,
+        });
     };
 
-    private sendResults = (
+    private preparePayload = (
         results: ScanResults,
         converter: ConvertScanResultsToUnifiedResultsDelegate,
         notificationMessage: TextGenerator,
-    ) => {
+    ): UnifiedScanCompletedPayload => {
         const scanIncompleteWarnings =
             this.scanIncompleteWarningDetector.detectScanIncompleteWarnings();
 
@@ -80,9 +90,6 @@ export class UnifiedResultSender {
             notificationText: notificationMessage(unifiedResults),
         };
 
-        this.sendMessage({
-            messageType: Messages.UnifiedScan.ScanCompleted,
-            payload,
-        });
+        return payload;
     };
 }

--- a/src/injected/client-store-listener.ts
+++ b/src/injected/client-store-listener.ts
@@ -4,6 +4,8 @@ import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
+import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
 import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
@@ -16,11 +18,13 @@ export interface TargetPageStoreData {
     tabStoreData: TabStoreData;
     visualizationScanResultStoreData: VisualizationScanResultData;
     unifiedScanResultStoreData: UnifiedScanResultStoreData;
+    needsReviewScanResultStoreData: NeedsReviewScanResultStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
     assessmentStoreData: AssessmentStoreData;
     userConfigurationStoreData: UserConfigurationStoreData;
     cardSelectionStoreData: CardSelectionStoreData;
     permissionsStateStoreData: PermissionsStateStoreData;
+    needsReviewCardSelectionStoreData: NeedsReviewCardSelectionStoreData;
 }
 
 export class ClientStoreListener {

--- a/src/injected/focus-change-handler.ts
+++ b/src/injected/focus-change-handler.ts
@@ -59,30 +59,31 @@ export class FocusChangeHandler {
         );
     }
 
-    private findAutomatedChecksFocusedResult(storeData: TargetPageStoreData): UnifiedResult | null {
+    private findAutomatedChecksFocusedResult(storeData: TargetPageStoreData): UnifiedResult {
         const focusedResult = storeData.unifiedScanResultStoreData.results.find(
             result => result.uid === storeData.cardSelectionStoreData.focusedResultUid,
         );
-        if (focusedResult != null) {
+
+        if (focusedResult !== undefined) {
             return focusedResult;
         }
 
         throw new Error('focused result was not found');
     }
 
-    private findNeedsReviewFocusedResult(storeData: TargetPageStoreData): UnifiedResult | null {
+    private findNeedsReviewFocusedResult(storeData: TargetPageStoreData): UnifiedResult {
         const focusedResult = storeData.needsReviewScanResultStoreData.results.find(
             result => result.uid === storeData.needsReviewCardSelectionStoreData.focusedResultUid,
         );
 
-        if (focusedResult !== null) {
+        if (focusedResult !== undefined) {
             return focusedResult;
         }
 
         throw new Error('focused result was not found');
     }
 
-    private getTargetFromUnifiedResult(UnifiedResult: UnifiedResult): string[] | null {
+    private getTargetFromUnifiedResult(UnifiedResult: UnifiedResult): string[] {
         return UnifiedResult.identifiers.identifier.split(';');
     }
 

--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
+import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { TargetPageStoreData } from 'injected/client-store-listener';
 import { GetElementBasedViewModelCallback } from 'injected/element-based-view-model-creator';
@@ -20,6 +22,8 @@ export type VisualizationRelatedStoreData = Pick<
     | 'unifiedScanResultStoreData'
     | 'visualizationScanResultStoreData'
     | 'cardSelectionStoreData'
+    | 'needsReviewCardSelectionStoreData'
+    | 'needsReviewScanResultStoreData'
 >;
 
 export class SelectorMapHelper {
@@ -39,6 +43,8 @@ export class SelectorMapHelper {
             unifiedScanResultStoreData,
             assessmentStoreData,
             cardSelectionStoreData,
+            needsReviewScanResultStoreData,
+            needsReviewCardSelectionStoreData,
         } = visualizationRelatedStoreData;
 
         if (this.isAdHocVisualization(visualizationType)) {
@@ -47,6 +53,8 @@ export class SelectorMapHelper {
                 visualizationScanResultStoreData,
                 unifiedScanResultStoreData,
                 cardSelectionStoreData,
+                needsReviewScanResultStoreData,
+                needsReviewCardSelectionStoreData,
             );
         }
 
@@ -80,10 +88,17 @@ export class SelectorMapHelper {
         visualizationScanResultData: VisualizationScanResultData,
         unifiedScanData: UnifiedScanResultStoreData,
         cardSelectionStoreData: CardSelectionStoreData,
+        needsReviewScanData: NeedsReviewScanResultStoreData,
+        needsReviewCardSelectionStoreData: NeedsReviewCardSelectionStoreData,
     ): SelectorToVisualizationMap {
         let selectorMap = {};
         switch (visualizationType) {
             case VisualizationType.NeedsReview:
+                selectorMap = this.getElementBasedViewModel(
+                    needsReviewScanData,
+                    needsReviewCardSelectionStoreData,
+                );
+                break;
             case VisualizationType.Issues:
                 selectorMap = this.getElementBasedViewModel(
                     unifiedScanData,

--- a/src/reports/combined-report-html-generator.tsx
+++ b/src/reports/combined-report-html-generator.tsx
@@ -7,6 +7,7 @@ import { NullComponent } from 'common/components/null-component';
 import { RecommendColor } from 'common/components/recommend-color';
 import { PropertyConfiguration } from 'common/configs/unified-result-property-configurations';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
@@ -37,6 +38,7 @@ export class CombinedReportHtmlGenerator {
     public generateHtml(
         scanMetadata: ScanMetadata,
         cardsByRule: CardsViewModel,
+        cardSelectionMessageCreator: CardSelectionMessageCreator,
         urlResultCounts: UrlResultCounts,
     ): string {
         const HeadSection = this.sectionFactory.HeadSection;
@@ -55,6 +57,7 @@ export class CombinedReportHtmlGenerator {
                 LinkComponent: NewTabLinkWithConfirmationDialog,
             } as SectionDeps,
             cardsViewData: cardsByRule,
+            cardSelectionMessageCreator,
             urlResultCounts,
             toUtcString: this.utcDateConverter,
             secondsToTimeString: this.secondsToTimeStringConverter,

--- a/src/reports/components/report-sections/collapsible-result-section.tsx
+++ b/src/reports/components/report-sections/collapsible-result-section.tsx
@@ -13,7 +13,6 @@ import { RulesOnly, RulesOnlyDeps, RulesOnlyProps } from './rules-only';
 
 export type CollapsibleResultSectionDeps = {
     collapsibleControl: (props: CollapsibleComponentCardsProps) => JSX.Element;
-    cardSelectionMessageCreator: CardSelectionMessageCreator;
 } & RulesOnlyDeps;
 
 export type CollapsibleResultSectionProps = RulesOnlyProps &
@@ -21,12 +20,13 @@ export type CollapsibleResultSectionProps = RulesOnlyProps &
         deps: CollapsibleResultSectionDeps;
         containerId: string;
         containerClassName: string;
+        cardSelectionMessageCreator: CardSelectionMessageCreator;
     };
 
 export const CollapsibleResultSection = NamedFC<CollapsibleResultSectionProps>(
     'CollapsibleResultSection',
     props => {
-        const { containerClassName, containerId, deps } = props;
+        const { containerClassName, containerId, deps, cardSelectionMessageCreator } = props;
         const CollapsibleContent = deps.collapsibleControl({
             id: containerId,
             header: <ResultSectionTitle {...props} titleSize="title" />,
@@ -34,7 +34,7 @@ export const CollapsibleResultSection = NamedFC<CollapsibleResultSectionProps>(
             headingLevel: 2,
             deps: null,
             onExpandToggle: (event: React.MouseEvent<HTMLDivElement>) => {
-                deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(containerId, event);
+                cardSelectionMessageCreator.toggleRuleExpandCollapse(containerId, event);
             },
         });
 

--- a/src/reports/components/report-sections/combined-report-failed-section.tsx
+++ b/src/reports/components/report-sections/combined-report-failed-section.tsx
@@ -11,20 +11,19 @@ import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import { OutcomeCounter } from 'reports/components/outcome-counter';
 
-export type CombinedReportFailedSectionDeps = ResultSectionDeps & {
-    cardSelectionMessageCreator: CardSelectionMessageCreator;
-};
+export type CombinedReportFailedSectionDeps = ResultSectionDeps;
 
 export type CombinedReportFailedSectionProps = {
     deps: CombinedReportFailedSectionDeps;
     cardsViewData: CardsViewModel;
     scanMetadata: ScanMetadata;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
 };
 
 export const CombinedReportFailedSection = NamedFC<CombinedReportFailedSectionProps>(
     'CombinedReportFailedSection',
     props => {
-        const { deps, cardsViewData, scanMetadata } = props;
+        const { deps, cardsViewData, scanMetadata, cardSelectionMessageCreator } = props;
 
         const ruleCount = cardsViewData.cards.fail.length;
 
@@ -50,10 +49,11 @@ export const CombinedReportFailedSection = NamedFC<CombinedReportFailedSectionPr
                     userConfigurationStoreData={null}
                     outcomeCounter={OutcomeCounter.countByIdentifierUrls}
                     headingLevel={4}
+                    cardSelectionMessageCreator={cardSelectionMessageCreator}
                 />
             ),
             onExpandToggle: (event: React.MouseEvent<HTMLDivElement>) => {
-                deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(sectionId, event);
+                cardSelectionMessageCreator.toggleRuleExpandCollapse(sectionId, event);
             },
             headingLevel: 3,
             deps: null,

--- a/src/reports/components/report-sections/combined-report-rules-only-sections.tsx
+++ b/src/reports/components/report-sections/combined-report-rules-only-sections.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CombinedReportResultSectionTitle } from 'common/components/cards/combined-report-result-section-title';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
@@ -10,11 +9,12 @@ import { RulesOnly } from 'reports/components/report-sections/rules-only';
 import { CollapsibleResultSectionDeps } from './collapsible-result-section';
 import { SectionProps } from './report-section-factory';
 
-export type CombinedReportRulesOnlySectionDeps = CollapsibleResultSectionDeps & {
-    cardSelectionMessageCreator: CardSelectionMessageCreator;
-};
+export type CombinedReportRulesOnlySectionDeps = CollapsibleResultSectionDeps;
 
-export type CombinedReportRulesOnlySectionProps = Pick<SectionProps, 'deps' | 'cardsViewData'>;
+export type CombinedReportRulesOnlySectionProps = Pick<
+    SectionProps,
+    'deps' | 'cardsViewData' | 'cardSelectionMessageCreator'
+>;
 
 const makeCombinedReportRulesOnlySection = (options: {
     outcomeType: InstanceOutcomeType;
@@ -22,7 +22,7 @@ const makeCombinedReportRulesOnlySection = (options: {
 }) =>
     NamedFC<CombinedReportRulesOnlySectionProps>(
         'CombinedReportRulesOnlySection',
-        ({ deps, cardsViewData }) => {
+        ({ deps, cardsViewData, cardSelectionMessageCreator }) => {
             const { outcomeType, title } = options;
             const cardRuleResults = cardsViewData.cards[outcomeType];
             const sectionId = `${outcomeType}-checks-section`;
@@ -45,7 +45,7 @@ const makeCombinedReportRulesOnlySection = (options: {
                     />
                 ),
                 onExpandToggle: (event: React.MouseEvent<HTMLDivElement>) => {
-                    deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(sectionId, event);
+                    cardSelectionMessageCreator.toggleRuleExpandCollapse(sectionId, event);
                 },
                 headingLevel: 3,
                 deps: null,

--- a/src/reports/components/report-sections/not-applicable-checks-section.tsx
+++ b/src/reports/components/report-sections/not-applicable-checks-section.tsx
@@ -11,11 +11,14 @@ import { SectionProps } from './report-section-factory';
 
 export type NotApplicableChecksSectionDeps = CollapsibleResultSectionDeps;
 
-export type NotApplicableChecksSectionProps = Pick<SectionProps, 'deps' | 'cardsViewData'>;
+export type NotApplicableChecksSectionProps = Pick<
+    SectionProps,
+    'deps' | 'cardsViewData' | 'cardSelectionMessageCreator'
+>;
 
 export const NotApplicableChecksSection = NamedFC<NotApplicableChecksSectionProps>(
     'NotApplicableChecksSection',
-    ({ deps, cardsViewData }) => {
+    ({ deps, cardsViewData, cardSelectionMessageCreator }) => {
         const cardRuleResults = cardsViewData.cards.inapplicable;
 
         return (
@@ -27,6 +30,7 @@ export const NotApplicableChecksSection = NamedFC<NotApplicableChecksSectionProp
                 outcomeType="inapplicable"
                 badgeCount={cardRuleResults.length}
                 containerId="not-applicable-checks-section"
+                cardSelectionMessageCreator={cardSelectionMessageCreator}
             />
         );
     },

--- a/src/reports/components/report-sections/passed-checks-section.tsx
+++ b/src/reports/components/report-sections/passed-checks-section.tsx
@@ -11,11 +11,14 @@ import { SectionProps } from './report-section-factory';
 
 export type PassedChecksSectionDeps = CollapsibleResultSectionDeps;
 
-export type PassedChecksSectionProps = Pick<SectionProps, 'deps' | 'cardsViewData'>;
+export type PassedChecksSectionProps = Pick<
+    SectionProps,
+    'deps' | 'cardsViewData' | 'cardSelectionMessageCreator'
+>;
 
 export const PassedChecksSection = NamedFC<PassedChecksSectionProps>(
     'PassedChecksSection',
-    ({ deps, cardsViewData }) => {
+    ({ deps, cardsViewData, cardSelectionMessageCreator }) => {
         const cardRuleResults = cardsViewData.cards.pass;
 
         return (
@@ -27,6 +30,7 @@ export const PassedChecksSection = NamedFC<PassedChecksSectionProps>(
                 outcomeType="pass"
                 badgeCount={cardRuleResults.length}
                 containerId="passed-checks-section"
+                cardSelectionMessageCreator={cardSelectionMessageCreator}
             />
         );
     },

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -4,6 +4,7 @@ import { CommonInstancesSectionDeps } from 'common/components/cards/common-insta
 import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { RecommendColor } from 'common/components/recommend-color';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ReactFCWithDisplayName } from 'common/react/named-fc';
 
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
@@ -25,6 +26,7 @@ export type SectionProps = {
     getCollapsibleScript: () => string;
     getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks;
     cardsViewData: CardsViewModel;
+    cardSelectionMessageCreator?: CardSelectionMessageCreator;
     userConfigurationStoreData: UserConfigurationStoreData;
     shouldAlertFailuresCount?: boolean;
     scanMetadata: ScanMetadata;

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as axe from 'axe-core';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 
 
 declare namespace AccessibilityInsightsReport {
@@ -119,6 +120,7 @@ declare namespace AccessibilityInsightsReport {
         browserResolution: string,
         scanDetails: ScanSummaryDetails,
         results: CombinedReportResults,
+        cardSelectionMessageCreator: CardSelectionMessageCreator;
     }
 
     export type Reporter = {

--- a/src/reports/package/combined-results-report.ts
+++ b/src/reports/package/combined-results-report.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ScanMetadata, ScanTimespan, ToolData } from 'common/types/store-data/unified-data-interface';
 import { CombinedReportHtmlGenerator } from 'reports/combined-report-html-generator';
 import { CombinedResultsToCardsModelConverter } from 'reports/package/combined-results-to-cards-model-converter';
@@ -7,6 +8,7 @@ import AccessibilityInsightsReport from './accessibilityInsightsReport';
 
 export type CombinedResultsReportDeps = {
     reportHtmlGenerator: CombinedReportHtmlGenerator;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
 };
 
 export class CombinedResultsReport implements AccessibilityInsightsReport.Report {
@@ -44,6 +46,7 @@ export class CombinedResultsReport implements AccessibilityInsightsReport.Report
         return this.deps.reportHtmlGenerator.generateHtml(
             scanMetadata,
             cardsByRule,
+            this.deps.cardSelectionMessageCreator,
             results.urlResults
         );
     }

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -172,6 +172,7 @@ const combinedResultsReportGenerator = (parameters: CombinedReportParameters) =>
     );
     const deps = {
         reportHtmlGenerator,
+        cardSelectionMessageCreator: parameters.cardSelectionMessageCreator,
     }
 
     const cardSelectionViewData: CardSelectionViewData = {

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`DetailsViewBody render render 1`] = `
           "resultDescription": "",
         }
       }
-      cardsViewData={
+      automatedChecksCardsViewData={
         Object {
           "allCardsCollapsed": true,
           "cards": Object {
@@ -358,7 +358,7 @@ exports[`DetailsViewBody render render 1`] = `
             "resultDescription": "",
           }
         }
-        cardsViewData={
+        automatedChecksCardsViewData={
           Object {
             "allCardsCollapsed": true,
             "cards": Object {
@@ -691,7 +691,7 @@ exports[`DetailsViewBody render render 1`] = `
                 "resultDescription": "",
               }
             }
-            cardsViewData={
+            automatedChecksCardsViewData={
               Object {
                 "allCardsCollapsed": true,
                 "cards": Object {

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -229,22 +229,6 @@ exports[` render renders normally 1`] = `
         "url": "http://detailsViewContainerTest/url/",
       }
     }
-    unifiedScanResultStoreData={
-      Object {
-        "results": Array [],
-        "rules": Array [],
-        "targetAppInfo": Object {
-          "name": "DetailsViewContainerTest title",
-          "url": "http://detailsViewContainerTest/url/",
-        },
-        "timestamp": "timestamp",
-        "toolInfo": Object {
-          "applicationProperties": Object {
-            "name": "some app",
-          },
-        },
-      }
-    }
     userConfigurationStoreData={
       Object {
         "adbLocation": null,

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -85,14 +85,7 @@ exports[` render renders normally 1`] = `
         "resultDescription": "",
       }
     }
-    cardSelectionStoreData={
-      Object {
-        "focusedResultUid": null,
-        "rules": Object {},
-        "visualHelperEnabled": false,
-      }
-    }
-    cardsViewData={Object {}}
+    automatedChecksCardsViewData={Object {}}
     deps={
       Object {
         "detailsViewActionMessageCreator": proxy {
@@ -183,6 +176,7 @@ exports[` render renders normally 1`] = `
         "isVirtualKeyboardCollapsed": false,
       }
     }
+    needsReviewCardsViewData={Object {}}
     pathSnippetStoreData={
       Object {
         "path": null,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
@@ -94,6 +94,7 @@ exports[`IssuesTableTest not scanning, issuesEnabled is true 1`] = `
     className="issuesTableContent"
   >
     <SomeInstancesSection
+      cardSelectionMessageCreator={Object {}}
       cardsViewData={
         Object {
           "allCardsCollapsed": true,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/test-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/test-view-container.test.tsx.snap
@@ -2,11 +2,18 @@
 
 exports[`TestViewContainer for testViewType=AdhocFailure renders per snapshot with no testViewOverrides 1`] = `
 <AdhocIssuesTestView
+  cardSelectionMessageCreator={Object {}}
   configuration={
     Object {
       "key": "configStub",
       "testViewOverrides": undefined,
       "testViewType": "AdhocFailure",
+    }
+  }
+  deps={
+    Object {
+      "automatedChecksCardSelectionMessageCreator": Object {},
+      "needsReviewCardSelectionMessageCreator": Object {},
     }
   }
   instancesSection={[Function]}
@@ -29,6 +36,7 @@ exports[`TestViewContainer for testViewType=AdhocFailure renders per snapshot wi
 
 exports[`TestViewContainer for testViewType=AdhocFailure renders per snapshot with testViewOverrides 1`] = `
 <AdhocIssuesTestView
+  cardSelectionMessageCreator={Object {}}
   configuration={
     Object {
       "key": "configStub",
@@ -40,6 +48,12 @@ exports[`TestViewContainer for testViewType=AdhocFailure renders per snapshot wi
     }
   }
   content="stub content page component \\"content\\""
+  deps={
+    Object {
+      "automatedChecksCardSelectionMessageCreator": Object {},
+      "needsReviewCardSelectionMessageCreator": Object {},
+    }
+  }
   guidance="stub content page component \\"guidance\\""
   instancesSection={[Function]}
   selectedTest={-1}
@@ -61,11 +75,18 @@ exports[`TestViewContainer for testViewType=AdhocFailure renders per snapshot wi
 
 exports[`TestViewContainer for testViewType=AdhocNeedsReview renders per snapshot with no testViewOverrides 1`] = `
 <AdhocIssuesTestView
+  cardSelectionMessageCreator={Object {}}
   configuration={
     Object {
       "key": "configStub",
       "testViewOverrides": undefined,
       "testViewType": "AdhocNeedsReview",
+    }
+  }
+  deps={
+    Object {
+      "automatedChecksCardSelectionMessageCreator": Object {},
+      "needsReviewCardSelectionMessageCreator": Object {},
     }
   }
   instancesSection={[Function]}
@@ -88,6 +109,7 @@ exports[`TestViewContainer for testViewType=AdhocNeedsReview renders per snapsho
 
 exports[`TestViewContainer for testViewType=AdhocNeedsReview renders per snapshot with testViewOverrides 1`] = `
 <AdhocIssuesTestView
+  cardSelectionMessageCreator={Object {}}
   configuration={
     Object {
       "key": "configStub",
@@ -99,6 +121,12 @@ exports[`TestViewContainer for testViewType=AdhocNeedsReview renders per snapsho
     }
   }
   content="stub content page component \\"content\\""
+  deps={
+    Object {
+      "automatedChecksCardSelectionMessageCreator": Object {},
+      "needsReviewCardSelectionMessageCreator": Object {},
+    }
+  }
   guidance="stub content page component \\"guidance\\""
   instancesSection={[Function]}
   selectedTest={-1}
@@ -125,6 +153,12 @@ exports[`TestViewContainer for testViewType=AdhocStatic renders per snapshot wit
       "key": "configStub",
       "testViewOverrides": undefined,
       "testViewType": "AdhocStatic",
+    }
+  }
+  deps={
+    Object {
+      "automatedChecksCardSelectionMessageCreator": Object {},
+      "needsReviewCardSelectionMessageCreator": Object {},
     }
   }
   selectedTest={-1}
@@ -157,6 +191,12 @@ exports[`TestViewContainer for testViewType=AdhocStatic renders per snapshot wit
     }
   }
   content="stub content page component \\"content\\""
+  deps={
+    Object {
+      "automatedChecksCardSelectionMessageCreator": Object {},
+      "needsReviewCardSelectionMessageCreator": Object {},
+    }
+  }
   guidance="stub content page component \\"guidance\\""
   selectedTest={-1}
   someParentProp="parent-prop"
@@ -186,6 +226,12 @@ exports[`TestViewContainer for testViewType=AdhocTabStops renders per snapshot w
           "testViewType": "AdhocTabStops",
         }
       }
+      deps={
+        Object {
+          "automatedChecksCardSelectionMessageCreator": Object {},
+          "needsReviewCardSelectionMessageCreator": Object {},
+        }
+      }
       selectedTest={-1}
       someParentProp="parent-prop"
       visualizationConfigurationFactory={
@@ -209,6 +255,12 @@ exports[`TestViewContainer for testViewType=AdhocTabStops renders per snapshot w
           "key": "configStub",
           "testViewOverrides": undefined,
           "testViewType": "AdhocTabStops",
+        }
+      }
+      deps={
+        Object {
+          "automatedChecksCardSelectionMessageCreator": Object {},
+          "needsReviewCardSelectionMessageCreator": Object {},
         }
       }
       selectedTest={-1}
@@ -246,6 +298,12 @@ exports[`TestViewContainer for testViewType=AdhocTabStops renders per snapshot w
         }
       }
       content="stub content page component \\"content\\""
+      deps={
+        Object {
+          "automatedChecksCardSelectionMessageCreator": Object {},
+          "needsReviewCardSelectionMessageCreator": Object {},
+        }
+      }
       guidance="stub content page component \\"guidance\\""
       selectedTest={-1}
       someParentProp="parent-prop"
@@ -276,6 +334,12 @@ exports[`TestViewContainer for testViewType=AdhocTabStops renders per snapshot w
         }
       }
       content="stub content page component \\"content\\""
+      deps={
+        Object {
+          "automatedChecksCardSelectionMessageCreator": Object {},
+          "needsReviewCardSelectionMessageCreator": Object {},
+        }
+      }
       guidance="stub content page component \\"guidance\\""
       selectedTest={-1}
       someParentProp="parent-prop"
@@ -304,6 +368,12 @@ exports[`TestViewContainer for testViewType=Assessment renders per snapshot with
       "key": "configStub",
       "testViewOverrides": undefined,
       "testViewType": "Assessment",
+    }
+  }
+  deps={
+    Object {
+      "automatedChecksCardSelectionMessageCreator": Object {},
+      "needsReviewCardSelectionMessageCreator": Object {},
     }
   }
   selectedTest={-1}
@@ -336,6 +406,12 @@ exports[`TestViewContainer for testViewType=Assessment renders per snapshot with
     }
   }
   content="stub content page component \\"content\\""
+  deps={
+    Object {
+      "automatedChecksCardSelectionMessageCreator": Object {},
+      "needsReviewCardSelectionMessageCreator": Object {},
+    }
+  }
   guidance="stub content page component \\"guidance\\""
   selectedTest={-1}
   someParentProp="parent-prop"

--- a/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { CommonInstancesSectionProps } from 'common/components/cards/common-instances-section-props';
 import { DateProvider } from 'common/date-provider';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC } from 'common/react/named-fc';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
@@ -140,6 +141,7 @@ class TestPropsBuilder {
             visualizationStoreData: {
                 selectedFastPassDetailsView: this.testType,
             } as VisualizationStoreData,
+            cardSelectionMessageCreator: {} as CardSelectionMessageCreator,
         };
     }
 }

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -89,7 +89,8 @@ describe('ReportExportDialogFactory', () => {
             featureFlagStoreData,
             assessmentStoreData,
             assessmentsProvider: assessmentsProviderMock.object,
-            cardsViewData,
+            automatedChecksCardsViewData: cardsViewData,
+            needsReviewCardsViewData: cardsViewData,
             scanMetadata,
             switcherNavConfiguration,
             isOpen,
@@ -100,7 +101,6 @@ describe('ReportExportDialogFactory', () => {
         shouldShowReportExportButtonProps = {
             visualizationConfigurationFactory: props.visualizationConfigurationFactory,
             selectedTest: props.selectedTest,
-            unifiedScanResultStoreData: props.unifiedScanResultStoreData,
             visualizationStoreData: props.visualizationStoreData,
             featureFlagStoreData: props.featureFlagStoreData,
         } as ShouldShowReportExportButtonProps;

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -46,7 +46,8 @@ describe('ShouldShowReportExportButton', () => {
             assessmentStoreData: null,
             assessmentsProvider: null,
             rightPanelConfiguration: null,
-            cardsViewData: null,
+            automatedChecksCardsViewData: null,
+            needsReviewCardsViewData: null,
             switcherNavConfiguration: null,
             scanMetadata: null,
             narrowModeStatus: null,
@@ -59,7 +60,7 @@ describe('ShouldShowReportExportButton', () => {
             .returns(() => scanData);
         visualizationConfigurationMock.setup(m => m.getTestStatus(scanData)).returns(() => enabled);
         visualizationConfigurationMock
-            .setup(m => m.shouldShowExportReport(unifiedScanResultStoreData, featureFlagStoreData))
+            .setup(m => m.shouldShowExportReport(featureFlagStoreData))
             .returns(() => shouldShow);
     }
 

--- a/src/tests/unit/tests/DetailsView/components/test-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-view-container.test.tsx
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
+import { NeedsReviewCardSelectionMessageCreator } from 'common/message-creators/needs-review-card-selection-message-creator';
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
 import { TestViewType } from 'common/types/test-view-type';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -36,6 +38,12 @@ describe('TestViewContainer', () => {
             } as VisualizationConfigurationFactory;
 
             props = {
+                deps: {
+                    automatedChecksCardSelectionMessageCreator:
+                        {} as AutomatedChecksCardSelectionMessageCreator,
+                    needsReviewCardSelectionMessageCreator:
+                        {} as NeedsReviewCardSelectionMessageCreator,
+                },
                 someParentProp: 'parent-prop',
                 visualizationConfigurationFactory: configFactoryStub,
                 selectedTest,

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -113,7 +113,7 @@ describe('DetailsViewBody', () => {
                 },
                 rightPanelConfiguration: rightPanelConfig,
                 switcherNavConfiguration: switcherNavConfig,
-                cardsViewData: {
+                automatedChecksCardsViewData: {
                     cards: exampleUnifiedStatusResults,
                     visualHelperEnabled: true,
                     allCardsCollapsed: true,

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -176,7 +176,8 @@ describe(DetailsViewContent, () => {
                 .setVisualizationStoreData(visualizationStoreData)
                 .setDetailsViewStoreData(detailsViewState)
                 .setUserConfigurationStoreData(userConfigurationStoreData)
-                .setUnifiedScanResultStoreData(unifiedScanResultStoreData);
+                .setUnifiedScanResultStoreData(unifiedScanResultStoreData)
+                .setNeedsReviewScanResultStoreData(unifiedScanResultStoreData);
 
             const storesHubMock = createStoresHubMock(storeMocks);
 
@@ -211,7 +212,7 @@ describe(DetailsViewContent, () => {
                     ),
                 )
                 .returns(() => cardSelectionViewData)
-                .verifiable(Times.once());
+                .verifiable(Times.exactly(2));
 
             const cardsViewData: CardsViewModel = {} as any;
             getCardViewDataMock
@@ -270,6 +271,9 @@ describe(DetailsViewContent, () => {
                         scopingPanelStateStoreData: storeMocks.scopingStoreData,
                         userConfigurationStoreData: storeMocks.userConfigurationStoreData,
                         unifiedScanResultStoreData: storeMocks.unifiedScanResultStoreData,
+                        needsReviewScanResultStoreData: storeMocks.needsReviewScanResultStoreData,
+                        needsReviewCardSelectionStoreData:
+                            storeMocks.needsReviewCardSelectionStoreData,
                         cardSelectionStoreData: storeMocks.cardSelectionStoreData,
                         tabStopsViewStoreData: storeMocks.tabStopsViewStoreData,
                     }
@@ -328,9 +332,11 @@ describe(DetailsViewContent, () => {
             visualizationScanResultStoreData: storeMocks.visualizationScanResultsStoreData,
             scopingPanelStateStoreData: storeMocks.scopingSelectorsData,
             unifiedScanResultStoreData: storeMocks.unifiedScanResultStoreData,
+            needsReviewScanResultStoreData: storeMocks.needsReviewScanResultStoreData,
             selectedDetailsView: viewType,
             selectedDetailsRightPanelConfiguration: rightPanel,
             cardSelectionStoreData: storeMocks.cardSelectionStoreData,
+            needsReviewCardSelectionStoreData: storeMocks.needsReviewCardSelectionStoreData,
             permissionsStateStoreData: storeMocks.permissionsStateStoreData,
             tabStopsViewStoreData: storeMocks.tabStopsViewStoreData,
         };

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -12,11 +12,15 @@ import { LaunchPanelStore } from 'background/stores/global/launch-panel-store';
 import { ScopingStore } from 'background/stores/global/scoping-store';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
 import { InspectStore } from 'background/stores/inspect-store';
+import { NeedsReviewCardSelectionStore } from 'background/stores/needs-review-card-selection-store';
+import { NeedsReviewScanResultStore } from 'background/stores/needs-review-scan-result-store';
 import { PathSnippetStore } from 'background/stores/path-snippet-store';
 import { TabStore } from 'background/stores/tab-store';
 import { VisualizationScanResultStore } from 'background/stores/visualization-scan-result-store';
 import { VisualizationStore } from 'background/stores/visualization-store';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
+import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
 import { TabStopsViewStore } from 'DetailsView/components/tab-stops/tab-stops-view-store';
 import { It, Mock, MockBehavior } from 'typemoq';
 import { PermissionsStateStore } from '../../../../background/stores/global/permissions-state-store';
@@ -59,6 +63,10 @@ export class StoreMocks {
     public unifiedScanResultStoreMock = Mock.ofType(UnifiedScanResultStore, MockBehavior.Strict);
     public permissionsStateStoreMock = Mock.ofType(PermissionsStateStore, MockBehavior.Strict);
     public tabStopsViewStoreMock = Mock.ofType(TabStopsViewStore, MockBehavior.Strict);
+    public needsReviewScanResultStoreMock = Mock.ofType(
+        NeedsReviewScanResultStore,
+        MockBehavior.Strict,
+    );
 
     public visualizationStoreData = new VisualizationStoreDataBuilder().build();
     public visualizationScanResultsStoreData =
@@ -84,6 +92,7 @@ export class StoreMocks {
     public inspectStoreData = new InspectStore(null, null).getDefaultState();
     public pathSnippetStoreData = new PathSnippetStore(null).getDefaultState();
     public unifiedScanResultStoreData = new UnifiedScanResultStore(null).getDefaultState();
+    public needsReviewScanResultStoreData = new NeedsReviewScanResultStore(null).getDefaultState();
     public launchPanelStateStoreData = new LaunchPanelStore(null, null, null).getDefaultState();
     public featureFlagStoreData: FeatureFlagStoreData = {
         [FeatureFlags[FeatureFlags.logTelemetryToConsole]]: false,
@@ -92,6 +101,10 @@ export class StoreMocks {
     public permissionsStateStoreData = new PermissionsStateStore(null).getDefaultState();
     public tabStopsViewStoreData = new TabStopsViewStore(null).getDefaultState();
     public cardSelectionStoreData = new CardSelectionStore(null, null).getDefaultState();
+    public needsReviewCardSelectionStoreData = new NeedsReviewCardSelectionStore(
+        null,
+        null,
+    ).getDefaultState();
 
     constructor() {
         this.assessmentsProviderMock.setup(ap => ap.all()).returns(() => []);
@@ -121,6 +134,11 @@ export class StoreMocks {
 
     public setUnifiedScanResultStoreData(data: UnifiedScanResultStoreData): StoreMocks {
         this.unifiedScanResultStoreData = data;
+        return this;
+    }
+
+    public setNeedsReviewScanResultStoreData(data: NeedsReviewScanResultStoreData): StoreMocks {
+        this.needsReviewScanResultStoreData = data;
         return this;
     }
 
@@ -164,6 +182,13 @@ export class StoreMocks {
         return this;
     }
 
+    public setNeedsReviewCardSelectionStoreData(
+        data: NeedsReviewCardSelectionStoreData,
+    ): StoreMocks {
+        this.needsReviewCardSelectionStoreData = data;
+        return this;
+    }
+
     public setPermissionsStateStoreData(data: PermissionsStateStoreData): StoreMocks {
         this.permissionsStateStoreData = data;
         return this;
@@ -175,6 +200,7 @@ export class StoreMocks {
         this.tabStoreMock.verifyAll();
         this.visualizationScanResultStoreMock.verifyAll();
         this.unifiedScanResultStoreMock.verifyAll();
+        this.needsReviewScanResultStoreMock.verifyAll();
         this.visualizationStoreMock.verifyAll();
         this.scopingStoreMock.verifyAll();
         this.inspectStoreMock.verifyAll();

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -17,6 +17,7 @@ import { CardSelectionActions } from 'background/actions/card-selection-actions'
 import { DetailsViewActions } from 'background/actions/details-view-actions';
 import { DevToolActions } from 'background/actions/dev-tools-actions';
 import { InspectActions } from 'background/actions/inspect-actions';
+import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
 import { ScopingActions } from 'background/actions/scoping-actions';
 import { SidePanelActions } from 'background/actions/side-panel-actions';
 import { TabStopRequirementActions } from 'background/actions/tab-stop-requirement-actions';
@@ -391,6 +392,8 @@ describe('ActionCreatorTest', () => {
             .setupVisualizationActionWithInvokeParameter(visualizationActionName, null)
             .setupActionOnCardSelectionActions(cardSelectionActionName)
             .setupCardSelectionActionWithInvokeParameter(cardSelectionActionName, null)
+            .setupActionOnNeedsReviewCardSelectionActions(cardSelectionActionName)
+            .setupNeedsReviewCardSelectionActionWithInvokeParameter(cardSelectionActionName, null)
             .setupRegistrationCallback(VisualizationMessage.Common.ScrollRequested, [null, tabId]);
 
         const actionCreator = builder.buildActionCreator();
@@ -926,6 +929,7 @@ class ActionCreatorValidator {
     private visualizationActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
     private devToolsActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
     private cardSelectionActionsMocks: DictionaryStringTo<IMock<Action<any>>> = {};
+    private needsReviewCardSelectionActionsMocks: DictionaryStringTo<IMock<Action<any>>> = {};
     private unifiedScanResultActionsMocks: DictionaryStringTo<IMock<Action<any>>> = {};
     private tabStopRequirementActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
     private visualizationScanResultActionsContainerMock = Mock.ofType(
@@ -940,6 +944,9 @@ class ActionCreatorValidator {
     private assessmentActionsContainerMock = Mock.ofType(AssessmentActions);
     private inspectActionsContainerMock = Mock.ofType(InspectActions);
     private cardSelectionActionsContainerMock = Mock.ofType(CardSelectionActions);
+    private needsReviewCardSelectionActionsContainerMock = Mock.ofType(
+        NeedsReviewCardSelectionActions,
+    );
     private unifiedScanResultsActionsContainerMock = Mock.ofType(UnifiedScanResultActions);
     private sidePanelActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
     private scopingActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
@@ -970,6 +977,7 @@ class ActionCreatorValidator {
         inspectActions: this.inspectActionsContainerMock.object,
         detailsViewActions: this.detailsViewActionsContainerMock.object,
         cardSelectionActions: this.cardSelectionActionsContainerMock.object,
+        needsReviewCardSelectionActions: this.needsReviewCardSelectionActionsContainerMock.object,
         scanResultActions: this.unifiedScanResultsActionsContainerMock.object,
     } as ActionHub;
 
@@ -1033,6 +1041,18 @@ class ActionCreatorValidator {
             actionName,
             expectedInvokeParam,
             this.cardSelectionActionsMocks,
+        );
+        return this;
+    }
+
+    public setupNeedsReviewCardSelectionActionWithInvokeParameter(
+        actionName: keyof NeedsReviewCardSelectionActions,
+        expectedInvokeParam: any,
+    ): ActionCreatorValidator {
+        this.setupActionWithInvokeParameter(
+            actionName,
+            expectedInvokeParam,
+            this.needsReviewCardSelectionActionsMocks,
         );
         return this;
     }
@@ -1182,6 +1202,18 @@ class ActionCreatorValidator {
         return this;
     }
 
+    public setupActionOnNeedsReviewCardSelectionActions(
+        actionName: keyof NeedsReviewCardSelectionActions,
+    ): ActionCreatorValidator {
+        this.setupAction(
+            actionName,
+            this.needsReviewCardSelectionActionsMocks,
+            this.needsReviewCardSelectionActionsContainerMock,
+        );
+
+        return this;
+    }
+
     public setupActionOnVisualizationActions(
         actionName: keyof VisualizationActions,
     ): ActionCreatorValidator {
@@ -1305,6 +1337,7 @@ class ActionCreatorValidator {
         this.verifyAllActions(this.sidePanelActionMocks);
         this.verifyAllActions(this.scopingActionMocks);
         this.verifyAllActions(this.cardSelectionActionsMocks);
+        this.verifyAllActions(this.needsReviewCardSelectionActionsMocks);
     }
 
     private verifyAllActions(actionsMap: DictionaryStringTo<IMock<Action<any>>>): void {

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/cards-visualization-modifier-buttons.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/cards-visualization-modifier-buttons.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ExpandCollapseOnlyModifierButtons renders per snapshot 1`] = `
 >
   <ExpandCollapseAllButton
     allCardsCollapsed={true}
-    deps={Object {}}
+    cardSelectionMessageCreator={Object {}}
     visualHelperEnabled={true}
   />
 </div>
@@ -18,12 +18,12 @@ exports[`ExpandCollapseVisualHelperModifierButtons renders per snapshot 1`] = `
 >
   <ExpandCollapseAllButton
     allCardsCollapsed={true}
-    deps={Object {}}
+    cardSelectionMessageCreator={Object {}}
     visualHelperEnabled={true}
   />
   <VisualHelperToggle
     allCardsCollapsed={true}
-    deps={Object {}}
+    cardSelectionMessageCreator={Object {}}
     visualHelperEnabled={true}
   />
 </div>

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details-group.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details-group.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`InstanceDetailsGroup renders 1`] = `
 >
   <li>
     <InstanceDetails
+      cardSelectionMessageCreator={Object {}}
       deps={Object {}}
       getPropertyConfigById={[Function]}
       index={0}

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -36,17 +36,6 @@ exports[`InstanceDetails isSelected drives the styling for the card 1`] = `
               "supportsHighlighting": true,
               "supportsIssueFiling": true,
             },
-            "cardSelectionMessageCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "collapseAllRules": [Function],
-              "dispatcher": undefined,
-              "expandAllRules": [Function],
-              "source": undefined,
-              "telemetryFactory": undefined,
-              "toggleCardSelection": [Function],
-              "toggleRuleExpandCollapse": [Function],
-              "toggleVisualHelper": [Function],
-            },
             "getPropertyConfigById": [Function],
           }
         }
@@ -107,17 +96,6 @@ exports[`InstanceDetails isSelected drives the styling for the card 2`] = `
               "supportsHighlighting": true,
               "supportsIssueFiling": true,
             },
-            "cardSelectionMessageCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "collapseAllRules": [Function],
-              "dispatcher": undefined,
-              "expandAllRules": [Function],
-              "source": undefined,
-              "telemetryFactory": undefined,
-              "toggleCardSelection": [Function],
-              "toggleRuleExpandCollapse": [Function],
-              "toggleVisualHelper": [Function],
-            },
             "getPropertyConfigById": [Function],
           }
         }
@@ -166,17 +144,6 @@ exports[`InstanceDetails renders 1`] = `
                     "supportsHighlighting": true,
                     "supportsIssueFiling": true,
                   },
-                  "cardSelectionMessageCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "collapseAllRules": [Function],
-                    "dispatcher": undefined,
-                    "expandAllRules": [Function],
-                    "source": undefined,
-                    "telemetryFactory": undefined,
-                    "toggleCardSelection": [Function],
-                    "toggleRuleExpandCollapse": [Function],
-                    "toggleVisualHelper": [Function],
-                  },
                   "getPropertyConfigById": [Function],
                 }
               }
@@ -193,17 +160,6 @@ exports[`InstanceDetails renders 1`] = `
                     "supportsHighlighting": true,
                     "supportsIssueFiling": true,
                   },
-                  "cardSelectionMessageCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "collapseAllRules": [Function],
-                    "dispatcher": undefined,
-                    "expandAllRules": [Function],
-                    "source": undefined,
-                    "telemetryFactory": undefined,
-                    "toggleCardSelection": [Function],
-                    "toggleRuleExpandCollapse": [Function],
-                    "toggleVisualHelper": [Function],
-                  },
                   "getPropertyConfigById": [Function],
                 }
               }
@@ -219,17 +175,6 @@ exports[`InstanceDetails renders 1`] = `
                     "supportsCopyFailureDetails": true,
                     "supportsHighlighting": true,
                     "supportsIssueFiling": true,
-                  },
-                  "cardSelectionMessageCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "collapseAllRules": [Function],
-                    "dispatcher": undefined,
-                    "expandAllRules": [Function],
-                    "source": undefined,
-                    "telemetryFactory": undefined,
-                    "toggleCardSelection": [Function],
-                    "toggleRuleExpandCollapse": [Function],
-                    "toggleVisualHelper": [Function],
                   },
                   "getPropertyConfigById": [Function],
                 }
@@ -264,17 +209,6 @@ exports[`InstanceDetails renders 1`] = `
               "supportsCopyFailureDetails": true,
               "supportsHighlighting": true,
               "supportsIssueFiling": true,
-            },
-            "cardSelectionMessageCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "collapseAllRules": [Function],
-              "dispatcher": undefined,
-              "expandAllRules": [Function],
-              "source": undefined,
-              "telemetryFactory": undefined,
-              "toggleCardSelection": [Function],
-              "toggleRuleExpandCollapse": [Function],
-              "toggleVisualHelper": [Function],
             },
             "getPropertyConfigById": [Function],
           }
@@ -346,17 +280,6 @@ exports[`InstanceDetails renders nothing when there is no card row configuration
               "supportsCopyFailureDetails": true,
               "supportsHighlighting": true,
               "supportsIssueFiling": true,
-            },
-            "cardSelectionMessageCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "collapseAllRules": [Function],
-              "dispatcher": undefined,
-              "expandAllRules": [Function],
-              "source": undefined,
-              "telemetryFactory": undefined,
-              "toggleCardSelection": [Function],
-              "toggleRuleExpandCollapse": [Function],
-              "toggleVisualHelper": [Function],
             },
             "getPropertyConfigById": [Function],
           }

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
@@ -11,6 +11,19 @@ exports[`RulesWithInstances renders 1`] = `
     containerClassName="collapsibleRuleDetailsGroup"
     content={
       <RuleContent
+        cardSelectionMessageCreator={
+          proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "collapseAllRules": [Function],
+            "dispatcher": undefined,
+            "expandAllRules": [Function],
+            "source": undefined,
+            "telemetryFactory": undefined,
+            "toggleCardSelection": [Function],
+            "toggleRuleExpandCollapse": [Function],
+            "toggleVisualHelper": [Function],
+          }
+        }
         deps={
           Object {
             "collapsibleControl": [Function],

--- a/src/tests/unit/tests/common/components/cards/cards-visualization-modifier-buttons.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/cards-visualization-modifier-buttons.test.tsx
@@ -5,15 +5,14 @@ import {
     ExpandCollapseOnlyModifierButtons,
     ExpandCollapseVisualHelperModifierButtons,
 } from 'common/components/cards/cards-visualization-modifier-buttons';
-import { ExpandCollapseAllButtonDeps } from 'common/components/cards/expand-collapse-all-button';
-import { VisualHelperToggleDeps } from 'common/components/cards/visual-helper-toggle';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
 const stubProps: CardsVisualizationModifierButtonsProps = {
-    deps: {} as VisualHelperToggleDeps & ExpandCollapseAllButtonDeps,
     visualHelperEnabled: true,
     allCardsCollapsed: true,
+    cardSelectionMessageCreator: {} as CardSelectionMessageCreator,
 };
 
 describe('ExpandCollapseVisualHelperModifierButtons', () => {

--- a/src/tests/unit/tests/common/components/cards/expand-collapse-all-button.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/expand-collapse-all-button.test.tsx
@@ -1,35 +1,31 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import {
-    ExpandCollapseAllButton,
-    ExpandCollapseAllButtonDeps,
-} from 'common/components/cards/expand-collapse-all-button';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
+import { ExpandCollapseAllButton } from 'common/components/cards/expand-collapse-all-button';
+import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
 import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
 describe('ExpandCollapseAllButton', () => {
-    let cardSelectionMessageCreatorMock: IMock<CardSelectionMessageCreator>;
-    let deps: ExpandCollapseAllButtonDeps;
+    let cardSelectionMessageCreatorMock: IMock<AutomatedChecksCardSelectionMessageCreator>;
     const stubClickEvent = {} as SupportedMouseEvent;
 
     beforeEach(() => {
         cardSelectionMessageCreatorMock = Mock.ofType(
-            CardSelectionMessageCreator,
+            AutomatedChecksCardSelectionMessageCreator,
             MockBehavior.Strict,
         );
-        deps = {
-            cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
-        };
     });
 
     it.each([true, false])(
         'renders per snapshot with allCardsCollapsed %p',
         (allCardsCollapsed: boolean) => {
             const testSubject = shallow(
-                <ExpandCollapseAllButton deps={deps} allCardsCollapsed={allCardsCollapsed} />,
+                <ExpandCollapseAllButton
+                    allCardsCollapsed={allCardsCollapsed}
+                    cardSelectionMessageCreator={cardSelectionMessageCreatorMock.object}
+                />,
             );
             expect(testSubject.getElement()).toMatchSnapshot();
         },
@@ -40,7 +36,10 @@ describe('ExpandCollapseAllButton', () => {
             .setup(mock => mock.expandAllRules(stubClickEvent))
             .verifiable();
         const testSubject = shallow(
-            <ExpandCollapseAllButton deps={deps} allCardsCollapsed={true} />,
+            <ExpandCollapseAllButton
+                cardSelectionMessageCreator={cardSelectionMessageCreatorMock.object}
+                allCardsCollapsed={true}
+            />,
         );
 
         testSubject.simulate('click', stubClickEvent);
@@ -53,7 +52,10 @@ describe('ExpandCollapseAllButton', () => {
             .setup(mock => mock.collapseAllRules(stubClickEvent))
             .verifiable();
         const testSubject = shallow(
-            <ExpandCollapseAllButton deps={deps} allCardsCollapsed={false} />,
+            <ExpandCollapseAllButton
+                cardSelectionMessageCreator={cardSelectionMessageCreatorMock.object}
+                allCardsCollapsed={false}
+            />,
         );
 
         testSubject.simulate('click', stubClickEvent);

--- a/src/tests/unit/tests/common/components/cards/instance-details-group.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/instance-details-group.test.tsx
@@ -7,6 +7,7 @@ import {
 } from 'common/components/cards/instance-details-group';
 import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { RecommendColor } from 'common/components/recommend-color';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -28,6 +29,7 @@ describe('InstanceDetailsGroup', () => {
             rule: rule,
             userConfigurationStoreData: null,
             targetAppInfo: { name: 'app' },
+            cardSelectionMessageCreator: {} as CardSelectionMessageCreator,
         };
 
         const wrapper = shallow(<InstanceDetailsGroup {...props} />);

--- a/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
@@ -14,6 +14,7 @@ import {
     CardRowProps,
     PropertyConfiguration,
 } from 'common/configs/unified-result-property-configurations';
+import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
 import { UnifiedResolution, UnifiedResult } from 'common/types/store-data/unified-data-interface';
@@ -48,19 +49,19 @@ describe('InstanceDetails', () => {
 
     beforeEach(() => {
         getPropertyConfigByIdMock = Mock.ofInstance(_ => null);
-        cardSelectionMessageCreatorMock = Mock.ofType(CardSelectionMessageCreator);
+        cardSelectionMessageCreatorMock = Mock.ofType(AutomatedChecksCardSelectionMessageCreator);
         resultStub = exampleUnifiedResult;
         indexStub = 22;
         hiddenButtonRefStub = { current: { focus: jest.fn(), click: jest.fn() } };
         deps = {
             getPropertyConfigById: getPropertyConfigByIdMock.object,
-            cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
             cardInteractionSupport: allCardInteractionsSupported,
         } as InstanceDetailsDeps;
         props = {
             deps,
             result: resultStub,
             index: indexStub,
+            cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
         } as InstanceDetailsProps;
     });
 

--- a/src/tests/unit/tests/common/components/cards/result-section-content.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/result-section-content.test.tsx
@@ -9,10 +9,12 @@ import {
     ResultSectionContentDeps,
     ResultSectionContentProps,
 } from 'common/components/cards/result-section-content';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC } from 'common/react/named-fc';
 import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { IMock, Mock } from 'typemoq';
 
 import { exampleUnifiedRuleResult } from './sample-view-model-data';
 
@@ -20,6 +22,11 @@ describe('ResultSectionContent', () => {
     const emptyRules: CardRuleResult[] = [];
     const someRules: CardRuleResult[] = [exampleUnifiedRuleResult];
     const depsStub = {} as ResultSectionContentDeps;
+    let cardSelectionMessageCreatorMock: IMock<CardSelectionMessageCreator>;
+
+    beforeEach(() => {
+        cardSelectionMessageCreatorMock = Mock.ofType<CardSelectionMessageCreator>();
+    });
 
     it('renders, with some rules', () => {
         const cardsVisualizationModifierButtonsStub: Readonly<CardsVisualizationModifierButtons> =
@@ -50,6 +57,7 @@ describe('ResultSectionContent', () => {
             allCardsCollapsed: true,
             outcomeCounter: null,
             headingLevel: 5,
+            cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
         };
 
         const wrapper = shallow(<ResultSectionContent {...props} />);

--- a/src/tests/unit/tests/common/components/cards/rules-with-instances.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/rules-with-instances.test.tsx
@@ -6,6 +6,8 @@ import {
     RulesWithInstancesDeps,
 } from 'common/components/cards/rules-with-instances';
 import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
+import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock } from 'typemoq';
@@ -15,9 +17,11 @@ import { exampleUnifiedRuleResult } from './sample-view-model-data';
 
 describe('RulesWithInstances', () => {
     let fixInstructionProcessorMock: IMock<FixInstructionProcessor>;
+    let cardSelectionMessageCreatorMock: IMock<CardSelectionMessageCreator>;
 
     beforeEach(() => {
         fixInstructionProcessorMock = Mock.ofType(FixInstructionProcessor);
+        cardSelectionMessageCreatorMock = Mock.ofType(AutomatedChecksCardSelectionMessageCreator);
     });
 
     it('renders', () => {
@@ -40,6 +44,7 @@ describe('RulesWithInstances', () => {
                 targetAppInfo={{ name: 'app' }}
                 outcomeCounter={outcomeCounterStub}
                 headingLevel={5}
+                cardSelectionMessageCreator={cardSelectionMessageCreatorMock.object}
             />,
         );
 

--- a/src/tests/unit/tests/common/components/cards/visual-helper-toggle.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/visual-helper-toggle.test.tsx
@@ -2,36 +2,32 @@
 // Licensed under the MIT License.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import {
-    VisualHelperToggle,
-    VisualHelperToggleDeps,
-} from 'common/components/cards/visual-helper-toggle';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
+import { VisualHelperToggle } from 'common/components/cards/visual-helper-toggle';
+import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
 import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
 describe('VisualHelperToggle', () => {
-    let deps: VisualHelperToggleDeps;
-    let mockCardSelectionMessageCreator: IMock<CardSelectionMessageCreator>;
+    let mockCardSelectionMessageCreator: IMock<AutomatedChecksCardSelectionMessageCreator>;
     const stubClickEvent = {} as SupportedMouseEvent;
 
     beforeEach(() => {
         mockCardSelectionMessageCreator = Mock.ofType(
-            CardSelectionMessageCreator,
+            AutomatedChecksCardSelectionMessageCreator,
             MockBehavior.Strict,
         );
-        deps = {
-            cardSelectionMessageCreator: mockCardSelectionMessageCreator.object,
-        };
     });
 
     it.each([true, false])(
         'renders per snapshot with visualHelperEnabled %s',
         (visualHelperEnabled: boolean) => {
             const testSubject = shallow(
-                <VisualHelperToggle deps={deps} visualHelperEnabled={visualHelperEnabled} />,
+                <VisualHelperToggle
+                    visualHelperEnabled={visualHelperEnabled}
+                    cardSelectionMessageCreator={mockCardSelectionMessageCreator.object}
+                />,
             );
             expect(testSubject.getElement()).toMatchSnapshot();
         },
@@ -42,7 +38,12 @@ describe('VisualHelperToggle', () => {
             .setup(m => m.toggleVisualHelper(stubClickEvent))
             .verifiable();
 
-        const testSubject = shallow(<VisualHelperToggle deps={deps} visualHelperEnabled={false} />);
+        const testSubject = shallow(
+            <VisualHelperToggle
+                visualHelperEnabled={false}
+                cardSelectionMessageCreator={mockCardSelectionMessageCreator.object}
+            />,
+        );
         testSubject.simulate('click', stubClickEvent);
 
         mockCardSelectionMessageCreator.verifyAll();

--- a/src/tests/unit/tests/common/message-creators/needs-review-card-selection-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/needs-review-card-selection-message-creator.test.ts
@@ -7,15 +7,15 @@ import {
 } from 'background/actions/action-payloads';
 import { BaseTelemetryData, TelemetryEventSource } from 'common/extension-telemetry-events';
 import { Message } from 'common/message';
-import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
+import { NeedsReviewCardSelectionMessageCreator } from 'common/message-creators/needs-review-card-selection-message-creator';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { Messages } from 'common/messages';
 import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { IMock, Mock, Times } from 'typemoq';
 
-describe('Card Selection Message Creator', () => {
+describe('Needs Review Card Selection Message Creator', () => {
     let dispatcherMock: IMock<ActionMessageDispatcher>;
-    let testSubject: AutomatedChecksCardSelectionMessageCreator;
+    let testSubject: NeedsReviewCardSelectionMessageCreator;
     let telemetryDataFactoryMock: IMock<TelemetryDataFactory>;
     let sourceStub: TelemetryEventSource;
     let eventStub: React.SyntheticEvent;
@@ -27,7 +27,7 @@ describe('Card Selection Message Creator', () => {
         sourceStub = -1;
         eventStub = {} as React.SyntheticEvent;
         telemetryStub = {} as BaseTelemetryData;
-        testSubject = new AutomatedChecksCardSelectionMessageCreator(
+        testSubject = new NeedsReviewCardSelectionMessageCreator(
             dispatcherMock.object,
             telemetryDataFactoryMock.object,
             sourceStub,
@@ -44,7 +44,7 @@ describe('Card Selection Message Creator', () => {
         };
 
         const expectedMessage: Message = {
-            messageType: Messages.CardSelection.CardSelectionToggled,
+            messageType: Messages.NeedsReviewCardSelection.CardSelectionToggled,
             payload,
         };
 
@@ -65,7 +65,7 @@ describe('Card Selection Message Creator', () => {
         };
 
         const expectedMessage: Message = {
-            messageType: Messages.CardSelection.RuleExpansionToggled,
+            messageType: Messages.NeedsReviewCardSelection.RuleExpansionToggled,
             payload,
         };
 
@@ -84,7 +84,7 @@ describe('Card Selection Message Creator', () => {
         };
 
         const expectedMessage: Message = {
-            messageType: Messages.CardSelection.CollapseAllRules,
+            messageType: Messages.NeedsReviewCardSelection.CollapseAllRules,
             payload,
         };
 
@@ -103,7 +103,7 @@ describe('Card Selection Message Creator', () => {
         };
 
         const expectedMessage: Message = {
-            messageType: Messages.CardSelection.ExpandAllRules,
+            messageType: Messages.NeedsReviewCardSelection.ExpandAllRules,
             payload,
         };
 
@@ -122,7 +122,7 @@ describe('Card Selection Message Creator', () => {
         };
 
         const expectedMessage: Message = {
-            messageType: Messages.CardSelection.ToggleVisualHelper,
+            messageType: Messages.NeedsReviewCardSelection.ToggleVisualHelper,
             payload,
         };
 

--- a/src/tests/unit/tests/injected/analyzers/unified-result-sender.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/unified-result-sender.test.ts
@@ -20,6 +20,7 @@ import { ScanResults } from 'scanner/iruleresults';
 import { IMock, Mock, Times } from 'typemoq';
 
 interface UnifiedResultSenderTestDefinition {
+    expectedMessageType: string;
     getMethodToTest: (testSubject: UnifiedResultSender) => PostResolveCallback;
     getInputResults: () => ScanResults;
     setupConverterMock: (
@@ -67,6 +68,7 @@ describe('sendConvertedResults', () => {
     });
 
     const automatedChecksTest: UnifiedResultSenderTestDefinition = {
+        expectedMessageType: Messages.UnifiedScan.ScanCompleted,
         getMethodToTest: testSubject => testSubject.sendAutomatedChecksResults,
         getInputResults: () => axeInputResults,
         setupConverterMock: (mock: IMock<ConvertScanResultsToUnifiedResults>, input: ScanResults) =>
@@ -79,6 +81,7 @@ describe('sendConvertedResults', () => {
     };
 
     const needsReviewTest: UnifiedResultSenderTestDefinition = {
+        expectedMessageType: Messages.NeedsReviewScan.ScanCompleted,
         getMethodToTest: testSubject => testSubject.sendNeedsReviewResults,
         getInputResults: () => filteredAxeInputResults,
         setupConverterMock: (mock: IMock<ConvertScanResultsToUnifiedResults>, input: ScanResults) =>
@@ -147,7 +150,7 @@ describe('sendConvertedResults', () => {
                     };
 
                     const expectedMessage: Message = {
-                        messageType: Messages.UnifiedScan.ScanCompleted,
+                        messageType: testDefinition.expectedMessageType,
                         payload: expectedPayload,
                     };
 

--- a/src/tests/unit/tests/injected/focus-change-handler.test.ts
+++ b/src/tests/unit/tests/injected/focus-change-handler.test.ts
@@ -33,7 +33,7 @@ describe('FocusChangeHandler', () => {
         );
     });
 
-    test('onStoreChange: no target in visualizationStoreData OR cardSelectionStoreData', () => {
+    test('onStoreChange: no target in visualizationStoreData, cardSelectionStoreData, or needsReviewCardSelectionStoreData', () => {
         const storeData: TargetPageStoreData = {
             visualizationStoreData: {
                 focusedTarget: null,
@@ -42,6 +42,12 @@ describe('FocusChangeHandler', () => {
                 results: [{}],
             },
             cardSelectionStoreData: {
+                focusedResultUid: null,
+            },
+            needsReviewScanResultStoreData: {
+                results: [{}],
+            },
+            needsReviewCardSelectionStoreData: {
                 focusedResultUid: null,
             },
         } as TargetPageStoreData;
@@ -168,6 +174,52 @@ describe('FocusChangeHandler', () => {
         scrollingControllerMock
             .setup(scm => scm.processRequest(It.isAny()))
             .verifiable(Times.never());
+
+        testSubject.handleFocusChangeWithStoreData(storeData);
+
+        targetPageActionMessageCreatorMock.verifyAll();
+        scrollingControllerMock.verifyAll();
+    });
+
+    test('onStoreChange: new target from needs review card selection is not null, matches a result, and different from old target', () => {
+        const storeData: TargetPageStoreData = {
+            visualizationStoreData: {
+                focusedTarget: null,
+            },
+            unifiedScanResultStoreData: {
+                results: [
+                    {
+                        uid: sampleUid,
+                        identifiers: {
+                            identifier: sampleTarget.join(';'),
+                        },
+                    },
+                ],
+            },
+            cardSelectionStoreData: {
+                focusedResultUid: null,
+            },
+            needsReviewScanResultStoreData: {
+                results: [
+                    {
+                        uid: sampleUid,
+                        identifiers: {
+                            identifier: sampleTarget.join(';'),
+                        },
+                    },
+                ],
+            },
+            needsReviewCardSelectionStoreData: {
+                focusedResultUid: sampleUid,
+            },
+        } as TargetPageStoreData;
+
+        targetPageActionMessageCreatorMock
+            .setup(acm => acm.scrollRequested())
+            .verifiable(Times.once());
+        scrollingControllerMock
+            .setup(scm => scm.processRequest(sampleMessage))
+            .verifiable(Times.once());
 
         testSubject.handleFocusChangeWithStoreData(storeData);
 

--- a/src/tests/unit/tests/injected/selector-map-helper.test.ts
+++ b/src/tests/unit/tests/injected/selector-map-helper.test.ts
@@ -76,9 +76,15 @@ describe('SelectorMapHelperTest', () => {
                 rules: rulesStub,
                 results: resultsStub,
             };
+            const needsReviewScanData = {
+                rules: rulesStub,
+                results: resultsStub,
+            };
             const storeData: VisualizationRelatedStoreData = {
                 unifiedScanResultStoreData: unifiedScanData,
                 cardSelectionStoreData: {},
+                needsReviewScanResultStoreData: needsReviewScanData,
+                needsReviewCardSelectionStoreData: {},
             } as VisualizationRelatedStoreData;
 
             getElementBasedViewModelMock

--- a/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
@@ -7,6 +7,7 @@ import { NullComponent } from 'common/components/null-component';
 import { RecommendColor } from 'common/components/recommend-color';
 import { DateProvider } from 'common/date-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import {
     ScanMetadata,
     ScanTimespan,
@@ -84,11 +85,13 @@ describe('CombinedReportHtmlGenerator', () => {
     let getScriptMock: IMock<() => string>;
     let sectionFactoryMock: IMock<ReportSectionFactory<CombinedReportSectionProps>>;
     let rendererMock: IMock<ReactStaticRenderer>;
+    let cardSelectionMessageCreatorMock: IMock<CardSelectionMessageCreator>;
 
     beforeEach(() => {
         getScriptMock = Mock.ofInstance(() => '');
         sectionFactoryMock = Mock.ofType<ReportSectionFactory<CombinedReportSectionProps>>();
         rendererMock = Mock.ofType<ReactStaticRenderer>();
+        cardSelectionMessageCreatorMock = Mock.ofType<CardSelectionMessageCreator>();
 
         testSubject = new CombinedReportHtmlGenerator(
             sectionFactoryMock.object,
@@ -119,6 +122,7 @@ describe('CombinedReportHtmlGenerator', () => {
             toUtcString: getUTCStringFromDateStub,
             secondsToTimeString: getTimeStringFromSecondsStub,
             getCollapsibleScript: getScriptMock.object,
+            cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
             scanMetadata,
             cardsViewData,
             urlResultCounts,
@@ -139,7 +143,12 @@ describe('CombinedReportHtmlGenerator', () => {
             .returns(() => '<body-markup />')
             .verifiable(Times.once());
 
-        const html = testSubject.generateHtml(scanMetadata, cardsViewData, urlResultCounts);
+        const html = testSubject.generateHtml(
+            scanMetadata,
+            cardsViewData,
+            cardSelectionMessageCreatorMock.object,
+            urlResultCounts,
+        );
 
         expect(html).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/combined-report-failed-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/combined-report-failed-section.test.tsx.snap
@@ -6,7 +6,17 @@ exports[`CombinedReportFailedSection renders 1`] = `
     <CombinedResultSectionTitle outcomeCount={1} outcomeType=\\"fail\\" title=\\"Failed rules\\" />
   </div>
   <div id=\\"collapsible-content\\">
-    <ResultSectionContent deps={{...}} outcomeType=\\"fail\\" targetAppInfo={[undefined]} results={{...}} visualHelperEnabled={true} allCardsCollapsed={true} userConfigurationStoreData={{...}} outcomeCounter={[Function: countByIdentifierUrls]} headingLevel={4} />
+    <ResultSectionContent deps={{...}} outcomeType=\\"fail\\" targetAppInfo={[undefined]} results={{...}} visualHelperEnabled={true} allCardsCollapsed={true} userConfigurationStoreData={{...}} outcomeCounter={[Function: countByIdentifierUrls]} headingLevel={4} cardSelectionMessageCreator={[Function: function () {
+                        var args = [];
+                        for (var _i = 0; _i < arguments.length; _i++) {
+                            args[_i] = arguments[_i];
+                        }
+                        _this._interceptor.removeInvocation(invocation_1);
+                        var method = new MethodInfo(target, p);
+                        var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                        _this._interceptor.intercept(methodInvocation);
+                        return methodInvocation.returnValue;
+                    }] { [Symbol(Symbol.toStringTag)]: [Function: bound toString] }} />
   </div>
 </div>"
 `;

--- a/src/tests/unit/tests/reports/components/report-sections/combined-report-failed-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/combined-report-failed-section.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CollapsibleComponentCardsProps } from 'common/components/cards/collapsible-component-cards';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -10,9 +11,14 @@ import {
     CombinedReportFailedSectionDeps,
 } from 'reports/components/report-sections/combined-report-failed-section';
 import { exampleUnifiedStatusResults } from 'tests/unit/tests/common/components/cards/sample-view-model-data';
-import { It, Mock, MockBehavior } from 'typemoq';
+import { IMock, It, Mock, MockBehavior } from 'typemoq';
 
 describe('CombinedReportFailedSection', () => {
+    let cardSelectionMessageCreatorMock: IMock<CardSelectionMessageCreator>;
+    beforeEach(() => {
+        cardSelectionMessageCreatorMock = Mock.ofType<CardSelectionMessageCreator>();
+    });
+
     it('renders', () => {
         const collapsibleControlMock = Mock.ofType<
             (props: CollapsibleComponentCardsProps) => JSX.Element
@@ -30,6 +36,7 @@ describe('CombinedReportFailedSection', () => {
                 visualHelperEnabled: true,
                 allCardsCollapsed: true,
             },
+            cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
             scanMetadata: scanMetaDataStub,
         } as CombinedReportFailedSectionProps;
 

--- a/src/tests/unit/tests/reports/fast-pass-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/fast-pass-report-html-generator.test.tsx
@@ -7,6 +7,7 @@ import { NullComponent } from 'common/components/null-component';
 import { RecommendColor } from 'common/components/recommend-color';
 import { DateProvider } from 'common/date-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import { FastPassReport, FastPassReportProps } from 'reports/components/fast-pass-report';

--- a/src/tests/unit/tests/reports/fast-pass-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/fast-pass-report-html-generator.test.tsx
@@ -7,7 +7,6 @@ import { NullComponent } from 'common/components/null-component';
 import { RecommendColor } from 'common/components/recommend-color';
 import { DateProvider } from 'common/date-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import { FastPassReport, FastPassReportProps } from 'reports/components/fast-pass-report';

--- a/src/tests/unit/tests/reports/package/combined-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/combined-results-report.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { CardSelectionMessageCreator } from "common/message-creators/card-selection-message-creator";
 import { CardsViewModel } from "common/types/store-data/card-view-model";
 import { ToolData } from "common/types/store-data/unified-data-interface";
 import { CombinedReportHtmlGenerator } from "reports/combined-report-html-generator";
@@ -12,6 +13,8 @@ import { IMock, Mock } from "typemoq";
 describe('CombinedResultsReport', () => {
     let reportHtmlGeneratorMock: IMock<CombinedReportHtmlGenerator>;
     let resultsToCardsConverterMock: IMock<CombinedResultsToCardsModelConverter>;
+    let cardSelectionMessageCreatorMock: IMock<CardSelectionMessageCreator>;
+    
 
     let combinedResultsReport: CombinedResultsReport;
 
@@ -55,15 +58,7 @@ describe('CombinedResultsReport', () => {
         urlResults: urlResultsCount,
     } as CombinedReportResults;
 
-    const parameters: CombinedReportParameters = {
-        serviceName: 'service name',
-        axeVersion: 'axe version',
-        userAgent: 'browser spec',
-        browserResolution: '1920x1080',
-        scanDetails: scanDetails,
-        results,
-    };
-
+    let parameters: CombinedReportParameters;
     const cardsViewDataStub: CardsViewModel = {
         visualHelperEnabled: false,
         allCardsCollapsed: true,
@@ -80,9 +75,21 @@ describe('CombinedResultsReport', () => {
     beforeEach(() => {
         reportHtmlGeneratorMock = Mock.ofType(CombinedReportHtmlGenerator);
         resultsToCardsConverterMock = Mock.ofType<CombinedResultsToCardsModelConverter>();
+        cardSelectionMessageCreatorMock = Mock.ofType<CardSelectionMessageCreator>();
+        parameters = {
+            serviceName: 'service name',
+            axeVersion: 'axe version',
+            userAgent: 'browser spec',
+            browserResolution: '1920x1080',
+            scanDetails: scanDetails,
+            results,
+            cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object
+        };
+    
 
         const deps = {
             reportHtmlGenerator: reportHtmlGeneratorMock.object,
+            cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
         };
         combinedResultsReport = new CombinedResultsReport(
             deps,
@@ -98,7 +105,7 @@ describe('CombinedResultsReport', () => {
             .returns(() => cardsViewDataStub);
 
         reportHtmlGeneratorMock
-            .setup(rhg => rhg.generateHtml(scanMetadataStub, cardsViewDataStub, urlResultsCount))
+            .setup(rhg => rhg.generateHtml(scanMetadataStub, cardsViewDataStub, cardSelectionMessageCreatorMock.object, urlResultsCount))
             .returns(() => expectedHtml);
 
         const html = combinedResultsReport.asHTML();


### PR DESCRIPTION
#### Details

This wires up the Needs Review section to the new NeedsReviewScanResultStore and NeedsReviewCardSelectionStore. 

##### Motivation

Feature work. We needed to be able to store both needs review and automated checks at the same time so that if you navigated to needs review, scan, and navigate back to tab stops to export, the data for automated checks will still exist.

##### Context

This doesn't change the current workflow for when you must scan/rescan a test. You still have to click the button to scan needs review, and if you return to automated checks you must rescan. This will be updated in a later PR to improve the user experience.

I considered various approaches to try to avoid the mass propagating of CardSelectionMessageCreators, including using the visualization configuration to hold the relevant CardSelectionMessageCreator. This would be potentially problematic on the android side, as we don't use visualization configurations. After trying various approaches, the solution that was the most straight forward was creating a generic interface (CardSelectionMessageCreator) that the AutomatedChecksCardSelectionMessageCreator and the NeedsReviewCardSelectionMessageCreator both implement. This allows us to pass the relevant one via props. This approach allowed me to reduce the amount of code duplication that would've been necessary to separate various shared props between the two.

Sorry for the very large PR. Once I started separating out Needs Review and Automated Checks I didn't see a straight-forward way of breaking it into smaller PRs without leaving the application in a broken intermediate state.


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
