### PR TITLE
feat(tabstops-auto-target-page-vis): Add telemetry for automated tab stops results

### DIFF
--- a/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
+++ b/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
@@ -11,9 +11,11 @@ import {
     ToggleTabStopRequirementExpandPayload,
     UpdateTabbingCompletedPayload,
     UpdateNeedToCollectTabbingResultsPayload,
+    BaseActionPayload,
 } from 'background/actions/action-payloads';
 import { DevToolActionMessageCreator } from 'common/message-creators/dev-tool-action-message-creator';
 import { Messages } from 'common/messages';
+import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 import { TabStopRequirementStatus } from '../../common/types/store-data/visualization-scan-result-data';
 const messages = Messages.Visualizations.TabStops;
@@ -132,6 +134,18 @@ export class TabStopRequirementActionMessageCreator extends DevToolActionMessage
 
         this.dispatcher.dispatchMessage({
             messageType: Messages.Visualizations.TabStops.NeedToCollectTabbingResults,
+            payload,
+        });
+    };
+
+    public automatedTabbingResultsCompleted = (results: TabStopRequirementResult[]) => {
+        const telemetry = this.telemetryFactory.forAutomatedTabStopsResults(results);
+        const payload: BaseActionPayload = {
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Visualizations.TabStops.AutomatedTabbingResultsCompleted,
             payload,
         });
     };

--- a/src/background/actions/tab-stop-requirement-action-creator.ts
+++ b/src/background/actions/tab-stop-requirement-action-creator.ts
@@ -6,6 +6,7 @@ import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import {
     AddTabStopInstancePayload,
+    BaseActionPayload,
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
@@ -62,6 +63,11 @@ export class TabStopRequirementActionCreator {
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Visualizations.TabStops.NeedToCollectTabbingResults,
             this.onNeedToCollectTabbingResults,
+        );
+
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.Visualizations.TabStops.AutomatedTabbingResultsCompleted,
+            this.onAutomatedTabbingResultsCompleted,
         );
     }
 
@@ -123,5 +129,13 @@ export class TabStopRequirementActionCreator {
         payload: UpdateNeedToCollectTabbingResultsPayload,
     ): void => {
         this.tabStopRequirementActions.updateNeedToCollectTabbingResults.invoke(payload);
+    };
+
+    private onAutomatedTabbingResultsCompleted = (payload: BaseActionPayload): void => {
+        this.tabStopRequirementActions.automatedTabbingResultsCompleted.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(
+            TelemetryEvents.TABSTOPS_AUTOMATED_RESULTS,
+            payload,
+        );
     };
 }

--- a/src/background/actions/tab-stop-requirement-actions.ts
+++ b/src/background/actions/tab-stop-requirement-actions.ts
@@ -5,6 +5,7 @@
 import { Action } from 'common/flux/action';
 import {
     AddTabStopInstancePayload,
+    BaseActionPayload,
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
@@ -28,4 +29,5 @@ export class TabStopRequirementActions {
     public readonly updateTabbingCompleted = new Action<UpdateTabbingCompletedPayload>();
     public readonly updateNeedToCollectTabbingResults =
         new Action<UpdateNeedToCollectTabbingResultsPayload>();
+    public readonly automatedTabbingResultsCompleted = new Action<BaseActionPayload>();
 }

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -11,6 +11,7 @@ export const LANDMARKS_TOGGLE: string = 'LandmarksToggled';
 export const TABSTOPS_TOGGLE: string = 'TabStopsToggled';
 export const TABSTOPS_RECORDING_COMPLETE: string = 'TabStopsRecordingComplete';
 export const ADD_TABSTOPS_REQUIREMENT_INSTANCE: string = 'AddTabStopsRequirementInstance';
+export const TABSTOPS_AUTOMATED_RESULTS: string = 'TabStopsAutomatedResults';
 export const REMOVE_TABSTOPS_REQUIREMENT_INSTANCE: string = 'RemoveTabStopsRequirementInstance';
 export const UPDATE_TABSTOPS_REQUIREMENT_INSTANCE: string = 'UpdateTabStopsRequirementInstance';
 export const UPDATE_TABSTOPS_REQUIREMENT_STATUS: string = 'UpdateTabStopsRequirementStatus';
@@ -213,6 +214,10 @@ export type AndroidScanCompletedTelemetryData = {
     scanDuration: number;
 } & InstanceCount;
 
+export type TabStopsAutomatedResultsTelemetryData = {
+    tabStopAutomatedFailuresInstanceCount: TabStopAutomatedFailuresInstanceCount;
+} & BaseTelemetryData;
+
 export type InstanceCount = {
     PASS: {
         [ruleId: string]: number;
@@ -235,6 +240,10 @@ export type TabStopRequirementInstanceCount = {
     unknown: {
         [requirementId: string]: number;
     };
+};
+
+export type TabStopAutomatedFailuresInstanceCount = {
+    [requirementId: string]: number;
 };
 
 export type AtfaInstanceCount = {

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -28,6 +28,7 @@ export const Messages = {
             RequirementExpansionToggled: `${messagePrefix}/visualization/tab-stops/toggleTabStopRequirementExpand`,
             TabbingCompleted: `${messagePrefix}/visualization/tab-stops/tabbingCompleted`,
             NeedToCollectTabbingResults: `${messagePrefix}/visualization/tab-stops/NeedToCollectTabbingResults`,
+            AutomatedTabbingResultsCompleted: `${messagePrefix}/visualization/tab-stops/AutomatedTabbingResultsCompleted`,
         },
         Issues: {
             UpdateFocusedInstance: `${messagePrefix}/visualization/issues/targets/focused/update`,

--- a/src/common/telemetry-data-factory.ts
+++ b/src/common/telemetry-data-factory.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
+import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
 import * as React from 'react';
 import { ReportExportServiceKey } from 'report-export/types/report-export-service';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
@@ -30,7 +31,9 @@ import {
     SetAllUrlsPermissionTelemetryData,
     SettingsOpenSourceItem,
     SettingsOpenTelemetryData,
+    TabStopAutomatedFailuresInstanceCount,
     TabStopRequirementInstanceCount,
+    TabStopsAutomatedResultsTelemetryData,
     TelemetryEventSource,
     ToggleTelemetryData,
     TriggeredBy,
@@ -471,6 +474,26 @@ export class TelemetryDataFactory {
         return {
             ...this.withTriggeredByAndSource(event, source),
             permissionState,
+        };
+    }
+
+    public forAutomatedTabStopsResults(
+        results: TabStopRequirementResult[],
+    ): TabStopsAutomatedResultsTelemetryData | undefined {
+        if (!results || results.length === 0) {
+            return undefined;
+        }
+
+        const tabStopAutomatedFailuresInstanceCount: TabStopAutomatedFailuresInstanceCount = {};
+        results.forEach(({ requirementId }) => {
+            const count = tabStopAutomatedFailuresInstanceCount[requirementId] ?? 0;
+            tabStopAutomatedFailuresInstanceCount[requirementId] = count + 1;
+        });
+
+        return {
+            triggeredBy: TriggeredByNotApplicable,
+            source: TelemetryEventSource.DetailsView,
+            tabStopAutomatedFailuresInstanceCount,
         };
     }
 }

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -102,6 +102,9 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         this.debouncedProcessTabEvents?.cancel();
         this.tabStopListenerRunner.stop();
         this.tabStopRequirementRunner.stop();
+        this.tabStopRequirementActionMessageCreator.automatedTabbingResultsCompleted(
+            this.seenTabStopRequirementResults,
+        );
 
         const payload: ScanBasePayload = {
             key: this.config.key,

--- a/src/injected/tab-stops-requirement-evaluator.ts
+++ b/src/injected/tab-stops-requirement-evaluator.ts
@@ -21,12 +21,12 @@ export interface TabStopsRequirementEvaluator {
     getFocusOrderResult(
         lastTabStop: HTMLElement,
         currentTabStop: HTMLElement,
-    ): TabStopRequirementResult;
+    ): TabStopRequirementResult | null;
     getTabbableFocusOrderResults(tabbableTabStops: FocusableElement[]): TabStopRequirementResult[];
     getKeyboardTrapResults(
         oldActiveElement: Element,
         newActiveElement: Element,
-    ): TabStopRequirementResult;
+    ): TabStopRequirementResult | null;
 }
 
 export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementEvaluator {
@@ -65,7 +65,7 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
     public getFocusOrderResult(
         lastTabStop: HTMLElement,
         currentTabStop: HTMLElement,
-    ): TabStopRequirementResult {
+    ): TabStopRequirementResult | null {
         if (this.htmlElementUtils.precedesInDOM(currentTabStop, lastTabStop)) {
             const lastSelector = this.generateSelector(lastTabStop);
             const currSelector = this.generateSelector(currentTabStop);
@@ -101,7 +101,7 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
     public getKeyboardTrapResults(
         oldActiveElement: Element,
         newActiveElement: Element,
-    ): TabStopRequirementResult {
+    ): TabStopRequirementResult | null {
         if (oldActiveElement === newActiveElement) {
             const selector = this.generateSelector(oldActiveElement as HTMLElement);
             return {

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-instance-section-props-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-instance-section-props-factory.test.tsx.snap
@@ -5,6 +5,7 @@ Object {
   "deps": Object {
     "tabStopRequirementActionMessageCreator": proxy {
       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+      "automatedTabbingResultsCompleted": [Function],
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
@@ -102,6 +103,7 @@ Object {
   "deps": Object {
     "tabStopRequirementActionMessageCreator": proxy {
       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+      "automatedTabbingResultsCompleted": [Function],
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
@@ -122,6 +124,7 @@ Object {
       Object {
         "tabStopRequirementActionMessageCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "automatedTabbingResultsCompleted": [Function],
           "dispatcher": undefined,
           "telemetryFactory": undefined,
           "toggleTabStopRequirementExpand": [Function],
@@ -170,6 +173,7 @@ Object {
   "deps": Object {
     "tabStopRequirementActionMessageCreator": proxy {
       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+      "automatedTabbingResultsCompleted": [Function],
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
@@ -270,6 +274,7 @@ Object {
   "deps": Object {
     "tabStopRequirementActionMessageCreator": proxy {
       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+      "automatedTabbingResultsCompleted": [Function],
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
@@ -290,6 +295,7 @@ Object {
       Object {
         "tabStopRequirementActionMessageCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "automatedTabbingResultsCompleted": [Function],
           "dispatcher": undefined,
           "telemetryFactory": undefined,
           "toggleTabStopRequirementExpand": [Function],
@@ -346,6 +352,7 @@ Object {
   "deps": Object {
     "tabStopRequirementActionMessageCreator": proxy {
       "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+      "automatedTabbingResultsCompleted": [Function],
       "dispatcher": undefined,
       "telemetryFactory": undefined,
       "toggleTabStopRequirementExpand": [Function],
@@ -366,6 +373,7 @@ Object {
       Object {
         "tabStopRequirementActionMessageCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "automatedTabbingResultsCompleted": [Function],
           "dispatcher": undefined,
           "telemetryFactory": undefined,
           "toggleTabStopRequirementExpand": [Function],

--- a/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
@@ -9,6 +9,7 @@ import {
     ToggleTabStopRequirementExpandPayload,
     UpdateTabbingCompletedPayload,
     UpdateNeedToCollectTabbingResultsPayload,
+    BaseActionPayload,
 } from 'background/actions/action-payloads';
 import { TabStopRequirementActionCreator } from 'background/actions/tab-stop-requirement-action-creator';
 import { TabStopRequirementActions } from 'background/actions/tab-stop-requirement-actions';
@@ -285,6 +286,37 @@ describe('TabStopRequirementActionCreator', () => {
         testSubject.registerCallbacks();
 
         onNeedToCollectTabbingResultsMock.verifyAll();
+    });
+
+    test('registerCallback for automated tabbing results completed', () => {
+        const actionName = 'automatedTabbingResultsCompleted';
+
+        const payload: BaseActionPayload = {
+            telemetry: {} as TelemetryEvents.TelemetryData,
+        };
+
+        const instanceMock = createActionMock(payload);
+
+        const actionsMock = createActionsMock(actionName, instanceMock.object);
+        const interpreterMock = createInterpreterMock(
+            Messages.Visualizations.TabStops.AutomatedTabbingResultsCompleted,
+            payload,
+        );
+
+        const testSubject = new TabStopRequirementActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        instanceMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler =>
+                handler.publishTelemetry(TelemetryEvents.TABSTOPS_AUTOMATED_RESULTS, payload),
+            Times.once(),
+        );
     });
 
     function createActionsMock<ActionName extends keyof TabStopRequirementActions>(

--- a/src/tests/unit/tests/common/telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/common/telemetry-data-factory.test.ts
@@ -770,7 +770,7 @@ describe('TelemetryDataFactoryTest', () => {
         expect(result).toEqual(expected);
     });
 
-    test('forAutomatedTabStopsResults returns null when no results', () => {
+    test('forAutomatedTabStopsResults returns undefined when no results', () => {
         const result = testObject.forAutomatedTabStopsResults([]);
         expect(result).toBeUndefined();
     });

--- a/src/tests/unit/tests/common/telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/common/telemetry-data-factory.test.ts
@@ -18,6 +18,7 @@ import {
     SetAllUrlsPermissionTelemetryData,
     SettingsOpenSourceItem,
     SettingsOpenTelemetryData,
+    TabStopsAutomatedResultsTelemetryData,
     TelemetryEventSource,
     ToggleTelemetryData,
     TriggeredByNotApplicable,
@@ -27,6 +28,7 @@ import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationType } from 'common/types/visualization-type';
+import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
 
 import { EventStubFactory } from './../../common/event-stub-factory';
 
@@ -748,5 +750,28 @@ describe('TelemetryDataFactoryTest', () => {
         const result = testObject.forLeftNavPanelExpanded(mouseClickEvent);
 
         expect(result).toEqual(expected);
+    });
+
+    test('forAutomatedTabStopsResults', () => {
+        const tabbingResults: TabStopRequirementResult[] = [
+            { requirementId: 'tab-order', html: null, selector: null, description: null },
+            { requirementId: 'tab-order', html: null, selector: null, description: null },
+            { requirementId: 'keyboard-traps', html: null, selector: null, description: null },
+        ];
+
+        const result = testObject.forAutomatedTabStopsResults(tabbingResults);
+
+        const expected: TabStopsAutomatedResultsTelemetryData = {
+            tabStopAutomatedFailuresInstanceCount: { 'tab-order': 2, 'keyboard-traps': 1 },
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: 'N/A',
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    test('forAutomatedTabStopsResults returns null when no results', () => {
+        const result = testObject.forAutomatedTabStopsResults([]);
+        expect(result).toBeUndefined();
     });
 });

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -241,6 +241,7 @@ describe('TabStopsAnalyzer', () => {
             await flushSettledPromises();
 
             tabStopsListenerMock.setup(tslm => tslm.stop()).verifiable(Times.once());
+
             setupSendMessageMock({
                 messageType: configStub.analyzerTerminatedMessageType,
                 payload: { key: configStub.key, testType: configStub.testType },
@@ -249,6 +250,10 @@ describe('TabStopsAnalyzer', () => {
             testSubject.teardown();
             await flushSettledPromises();
             verifyAll();
+            tabStopRequirementActionMessageCreatorMock.verify(
+                m => m.automatedTabbingResultsCompleted(It.isAny()),
+                Times.exactly(1),
+            );
 
             simulateTabEvent(tabEventStub1); // no corresponding setupSendMessageMock
             debounceFaker.flush();

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -251,7 +251,7 @@ describe('TabStopsAnalyzer', () => {
             await flushSettledPromises();
             verifyAll();
             tabStopRequirementActionMessageCreatorMock.verify(
-                m => m.automatedTabbingResultsCompleted(It.isAny()),
+                m => m.automatedTabbingResultsCompleted([]),
                 Times.exactly(1),
             );
 


### PR DESCRIPTION
#### Details

Add telemetry for automated tab stops results. Telemetry event includes the number of issues by requirement when results are found. When results are not found, no telemetry is sent.

##### Motivation

Feature work.

##### Context

Ideally we wouldn't have to add another message for adding telemetry. I considered reusing the `NeedToCollectTabbingResults` message for this but at the moment it only keeps track of if tabbing results need to be collected or not (a boolean) and doesn't know what the results actually are. Further, we only want to send the telemetry event once so we would have to add telemetry only when the payload is false (that is, we have finished collecting tabbing results, which should only happen once). We could update this message to take in the results as well and handle the telemetry, but I opted to create a new message instead to keep it logically separated. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
