### PR TITLE
feat(tabstops-report): Fix logic for when to show export button

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -208,8 +208,8 @@ export class DetailsViewCommandBar extends React.Component<
         const shouldShowReportExportButtonProps: ShouldShowReportExportButtonProps = {
             visualizationConfigurationFactory: this.props.visualizationConfigurationFactory,
             selectedTest: this.props.selectedTest,
-            visualizationStoreData: this.props.visualizationStoreData,
             featureFlagStoreData: this.props.featureFlagStoreData,
+            tabStoreData: this.props.tabStoreData,
         };
 
         const showButton = this.props.switcherNavConfiguration.shouldShowReportExportButton(

--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -77,8 +77,8 @@ export function getReportExportDialogForFastPass(
     const shouldShowReportExportButtonProps: ShouldShowReportExportButtonProps = {
         visualizationConfigurationFactory: props.visualizationConfigurationFactory,
         selectedTest: props.selectedTest,
-        visualizationStoreData: props.visualizationStoreData,
         featureFlagStoreData: props.featureFlagStoreData,
+        tabStoreData: props.tabStoreData,
     };
 
     if (

--- a/src/DetailsView/components/should-show-report-export-button.ts
+++ b/src/DetailsView/components/should-show-report-export-button.ts
@@ -23,5 +23,8 @@ export function shouldShowReportExportButtonForFastpass(
     props: ShouldShowReportExportButtonProps,
 ): boolean {
     const config = props.visualizationConfigurationFactory.getConfiguration(props.selectedTest);
-    return config.shouldShowExportReport(props.tabStoreData, props.featureFlagStoreData);
+    const isTargetPageChangedViewVisible = props.tabStoreData.isChanged;
+    return (
+        config.shouldShowExportReport(props.featureFlagStoreData) && !isTargetPageChangedViewVisible
+    );
 }

--- a/src/DetailsView/components/should-show-report-export-button.ts
+++ b/src/DetailsView/components/should-show-report-export-button.ts
@@ -25,9 +25,6 @@ export function shouldShowReportExportButtonForFastpass(
     props: ShouldShowReportExportButtonProps,
 ): boolean {
     const config = props.visualizationConfigurationFactory.getConfiguration(props.selectedTest);
-    const shouldShow = config.shouldShowExportReport(props.featureFlagStoreData);
-
     const scanData = config.getStoreData(props.visualizationStoreData.tests);
-    const isEnabled = config.getTestStatus(scanData);
-    return shouldShow || isEnabled;
+    return config.shouldShowExportReport(scanData, props.featureFlagStoreData);
 }

--- a/src/DetailsView/components/should-show-report-export-button.ts
+++ b/src/DetailsView/components/should-show-report-export-button.ts
@@ -3,21 +3,19 @@
 
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 
 export interface ShouldShowReportExportButtonProps {
     visualizationConfigurationFactory: VisualizationConfigurationFactory;
     selectedTest: VisualizationType;
-    visualizationStoreData: VisualizationStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
+    tabStoreData: TabStoreData;
 }
 
 export type ShouldShowReportExportButton = (props: ShouldShowReportExportButtonProps) => boolean;
 
-export function shouldShowReportExportButtonForAssessment(
-    props: ShouldShowReportExportButtonProps,
-): boolean {
+export function shouldShowReportExportButtonForAssessment(): boolean {
     return true;
 }
 
@@ -25,6 +23,5 @@ export function shouldShowReportExportButtonForFastpass(
     props: ShouldShowReportExportButtonProps,
 ): boolean {
     const config = props.visualizationConfigurationFactory.getConfiguration(props.selectedTest);
-    const scanData = config.getStoreData(props.visualizationStoreData.tests);
-    return config.shouldShowExportReport(scanData, props.featureFlagStoreData);
+    return config.shouldShowExportReport(props.tabStoreData, props.featureFlagStoreData);
 }

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -5,7 +5,6 @@ import { NewTabLink } from 'common/components/new-tab-link';
 import { AdHocTestkeys } from 'common/configs/adhoc-test-keys';
 import { TestMode } from 'common/configs/test-mode';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
-import { FeatureFlags } from 'common/feature-flags';
 import { Messages } from 'common/messages';
 import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -35,8 +34,7 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     enableTest: data => (data.adhoc[issuesTestKey].enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: featureflagStoreData =>
-        featureflagStoreData[FeatureFlags.newTabStopsDetailsView],
+    shouldShowExportReport: scanData => scanData.enabled,
     displayableData: {
         title: 'Automated checks',
         subtitle: (

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -34,7 +34,7 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     enableTest: data => (data.adhoc[issuesTestKey].enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: scanData => scanData.enabled,
+    shouldShowExportReport: tabStoreData => !tabStoreData.isChanged,
     displayableData: {
         title: 'Automated checks',
         subtitle: (

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -34,7 +34,7 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     enableTest: data => (data.adhoc[issuesTestKey].enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: tabStoreData => !tabStoreData.isChanged,
+    shouldShowExportReport: () => true,
     displayableData: {
         title: 'Automated checks',
         subtitle: (

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -35,8 +35,8 @@ export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     enableTest: (data, _) => (data.adhoc[tabStopsTestKey].enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: (tabStoreData, featureflagStoreData) =>
-        !tabStoreData.isChanged && featureflagStoreData[FeatureFlags.newTabStopsDetailsView],
+    shouldShowExportReport: featureflagStoreData =>
+        featureflagStoreData[FeatureFlags.newTabStopsDetailsView],
     displayableData: {
         title: 'Tab stops',
         enableMessage: 'Start pressing Tab to start visualizing tab stops.',

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -35,7 +35,7 @@ export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     enableTest: (data, _) => (data.adhoc[tabStopsTestKey].enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: featureflagStoreData =>
+    shouldShowExportReport: (scanData, featureflagStoreData) =>
         featureflagStoreData[FeatureFlags.newTabStopsDetailsView],
     displayableData: {
         title: 'Tab stops',

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -35,8 +35,8 @@ export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     enableTest: (data, _) => (data.adhoc[tabStopsTestKey].enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
-    shouldShowExportReport: (scanData, featureflagStoreData) =>
-        featureflagStoreData[FeatureFlags.newTabStopsDetailsView],
+    shouldShowExportReport: (tabStoreData, featureflagStoreData) =>
+        !tabStoreData.isChanged && featureflagStoreData[FeatureFlags.newTabStopsDetailsView],
     displayableData: {
         title: 'Tab stops',
         enableMessage: 'Start pressing Tab to start visualizing tab stops.',

--- a/src/common/configs/visualization-configuration.ts
+++ b/src/common/configs/visualization-configuration.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { ContentPageComponent } from 'views/content/content-page';
 import { DictionaryStringTo } from '../../types/common-types';
 import { DisplayableVisualizationTypeData } from '../types/displayable-visualization-type-data';
@@ -28,7 +29,7 @@ export interface VisualizationConfiguration extends AssessmentVisualizationConfi
     analyzerTerminatedMessageType?: string;
     guidance?: ContentPageComponent;
     shouldShowExportReport: (
-        scanData?: ScanData,
+        tabStoreData?: TabStoreData,
         featureFlagStoreData?: FeatureFlagStoreData,
     ) => boolean;
 }

--- a/src/common/configs/visualization-configuration.ts
+++ b/src/common/configs/visualization-configuration.ts
@@ -27,5 +27,8 @@ export interface VisualizationConfiguration extends AssessmentVisualizationConfi
     analyzerProgressMessageType?: string;
     analyzerTerminatedMessageType?: string;
     guidance?: ContentPageComponent;
-    shouldShowExportReport: (featureFlagStoreData: FeatureFlagStoreData) => boolean;
+    shouldShowExportReport: (
+        scanData?: ScanData,
+        featureFlagStoreData?: FeatureFlagStoreData,
+    ) => boolean;
 }

--- a/src/common/configs/visualization-configuration.ts
+++ b/src/common/configs/visualization-configuration.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { ContentPageComponent } from 'views/content/content-page';
 import { DictionaryStringTo } from '../../types/common-types';
 import { DisplayableVisualizationTypeData } from '../types/displayable-visualization-type-data';
@@ -28,8 +27,5 @@ export interface VisualizationConfiguration extends AssessmentVisualizationConfi
     analyzerProgressMessageType?: string;
     analyzerTerminatedMessageType?: string;
     guidance?: ContentPageComponent;
-    shouldShowExportReport: (
-        tabStoreData?: TabStoreData,
-        featureFlagStoreData?: FeatureFlagStoreData,
-    ) => boolean;
+    shouldShowExportReport: (featureFlagStoreData?: FeatureFlagStoreData) => boolean;
 }

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -105,8 +105,8 @@ describe('ReportExportDialogFactory', () => {
         shouldShowReportExportButtonProps = {
             visualizationConfigurationFactory: props.visualizationConfigurationFactory,
             selectedTest: props.selectedTest,
-            visualizationStoreData: props.visualizationStoreData,
             featureFlagStoreData: props.featureFlagStoreData,
+            tabStoreData: props.tabStoreData,
         } as ShouldShowReportExportButtonProps;
     });
 

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -61,7 +61,7 @@ describe('ShouldShowReportExportButton', () => {
             .returns(() => scanData);
         visualizationConfigurationMock.setup(m => m.getTestStatus(scanData)).returns(() => enabled);
         visualizationConfigurationMock
-            .setup(m => m.shouldShowExportReport(featureFlagStoreData))
+            .setup(m => m.shouldShowExportReport(scanData, featureFlagStoreData))
             .returns(() => shouldShow);
     }
 

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -3,13 +3,11 @@
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
-import { ScanData, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
-import {
-    CommandBarProps,
-    DetailsViewCommandBarProps,
-} from 'DetailsView/components/details-view-command-bar';
+import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import {
     shouldShowReportExportButtonForAssessment,
     shouldShowReportExportButtonForFastpass,
@@ -23,7 +21,7 @@ describe('ShouldShowReportExportButton', () => {
     const visualizationStoreData = { tests: {} } as VisualizationStoreData;
     const unifiedScanResultStoreData = {} as UnifiedScanResultStoreData;
     const featureFlagStoreData = {} as FeatureFlagStoreData;
-    const scanData = {} as ScanData;
+    const tabStoreData = {} as TabStoreData;
     const selectedTest = -1 as VisualizationType;
 
     beforeEach(() => {
@@ -42,7 +40,7 @@ describe('ShouldShowReportExportButton', () => {
             featureFlagStoreData: featureFlagStoreData,
             selectedTest: selectedTest,
             deps: null,
-            tabStoreData: null,
+            tabStoreData: tabStoreData,
             assessmentStoreData: null,
             assessmentsProvider: null,
             rightPanelConfiguration: null,
@@ -55,20 +53,15 @@ describe('ShouldShowReportExportButton', () => {
         } as DetailsViewCommandBarProps;
     }
 
-    function setupVisualizationConfigurationMock(shouldShow: boolean, enabled?: boolean): void {
+    function setupVisualizationConfigurationMock(shouldShow: boolean): void {
         visualizationConfigurationMock
-            .setup(m => m.getStoreData(visualizationStoreData.tests))
-            .returns(() => scanData);
-        visualizationConfigurationMock.setup(m => m.getTestStatus(scanData)).returns(() => enabled);
-        visualizationConfigurationMock
-            .setup(m => m.shouldShowExportReport(scanData, featureFlagStoreData))
+            .setup(m => m.shouldShowExportReport(tabStoreData, featureFlagStoreData))
             .returns(() => shouldShow);
     }
 
     describe('shouldShowReportExportButtonForAssessment', () => {
-        test('returns true', () => {
-            const props = {} as CommandBarProps;
-            const shouldShowButton = shouldShowReportExportButtonForAssessment(props);
+        test('shouldShowReportExportButtonForAssessment returns true', () => {
+            const shouldShowButton = shouldShowReportExportButtonForAssessment();
             expect(shouldShowButton).toBe(true);
         });
     });

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -17,11 +17,12 @@ import { IMock, Mock } from 'typemoq';
 describe('ShouldShowReportExportButton', () => {
     let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
     let visualizationConfigurationMock: IMock<VisualizationConfiguration>;
+    let tabStoreData: TabStoreData;
 
     const visualizationStoreData = { tests: {} } as VisualizationStoreData;
     const unifiedScanResultStoreData = {} as UnifiedScanResultStoreData;
     const featureFlagStoreData = {} as FeatureFlagStoreData;
-    const tabStoreData = {} as TabStoreData;
+
     const selectedTest = -1 as VisualizationType;
 
     beforeEach(() => {
@@ -30,6 +31,7 @@ describe('ShouldShowReportExportButton', () => {
         visualizationConfigurationFactoryMock
             .setup(m => m.getConfiguration(selectedTest))
             .returns(() => visualizationConfigurationMock.object);
+        tabStoreData = { isChanged: false } as TabStoreData;
     });
 
     function getProps(): DetailsViewCommandBarProps {
@@ -55,7 +57,7 @@ describe('ShouldShowReportExportButton', () => {
 
     function setupVisualizationConfigurationMock(shouldShow: boolean): void {
         visualizationConfigurationMock
-            .setup(m => m.shouldShowExportReport(tabStoreData, featureFlagStoreData))
+            .setup(m => m.shouldShowExportReport(featureFlagStoreData))
             .returns(() => shouldShow);
     }
 
@@ -67,11 +69,26 @@ describe('ShouldShowReportExportButton', () => {
     });
 
     describe('shouldShowReportExportButtonForFastpass', () => {
-        test('returns true if shouldShow is true, ', () => {
+        test('returns true if shouldShow is true and target page changed is false, ', () => {
             setupVisualizationConfigurationMock(true);
             const props = getProps();
             const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
             expect(shouldShowButton).toBe(true);
+        });
+
+        test('returns false if shouldShow is true and target page changed is true', () => {
+            setupVisualizationConfigurationMock(true);
+            const props = getProps();
+            props.tabStoreData.isChanged = true;
+            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
+            expect(shouldShowButton).toBe(false);
+        });
+
+        test('returns false if shouldShow is false', () => {
+            setupVisualizationConfigurationMock(false);
+            const props = getProps();
+            const shouldShowButton = shouldShowReportExportButtonForFastpass(props);
+            expect(shouldShowButton).toBe(false);
         });
     });
 });


### PR DESCRIPTION
#### Details

This adjusts the logic for when the export report button shows. Here are the before and after scenarios for when it shows in each test:
1. Automated Checks
- Before: Shows whenever visualization is enabled.
- After: Shows whenever target page changed view is not visible, which equates to whenever the visualization is enabled with the new navigation flow.
2.  Tab Stops:
- Before: Always shows
- After: Shows whenever target page changed view is not visible.
3. Needs Review: 
- Before: incorrectly shows when test is enabled.
- After: Never shows.

##### Motivation

feature work

##### Context

This passes in `featureFlagStoreData` as a second parameter. The `featureFlagStoreData` parameter will be removed before release, at which point `shouldShowExportReport` in `tab-stops/visualization.tsx` will also need to be updated to exclude it.

I had initially used the existing scanData.isEnabled to make this change but realized that the tab stops test is not enabled by default. Rather than have the tab stops view always display the export button, I realized that the only time we don't want the export to show in Automated Checks and Tab Stops is when the target page changed view is visible and no test has been started over. Due to this, it made sense to pass in the tabStoreData instead, as it captures the desired result in both Automated Checks and Tab Stops.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
