### PR TITLE
feat(tabstops-auto-impl): Add tabStopsAutomation feature flag

### DIFF
--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -14,6 +14,7 @@ export class FeatureFlags {
     public static readonly debugTools = 'debugTools';
     public static readonly exportReportOptions = 'exportReportOptions';
     public static readonly newTabStopsDetailsView = 'newTabStopsDetailsView';
+    public static readonly tabStopsAutomation = 'tabStopsAutomation';
 }
 
 export interface FeatureFlagDetail {
@@ -103,6 +104,14 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
             defaultValue: false,
             displayableName: 'New tab stops details view',
             displayableDescription: 'show the new tabstops details view UI',
+            isPreviewFeature: false,
+            forceDefault: false,
+        },
+        {
+            id: FeatureFlags.tabStopsAutomation,
+            defaultValue: false,
+            displayableName: 'Tab Stops Automation',
+            displayableDescription: 'Enables the new tab stops automation',
             isPreviewFeature: false,
             forceDefault: false,
         },

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -26,6 +26,7 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.debugTools]: false,
             [FeatureFlags.exportReportOptions]: false,
             [FeatureFlags.newTabStopsDetailsView]: false,
+            [FeatureFlags.tabStopsAutomation]: false,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Details

This PR adds the `tabStopsAutomation` feature flag (not yet used).

##### Motivation

To support future PRs for this feature

##### Context

A subsequent PR will put this feature flag to use

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
