### PR TITLE
feat(tabstops-report): add combined fastpass summary components 

### DIFF
--- a/src/reports/components/fast-pass-outcome-summary-bar.tsx
+++ b/src/reports/components/fast-pass-outcome-summary-bar.tsx
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import * as React from 'react';
+
+export type FastPassOutcomeSummaryBarProps = {};
+
+export const FastPassOutcomeSummaryBar = NamedFC<FastPassOutcomeSummaryBarProps>(
+    'FastPassOutcomeSummaryBar',
+    props => <></>,
+);

--- a/src/reports/components/fast-pass-report-summary.tsx
+++ b/src/reports/components/fast-pass-report-summary.tsx
@@ -3,17 +3,15 @@
 import * as React from 'react';
 import { FastPassOutcomeSummaryBar } from 'reports/components/fast-pass-outcome-summary-bar';
 
-export interface FastPassReportSummaryProps {
-
-};
+export interface FastPassReportSummaryProps {}
 
 export class FastPassReportSummary extends React.Component<FastPassReportSummaryProps> {
     public render(): JSX.Element {
         return (
             <>
-            <h2>Summary</h2>
-            <FastPassOutcomeSummaryBar />
+                <h2>Summary</h2>
+                <FastPassOutcomeSummaryBar />
             </>
         );
     }
-};
+}

--- a/src/reports/components/fast-pass-report-summary.tsx
+++ b/src/reports/components/fast-pass-report-summary.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
+import { FastPassOutcomeSummaryBar } from 'reports/components/fast-pass-outcome-summary-bar';
 
 export interface FastPassReportSummaryProps {
 
@@ -9,7 +10,10 @@ export interface FastPassReportSummaryProps {
 export class FastPassReportSummary extends React.Component<FastPassReportSummaryProps> {
     public render(): JSX.Element {
         return (
+            <>
             <h2>Summary</h2>
+            <FastPassOutcomeSummaryBar />
+            </>
         );
     }
 };

--- a/src/reports/components/fast-pass-report-summary.tsx
+++ b/src/reports/components/fast-pass-report-summary.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+export interface FastPassReportSummaryProps {
+
+};
+
+export class FastPassReportSummary extends React.Component<FastPassReportSummaryProps> {
+    public render(): JSX.Element {
+        return (
+            <h2>Summary</h2>
+        );
+    }
+};

--- a/src/reports/components/fast-pass-report.tsx
+++ b/src/reports/components/fast-pass-report.tsx
@@ -7,6 +7,7 @@ import { TabStopRequirementState } from 'common/types/store-data/visualization-s
 import { TabStopsFailedInstanceSection } from 'DetailsView/components/tab-stops-failed-instance-section';
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import * as React from 'react';
+import { FastPassReportSummary } from 'reports/components/fast-pass-report-summary';
 import { AutomatedChecksHeaderSection } from 'reports/components/report-sections/automated-checks-header-section';
 import { BodySection } from 'reports/components/report-sections/body-section';
 import { ContentContainer } from 'reports/components/report-sections/content-container';
@@ -44,6 +45,7 @@ export const FastPassReport = NamedFC<FastPassReportProps>('FastPassReport', pro
                 <FastPassTitleSection />
                 <DetailsSection {...props} />
                 <p>Placeholder for combined summary section</p>
+                <FastPassReportSummary />
 
                 <ResultsContainer {...props}>
                     <FastPassResultsTitleSection title="Automated checks" />

--- a/src/reports/components/fast-pass-report.tsx
+++ b/src/reports/components/fast-pass-report.tsx
@@ -44,9 +44,9 @@ export const FastPassReport = NamedFC<FastPassReportProps>('FastPassReport', pro
             <ContentContainer>
                 <FastPassTitleSection />
                 <DetailsSection {...props} />
-                
-                <p>Placeholder for combined summary section</p>
+
                 <FastPassReportSummary />
+                <p>Placeholder for combined summary section</p>
 
                 <ResultsContainer {...props}>
                     <FastPassResultsTitleSection title="Automated checks" />

--- a/src/reports/components/fast-pass-report.tsx
+++ b/src/reports/components/fast-pass-report.tsx
@@ -44,6 +44,7 @@ export const FastPassReport = NamedFC<FastPassReportProps>('FastPassReport', pro
             <ContentContainer>
                 <FastPassTitleSection />
                 <DetailsSection {...props} />
+                
                 <p>Placeholder for combined summary section</p>
                 <FastPassReportSummary />
 

--- a/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-outcome-summary-bar.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-outcome-summary-bar.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FastPassOutcomeSummaryBar renders per the snapshot 1`] = `<React.Fragment />`;

--- a/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report-summary.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report-summary.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FastPassReportSummary renders per the snapshot 1`] = `
+<h2>
+  Summary
+</h2>
+`;

--- a/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report-summary.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report-summary.test.tsx.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FastPassReportSummary renders per the snapshot 1`] = `
-<h2>
-  Summary
-</h2>
+<React.Fragment>
+  <h2>
+    Summary
+  </h2>
+  <FastPassOutcomeSummaryBar />
+</React.Fragment>
 `;

--- a/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report.test.tsx.snap
@@ -11,6 +11,7 @@ exports[` renders 1`] = `
       <p>
         Placeholder for combined summary section
       </p>
+      <FastPassReportSummary />
       <ResultsContainer deps={{...}} fixInstructionProcessor={{...}} recommendColor={{...}} pageTitle=\\"page-title\\" pageUrl=\\"url:target-page\\" description=\\"test description\\" toolData={{...}} scanResult={{...}} toUtcString={[Function: toUtcString]} getCollapsibleScript={[Function: getScriptStub]} getGuidanceTagsFromGuidanceLinks={[Function: getGuidanceTagsStub]} results={{...}} userConfigurationStoreData={{...}} targetAppInfo={{...}} shouldAlertFailuresCount={false} scanMetadata={{...}}>
         <FastPassResultsTitleSection title=\\"Automated checks\\" />
         <FailedInstancesSection deps={{...}} fixInstructionProcessor={{...}} recommendColor={{...}} pageTitle=\\"page-title\\" pageUrl=\\"url:target-page\\" description=\\"test description\\" toolData={{...}} scanResult={{...}} toUtcString={[Function: toUtcString]} getCollapsibleScript={[Function: getScriptStub]} getGuidanceTagsFromGuidanceLinks={[Function: getGuidanceTagsStub]} results={{...}} userConfigurationStoreData={{...}} targetAppInfo={{...}} shouldAlertFailuresCount={false} scanMetadata={{...}} cardsViewData={{...}} />

--- a/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report.test.tsx.snap
@@ -8,10 +8,10 @@ exports[` renders 1`] = `
     <ContentSection>
       <FastPassTitleSection />
       <DetailsSection deps={{...}} fixInstructionProcessor={{...}} recommendColor={{...}} pageTitle=\\"page-title\\" pageUrl=\\"url:target-page\\" description=\\"test description\\" toolData={{...}} scanResult={{...}} toUtcString={[Function: toUtcString]} getCollapsibleScript={[Function: getScriptStub]} getGuidanceTagsFromGuidanceLinks={[Function: getGuidanceTagsStub]} results={{...}} userConfigurationStoreData={{...}} targetAppInfo={{...}} shouldAlertFailuresCount={false} scanMetadata={{...}} />
+      <FastPassReportSummary />
       <p>
         Placeholder for combined summary section
       </p>
-      <FastPassReportSummary />
       <ResultsContainer deps={{...}} fixInstructionProcessor={{...}} recommendColor={{...}} pageTitle=\\"page-title\\" pageUrl=\\"url:target-page\\" description=\\"test description\\" toolData={{...}} scanResult={{...}} toUtcString={[Function: toUtcString]} getCollapsibleScript={[Function: getScriptStub]} getGuidanceTagsFromGuidanceLinks={[Function: getGuidanceTagsStub]} results={{...}} userConfigurationStoreData={{...}} targetAppInfo={{...}} shouldAlertFailuresCount={false} scanMetadata={{...}}>
         <FastPassResultsTitleSection title=\\"Automated checks\\" />
         <FailedInstancesSection deps={{...}} fixInstructionProcessor={{...}} recommendColor={{...}} pageTitle=\\"page-title\\" pageUrl=\\"url:target-page\\" description=\\"test description\\" toolData={{...}} scanResult={{...}} toUtcString={[Function: toUtcString]} getCollapsibleScript={[Function: getScriptStub]} getGuidanceTagsFromGuidanceLinks={[Function: getGuidanceTagsStub]} results={{...}} userConfigurationStoreData={{...}} targetAppInfo={{...}} shouldAlertFailuresCount={false} scanMetadata={{...}} cardsViewData={{...}} />

--- a/src/tests/unit/tests/reports/components/fast-pass-outcome-summary-bar.test.tsx
+++ b/src/tests/unit/tests/reports/components/fast-pass-outcome-summary-bar.test.tsx
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { FastPassOutcomeSummaryBar } from 'reports/components/fast-pass-outcome-summary-bar';
+
+describe('FastPassOutcomeSummaryBar', () => {
+    it('renders per the snapshot', () => {
+        const rendered = shallow(<FastPassOutcomeSummaryBar />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
+++ b/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
@@ -10,5 +10,4 @@ describe('FastPassReportSummary', () => {
         const rendered = shallow(<FastPassReportSummary />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
-
 });

--- a/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
+++ b/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { FastPassReportSummary } from 'reports/components/fast-pass-report-summary';
+
+describe('FastPassReportSummary', () => {
+    it('renders per the snapshot', () => {
+        const rendered = shallow(<FastPassReportSummary />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+});


### PR DESCRIPTION
#### Details

This PR adds `FastPassReportSummary` and `FastPassOutcomeSummaryBar` (empty) components. 

##### Motivation

Feature 1872889.

##### Context

The contents of the components will be included in a separate PR. 
There already exists an `OutcomeSummaryBar` for the exported assessment report. The functionality will differ, which is why I created a FastPass specific outcome bar. I think `OutcomeSummaryBar` should be re-named to `AssessmentOutcomeSummaryBar` or something similar to differentiate the two clearly. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.