### PR TITLE
feat(tabstops-auto-impl): remove duplicate results & reset state between consecutive tab-stop-analyzer invocations

### DIFF
--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -112,7 +112,7 @@ describe('TabStopsAnalyzer', () => {
             verifyAll();
         });
 
-        it('adds tab stop instances when processing tab stops requirement result', async () => {
+        it('adds unique tab stop instances when processing tab stops requirement result', async () => {
             const requirementResult: TabStopRequirementResult = {
                 requirementId: 'keyboard-navigation',
                 description: 'some description',
@@ -125,7 +125,14 @@ describe('TabStopsAnalyzer', () => {
 
             testSubject.analyze();
             await flushSettledPromises();
+
+            // send 1 duplicate and 2 unique results
             requirementResultRunnerCallback(requirementResult);
+            requirementResultRunnerCallback(requirementResult);
+            requirementResultRunnerCallback({
+                ...requirementResult,
+                html: 'new html',
+            });
 
             tabStopRequirementActionMessageCreatorMock.verify(
                 m =>
@@ -133,7 +140,7 @@ describe('TabStopsAnalyzer', () => {
                         requirementResult.requirementId,
                         requirementResult.description,
                     ),
-                Times.once(),
+                Times.exactly(2),
             );
         });
 

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-orchestrator.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-orchestrator.test.ts
@@ -141,40 +141,17 @@ describe('TabStopRequirementOrchestrator', () => {
         reportResultsMock.verifyAll();
     });
 
-    test('stop removes event listeners and sends keyboard navigation results', () => {
-        const keyboardNavigationResultsStub = getTabStopRequirementResultStubs();
-
-        testSubject.setResultCallback(reportResultsMock.object);
-        testSubject.start();
-
-        domMock.setup(m => m.removeEventListener('focusin', focusInCallback)).verifiable();
-        domMock.setup(m => m.removeEventListener('keydown', keydownCallback)).verifiable();
-        tabStopsRequirementEvaluatorMock
-            .setup(m =>
-                m.getKeyboardNavigationResults(focusableElementsStub, It.isValue(new Set())),
-            )
-            .returns(() => keyboardNavigationResultsStub);
-        keyboardNavigationResultsStub.forEach(result => {
-            reportResultsMock.setup(m => m(result)).verifiable(Times.once());
-        });
-
-        testSubject.stop();
-
-        domMock.verifyAll();
-        reportResultsMock.verifyAll();
-    });
-
-    test('stop does not resend stale events when called twice', () => {
+    function testStopOnce() {
         const keyboardNavigationResultsStub = getTabStopRequirementResultStubs();
         testSubject.setResultCallback(reportResultsMock.object);
         testSubject.start();
 
         domMock
             .setup(m => m.removeEventListener('focusin', focusInCallback))
-            .verifiable(Times.exactly(2));
+            .verifiable(Times.once());
         domMock
             .setup(m => m.removeEventListener('keydown', keydownCallback))
-            .verifiable(Times.exactly(2));
+            .verifiable(Times.once());
         tabStopsRequirementEvaluatorMock
             .setup(m =>
                 m.getKeyboardNavigationResults(focusableElementsStub, It.isValue(new Set())),
@@ -185,15 +162,35 @@ describe('TabStopRequirementOrchestrator', () => {
         });
 
         testSubject.stop();
+    }
 
+    test('stop removes event listeners and sends keyboard navigation results', () => {
+        testStopOnce();
+
+        domMock.verifyAll();
+        reportResultsMock.verifyAll();
+    });
+
+    test('stop does not resend stale events when called twice', () => {
+        testStopOnce();
+        domMock.reset();
         tabStopsRequirementEvaluatorMock.reset();
+
+        domMock
+            .setup(m => m.removeEventListener('focusin', focusInCallback))
+            .verifiable(Times.once());
+        domMock
+            .setup(m => m.removeEventListener('keydown', keydownCallback))
+            .verifiable(Times.once());
+
         tabStopsRequirementEvaluatorMock
             .setup(m => m.getKeyboardNavigationResults([], It.isValue(new Set())))
             .returns(() => [])
             .verifiable(Times.once());
-        testSubject.stop();
-        tabStopsRequirementEvaluatorMock.verifyAll();
 
+        testSubject.stop();
+
+        tabStopsRequirementEvaluatorMock.verifyAll();
         domMock.verifyAll();
         reportResultsMock.verifyAll();
     });


### PR DESCRIPTION
#### Details

This PR addresses two issues in the current automated tab-stops implementation:
- duplicate results are not ignored. The impact is that users can be presented with unnecessary results they must manually delete. Our focus-order test implementation will produce duplicate results often (by design), so we need to filter those out.
- orchestrator-held state (in the target page) is not reset between consecutive start()/stop() calls. The impact is that hitting "start over" will act as a continuation of the last test (for example, the test will ignore any tab stops it found the first time)

##### Motivation

Fix behavior, unblock correct e2e tests

##### Context

I expect this code to change again in the upcoming visualization feature. The current feature is mainly scoped to gathering automated tab stops instances in /background. We have an upcoming feature that:
- changes the visualization experience in the target page
- decouples the details view toggle behavior from starting/stopping the test
- (most relevant) defers issue reporting until the scan is done

Depending on where the visualization feature crew decides to store requirement results before reporting, this duplication logic might move elsewhere. Therefore duplication logic is simple for now and merely checks deep equality per result.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
