### PR TITLE
chore: disable PR trigger for ADO CI build

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,14 +1,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-trigger: # trigger only affects CI builds
+
+# Note that this Azure DevOps pipeline is largely redundant with /.github/workflows/ci.yml, which
+# is what we use instead for validation builds of pull requests. This CI build only runs against
+# pushes to main, not PRs; it exists in tandem with the GitHub Actions CI build because it
+# integrates better with our ADO-based release process.
+
+trigger:
     branches:
         include:
             - main
-
-pr: # pr does not trigger CI builds
-    branches:
-        include:
-            - '*' # must quote since "*" is a YAML reserved character; we want a string
 
 variables:
     windowsImage: 'windows-2019'


### PR DESCRIPTION
#### Details

This PR disables the PR trigger for our ADO CI build in favor of running just the GitHub Actions CI build in PRs, per engineering discussion earlier today. I've left the ADO build in place to run with pushes to main, since that's what our release infrastructure uses as its starting point.

Note that it's expected that the ADO build is still being triggered for this PR itself; ADO's determines which pipelines to trigger based on the pipeline's definition in main, not the one in the target branch.

I have already updated the repo's branch protection rules to start requiring the GitHub Actions and stop requiring the ADO build (you can see this in the checks for this PR).

##### Motivation

Per engineering discussion

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
