### PR TITLE
feat(tabstops-auto-impl): Create tab stops orchestrator

### DIFF
--- a/src/injected/analyzers/tab-stops-orchestrator.ts
+++ b/src/injected/analyzers/tab-stops-orchestrator.ts
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { WindowUtils } from 'common/window-utils';
+import { AllFrameRunnerTarget } from 'injected/all-frame-runner';
+import {
+    TabStopRequirementResult,
+    TabStopsRequirementEvaluator,
+} from 'injected/tab-stops-requirement-evaluator';
+import { TabbableElementGetter } from 'injected/tabbable-element-getter';
+import { FocusableElement } from 'tabbable';
+
+export class TabStopRequirementOrchestrator
+    implements AllFrameRunnerTarget<TabStopRequirementResult>
+{
+    public readonly name: string = 'TabStopRequirementOrchestrator';
+    private tabbableTabStops: FocusableElement[];
+    private actualTabStops: Set<HTMLElement> = new Set();
+    private latestVisitedTabStop: HTMLElement = null;
+    private reportResults: (payload: TabStopRequirementResult) => Promise<void>;
+
+    constructor(
+        private readonly dom: Document,
+        private readonly tabbableElementGetter: TabbableElementGetter,
+        private readonly windowUtils: WindowUtils,
+        private readonly tabStopsRequirementEvaluator: TabStopsRequirementEvaluator,
+        private readonly getUniqueSelector: (element: HTMLElement) => string,
+    ) {}
+
+    public start = () => {
+        this.dom.addEventListener('keydown', this.onKeydownForFocusTraps);
+        this.dom.addEventListener('focusin', this.addNewTabStop);
+        this.tabbableTabStops = this.tabbableElementGetter.getRawElements();
+        const tabbableFocusOrderResults =
+            this.tabStopsRequirementEvaluator.getTabbableFocusOrderResults(this.tabbableTabStops);
+        tabbableFocusOrderResults.forEach(result => {
+            this.reportResults(result);
+        });
+    };
+
+    public stop = () => {
+        this.dom.removeEventListener('keydown', this.onKeydownForFocusTraps);
+        this.dom.removeEventListener('focusin', this.addNewTabStop);
+        const keyboardNavigationResults =
+            this.tabStopsRequirementEvaluator.getKeyboardNavigationResults(
+                this.tabbableTabStops,
+                this.actualTabStops,
+            );
+        keyboardNavigationResults.forEach(this.reportResults);
+    };
+
+    public setResultCallback = (
+        reportResultCallback: (payload: TabStopRequirementResult) => Promise<void>,
+    ) => {
+        this.reportResults = reportResultCallback;
+    };
+
+    public transformChildResultForParent = (
+        result: TabStopRequirementResult,
+        messageSourceFrame: HTMLIFrameElement,
+    ): TabStopRequirementResult => {
+        const frameSelector = this.getUniqueSelector(messageSourceFrame);
+        result.selector = [frameSelector, ...result.selector];
+        return result;
+    };
+
+    private addNewTabStop = (focusEvent: FocusEvent) => {
+        const newTabStop = focusEvent.target as HTMLElement;
+        if (this.actualTabStops.size > 0 && this.actualTabStops.has(newTabStop)) {
+            return;
+        }
+
+        this.actualTabStops.add(newTabStop);
+        this.latestVisitedTabStop = newTabStop;
+
+        const result = this.tabStopsRequirementEvaluator.getFocusOrderResult(
+            this.latestVisitedTabStop,
+            newTabStop,
+        );
+
+        if (result == null) {
+            return;
+        }
+        this.reportResults(result);
+    };
+
+    private onKeydownForFocusTraps = (e: KeyboardEvent) => {
+        if (e.key !== 'Tab') {
+            return;
+        }
+
+        const oldElement = this.dom.activeElement;
+        this.windowUtils.setTimeout(() => {
+            const result = this.tabStopsRequirementEvaluator.getKeyboardTrapResults(
+                this.dom.activeElement,
+                oldElement,
+            );
+            if (result == null) {
+                return;
+            }
+            this.reportResults(result);
+        }, 500);
+    };
+}

--- a/src/injected/analyzers/tab-stops-orchestrator.ts
+++ b/src/injected/analyzers/tab-stops-orchestrator.ts
@@ -66,17 +66,24 @@ export class TabStopRequirementOrchestrator
 
     private addNewTabStop = (focusEvent: FocusEvent) => {
         const newTabStop = focusEvent.target as HTMLElement;
-        if (this.actualTabStops.size > 0 && this.actualTabStops.has(newTabStop)) {
+
+        if (this.latestVisitedTabStop == null) {
+            this.actualTabStops.add(newTabStop);
+            this.latestVisitedTabStop = newTabStop;
+            return;
+        }
+
+        if (this.actualTabStops.has(newTabStop)) {
+            this.latestVisitedTabStop = newTabStop;
             return;
         }
 
         this.actualTabStops.add(newTabStop);
-        this.latestVisitedTabStop = newTabStop;
-
         const result = this.tabStopsRequirementEvaluator.getFocusOrderResult(
             this.latestVisitedTabStop,
             newTabStop,
         );
+        this.latestVisitedTabStop = newTabStop;
 
         if (result == null) {
             return;

--- a/src/injected/tab-stops-requirement-evaluator.ts
+++ b/src/injected/tab-stops-requirement-evaluator.ts
@@ -7,14 +7,11 @@ import { FocusableElement } from 'tabbable';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 
 export type TabStopRequirementResult = {
+    requirementId: TabStopRequirementId;
     description: string;
     selector: string[];
     html: string;
 };
-
-export type TabStopRequirementResults = Partial<
-    Record<TabStopRequirementId, TabStopRequirementResult[]>
->;
 
 export interface TabStopsRequirementEvaluator {
     getKeyboardNavigationResults(
@@ -58,6 +55,7 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
                     description: this.keyboardNavigationDescription(selector),
                     selector: [selector],
                     html: expectedTabStop.outerHTML,
+                    requirementId: 'keyboard-navigation',
                 });
             }
         });
@@ -75,6 +73,7 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
                 description: this.focusOrderDescription(currSelector, lastSelector),
                 selector: [currSelector],
                 html: currentTabStop.outerHTML,
+                requirementId: 'tab-order',
             };
         }
         return null;
@@ -109,6 +108,7 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
                 description: this.focusTrapsDescription(selector),
                 selector: [selector],
                 html: oldActiveElement.outerHTML,
+                requirementId: 'keyboard-traps',
             };
         }
         return null;

--- a/src/injected/tabbable-element-getter.ts
+++ b/src/injected/tabbable-element-getter.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { getUniqueSelector } from 'scanner/axe-utils';
-import { tabbable } from 'tabbable';
+import { FocusableElement, tabbable } from 'tabbable';
 
 export interface TabbableElementInfo {
     html: string;
@@ -23,5 +23,9 @@ export class TabbableElementGetter {
             selector: this.generateSelector(elem as HTMLElement),
             order: index,
         }));
+    };
+
+    public getRawElements: () => FocusableElement[] = () => {
+        return this.getTabbableElements(this.doc.documentElement);
     };
 }

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-orchestrator.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-orchestrator.test.ts
@@ -1,0 +1,281 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { WindowUtils } from 'common/window-utils';
+import { TabStopRequirementOrchestrator } from 'injected/analyzers/tab-stops-orchestrator';
+import {
+    TabStopRequirementResult,
+    TabStopsRequirementEvaluator,
+} from 'injected/tab-stops-requirement-evaluator';
+import { TabbableElementGetter } from 'injected/tabbable-element-getter';
+import { FocusableElement } from 'tabbable';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+describe('TabStopRequirementOrchestrator', () => {
+    let domMock: IMock<Document>;
+    let tabbabbleElementGetterMock: IMock<TabbableElementGetter>;
+    let windowUtilsMock: IMock<WindowUtils>;
+    let tabStopsRequirementEvaluatorMock: IMock<TabStopsRequirementEvaluator>;
+    let getUniqueSelectorMock: IMock<(e: HTMLElement) => string>;
+    let reportResultsMock: IMock<(payload: TabStopRequirementResult) => Promise<void>>;
+
+    let focusableElementsStub: FocusableElement[];
+
+    let testSubject: TabStopRequirementOrchestrator;
+    beforeEach(() => {
+        domMock = Mock.ofType<Document>();
+        tabbabbleElementGetterMock = Mock.ofType<TabbableElementGetter>();
+        windowUtilsMock = Mock.ofType<WindowUtils>();
+        tabStopsRequirementEvaluatorMock = Mock.ofType<TabStopsRequirementEvaluator>();
+        getUniqueSelectorMock = Mock.ofType<(e: HTMLElement) => string>();
+        reportResultsMock = Mock.ofType<(payload: TabStopRequirementResult) => Promise<void>>();
+
+        testSubject = new TabStopRequirementOrchestrator(
+            domMock.object,
+            tabbabbleElementGetterMock.object,
+            windowUtilsMock.object,
+            tabStopsRequirementEvaluatorMock.object,
+            getUniqueSelectorMock.object,
+        );
+
+        focusableElementsStub = [
+            {
+                innerText: 'some focusable element',
+            },
+        ] as FocusableElement[];
+    });
+
+    test('transformChildResultForParent', () => {
+        const frameStub = {} as HTMLIFrameElement;
+        const selectorStub = 'some selector';
+        const anotherSelectorStub = 'some other selector';
+        const result = {
+            selector: [anotherSelectorStub],
+        } as TabStopRequirementResult;
+        const expectedResult = {
+            selector: [selectorStub, anotherSelectorStub],
+        };
+
+        getUniqueSelectorMock.setup(m => m(frameStub)).returns(() => selectorStub);
+
+        expect(testSubject.transformChildResultForParent(result, frameStub)).toEqual(
+            expectedResult,
+        );
+    });
+
+    test('start: addNewTabStop gets non-null result and reports it', () => {
+        const tabStopRequirementResultStub = {
+            html: 'some html',
+        } as TabStopRequirementResult;
+        testAddNewStopWithResult(tabStopRequirementResultStub, Times.once());
+    });
+
+    test('start: addNewTabStop gets null result and does not report it', () => {
+        testAddNewStopWithResult(null, Times.never());
+    });
+
+    function testAddNewStopWithResult(
+        tabStopRequirementResultStub: TabStopRequirementResult,
+        givenTimes: Times,
+    ) {
+        const elementStub = {
+            innerText: 'some element',
+        } as HTMLElement;
+        const eventStub = {
+            target: elementStub as EventTarget,
+        } as Event;
+
+        prepareTabbableFocusOrderResults();
+        domMock
+            .setup(m => m.addEventListener('focusin', It.isAny()))
+            .callback((_, callback) => {
+                callback(eventStub);
+            });
+
+        tabStopsRequirementEvaluatorMock
+            .setup(m => m.getFocusOrderResult(elementStub, elementStub))
+            .returns(() => tabStopRequirementResultStub);
+        reportResultsMock.setup(m => m(tabStopRequirementResultStub)).verifiable(givenTimes);
+
+        testSubject.setResultCallback(reportResultsMock.object);
+        testSubject.start();
+
+        reportResultsMock.verifyAll();
+    }
+
+    test('start: addNewTabStop tab stop already seen, does nothing', () => {
+        const elementStub = {
+            innerText: 'some element',
+        } as HTMLElement;
+        const eventStub = {
+            target: elementStub as EventTarget,
+        } as Event;
+        const tabStopRequirementResultStub = {
+            html: 'some html',
+        } as TabStopRequirementResult;
+        let focusInCallback: (event: Event) => void;
+
+        prepareTabbableFocusOrderResults();
+        domMock
+            .setup(m => m.addEventListener('focusin', It.isAny()))
+            .callback((_, callback) => {
+                focusInCallback = callback;
+            });
+
+        tabStopsRequirementEvaluatorMock
+            .setup(m => m.getFocusOrderResult(elementStub, elementStub))
+            .returns(() => tabStopRequirementResultStub);
+        reportResultsMock.setup(m => m(tabStopRequirementResultStub)).verifiable(Times.once());
+
+        testSubject.setResultCallback(reportResultsMock.object);
+        testSubject.start();
+
+        focusInCallback(eventStub);
+
+        reportResultsMock.verifyAll();
+        reportResultsMock.reset();
+        reportResultsMock.setup(m => m(tabStopRequirementResultStub)).verifiable(Times.never());
+
+        focusInCallback(eventStub);
+
+        reportResultsMock.verifyAll();
+    });
+
+    test('stop removes event listeners and sends keyboard navigation results', () => {
+        let focusInCallback: (event: Event) => void;
+        let keydownCallback: (event: Event) => void;
+        const keyboardNavigationResultsStub = getTabStopRequirementResultStubs();
+
+        domMock
+            .setup(m => m.addEventListener('focusin', It.isAny()))
+            .callback((_, callback) => {
+                focusInCallback = callback;
+            });
+        domMock
+            .setup(m => m.addEventListener('keydown', It.isAny()))
+            .callback((_, callback) => {
+                keydownCallback = callback;
+            });
+        prepareTabbableFocusOrderResults();
+
+        testSubject.setResultCallback(reportResultsMock.object);
+        testSubject.start();
+
+        domMock.setup(m => m.removeEventListener('focusin', focusInCallback)).verifiable();
+        domMock.setup(m => m.removeEventListener('keydown', keydownCallback)).verifiable();
+        tabStopsRequirementEvaluatorMock
+            .setup(m =>
+                m.getKeyboardNavigationResults(focusableElementsStub, It.isValue(new Set())),
+            )
+            .returns(() => keyboardNavigationResultsStub);
+        keyboardNavigationResultsStub.forEach(result => {
+            reportResultsMock.setup(m => m(result)).verifiable(Times.once());
+        });
+
+        testSubject.stop();
+
+        domMock.verifyAll();
+        reportResultsMock.verifyAll();
+    });
+
+    test('start: onKeydownForFocusTraps tab event with a non-null result is reported', () => {
+        const tabStopRequirementResultStub = {
+            html: 'some html',
+        } as TabStopRequirementResult;
+        testOnkeydownForFocusTrapsWithResult(tabStopRequirementResultStub, Times.once());
+    });
+
+    test('start: onKeydownForFocusTraps tab event with a null result and is not reported', () => {
+        testOnkeydownForFocusTrapsWithResult(null, Times.never());
+    });
+
+    function testOnkeydownForFocusTrapsWithResult(
+        tabStopRequirementResultStub: TabStopRequirementResult,
+        givenTimes: Times,
+    ) {
+        const elementStub = {
+            innerText: 'some element 1 ',
+        } as HTMLElement;
+        const newElementStub = {
+            innerText: 'some element 2',
+        } as HTMLElement;
+        const eventStub = {
+            key: 'Tab',
+        } as KeyboardEvent;
+        let windowUtilsCallback: () => void;
+
+        prepareTabbableFocusOrderResults();
+        domMock
+            .setup(m => m.addEventListener('keydown', It.isAny()))
+            .callback((_, callback) => {
+                callback(eventStub);
+            });
+        domMock.setup(m => m.activeElement).returns(() => elementStub);
+        windowUtilsMock
+            .setup(m => m.setTimeout(It.isAny(), 500))
+            .callback(callback => {
+                windowUtilsCallback = callback;
+            });
+
+        testSubject.setResultCallback(reportResultsMock.object);
+        testSubject.start();
+
+        domMock.reset();
+        domMock.setup(m => m.activeElement).returns(() => newElementStub);
+        tabStopsRequirementEvaluatorMock
+            .setup(m => m.getKeyboardTrapResults(newElementStub, elementStub))
+            .returns(() => tabStopRequirementResultStub);
+        reportResultsMock.setup(m => m(tabStopRequirementResultStub)).verifiable(givenTimes);
+
+        windowUtilsCallback();
+
+        reportResultsMock.verifyAll();
+    }
+
+    test('start: onKeydownForFocusTraps event is not tab so do nothing', () => {
+        const eventStub = {
+            key: 'Enter',
+        } as KeyboardEvent;
+        const tabStopRequirementResultStub = {
+            html: 'some html',
+        } as TabStopRequirementResult;
+
+        prepareTabbableFocusOrderResults();
+        domMock
+            .setup(m => m.addEventListener('keydown', It.isAny()))
+            .callback((_, callback) => {
+                callback(eventStub);
+            });
+
+        reportResultsMock.setup(m => m(tabStopRequirementResultStub)).verifiable(Times.never());
+
+        testSubject.setResultCallback(reportResultsMock.object);
+        testSubject.start();
+
+        reportResultsMock.verifyAll();
+    });
+
+    function prepareTabbableFocusOrderResults() {
+        const tabbableFocusOrderResults = getTabStopRequirementResultStubs();
+        tabbabbleElementGetterMock
+            .setup(m => m.getRawElements())
+            .returns(() => focusableElementsStub);
+        tabStopsRequirementEvaluatorMock
+            .setup(m => m.getTabbableFocusOrderResults(focusableElementsStub))
+            .returns(() => tabbableFocusOrderResults);
+        tabbableFocusOrderResults.forEach(result => {
+            reportResultsMock.setup(m => m(result)).verifiable(Times.once());
+        });
+    }
+
+    function getTabStopRequirementResultStubs(): TabStopRequirementResult[] {
+        return [
+            {
+                html: 'result 1',
+            },
+            {
+                html: 'result 2',
+            },
+        ] as TabStopRequirementResult[];
+    }
+});

--- a/src/tests/unit/tests/injected/tabbable-element-getter.test.ts
+++ b/src/tests/unit/tests/injected/tabbable-element-getter.test.ts
@@ -64,4 +64,23 @@ describe('TabbableElementGetter', () => {
 
         expect(testSubject.get()).toEqual(expectedTabbleElementInfo);
     });
+
+    test('getRawElements', () => {
+        docMock.setup(m => m.documentElement).returns(() => documentElementStub);
+
+        const focusableElementsStub: FocusableElement[] = [
+            {
+                outerHTML: 'some outer html',
+            },
+            {
+                outerHTML: 'some other outer html',
+            },
+        ] as FocusableElement[];
+
+        getTabbableElementsMock
+            .setup(m => m(documentElementStub))
+            .returns(() => focusableElementsStub);
+
+        expect(testSubject.getRawElements()).toEqual(focusableElementsStub);
+    });
 });

--- a/src/tests/unit/tests/injected/tabbable-element-getter.test.ts
+++ b/src/tests/unit/tests/injected/tabbable-element-getter.test.ts
@@ -12,23 +12,15 @@ describe('TabbableElementGetter', () => {
     let getTabbableElementsMock: IMock<typeof tabbable>;
     let testSubject: TabbableElementGetter;
     let documentElementStub: HTMLElement;
+    let focusableElementsStub: FocusableElement[];
 
     beforeEach(() => {
         docMock = Mock.ofType<Document>();
         generateSelectorMock = Mock.ofType<typeof getUniqueSelector>();
         getTabbableElementsMock = Mock.ofType<typeof tabbable>();
         documentElementStub = {} as HTMLElement;
-        testSubject = new TabbableElementGetter(
-            docMock.object,
-            generateSelectorMock.object,
-            getTabbableElementsMock.object,
-        );
-    });
 
-    test('get', () => {
-        docMock.setup(m => m.documentElement).returns(() => documentElementStub);
-
-        const focusableElementsStub: FocusableElement[] = [
+        focusableElementsStub = [
             {
                 outerHTML: 'some outer html',
             },
@@ -40,6 +32,16 @@ describe('TabbableElementGetter', () => {
         getTabbableElementsMock
             .setup(m => m(documentElementStub))
             .returns(() => focusableElementsStub);
+
+        testSubject = new TabbableElementGetter(
+            docMock.object,
+            generateSelectorMock.object,
+            getTabbableElementsMock.object,
+        );
+    });
+
+    test('get', () => {
+        docMock.setup(m => m.documentElement).returns(() => documentElementStub);
 
         generateSelectorMock
             .setup(m => m(focusableElementsStub[0] as HTMLElement))
@@ -67,19 +69,6 @@ describe('TabbableElementGetter', () => {
 
     test('getRawElements', () => {
         docMock.setup(m => m.documentElement).returns(() => documentElementStub);
-
-        const focusableElementsStub: FocusableElement[] = [
-            {
-                outerHTML: 'some outer html',
-            },
-            {
-                outerHTML: 'some other outer html',
-            },
-        ] as FocusableElement[];
-
-        getTabbableElementsMock
-            .setup(m => m(documentElementStub))
-            .returns(() => focusableElementsStub);
 
         expect(testSubject.getRawElements()).toEqual(focusableElementsStub);
     });


### PR DESCRIPTION
#### Details

Creates tab stops orchestrator which should be used in all frames via all frame runner in a future PR.

##### Motivation

feature work.

##### Context

This is **definitely** making an assumption that when the orchestrator is stopped is equivalent to when the user is done testing. If that assumption ends up being not true, we'll have to expose a different API where we get the keyboard navigation results.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
