### PR TITLE
feat(tabstops-auto-impl): Add tab stops requirement evaluator

### DIFF
--- a/src/common/html-element-utils.ts
+++ b/src/common/html-element-utils.ts
@@ -72,4 +72,8 @@ export class HTMLElementUtils {
             elements[i].remove();
         }
     }
+
+    public precedesInDOM(current: HTMLElement, previous: HTMLElement): boolean {
+        return previous.compareDocumentPosition(current) === Node.DOCUMENT_POSITION_PRECEDING;
+    }
 }

--- a/src/injected/tab-stops-requirement-evaluator.ts
+++ b/src/injected/tab-stops-requirement-evaluator.ts
@@ -25,7 +25,7 @@ export interface TabStopsRequirementEvaluator {
         lastTabStop: HTMLElement,
         currentTabStop: HTMLElement,
     ): TabStopRequirementResult;
-    getTabbableFocusOrderResults(tabbableTabStops: HTMLElement[]): TabStopRequirementResult[];
+    getTabbableFocusOrderResults(tabbableTabStops: FocusableElement[]): TabStopRequirementResult[];
     getKeyboardTrapResults(
         oldActiveElement: Element,
         newActiveElement: Element,
@@ -81,13 +81,14 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
     }
 
     public getTabbableFocusOrderResults(
-        tabbableTabStops: HTMLElement[],
+        tabbableTabStops: FocusableElement[],
     ): TabStopRequirementResult[] {
         const requirementResults: TabStopRequirementResult[] = [];
-        tabbableTabStops.forEach((expectedTabStop, index) => {
+        const tabStops = tabbableTabStops as HTMLElement[];
+        tabStops.forEach((expectedTabStop, index) => {
             if (index > 0) {
                 const comparisonResult = this.getFocusOrderResult(
-                    tabbableTabStops[index - 1],
+                    tabStops[index - 1],
                     expectedTabStop,
                 );
                 if (comparisonResult) {

--- a/src/injected/tab-stops-requirement-evaluator.ts
+++ b/src/injected/tab-stops-requirement-evaluator.ts
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { HTMLElementUtils } from 'common/html-element-utils';
+import { getUniqueSelector } from 'scanner/axe-utils';
+import { FocusableElement } from 'tabbable';
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
+
+export type TabStopRequirementResult = {
+    description: string;
+};
+
+export type TabStopRequirementResults = Partial<
+    Record<TabStopRequirementId, TabStopRequirementResult[]>
+>;
+
+export interface TabStopsRequirementEvaluator {
+    getKeyboardNavigationResults(
+        tabbableTabStops: FocusableElement[],
+        actualTabStops: Set<HTMLElement>,
+    ): TabStopRequirementResult[];
+    getFocusOrderResult(
+        lastTabStop: HTMLElement,
+        currentTabStop: HTMLElement,
+    ): TabStopRequirementResult[];
+    getKeyboardTrapResults(
+        oldActiveElement: Element,
+        newActiveElement: Element,
+    ): TabStopRequirementResult[];
+}
+
+export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementEvaluator {
+    public readonly keyboardNavigationDescription: (string) => string = selector =>
+        `Element ${selector} was expected, but not reached in tab order`;
+    public readonly focusOrderDescription: (currSelector: string, lastSelector: string) => string =
+        (currSelector, lastSelector) =>
+            `Element ${currSelector} precedes ${lastSelector} but was visited first in tab order`;
+    public readonly focusTrapsDescription: (string) => string = selector =>
+        `Focus is still on element ${selector} 500ms after pressing tab`;
+
+    constructor(
+        private readonly htmlElementUtils: HTMLElementUtils,
+        private readonly generateSelector: typeof getUniqueSelector,
+    ) {}
+
+    public getKeyboardNavigationResults(
+        tabbableTabStops: FocusableElement[],
+        actualTabStops: Set<HTMLElement>,
+    ): TabStopRequirementResult[] {
+        const requirementResults: TabStopRequirementResult[] = [];
+        (tabbableTabStops as HTMLElement[]).forEach(expectedTabStop => {
+            if (!actualTabStops.has(expectedTabStop)) {
+                const selector = this.generateSelector(expectedTabStop);
+                requirementResults.push({
+                    description: this.keyboardNavigationDescription(selector),
+                });
+            }
+        });
+        return requirementResults;
+    }
+
+    public getFocusOrderResult(
+        lastTabStop: HTMLElement,
+        currentTabStop: HTMLElement,
+    ): TabStopRequirementResult[] {
+        if (this.htmlElementUtils.precedesInDOM(currentTabStop, lastTabStop)) {
+            const lastSelector = this.generateSelector(lastTabStop);
+            const currSelector = this.generateSelector(currentTabStop);
+            return [
+                {
+                    description: this.focusOrderDescription(currSelector, lastSelector),
+                },
+            ];
+        }
+        return [];
+    }
+
+    public getKeyboardTrapResults(
+        oldActiveElement: Element,
+        newActiveElement: Element,
+    ): TabStopRequirementResult[] {
+        if (oldActiveElement === newActiveElement) {
+            const selector = this.generateSelector(oldActiveElement as HTMLElement);
+            return [
+                {
+                    description: this.focusTrapsDescription(selector),
+                },
+            ];
+        }
+        return [];
+    }
+}

--- a/src/tests/unit/tests/common/html-element-utils.test.ts
+++ b/src/tests/unit/tests/common/html-element-utils.test.ts
@@ -243,6 +243,22 @@ describe('HTMLElementUtils', () => {
         expect(containerElement.querySelectorAll('.do-not-delete').length).toBe(1);
     });
 
+    test('precedesInDOM', () => {
+        const containerElement = createElementWithId('container');
+        const element1 = createElementWithClassName('element1') as HTMLElement;
+        const element2 = createElementWithClassName('element2') as HTMLElement;
+        containerElement.appendChild(element1);
+        containerElement.appendChild(element2);
+
+        const utils = new HTMLElementUtils(containerElement as any, null);
+
+        const precedingResult = utils.precedesInDOM(element1, element2);
+        expect(precedingResult).toBe(true);
+
+        const proceedingResult = utils.precedesInDOM(element2, element1);
+        expect(proceedingResult).toBe(false);
+    });
+
     function createElementWithId(id: string): Element {
         const element = document.createElement('p');
         element.id = id;

--- a/src/tests/unit/tests/injected/tab-stops-requirement-evaluator.test.ts
+++ b/src/tests/unit/tests/injected/tab-stops-requirement-evaluator.test.ts
@@ -25,7 +25,7 @@ describe('TabStopsRequirementEvaluator', () => {
         );
     });
 
-    test('addKeyboardNavigationResults', () => {
+    test('addKeyboardNavigationResults returns violations', () => {
         const tabbableTabStops = [
             tabStopElement1 as FocusableElement,
             tabStopElement2 as FocusableElement,
@@ -40,14 +40,20 @@ describe('TabStopsRequirementEvaluator', () => {
                 html: 'html1',
             },
         ]);
+    });
 
+    test('addKeyboardNavigationResults returns empty set with no violations', () => {
+        const tabbableTabStops = [
+            tabStopElement1 as FocusableElement,
+            tabStopElement2 as FocusableElement,
+        ];
         const correctTabStops = new Set<HTMLElement>([tabStopElement1, tabStopElement2]);
         expect(testSubject.getKeyboardNavigationResults(tabbableTabStops, correctTabStops)).toEqual(
             [],
         );
     });
 
-    test('addFocusOrderResults', () => {
+    test('addFocusOrderResults returns violations', () => {
         htmlElementUtilsMock
             .setup(m => m.precedesInDOM(It.isAny(), It.isAny()))
             .returns(() => true);
@@ -56,16 +62,20 @@ describe('TabStopsRequirementEvaluator', () => {
             selector: ['element1'],
             html: 'html1',
         });
+    });
 
+    test('addFocusOrderResults returns null with no violations', () => {
         htmlElementUtilsMock
             .setup(m => m.precedesInDOM(It.isAny(), It.isAny()))
             .returns(() => false);
         expect(testSubject.getFocusOrderResult(tabStopElement1, tabStopElement2)).toEqual(null);
     });
 
-    test('addTabbableFocusOrderResults', () => {
+    test('addTabbableFocusOrderResults returns empty with single tab element', () => {
         expect(testSubject.getTabbableFocusOrderResults([tabStopElement1])).toEqual([]);
+    });
 
+    test('addTabbableFocusOrderResults returns violations', () => {
         htmlElementUtilsMock
             .setup(m => m.precedesInDOM(It.isAny(), It.isAny()))
             .returns(() => true);
@@ -79,7 +89,9 @@ describe('TabStopsRequirementEvaluator', () => {
                 html: 'html1',
             },
         ]);
+    });
 
+    test('addTabbableFocusOrderResults returns empty set with no violations', () => {
         htmlElementUtilsMock
             .setup(m => m.precedesInDOM(It.isAny(), It.isAny()))
             .returns(() => false);
@@ -88,11 +100,13 @@ describe('TabStopsRequirementEvaluator', () => {
         ).toEqual([]);
     });
 
-    test('onKeydownForFocusTraps', async () => {
+    test('onKeydownForFocusTraps returns null with no violations', async () => {
         expect(await testSubject.getKeyboardTrapResults(tabStopElement1, tabStopElement2)).toEqual(
             null,
         );
+    });
 
+    test('onKeydownForFocusTraps returns violations', async () => {
         expect(await testSubject.getKeyboardTrapResults(tabStopElement1, tabStopElement1)).toEqual({
             description: 'Focus is still on element element1 500ms after pressing tab',
             selector: ['element1'],

--- a/src/tests/unit/tests/injected/tab-stops-requirement-evaluator.test.ts
+++ b/src/tests/unit/tests/injected/tab-stops-requirement-evaluator.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { HTMLElementUtils } from 'common/html-element-utils';
+import { DefaultTabStopsRequirementEvaluator } from 'injected/tab-stops-requirement-evaluator';
+import { getUniqueSelector } from 'scanner/axe-utils';
+import { FocusableElement } from 'tabbable';
+import { IMock, It, Mock } from 'typemoq';
+
+describe('TabStopsRequirementEvaluator', () => {
+    let htmlElementUtilsMock: IMock<HTMLElementUtils>;
+    let generateSelectorMock: IMock<typeof getUniqueSelector>;
+    let testSubject: DefaultTabStopsRequirementEvaluator;
+
+    const tabStopElement1: HTMLElement = { tagName: 'element1' } as HTMLElement;
+    const tabStopElement2: HTMLElement = { tagName: 'element2' } as HTMLElement;
+
+    beforeEach(() => {
+        htmlElementUtilsMock = Mock.ofType(HTMLElementUtils);
+        generateSelectorMock = Mock.ofType<typeof getUniqueSelector>();
+        generateSelectorMock.setup(m => m(It.isAny())).returns(element => element.tagName);
+        testSubject = new DefaultTabStopsRequirementEvaluator(
+            htmlElementUtilsMock.object,
+            generateSelectorMock.object,
+        );
+    });
+
+    test('addKeyboardNavigationResults', () => {
+        const tabbableTabStops = [
+            tabStopElement1 as FocusableElement,
+            tabStopElement2 as FocusableElement,
+        ];
+        const incorrectTabStops = new Set<HTMLElement>([tabStopElement2]);
+        expect(
+            testSubject.getKeyboardNavigationResults(tabbableTabStops, incorrectTabStops),
+        ).toEqual([
+            {
+                description: testSubject.keyboardNavigationDescription('element1'),
+            },
+        ]);
+
+        const correctTabStops = new Set<HTMLElement>([tabStopElement1, tabStopElement2]);
+        expect(testSubject.getKeyboardNavigationResults(tabbableTabStops, correctTabStops)).toEqual(
+            [],
+        );
+    });
+
+    test('addFocusOrderResults', () => {
+        htmlElementUtilsMock
+            .setup(m => m.precedesInDOM(It.isAny(), It.isAny()))
+            .returns(() => true);
+        expect(testSubject.getFocusOrderResult(tabStopElement2, tabStopElement1)).toEqual([
+            {
+                description: testSubject.focusOrderDescription('element1', 'element2'),
+            },
+        ]);
+
+        htmlElementUtilsMock
+            .setup(m => m.precedesInDOM(It.isAny(), It.isAny()))
+            .returns(() => false);
+        expect(testSubject.getFocusOrderResult(tabStopElement1, tabStopElement2)).toEqual([]);
+    });
+
+    test('onKeydownForFocusTraps', async () => {
+        expect(await testSubject.getKeyboardTrapResults(tabStopElement1, tabStopElement2)).toEqual(
+            [],
+        );
+
+        expect(await testSubject.getKeyboardTrapResults(tabStopElement1, tabStopElement1)).toEqual([
+            {
+                description: testSubject.focusTrapsDescription('element1'),
+            },
+        ]);
+    });
+});


### PR DESCRIPTION
#### Details

Add `TabStopsRequirementEvaluator` and unit tests. This class will be leveraged by automated tab stops analyzer added in future PRs. 

##### Motivation

Support future PRs for this feature.

##### Context

A subsequent PR will add logic to call into this evaluator and use it to generate tab stops results automatically. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
