### PR TITLE
feat(tabstops-auto-impl): wire up new tab stops automation behind feature flag

### DIFF
--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -177,6 +177,7 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
 
     private onAddTabStopInstance = (payload: AddTabStopInstancePayload): void => {
         const { requirementId, description } = payload;
+        this.state.tabStops.requirements[requirementId].status = 'fail';
         this.state.tabStops.requirements[requirementId].instances.push({
             description,
             id: this.generateUID(),

--- a/src/common/self-fast-pass.ts
+++ b/src/common/self-fast-pass.ts
@@ -77,7 +77,7 @@ class SelfFastPassAnalyzer implements Analyzer {
 
 class SelfFastPassAnalyzerProvider extends AnalyzerProvider {
     constructor(private readonly deps: SelfFastPassAnalyzerDeps) {
-        super(null, null, null, null, null, null, null, null, null, null, null);
+        super(null, null, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     public override createRuleAnalyzerUnifiedScanForNeedsReview(

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Logger } from 'common/logging/logger';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStopEvent } from 'common/types/tab-stop-event';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { AllFrameRunner } from 'injected/all-frame-runner';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
-
+import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
 import { BaseStore } from '../../common/base-store';
 import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
 import { ScopingStoreData } from '../../common/types/store-data/scoping-store-data';
@@ -23,6 +25,9 @@ import { TabStopsAnalyzer } from './tab-stops-analyzer';
 export class AnalyzerProvider {
     constructor(
         private readonly tabStopsListener: AllFrameRunner<TabStopEvent>,
+        private readonly tabStopsRequirementRunner: AllFrameRunner<TabStopRequirementResult>,
+        private readonly tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator,
+        private readonly featureFlagStore: BaseStore<FeatureFlagStoreData>,
         private readonly scopingStore: BaseStore<ScopingStoreData>,
         private readonly sendMessageDelegate: (message) => void,
         private readonly scanner: ScannerUtils,
@@ -109,6 +114,9 @@ export class AnalyzerProvider {
             this.sendMessageDelegate,
             this.scanIncompleteWarningDetector,
             this.logger,
+            this.featureFlagStore,
+            this.tabStopsRequirementRunner,
+            this.tabStopRequirementActionMessageCreator,
         );
     }
 

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -14,6 +14,7 @@ import { PermissionsStateStoreData } from 'common/types/store-data/permissions-s
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationType } from 'common/types/visualization-type';
 import { toolName } from 'content/strings/application';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { getCheckResolution, getFixResolution } from 'injected/adapters/resolution-creator';
 import { filterNeedsReviewResults } from 'injected/analyzers/filter-results';
 import { NotificationTextCreator } from 'injected/analyzers/notification-text-creator';
@@ -207,6 +208,10 @@ export class MainWindowInitializer extends WindowInitializer {
             telemetryDataFactory,
             TelemetryEventSource.TargetPage,
         );
+        const tabStopRequirementActionMessageCreator = new TabStopRequirementActionMessageCreator(
+            telemetryDataFactory,
+            actionMessageDispatcher,
+        );
 
         const userConfigMessageCreator = new UserConfigMessageCreator(actionMessageDispatcher);
 
@@ -318,6 +323,9 @@ export class MainWindowInitializer extends WindowInitializer {
 
         const analyzerProvider = new AnalyzerProvider(
             this.manualTabStopListener,
+            this.tabStopRequirementRunner,
+            tabStopRequirementActionMessageCreator,
+            this.featureFlagStoreProxy,
             this.scopingStoreProxy,
             this.browserAdapter.sendMessageToFrames,
             new ScannerUtils(scan, logger, generateUID),

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -440,6 +440,7 @@ describe('VisualizationScanResultStoreTest', () => {
         const expectedState = new VisualizationScanResultStoreDataBuilder()
             .withTabStopRequirement(requirement)
             .build();
+        expectedState.tabStops.requirements[payload.requirementId].status = 'fail';
 
         createStoreTesterForTabStopRequirementActions('addTabStopInstance')
             .withActionParam(payload)

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { ScopingStore } from 'background/stores/global/scoping-store';
 import { TabStopEvent } from 'common/types/tab-stop-event';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { AllFrameRunner } from 'injected/all-frame-runner';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, Mock } from 'typemoq';
-
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import {
@@ -38,6 +40,9 @@ describe('AnalyzerProviderTests', () => {
     let sendConvertedResultsMock: IMock<PostResolveCallback>;
     let sendNeedsReviewResultsMock: IMock<PostResolveCallback>;
     let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
+    let tabStopRequirementRunnerMock: IMock<AllFrameRunner<TabStopRequirementResult>>;
+    let tabStopRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
+    let featureFlagStoreMock: IMock<FeatureFlagStore>;
 
     beforeEach(() => {
         typeStub = -1;
@@ -54,9 +59,16 @@ describe('AnalyzerProviderTests', () => {
         sendConvertedResultsMock = Mock.ofInstance(() => null);
         sendNeedsReviewResultsMock = Mock.ofInstance(() => null);
         scanIncompleteWarningDetectorMock = Mock.ofType<ScanIncompleteWarningDetector>();
+        tabStopRequirementRunnerMock = Mock.ofType<AllFrameRunner<TabStopRequirementResult>>();
+        tabStopRequirementActionMessageCreatorMock =
+            Mock.ofType<TabStopRequirementActionMessageCreator>();
+        featureFlagStoreMock = Mock.ofType<FeatureFlagStore>();
 
         testObject = new AnalyzerProvider(
             tabStopsListener.object,
+            tabStopRequirementRunnerMock.object,
+            tabStopRequirementActionMessageCreatorMock.object,
+            featureFlagStoreMock.object,
             scopingStoreMock.object,
             sendMessageMock.object,
             scannerMock.object,
@@ -144,6 +156,11 @@ describe('AnalyzerProviderTests', () => {
         const openAnalyzer = analyzer as any;
         expect(analyzer).toBeInstanceOf(BaseAnalyzer);
         expect(openAnalyzer.tabStopListenerRunner).toEqual(tabStopsListener.object);
+        expect(openAnalyzer.tabStopRequirementRunner).toEqual(tabStopRequirementRunnerMock.object);
+        expect(openAnalyzer.tabStopRequirementActionMessageCreator).toEqual(
+            tabStopRequirementActionMessageCreatorMock.object,
+        );
+        expect(openAnalyzer.featureFlagStore).toEqual(featureFlagStoreMock.object);
         expect(openAnalyzer.config).toEqual(config);
         expect(openAnalyzer.sendMessage).toEqual(sendMessageMock.object);
     });

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
+import { FeatureFlags } from 'common/feature-flags';
 import { Message } from 'common/message';
 import { TabStopEvent } from 'common/types/tab-stop-event';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -15,7 +16,6 @@ import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { DebounceFaker } from 'tests/unit/common/debounce-faker';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { FeatureFlags } from 'common/feature-flags';
 
 describe('TabStopsAnalyzer', () => {
     let sendMessageMock: IMock<(message) => void>;

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -1,17 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { Message } from 'common/message';
 import { TabStopEvent } from 'common/types/tab-stop-event';
 import { VisualizationType } from 'common/types/visualization-type';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { AllFrameRunner } from 'injected/all-frame-runner';
 import { FocusAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { TabStopsAnalyzer } from 'injected/analyzers/tab-stops-analyzer';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
 import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { DebounceFaker } from 'tests/unit/common/debounce-faker';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { FeatureFlags } from 'common/feature-flags';
 
 describe('TabStopsAnalyzer', () => {
     let sendMessageMock: IMock<(message) => void>;
@@ -19,10 +23,15 @@ describe('TabStopsAnalyzer', () => {
     let visualizationTypeStub: VisualizationType;
     let testSubject: TabStopsAnalyzer;
     let tabStopsListenerMock: IMock<AllFrameRunner<TabStopEvent>>;
+    let tabStopRequirementRunnerMock: IMock<AllFrameRunner<TabStopRequirementResult>>;
     let simulateTabEvent: (tabEvent: TabStopEvent) => void;
     let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
     let emptyScanCompleteMessage: Message;
     let debounceFaker: DebounceFaker<() => void>;
+    let featureFlagStoreMock: IMock<FeatureFlagStore>;
+    let tabStopRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
+    let requirementResultRunnerCallback: (requirementResult: TabStopRequirementResult) => void;
+
     const tabEventStub1: TabStopEvent = {
         target: ['selector1'],
         html: 'test',
@@ -52,10 +61,19 @@ describe('TabStopsAnalyzer', () => {
             stop: () => {},
             initialize: () => {},
         } as AllFrameRunner<TabStopEvent>);
+        tabStopRequirementRunnerMock = Mock.ofInstance({
+            topWindowCallback: null,
+            start: () => {},
+            stop: () => {},
+            initialize: () => {},
+        } as AllFrameRunner<TabStopRequirementResult>);
 
         scanIncompleteWarningDetectorMock
             .setup(idm => idm.detectScanIncompleteWarnings())
             .returns(() => []);
+        featureFlagStoreMock = Mock.ofType<FeatureFlagStore>();
+        tabStopRequirementActionMessageCreatorMock =
+            Mock.ofType<TabStopRequirementActionMessageCreator>();
 
         testSubject = new TabStopsAnalyzer(
             configStub,
@@ -63,6 +81,9 @@ describe('TabStopsAnalyzer', () => {
             sendMessageMock.object,
             scanIncompleteWarningDetectorMock.object,
             failTestOnErrorLogger,
+            featureFlagStoreMock.object,
+            tabStopRequirementRunnerMock.object,
+            tabStopRequirementActionMessageCreatorMock.object,
             debounceFaker.debounce,
         );
         visualizationTypeStub = -1 as VisualizationType;
@@ -81,6 +102,7 @@ describe('TabStopsAnalyzer', () => {
 
     describe('analyze', () => {
         it('emits an empty ScanCompleted message immediately on startup', async () => {
+            setTabStopsAutomationFeatureFlag(false);
             setupTabStopsListenerForStartTabStops();
             setupSendMessageMock(emptyScanCompleteMessage);
 
@@ -88,6 +110,31 @@ describe('TabStopsAnalyzer', () => {
             await flushSettledPromises();
 
             verifyAll();
+        });
+
+        it('adds tab stop instances when processing tab stops requirement result', async () => {
+            const requirementResult: TabStopRequirementResult = {
+                requirementId: 'keyboard-navigation',
+                description: 'some description',
+            } as TabStopRequirementResult;
+
+            setTabStopsAutomationFeatureFlag(true);
+            setupTabStopsListenerForStartTabStops();
+            setupTabStopRequirementRunner();
+            setupSendMessageMock(emptyScanCompleteMessage);
+
+            testSubject.analyze();
+            await flushSettledPromises();
+            requirementResultRunnerCallback(requirementResult);
+
+            tabStopRequirementActionMessageCreatorMock.verify(
+                m =>
+                    m.addTabStopInstance(
+                        requirementResult.requirementId,
+                        requirementResult.description,
+                    ),
+                Times.once(),
+            );
         });
 
         it('emits ScanUpdated messages when tab events are detected', async () => {
@@ -101,6 +148,7 @@ describe('TabStopsAnalyzer', () => {
                 },
             };
 
+            setTabStopsAutomationFeatureFlag(false);
             setupTabStopsListenerForStartTabStops();
             setupSendMessageMock(emptyScanCompleteMessage);
             testSubject.analyze();
@@ -125,6 +173,7 @@ describe('TabStopsAnalyzer', () => {
                 },
             };
 
+            setTabStopsAutomationFeatureFlag(false);
             setupTabStopsListenerForStartTabStops();
             setupSendMessageMock(emptyScanCompleteMessage);
             testSubject.analyze();
@@ -140,6 +189,7 @@ describe('TabStopsAnalyzer', () => {
         });
 
         it('emits a ScanTerminated message and stops emitting ScanUpdated messages after teardown() is invoked', async () => {
+            setTabStopsAutomationFeatureFlag(false);
             setupTabStopsListenerForStartTabStops();
             setupSendMessageMock(emptyScanCompleteMessage);
             testSubject.analyze();
@@ -171,6 +221,21 @@ describe('TabStopsAnalyzer', () => {
             .setup(t => (t.topWindowCallback = It.isAny()))
             .callback(cb => (simulateTabEvent = cb));
         tabStopsListenerMock.setup(t => t.start()).verifiable(Times.once());
+    }
+
+    function setupTabStopRequirementRunner(): void {
+        tabStopRequirementRunnerMock
+            .setup(t => (t.topWindowCallback = It.isAny()))
+            .callback(cb => (requirementResultRunnerCallback = cb));
+        tabStopRequirementRunnerMock.setup(t => t.start()).verifiable(Times.once());
+    }
+
+    function setTabStopsAutomationFeatureFlag(enabled: boolean) {
+        featureFlagStoreMock
+            .setup(m => m.getState())
+            .returns(() => ({
+                [FeatureFlags.tabStopsAutomation]: enabled,
+            }));
     }
 
     function setupSendMessageMock(message, callback?): void {


### PR DESCRIPTION
#### Details

Wires up the tab stops orchestrator with tab stops analyzer via an all frame runner.

##### Motivation

feature work.

##### Context

Probably need to refine the tests a bit more and potentially debounce calls but that will be in the future.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
