### PR TITLE
chore: Add color contrast recommendations end to end tests

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -2137,6 +2137,7 @@
                                               font weight: normal). Expected
                                               contrast ratio of 4.5:1</span
                                             ><ul
+                                              data-automation-id="recommendations"
                                               ><li
                                                 ><span aria-hidden="true"
                                                   ><span>
@@ -2249,6 +2250,7 @@
                                               font weight: normal). Expected
                                               contrast ratio of 4.5:1</span
                                             ><ul
+                                              data-automation-id="recommendations"
                                               ><li
                                                 ><span aria-hidden="true"
                                                   ><span>
@@ -2361,6 +2363,7 @@
                                               font weight: normal). Expected
                                               contrast ratio of 4.5:1</span
                                             ><ul
+                                              data-automation-id="recommendations"
                                               ><li
                                                 ><span aria-hidden="true"
                                                   ><span>
@@ -2473,6 +2476,7 @@
                                               font weight: normal). Expected
                                               contrast ratio of 4.5:1</span
                                             ><ul
+                                              data-automation-id="recommendations"
                                               ><li
                                                 ><span aria-hidden="true"
                                                   ><span>

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -2426,6 +2426,7 @@
                                                   weight: normal). Expected
                                                   contrast ratio of 4.5:1</span
                                                 ><ul
+                                                  data-automation-id="recommendations"
                                                   ><li
                                                     ><span aria-hidden="true"
                                                       ><span>

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -2414,6 +2414,7 @@
                                                   weight: normal). Expected
                                                   contrast ratio of 4.5:1</span
                                                 ><ul
+                                                  data-automation-id="recommendations"
                                                   ><li
                                                     ><span aria-hidden="true"
                                                       ><span>

--- a/src/common/components/fix-instruction-processor.tsx
+++ b/src/common/components/fix-instruction-processor.tsx
@@ -9,6 +9,8 @@ type ColorMatch = {
     colorHexValue: string;
 };
 
+export const recommendationsAutomationId = 'recommendations';
+
 export class FixInstructionProcessor {
     private readonly colorValueMatcher = `(#[0-9a-f]{6})`;
     private readonly foregroundColorText = 'foreground color: ';
@@ -197,7 +199,7 @@ export class FixInstructionProcessor {
         return (
             <>
                 {results}
-                <ul key="recommendations-list">
+                <ul key="recommendations-list" data-automation-id={recommendationsAutomationId}>
                     {recommendations.map((rec, idx) => (
                         <li key={`recommendation-${idx}`}>{rec}</li>
                     ))}

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { collapsibleButtonAutomationId } from 'common/components/cards/collapsible-component-cards';
-import { instanceCardAutomationId } from 'common/components/cards/instance-details';
 import { resultSectionAutomationId } from 'common/components/cards/result-section';
 import { ruleDetailsGroupAutomationId } from 'common/components/cards/rules-with-instances';
+import { recommendationsAutomationId } from 'common/components/fix-instruction-processor';
 import { instanceTableTextContentAutomationId } from 'DetailsView/components/assessment-instance-details-column';
 import { visualHelperToggleAutomationId } from 'DetailsView/components/base-visual-helper-toggle';
 import { settingsPanelAutomationId } from 'DetailsView/components/details-view-overlay/settings-panel/settings-panel';
@@ -86,7 +86,7 @@ export const fastPassAutomatedChecksSelectors = {
     failureCount: getAutomationIdSelector(failureCountAutomationId),
     iframeWarning: getAutomationIdSelector(IframeWarningContainerAutomationId),
     expandButton: getAutomationIdSelector(collapsibleButtonAutomationId),
-    instanceCard: getAutomationIdSelector(instanceCardAutomationId),
+    recommendationsCard: getAutomationIdSelector(recommendationsAutomationId),
 };
 
 export const tabStopsSelectors = {

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { collapsibleButtonAutomationId } from 'common/components/cards/collapsible-component-cards';
+import { instanceCardAutomationId } from 'common/components/cards/instance-details';
 import { resultSectionAutomationId } from 'common/components/cards/result-section';
 import { ruleDetailsGroupAutomationId } from 'common/components/cards/rules-with-instances';
 import { instanceTableTextContentAutomationId } from 'DetailsView/components/assessment-instance-details-column';
@@ -84,6 +85,8 @@ export const fastPassAutomatedChecksSelectors = {
     cardsRuleId: getAutomationIdSelector(cardsRuleIdAutomationId),
     failureCount: getAutomationIdSelector(failureCountAutomationId),
     iframeWarning: getAutomationIdSelector(IframeWarningContainerAutomationId),
+    expandButton: getAutomationIdSelector(collapsibleButtonAutomationId),
+    instanceCard: getAutomationIdSelector(instanceCardAutomationId),
 };
 
 export const tabStopsSelectors = {

--- a/src/tests/end-to-end/test-resources/color-contrast/poor-color-contrast.html
+++ b/src/tests/end-to-end/test-resources/color-contrast/poor-color-contrast.html
@@ -1,0 +1,15 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Poor Color Contrast</title>
+    </head>
+
+    <body>
+        <h1 style="background-color: #33475b">Poor color contrast</h1>
+    </body>
+</html>

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/color-contrast.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/color-contrast.test.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Color Contrast Violations should provide color recommendations on contrast violation 1`] = `
+<DocumentFragment>
+  <ul
+    data-automation-id="recommendations"
+  >
+    <li>
+      <span
+        aria-hidden="true"
+      >
+        <span>
+             Use background color: 
+        </span>
+        <span
+          aria-hidden="true"
+          class="fix-instruction-color-box--{{CSS_MODULE_HASH}}"
+          style="background-color: rgb(64, 92, 118);"
+        />
+        <span>
+          #405c76 and the original foreground color: 
+        </span>
+        <span
+          aria-hidden="true"
+          class="fix-instruction-color-box--{{CSS_MODULE_HASH}}"
+          style="background-color: rgb(0, 0, 0);"
+        />
+        <span>
+          #000000 to meet a contrast ratio of 3.01:1.
+        </span>
+      </span>
+      <span
+        class="screen-reader-only--{{CSS_MODULE_HASH}}"
+      >
+           Use background color: #405c76 and the original foreground color: #000000 to meet a contrast ratio of 3.01:1.
+      </span>
+    </li>
+  </ul>
+</DocumentFragment>
+`;

--- a/src/tests/end-to-end/tests/details-view/color-contrast.test.ts
+++ b/src/tests/end-to-end/tests/details-view/color-contrast.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { formatPageElementForSnapshot } from 'tests/common/element-snapshot-formatter';
 import {
     detailsViewSelectors,
     fastPassAutomatedChecksSelectors,
@@ -48,14 +49,12 @@ describe('Color Contrast Violations', () => {
         expect(ruleDetails).toHaveLength(1);
 
         await detailsViewPage.clickSelector(fastPassAutomatedChecksSelectors.expandButton);
-        const instanceCard = await detailsViewPage.getSelectorElements(
-            fastPassAutomatedChecksSelectors.instanceCard,
+
+        const recCard = await formatPageElementForSnapshot(
+            detailsViewPage,
+            fastPassAutomatedChecksSelectors.recommendationsCard,
         );
-        expect(instanceCard).toHaveLength(1);
-        const instanceCardContent = await instanceCard[0].innerText();
-        expect(instanceCardContent).toContain('Element has insufficient color contrast');
-        expect(instanceCardContent).toContain(
-            'Use background color: #405c76 and the original foreground color: #000000 to meet a contrast ratio of 3.01:1.',
-        );
+
+        expect(recCard).toMatchSnapshot();
     });
 });

--- a/src/tests/end-to-end/tests/target-page/color-contrast.test.ts
+++ b/src/tests/end-to-end/tests/target-page/color-contrast.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    detailsViewSelectors,
+    fastPassAutomatedChecksSelectors,
+} from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
+import { DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS } from 'tests/end-to-end/common/timeouts';
+import { Browser } from '../../common/browser';
+import { launchBrowser } from '../../common/browser-factory';
+import { TargetPage } from '../../common/page-controllers/target-page';
+
+describe('Color Contrast Violations', () => {
+    let browser: Browser;
+    let targetPage: TargetPage;
+
+    beforeAll(async () => {
+        browser = await launchBrowser({
+            suppressFirstTimeDialog: true,
+            addExtraPermissionsToManifest: 'all-origins',
+        });
+    });
+
+    beforeEach(async () => {
+        targetPage = await browser.newTargetPage({
+            testResourcePath: 'color-contrast/poor-color-contrast.html',
+        });
+    });
+
+    afterEach(async () => {
+        await browser?.closeAllPages();
+    });
+
+    afterAll(async () => {
+        await browser?.close();
+    });
+
+    it('should provide color recommendations on contrast violation', async () => {
+        await browser.newPopupPage(targetPage);
+        const detailsViewPage = await browser.newDetailsViewPage(targetPage);
+        await detailsViewPage.clickSelector(fastPassAutomatedChecksSelectors.startOverButton);
+        await detailsViewPage.waitForSelector(detailsViewSelectors.automatedChecksResultSection, {
+            timeout: DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
+        });
+
+        const ruleDetails = await detailsViewPage.getSelectorElements(
+            fastPassAutomatedChecksSelectors.ruleDetail,
+        );
+        expect(ruleDetails).toHaveLength(1);
+
+        await detailsViewPage.clickSelector(fastPassAutomatedChecksSelectors.expandButton);
+        const instanceCard = await detailsViewPage.getSelectorElements(
+            fastPassAutomatedChecksSelectors.instanceCard,
+        );
+        expect(instanceCard).toHaveLength(1);
+        const instanceCardContent = await instanceCard[0].innerText();
+        expect(instanceCardContent).toContain('Element has insufficient color contrast');
+        expect(instanceCardContent).toContain(
+            'Use background color: #405c76 and the original foreground color: #000000 to meet a contrast ratio of 3.01:1.',
+        );
+    });
+});

--- a/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
@@ -40,7 +40,9 @@ exports[`FixInstructionProcessor background and foreground on the message (mind 
       Element has insufficient color contrast of 2.52 (background color: #8a94a8, foreground color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
     </span>
   </React.Fragment>
-  <ul>
+  <ul
+    data-automation-id="recommendations"
+  >
     <li>
       <React.Fragment>
         <span
@@ -101,7 +103,9 @@ exports[`FixInstructionProcessor foreground and background color on the message 
       Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
     </span>
   </React.Fragment>
-  <ul>
+  <ul
+    data-automation-id="recommendations"
+  >
     <li>
       <React.Fragment>
         <span
@@ -199,7 +203,9 @@ exports[`FixInstructionProcessor recommendColor has one recommendation 1`] = `
       Element has insufficient color contrast of 4.48 (foreground color: #fefefe, background color: #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1
     </span>
   </React.Fragment>
-  <ul>
+  <ul
+    data-automation-id="recommendations"
+  >
     <li>
       <React.Fragment>
         <span
@@ -324,7 +330,9 @@ exports[`FixInstructionProcessor recommendColor has two recommendations 1`] = `
       Element has insufficient color contrast of 4.48 (foreground color: #fefefe, background color: #21809d, font size: 10.8pt (14.4px), font weight: normal). Expected contrast ratio of 4.5:1
     </span>
   </React.Fragment>
-  <ul>
+  <ul
+    data-automation-id="recommendations"
+  >
     <li>
       <React.Fragment>
         <span
@@ -409,7 +417,9 @@ exports[`FixInstructionProcessor we assume only one instance of fore/background 
       first foreground color: #ffffff, second foreground: #000000, first background color: #AAAAAA, second background color: #bbBBbb
     </span>
   </React.Fragment>
-  <ul>
+  <ul
+    data-automation-id="recommendations"
+  >
     <li>
       <React.Fragment>
         <span


### PR DESCRIPTION
#### Details

Add end to end tests for color contrast recommendations. For this PR, just adding simple test that recommendation is displayed for a failing page. 

##### Motivation

Addresses issue #4379

##### Context

#4360 added color contrast recommendations but no end to end tests were added. This PR adds e2e tests for this feature.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4379
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
