### PR TITLE
feat(tabstops-report): add results data to outcome summary bar

### DIFF
--- a/src/reports/components/fast-pass-report-summary.tsx
+++ b/src/reports/components/fast-pass-report-summary.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import { requirements } from 'DetailsView/components/tab-stops/requirements';
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import * as React from 'react';
@@ -49,12 +50,20 @@ export class FastPassReportSummary extends React.Component<FastPassReportSummary
         const totalIncompleteTabCount: number = incompleteTabResults.length;
         const totalPassedTabCount: number = passedTabResults.length;
 
-        const failedAutomatedChecks = this.props.results.automatedChecks.cards.fail.length;
+        const failedAutomatedChecks = this.props.results.automatedChecks.cards.fail;
+        const getTotalAutomatedChecksFailed = (results: CardRuleResult[]): number => {
+            return results.reduce((total, rule) => {
+                return total + rule.nodes.length;
+            }, 0);
+        };
+
+        const totalfailedAutomatedChecks: number =
+            getTotalAutomatedChecksFailed(failedAutomatedChecks);
         const passedAutomatedChecks = this.props.results.automatedChecks.cards.pass.length;
         const incompleteAutomatedChecks = this.props.results.automatedChecks.cards.unknown.length;
 
         const stats: Partial<OutcomeStats> = {
-            fail: failedAutomatedChecks + totalFailedTabInstancesCount,
+            fail: totalfailedAutomatedChecks + totalFailedTabInstancesCount,
             incomplete: incompleteAutomatedChecks + totalIncompleteTabCount, //incomplete automated checks to be added in 1906107
             pass: passedAutomatedChecks + totalPassedTabCount,
         };

--- a/src/reports/components/fast-pass-report-summary.tsx
+++ b/src/reports/components/fast-pass-report-summary.tsx
@@ -1,12 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { requirements } from 'DetailsView/components/tab-stops/requirements';
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import * as React from 'react';
 import { FastPassReportResultData } from 'reports/components/fast-pass-report';
 import { OutcomeSummaryBar } from 'reports/components/outcome-summary-bar';
 import { OutcomeStats } from 'reports/components/outcome-type';
 import { RequirementOutcomeType } from 'reports/components/requirement-outcome-type';
 
+export type FastPassReportSummaryDeps = {
+    tabStopsFailedCounter: TabStopsFailedCounter;
+};
+
 export interface FastPassReportSummaryProps {
+    deps: FastPassReportSummaryDeps;
     results: FastPassReportResultData;
 }
 
@@ -14,11 +21,66 @@ export const allOutcomeTypes: RequirementOutcomeType[] = ['fail', 'incomplete', 
 
 export class FastPassReportSummary extends React.Component<FastPassReportSummaryProps> {
     public render(): JSX.Element {
+        const tabResults = [];
+
+        for (const [requirementId, data] of Object.entries(this.props.results.tabStops)) {
+            if (data.status !== 'fail') {
+                continue;
+            }
+
+            tabResults.push({
+                id: requirementId,
+                name: requirements[requirementId].name,
+                description: requirements[requirementId].description,
+                instances: data.instances,
+                isExpanded: data.isExpanded,
+            });
+        }
+
+        const totalFailedTabInstancesCount: number =
+            this.props.deps.tabStopsFailedCounter.getTotalFailed(tabResults);
+
+        const passedTabResults = [];
+        for (const [requirementId, data] of Object.entries(this.props.results.tabStops)) {
+            if (data.status !== 'pass') {
+                continue;
+            }
+
+            passedTabResults.push({
+                id: requirementId,
+                name: requirements[requirementId].name,
+                description: requirements[requirementId].description,
+                instances: data.instances,
+                isExpanded: data.isExpanded,
+            });
+        }
+
+        const totalPassedTabCount: number = passedTabResults.length;
+
+        const incompleteTabResults = [];
+        for (const [requirementId, data] of Object.entries(this.props.results.tabStops)) {
+            if (data.status !== 'unknown') {
+                continue;
+            }
+
+            incompleteTabResults.push({
+                id: requirementId,
+                name: requirements[requirementId].name,
+                description: requirements[requirementId].description,
+                instances: data.instances,
+                isExpanded: data.isExpanded,
+            });
+        }
+        const totalIncompleteTabCount: number = incompleteTabResults.length;
+
+        const failedAutomatedChecks = this.props.results.automatedChecks.cards.fail.length;
+        const passedAutomatedChecks = this.props.results.automatedChecks.cards.pass.length;
+        const incompleteAutomatedChecks = this.props.results.automatedChecks.cards.unknown.length;
+
         const stats: Partial<OutcomeStats> = {
-            //hardcoded sample stats, real numbers to be added in #1906951
-            fail: this.props.results.automatedChecks.cards.fail.length,
-            incomplete: this.props.results.automatedChecks.cards.unknown.length,
-            pass: this.props.results.automatedChecks.cards.pass.length,
+            fail: failedAutomatedChecks + totalFailedTabInstancesCount,
+            incomplete: incompleteAutomatedChecks + totalIncompleteTabCount, //incomplete automated checks to be added in 1906107
+            pass: passedAutomatedChecks + totalPassedTabCount,
         };
 
         return (

--- a/src/reports/components/fast-pass-report-summary.tsx
+++ b/src/reports/components/fast-pass-report-summary.tsx
@@ -21,57 +21,33 @@ export const allOutcomeTypes: RequirementOutcomeType[] = ['fail', 'incomplete', 
 
 export class FastPassReportSummary extends React.Component<FastPassReportSummaryProps> {
     public render(): JSX.Element {
-        const tabResults = [];
+        const failedTabResults = [];
+        const incompleteTabResults = [];
+        const passedTabResults = [];
 
         for (const [requirementId, data] of Object.entries(this.props.results.tabStops)) {
-            if (data.status !== 'fail') {
-                continue;
-            }
-
-            tabResults.push({
+            const resultsObject = {
                 id: requirementId,
                 name: requirements[requirementId].name,
                 description: requirements[requirementId].description,
                 instances: data.instances,
                 isExpanded: data.isExpanded,
-            });
+            };
+            if (data.status === 'fail') {
+                failedTabResults.push(resultsObject);
+            }
+            if (data.status === 'pass') {
+                passedTabResults.push(resultsObject);
+            }
+            if (data.status === 'unknown') {
+                incompleteTabResults.push(resultsObject);
+            }
         }
 
         const totalFailedTabInstancesCount: number =
-            this.props.deps.tabStopsFailedCounter.getTotalFailed(tabResults);
-
-        const passedTabResults = [];
-        for (const [requirementId, data] of Object.entries(this.props.results.tabStops)) {
-            if (data.status !== 'pass') {
-                continue;
-            }
-
-            passedTabResults.push({
-                id: requirementId,
-                name: requirements[requirementId].name,
-                description: requirements[requirementId].description,
-                instances: data.instances,
-                isExpanded: data.isExpanded,
-            });
-        }
-
-        const totalPassedTabCount: number = passedTabResults.length;
-
-        const incompleteTabResults = [];
-        for (const [requirementId, data] of Object.entries(this.props.results.tabStops)) {
-            if (data.status !== 'unknown') {
-                continue;
-            }
-
-            incompleteTabResults.push({
-                id: requirementId,
-                name: requirements[requirementId].name,
-                description: requirements[requirementId].description,
-                instances: data.instances,
-                isExpanded: data.isExpanded,
-            });
-        }
+            this.props.deps.tabStopsFailedCounter.getTotalFailed(failedTabResults);
         const totalIncompleteTabCount: number = incompleteTabResults.length;
+        const totalPassedTabCount: number = passedTabResults.length;
 
         const failedAutomatedChecks = this.props.results.automatedChecks.cards.fail.length;
         const passedAutomatedChecks = this.props.results.automatedChecks.cards.pass.length;

--- a/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report-summary.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report-summary.test.tsx.snap
@@ -15,9 +15,9 @@ exports[`FastPassReportSummary renders per the snapshot 1`] = `
     }
     outcomeStats={
       Object {
-        "fail": 1,
+        "fail": NaN,
         "incomplete": 0,
-        "pass": 0,
+        "pass": 1,
       }
     }
   />

--- a/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report-summary.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report-summary.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`FastPassReportSummary renders per the snapshot 1`] = `
     }
     outcomeStats={
       Object {
-        "fail": NaN,
+        "fail": 3,
         "incomplete": 0,
         "pass": 1,
       }

--- a/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
+++ b/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
@@ -8,7 +8,7 @@ import {
     FastPassReportSummaryDeps,
     FastPassReportSummaryProps,
 } from 'reports/components/fast-pass-report-summary';
-import { IMock, Mock } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 import { exampleUnifiedStatusResults } from '../../common/components/cards/sample-view-model-data';
 
 describe('FastPassReportSummary', () => {
@@ -33,10 +33,21 @@ describe('FastPassReportSummary', () => {
                         instances: [{ id: 'test-id-2', description: 'test desc 2' }],
                         isExpanded: false,
                     },
+                    'tab-order': {
+                        status: 'fail',
+                        instances: [{ id: 'test-id-4', description: 'test desc 4' }],
+                        isExpanded: false,
+                    },
                 },
             },
             deps: deps,
         };
+
+        tabStopsFailedCounterMock
+            .setup(tsf => tsf.getTotalFailed(It.isAny()))
+            .returns(() => 2)
+            .verifiable(Times.once());
+
         const rendered = shallow(<FastPassReportSummary {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
+++ b/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
@@ -1,25 +1,41 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
+import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import {
     FastPassReportSummary,
+    FastPassReportSummaryDeps,
     FastPassReportSummaryProps,
 } from 'reports/components/fast-pass-report-summary';
+import { IMock, Mock } from 'typemoq';
 import { exampleUnifiedStatusResults } from '../../common/components/cards/sample-view-model-data';
 
 describe('FastPassReportSummary', () => {
+    let tabStopsFailedCounterMock: IMock<TabStopsFailedCounter>;
+    let props: FastPassReportSummaryProps;
+    let deps: FastPassReportSummaryDeps;
+
     it('renders per the snapshot', () => {
-        const props: FastPassReportSummaryProps = {
+        tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
+        deps = { tabStopsFailedCounter: tabStopsFailedCounterMock.object };
+
+        props = {
             results: {
                 automatedChecks: {
                     cards: exampleUnifiedStatusResults,
                     visualHelperEnabled: true,
                     allCardsCollapsed: true,
                 },
-                tabStops: null,
+                tabStops: {
+                    'keyboard-traps': {
+                        status: 'pass',
+                        instances: [{ id: 'test-id-2', description: 'test desc 2' }],
+                        isExpanded: false,
+                    },
+                },
             },
+            deps: deps,
         };
         const rendered = shallow(<FastPassReportSummary {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();

--- a/src/tests/unit/tests/reports/components/fast-pass-report.test.tsx
+++ b/src/tests/unit/tests/reports/components/fast-pass-report.test.tsx
@@ -61,7 +61,18 @@ describe(FastPassReport, () => {
                     visualHelperEnabled: true,
                     allCardsCollapsed: true,
                 },
-                tabStops: null, // Should be filled in as part of #1897876
+                tabStops: {
+                    'keyboard-traps': {
+                        status: 'pass',
+                        instances: [{ id: 'test-id-2', description: 'test desc 2' }],
+                        isExpanded: false,
+                    },
+                    'tab-order': {
+                        status: 'fail',
+                        instances: [{ id: 'test-id-4', description: 'test desc 4' }],
+                        isExpanded: false,
+                    },
+                },
             },
             userConfigurationStoreData: null,
             targetAppInfo,


### PR DESCRIPTION
#### Details

This PR adds the results data to the `OutcomeSummaryBar` in `FastPassReportSummary`.

##### Motivation

Feature 1872889.

##### Context

Incomplete automated checks data will be added after the completion of 1906107.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
