### PR TITLE
feat(tabstops-report): fix summary count when automated checks is null

### DIFF
--- a/src/reports/components/fast-pass-report-summary.tsx
+++ b/src/reports/components/fast-pass-report-summary.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import { requirements } from 'DetailsView/components/tab-stops/requirements';
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import * as React from 'react';
@@ -22,11 +21,12 @@ export const allOutcomeTypes: RequirementOutcomeType[] = ['fail', 'incomplete', 
 
 export class FastPassReportSummary extends React.Component<FastPassReportSummaryProps> {
     public render(): JSX.Element {
+        const { results, deps } = this.props;
         const failedTabResults = [];
         const incompleteTabResults = [];
         const passedTabResults = [];
 
-        for (const [requirementId, data] of Object.entries(this.props.results.tabStops)) {
+        for (const [requirementId, data] of Object.entries(results.tabStops)) {
             const resultsObject = {
                 id: requirementId,
                 name: requirements[requirementId].name,
@@ -46,21 +46,24 @@ export class FastPassReportSummary extends React.Component<FastPassReportSummary
         }
 
         const totalFailedTabInstancesCount: number =
-            this.props.deps.tabStopsFailedCounter.getTotalFailed(failedTabResults);
+            deps.tabStopsFailedCounter.getTotalFailed(failedTabResults);
         const totalIncompleteTabCount: number = incompleteTabResults.length;
         const totalPassedTabCount: number = passedTabResults.length;
 
-        const failedAutomatedChecks = this.props.results.automatedChecks.cards.fail;
-        const getTotalAutomatedChecksFailed = (results: CardRuleResult[]): number => {
-            return results.reduce((total, rule) => {
+        const getTotalAutomatedChecksFailed = (): number => {
+            if (results.automatedChecks === null) {
+                return 0;
+            }
+            return results.automatedChecks.cards.fail.reduce((total, rule) => {
                 return total + rule.nodes.length;
             }, 0);
         };
 
-        const totalfailedAutomatedChecks: number =
-            getTotalAutomatedChecksFailed(failedAutomatedChecks);
-        const passedAutomatedChecks = this.props.results.automatedChecks.cards.pass.length;
-        const incompleteAutomatedChecks = this.props.results.automatedChecks.cards.unknown.length;
+        const totalfailedAutomatedChecks: number = getTotalAutomatedChecksFailed();
+        const passedAutomatedChecks =
+            results.automatedChecks !== null ? results.automatedChecks.cards.pass.length : 0;
+        const incompleteAutomatedChecks =
+            results.automatedChecks !== null ? results.automatedChecks.cards.unknown.length : 0;
 
         const stats: Partial<OutcomeStats> = {
             fail: totalfailedAutomatedChecks + totalFailedTabInstancesCount,

--- a/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report-summary.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/fast-pass-report-summary.test.tsx.snap
@@ -23,3 +23,27 @@ exports[`FastPassReportSummary renders per the snapshot 1`] = `
   />
 </React.Fragment>
 `;
+
+exports[`FastPassReportSummary renders when automated checks are null 1`] = `
+<React.Fragment>
+  <h2>
+    Summary
+  </h2>
+  <OutcomeSummaryBar
+    allOutcomeTypes={
+      Array [
+        "fail",
+        "incomplete",
+        "pass",
+      ]
+    }
+    outcomeStats={
+      Object {
+        "fail": 2,
+        "incomplete": 0,
+        "pass": 1,
+      }
+    }
+  />
+</React.Fragment>
+`;

--- a/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
+++ b/src/tests/unit/tests/reports/components/fast-pass-report-summary.test.tsx
@@ -51,4 +51,36 @@ describe('FastPassReportSummary', () => {
         const rendered = shallow(<FastPassReportSummary {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
+
+    it('renders when automated checks are null', () => {
+        tabStopsFailedCounterMock = Mock.ofType<TabStopsFailedCounter>();
+        deps = { tabStopsFailedCounter: tabStopsFailedCounterMock.object };
+
+        props = {
+            results: {
+                automatedChecks: null,
+                tabStops: {
+                    'keyboard-traps': {
+                        status: 'pass',
+                        instances: [{ id: 'test-id-2', description: 'test desc 2' }],
+                        isExpanded: false,
+                    },
+                    'tab-order': {
+                        status: 'fail',
+                        instances: [{ id: 'test-id-4', description: 'test desc 4' }],
+                        isExpanded: false,
+                    },
+                },
+            },
+            deps: deps,
+        };
+
+        tabStopsFailedCounterMock
+            .setup(tsf => tsf.getTotalFailed(It.isAny()))
+            .returns(() => 2)
+            .verifiable(Times.once());
+
+        const rendered = shallow(<FastPassReportSummary {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Details

This updates the summary bar counts to handle the scenario when `results.automatedChecks` is null. This happens when a user is on the tab stops test, navigates to a new target page, restarts the tab stops test then exports without ever running automated checks.

##### Motivation

feature work


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
