### PR TITLE
fix(tabstops-report): prevent tab stops requirement rows from bobbing

### DIFF
--- a/src/DetailsView/components/tab-stops/tab-stops-requirement-table.scss
+++ b/src/DetailsView/components/tab-stops/tab-stops-requirement-table.scss
@@ -12,6 +12,7 @@
 .pass-fail-column-cell {
     display: flex;
     align-items: center;
+    min-height: 47px;
 }
 
 .requirement-name {


### PR DESCRIPTION
#### Details

Currently, in the Details View for FastPass > Tab stops, the rows of the Requirements table shift bob up and down when they transition from an "unknown" state to a "pass" or "fail" state. This happens because in the pass/fail states, the "Undo" button is unhidden, and it has the greatest interior height of the elements within that row (25px).

This fix adjusts the cell containing the buttons to ensure that it has enough `min-height` to account for the undo button, even when the undo button is hidden.

Before:

![animation showing the row heights changing during selection](https://user-images.githubusercontent.com/376284/150892580-86722560-0409-4e13-bfea-541d9c651997.gif)

After:

![animation showing the row heights not changing during selection](https://user-images.githubusercontent.com/376284/150892593-2ac42526-e882-4bab-863f-c1be0c48498a.gif)

##### Motivation

Partially addresses #5099 

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5099 (partial)
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
