### PR TITLE
feat(tabstops-report): fix automated checks data clearing on rescan of needs review

### DIFF
--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -16,7 +16,6 @@ import { VisualizationInstanceProcessor } from 'injected/visualization-instance-
 import * as React from 'react';
 
 const issuesTestKey = AdHocTestkeys.Issues;
-const needsReviewTestKey = AdHocTestkeys.NeedsReview;
 
 const issuesRuleAnalyzerConfiguration: RuleAnalyzerConfiguration = {
     rules: null,
@@ -33,10 +32,7 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     testMode: TestMode.Adhoc,
     testViewType: 'AdhocFailure',
     getStoreData: data => data.adhoc[issuesTestKey],
-    enableTest: (data, _) => {
-        data.adhoc[issuesTestKey].enabled = true;
-        data.adhoc[needsReviewTestKey].enabled = false;
-    },
+    enableTest: data => (data.adhoc[issuesTestKey].enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
     shouldShowExportReport: featureflagStoreData =>

--- a/src/ad-hoc-visualizations/needs-review/visualization.tsx
+++ b/src/ad-hoc-visualizations/needs-review/visualization.tsx
@@ -14,7 +14,6 @@ import { ScannerUtils } from '../../injected/scanner-utils';
 import { VisualizationInstanceProcessor } from '../../injected/visualization-instance-processor';
 
 const needsReviewTestKey = AdHocTestkeys.NeedsReview;
-const issuesTestKey = AdHocTestkeys.Issues;
 
 const needsReviewRuleAnalyzerConfiguration: RuleAnalyzerConfiguration = {
     rules: [
@@ -38,10 +37,7 @@ export const NeedsReviewAdHocVisualization: VisualizationConfiguration = {
     testMode: TestMode.Adhoc,
     testViewType: 'AdhocNeedsReview',
     getStoreData: data => data.adhoc[needsReviewTestKey],
-    enableTest: data => {
-        data.adhoc[needsReviewTestKey].enabled = true;
-        data.adhoc[issuesTestKey].enabled = false;
-    },
+    enableTest: data => (data.adhoc[needsReviewTestKey].enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
     shouldShowExportReport: () => false,

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -3,7 +3,6 @@
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
 import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
 import { SidePanelActions } from 'background/actions/side-panel-actions';
-import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
 import { TestMode } from 'common/configs/test-mode';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import * as TelemetryEvents from 'common/extension-telemetry-events';
@@ -48,7 +47,6 @@ export class ActionCreator {
     private inspectActions: InspectActions;
     private cardSelectionActions: CardSelectionActions;
     private needsReviewCardSelectionActions: NeedsReviewCardSelectionActions;
-    private unifiedScanResultActions: UnifiedScanResultActions;
     private sidePanelActions: SidePanelActions;
 
     constructor(
@@ -66,7 +64,6 @@ export class ActionCreator {
         this.inspectActions = actionHub.inspectActions;
         this.cardSelectionActions = actionHub.cardSelectionActions;
         this.needsReviewCardSelectionActions = actionHub.needsReviewCardSelectionActions;
-        this.unifiedScanResultActions = actionHub.scanResultActions;
         this.sidePanelActions = actionHub.sidePanelActions;
     }
 
@@ -335,7 +332,6 @@ export class ActionCreator {
     private onVisualizationToggle = (payload: VisualizationTogglePayload): void => {
         const telemetryEvent = this.adHocTestTypeToTelemetryEvent[payload.test];
         this.telemetryEventHandler.publishTelemetry(telemetryEvent, payload);
-        this.unifiedScanResultActions.startScan.invoke(null);
 
         if (payload.enabled) {
             this.visualizationActions.enableVisualization.invoke(payload);
@@ -346,9 +342,8 @@ export class ActionCreator {
 
     private onRescanVisualization = (payload: RescanVisualizationPayload) => {
         this.visualizationActions.disableVisualization.invoke(payload.test);
-        this.visualizationActions.enableVisualization.invoke(payload);
         this.visualizationActions.rescanVisualization.invoke(payload.test);
-        this.unifiedScanResultActions.startScan.invoke(null);
+        this.visualizationActions.enableVisualization.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.RESCAN_VISUALIZATION, payload);
     };
 

--- a/src/background/actions/needs-review-scan-result-actions.ts
+++ b/src/background/actions/needs-review-scan-result-actions.ts
@@ -7,5 +7,4 @@ import { UnifiedScanCompletedPayload } from './action-payloads';
 export class NeedsReviewScanResultActions extends UnifiedScanResultActions {
     public readonly scanCompleted = new Action<UnifiedScanCompletedPayload>();
     public readonly getCurrentState = new Action();
-    public readonly startScan = new Action();
 }

--- a/src/background/actions/unified-scan-result-actions.ts
+++ b/src/background/actions/unified-scan-result-actions.ts
@@ -6,5 +6,4 @@ import { UnifiedScanCompletedPayload } from './action-payloads';
 export class UnifiedScanResultActions {
     public readonly scanCompleted = new Action<UnifiedScanCompletedPayload>();
     public readonly getCurrentState = new Action();
-    public readonly startScan = new Action();
 }

--- a/src/background/stores/needs-review-scan-result-store.ts
+++ b/src/background/stores/needs-review-scan-result-store.ts
@@ -29,7 +29,6 @@ export class NeedsReviewScanResultStore extends BaseStoreImpl<NeedsReviewScanRes
     protected addActionListeners(): void {
         this.needsReviewScanResultActions.getCurrentState.addListener(this.onGetCurrentState);
         this.needsReviewScanResultActions.scanCompleted.addListener(this.onScanCompleted);
-        this.needsReviewScanResultActions.startScan.addListener(this.onScanStarted);
     }
 
     private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
@@ -41,11 +40,6 @@ export class NeedsReviewScanResultStore extends BaseStoreImpl<NeedsReviewScanRes
         this.state.scanIncompleteWarnings = payload.scanIncompleteWarnings;
         this.state.screenshotData = payload.screenshotData;
         this.state.platformInfo = payload.platformInfo;
-        this.emitChanged();
-    };
-
-    private onScanStarted = (): void => {
-        this.state = this.getDefaultState();
         this.emitChanged();
     };
 }

--- a/src/background/stores/unified-scan-result-store.ts
+++ b/src/background/stores/unified-scan-result-store.ts
@@ -29,7 +29,6 @@ export class UnifiedScanResultStore extends BaseStoreImpl<UnifiedScanResultStore
     protected addActionListeners(): void {
         this.unifiedScanResultActions.getCurrentState.addListener(this.onGetCurrentState);
         this.unifiedScanResultActions.scanCompleted.addListener(this.onScanCompleted);
-        this.unifiedScanResultActions.startScan.addListener(this.onScanStarted);
     }
 
     private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
@@ -41,11 +40,6 @@ export class UnifiedScanResultStore extends BaseStoreImpl<UnifiedScanResultStore
         this.state.scanIncompleteWarnings = payload.scanIncompleteWarnings;
         this.state.screenshotData = payload.screenshotData;
         this.state.platformInfo = payload.platformInfo;
-        this.emitChanged();
-    };
-
-    private onScanStarted = (): void => {
-        this.state = this.getDefaultState();
         this.emitChanged();
     };
 }

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -60,7 +60,6 @@ describe('ActionCreatorTest', () => {
 
     test('registerCallback for tab stops visualization toggle (to enable)', () => {
         const actionName = 'enableVisualization';
-        const startScanActionName = 'startScan';
         const test = VisualizationType.TabStops;
         const tabId = 1;
         const enabled = true;
@@ -81,9 +80,7 @@ describe('ActionCreatorTest', () => {
 
         const validator = new ActionCreatorValidator()
             .setupActionOnVisualizationActions(actionName)
-            .setupActionOnUnifiedScanResultActions(startScanActionName)
             .setupVisualizationActionWithInvokeParameter(actionName, payload)
-            .setupUnifiedScanResultActionWithInvokeParameter(startScanActionName, null)
             .setupSwitchToTab(tabId)
             .setupRegistrationCallback(VisualizationMessage.Common.Toggle, args)
             .setupTelemetrySend(TelemetryEvents.TABSTOPS_TOGGLE, payload, tabId);
@@ -96,7 +93,6 @@ describe('ActionCreatorTest', () => {
 
     test('registerCallback for tab stops visualization toggle (to disabled)', () => {
         const actionName = 'disableVisualization';
-        const startScanActionName = 'startScan';
         const test = VisualizationType.TabStops;
         const tabId = 1;
         const enabled = false;
@@ -117,9 +113,7 @@ describe('ActionCreatorTest', () => {
 
         const validator = new ActionCreatorValidator()
             .setupActionOnVisualizationActions(actionName)
-            .setupActionOnUnifiedScanResultActions(startScanActionName)
             .setupVisualizationActionWithInvokeParameter(actionName, test)
-            .setupUnifiedScanResultActionWithInvokeParameter(startScanActionName, null)
             .setupRegistrationCallback(VisualizationMessage.Common.Toggle, args)
             .setupTelemetrySend(TelemetryEvents.TABSTOPS_TOGGLE, payload, tabId);
 
@@ -131,7 +125,6 @@ describe('ActionCreatorTest', () => {
 
     test('registerCallback for visualization toggle (to enable)', () => {
         const actionName = 'enableVisualization';
-        const startScanActionName = 'startScan';
         const test = VisualizationType.Headings;
         const tabId = 1;
         const enabled = true;
@@ -152,9 +145,7 @@ describe('ActionCreatorTest', () => {
 
         const validator = new ActionCreatorValidator()
             .setupActionOnVisualizationActions(actionName)
-            .setupActionOnUnifiedScanResultActions(startScanActionName)
             .setupVisualizationActionWithInvokeParameter(actionName, payload)
-            .setupUnifiedScanResultActionWithInvokeParameter(startScanActionName, null)
             .setupRegistrationCallback(VisualizationMessage.Common.Toggle, args)
             .setupTelemetrySend(TelemetryEvents.HEADINGS_TOGGLE, payload, tabId);
 
@@ -166,7 +157,6 @@ describe('ActionCreatorTest', () => {
 
     test('registerCallback for visualization toggle (to disable)', () => {
         const actionName = 'disableVisualization';
-        const startScanActionName = 'startScan';
         const test = VisualizationType.Headings;
         const tabId = 1;
         const enabled = false;
@@ -187,9 +177,7 @@ describe('ActionCreatorTest', () => {
 
         const validator = new ActionCreatorValidator()
             .setupActionOnVisualizationActions(actionName)
-            .setupActionOnUnifiedScanResultActions(startScanActionName)
             .setupVisualizationActionWithInvokeParameter(actionName, test)
-            .setupUnifiedScanResultActionWithInvokeParameter(startScanActionName, null)
             .setupRegistrationCallback(VisualizationMessage.Common.Toggle, args)
             .setupTelemetrySend(TelemetryEvents.HEADINGS_TOGGLE, payload, tabId);
 
@@ -291,7 +279,6 @@ describe('ActionCreatorTest', () => {
 
         const updateViewActionName = 'updateSelectedPivotChild';
         const enablingIssuesActionName = 'enableVisualization';
-        const startScanActionName = 'startScan';
         const enableVisualizationTelemetryPayload: VisualizationTogglePayload = {
             enabled: true,
             test: viewType,
@@ -305,8 +292,6 @@ describe('ActionCreatorTest', () => {
             ])
             .setupActionOnVisualizationActions(updateViewActionName)
             .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
-            .setupActionOnUnifiedScanResultActions(startScanActionName)
-            .setupUnifiedScanResultActionWithInvokeParameter(startScanActionName, null)
             .setupActionOnVisualizationActions(enablingIssuesActionName)
             .setupVisualizationActionWithInvokeParameter(
                 enablingIssuesActionName,
@@ -740,7 +725,6 @@ describe('ActionCreatorTest', () => {
         };
         const disableActionName = 'disableVisualization';
         const enableActionName = 'enableVisualization';
-        const startScanActionName = 'startScan';
         const rescanVisualization = 'rescanVisualization';
 
         const validator = new ActionCreatorValidator()
@@ -751,11 +735,9 @@ describe('ActionCreatorTest', () => {
             .setupActionOnVisualizationActions(disableActionName)
             .setupActionOnVisualizationActions(rescanVisualization)
             .setupActionOnVisualizationActions(enableActionName)
-            .setupActionOnUnifiedScanResultActions(startScanActionName)
             .setupVisualizationActionWithInvokeParameter(disableActionName, payload.test)
             .setupVisualizationActionWithInvokeParameter(rescanVisualization, payload.test)
             .setupVisualizationActionWithInvokeParameter(enableActionName, payload)
-            .setupUnifiedScanResultActionWithInvokeParameter(startScanActionName, null)
             .setupTelemetrySend(TelemetryEvents.RESCAN_VISUALIZATION, payload, tabId);
         const actionCreator = validator.buildActionCreator();
 

--- a/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
@@ -88,16 +88,6 @@ describe('NeedsReviewScanResultStore Test', () => {
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onScanStarted', () => {
-        const initialState = getDefaultState();
-        const finalState = getDefaultState();
-
-        createStoreForNeedsReviewScanResultActions('startScan').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
-    });
-
     function getDefaultState(): NeedsReviewScanResultStoreData {
         return createStoreWithNullParams(NeedsReviewScanResultStore).getDefaultState();
     }

--- a/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
@@ -88,16 +88,6 @@ describe('UnifiedScanResultStore Test', () => {
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onScanStarted', () => {
-        const initialState = getDefaultState();
-        const finalState = getDefaultState();
-
-        createStoreForUnifiedScanResultActions('startScan').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
-    });
-
     function getDefaultState(): UnifiedScanResultStoreData {
         return createStoreWithNullParams(UnifiedScanResultStore).getDefaultState();
     }


### PR DESCRIPTION
#### Details

This removes behavior that was clearing the automated checks results on any visualization toggle or rescan of any test.

##### Motivation

feature work

##### Context

the UnifiedScanResultActions.startScan action was created to fix issues that stemmed from automated checks and needs review being in the same store. It's only purpose was to clear the current results data in the UnifiedScanResultStore to avoid premature flashing of previous visualizations due to data from a different test being populated in the store.

I also removed the NeedsReviewScanResultActions.startScan. It was initially copied over from the UnifiedScanResultActions but was never used.



#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
