### PR TITLE
chore(deps): update node in CI builds to 14.19.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ on:
     - cron: '0 19 * * 0'
 
 env:
-  NODE_VERSION: 14.17.0
+  # Keep this in sync with /pipeline/install-node-prerequisites.yaml
+  NODE_VERSION: 14.19.0
 
 jobs:
   build:

--- a/docs/building-web.md
+++ b/docs/building-web.md
@@ -13,7 +13,7 @@ This document describes how to build and test Accessibility Insights for Web (th
 
 You will need the following tools installed:
 
--   [Node](https://nodejs.org) >= 14.15.0 (check by running `node --version`) - This is the version being enforced on our builds
+-   [Node](https://nodejs.org) >= 14.19.0 (check by running `node --version`) - This is the version being enforced on our builds
 -   [Yarn](https://yarnpkg.com/getting-started/install) >= 1.22.10 (check by running `yarn --version`)
     -    Note: There is a [known name collision](https://github.com/yarnpkg/yarn/issues/673) between Yarn package manager and Hadoop YARN. If you have Hadoop YARN installed, replace `yarn` with `yarnpkg` in the commands below.
 -   **macOS only** [Xcode](https://wilsonmar.github.io/xcode/#XcodeInstall). This is needed when installing some dev dependencies (like spectron). After installing Xcode, run the following commands from a command terminal:

--- a/pipeline/install-node-prerequisites.yaml
+++ b/pipeline/install-node-prerequisites.yaml
@@ -3,8 +3,9 @@
 steps:
     - task: NodeTool@0
       inputs:
-          versionSpec: '14.15.0'
-      displayName: use node 14.15.0
+          # Keep this in sync with /.github/workflows/ci.yml
+          versionSpec: '14.19.0'
+      displayName: use node 14.19.0
       timeoutInMinutes: 2
 
     - script: npm install yarn@1.22.10 -g


### PR DESCRIPTION
#### Details

This PR bumps the version of Node we use in CI builds on both GitHub Actions and Azure DevOps to the latest v14 (`14.19.0`).

This is primarily in the hopes of resolving an issue we've seen in a few recent PR builds for dependabot PRs where builds fail in webpack with an error that looks like this:

```
Running "concurrent:webpack-all" (concurrent) task

    Running "exec:webpack-prod" (exec) task
    >> internal/child_process/serialization.js:70
    >>       yield deserializer.readValue();
    >>                          ^
    >> 
    >> Error: Unable to deserialize cloned data.
    >>     at parseChannelMessages (internal/child_process/serialization.js:70:26)
    >>     at parseChannelMessages.next (<anonymous>)
    >>     at Pipe.channel.onread (internal/child_process.js:599:18)
    >> Exited with code: 1.
    >> Error executing child process: Error: Process exited with code 1.
```

This symptom is similar to the one resolved by https://github.com/nodejs/node/pull/38728, which is included in 14.17.4

##### Motivation

* Keep deps up to date
* Attempt to avoid an error blocking PR builds (#5134, #5135, #5136)

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
