### PR TITLE
feat(tabstops-report): update report filename to use FastPass instead of AutomatedChecks

### DIFF
--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -111,7 +111,7 @@ export function getReportExportDialogForFastPass(
         deps: deps,
         pageTitle: props.scanMetadata.targetAppInfo.name,
         scanDate: props.scanMetadata.timespan.scanComplete,
-        reportExportFormat: 'AutomatedChecks',
+        reportExportFormat: 'FastPass',
         htmlGenerator: generateReportFromDescription,
         jsonGenerator: () => null,
         updatePersistedDescription: () => null,

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -82,7 +82,7 @@ export const NAVIGATE_TO_NEW_CARDS_VIEW: string = 'NavigateToNewCardsView';
 export const TriggeredByNotApplicable: TriggeredBy = 'N/A';
 export type TriggeredBy = 'mouseclick' | 'keypress' | 'shortcut' | 'N/A';
 
-export type ReportExportFormat = 'Assessment' | 'AutomatedChecks';
+export type ReportExportFormat = 'Assessment' | 'FastPass';
 
 export enum TelemetryEventSource {
     LaunchPad,

--- a/src/electron/views/results/components/reflow-command-bar.tsx
+++ b/src/electron/views/results/components/reflow-command-bar.tsx
@@ -85,7 +85,7 @@ export class ReflowCommandBar extends React.Component<
                 <ReportExportComponent
                     deps={deps}
                     isOpen={this.state.reportExportDialogIsOpen}
-                    reportExportFormat={'AutomatedChecks'}
+                    reportExportFormat={'FastPass'}
                     pageTitle={scanMetadata.targetAppInfo.name}
                     scanDate={scanMetadata.timespan.scanComplete}
                     htmlGenerator={description =>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`ReportExportDialogFactory getReportExportDialogForFastPass expected pro
   isOpen={true}
   jsonGenerator={[Function]}
   pageTitle="command-bar-test-tab-title"
-  reportExportFormat="AutomatedChecks"
+  reportExportFormat="FastPass"
   reportExportServices={
     Array [
       Object {

--- a/src/tests/unit/tests/common/telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/common/telemetry-data-factory.test.ts
@@ -626,7 +626,7 @@ describe('TelemetryDataFactoryTest', () => {
     test('forExportedResults by mouseclick', () => {
         const serviceKey = 'html';
         const event = mouseClickEvent;
-        const exportResultsType = 'AutomatedChecks';
+        const exportResultsType = 'FastPass';
 
         const result = testObject.forExportedResults(
             exportResultsType,

--- a/src/tests/unit/tests/electron/views/results/components/__snapshots__/reflow-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/results/components/__snapshots__/reflow-command-bar.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ReflowCommandBar reflow behavior isCommandBarCollapsed is true 1`] = `
   <div className=\\"farItems reflow\\">
     <CommandBarButtonsMenu renderExportReportButton={[Function (anonymous)]} getStartOverMenuItem={[Function (anonymous)]} buttonRef={[Function: buttonRef]} />
     <InsightsCommandButton data-automation-id=\\"command-button-settings\\" ariaLabel=\\"settings\\" iconProps={{...}} onClick={[Function: onClick]} className=\\"settingsGearButton\\" />
-    <ReportExportComponent deps={{...}} isOpen={false} reportExportFormat=\\"AutomatedChecks\\" pageTitle=\\"scan target name\\" scanDate={{...}} htmlGenerator={[Function: htmlGenerator]} jsonGenerator={[Function: jsonGenerator]} updatePersistedDescription={[Function: updatePersistedDescription]} getExportDescription={[Function: getExportDescription]} featureFlagStoreData={{...}} dismissExportDialog={[Function: dismissExportDialog]} afterDialogDismissed={[Function: afterDialogDismissed]} reportExportServices={{...}} />
+    <ReportExportComponent deps={{...}} isOpen={false} reportExportFormat=\\"FastPass\\" pageTitle=\\"scan target name\\" scanDate={{...}} htmlGenerator={[Function: htmlGenerator]} jsonGenerator={[Function: jsonGenerator]} updatePersistedDescription={[Function: updatePersistedDescription]} getExportDescription={[Function: getExportDescription]} featureFlagStoreData={{...}} dismissExportDialog={[Function: dismissExportDialog]} afterDialogDismissed={[Function: afterDialogDismissed]} reportExportServices={{...}} />
   </div>
 </section>"
 `;
@@ -23,7 +23,7 @@ exports[`ReflowCommandBar reflow behavior isHeaderAndNavCollapsed is true 1`] = 
     <ReportExportButton showReportExportDialog={[Function (anonymous)]} />
     <InsightsCommandButton data-automation-id=\\"command-button-refresh\\" text=\\"Start over\\" iconProps={{...}} onClick={[Function: onClick]} disabled={false} />
     <InsightsCommandButton data-automation-id=\\"command-button-settings\\" ariaLabel=\\"settings\\" iconProps={{...}} onClick={[Function: onClick]} className=\\"settingsGearButton\\" />
-    <ReportExportComponent deps={{...}} isOpen={false} reportExportFormat=\\"AutomatedChecks\\" pageTitle=\\"scan target name\\" scanDate={{...}} htmlGenerator={[Function: htmlGenerator]} jsonGenerator={[Function: jsonGenerator]} updatePersistedDescription={[Function: updatePersistedDescription]} getExportDescription={[Function: getExportDescription]} featureFlagStoreData={{...}} dismissExportDialog={[Function: dismissExportDialog]} afterDialogDismissed={[Function: afterDialogDismissed]} reportExportServices={{...}} />
+    <ReportExportComponent deps={{...}} isOpen={false} reportExportFormat=\\"FastPass\\" pageTitle=\\"scan target name\\" scanDate={{...}} htmlGenerator={[Function: htmlGenerator]} jsonGenerator={[Function: jsonGenerator]} updatePersistedDescription={[Function: updatePersistedDescription]} getExportDescription={[Function: getExportDescription]} featureFlagStoreData={{...}} dismissExportDialog={[Function: dismissExportDialog]} afterDialogDismissed={[Function: afterDialogDismissed]} reportExportServices={{...}} />
   </div>
 </section>"
 `;
@@ -33,7 +33,7 @@ exports[`ReflowCommandBar renders does not create report export when allowsExpor
   <div className=\\"farItems reflow\\">
     <InsightsCommandButton data-automation-id=\\"command-button-refresh\\" text=\\"Start over\\" iconProps={{...}} onClick={[Function: onClick]} disabled={false} />
     <InsightsCommandButton data-automation-id=\\"command-button-settings\\" ariaLabel=\\"settings\\" iconProps={{...}} onClick={[Function: onClick]} className=\\"settingsGearButton\\" />
-    <ReportExportComponent deps={{...}} isOpen={false} reportExportFormat=\\"AutomatedChecks\\" pageTitle=\\"scan target name\\" scanDate={{...}} htmlGenerator={[Function: htmlGenerator]} jsonGenerator={[Function: jsonGenerator]} updatePersistedDescription={[Function: updatePersistedDescription]} getExportDescription={[Function: getExportDescription]} featureFlagStoreData={{...}} dismissExportDialog={[Function: dismissExportDialog]} afterDialogDismissed={[Function: afterDialogDismissed]} reportExportServices={{...}} />
+    <ReportExportComponent deps={{...}} isOpen={false} reportExportFormat=\\"FastPass\\" pageTitle=\\"scan target name\\" scanDate={{...}} htmlGenerator={[Function: htmlGenerator]} jsonGenerator={[Function: jsonGenerator]} updatePersistedDescription={[Function: updatePersistedDescription]} getExportDescription={[Function: getExportDescription]} featureFlagStoreData={{...}} dismissExportDialog={[Function: dismissExportDialog]} afterDialogDismissed={[Function: afterDialogDismissed]} reportExportServices={{...}} />
   </div>
 </section>"
 `;
@@ -53,7 +53,7 @@ exports[`ReflowCommandBar renders with start over button disabled 1`] = `
     <ReportExportButton showReportExportDialog={[Function (anonymous)]} />
     <InsightsCommandButton data-automation-id=\\"command-button-refresh\\" text=\\"Start over\\" iconProps={{...}} onClick={[Function: onClick]} disabled={true} />
     <InsightsCommandButton data-automation-id=\\"command-button-settings\\" ariaLabel=\\"settings\\" iconProps={{...}} onClick={[Function: onClick]} className=\\"settingsGearButton\\" />
-    <ReportExportComponent deps={{...}} isOpen={false} reportExportFormat=\\"AutomatedChecks\\" pageTitle=\\"scan target name\\" scanDate={[undefined]} htmlGenerator={[Function: htmlGenerator]} jsonGenerator={[Function: jsonGenerator]} updatePersistedDescription={[Function: updatePersistedDescription]} getExportDescription={[Function: getExportDescription]} featureFlagStoreData={{...}} dismissExportDialog={[Function: dismissExportDialog]} afterDialogDismissed={[Function: afterDialogDismissed]} reportExportServices={{...}} />
+    <ReportExportComponent deps={{...}} isOpen={false} reportExportFormat=\\"FastPass\\" pageTitle=\\"scan target name\\" scanDate={[undefined]} htmlGenerator={[Function: htmlGenerator]} jsonGenerator={[Function: jsonGenerator]} updatePersistedDescription={[Function: updatePersistedDescription]} getExportDescription={[Function: getExportDescription]} featureFlagStoreData={{...}} dismissExportDialog={[Function: dismissExportDialog]} afterDialogDismissed={[Function: afterDialogDismissed]} reportExportServices={{...}} />
   </div>
 </section>"
 `;


### PR DESCRIPTION
#### Details

This updates the basename of the filename for the FastPass report from `AutomatedChecks` to `FastPass`.

##### Motivation

feature work


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
