### PR TITLE
feat(tabstops-auto-impl): Fix results reporting loop bug

### DIFF
--- a/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
+++ b/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
@@ -10,6 +10,7 @@ import {
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
     UpdateTabbingCompletedPayload,
+    UpdateNeedToCollectTabbingResultsPayload,
 } from 'background/actions/action-payloads';
 import { DevToolActionMessageCreator } from 'common/message-creators/dev-tool-action-message-creator';
 import { Messages } from 'common/messages';
@@ -120,6 +121,17 @@ export class TabStopRequirementActionMessageCreator extends DevToolActionMessage
 
         this.dispatcher.dispatchMessage({
             messageType: Messages.Visualizations.TabStops.TabbingCompleted,
+            payload,
+        });
+    };
+
+    public updateNeedToCollectTabbingResults = (needToCollectTabbingResults: boolean) => {
+        const payload: UpdateNeedToCollectTabbingResultsPayload = {
+            needToCollectTabbingResults,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Visualizations.TabStops.NeedToCollectTabbingResults,
             payload,
         });
     };

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -149,6 +149,9 @@ export interface ToggleTabStopRequirementExpandPayload extends BaseActionPayload
 export interface UpdateTabbingCompletedPayload extends BaseActionPayload {
     tabbingCompleted: boolean;
 }
+export interface UpdateNeedToCollectTabbingResultsPayload extends BaseActionPayload {
+    needToCollectTabbingResults: boolean;
+}
 export interface AddTabStopInstancePayload extends BaseActionPayload {
     requirementId: TabStopRequirementId;
     description: string;

--- a/src/background/actions/tab-stop-requirement-action-creator.ts
+++ b/src/background/actions/tab-stop-requirement-action-creator.ts
@@ -9,6 +9,7 @@ import {
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
+    UpdateNeedToCollectTabbingResultsPayload,
     UpdateTabbingCompletedPayload,
     UpdateTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
@@ -56,6 +57,11 @@ export class TabStopRequirementActionCreator {
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Visualizations.TabStops.TabbingCompleted,
             this.onTabbingCompleted,
+        );
+
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.Visualizations.TabStops.NeedToCollectTabbingResults,
+            this.onNeedToCollectTabbingResults,
         );
     }
 
@@ -111,5 +117,11 @@ export class TabStopRequirementActionCreator {
 
     private onTabbingCompleted = (payload: UpdateTabbingCompletedPayload): void => {
         this.tabStopRequirementActions.updateTabbingCompleted.invoke(payload);
+    };
+
+    private onNeedToCollectTabbingResults = (
+        payload: UpdateNeedToCollectTabbingResultsPayload,
+    ): void => {
+        this.tabStopRequirementActions.updateNeedToCollectTabbingResults.invoke(payload);
     };
 }

--- a/src/background/actions/tab-stop-requirement-actions.ts
+++ b/src/background/actions/tab-stop-requirement-actions.ts
@@ -8,6 +8,7 @@ import {
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
+    UpdateNeedToCollectTabbingResultsPayload,
     UpdateTabbingCompletedPayload,
     UpdateTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
@@ -25,4 +26,6 @@ export class TabStopRequirementActions {
     public readonly toggleTabStopRequirementExpand =
         new Action<ToggleTabStopRequirementExpandPayload>();
     public readonly updateTabbingCompleted = new Action<UpdateTabbingCompletedPayload>();
+    public readonly updateNeedToCollectTabbingResults =
+        new Action<UpdateNeedToCollectTabbingResultsPayload>();
 }

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -23,6 +23,7 @@ import {
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
+    UpdateNeedToCollectTabbingResultsPayload,
     UpdateTabbingCompletedPayload,
     UpdateTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
@@ -56,6 +57,7 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
                 tabbedElements: null,
                 requirements,
                 tabbingCompleted: false,
+                needToCollectTabbingResults: true,
             },
         };
 
@@ -104,6 +106,9 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         );
         this.tabStopRequirementActions.updateTabbingCompleted.addListener(
             this.onUpdateTabbingCompleted,
+        );
+        this.tabStopRequirementActions.updateNeedToCollectTabbingResults.addListener(
+            this.onUpdateNeedToCollectTabbingResults,
         );
         this.tabActions.existingTabUpdated.addListener(this.onExistingTabUpdated);
     }
@@ -251,6 +256,13 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
 
     private onUpdateTabbingCompleted = (payload: UpdateTabbingCompletedPayload): void => {
         this.state.tabStops.tabbingCompleted = payload.tabbingCompleted;
+        this.emitChanged();
+    };
+
+    private onUpdateNeedToCollectTabbingResults = (
+        payload: UpdateNeedToCollectTabbingResultsPayload,
+    ): void => {
+        this.state.tabStops.needToCollectTabbingResults = payload.needToCollectTabbingResults;
         this.emitChanged();
     };
 }

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -27,6 +27,7 @@ export const Messages = {
             RemoveTabStopInstance: `${messagePrefix}/visualization/tab-stops/instance-removed`,
             RequirementExpansionToggled: `${messagePrefix}/visualization/tab-stops/toggleTabStopRequirementExpand`,
             TabbingCompleted: `${messagePrefix}/visualization/tab-stops/tabbingCompleted`,
+            NeedToCollectTabbingResults: `${messagePrefix}/visualization/tab-stops/NeedToCollectTabbingResults`,
         },
         Issues: {
             UpdateFocusedInstance: `${messagePrefix}/visualization/issues/targets/focused/update`,

--- a/src/common/types/store-data/visualization-scan-result-data.ts
+++ b/src/common/types/store-data/visualization-scan-result-data.ts
@@ -41,6 +41,7 @@ interface TabStopsScanResultData {
     tabbedElements: TabbedElementData[];
     requirements?: TabStopRequirementState;
     tabbingCompleted: boolean;
+    needToCollectTabbingResults: boolean;
 }
 
 export interface VisualizationScanResultData {

--- a/src/injected/analyzer-controller.ts
+++ b/src/injected/analyzer-controller.ts
@@ -3,6 +3,7 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AdHocTestkeys } from 'common/configs/adhoc-test-keys';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { BaseStore } from '../common/base-store';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { EnumHelper } from '../common/enum-helper';
@@ -25,6 +26,7 @@ export class AnalyzerController {
     private visualizationConfigurationFactory: VisualizationConfigurationFactory;
     private analyzerStateUpdateHandler: AnalyzerStateUpdateHandler;
     private assessmentsProvider: AssessmentsProvider;
+    private tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator;
 
     constructor(
         visualizationstore: BaseStore<VisualizationStoreData>,
@@ -35,6 +37,7 @@ export class AnalyzerController {
         analyzerProvider: AnalyzerProvider,
         analyzerStateUpdateHandler: AnalyzerStateUpdateHandler,
         assessmentsProvider: AssessmentsProvider,
+        tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator,
     ) {
         this.analyzers = {};
         this.visualizationstore = visualizationstore;
@@ -45,6 +48,7 @@ export class AnalyzerController {
         this.analyzerProvider = analyzerProvider;
         this.assessmentsProvider = assessmentsProvider;
         this.analyzerStateUpdateHandler = analyzerStateUpdateHandler;
+        this.tabStopRequirementActionMessageCreator = tabStopRequirementActionMessageCreator;
         this.analyzerStateUpdateHandler.setupHandlers(this.startScan, this.teardown);
     }
 
@@ -66,7 +70,9 @@ export class AnalyzerController {
     };
 
     private onResultsChangedState = (): void => {
-        if (this.visualizationResultsStore.getState().tabStops.tabbingCompleted) {
+        const state = this.visualizationResultsStore.getState();
+        if (state.tabStops.tabbingCompleted && state.tabStops.needToCollectTabbingResults) {
+            this.tabStopRequirementActionMessageCreator.updateNeedToCollectTabbingResults(false);
             this.teardown(AdHocTestkeys.TabStops);
         }
     };

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -350,6 +350,7 @@ export class MainWindowInitializer extends WindowInitializer {
             analyzerProvider,
             analyzerStateUpdateHandler,
             Assessments,
+            tabStopRequirementActionMessageCreator,
         );
 
         this.analyzerController.listenToStore();

--- a/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
@@ -34,6 +34,13 @@ export class VisualizationScanResultStoreDataBuilder extends BaseDataBuilder<Vis
         return this;
     }
 
+    public withNeedToCollectTabbingResults(
+        needToCollectTabbingResults: boolean,
+    ): VisualizationScanResultStoreDataBuilder {
+        this.data.tabStops.needToCollectTabbingResults = needToCollectTabbingResults;
+        return this;
+    }
+
     public withTabStopRequirement(
         requirement: TabStopRequirementState,
     ): VisualizationScanResultStoreDataBuilder {

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -169,6 +169,7 @@ exports[`DetailsViewBody render render 1`] = `
             "scanResult": null,
           },
           "tabStops": Object {
+            "needToCollectTabbingResults": true,
             "requirements": Object {
               "focus-indicator": Object {
                 "instances": Array [],
@@ -496,6 +497,7 @@ exports[`DetailsViewBody render render 1`] = `
               "scanResult": null,
             },
             "tabStops": Object {
+              "needToCollectTabbingResults": true,
               "requirements": Object {
                 "focus-indicator": Object {
                   "instances": Array [],
@@ -830,6 +832,7 @@ exports[`DetailsViewBody render render 1`] = `
                   "scanResult": null,
                 },
                 "tabStops": Object {
+                  "needToCollectTabbingResults": true,
                   "requirements": Object {
                     "focus-indicator": Object {
                       "instances": Array [],

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -305,6 +305,7 @@ exports[` render renders normally 1`] = `
           "scanResult": null,
         },
         "tabStops": Object {
+          "needToCollectTabbingResults": true,
           "requirements": Object {
             "focus-indicator": Object {
               "instances": Array [],

--- a/src/tests/unit/tests/DetailsView/actions/tab-stop-requirement-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/tab-stop-requirement-action-message-creator.test.ts
@@ -225,4 +225,24 @@ describe('TabStopRequirementActionMessageCreatorTest', () => {
 
         telemetryFactoryMock.verifyAll();
     });
+
+    test('updateNeedToCollectTabbingResults', () => {
+        const needToCollectTabbingResults = true;
+
+        const expectedMessage = {
+            messageType: Messages.Visualizations.TabStops.NeedToCollectTabbingResults,
+            payload: {
+                needToCollectTabbingResults,
+            },
+        };
+
+        testSubject.updateNeedToCollectTabbingResults(needToCollectTabbingResults);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+
+        telemetryFactoryMock.verifyAll();
+    });
 });

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-instance-section-props-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-instance-section-props-factory.test.tsx.snap
@@ -8,6 +8,7 @@ Object {
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
+      "updateNeedToCollectTabbingResults": [Function],
       "updateTabbingCompleted": [Function],
     },
     "tabStopsTestViewController": proxy {
@@ -104,6 +105,7 @@ Object {
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
+      "updateNeedToCollectTabbingResults": [Function],
       "updateTabbingCompleted": [Function],
     },
     "tabStopsTestViewController": proxy {
@@ -123,6 +125,7 @@ Object {
           "dispatcher": undefined,
           "telemetryFactory": undefined,
           "toggleTabStopRequirementExpand": [Function],
+          "updateNeedToCollectTabbingResults": [Function],
           "updateTabbingCompleted": [Function],
         },
         "tabStopsTestViewController": proxy {
@@ -170,6 +173,7 @@ Object {
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
+      "updateNeedToCollectTabbingResults": [Function],
       "updateTabbingCompleted": [Function],
     },
     "tabStopsTestViewController": proxy {
@@ -269,6 +273,7 @@ Object {
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
+      "updateNeedToCollectTabbingResults": [Function],
       "updateTabbingCompleted": [Function],
     },
     "tabStopsTestViewController": proxy {
@@ -288,6 +293,7 @@ Object {
           "dispatcher": undefined,
           "telemetryFactory": undefined,
           "toggleTabStopRequirementExpand": [Function],
+          "updateNeedToCollectTabbingResults": [Function],
           "updateTabbingCompleted": [Function],
         },
         "tabStopsTestViewController": proxy {
@@ -343,6 +349,7 @@ Object {
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
+      "updateNeedToCollectTabbingResults": [Function],
       "updateTabbingCompleted": [Function],
     },
     "tabStopsTestViewController": proxy {
@@ -362,6 +369,7 @@ Object {
           "dispatcher": undefined,
           "telemetryFactory": undefined,
           "toggleTabStopRequirementExpand": [Function],
+          "updateNeedToCollectTabbingResults": [Function],
           "updateTabbingCompleted": [Function],
         },
         "tabStopsTestViewController": proxy {

--- a/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
@@ -8,6 +8,7 @@ import {
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
     UpdateTabbingCompletedPayload,
+    UpdateNeedToCollectTabbingResultsPayload,
 } from 'background/actions/action-payloads';
 import { TabStopRequirementActionCreator } from 'background/actions/tab-stop-requirement-action-creator';
 import { TabStopRequirementActions } from 'background/actions/tab-stop-requirement-actions';
@@ -259,6 +260,31 @@ describe('TabStopRequirementActionCreator', () => {
         testSubject.registerCallbacks();
 
         onTabbingCompletedMock.verifyAll();
+    });
+
+    test('registerCallback for on need to collect tabbing results', () => {
+        const actionName = 'updateNeedToCollectTabbingResults';
+        const payload: UpdateNeedToCollectTabbingResultsPayload = {
+            needToCollectTabbingResults: true,
+        };
+
+        const onNeedToCollectTabbingResultsMock = createActionMock(payload);
+
+        const actionsMock = createActionsMock(actionName, onNeedToCollectTabbingResultsMock.object);
+        const interpreterMock = createInterpreterMock(
+            Messages.Visualizations.TabStops.NeedToCollectTabbingResults,
+            payload,
+        );
+
+        const testSubject = new TabStopRequirementActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        onNeedToCollectTabbingResultsMock.verifyAll();
     });
 
     function createActionsMock<ActionName extends keyof TabStopRequirementActions>(

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -5,6 +5,7 @@ import {
     AddTabStopInstancePayload,
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
+    UpdateNeedToCollectTabbingResultsPayload,
     UpdateTabbingCompletedPayload,
     UpdateTabStopInstancePayload,
     UpdateTabStopRequirementStatusPayload,
@@ -528,6 +529,22 @@ describe('VisualizationScanResultStoreTest', () => {
         };
 
         createStoreTesterForTabStopRequirementActions('updateTabbingCompleted')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('onUpdateNeedToCollectTabbingResults', () => {
+        const initialState = new VisualizationScanResultStoreDataBuilder().build();
+
+        const expectedState = new VisualizationScanResultStoreDataBuilder()
+            .withNeedToCollectTabbingResults(true)
+            .build();
+
+        const payload: UpdateNeedToCollectTabbingResultsPayload = {
+            needToCollectTabbingResults: true,
+        };
+
+        createStoreTesterForTabStopRequirementActions('updateNeedToCollectTabbingResults')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, expectedState);
     });

--- a/src/tests/unit/tests/injected/analyzer-controller.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-controller.test.ts
@@ -7,6 +7,7 @@ import { ScopingStore } from 'background/stores/global/scoping-store';
 import { VisualizationScanResultStore } from 'background/stores/visualization-scan-result-store';
 import { VisualizationStore } from 'background/stores/visualization-store';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { BaseStore } from '../../../../common/base-store';
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
@@ -41,7 +42,7 @@ describe('AnalyzerControllerTests', () => {
     let configStub: VisualizationConfiguration;
 
     let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
-
+    let tabStopRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
     let visualizationStoreState: VisualizationStoreData;
     let visualizationScanResultsStoreState: VisualizationScanResultData;
     let featureFlagStoreState: FeatureFlagStoreData;
@@ -77,6 +78,8 @@ describe('AnalyzerControllerTests', () => {
         visualizationScanResultsStoreMock = Mock.ofType<VisualizationScanResultStore>();
         featureFlagStoreStoreMock = Mock.ofType<FeatureFlagStore>();
         scopingStoreMock = Mock.ofType<ScopingStore>(ScopingStore);
+        tabStopRequirementActionMessageCreatorMock =
+            Mock.ofType<TabStopRequirementActionMessageCreator>();
 
         visualizationStoreMock.setup(sm => sm.getState()).returns(() => visualizationStoreState);
 
@@ -126,6 +129,7 @@ describe('AnalyzerControllerTests', () => {
             analyzerProviderStrictMock.object,
             analyzerStateUpdateHandlerStrictMock.object,
             assessmentsMock.object,
+            tabStopRequirementActionMessageCreatorMock.object,
         );
     });
 
@@ -159,6 +163,48 @@ describe('AnalyzerControllerTests', () => {
         analyzerStateUpdateHandlerStrictMock.verifyAll();
         getAnalyzerMock.verifyAll();
         getIdentifierMock.verifyAll();
+    });
+
+    test('onResultsChangedState sends message when tabbing is completed', () => {
+        tabStopRequirementActionMessageCreatorMock
+            .setup(m => m.updateNeedToCollectTabbingResults(false))
+            .verifiable(Times.once());
+
+        visualizationScanResultsStoreState = {
+            tabStops: { tabbingCompleted: true, needToCollectTabbingResults: true },
+        } as VisualizationScanResultData;
+
+        assessmentsMock
+            .setup(mock => mock.isValidType(It.isAny()))
+            .returns(() => false)
+            .verifiable(Times.atLeastOnce());
+        setupVisualizationConfigurationFactory(VisualizationType.TabStops, configStub);
+        setupTeardownCall();
+        getIdentifierMock.reset();
+        setupGetIdentifierMock('tabStops', Times.atLeastOnce());
+
+        const visualizationResultsListener = setupTabbingStoreData();
+        visualizationResultsListener();
+
+        tabStopRequirementActionMessageCreatorMock.verifyAll();
+        getIdentifierMock.verifyAll();
+        assessmentsMock.verifyAll();
+        analyzerMock.verifyAll();
+    });
+
+    test('onResultsChangedState does not send message when tabbing is not completed', () => {
+        tabStopRequirementActionMessageCreatorMock
+            .setup(m => m.updateNeedToCollectTabbingResults(It.isAny()))
+            .verifiable(Times.never());
+
+        visualizationScanResultsStoreState = {
+            tabStops: { tabbingCompleted: false, needToCollectTabbingResults: false },
+        } as VisualizationScanResultData;
+
+        const visualizationResultsListener = setupTabbingStoreData();
+        visualizationResultsListener();
+
+        tabStopRequirementActionMessageCreatorMock.verifyAll();
     });
 
     test('do not scan on if any store state is null', () => {
@@ -212,6 +258,18 @@ describe('AnalyzerControllerTests', () => {
         getIdentifierMock.verifyAll();
         analyzerMock.verifyAll();
     });
+
+    function setupTabbingStoreData(): () => void {
+        let visualizationResultsListener;
+        visualizationScanResultsStoreMock
+            .setup(m => m.addChangedListener(It.isAny()))
+            .returns(listener => {
+                visualizationResultsListener = listener;
+            });
+
+        testObject.listenToStore();
+        return visualizationResultsListener;
+    }
 
     function setupAnalyzeCall(): void {
         analyzerMock.setup(am => am.analyze()).verifiable();


### PR DESCRIPTION
#### Details

Fix bug introduced in latest tabstops-auto-impl feature work. If a user does not finish tabbing through the target page then the analyzer-controller enters a loop in which it sends automatic tabbing results to the store over and over, causing a crash. This PR fixes this bug and adds test coverage. 

##### Motivation

Bug fix for feature work.

##### Context

This fix adds an additional field to tab stops store data which allows us to track both if the user is finished tabbing (`tabbingCompleted`) as well as if results have not been reported and need to be updated (`needToCollectTabbingResults`). The second field is necessary because we only want to report results once, the very first time tabbing is completed. We considered fixing this bug by marking `tabbingCompleted = false` in `analyzer-controller`'s `onResultsChangedState`, but without the second `needToCollectTabbingResults` field, this meant that we would resend results every time we received a `tabbingCompleted` trigger- so we would resend results every time the user refocused on the details view. With 2 fields, we're able to only send results when both `tabbingCompleted=true` and `needToCollectTabbingResults=true`, which only happens once in the testing.

An alternative approach could be to only fire the `updateTabbingCompleted` message once, when we get a done trigger (by either focus shifting to the details view or reaching the same tabbed element twice) and we know the test is still active. The problem here is that we don't necessarily know when the test is active at the moment. We expect that a future refactor/ future feature work in this area may end up devising a better way to represent if the test is in progress or not, and if that is the case then using that heuristic to determine if we should fire off an `updateTabbingCompleted` message will likely be more readable than this current implementation. 

This fix runs up against another known bug with the tab stops visualization toggle, which will be fixed in the following feature: 
- Repro steps:
  - Open tab stops tab, toggle visual helper on, tab through target page as normal
  - Return focus to details view to see failures
  - Toggle visual helper on and immediately back off
  - BUG: new failure instances are added to the list
- Explanation
  - Current behavior of the visual helper is that it resets the tabbed elements in the data store and restarts the tab-stops-listener, which can be viewed as a sort of 'soft start over' of the tabbing test
  - The tab stops analyzer tries to re-run the automated checks, and comes up with new results, which are returned and displayed in addition to the results that were already present in the details view
  - The issue seems to be that the behavior of the toggle is unclear- at the moment it is acting similarly to start over, when the desired behavior is that it controls only the visualization on the target page and does not effect the tab stops analyzer at all
- Way forward
  - The way forward is likely to change the behavior of the toggle so it only turns on and off the existing visualization but does not make changes to the tabbed elements or the tab stop analyzer

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
