### PR TITLE
feat(ado-improvements-1): fix React warning in report & simplify combined report parameters

### DIFF
--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-report",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "description": "Accessibility Insights Report",
     "license": "MIT",
     "files": [

--- a/src/reports/combined-report-html-generator.tsx
+++ b/src/reports/combined-report-html-generator.tsx
@@ -38,7 +38,6 @@ export class CombinedReportHtmlGenerator {
     public generateHtml(
         scanMetadata: ScanMetadata,
         cardsByRule: CardsViewModel,
-        cardSelectionMessageCreator: CardSelectionMessageCreator,
         urlResultCounts: UrlResultCounts,
     ): string {
         const HeadSection = this.sectionFactory.HeadSection;
@@ -57,7 +56,7 @@ export class CombinedReportHtmlGenerator {
                 LinkComponent: NewTabLinkWithConfirmationDialog,
             } as SectionDeps,
             cardsViewData: cardsByRule,
-            cardSelectionMessageCreator,
+            cardSelectionMessageCreator: nullCardSelectionMessageCreator,
             urlResultCounts,
             toUtcString: this.utcDateConverter,
             secondsToTimeString: this.secondsToTimeStringConverter,
@@ -76,3 +75,11 @@ export class CombinedReportHtmlGenerator {
         return '<!DOCTYPE html><html lang="en">' + headMarkup + bodyMarkup + '</html>';
     }
 }
+
+const nullCardSelectionMessageCreator: CardSelectionMessageCreator = {
+    toggleCardSelection: () => null,
+    toggleRuleExpandCollapse: () => null,
+    collapseAllRules: () => null,
+    expandAllRules: () => null,
+    toggleVisualHelper: () => null,
+};

--- a/src/reports/combined-report-html-generator.tsx
+++ b/src/reports/combined-report-html-generator.tsx
@@ -7,7 +7,6 @@ import { NullComponent } from 'common/components/null-component';
 import { RecommendColor } from 'common/components/recommend-color';
 import { PropertyConfiguration } from 'common/configs/unified-result-property-configurations';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
@@ -56,7 +55,6 @@ export class CombinedReportHtmlGenerator {
                 LinkComponent: NewTabLinkWithConfirmationDialog,
             } as SectionDeps,
             cardsViewData: cardsByRule,
-            cardSelectionMessageCreator: nullCardSelectionMessageCreator,
             urlResultCounts,
             toUtcString: this.utcDateConverter,
             secondsToTimeString: this.secondsToTimeStringConverter,
@@ -75,11 +73,3 @@ export class CombinedReportHtmlGenerator {
         return '<!DOCTYPE html><html lang="en">' + headMarkup + bodyMarkup + '</html>';
     }
 }
-
-const nullCardSelectionMessageCreator: CardSelectionMessageCreator = {
-    toggleCardSelection: () => null,
-    toggleRuleExpandCollapse: () => null,
-    collapseAllRules: () => null,
-    expandAllRules: () => null,
-    toggleVisualHelper: () => null,
-};

--- a/src/reports/components/report-sections/combined-report-failed-section.tsx
+++ b/src/reports/components/report-sections/combined-report-failed-section.tsx
@@ -17,13 +17,12 @@ export type CombinedReportFailedSectionProps = {
     deps: CombinedReportFailedSectionDeps;
     cardsViewData: CardsViewModel;
     scanMetadata: ScanMetadata;
-    cardSelectionMessageCreator: CardSelectionMessageCreator;
 };
 
 export const CombinedReportFailedSection = NamedFC<CombinedReportFailedSectionProps>(
     'CombinedReportFailedSection',
     props => {
-        const { deps, cardsViewData, scanMetadata, cardSelectionMessageCreator } = props;
+        const { deps, cardsViewData, scanMetadata } = props;
 
         const ruleCount = cardsViewData.cards.fail.length;
 
@@ -49,12 +48,10 @@ export const CombinedReportFailedSection = NamedFC<CombinedReportFailedSectionPr
                     userConfigurationStoreData={null}
                     outcomeCounter={OutcomeCounter.countByIdentifierUrls}
                     headingLevel={4}
-                    cardSelectionMessageCreator={cardSelectionMessageCreator}
+                    cardSelectionMessageCreator={nullCardSelectionMessageCreator}
                 />
             ),
-            onExpandToggle: (event: React.MouseEvent<HTMLDivElement>) => {
-                cardSelectionMessageCreator.toggleRuleExpandCollapse(sectionId, event);
-            },
+            onExpandToggle: null,
             headingLevel: 3,
             deps: null,
         });
@@ -62,3 +59,11 @@ export const CombinedReportFailedSection = NamedFC<CombinedReportFailedSectionPr
         return <div className="result-section">{CollapsibleContent}</div>;
     },
 );
+
+const nullCardSelectionMessageCreator: CardSelectionMessageCreator = {
+    toggleCardSelection: () => null,
+    toggleRuleExpandCollapse: () => null,
+    collapseAllRules: () => null,
+    expandAllRules: () => null,
+    toggleVisualHelper: () => null,
+};

--- a/src/reports/components/report-sections/summary-report-details-section.tsx
+++ b/src/reports/components/report-sections/summary-report-details-section.tsx
@@ -22,7 +22,7 @@ export const SummaryReportDetailsSection = NamedFC<BaseSummaryReportSectionProps
             className?: string,
         ) =>
             icon ? (
-                <li className={className}>
+                <li key={label} className={className}>
                     <span className={styles.icon} aria-hidden="true">
                         {icon}
                     </span>
@@ -30,7 +30,7 @@ export const SummaryReportDetailsSection = NamedFC<BaseSummaryReportSectionProps
                     <span className={styles.text}>{content}</span>
                 </li>
             ) : (
-                <li className={className}>
+                <li key={label} className={className}>
                     <span className={css(styles.noIcon, styles.label)}>{`${label} `}</span>
                     <span className={styles.text}>{content}</span>
                 </li>

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as axe from 'axe-core';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
-
 
 declare namespace AccessibilityInsightsReport {
     export type Report = {
@@ -120,7 +118,6 @@ declare namespace AccessibilityInsightsReport {
         browserResolution: string,
         scanDetails: ScanSummaryDetails,
         results: CombinedReportResults,
-        cardSelectionMessageCreator: CardSelectionMessageCreator;
     }
 
     export type Reporter = {

--- a/src/reports/package/combined-results-report.ts
+++ b/src/reports/package/combined-results-report.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ScanMetadata, ScanTimespan, ToolData } from 'common/types/store-data/unified-data-interface';
 import { CombinedReportHtmlGenerator } from 'reports/combined-report-html-generator';
 import { CombinedResultsToCardsModelConverter } from 'reports/package/combined-results-to-cards-model-converter';
@@ -8,7 +7,6 @@ import AccessibilityInsightsReport from './accessibilityInsightsReport';
 
 export type CombinedResultsReportDeps = {
     reportHtmlGenerator: CombinedReportHtmlGenerator;
-    cardSelectionMessageCreator: CardSelectionMessageCreator;
 };
 
 export class CombinedResultsReport implements AccessibilityInsightsReport.Report {
@@ -46,7 +44,6 @@ export class CombinedResultsReport implements AccessibilityInsightsReport.Report
         return this.deps.reportHtmlGenerator.generateHtml(
             scanMetadata,
             cardsByRule,
-            this.deps.cardSelectionMessageCreator,
             results.urlResults
         );
     }

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -16,7 +16,7 @@ import { getDefaultAddListenerForCollapsibleSection } from 'reports/components/r
 import { CombinedReportSectionFactory } from 'reports/components/report-sections/combined-report-section-factory';
 import { SummaryReportSectionFactory } from 'reports/components/report-sections/summary-report-section-factory';
 import { AxeResultsReport, AxeResultsReportDeps } from 'reports/package/axe-results-report';
-import { CombinedResultsReport } from 'reports/package/combined-results-report';
+import { CombinedResultsReport, CombinedResultsReportDeps } from 'reports/package/combined-results-report';
 import { CombinedResultsToCardsModelConverter } from 'reports/package/combined-results-to-cards-model-converter';
 import { SummaryResultsReport } from 'reports/package/summary-results-report';
 import { ReactStaticRenderer } from 'reports/react-static-renderer';
@@ -161,9 +161,8 @@ const combinedResultsReportGenerator = (parameters: CombinedReportParameters) =>
         recommendColor,
         getPropertyConfiguration,
     );
-    const deps = {
+    const deps: CombinedResultsReportDeps = {
         reportHtmlGenerator,
-        cardSelectionMessageCreator: parameters.cardSelectionMessageCreator,
     }
 
     const cardSelectionViewData: CardSelectionViewData = {

--- a/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
@@ -144,12 +144,7 @@ describe('CombinedReportHtmlGenerator', () => {
             .returns(() => '<body-markup />')
             .verifiable(Times.once());
 
-        const html = testSubject.generateHtml(
-            scanMetadata,
-            cardsViewData,
-            cardSelectionMessageCreatorMock.object,
-            urlResultCounts,
-        );
+        const html = testSubject.generateHtml(scanMetadata, cardsViewData, urlResultCounts);
 
         expect(html).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/combined-report-html-generator.test.tsx
@@ -7,7 +7,6 @@ import { NullComponent } from 'common/components/null-component';
 import { RecommendColor } from 'common/components/recommend-color';
 import { DateProvider } from 'common/date-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import {
     ScanMetadata,
     ScanTimespan,
@@ -85,13 +84,11 @@ describe('CombinedReportHtmlGenerator', () => {
     let getScriptMock: IMock<() => string>;
     let sectionFactoryMock: IMock<ReportSectionFactory<CombinedReportSectionProps>>;
     let rendererMock: IMock<ReactStaticRenderer>;
-    let cardSelectionMessageCreatorMock: IMock<CardSelectionMessageCreator>;
 
     beforeEach(() => {
         getScriptMock = Mock.ofInstance(() => '');
         sectionFactoryMock = Mock.ofType<ReportSectionFactory<CombinedReportSectionProps>>();
         rendererMock = Mock.ofType<ReactStaticRenderer>();
-        cardSelectionMessageCreatorMock = Mock.ofType<CardSelectionMessageCreator>();
 
         testSubject = new CombinedReportHtmlGenerator(
             sectionFactoryMock.object,
@@ -122,7 +119,6 @@ describe('CombinedReportHtmlGenerator', () => {
             toUtcString: getUTCStringFromDateStub,
             secondsToTimeString: getTimeStringFromSecondsStub,
             getCollapsibleScript: getScriptMock.object,
-            cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
             scanMetadata,
             cardsViewData,
             urlResultCounts,

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/combined-report-failed-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/combined-report-failed-section.test.tsx.snap
@@ -6,17 +6,7 @@ exports[`CombinedReportFailedSection renders 1`] = `
     <CombinedResultSectionTitle outcomeCount={1} outcomeType=\\"fail\\" title=\\"Failed rules\\" />
   </div>
   <div id=\\"collapsible-content\\">
-    <ResultSectionContent deps={{...}} outcomeType=\\"fail\\" targetAppInfo={[undefined]} results={{...}} visualHelperEnabled={true} allCardsCollapsed={true} userConfigurationStoreData={{...}} outcomeCounter={[Function: countByIdentifierUrls]} headingLevel={4} cardSelectionMessageCreator={[Function: function () {
-                        var args = [];
-                        for (var _i = 0; _i < arguments.length; _i++) {
-                            args[_i] = arguments[_i];
-                        }
-                        _this._interceptor.removeInvocation(invocation_1);
-                        var method = new MethodInfo(target, p);
-                        var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
-                        _this._interceptor.intercept(methodInvocation);
-                        return methodInvocation.returnValue;
-                    }] { [Symbol(Symbol.toStringTag)]: [Function: bound toString] }} />
+    <ResultSectionContent deps={{...}} outcomeType=\\"fail\\" targetAppInfo={[undefined]} results={{...}} visualHelperEnabled={true} allCardsCollapsed={true} userConfigurationStoreData={{...}} outcomeCounter={[Function: countByIdentifierUrls]} headingLevel={4} cardSelectionMessageCreator={{...}} />
   </div>
 </div>"
 `;

--- a/src/tests/unit/tests/reports/components/report-sections/combined-report-failed-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/combined-report-failed-section.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CollapsibleComponentCardsProps } from 'common/components/cards/collapsible-component-cards';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -11,14 +10,9 @@ import {
     CombinedReportFailedSectionDeps,
 } from 'reports/components/report-sections/combined-report-failed-section';
 import { exampleUnifiedStatusResults } from 'tests/unit/tests/common/components/cards/sample-view-model-data';
-import { IMock, It, Mock, MockBehavior } from 'typemoq';
+import { It, Mock, MockBehavior } from 'typemoq';
 
 describe('CombinedReportFailedSection', () => {
-    let cardSelectionMessageCreatorMock: IMock<CardSelectionMessageCreator>;
-    beforeEach(() => {
-        cardSelectionMessageCreatorMock = Mock.ofType<CardSelectionMessageCreator>();
-    });
-
     it('renders', () => {
         const collapsibleControlMock = Mock.ofType<
             (props: CollapsibleComponentCardsProps) => JSX.Element
@@ -36,7 +30,6 @@ describe('CombinedReportFailedSection', () => {
                 visualHelperEnabled: true,
                 allCardsCollapsed: true,
             },
-            cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
             scanMetadata: scanMetaDataStub,
         } as CombinedReportFailedSectionProps;
 

--- a/src/tests/unit/tests/reports/package/combined-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/combined-results-report.test.ts
@@ -105,7 +105,7 @@ describe('CombinedResultsReport', () => {
             .returns(() => cardsViewDataStub);
 
         reportHtmlGeneratorMock
-            .setup(rhg => rhg.generateHtml(scanMetadataStub, cardsViewDataStub, cardSelectionMessageCreatorMock.object, urlResultsCount))
+            .setup(rhg => rhg.generateHtml(scanMetadataStub, cardsViewDataStub, urlResultsCount))
             .returns(() => expectedHtml);
 
         const html = combinedResultsReport.asHTML();


### PR DESCRIPTION
#### Details

In this PR we:

1. fix the React warning in the report package: `Each child in a list should have a unique "key" prop` so that consumers of the package don't see unnecessary output logs
2. unblock releasing the report package by removing an unnecessary parameter

I plan to release the report package after this PR is merged.

##### Context for 1:
`SummaryReportDetailsSection` was missing `key` values for sibling listitems. This leads to a React warning not only for us, but also for consumers of the report package. The text below comes from an ADO extension run (copied from https://github.com/microsoft/accessibility-insights-action/issues/950):

```
2021-11-02T19:50:21.6436274Z Warning: Each child in a list should have a unique "key" prop.
2021-11-02T19:50:21.6437698Z 
2021-11-02T19:50:21.6439176Z Check the top-level render call using <ul>. See https://fb.me/react-warning-keys for more information.
2021-11-02T19:50:21.6442305Z     in li
2021-11-02T19:50:21.6442623Z     in SummaryReportDetailsSection
2021-11-02T19:50:21.6442929Z     in div
2021-11-02T19:50:21.6443185Z     in main
2021-11-02T19:50:21.6443472Z     in ContentSection
2021-11-02T19:50:21.6443757Z     in body
2021-11-02T19:50:21.6444016Z     in BodySection
2021-11-02T19:50:21.6444303Z     in ReportBody
```

After this PR, I expect this log output to go away in the ADO extension. I tested this by building a local version of the report package (`npm pack` after `yarn build:packages:report`) and using it from a sample TypeScript + webpack consumer.

##### Context for 2:
`cardSelectionMessageCreator` was a required parameter for combined reports, but it wasn't being used. We couldn't release the report package because its typings [referenced a file](https://github.com/microsoft/accessibility-insights-web/blob/1fad4612c99dc5d03915d6ae1d1db5a2a4527329/src/reports/package/accessibilityInsightsReport.d.ts#L4) that wasn't included in the package.

Between "fixing the typings" and "removing the parameter", I chose to remove the parameter because it isn't used. I verified this by exploring the code, and also by passing in `console.log` statements for every method in `cardSelectionMessageCreator`. When I interacted with the generated report, none of the callbacks were triggered. This functionality is helpful for interactive cards (The report shares components with the normal FastPass interactive web experience), but the cards in the report are read-only. I resolved this by explicitly passing in a `null` version of the object, similar to `noCardInteractionsSupported` and other `null` deps in the report.

##### Motivation

addresses part of https://github.com/microsoft/accessibility-insights-action/issues/950 - Fix the Warning: Each child in a list should have a unique "key" prop. issue in the report package

unblocks release

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses part of https://github.com/microsoft/accessibility-insights-action/issues/950
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
