### PR TITLE
feat(tabstops-auto-impl): end tab stops test if the user re-encounters the first tabbed element

### DIFF
--- a/src/common/self-fast-pass.ts
+++ b/src/common/self-fast-pass.ts
@@ -77,7 +77,23 @@ class SelfFastPassAnalyzer implements Analyzer {
 
 class SelfFastPassAnalyzerProvider extends AnalyzerProvider {
     constructor(private readonly deps: SelfFastPassAnalyzerDeps) {
-        super(null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+        super(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+        );
     }
 
     public override createRuleAnalyzerUnifiedScanForNeedsReview(

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -5,6 +5,7 @@ import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store
 import { TabStopEvent } from 'common/types/tab-stop-event';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { AllFrameRunner } from 'injected/all-frame-runner';
+import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
 import { BaseStore } from '../../common/base-store';
@@ -27,6 +28,7 @@ export class AnalyzerProvider {
         private readonly tabStopsListener: AllFrameRunner<TabStopEvent>,
         private readonly tabStopsRequirementRunner: AllFrameRunner<TabStopRequirementResult>,
         private readonly tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator,
+        private readonly tabStopsDoneAnalyzingTracker: TabStopsDoneAnalyzingTracker,
         private readonly featureFlagStore: BaseStore<FeatureFlagStoreData>,
         private readonly scopingStore: BaseStore<ScopingStoreData>,
         private readonly sendMessageDelegate: (message) => void,
@@ -117,6 +119,7 @@ export class AnalyzerProvider {
             this.featureFlagStore,
             this.tabStopsRequirementRunner,
             this.tabStopRequirementActionMessageCreator,
+            this.tabStopsDoneAnalyzingTracker,
         );
     }
 

--- a/src/injected/analyzers/tab-stops-done-analyzing-tracker.ts
+++ b/src/injected/analyzers/tab-stops-done-analyzing-tracker.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TabStopEvent } from 'common/types/tab-stop-event';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
+import { isEqual } from 'lodash';
+
+export class TabStopsDoneAnalyzingTracker {
+    private firstSeenTabStopEvent: TabStopEvent | null = null;
+
+    constructor(
+        private readonly tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator,
+    ) {}
+
+    public reset() {
+        this.firstSeenTabStopEvent = null;
+    }
+
+    public addTabStopEvents(events: TabStopEvent[]) {
+        let startSearchingIndex = 0;
+
+        if (this.firstSeenTabStopEvent === null) {
+            this.firstSeenTabStopEvent = events[0];
+            startSearchingIndex = 1;
+        }
+
+        const completedTabLoop = events.some((e, i) => {
+            return (
+                i >= startSearchingIndex && isEqual(e.target, this.firstSeenTabStopEvent!.target)
+            );
+        });
+
+        if (completedTabLoop) {
+            this.tabStopRequirementActionMessageCreator.updateTabbingCompleted(true);
+        }
+    }
+}

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -18,6 +18,7 @@ import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-
 import { getCheckResolution, getFixResolution } from 'injected/adapters/resolution-creator';
 import { filterNeedsReviewResults } from 'injected/analyzers/filter-results';
 import { NotificationTextCreator } from 'injected/analyzers/notification-text-creator';
+import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
 import { ClientStoreListener, TargetPageStoreData } from 'injected/client-store-listener';
 import { ElementBasedViewModelCreator } from 'injected/element-based-view-model-creator';
 import { FocusChangeHandler } from 'injected/focus-change-handler';
@@ -321,10 +322,15 @@ export class MainWindowInitializer extends WindowInitializer {
             filterNeedsReviewResults,
         );
 
+        const tabStopsDoneAnalyzingTracker = new TabStopsDoneAnalyzingTracker(
+            tabStopRequirementActionMessageCreator,
+        );
+
         const analyzerProvider = new AnalyzerProvider(
             this.manualTabStopListener,
             this.tabStopRequirementRunner,
             tabStopRequirementActionMessageCreator,
+            tabStopsDoneAnalyzingTracker,
             this.featureFlagStoreProxy,
             this.scopingStoreProxy,
             this.browserAdapter.sendMessageToFrames,

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -64,6 +64,7 @@ describe('AnalyzerProviderTests', () => {
         tabStopRequirementRunnerMock = Mock.ofType<AllFrameRunner<TabStopRequirementResult>>();
         tabStopRequirementActionMessageCreatorMock =
             Mock.ofType<TabStopRequirementActionMessageCreator>();
+        tabStopsDoneAnalyzingTrackerMock = Mock.ofType<TabStopsDoneAnalyzingTracker>();
         featureFlagStoreMock = Mock.ofType<FeatureFlagStore>();
 
         testObject = new AnalyzerProvider(

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -5,6 +5,7 @@ import { ScopingStore } from 'background/stores/global/scoping-store';
 import { TabStopEvent } from 'common/types/tab-stop-event';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { AllFrameRunner } from 'injected/all-frame-runner';
+import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
@@ -42,6 +43,7 @@ describe('AnalyzerProviderTests', () => {
     let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
     let tabStopRequirementRunnerMock: IMock<AllFrameRunner<TabStopRequirementResult>>;
     let tabStopRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
+    let tabStopsDoneAnalyzingTrackerMock: IMock<TabStopsDoneAnalyzingTracker>;
     let featureFlagStoreMock: IMock<FeatureFlagStore>;
 
     beforeEach(() => {
@@ -68,6 +70,7 @@ describe('AnalyzerProviderTests', () => {
             tabStopsListener.object,
             tabStopRequirementRunnerMock.object,
             tabStopRequirementActionMessageCreatorMock.object,
+            tabStopsDoneAnalyzingTrackerMock.object,
             featureFlagStoreMock.object,
             scopingStoreMock.object,
             sendMessageMock.object,
@@ -159,6 +162,9 @@ describe('AnalyzerProviderTests', () => {
         expect(openAnalyzer.tabStopRequirementRunner).toEqual(tabStopRequirementRunnerMock.object);
         expect(openAnalyzer.tabStopRequirementActionMessageCreator).toEqual(
             tabStopRequirementActionMessageCreatorMock.object,
+        );
+        expect(openAnalyzer.tabStopsDoneAnalyzingTracker).toEqual(
+            tabStopsDoneAnalyzingTrackerMock.object,
         );
         expect(openAnalyzer.featureFlagStore).toEqual(featureFlagStoreMock.object);
         expect(openAnalyzer.config).toEqual(config);

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-done-analyzing-tracker.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-done-analyzing-tracker.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { TabStopEvent } from 'common/types/tab-stop-event';
+import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
+import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
+import { Mock, MockBehavior, Times } from 'typemoq';
+
+describe('TabStopsDoneAnalyzingTracker', () => {
+    const tabStopEvent: TabStopEvent = {
+        html: 'html',
+        target: ['target', 'target'],
+        timestamp: 0,
+    };
+
+    test('addTabStops sends a tabbingCompleted message when given batched sequence (A, B, A)', () => {
+        const tabStopRequirementActionMessageCreatorMock =
+            Mock.ofType<TabStopRequirementActionMessageCreator>(null, MockBehavior.Strict);
+        const tracker = new TabStopsDoneAnalyzingTracker(
+            tabStopRequirementActionMessageCreatorMock.object,
+        );
+
+        tabStopRequirementActionMessageCreatorMock
+            .setup(m => m.updateTabbingCompleted(true))
+            .verifiable(Times.once());
+
+        tracker.addTabStopEvents([
+            tabStopEvent,
+            {
+                ...tabStopEvent,
+                target: ['different-target'],
+            },
+            tabStopEvent,
+        ]);
+
+        tabStopRequirementActionMessageCreatorMock.verifyAll();
+    });
+
+    test('addTabStops sends a tabbingCompleted message when given batched sequences (A, B), (A)', () => {
+        const tabStopRequirementActionMessageCreatorMock =
+            Mock.ofType<TabStopRequirementActionMessageCreator>(null, MockBehavior.Strict);
+        const tracker = new TabStopsDoneAnalyzingTracker(
+            tabStopRequirementActionMessageCreatorMock.object,
+        );
+
+        tracker.addTabStopEvents([
+            tabStopEvent,
+            {
+                ...tabStopEvent,
+                target: ['different-target'],
+            },
+        ]);
+
+        tabStopRequirementActionMessageCreatorMock
+            .setup(m => m.updateTabbingCompleted(true))
+            .verifiable(Times.once());
+
+        tracker.addTabStopEvents([tabStopEvent]);
+
+        tabStopRequirementActionMessageCreatorMock.verifyAll();
+    });
+
+    test('addTabStops does not send a tabbingCompleted message when presented with unique tab events', () => {
+        const tabStopRequirementActionMessageCreatorMock =
+            Mock.ofType<TabStopRequirementActionMessageCreator>(null, MockBehavior.Strict);
+        const tracker = new TabStopsDoneAnalyzingTracker(
+            tabStopRequirementActionMessageCreatorMock.object,
+        );
+
+        tabStopRequirementActionMessageCreatorMock
+            .setup(m => m.updateTabbingCompleted(true))
+            .verifiable(Times.never());
+
+        tracker.addTabStopEvents([
+            tabStopEvent,
+            {
+                ...tabStopEvent,
+                target: ['different-target'],
+            },
+            {
+                ...tabStopEvent,
+                target: ['different-different-target'],
+            },
+        ]);
+
+        tabStopRequirementActionMessageCreatorMock.verifyAll();
+    });
+
+    test('reset() between consecutive addTabStop() calls properly resets state', () => {
+        const tabStopRequirementActionMessageCreatorMock =
+            Mock.ofType<TabStopRequirementActionMessageCreator>(null, MockBehavior.Strict);
+        const tracker = new TabStopsDoneAnalyzingTracker(
+            tabStopRequirementActionMessageCreatorMock.object,
+        );
+
+        tabStopRequirementActionMessageCreatorMock
+            .setup(m => m.updateTabbingCompleted(true))
+            .verifiable(Times.never());
+
+        tracker.addTabStopEvents([tabStopEvent]);
+        tracker.reset();
+        tracker.addTabStopEvents([tabStopEvent]);
+
+        tabStopRequirementActionMessageCreatorMock.verifyAll();
+    });
+});

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -357,6 +357,7 @@
         "./src/injected/all-frame-runner.ts",
         "./src/injected/analyzers/filter-results.ts",
         "./src/injected/analyzers/notification-text-creator.ts",
+        "./src/injected/analyzers/tab-stops-done-analyzing-tracker.ts",
         "./src/injected/bounding-rect.ts",
         "./src/injected/client-store-listener.ts",
         "./src/injected/client-utils.ts",


### PR DESCRIPTION
#### Details

This PR follows https://github.com/microsoft/accessibility-insights-web/pull/5087 - the second way automated tab stops "completes" is if the user completes a global cycle when tabbing in the target page.

Similar to #5112 we put this in `tab-stops-analyzer` to co-locate with the duplicate-filtering. Alternatives include `background` (since we're working with transformed `TabStopEvent` objects directly) or in `tab-stops-orchestrator`, which felt less ideal. This code needs to run in the top frame.

In the video below note that the "keyboard navigation" results (computed only after tabbing completes) show up when we revisit the first node.

https://user-images.githubusercontent.com/7775527/151274007-9632ffa1-fe87-43a2-8854-3d22c839ac69.mp4


##### Motivation

feature behavior, stop tab stops test if the user completes a global cycle

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
