### PR TITLE
feat(tabstops-report) Update failed counter on fastpass report

### DIFF
--- a/src/DetailsView/components/tab-stops/tab-stops-instance-section-props-factory.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-instance-section-props-factory.tsx
@@ -109,7 +109,11 @@ export const ReportTabStopsInstanceSectionPropsFactory: TabStopsInstanceSectionP
                         requirement={result}
                     />
                 ),
-                content: <span>This requirement has failed but no comment has been added</span>,
+                content: (
+                    <span className={styles.noInstances}>
+                        This requirement has failed but no comment has been added
+                    </span>
+                ),
                 containerAutomationId: resultsGroupAutomationId,
                 containerClassName: styles.collapsibleRequirementDetailsGroup,
                 buttonAriaLabel: buttonAriaLabel,

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -44,7 +44,10 @@ import { TabStopsViewActions } from 'DetailsView/components/tab-stops/tab-stops-
 import { TabStopsViewStore } from 'DetailsView/components/tab-stops/tab-stops-view-store';
 import { AllUrlsPermissionHandler } from 'DetailsView/handlers/allurls-permission-handler';
 import { NoContentAvailableViewRenderer } from 'DetailsView/no-content-available-view-renderer';
-import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
+import {
+    TabStopsFailedCounterIncludingNoInstance,
+    TabStopsFailedCounterInstancesOnly,
+} from 'DetailsView/tab-stops-failed-counter';
 import { NullStoreActionMessageCreator } from 'electron/adapters/null-store-action-message-creator';
 import { loadTheme, setFocusVisibility } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
@@ -355,7 +358,6 @@ if (tabId != null) {
 
             const fixInstructionProcessor = new FixInstructionProcessor();
             const recommendColor = new RecommendColor();
-            const tabStopsFailedCounter = new TabStopsFailedCounter();
 
             // This is for a soon-to-be-legacy FastPass report format.
             // It should be removed with #1897885.
@@ -378,7 +380,7 @@ if (tabId != null) {
                 fixInstructionProcessor,
                 recommendColor,
                 getPropertyConfiguration,
-                tabStopsFailedCounter,
+                new TabStopsFailedCounterIncludingNoInstance(),
                 toolData,
                 DateProvider.getCurrentDate,
             );
@@ -580,7 +582,7 @@ if (tabId != null) {
                 navLinkRenderer,
                 getNarrowModeThresholds: getNarrowModeThresholdsForWeb,
                 tabStopRequirements: requirements,
-                tabStopsFailedCounter,
+                tabStopsFailedCounter: new TabStopsFailedCounterInstancesOnly(),
                 tabStopsTestViewController,
                 tabStopsInstanceSectionPropsFactory: FastPassTabStopsInstanceSectionPropsFactory,
             };

--- a/src/DetailsView/tab-stops-failed-counter.ts
+++ b/src/DetailsView/tab-stops-failed-counter.ts
@@ -3,15 +3,22 @@
 
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 
-export class TabStopsFailedCounter {
-    public getFailedByRequirementId = (
+export interface TabStopsFailedCounter {
+    getTotalFailedByRequirementId: (
         results: TabStopsRequirementResult[],
         requirementId: string,
-    ): number => {
-        return results.reduce((total, result) => {
-            return result.id === requirementId ? total + result.instances.length : total;
-        }, 0);
-    };
+    ) => number;
+    getFailedInstancesByRequirementId: (
+        results: TabStopsRequirementResult[],
+        requirementId: string,
+    ) => number;
+    getTotalFailed: (results: TabStopsRequirementResult[]) => number;
+}
+
+export class TabStopsFailedCounterInstancesOnly implements TabStopsFailedCounter {
+    public getTotalFailedByRequirementId = getFailedInstancesByRequirementId;
+
+    public getFailedInstancesByRequirementId = getFailedInstancesByRequirementId;
 
     public getTotalFailed = (results: TabStopsRequirementResult[]): number => {
         return results.reduce((total, result) => {
@@ -19,3 +26,31 @@ export class TabStopsFailedCounter {
         }, 0);
     };
 }
+
+export class TabStopsFailedCounterIncludingNoInstance implements TabStopsFailedCounter {
+    public getTotalFailedByRequirementId = (
+        results: TabStopsRequirementResult[],
+        requirementId: string,
+    ): number => {
+        return results.reduce((total, result) => {
+            return result.id === requirementId ? total + (result.instances.length || 1) : total;
+        }, 0);
+    };
+
+    public getFailedInstancesByRequirementId = getFailedInstancesByRequirementId;
+
+    public getTotalFailed = (results: TabStopsRequirementResult[]): number => {
+        return results.reduce((total, result) => {
+            return total + (result.instances.length || 1);
+        }, 0);
+    };
+}
+
+const getFailedInstancesByRequirementId = (
+    results: TabStopsRequirementResult[],
+    requirementId: string,
+): number => {
+    return results.reduce((total, result) => {
+        return result.id === requirementId ? total + result.instances.length : total;
+    }, 0);
+};

--- a/src/DetailsView/tab-stops-minimal-requirement-header.tsx
+++ b/src/DetailsView/tab-stops-minimal-requirement-header.tsx
@@ -22,7 +22,7 @@ export const TabStopsMinimalRequirementHeader = NamedFC<TabStopsMinimalRequireme
         const { requirement } = props;
 
         const renderCountBadge = () => {
-            const count = props.deps.tabStopsFailedCounter.getFailedByRequirementId(
+            const count = props.deps.tabStopsFailedCounter.getTotalFailedByRequirementId(
                 [requirement],
                 requirement.id,
             );

--- a/src/DetailsView/tab-stops-requirements-with-instances.scss
+++ b/src/DetailsView/tab-stops-requirements-with-instances.scss
@@ -6,6 +6,10 @@
 .collapsible-requirement-details-group {
     box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
 
+    .no-instances {
+        font-style: italic;
+    }
+
     &:global(:not(.collapsed)) {
         box-shadow: unset;
     }

--- a/src/DetailsView/tab-stops-requirements-with-instances.tsx
+++ b/src/DetailsView/tab-stops-requirements-with-instances.tsx
@@ -48,18 +48,26 @@ export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWit
             <div>
                 {results.map((requirement, idx) => {
                     const { pastTense } = outcomeTypeSemantics.fail;
-                    const count = deps.tabStopsFailedCounter.getFailedByRequirementId(
+                    const instanceCount =
+                        deps.tabStopsFailedCounter.getFailedInstancesByRequirementId(
+                            results,
+                            requirement.id,
+                        );
+                    const totalCount = deps.tabStopsFailedCounter.getTotalFailedByRequirementId(
                         results,
                         requirement.id,
                     );
 
-                    if (count === 0 && getCollapsibleComponentPropsWithoutInstance === undefined) {
+                    if (
+                        instanceCount === 0 &&
+                        getCollapsibleComponentPropsWithoutInstance === undefined
+                    ) {
                         return null;
                     }
 
                     let collapsibleComponentProps: CollapsibleComponentCardsProps;
-                    const buttonAriaLabel = `${requirement.id} ${count} ${pastTense} ${requirement.description}`;
-                    if (count === 0) {
+                    const buttonAriaLabel = `${requirement.id} ${totalCount} ${pastTense} ${requirement.description}`;
+                    if (instanceCount === 0) {
                         collapsibleComponentProps = getCollapsibleComponentPropsWithoutInstance(
                             requirement,
                             idx,

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-counter.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-counter.test.ts
@@ -1,13 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
+import {
+    TabStopsFailedCounterIncludingNoInstance,
+    TabStopsFailedCounterInstancesOnly,
+} from 'DetailsView/tab-stops-failed-counter';
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 
 // Licensed under the MIT License.
 describe('TabStopsFailedCounter', () => {
     let results = [] as TabStopsRequirementResult[];
-    const testSubject = new TabStopsFailedCounter();
+    const testSubjectInstancesOnly = new TabStopsFailedCounterInstancesOnly();
+    const testSubjectIncludingNoInstance = new TabStopsFailedCounterIncludingNoInstance();
 
     beforeEach(() => {
         results = [
@@ -17,14 +21,16 @@ describe('TabStopsFailedCounter', () => {
 
     test('getTotalFailed returns zero when there are no instances', () => {
         results = [];
-        expect(testSubject.getTotalFailed(results)).toBe(0);
+        expect(testSubjectInstancesOnly.getTotalFailed(results)).toBe(0);
+        expect(testSubjectIncludingNoInstance.getTotalFailed(results)).toBe(0);
     });
 
     test('getTotalFailed returns one result when a single failed instance is passed', () => {
         results = [
             { instances: [{ id: 'test-id-1', description: 'test desc 1' }] },
         ] as TabStopsRequirementResult[];
-        expect(testSubject.getTotalFailed(results)).toBe(1);
+        expect(testSubjectInstancesOnly.getTotalFailed(results)).toBe(1);
+        expect(testSubjectIncludingNoInstance.getTotalFailed(results)).toBe(1);
     });
 
     test('getTotalFailed counts all instances from all requirements', () => {
@@ -41,7 +47,23 @@ describe('TabStopsFailedCounter', () => {
                 ],
             },
         ] as TabStopsRequirementResult[];
-        expect(testSubject.getTotalFailed(results)).toBe(3);
+        expect(testSubjectInstancesOnly.getTotalFailed(results)).toBe(3);
+        expect(testSubjectIncludingNoInstance.getTotalFailed(results)).toBe(3);
+    });
+
+    test('getTotalFailed counts requirements without instances based on implementation', () => {
+        results = [
+            {
+                id: 'keyboard-navigation',
+                instances: [{ id: 'test-id-1', description: 'test desc 1' }],
+            },
+            {
+                id: 'input-focus',
+                instances: [],
+            },
+        ] as TabStopsRequirementResult[];
+        expect(testSubjectInstancesOnly.getTotalFailed(results)).toBe(1);
+        expect(testSubjectIncludingNoInstance.getTotalFailed(results)).toBe(2);
     });
 
     test('getFailedByRequirementId returns zero when requirementId does not exist', () => {
@@ -51,7 +73,15 @@ describe('TabStopsFailedCounter', () => {
                 instances: [{ id: 'test-id-1', description: 'test desc 1' }],
             },
         ] as TabStopsRequirementResult[];
-        expect(testSubject.getFailedByRequirementId(results, 'non-existent-id')).toBe(0);
+        expect(
+            testSubjectInstancesOnly.getTotalFailedByRequirementId(results, 'non-existent-id'),
+        ).toBe(0);
+        expect(
+            testSubjectIncludingNoInstance.getTotalFailedByRequirementId(
+                results,
+                'non-existent-id',
+            ),
+        ).toBe(0);
     });
 
     test('getFailedByRequirementId returns correct number of instances for requirement', () => {
@@ -68,6 +98,30 @@ describe('TabStopsFailedCounter', () => {
                 ],
             },
         ] as TabStopsRequirementResult[];
-        expect(testSubject.getFailedByRequirementId(results, 'input-focus')).toBe(2);
+        expect(testSubjectInstancesOnly.getTotalFailedByRequirementId(results, 'input-focus')).toBe(
+            2,
+        );
+        expect(
+            testSubjectIncludingNoInstance.getTotalFailedByRequirementId(results, 'input-focus'),
+        ).toBe(2);
+    });
+
+    test('getFailedByRequirementId returns correct number for requirement with no instances', () => {
+        results = [
+            {
+                id: 'keyboard-navigation',
+                instances: [{ id: 'test-id-1', description: 'test desc 1' }],
+            },
+            {
+                id: 'input-focus',
+                instances: [],
+            },
+        ] as TabStopsRequirementResult[];
+        expect(testSubjectInstancesOnly.getTotalFailedByRequirementId(results, 'input-focus')).toBe(
+            0,
+        );
+        expect(
+            testSubjectIncludingNoInstance.getTotalFailedByRequirementId(results, 'input-focus'),
+        ).toBe(1);
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-failed-instance-section.test.tsx
@@ -22,7 +22,7 @@ describe('TabStopsFailedInstanceSection', () => {
     let deps: TabStopsFailedInstanceSectionDeps;
 
     beforeEach(() => {
-        tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
+        tabStopsFailedCounterMock = Mock.ofType<TabStopsFailedCounter>();
         tabStopsInstanceSectionPropsFactoryMock =
             Mock.ofType<TabStopsInstanceSectionPropsFactory>();
 

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-minimal-requirement-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-minimal-requirement-header.test.tsx
@@ -26,7 +26,7 @@ describe('TabStopsMinimalRequirementHeader', () => {
     let deps: TabStopsMinimalRequirementHeaderDeps;
 
     beforeEach(() => {
-        tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
+        tabStopsFailedCounterMock = Mock.ofType<TabStopsFailedCounter>();
 
         deps = {
             tabStopsFailedCounter: tabStopsFailedCounterMock.object,
@@ -40,7 +40,7 @@ describe('TabStopsMinimalRequirementHeader', () => {
         };
 
         tabStopsFailedCounterMock
-            .setup(tsf => tsf.getFailedByRequirementId(It.isAny(), It.isAnyString()))
+            .setup(tsf => tsf.getTotalFailedByRequirementId(It.isAny(), It.isAnyString()))
             .returns(() => 2)
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/DetailsView/components/tab-stops-requirements-with-instances.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops-requirements-with-instances.test.tsx
@@ -29,7 +29,7 @@ describe('TabStopsRequirementsWithInstances', () => {
         buttonAriaLabel: string,
     ) => CollapsibleComponentCardsProps;
     beforeEach(() => {
-        tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
+        tabStopsFailedCounterMock = Mock.ofType<TabStopsFailedCounter>();
         tabStopsRequirementActionMessageCreatorMock = Mock.ofType(
             TabStopRequirementActionMessageCreator,
         );
@@ -75,7 +75,7 @@ describe('TabStopsRequirementsWithInstances', () => {
 
     it('renders when instance count > 0', () => {
         tabStopsFailedCounterMock
-            .setup(m => m.getFailedByRequirementId(It.isAny(), It.isAny()))
+            .setup(m => m.getTotalFailedByRequirementId(It.isAny(), It.isAny()))
             .returns(() => 2);
         const wrapper = shallow(<TabStopsRequirementsWithInstances {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
@@ -83,7 +83,10 @@ describe('TabStopsRequirementsWithInstances', () => {
 
     it('renders empty div when instance count === 0', () => {
         tabStopsFailedCounterMock
-            .setup(m => m.getFailedByRequirementId(It.isAny(), It.isAny()))
+            .setup(m => m.getTotalFailedByRequirementId(It.isAny(), It.isAny()))
+            .returns(() => 0);
+        tabStopsFailedCounterMock
+            .setup(m => m.getFailedInstancesByRequirementId(It.isAny(), It.isAny()))
             .returns(() => 0);
         const wrapper = shallow(<TabStopsRequirementsWithInstances {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
@@ -91,7 +94,10 @@ describe('TabStopsRequirementsWithInstances', () => {
 
     it('renders component instance count === 0', () => {
         tabStopsFailedCounterMock
-            .setup(m => m.getFailedByRequirementId(It.isAny(), It.isAny()))
+            .setup(m => m.getTotalFailedByRequirementId(It.isAny(), It.isAny()))
+            .returns(() => 0);
+        tabStopsFailedCounterMock
+            .setup(m => m.getFailedInstancesByRequirementId(It.isAny(), It.isAny()))
             .returns(() => 0);
         props.getCollapsibleComponentPropsWithoutInstance = (result, idx, button) => {
             return {

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-instance-section-props-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-instance-section-props-factory.test.tsx.snap
@@ -326,7 +326,9 @@ Object {
   "buttonAriaLabel": "label",
   "containerAutomationId": "tab-stops-results-group",
   "containerClassName": "collapsibleRequirementDetailsGroup",
-  "content": <span>
+  "content": <span
+    className="noInstances"
+  >
     This requirement has failed but no comment has been added
   </span>,
   "deps": Object {

--- a/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
+++ b/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
@@ -17,7 +17,7 @@ describe('FastPassReportSummary', () => {
     let deps: FastPassReportSummaryDeps;
 
     it('renders per the snapshot', () => {
-        tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
+        tabStopsFailedCounterMock = Mock.ofType<TabStopsFailedCounter>();
         deps = { tabStopsFailedCounter: tabStopsFailedCounterMock.object };
 
         props = {

--- a/src/tests/unit/tests/reports/fast-pass-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/fast-pass-report-html-generator.test.tsx
@@ -36,7 +36,7 @@ describe(FastPassReportHtmlGenerator, () => {
         const recommendColorMock = Mock.ofType(RecommendColor);
         const getPropertyConfigurationStub = (id: string) => null;
         const cardInteractionSupport = noCardInteractionsSupported;
-        const tabStopsFailedCounterMock = Mock.ofType(TabStopsFailedCounter);
+        const tabStopsFailedCounterMock = Mock.ofType<TabStopsFailedCounter>();
 
         const getUTCStringFromDateStub: typeof DateProvider.getUTCStringFromDate = () => '';
         const getGuidanceTagsStub: GetGuidanceTagsFromGuidanceLinks = () => [];


### PR DESCRIPTION
#### Details
This PR makes two updates to the FastPassReport:
1. It updates the failed instance count for tab stops to count each failed requirement with no user comments as 1 towards the requirement and overall section count
2. It italicizes the "This requirement has failed but no comment has been added" message for failed requirements with no instances

To accomplish 1, `TabStopsFailedCounter` has been split into two implementations: one for the extension details view that maintains existing behavior and one for the report that counts no instance requirements as described above. This PR has no impact on the behavior of the extension details view.

Screenshot showing both changes:
![Screenshot showing both changes](https://user-images.githubusercontent.com/4615491/149244174-1ced6204-b037-47ca-89f4-9dff79810906.png)


##### Motivation
Bringing report closer to spec

##### Context
I considered breaking the no comment message out into its own component, but it seemed to trivial to deserve that. Happy to do so if anyone feels differently.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
