### PR TITLE
chore(tabstops-auto-impl): small refactors to all-frame-runner

### DIFF
--- a/src/injected/all-frame-runner.ts
+++ b/src/injected/all-frame-runner.ts
@@ -67,12 +67,12 @@ export class AllFrameRunner<T> {
 
     public start = async () => {
         this.listener.start();
-        this.sendCommandToFrames(this.startCommand);
+        await this.sendCommandToFrames(this.startCommand);
     };
 
     public stop = async () => {
         this.listener.stop();
-        this.sendCommandToFrames(this.stopCommand);
+        await this.sendCommandToFrames(this.stopCommand);
     };
 
     private reportResultsThroughFrames = async (

--- a/src/injected/analyzers/tab-stops-orchestrator.ts
+++ b/src/injected/analyzers/tab-stops-orchestrator.ts
@@ -13,7 +13,7 @@ import { FocusableElement } from 'tabbable';
 export class TabStopRequirementOrchestrator
     implements AllFrameRunnerTarget<TabStopRequirementResult>
 {
-    public readonly name: string = 'TabStopRequirementOrchestrator';
+    public readonly commandSuffix: string = 'TabStopRequirementOrchestrator';
     private tabbableTabStops: FocusableElement[];
     private actualTabStops: Set<HTMLElement> = new Set();
     private latestVisitedTabStop: HTMLElement = null;

--- a/src/injected/single-frame-tab-stop-listener.ts
+++ b/src/injected/single-frame-tab-stop-listener.ts
@@ -9,7 +9,7 @@ export class SingleFrameTabStopListener implements AllFrameRunnerTarget<TabStopE
     private reportResults: (payload: TabStopEvent) => Promise<void>;
 
     constructor(
-        public readonly name: string,
+        public readonly commandSuffix: string,
         private readonly getUniqueSelector: (element: HTMLElement) => string,
         private readonly dom: Document,
         private readonly getCurrentDate: typeof DateProvider.getCurrentDate = DateProvider.getCurrentDate,


### PR DESCRIPTION
#### Details

This PR applies some changes based on comments in #5036 - we decided to merge that in early and address follow-up comments in a separate PR:
- change `AllFrameRunnerTarget.name` to `AllFrameRunnerTarget.commandSuffix` to better illustrate its usage
- change `AllFrameRunner.start()` and `AllFrameRunner.stop()`  to `void` functions. While the frame-messenger has support for responses from child frames, we weren't making use of it for start/stop. The frame-messenger listener expects an explicit return type of `CommandMessageResponse | null`, but this didn't make sense for clients of `AllFrameRunner` who need to just fire-and-forget start and stop. When registering commands to the frame messenger, we wrap the public-facing void methods and explicitly return `null`. If we need response data later (maybe we want to "collect" data on stop), we can, but so far we've been using the `reportResults` callback to accomplish the same thing.
- refactor all-frame-runner.test.ts to improve readability. I don't like that `start` and `stop` share so much test code, but I'm wary of creating more helper methods that obfuscate the unit tests. Happy to adjust in either direction based on feedback.

##### Motivation

respond to feedback from original PR

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
