### PR TITLE
feat(tabstops-auto-impl): Trigger tabbing completed based on details view focus

### DIFF
--- a/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
+++ b/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
@@ -9,6 +9,7 @@ import {
     UpdateTabStopRequirementStatusPayload,
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
+    UpdateTabbingCompletedPayload,
 } from 'background/actions/action-payloads';
 import { DevToolActionMessageCreator } from 'common/message-creators/dev-tool-action-message-creator';
 import { Messages } from 'common/messages';
@@ -108,6 +109,17 @@ export class TabStopRequirementActionMessageCreator extends DevToolActionMessage
 
         this.dispatcher.dispatchMessage({
             messageType: Messages.Visualizations.TabStops.RequirementExpansionToggled,
+            payload,
+        });
+    };
+
+    public updateTabbingCompleted = (tabbingCompleted: boolean) => {
+        const payload: UpdateTabbingCompletedPayload = {
+            tabbingCompleted,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Visualizations.TabStops.TabbingCompleted,
             payload,
         });
     };

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { CollapsibleComponent } from 'common/components/collapsible-component';
+import { FocusComponent } from 'common/components/focus-component';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { NamedFC } from 'common/react/named-fc';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -9,6 +10,7 @@ import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
+import { WindowUtils } from 'common/window-utils';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import * as styles from 'DetailsView/components/adhoc-tab-stops-test-view.scss';
 import * as requirementInstructionStyles from 'DetailsView/components/requirement-instructions.scss';
@@ -36,6 +38,7 @@ import * as Markup from '../../assessments/markup';
 
 export type AdhocTabStopsTestViewDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+    windowUtils: WindowUtils;
 } & TabStopsRequirementsTableDeps &
     TabStopsFailedInstancePanelDeps &
     TabStopsFailedInstanceSectionDeps &
@@ -150,6 +153,14 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                         deps={props.deps}
                         failureInstanceState={props.tabStopsViewStoreData.failureInstanceState}
                         requirementState={requirementState}
+                    />
+                    <FocusComponent
+                        windowUtils={props.deps.windowUtils}
+                        configuration={props.configuration}
+                        visualizationStoreData={props.visualizationStoreData}
+                        tabStopRequirementActionMessageCreator={
+                            props.deps.tabStopRequirementActionMessageCreator
+                        }
                     />
                 </div>
             </div>

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -2,15 +2,16 @@
 // Licensed under the MIT License.
 
 import { CollapsibleComponent } from 'common/components/collapsible-component';
-import { FocusComponent } from 'common/components/focus-component';
+import { FlaggedComponent } from 'common/components/flagged-component';
+import { FocusComponent, FocusComponentDeps } from 'common/components/focus-component';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { FeatureFlags } from 'common/feature-flags';
 import { NamedFC } from 'common/react/named-fc';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
-import { WindowUtils } from 'common/window-utils';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import * as styles from 'DetailsView/components/adhoc-tab-stops-test-view.scss';
 import * as requirementInstructionStyles from 'DetailsView/components/requirement-instructions.scss';
@@ -38,11 +39,11 @@ import * as Markup from '../../assessments/markup';
 
 export type AdhocTabStopsTestViewDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-    windowUtils: WindowUtils;
 } & TabStopsRequirementsTableDeps &
     TabStopsFailedInstancePanelDeps &
     TabStopsFailedInstanceSectionDeps &
-    ContentLinkDeps;
+    ContentLinkDeps &
+    FocusComponentDeps;
 
 export interface AdhocTabStopsTestViewProps {
     deps: AdhocTabStopsTestViewDeps;
@@ -154,12 +155,15 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                         failureInstanceState={props.tabStopsViewStoreData.failureInstanceState}
                         requirementState={requirementState}
                     />
-                    <FocusComponent
-                        windowUtils={props.deps.windowUtils}
-                        configuration={props.configuration}
-                        visualizationStoreData={props.visualizationStoreData}
-                        tabStopRequirementActionMessageCreator={
-                            props.deps.tabStopRequirementActionMessageCreator
+                    <FlaggedComponent
+                        featureFlag={FeatureFlags.tabStopsAutomation}
+                        featureFlagStoreData={props.featureFlagStoreData}
+                        enableJSXElement={
+                            <FocusComponent
+                                deps={props.deps}
+                                configuration={props.configuration}
+                                visualizationStoreData={props.visualizationStoreData}
+                            />
                         }
                     />
                 </div>

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -159,11 +159,7 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                         featureFlag={FeatureFlags.tabStopsAutomation}
                         featureFlagStoreData={props.featureFlagStoreData}
                         enableJSXElement={
-                            <FocusComponent
-                                deps={props.deps}
-                                configuration={props.configuration}
-                                visualizationStoreData={props.visualizationStoreData}
-                            />
+                            <FocusComponent deps={props.deps} tabbingEnabled={scanData.enabled} />
                         }
                     />
                 </div>

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -146,6 +146,9 @@ export interface RemoveTabStopInstancePayload extends BaseActionPayload {
 export interface ToggleTabStopRequirementExpandPayload extends BaseActionPayload {
     requirementId: TabStopRequirementId;
 }
+export interface UpdateTabbingCompletedPayload extends BaseActionPayload {
+    tabbingCompleted: boolean;
+}
 export interface AddTabStopInstancePayload extends BaseActionPayload {
     requirementId: TabStopRequirementId;
     description: string;

--- a/src/background/actions/tab-stop-requirement-action-creator.ts
+++ b/src/background/actions/tab-stop-requirement-action-creator.ts
@@ -9,6 +9,7 @@ import {
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
+    UpdateTabbingCompletedPayload,
     UpdateTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
 } from './action-payloads';
@@ -50,6 +51,11 @@ export class TabStopRequirementActionCreator {
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Visualizations.TabStops.RequirementExpansionToggled,
             this.onRequirementExpansionToggled,
+        );
+
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.Visualizations.TabStops.TabbingCompleted,
+            this.onTabbingCompleted,
         );
     }
 
@@ -101,5 +107,9 @@ export class TabStopRequirementActionCreator {
         payload: ToggleTabStopRequirementExpandPayload,
     ): void => {
         this.tabStopRequirementActions.toggleTabStopRequirementExpand.invoke(payload);
+    };
+
+    private onTabbingCompleted = (payload: UpdateTabbingCompletedPayload): void => {
+        this.tabStopRequirementActions.updateTabbingCompleted.invoke(payload);
     };
 }

--- a/src/background/actions/tab-stop-requirement-actions.ts
+++ b/src/background/actions/tab-stop-requirement-actions.ts
@@ -8,6 +8,7 @@ import {
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
+    UpdateTabbingCompletedPayload,
     UpdateTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
 } from './action-payloads';
@@ -23,4 +24,5 @@ export class TabStopRequirementActions {
         new Action<ResetTabStopRequirementStatusPayload>();
     public readonly toggleTabStopRequirementExpand =
         new Action<ToggleTabStopRequirementExpandPayload>();
+    public readonly updateTabbingCompleted = new Action<UpdateTabbingCompletedPayload>();
 }

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -108,8 +108,6 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         this.tabActions.existingTabUpdated.addListener(this.onExistingTabUpdated);
     }
 
-    // Called when toggle is turned off-> clear tabbed elements so we can't get the visualization back
-    // For all intents and purposes right now this resets all data
     private onTabStopsDisabled = (): void => {
         this.state.tabStops.tabbedElements = null;
         this.emitChanged();

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -100,6 +100,12 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         this.tabStopRequirementActions.toggleTabStopRequirementExpand.addListener(
             this.onToggleTabStopRequirementExpandCollapse,
         );
+
+        // TODO
+        this.tabStopRequirementActions.updateTabbingCompleted.addListener(() => {
+            console.log('Received tabbing completed in background store');
+        });
+
         this.tabActions.existingTabUpdated.addListener(this.onExistingTabUpdated);
     }
 

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -23,6 +23,7 @@ import {
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
+    UpdateTabbingCompletedPayload,
     UpdateTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
 } from '../actions/action-payloads';
@@ -54,6 +55,7 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
             [AdHocTestkeys.TabStops]: {
                 tabbedElements: null,
                 requirements,
+                tabbingCompleted: false,
             },
         };
 
@@ -100,15 +102,14 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         this.tabStopRequirementActions.toggleTabStopRequirementExpand.addListener(
             this.onToggleTabStopRequirementExpandCollapse,
         );
-
-        // TODO
-        this.tabStopRequirementActions.updateTabbingCompleted.addListener(() => {
-            console.log('Received tabbing completed in background store');
-        });
-
+        this.tabStopRequirementActions.updateTabbingCompleted.addListener(
+            this.onUpdateTabbingCompleted,
+        );
         this.tabActions.existingTabUpdated.addListener(this.onExistingTabUpdated);
     }
 
+    // Called when toggle is turned off-> clear tabbed elements so we can't get the visualization back
+    // For all intents and purposes right now this resets all data
     private onTabStopsDisabled = (): void => {
         this.state.tabStops.tabbedElements = null;
         this.emitChanged();
@@ -248,4 +249,9 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
 
         return selectedRows;
     }
+
+    private onUpdateTabbingCompleted = (payload: UpdateTabbingCompletedPayload): void => {
+        this.state.tabStops.tabbingCompleted = payload.tabbingCompleted;
+        this.emitChanged();
+    };
 }

--- a/src/common/components/focus-component.tsx
+++ b/src/common/components/focus-component.tsx
@@ -39,8 +39,6 @@ export class FocusComponent extends React.Component<FocusComponentProps> {
             this.props.visualizationStoreData.tests,
         );
         if (tabbing.enabled) {
-            console.log('Send message to end tabbing...');
-            // TODO when will we need to set this back to false?
             this.props.tabStopRequirementActionMessageCreator.updateTabbingCompleted(true);
         }
     };

--- a/src/common/components/focus-component.tsx
+++ b/src/common/components/focus-component.tsx
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
-import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { WindowUtils } from 'common/window-utils';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import * as React from 'react';
@@ -13,8 +11,7 @@ export type FocusComponentDeps = {
 
 export interface FocusComponentProps {
     deps: FocusComponentDeps;
-    configuration: VisualizationConfiguration;
-    visualizationStoreData: VisualizationStoreData;
+    tabbingEnabled: boolean;
 }
 
 export class FocusComponent extends React.Component<FocusComponentProps> {
@@ -39,10 +36,7 @@ export class FocusComponent extends React.Component<FocusComponentProps> {
     }
 
     private handleFocusEvent = () => {
-        const tabbing = this.props.configuration.getStoreData(
-            this.props.visualizationStoreData.tests,
-        );
-        if (tabbing.enabled) {
+        if (this.props.tabbingEnabled) {
             this.props.deps.tabStopRequirementActionMessageCreator.updateTabbingCompleted(true);
         }
     };

--- a/src/common/components/focus-component.tsx
+++ b/src/common/components/focus-component.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { WindowUtils } from 'common/window-utils';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
+import * as React from 'react';
+
+export interface FocusComponentProps {
+    windowUtils: WindowUtils;
+    configuration: VisualizationConfiguration;
+    visualizationStoreData: VisualizationStoreData;
+    tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
+}
+
+export class FocusComponent extends React.Component<FocusComponentProps> {
+    private static readonly focusEventName = 'focus';
+
+    public componentDidMount(): void {
+        this.props.windowUtils.addEventListener(
+            this.props.windowUtils.getWindow(),
+            FocusComponent.focusEventName,
+            this.handleFocusEvent,
+            false,
+        );
+    }
+
+    public componentWillUnmount(): void {
+        this.props.windowUtils.removeEventListener(
+            this.props.windowUtils.getWindow(),
+            FocusComponent.focusEventName,
+            this.handleFocusEvent,
+            false,
+        );
+    }
+
+    private handleFocusEvent = () => {
+        const tabbing = this.props.configuration.getStoreData(
+            this.props.visualizationStoreData.tests,
+        );
+        if (tabbing.enabled) {
+            console.log('Send message to end tabbing...');
+            // TODO when will we need to set this back to false?
+            this.props.tabStopRequirementActionMessageCreator.updateTabbingCompleted(true);
+        }
+    };
+
+    public render(): JSX.Element {
+        return null;
+    }
+}

--- a/src/common/components/focus-component.tsx
+++ b/src/common/components/focus-component.tsx
@@ -6,19 +6,23 @@ import { WindowUtils } from 'common/window-utils';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import * as React from 'react';
 
-export interface FocusComponentProps {
+export type FocusComponentDeps = {
     windowUtils: WindowUtils;
+    tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
+};
+
+export interface FocusComponentProps {
+    deps: FocusComponentDeps;
     configuration: VisualizationConfiguration;
     visualizationStoreData: VisualizationStoreData;
-    tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
 }
 
 export class FocusComponent extends React.Component<FocusComponentProps> {
     private static readonly focusEventName = 'focus';
 
     public componentDidMount(): void {
-        this.props.windowUtils.addEventListener(
-            this.props.windowUtils.getWindow(),
+        this.props.deps.windowUtils.addEventListener(
+            this.props.deps.windowUtils.getWindow(),
             FocusComponent.focusEventName,
             this.handleFocusEvent,
             false,
@@ -26,8 +30,8 @@ export class FocusComponent extends React.Component<FocusComponentProps> {
     }
 
     public componentWillUnmount(): void {
-        this.props.windowUtils.removeEventListener(
-            this.props.windowUtils.getWindow(),
+        this.props.deps.windowUtils.removeEventListener(
+            this.props.deps.windowUtils.getWindow(),
             FocusComponent.focusEventName,
             this.handleFocusEvent,
             false,
@@ -39,7 +43,7 @@ export class FocusComponent extends React.Component<FocusComponentProps> {
             this.props.visualizationStoreData.tests,
         );
         if (tabbing.enabled) {
-            this.props.tabStopRequirementActionMessageCreator.updateTabbingCompleted(true);
+            this.props.deps.tabStopRequirementActionMessageCreator.updateTabbingCompleted(true);
         }
     };
 

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -26,6 +26,7 @@ export const Messages = {
             UpdateTabStopInstance: `${messagePrefix}/visualization/tab-stops/instance-updated`,
             RemoveTabStopInstance: `${messagePrefix}/visualization/tab-stops/instance-removed`,
             RequirementExpansionToggled: `${messagePrefix}/visualization/tab-stops/toggleTabStopRequirementExpand`,
+            TabbingCompleted: `${messagePrefix}/visualization/tab-stops/tabbingCompleted`,
         },
         Issues: {
             UpdateFocusedInstance: `${messagePrefix}/visualization/issues/targets/focused/update`,

--- a/src/common/types/store-data/visualization-scan-result-data.ts
+++ b/src/common/types/store-data/visualization-scan-result-data.ts
@@ -40,6 +40,7 @@ export type TabStopRequirementState = {
 interface TabStopsScanResultData {
     tabbedElements: TabbedElementData[];
     requirements?: TabStopRequirementState;
+    tabbingCompleted: boolean;
 }
 
 export interface VisualizationScanResultData {

--- a/src/injected/analyzer-controller.ts
+++ b/src/injected/analyzer-controller.ts
@@ -65,10 +65,8 @@ export class AnalyzerController {
         this.analyzerStateUpdateHandler.handleUpdate(this.visualizationstore.getState());
     };
 
-    // TODO better place for this?
     private onResultsChangedState = (): void => {
         if (this.visualizationResultsStore.getState().tabStops.tabbingCompleted) {
-            // visualization remains, but no new tabstops are added
             this.teardown(AdHocTestkeys.TabStops);
         }
     };

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -335,6 +335,7 @@ export class MainWindowInitializer extends WindowInitializer {
         );
         this.analyzerController = new AnalyzerController(
             this.visualizationStoreProxy,
+            this.visualizationScanResultStoreProxy,
             this.featureFlagStoreProxy,
             this.scopingStoreProxy,
             this.visualizationConfigurationFactory,

--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -112,6 +112,14 @@ export class SelectorMapHelper {
                 selectorMap = visualizationScanResultData.landmarks.fullAxeResultsMap;
                 break;
             case VisualizationType.TabStops:
+                // TODO options if we want to be able to toggle the visualization on and off without
+                // user having to redo tabbing after toggle off:
+                //      - Add separate list ('tabbedResultsMap'?) analogous to tabbedElements that can
+                //          be safely reset when visualization is toggled off.
+                //      - Add boolean ('showingVisualization'?) and update IsVisualizationEnabledCallback
+                //          to return false when type of test is tabstops and showingVisualization is false.
+                //      - Add boolean ('showingVisualization'?) and add logic here to return null when
+                //          false.
                 selectorMap = visualizationScanResultData.tabStops.tabbedElements;
                 break;
             default:

--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -112,14 +112,6 @@ export class SelectorMapHelper {
                 selectorMap = visualizationScanResultData.landmarks.fullAxeResultsMap;
                 break;
             case VisualizationType.TabStops:
-                // TODO options if we want to be able to toggle the visualization on and off without
-                // user having to redo tabbing after toggle off:
-                //      - Add separate list ('tabbedResultsMap'?) analogous to tabbedElements that can
-                //          be safely reset when visualization is toggled off.
-                //      - Add boolean ('showingVisualization'?) and update IsVisualizationEnabledCallback
-                //          to return false when type of test is tabstops and showingVisualization is false.
-                //      - Add boolean ('showingVisualization'?) and add logic here to return null when
-                //          false.
                 selectorMap = visualizationScanResultData.tabStops.tabbedElements;
                 break;
             default:

--- a/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
@@ -29,6 +29,11 @@ export class VisualizationScanResultStoreDataBuilder extends BaseDataBuilder<Vis
         return this;
     }
 
+    public withTabbingCompleted(completed: boolean): VisualizationScanResultStoreDataBuilder {
+        this.data.tabStops.tabbingCompleted = completed;
+        return this;
+    }
+
     public withTabStopRequirement(
         requirement: TabStopRequirementState,
     ): VisualizationScanResultStoreDataBuilder {

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -197,6 +197,7 @@ exports[`DetailsViewBody render render 1`] = `
               },
             },
             "tabbedElements": null,
+            "tabbingCompleted": false,
           },
         }
       }
@@ -523,6 +524,7 @@ exports[`DetailsViewBody render render 1`] = `
                 },
               },
               "tabbedElements": null,
+              "tabbingCompleted": false,
             },
           }
         }
@@ -856,6 +858,7 @@ exports[`DetailsViewBody render render 1`] = `
                     },
                   },
                   "tabbedElements": null,
+                  "tabbingCompleted": false,
                 },
               }
             }

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -333,6 +333,7 @@ exports[` render renders normally 1`] = `
             },
           },
           "tabbedElements": null,
+          "tabbingCompleted": false,
         },
       }
     }

--- a/src/tests/unit/tests/DetailsView/actions/tab-stop-requirement-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/tab-stop-requirement-action-message-creator.test.ts
@@ -205,4 +205,24 @@ describe('TabStopRequirementActionMessageCreatorTest', () => {
 
         telemetryFactoryMock.verifyAll();
     });
+
+    test('updateTabbingCompleted', () => {
+        const tabbingCompleted = true;
+
+        const expectedMessage = {
+            messageType: Messages.Visualizations.TabStops.TabbingCompleted,
+            payload: {
+                tabbingCompleted,
+            },
+        };
+
+        testSubject.updateTabbingCompleted(tabbingCompleted);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+
+        telemetryFactoryMock.verifyAll();
+    });
 });

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -85,6 +85,22 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
         }
       }
     />
+    <FocusComponent
+      configuration={
+        Object {
+          "displayableData": Object {
+            "title": "test title",
+            "toggleLabel": "test toggle label",
+          },
+          "getStoreData": [Function],
+        }
+      }
+      visualizationStoreData={
+        Object {
+          "tests": Object {},
+        }
+      }
+    />
   </div>
 </div>
 `;
@@ -170,6 +186,22 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
       failureInstanceState={
         Object {
           "actionType": "CREATE",
+        }
+      }
+    />
+    <FocusComponent
+      configuration={
+        Object {
+          "displayableData": Object {
+            "title": "test title",
+            "toggleLabel": "test toggle label",
+          },
+          "getStoreData": [Function],
+        }
+      }
+      visualizationStoreData={
+        Object {
+          "tests": Object {},
         }
       }
     />

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -88,21 +88,8 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
     <FlaggedComponent
       enableJSXElement={
         <FocusComponent
-          configuration={
-            Object {
-              "displayableData": Object {
-                "title": "test title",
-                "toggleLabel": "test toggle label",
-              },
-              "getStoreData": [Function],
-            }
-          }
           deps="stub-deps"
-          visualizationStoreData={
-            Object {
-              "tests": Object {},
-            }
-          }
+          tabbingEnabled={true}
         />
       }
       featureFlag="tabStopsAutomation"
@@ -199,21 +186,8 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
     <FlaggedComponent
       enableJSXElement={
         <FocusComponent
-          configuration={
-            Object {
-              "displayableData": Object {
-                "title": "test title",
-                "toggleLabel": "test toggle label",
-              },
-              "getStoreData": [Function],
-            }
-          }
           deps="stub-deps"
-          visualizationStoreData={
-            Object {
-              "tests": Object {},
-            }
-          }
+          tabbingEnabled={true}
         />
       }
       featureFlag="tabStopsAutomation"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -85,21 +85,28 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
         }
       }
     />
-    <FocusComponent
-      configuration={
-        Object {
-          "displayableData": Object {
-            "title": "test title",
-            "toggleLabel": "test toggle label",
-          },
-          "getStoreData": [Function],
-        }
+    <FlaggedComponent
+      enableJSXElement={
+        <FocusComponent
+          configuration={
+            Object {
+              "displayableData": Object {
+                "title": "test title",
+                "toggleLabel": "test toggle label",
+              },
+              "getStoreData": [Function],
+            }
+          }
+          deps="stub-deps"
+          visualizationStoreData={
+            Object {
+              "tests": Object {},
+            }
+          }
+        />
       }
-      visualizationStoreData={
-        Object {
-          "tests": Object {},
-        }
-      }
+      featureFlag="tabStopsAutomation"
+      featureFlagStoreData={Object {}}
     />
   </div>
 </div>
@@ -189,21 +196,28 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
         }
       }
     />
-    <FocusComponent
-      configuration={
-        Object {
-          "displayableData": Object {
-            "title": "test title",
-            "toggleLabel": "test toggle label",
-          },
-          "getStoreData": [Function],
-        }
+    <FlaggedComponent
+      enableJSXElement={
+        <FocusComponent
+          configuration={
+            Object {
+              "displayableData": Object {
+                "title": "test title",
+                "toggleLabel": "test toggle label",
+              },
+              "getStoreData": [Function],
+            }
+          }
+          deps="stub-deps"
+          visualizationStoreData={
+            Object {
+              "tests": Object {},
+            }
+          }
+        />
       }
-      visualizationStoreData={
-        Object {
-          "tests": Object {},
-        }
-      }
+      featureFlag="tabStopsAutomation"
+      featureFlagStoreData={Object {}}
     />
   </div>
 </div>

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-instance-section-props-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-instance-section-props-factory.test.tsx.snap
@@ -8,6 +8,7 @@ Object {
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
+      "updateTabbingCompleted": [Function],
     },
     "tabStopsTestViewController": proxy {
       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -103,6 +104,7 @@ Object {
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
+      "updateTabbingCompleted": [Function],
     },
     "tabStopsTestViewController": proxy {
       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -121,6 +123,7 @@ Object {
           "dispatcher": undefined,
           "telemetryFactory": undefined,
           "toggleTabStopRequirementExpand": [Function],
+          "updateTabbingCompleted": [Function],
         },
         "tabStopsTestViewController": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -167,6 +170,7 @@ Object {
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
+      "updateTabbingCompleted": [Function],
     },
     "tabStopsTestViewController": proxy {
       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -265,6 +269,7 @@ Object {
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
+      "updateTabbingCompleted": [Function],
     },
     "tabStopsTestViewController": proxy {
       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -283,6 +288,7 @@ Object {
           "dispatcher": undefined,
           "telemetryFactory": undefined,
           "toggleTabStopRequirementExpand": [Function],
+          "updateTabbingCompleted": [Function],
         },
         "tabStopsTestViewController": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -337,6 +343,7 @@ Object {
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
+      "updateTabbingCompleted": [Function],
     },
     "tabStopsTestViewController": proxy {
       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -355,6 +362,7 @@ Object {
           "dispatcher": undefined,
           "telemetryFactory": undefined,
           "toggleTabStopRequirementExpand": [Function],
+          "updateTabbingCompleted": [Function],
         },
         "tabStopsTestViewController": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/focus-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/focus-component.test.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FocusComponent, FocusComponentProps } from 'common/components/focus-component';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { WindowUtils } from 'common/window-utils';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+describe('FocusComponent', () => {
+    let props: FocusComponentProps;
+    let windowUtilsMock: IMock<WindowUtils>;
+    let configurationMock: IMock<VisualizationConfiguration>;
+    let visualizationStoreData: VisualizationStoreData;
+    let tabStopRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
+
+    beforeEach(() => {
+        windowUtilsMock = Mock.ofType(WindowUtils);
+        configurationMock = Mock.ofType<VisualizationConfiguration>();
+        tabStopRequirementActionMessageCreatorMock = Mock.ofType(
+            TabStopRequirementActionMessageCreator,
+        );
+        props = {
+            windowUtils: windowUtilsMock.object,
+            configuration: configurationMock.object,
+            visualizationStoreData,
+            tabStopRequirementActionMessageCreator:
+                tabStopRequirementActionMessageCreatorMock.object,
+        };
+    });
+
+    test('render', () => {
+        const testSubject = shallow(<FocusComponent {...props} />);
+        expect(testSubject.getElement()).toBeNull();
+    });
+
+    test('componentDidMount adds focus listener', () => {
+        windowUtilsMock
+            .setup(util => util.addEventListener(It.isAny(), 'focus', It.isAny(), false))
+            .verifiable(Times.once());
+
+        const testSubject = new FocusComponent(props);
+        testSubject.componentDidMount();
+
+        windowUtilsMock.verifyAll();
+    });
+
+    test('componentWillUnmount removes listener', () => {
+        windowUtilsMock
+            .setup(util => util.removeEventListener(It.isAny(), 'focus', It.isAny(), false))
+            .verifiable(Times.once());
+
+        const testSubject = new FocusComponent(props);
+        testSubject.componentWillUnmount();
+
+        windowUtilsMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/focus-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/focus-component.test.tsx
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 import { FocusComponent, FocusComponentProps } from 'common/components/focus-component';
-import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
-import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { WindowUtils } from 'common/window-utils';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { shallow } from 'enzyme';
@@ -13,19 +11,15 @@ import { IMock, It, Mock, Times } from 'typemoq';
 describe('FocusComponent', () => {
     let props: FocusComponentProps;
     let windowUtilsMock: IMock<WindowUtils>;
-    let configurationMock: IMock<VisualizationConfiguration>;
-    let visualizationStoreData: VisualizationStoreData;
     let tabStopRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
 
     beforeEach(() => {
         windowUtilsMock = Mock.ofType(WindowUtils);
-        configurationMock = Mock.ofType<VisualizationConfiguration>();
         tabStopRequirementActionMessageCreatorMock = Mock.ofType(
             TabStopRequirementActionMessageCreator,
         );
         props = {
-            visualizationStoreData,
-            configuration: configurationMock.object,
+            tabbingEnabled: true,
             deps: {
                 windowUtils: windowUtilsMock.object,
                 tabStopRequirementActionMessageCreator:

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/focus-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/focus-component.test.tsx
@@ -24,11 +24,13 @@ describe('FocusComponent', () => {
             TabStopRequirementActionMessageCreator,
         );
         props = {
-            windowUtils: windowUtilsMock.object,
-            configuration: configurationMock.object,
             visualizationStoreData,
-            tabStopRequirementActionMessageCreator:
-                tabStopRequirementActionMessageCreatorMock.object,
+            configuration: configurationMock.object,
+            deps: {
+                windowUtils: windowUtilsMock.object,
+                tabStopRequirementActionMessageCreator:
+                    tabStopRequirementActionMessageCreatorMock.object,
+            },
         };
     });
 

--- a/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
@@ -7,6 +7,7 @@ import {
     UpdateTabStopRequirementStatusPayload,
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
+    UpdateTabbingCompletedPayload,
 } from 'background/actions/action-payloads';
 import { TabStopRequirementActionCreator } from 'background/actions/tab-stop-requirement-action-creator';
 import { TabStopRequirementActions } from 'background/actions/tab-stop-requirement-actions';
@@ -233,6 +234,31 @@ describe('TabStopRequirementActionCreator', () => {
                 ),
             Times.once(),
         );
+    });
+
+    test('registerCallback for on tabbing completed', () => {
+        const actionName = 'updateTabbingCompleted';
+        const payload: UpdateTabbingCompletedPayload = {
+            tabbingCompleted: true,
+        };
+
+        const onTabbingCompletedMock = createActionMock(payload);
+
+        const actionsMock = createActionsMock(actionName, onTabbingCompletedMock.object);
+        const interpreterMock = createInterpreterMock(
+            Messages.Visualizations.TabStops.TabbingCompleted,
+            payload,
+        );
+
+        const testSubject = new TabStopRequirementActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        onTabbingCompletedMock.verifyAll();
     });
 
     function createActionsMock<ActionName extends keyof TabStopRequirementActions>(

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -5,6 +5,7 @@ import {
     AddTabStopInstancePayload,
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
+    UpdateTabbingCompletedPayload,
     UpdateTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
 } from 'background/actions/action-payloads';
@@ -510,6 +511,22 @@ describe('VisualizationScanResultStoreTest', () => {
             .build();
 
         createStoreTesterForTabStopRequirementActions('addTabStopInstance')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('onUpdateTabbingCompleted', () => {
+        const initialState = new VisualizationScanResultStoreDataBuilder().build();
+
+        const expectedState = new VisualizationScanResultStoreDataBuilder()
+            .withTabbingCompleted(true)
+            .build();
+
+        const payload: UpdateTabbingCompletedPayload = {
+            tabbingCompleted: true,
+        };
+
+        createStoreTesterForTabStopRequirementActions('updateTabbingCompleted')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, expectedState);
     });

--- a/src/tests/unit/tests/injected/analyzer-controller.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-controller.test.ts
@@ -4,7 +4,9 @@ import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { ScopingStore } from 'background/stores/global/scoping-store';
+import { VisualizationScanResultStore } from 'background/stores/visualization-scan-result-store';
 import { VisualizationStore } from 'background/stores/visualization-store';
+import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { BaseStore } from '../../../../common/base-store';
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
@@ -28,6 +30,7 @@ import { VisualizationStoreDataBuilder } from '../../common/visualization-store-
 
 describe('AnalyzerControllerTests', () => {
     let visualizationStoreMock: IMock<VisualizationStore>;
+    let visualizationScanResultsStoreMock: IMock<VisualizationScanResultStore>;
     let scopingStoreMock: IMock<BaseStore<ScopingStoreData>>;
     let featureFlagStoreStoreMock: IMock<FeatureFlagStore>;
     let testType: VisualizationType;
@@ -40,6 +43,7 @@ describe('AnalyzerControllerTests', () => {
     let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
 
     let visualizationStoreState: VisualizationStoreData;
+    let visualizationScanResultsStoreState: VisualizationScanResultData;
     let featureFlagStoreState: FeatureFlagStoreData;
     let scopingStoreState: ScopingStoreData;
     let analyzerProviderStrictMock: IMock<AnalyzerProvider>;
@@ -70,10 +74,15 @@ describe('AnalyzerControllerTests', () => {
         visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
         assessmentsMock = Mock.ofType(AssessmentsProviderImpl);
         visualizationStoreMock = Mock.ofType<VisualizationStore>();
+        visualizationScanResultsStoreMock = Mock.ofType<VisualizationScanResultStore>();
         featureFlagStoreStoreMock = Mock.ofType<FeatureFlagStore>();
         scopingStoreMock = Mock.ofType<ScopingStore>(ScopingStore);
 
         visualizationStoreMock.setup(sm => sm.getState()).returns(() => visualizationStoreState);
+
+        visualizationScanResultsStoreMock
+            .setup(sm => sm.getState())
+            .returns(() => visualizationScanResultsStoreState);
 
         featureFlagStoreStoreMock.setup(sm => sm.getState()).returns(() => featureFlagStoreState);
 
@@ -96,6 +105,7 @@ describe('AnalyzerControllerTests', () => {
 
         featureFlagStoreState = {};
         visualizationStoreState = null;
+        visualizationScanResultsStoreState = null;
         scopingStoreState = null;
 
         EnumHelper.getNumericValues(VisualizationType).forEach((test: VisualizationType) => {
@@ -109,7 +119,7 @@ describe('AnalyzerControllerTests', () => {
 
         testObject = new AnalyzerController(
             visualizationStoreMock.object,
-            null, // TODO
+            visualizationScanResultsStoreMock.object,
             featureFlagStoreStoreMock.object,
             scopingStoreMock.object,
             visualizationConfigurationFactoryMock.object,
@@ -121,6 +131,7 @@ describe('AnalyzerControllerTests', () => {
 
     afterEach(() => {
         visualizationStoreMock.verifyAll();
+        visualizationScanResultsStoreMock.verifyAll();
         featureFlagStoreStoreMock.verifyAll();
         scopingStoreMock.verifyAll();
         analyzerProviderStrictMock.verifyAll();

--- a/src/tests/unit/tests/injected/analyzer-controller.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-controller.test.ts
@@ -109,6 +109,7 @@ describe('AnalyzerControllerTests', () => {
 
         testObject = new AnalyzerController(
             visualizationStoreMock.object,
+            null, // TODO
             featureFlagStoreStoreMock.object,
             scopingStoreMock.object,
             visualizationConfigurationFactoryMock.object,


### PR DESCRIPTION
#### Details

Adds `tabbingCompleted` field to store data to keep track of if the tab stop analyzer is listening for user tabs or not. Tabbing is marked as complete when focus shifts from the target page to the details page. 

##### Motivation

Feature work

##### Context

A future PR will add another criteria for tabbing 'done-ness'- the tabbingCompleted field will also be set to true if we reach the same element multiple times in our tabbing. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
