### PR TITLE
feat(tabstops-report): Add tab stops failures to FastPassReport

### DIFF
--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -141,7 +141,9 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                     />
                     <TabStopsFailedInstanceSection
                         deps={props.deps}
-                        visualizationScanResultData={props.visualizationScanResultData}
+                        tabStopRequirementState={
+                            props.visualizationScanResultData.tabStops.requirements
+                        }
                     />
                     <TabStopsFailedInstancePanel
                         deps={props.deps}

--- a/src/DetailsView/components/tab-stops-failed-instance-section.tsx
+++ b/src/DetailsView/components/tab-stops-failed-instance-section.tsx
@@ -3,7 +3,7 @@
 
 import { ResultSectionTitle } from 'common/components/cards/result-section-title';
 import { NamedFC } from 'common/react/named-fc';
-import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
+import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
 import { requirements } from 'DetailsView/components/tab-stops/requirements';
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import {
@@ -19,7 +19,7 @@ export type TabStopsFailedInstanceSectionDeps = TabStopsRequirementsWithInstance
 
 export interface TabStopsFailedInstanceSectionProps {
     deps: TabStopsFailedInstanceSectionDeps;
-    visualizationScanResultData: VisualizationScanResultData;
+    tabStopRequirementState: TabStopRequirementState;
 }
 
 export const tabStopsFailedInstanceSectionAutomationId = 'tab-stops-failure-instance-section';
@@ -28,8 +28,8 @@ export const TabStopsFailedInstanceSection = NamedFC<TabStopsFailedInstanceSecti
     'TabStopsFailedInstanceSection',
     props => {
         const results = [];
-        const storeData = props.visualizationScanResultData;
-        for (const [requirementId, data] of Object.entries(storeData.tabStops.requirements)) {
+
+        for (const [requirementId, data] of Object.entries(props.tabStopRequirementState)) {
             if (data.status !== 'fail') {
                 continue;
             }

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -354,6 +354,7 @@ if (tabId != null) {
 
             const fixInstructionProcessor = new FixInstructionProcessor();
             const recommendColor = new RecommendColor();
+            const tabStopsFailedCounter = new TabStopsFailedCounter();
 
             // This is for a soon-to-be-legacy FastPass report format.
             // It should be removed with #1897885.
@@ -376,6 +377,7 @@ if (tabId != null) {
                 fixInstructionProcessor,
                 recommendColor,
                 getPropertyConfiguration,
+                tabStopsFailedCounter,
             );
 
             // Represents the language in which pages are to be displayed
@@ -493,8 +495,6 @@ if (tabId != null) {
                 document,
                 loadAssessmentDataValidator,
             );
-
-            const tabStopsFailedCounter = new TabStopsFailedCounter();
 
             const deps: DetailsViewContainerDeps = {
                 textContent,

--- a/src/reports/components/fast-pass-report.tsx
+++ b/src/reports/components/fast-pass-report.tsx
@@ -5,8 +5,6 @@ import { NamedFC } from 'common/react/named-fc';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
 import { TabStopsFailedInstanceSection } from 'DetailsView/components/tab-stops-failed-instance-section';
-import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
-import { TabStopsViewActions } from 'DetailsView/components/tab-stops/tab-stops-view-actions';
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import * as React from 'react';
 import { AutomatedChecksHeaderSection } from 'reports/components/report-sections/automated-checks-header-section';
@@ -19,22 +17,23 @@ import { FooterText } from 'reports/components/report-sections/footer-text';
 import { PassedChecksSection } from 'reports/components/report-sections/passed-checks-section';
 import { ReportFooter } from 'reports/components/report-sections/report-footer';
 import { ResultsContainer } from 'reports/components/report-sections/results-container';
-import { SectionProps } from './report-sections/report-section-factory';
+import { SectionDeps, SectionProps } from './report-sections/report-section-factory';
 import { WebReportHead } from './web-report-head';
 
 export type FastPassReportResultData = {
     automatedChecks: CardsViewModel;
     tabStops: TabStopRequirementState;
 };
-
+export type FastPassReportDeps = {
+    tabStopsFailedCounter: TabStopsFailedCounter;
+} & SectionDeps;
 export type FastPassReportProps = Omit<
     SectionProps,
     'cardsViewData' | 'userConfigurationStoreData'
 > & {
+    deps: FastPassReportDeps;
     results: FastPassReportResultData;
 };
-const tabStopsViewActions = new TabStopsViewActions();
-const tabStopsTestViewController = new TabStopsTestViewController(tabStopsViewActions);
 
 export const FastPassReport = NamedFC<FastPassReportProps>('FastPassReport', props => (
     <>
@@ -61,13 +60,13 @@ export const FastPassReport = NamedFC<FastPassReportProps>('FastPassReport', pro
                         cardsViewData={props.results.automatedChecks}
                     />
 
-                    <FastPassResultsTitleSection title="Tab stops" />
+                    <FastPassResultsTitleSection key={4} title="Tab stops" />
 
                     <TabStopsFailedInstanceSection
+                        key={5}
                         deps={{
-                            tabStopsFailedCounter: new TabStopsFailedCounter(),
                             tabStopRequirementActionMessageCreator: undefined,
-                            tabStopsTestViewController: tabStopsTestViewController,
+                            tabStopsTestViewController: undefined,
                             ...props.deps,
                         }}
                         tabStopRequirementState={props.results.tabStops}

--- a/src/reports/components/fast-pass-report.tsx
+++ b/src/reports/components/fast-pass-report.tsx
@@ -4,11 +4,16 @@ import { FailedInstancesSection } from 'common/components/cards/failed-instances
 import { NamedFC } from 'common/react/named-fc';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
+import { TabStopsFailedInstanceSection } from 'DetailsView/components/tab-stops-failed-instance-section';
+import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
+import { TabStopsViewActions } from 'DetailsView/components/tab-stops/tab-stops-view-actions';
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import * as React from 'react';
 import { AutomatedChecksHeaderSection } from 'reports/components/report-sections/automated-checks-header-section';
 import { BodySection } from 'reports/components/report-sections/body-section';
 import { ContentContainer } from 'reports/components/report-sections/content-container';
 import { DetailsSection } from 'reports/components/report-sections/details-section';
+import { FastPassResultsTitleSection } from 'reports/components/report-sections/fast-pass-results-title-section';
 import { FastPassTitleSection } from 'reports/components/report-sections/fast-pass-title-section';
 import { FooterText } from 'reports/components/report-sections/footer-text';
 import { PassedChecksSection } from 'reports/components/report-sections/passed-checks-section';
@@ -28,6 +33,8 @@ export type FastPassReportProps = Omit<
 > & {
     results: FastPassReportResultData;
 };
+const tabStopsViewActions = new TabStopsViewActions();
+const tabStopsTestViewController = new TabStopsTestViewController(tabStopsViewActions);
 
 export const FastPassReport = NamedFC<FastPassReportProps>('FastPassReport', props => (
     <>
@@ -39,8 +46,8 @@ export const FastPassReport = NamedFC<FastPassReportProps>('FastPassReport', pro
                 <DetailsSection {...props} />
                 <p>Placeholder for combined summary section</p>
 
-                <p>Placeholder for "Automated Checks" heading component</p>
                 <ResultsContainer {...props}>
+                    <FastPassResultsTitleSection title="Automated checks" />
                     <FailedInstancesSection
                         key={1}
                         {...props}
@@ -53,11 +60,18 @@ export const FastPassReport = NamedFC<FastPassReportProps>('FastPassReport', pro
                         {...props}
                         cardsViewData={props.results.automatedChecks}
                     />
-                </ResultsContainer>
 
-                <p>Placeholder for "Tab stops" heading component</p>
-                <ResultsContainer {...props}>
-                    <p>Placeholder for results.tabStops rendering</p>
+                    <FastPassResultsTitleSection title="Tab stops" />
+
+                    <TabStopsFailedInstanceSection
+                        deps={{
+                            tabStopsFailedCounter: new TabStopsFailedCounter(),
+                            tabStopRequirementActionMessageCreator: undefined,
+                            tabStopsTestViewController: tabStopsTestViewController,
+                            ...props.deps,
+                        }}
+                        tabStopRequirementState={props.results.tabStops}
+                    />
                 </ResultsContainer>
             </ContentContainer>
             <ReportFooter>

--- a/src/reports/components/report-sections/fast-pass-results-title-section.tsx
+++ b/src/reports/components/report-sections/fast-pass-results-title-section.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import * as React from 'react';
+
+export type FastPassResultsTitleSectionProps = {
+    title: string;
+};
+
+export const FastPassResultsTitleSection = NamedFC<FastPassResultsTitleSectionProps>(
+    'FastPassResultsTitleSection',
+    props => {
+        return (
+            <div className="title-section">
+                <h2>{props.title}</h2>
+            </div>
+        );
+    },
+);

--- a/src/reports/fast-pass-report-html-generator.tsx
+++ b/src/reports/fast-pass-report-html-generator.tsx
@@ -10,11 +10,15 @@ import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import * as React from 'react';
-import { FastPassReport, FastPassReportProps } from 'reports/components/fast-pass-report';
+import {
+    FastPassReport,
+    FastPassReportDeps,
+    FastPassReportProps,
+} from 'reports/components/fast-pass-report';
 
 import { ReportCollapsibleContainerControl } from './components/report-sections/report-collapsible-container';
-import { SectionDeps } from './components/report-sections/report-section-factory';
 import { ReactStaticRenderer } from './react-static-renderer';
 
 export type FastPassReportModel = {
@@ -35,6 +39,7 @@ export class FastPassReportHtmlGenerator {
         private readonly fixInstructionProcessor: FixInstructionProcessor,
         private readonly recommendColor: RecommendColor,
         private readonly getPropertyConfiguration: (id: string) => Readonly<PropertyConfiguration>,
+        private readonly tabStopsFailedCounter: TabStopsFailedCounter,
     ) {}
 
     public generateHtml(model: FastPassReportModel): string {
@@ -51,7 +56,8 @@ export class FastPassReportHtmlGenerator {
                 cardInteractionSupport: noCardInteractionsSupported,
                 cardsVisualizationModifierButtons: NullComponent,
                 LinkComponent: NewTabLink,
-            } as SectionDeps,
+                tabStopsFailedCounter: this.tabStopsFailedCounter,
+            } as FastPassReportDeps,
             toUtcString: this.utcDateConverter,
             getCollapsibleScript: this.getCollapsibleScript,
             getGuidanceTagsFromGuidanceLinks: this.getGuidanceTagsFromGuidanceLinks,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -75,11 +75,6 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
     />
     <TabStopsFailedInstanceSection
       deps="stub-deps"
-      visualizationScanResultData={
-        Object {
-          "tabStops": Object {},
-        }
-      }
     />
     <TabStopsFailedInstancePanel
       deps="stub-deps"
@@ -167,11 +162,6 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
     />
     <TabStopsFailedInstanceSection
       deps="stub-deps"
-      visualizationScanResultData={
-        Object {
-          "tabStops": Object {},
-        }
-      }
     />
     <TabStopsFailedInstancePanel
       deps="stub-deps"

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import {
     TabStopsFailedInstanceSection,
     TabStopsFailedInstanceSectionDeps,
@@ -15,10 +14,6 @@ import { IMock, It, Mock, Times } from 'typemoq';
 describe('TabStopsFailedInstanceSection', () => {
     let tabStopsFailedCounterMock: IMock<TabStopsFailedCounter>;
 
-    const visualizationScanResultDataStub = {
-        tabStops: { requirements: {} },
-    } as VisualizationScanResultData;
-
     let props: TabStopsFailedInstanceSectionProps;
     let deps: TabStopsFailedInstanceSectionDeps;
 
@@ -31,18 +26,17 @@ describe('TabStopsFailedInstanceSection', () => {
 
         props = {
             deps: deps,
-            visualizationScanResultData: visualizationScanResultDataStub,
-        };
-        props.visualizationScanResultData.tabStops.requirements = {
-            'keyboard-navigation': {
-                status: 'fail',
-                instances: [{ id: 'test-id-1', description: 'test desc 1' }],
-                isExpanded: false,
-            },
-            'keyboard-traps': {
-                status: 'fail',
-                instances: [{ id: 'test-id-2', description: 'test desc 2' }],
-                isExpanded: false,
+            tabStopRequirementState: {
+                'keyboard-navigation': {
+                    status: 'fail',
+                    instances: [{ id: 'test-id-1', description: 'test desc 1' }],
+                    isExpanded: false,
+                },
+                'keyboard-traps': {
+                    status: 'fail',
+                    instances: [{ id: 'test-id-2', description: 'test desc 2' }],
+                    isExpanded: false,
+                },
             },
         };
     });
@@ -53,18 +47,13 @@ describe('TabStopsFailedInstanceSection', () => {
             .returns(() => 10)
             .verifiable(Times.once());
 
-        const wrapper = shallow(
-            <TabStopsFailedInstanceSection
-                deps={deps}
-                visualizationScanResultData={visualizationScanResultDataStub}
-            />,
-        );
+        const wrapper = shallow(<TabStopsFailedInstanceSection {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
         tabStopsFailedCounterMock.verifyAll();
     });
 
     it('does not render when no results are failing', () => {
-        const requirementsStub = props.visualizationScanResultData.tabStops.requirements;
+        const requirementsStub = props.tabStopRequirementState;
         for (const requirementId of Object.keys(requirementsStub)) {
             requirementsStub[requirementId].status = 'pass';
             requirementsStub[requirementId].instances = [];
@@ -75,12 +64,7 @@ describe('TabStopsFailedInstanceSection', () => {
             .returns(() => 0)
             .verifiable(Times.once());
 
-        const wrapper = shallow(
-            <TabStopsFailedInstanceSection
-                deps={deps}
-                visualizationScanResultData={visualizationScanResultDataStub}
-            />,
-        );
+        const wrapper = shallow(<TabStopsFailedInstanceSection {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
         tabStopsFailedCounterMock.verifyAll();
     });

--- a/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report.test.tsx.snap
@@ -11,23 +11,15 @@ exports[` renders 1`] = `
       <p>
         Placeholder for combined summary section
       </p>
-      <p>
-        Placeholder for &quot;Automated Checks&quot; heading component
-      </p>
       <ResultsContainer deps={{...}} fixInstructionProcessor={{...}} recommendColor={{...}} pageTitle=\\"page-title\\" pageUrl=\\"url:target-page\\" description=\\"test description\\" toolData={{...}} scanResult={{...}} toUtcString={[Function: toUtcString]} getCollapsibleScript={[Function: getScriptStub]} getGuidanceTagsFromGuidanceLinks={[Function: getGuidanceTagsStub]} results={{...}} userConfigurationStoreData={{...}} targetAppInfo={{...}} shouldAlertFailuresCount={false} scanMetadata={{...}}>
+        <FastPassResultsTitleSection title=\\"Automated checks\\" />
         <FailedInstancesSection deps={{...}} fixInstructionProcessor={{...}} recommendColor={{...}} pageTitle=\\"page-title\\" pageUrl=\\"url:target-page\\" description=\\"test description\\" toolData={{...}} scanResult={{...}} toUtcString={[Function: toUtcString]} getCollapsibleScript={[Function: getScriptStub]} getGuidanceTagsFromGuidanceLinks={[Function: getGuidanceTagsStub]} results={{...}} userConfigurationStoreData={{...}} targetAppInfo={{...}} shouldAlertFailuresCount={false} scanMetadata={{...}} cardsViewData={{...}} />
         <p>
           Placeholder for incomplete checks
         </p>
         <PassedChecksSection deps={{...}} fixInstructionProcessor={{...}} recommendColor={{...}} pageTitle=\\"page-title\\" pageUrl=\\"url:target-page\\" description=\\"test description\\" toolData={{...}} scanResult={{...}} toUtcString={[Function: toUtcString]} getCollapsibleScript={[Function: getScriptStub]} getGuidanceTagsFromGuidanceLinks={[Function: getGuidanceTagsStub]} results={{...}} userConfigurationStoreData={{...}} targetAppInfo={{...}} shouldAlertFailuresCount={false} scanMetadata={{...}} cardsViewData={{...}} />
-      </ResultsContainer>
-      <p>
-        Placeholder for &quot;Tab stops&quot; heading component
-      </p>
-      <ResultsContainer deps={{...}} fixInstructionProcessor={{...}} recommendColor={{...}} pageTitle=\\"page-title\\" pageUrl=\\"url:target-page\\" description=\\"test description\\" toolData={{...}} scanResult={{...}} toUtcString={[Function: toUtcString]} getCollapsibleScript={[Function: getScriptStub]} getGuidanceTagsFromGuidanceLinks={[Function: getGuidanceTagsStub]} results={{...}} userConfigurationStoreData={{...}} targetAppInfo={{...}} shouldAlertFailuresCount={false} scanMetadata={{...}}>
-        <p>
-          Placeholder for results.tabStops rendering
-        </p>
+        <FastPassResultsTitleSection title=\\"Tab stops\\" />
+        <TabStopsFailedInstanceSection deps={{...}} tabStopRequirementState={{...}} />
       </ResultsContainer>
     </ContentSection>
     <ReportFooter>

--- a/src/tests/unit/tests/reports/components/fast-pass-report.test.tsx
+++ b/src/tests/unit/tests/reports/components/fast-pass-report.test.tsx
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CommonInstancesSectionDeps } from 'common/components/cards/common-instances-section-props';
 import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { RecommendColor } from 'common/components/recommend-color';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { FastPassReport, FastPassReportProps } from 'reports/components/fast-pass-report';
+import {
+    FastPassReport,
+    FastPassReportDeps,
+    FastPassReportProps,
+} from 'reports/components/fast-pass-report';
 import { Mock } from 'typemoq';
 
 import { exampleUnifiedStatusResults } from '../../common/components/cards/sample-view-model-data';
@@ -33,7 +36,7 @@ describe(FastPassReport, () => {
         const targetAppInfo = { name: 'app' };
 
         const props: FastPassReportProps = {
-            deps: {} as CommonInstancesSectionDeps,
+            deps: {} as FastPassReportDeps,
             fixInstructionProcessor: fixInstructionProcessorMock.object,
             recommendColor: recommendColorMock.object,
             pageTitle,

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/fast-pass-results-title-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/fast-pass-results-title-section.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FastPassResultsTitleSection renders 1`] = `
+<div
+  className="title-section"
+>
+  <h2>
+    Test title
+  </h2>
+</div>
+`;

--- a/src/tests/unit/tests/reports/components/report-sections/fast-pass-results-title-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/fast-pass-results-title-section.test.tsx
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { FastPassResultsTitleSection } from 'reports/components/report-sections/fast-pass-results-title-section';
+
+describe('FastPassResultsTitleSection', () => {
+    it('renders', () => {
+        const wrapped = shallow(<FastPassResultsTitleSection title="Test title" />);
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/reports/fast-pass-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/fast-pass-report-html-generator.test.tsx
@@ -8,10 +8,14 @@ import { RecommendColor } from 'common/components/recommend-color';
 import { DateProvider } from 'common/date-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-interface';
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import * as React from 'react';
-import { FastPassReport, FastPassReportProps } from 'reports/components/fast-pass-report';
+import {
+    FastPassReport,
+    FastPassReportDeps,
+    FastPassReportProps,
+} from 'reports/components/fast-pass-report';
 import { ReportCollapsibleContainerControl } from 'reports/components/report-sections/report-collapsible-container';
-import { SectionDeps } from 'reports/components/report-sections/report-section-factory';
 import {
     FastPassReportHtmlGenerator,
     FastPassReportModel,
@@ -31,6 +35,7 @@ describe(FastPassReportHtmlGenerator, () => {
         const recommendColorMock = Mock.ofType(RecommendColor);
         const getPropertyConfigurationStub = (id: string) => null;
         const cardInteractionSupport = noCardInteractionsSupported;
+        const tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
 
         const getUTCStringFromDateStub: typeof DateProvider.getUTCStringFromDate = () => '';
         const getGuidanceTagsStub: GetGuidanceTagsFromGuidanceLinks = () => [];
@@ -85,7 +90,8 @@ describe(FastPassReportHtmlGenerator, () => {
                 cardInteractionSupport: cardInteractionSupport,
                 cardsVisualizationModifierButtons: NullComponent,
                 LinkComponent: NewTabLink,
-            } as SectionDeps,
+                tabStopsFailedCounter: tabStopsFailedCounterMock.object,
+            } as FastPassReportDeps,
             fixInstructionProcessor: fixInstructionProcessorMock.object,
             recommendColor: recommendColorMock.object,
             description,
@@ -112,6 +118,7 @@ describe(FastPassReportHtmlGenerator, () => {
             fixInstructionProcessorMock.object,
             recommendColorMock.object,
             getPropertyConfigurationStub,
+            tabStopsFailedCounterMock.object,
         );
 
         const actual = testObject.generateHtml(model);


### PR DESCRIPTION
#### Details
This PR makes a few pieces of incremental progress building out the FastPassReport. It:
- Adds headers for the Automated checks and Tab stops sections
- Adds tab stops failures to the report
- Fixes the expand/collapse behavior of the automated checks instances

Some minor refactoring was required to achieve this.

Screenshot:
![Screenshot of fastpass report](https://user-images.githubusercontent.com/4615491/146054796-c7717a9f-143b-4c53-8230-be207cf303e5.png)

##### Motivation
Tab stops report feature

##### Context
This is just incremental progress. Things out of scope:
- All unmentioned aspects of the FastPassReport
- Expand/collapse behavior not fully functional for tab stops failures
- Only tab stops failures with failed instances are displayed

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
