### PR TITLE
feat(tabstops-auto-impl):Fix tab stops description and body bugs

### DIFF
--- a/src/injected/analyzers/tab-stops-orchestrator.ts
+++ b/src/injected/analyzers/tab-stops-orchestrator.ts
@@ -102,7 +102,7 @@ export class TabStopRequirementOrchestrator
     };
 
     private onKeydownForFocusTraps = (e: KeyboardEvent) => {
-        if (e.key !== 'Tab') {
+        if (e.key !== 'Tab' || this.dom.activeElement === this.dom.body) {
             return;
         }
 

--- a/src/injected/tab-stops-requirement-evaluator.ts
+++ b/src/injected/tab-stops-requirement-evaluator.ts
@@ -34,7 +34,7 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
         `Element ${selector} was expected, but not reached in tab order`;
     private readonly focusOrderDescription: (currSelector: string, lastSelector: string) => string =
         (currSelector, lastSelector) =>
-            `Element ${currSelector} precedes ${lastSelector} but was visited first in tab order`;
+            `Element ${currSelector} precedes ${lastSelector} but ${lastSelector} was visited first in tab order`;
     private readonly focusTrapsDescription: (string) => string = selector =>
         `Focus is still on element ${selector} 500ms after pressing tab`;
 

--- a/src/tests/end-to-end/tests/details-view/automated-tabstops.test.ts
+++ b/src/tests/end-to-end/tests/details-view/automated-tabstops.test.ts
@@ -22,6 +22,23 @@ describe('Automated TabStops Results', () => {
         await browser?.close();
     });
 
+    test('No failures are displayed when there are no tab elements', async () => {
+        await openTabStopsPage('shadow-doms.html');
+
+        for (let i = 0; i < 4; i++) {
+            await targetPage.keyPress('Tab'); // tabbing through the browser items
+        }
+
+        await detailsViewPage.setToggleState(tabStopsSelectors.visualHelperToggleButton, false);
+
+        // No results, so results selectors shouldn't show up
+        await detailsViewPage.waitForTimeout(100);
+        const element = await detailsViewPage.getSelectorElement(
+            tabStopsSelectors.automatedChecksResultSection,
+        );
+        expect(element).toBeNull();
+    });
+
     test('Detect and display out of order failures', async () => {
         await openTabStopsPage('tab-stops/out-of-order.html');
 

--- a/src/tests/end-to-end/tests/details-view/automated-tabstops.test.ts
+++ b/src/tests/end-to-end/tests/details-view/automated-tabstops.test.ts
@@ -18,7 +18,7 @@ describe('Automated TabStops Results', () => {
     let detailsViewPage: DetailsViewPage;
     let backgroundPage: BackgroundPage;
 
-    afterAll(async () => {
+    afterEach(async () => {
         await browser?.close();
     });
 

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-orchestrator.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-orchestrator.test.ts
@@ -252,6 +252,22 @@ describe('TabStopRequirementOrchestrator', () => {
         reportResultsMock.verifyAll();
     });
 
+    test('start: onKeydownForFocusTraps active element is body so do nothing', () => {
+        const eventStub = {
+            key: 'Tab',
+        } as KeyboardEvent;
+        reportResultsMock.setup(m => m(tabStopRequirementResultStub)).verifiable(Times.never());
+        const bodyElement = {} as HTMLElement;
+        domMock.setup(m => m.activeElement).returns(() => bodyElement);
+        domMock.setup(m => m.body).returns(() => bodyElement);
+
+        testSubject.setResultCallback(reportResultsMock.object);
+        testSubject.start();
+        keydownCallback(eventStub);
+
+        reportResultsMock.verifyAll();
+    });
+
     function setupStartTabStopsOrchestrator() {
         prepareTabbableFocusOrderResults();
         domMock

--- a/src/tests/unit/tests/injected/tab-stops-requirement-evaluator.test.ts
+++ b/src/tests/unit/tests/injected/tab-stops-requirement-evaluator.test.ts
@@ -58,7 +58,8 @@ describe('TabStopsRequirementEvaluator', () => {
 
     test('addFocusOrderResults returns violations', () => {
         const expectedResult: TabStopRequirementResult = {
-            description: 'Element element1 precedes element2 but was visited first in tab order',
+            description:
+                'Element element1 precedes element2 but element2 was visited first in tab order',
             selector: ['element1'],
             html: 'html1',
             requirementId: 'tab-order',
@@ -86,7 +87,8 @@ describe('TabStopsRequirementEvaluator', () => {
 
     test('addTabbableFocusOrderResults returns violations', () => {
         const expectedResult: TabStopRequirementResult = {
-            description: 'Element element1 precedes element2 but was visited first in tab order',
+            description:
+                'Element element1 precedes element2 but element2 was visited first in tab order',
             selector: ['element1'],
             html: 'html1',
             requirementId: 'tab-order',


### PR DESCRIPTION
#### Details

Fixes 2 bugs discovered in smoke testing: focus order result description was unclear and tabbing through a page with no elements returned a false positive. 

##### Motivation

Fix bugs introduced by feature work.

##### Context

- Description wording for focus order results comment was misleading, updating language.
- When tabbing on a page with no tabbable elements, automated tests returned a false positive focus trap result, because our tests detect that the focus remains on the body. Fixing this by ignoring the body in the focus trap test.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
