### PR TITLE
feat(manifest-v3): Create dev-mv3 build as a sandbox for MV3 conversion

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -871,6 +871,7 @@ module.exports = function (grunt) {
         'concurrent:webpack-all',
         'build-assets',
         'drop:dev',
+        'drop:dev-mv3',
         'drop:unified-dev',
         'extension-release-drops',
     ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,7 +51,12 @@ module.exports = function (grunt) {
             scss: path.join('src', '**/*.scss.d.ts'),
         },
         concurrent: {
-            'webpack-all': ['exec:webpack-dev', 'exec:webpack-unified', 'exec:webpack-prod'],
+            'webpack-all': [
+                'exec:webpack-dev',
+                'exed:webpack;dev-mv3',
+                'exec:webpack-unified',
+                'exec:webpack-prod',
+            ],
         },
         copy: {
             code: {
@@ -169,6 +174,7 @@ module.exports = function (grunt) {
         },
         exec: {
             'webpack-dev': `"${webpackPath}" --config-name dev`,
+            'webpack-dev-mv3': `"${webpackPath}" --config-name dev-mv3`,
             'webpack-prod': `"${webpackPath}" --config-name prod`,
             'webpack-unified': `"${webpackPath}" --config-name unified`,
             'webpack-package-report': `"${webpackPath}" --config-name package-report`,
@@ -204,20 +210,25 @@ module.exports = function (grunt) {
         watch: {
             images: {
                 files: ['src/**/*.{png,ico,icns}'],
-                tasks: ['copy:images', 'drop:dev', 'drop:unified-dev'],
+                tasks: ['copy:images', 'drop:dev', 'drop:dev-mv3', 'drop:unified-dev'],
             },
             'non-webpack-code': {
                 files: ['src/**/*.html', 'src/manifest.json'],
-                tasks: ['copy:code', 'drop:dev', 'drop:unified-dev'],
+                tasks: ['copy:code', 'drop:dev', 'drop:dev-mv3', 'drop:unified-dev'],
             },
             scss: {
                 files: ['src/**/*.scss'],
-                tasks: ['sass', 'copy:styles', 'drop:dev', 'drop:unified-dev'],
+                tasks: ['sass', 'copy:styles', 'drop:dev', 'drop:dev-mv3', 'drop:unified-dev'],
             },
             // We assume webpack --watch is running separately (usually via 'yarn watch')
             'webpack-dev-output': {
                 files: ['extension/devBundle/**/*.*'],
                 tasks: ['drop:dev'],
+            },
+            // We assume webpack --watch is running separately (usually via 'yarn watch')
+            'webpack-dev-mv3-output': {
+                files: ['extension/devBundle/**/*.*'],
+                tasks: ['drop:dev-mv3'],
             },
             'webpack-unified-output': {
                 files: ['extension/unifiedBundle/**/*.*'],
@@ -442,6 +453,7 @@ module.exports = function (grunt) {
         merge(manifestJSON, {
             name: config.options.fullName,
             description: config.options.extensionDescription,
+            manifest_version: config.options.manifestVersion,
             icons: {
                 16: config.options.icon16,
                 48: config.options.icon48,
@@ -721,6 +733,13 @@ module.exports = function (grunt) {
         'exec:webpack-dev',
         'build-assets',
         'drop:dev',
+    ]);
+    grunt.registerTask('build-dev-mv3', [
+        'clean:intermediates',
+        'exec:generate-scss-typings',
+        'exec:webpack-dev-mv3',
+        'build-assets',
+        'drop:dev-mv3',
     ]);
     grunt.registerTask('build-prod', [
         'clean:intermediates',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -447,7 +447,7 @@ module.exports = function (grunt) {
                 48: config.options.icon48,
                 128: config.options.icon128,
             },
-            browser_action: {
+            action: {
                 default_icon: {
                     20: config.options.icon16,
                     40: config.options.icon48,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -450,6 +450,8 @@ module.exports = function (grunt) {
     grunt.registerMultiTask('manifest', function () {
         const { config, manifestSrc, manifestDest } = this.data;
         const manifestJSON = grunt.file.readJSON(manifestSrc);
+
+        // Build-specific settings that exist in both MV2 and MV3
         merge(manifestJSON, {
             name: config.options.fullName,
             description: config.options.extensionDescription,
@@ -462,6 +464,7 @@ module.exports = function (grunt) {
         });
 
         if (config.options.manifestVersion === 3) {
+            // Settings that are specific to MV3
             merge(manifestJSON, {
                 action: {
                     default_icon: {
@@ -475,9 +478,9 @@ module.exports = function (grunt) {
                 host_permissions: [],
             });
         } else {
-            // Note: We're intentionally keeping the V3 manifest file small for now. As items
-            // are identified as being common to V2 and V3, please move them from this method
-            // into manifest.json
+            // Settings that are specific to MV2. Note that many of these settings--especially the
+            // commands--will eventually be restored to manifest.json. They are here only because
+            // we want to vet each settings as we convert from MV2 to MV3.
             merge(manifestJSON, {
                 browser_action: {
                     default_popup: 'popup/popup.html',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,7 +53,7 @@ module.exports = function (grunt) {
         concurrent: {
             'webpack-all': [
                 'exec:webpack-dev',
-                'exed:webpack;dev-mv3',
+                'exec:webpack-dev-mv3',
                 'exec:webpack-unified',
                 'exec:webpack-prod',
             ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,7 +227,7 @@ module.exports = function (grunt) {
             },
             // We assume webpack --watch is running separately (usually via 'yarn watch')
             'webpack-dev-mv3-output': {
-                files: ['extension/devBundle/**/*.*'],
+                files: ['extension/devMv3Bundle/**/*.*'],
                 tasks: ['drop:dev-mv3'],
             },
             'webpack-unified-output': {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -459,13 +459,100 @@ module.exports = function (grunt) {
                 48: config.options.icon48,
                 128: config.options.icon128,
             },
-            action: {
-                default_icon: {
-                    20: config.options.icon16,
-                    40: config.options.icon48,
-                },
-            },
         });
+
+        if (config.options.manifestVersion === 3) {
+            merge(manifestJSON, {
+                action: {
+                    default_icon: {
+                        20: config.options.icon16,
+                        40: config.options.icon48,
+                    },
+                },
+                background: {
+                    service_worker: 'bundle/serviceWorker.bundle.js',
+                },
+                host_permissions: [],
+            });
+        } else {
+            // Note: We're intentionally keeping the V3 manifest file small for now. As items
+            // are identified as being common to V2 and V3, please move them from this method
+            // into manifest.json
+            merge(manifestJSON, {
+                browser_action: {
+                    default_popup: 'popup/popup.html',
+                    default_icon: {
+                        20: config.options.icon16,
+                        40: config.options.icon48,
+                    },
+                },
+                background: {
+                    page: 'background/background.html',
+                    persistent: true,
+                },
+                web_accessible_resources: [
+                    'insights.html',
+                    'assessments/*',
+                    'injected/*',
+                    'background/*',
+                    'common/*',
+                    'DetailsView/*',
+                    'bundle/*',
+                    'NOTICE.html',
+                ],
+                content_security_policy:
+                    "script-src 'self' 'unsafe-eval' https://az416426.vo.msecnd.net; object-src 'self'",
+                optional_permissions: ['*://*/*'],
+                commands: {
+                    _execute_browser_action: {
+                        suggested_key: {
+                            windows: 'Alt+Shift+K',
+                            mac: 'Alt+Shift+K',
+                            chromeos: 'Alt+Shift+K',
+                            linux: 'Alt+Shift+K',
+                        },
+                        description: 'Activate the extension',
+                    },
+                    '01_toggle-issues': {
+                        suggested_key: {
+                            windows: 'Alt+Shift+1',
+                            mac: 'Alt+Shift+1',
+                            chromeos: 'Alt+Shift+1',
+                            linux: 'Alt+Shift+1',
+                        },
+                        description: 'Toggle Automated checks',
+                    },
+                    '02_toggle-landmarks': {
+                        suggested_key: {
+                            windows: 'Alt+Shift+2',
+                            mac: 'Alt+Shift+2',
+                            chromeos: 'Alt+Shift+2',
+                            linux: 'Alt+Shift+2',
+                        },
+                        description: 'Toggle Landmarks',
+                    },
+                    '03_toggle-headings': {
+                        suggested_key: {
+                            windows: 'Alt+Shift+3',
+                            mac: 'Alt+Shift+3',
+                            chromeos: 'Alt+Shift+3',
+                            linux: 'Alt+Shift+3',
+                        },
+                        description: 'Toggle Headings',
+                    },
+                    '04_toggle-tabStops': {
+                        description: 'Toggle Tab stops',
+                    },
+                    '05_toggle-color': {
+                        description: 'Toggle Color',
+                    },
+                    '06_toggle-needsReview': {
+                        description: 'Toggle Needs review',
+                    },
+                },
+            });
+        }
+
         grunt.file.write(manifestDest, JSON.stringify(manifestJSON, undefined, 2));
     });
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "build": "grunt",
         "build:all": "grunt build-all",
         "build:dev": "grunt build-dev",
+        "build:dev:mv3": "grunt build-dev-mv3",
         "build:mock-adb": "grunt exec:pkg-mock-adb",
         "build:unified": "grunt build-unified",
         "build:unified:all": "grunt build-unified-all",

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const state = {
+    count: 0,
+    interval: 0,
+};
+
+chrome.action.onClicked.addListener(onClicked);
+chrome.runtime.onInstalled.addListener(onInstalled);
+
+function onInstalled() {
+    state.interval = Math.ceil(5 * Math.random());
+    console.log(`interval = ${state.interval}`);
+}
+
+function onClicked() {
+    console.log(`count = ${state.count}`);
+    state.count += state.interval;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,6 @@
     "version": "1.0.4",
     "manifest_version": 3,
     "host_permissions": [],
-    "action": {},
     "icons": {
         "16": "icons/brand/blue/brand-blue-16px.png",
         "48": "icons/brand/blue/brand-blue-48px.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,15 +3,10 @@
     "author": "Microsoft Corporation",
     "description": "Accessibility Insights for Web helps developers quickly find and fix accessibility issues.",
     "version": "1.0.4",
-    "manifest_version": 3,
-    "host_permissions": [],
     "icons": {
         "16": "icons/brand/blue/brand-blue-16px.png",
         "48": "icons/brand/blue/brand-blue-48px.png",
         "128": "icons/brand/blue/brand-blue-128px.png"
-    },
-    "background": {
-        "service_worker": "bundle/serviceWorker.bundle.js"
     },
     "devtools_page": "Devtools/devtools.html",
     "permissions": ["storage", "webNavigation", "tabs", "notifications", "activeTab"]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "Accessibility Insights for Web (feature version)",
+    "name": "Accessibility Insights for Web",
     "author": "Microsoft Corporation",
     "description": "Accessibility Insights for Web helps developers quickly find and fix accessibility issues.",
     "version": "1.0.4",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,84 +1,19 @@
 {
-    "manifest_version": 2,
-    "name": "Accessibility Insights for Web",
+    "name": "Accessibility Insights for Web (feature version)",
     "author": "Microsoft Corporation",
     "description": "Accessibility Insights for Web helps developers quickly find and fix accessibility issues.",
     "version": "1.0.4",
-    "browser_action": {
-        "default_popup": "popup/popup.html",
-        "default_icon": {
-            "20": "icons/brand/blue/brand-blue-16px.png",
-            "40": "icons/brand/blue/brand-blue-48px.png"
-        }
-    },
+    "manifest_version": 3,
+    "host_permissions": [],
+    "action": {},
     "icons": {
         "16": "icons/brand/blue/brand-blue-16px.png",
         "48": "icons/brand/blue/brand-blue-48px.png",
         "128": "icons/brand/blue/brand-blue-128px.png"
     },
-    "content_security_policy": "script-src 'self' 'unsafe-eval' https://az416426.vo.msecnd.net; object-src 'self'",
     "background": {
-        "page": "background/background.html",
-        "persistent": true
+        "service_worker": "bundle/serviceWorker.bundle.js"
     },
     "devtools_page": "Devtools/devtools.html",
-    "web_accessible_resources": [
-        "insights.html",
-        "assessments/*",
-        "injected/*",
-        "background/*",
-        "common/*",
-        "DetailsView/*",
-        "bundle/*",
-        "NOTICE.html"
-    ],
-    "permissions": ["storage", "webNavigation", "tabs", "notifications", "activeTab"],
-    "optional_permissions": ["*://*/*"],
-    "commands": {
-        "_execute_browser_action": {
-            "suggested_key": {
-                "windows": "Alt+Shift+K",
-                "mac": "Alt+Shift+K",
-                "chromeos": "Alt+Shift+K",
-                "linux": "Alt+Shift+K"
-            },
-            "description": "Activate the extension"
-        },
-        "01_toggle-issues": {
-            "suggested_key": {
-                "windows": "Alt+Shift+1",
-                "mac": "Alt+Shift+1",
-                "chromeos": "Alt+Shift+1",
-                "linux": "Alt+Shift+1"
-            },
-            "description": "Toggle Automated checks"
-        },
-        "02_toggle-landmarks": {
-            "suggested_key": {
-                "windows": "Alt+Shift+2",
-                "mac": "Alt+Shift+2",
-                "chromeos": "Alt+Shift+2",
-                "linux": "Alt+Shift+2"
-            },
-            "description": "Toggle Landmarks"
-        },
-        "03_toggle-headings": {
-            "suggested_key": {
-                "windows": "Alt+Shift+3",
-                "mac": "Alt+Shift+3",
-                "chromeos": "Alt+Shift+3",
-                "linux": "Alt+Shift+3"
-            },
-            "description": "Toggle Headings"
-        },
-        "04_toggle-tabStops": {
-            "description": "Toggle Tab stops"
-        },
-        "05_toggle-color": {
-            "description": "Toggle Color"
-        },
-        "06_toggle-needsReview": {
-            "description": "Toggle Needs review"
-        }
-    }
+    "permissions": ["storage", "webNavigation", "tabs", "notifications", "activeTab"]
 }

--- a/targets.config.js
+++ b/targets.config.js
@@ -39,8 +39,22 @@ module.exports = {
             options: {
                 ...commonExtensionOptions,
                 ...icons.dev,
+                manifestVersion: 2,
                 fullName: 'Accessibility Insights for Web - Dev',
                 telemetryBuildName: 'Dev',
+            },
+        },
+        bundleFolder: 'devBundle',
+        mustExistFile: 'background.bundle.js',
+    },
+    'dev-mv3': {
+        config: {
+            options: {
+                ...commonExtensionOptions,
+                ...icons.dev,
+                manifestVersion: 3,
+                fullName: 'Accessibility Insights for Web - Dev (Manifest 3)',
+                telemetryBuildName: 'DevMV3',
             },
         },
         bundleFolder: 'devBundle',

--- a/targets.config.js
+++ b/targets.config.js
@@ -25,6 +25,7 @@ const commonExtensionOptions = {
         'Accessibility Insights for Web helps developers quickly find and fix accessibility issues.',
     bundled: true,
     productCategory: 'extension',
+    manifestVersion: 2, // Will get overwritten for MV3 configs
 };
 
 const commonUnifiedOptions = {
@@ -39,7 +40,6 @@ module.exports = {
             options: {
                 ...commonExtensionOptions,
                 ...icons.dev,
-                manifestVersion: 2,
                 fullName: 'Accessibility Insights for Web - Dev',
                 telemetryBuildName: 'Dev',
             },

--- a/targets.config.js
+++ b/targets.config.js
@@ -57,8 +57,8 @@ module.exports = {
                 telemetryBuildName: 'DevMV3',
             },
         },
-        bundleFolder: 'devBundle',
-        mustExistFile: 'background.bundle.js',
+        bundleFolder: 'devMv3Bundle',
+        mustExistFile: 'serviceWorker.bundle.js',
     },
     playground: {
         release: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "target": "es2020",
         "module": "es2020",
-        "lib": ["es2020", "dom", "scripthost"],
+        "lib": ["es2020", "dom", "scripthost", "webworker"],
         "outDir": "./dist/",
         "rootDir": "./",
         "baseUrl": "./src",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -175,6 +175,25 @@ const devConfig = {
     },
 };
 
+const devMv3Config = {
+    ...commonConfig,
+    entry: {
+        ...commonEntryFiles,
+        detailsView: [...reactDevtoolsEntryFiles, ...commonEntryFiles.detailsView],
+        popup: [...reactDevtoolsEntryFiles, ...commonEntryFiles.popup],
+    },
+    name: 'dev-mv3',
+    mode: 'development',
+    devtool: 'inline-cheap-source-map',
+    output: {
+        path: path.join(__dirname, 'extension/devBundle'),
+        filename: '[name].bundle.js',
+    },
+    optimization: {
+        splitChunks: false,
+    },
+};
+
 const prodConfig = {
     ...commonConfig,
     name: 'prod',
@@ -246,4 +265,11 @@ const packageUIConfig = {
 };
 
 // For just one config, use "webpack --config-name dev", "webpack --config-name prod", etc
-module.exports = [devConfig, prodConfig, unifiedConfig, packageReportConfig, packageUIConfig];
+module.exports = [
+    devConfig,
+    devMv3Config,
+    prodConfig,
+    unifiedConfig,
+    packageReportConfig,
+    packageUIConfig,
+];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -165,7 +165,7 @@ const devConfig = {
     },
     name: 'dev',
     mode: 'development',
-    devtool: 'inline-cheap-source-map',
+    devtool: 'eval-source-map',
     output: {
         path: path.join(__dirname, 'extension/devBundle'),
         filename: '[name].bundle.js',
@@ -186,7 +186,7 @@ const devMv3Config = {
     mode: 'development',
     devtool: 'inline-cheap-source-map',
     output: {
-        path: path.join(__dirname, 'extension/devBundle'),
+        path: path.join(__dirname, 'extension/devMv3Bundle'),
         filename: '[name].bundle.js',
     },
     optimization: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -165,7 +165,7 @@ const devConfig = {
     },
     name: 'dev',
     mode: 'development',
-    devtool: 'inline-cheap-source-map',
+    devtool: 'eval-source-map',
     output: {
         path: path.join(__dirname, 'extension/devBundle'),
         filename: '[name].bundle.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ const commonEntryFiles = {
     detailsView: [path.resolve(__dirname, 'src/DetailsView/details-view-initializer.ts')],
     devtools: [path.resolve(__dirname, 'src/Devtools/dev-tool-init.ts')],
     background: [path.resolve(__dirname, 'src/background/background-init.ts')],
+    serviceWorker: [path.resolve(__dirname, 'src/background/service-worker-init.ts')],
     debugTools: path.resolve(__dirname, 'src/debug-tools/initializer/debug-tools-init.tsx'),
 };
 
@@ -164,7 +165,7 @@ const devConfig = {
     },
     name: 'dev',
     mode: 'development',
-    devtool: 'eval-source-map',
+    devtool: 'inline-cheap-source-map',
     output: {
         path: path.join(__dirname, 'extension/devBundle'),
         filename: '[name].bundle.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -184,7 +184,7 @@ const devMv3Config = {
     },
     name: 'dev-mv3',
     mode: 'development',
-    devtool: 'inline-cheap-source-map',
+    devtool: 'inline-source-map',
     output: {
         path: path.join(__dirname, 'extension/devMv3Bundle'),
         filename: '[name].bundle.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -165,7 +165,7 @@ const devConfig = {
     },
     name: 'dev',
     mode: 'development',
-    devtool: 'eval-source-map',
+    devtool: 'inline-cheap-source-map',
     output: {
         path: path.join(__dirname, 'extension/devBundle'),
         filename: '[name].bundle.js',


### PR DESCRIPTION
#### Details

This PR updates the build system to create both a `dev` and a `dev-mv3` build. The `dev-mv3` build will eventually replace the `dev` build, but only after we complete the work needed to migrate from manifest version 2 (MV2) to manifest version 3 (MV3). Since the Chrome team chose to change the schema between MV2 and MV3, some extra work is needed to create a version-specific manifest.json file. MV3 doesn't support `eval`, so we had to change the webpack's [devtool](https://webpack.js.org/configuration/devtool/) option from `eval-source-map` to an option that doesn't use `eval`. I experimented with both `inline-cheap-source-map` and `inline-source-map`, which is slightly faster. I opted for the slower option because the difference was only about 5 seconds per build.

The `dev-mv3` build doesn't scan--it's only action when you click the button is to log some data to the service worker's console. Future changes will work on migrating the current background worker to the service worker.

Finally, the MV3 manifest file intentionally minimal. We'll need to vet the settings as we port the current background page over, and this makes it easy to keep track of what still needs to be vetted.

##### Motivation

Feature to allow us to keep running after MV2 support is turned off.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1906550](https://mseng.visualstudio.com/1ES/_workitems/edit/1906550) and [1906551](https://mseng.visualstudio.com/1ES/_workitems/edit/1906551)
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
