### PR TITLE
feat(tabstops-auto-impl): add AllFrameRunnerTarget interface

### DIFF
--- a/src/injected/all-frame-runner.ts
+++ b/src/injected/all-frame-runner.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/*
+This interface defines a target used by the upcoming class
+AllFrameRunner (see ai-web@5036). Adding the interface early
+to enable parallel work.
+*/
+
+export interface AllFrameRunnerTarget<T> {
+    name: string;
+    start: () => void;
+    stop: () => void;
+    transformChildResultForParent: (fromChild: T, messageSourceFrame: HTMLIFrameElement) => T;
+    setResultCallback: (reportResults: (payload: T) => Promise<void>) => void;
+}


### PR DESCRIPTION
#### Details

This PR pulls out the interface from https://github.com/microsoft/accessibility-insights-web/pull/5036 so that we can enable work in parallel.

Here are comments copied over from that PR describing upcoming the `AllFrameRunner` class.

---

This class ('runner' below) runs methods in AllFrameRunnerTargets ('target' below) in all child
frames. Runner manages communication between child frames and the top-level window so that the
target can produce results without explicit frame-communication code. 

It follows these semantics:
- runner.initialize() should be called & runner.topWindowCallback should be set 
before calling runner.start() / runner.stop()
- runner.start() will run target.start() in the current frame, and then in any child frames
- runner.stop() will run target.stop() in the current frame, and then in any child frames
- runner provides target with a reportResults callback. When target.reportResults(payload) is 
called, runner propogates payload to parent frames. In each parent frame, runner replaces the 
payload with target.transformChildResultForParent(payload). When the result reaches the top window, 
runner calls topWindowCallback(payload)
- runner uses target.name as a suffix for frame communication messages

---

##### Motivation

enables other team members to work against this interface while we productionize the full class

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
