### PR TITLE
refactor(tabstops-auto-target-page-vis): TabStopRequirementResult to AutomatedTabStopRequirementResult rename

### DIFF
--- a/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
+++ b/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
@@ -4,21 +4,20 @@
 // Licensed under the MIT License.
 import {
     AddTabStopInstancePayload,
+    BaseActionPayload,
     RemoveTabStopInstancePayload,
-    UpdateTabStopInstancePayload,
-    UpdateTabStopRequirementStatusPayload,
     ResetTabStopRequirementStatusPayload,
     ToggleTabStopRequirementExpandPayload,
-    UpdateTabbingCompletedPayload,
     UpdateNeedToCollectTabbingResultsPayload,
-    BaseActionPayload,
+    UpdateTabbingCompletedPayload,
+    UpdateTabStopInstancePayload,
+    UpdateTabStopRequirementStatusPayload,
 } from 'background/actions/action-payloads';
 import { DevToolActionMessageCreator } from 'common/message-creators/dev-tool-action-message-creator';
 import { Messages } from 'common/messages';
-import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 import { TabStopRequirementStatus } from '../../common/types/store-data/visualization-scan-result-data';
-import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 const messages = Messages.Visualizations.TabStops;
 
 export class TabStopRequirementActionMessageCreator extends DevToolActionMessageCreator {

--- a/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
+++ b/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
@@ -18,6 +18,7 @@ import { Messages } from 'common/messages';
 import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 import { TabStopRequirementStatus } from '../../common/types/store-data/visualization-scan-result-data';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 const messages = Messages.Visualizations.TabStops;
 
 export class TabStopRequirementActionMessageCreator extends DevToolActionMessageCreator {
@@ -138,7 +139,7 @@ export class TabStopRequirementActionMessageCreator extends DevToolActionMessage
         });
     };
 
-    public automatedTabbingResultsCompleted = (results: TabStopRequirementResult[]) => {
+    public automatedTabbingResultsCompleted = (results: AutomatedTabStopRequirementResult[]) => {
         const telemetry = this.telemetryFactory.forAutomatedTabStopsResults(results);
         const payload: BaseActionPayload = {
             telemetry,

--- a/src/common/telemetry-data-factory.ts
+++ b/src/common/telemetry-data-factory.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
-import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 import * as React from 'react';
 import { ReportExportServiceKey } from 'report-export/types/report-export-service';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
-
 import { DictionaryStringTo } from '../types/common-types';
 import {
     AssessmentRequirementScanTelemetryData,
@@ -478,7 +477,7 @@ export class TelemetryDataFactory {
     }
 
     public forAutomatedTabStopsResults(
-        results: TabStopRequirementResult[],
+        results: AutomatedTabStopRequirementResult[],
     ): TabStopsAutomatedResultsTelemetryData | undefined {
         if (!results || results.length === 0) {
             return undefined;

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -7,7 +7,7 @@ import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-
 import { AllFrameRunner } from 'injected/all-frame-runner';
 import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
-import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 import { BaseStore } from '../../common/base-store';
 import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
 import { ScopingStoreData } from '../../common/types/store-data/scoping-store-data';
@@ -26,7 +26,7 @@ import { TabStopsAnalyzer } from './tab-stops-analyzer';
 export class AnalyzerProvider {
     constructor(
         private readonly tabStopsListener: AllFrameRunner<TabStopEvent>,
-        private readonly tabStopsRequirementRunner: AllFrameRunner<TabStopRequirementResult>,
+        private readonly tabStopsRequirementRunner: AllFrameRunner<AutomatedTabStopRequirementResult>,
         private readonly tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator,
         private readonly tabStopsDoneAnalyzingTracker: TabStopsDoneAnalyzingTracker,
         private readonly featureFlagStore: BaseStore<FeatureFlagStoreData>,

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -11,7 +11,7 @@ import { AllFrameRunner } from 'injected/all-frame-runner';
 import { BaseAnalyzer } from 'injected/analyzers/base-analyzer';
 import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
-import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 import { debounce, DebouncedFunc, isEqual } from 'lodash';
 import { FocusAnalyzerConfiguration, ScanBasePayload, ScanUpdatePayload } from './analyzer';
 
@@ -24,7 +24,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
     private pendingTabbedElements: TabStopEvent[] = [];
     protected config: FocusAnalyzerConfiguration;
 
-    private seenTabStopRequirementResults: TabStopRequirementResult[] = [];
+    private seenTabStopRequirementResults: AutomatedTabStopRequirementResult[] = [];
 
     constructor(
         config: FocusAnalyzerConfiguration,
@@ -33,7 +33,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
         logger: Logger,
         private readonly featureFlagStore: BaseStore<FeatureFlagStoreData>,
-        private readonly tabStopRequirementRunner: AllFrameRunner<TabStopRequirementResult>,
+        private readonly tabStopRequirementRunner: AllFrameRunner<AutomatedTabStopRequirementResult>,
         private readonly tabStopRequirementActionMessageCreator: TabStopRequirementActionMessageCreator,
         private readonly tabStopsDoneAnalyzingTracker: TabStopsDoneAnalyzingTracker,
         private readonly debounceImpl: typeof debounce = debounce,
@@ -61,7 +61,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
     };
 
     private processTabStopRequirementResults = (
-        tabStopRequirementResult: TabStopRequirementResult,
+        tabStopRequirementResult: AutomatedTabStopRequirementResult,
     ): void => {
         const duplicateResult = this.seenTabStopRequirementResults.some(r =>
             isEqual(r, tabStopRequirementResult),

--- a/src/injected/analyzers/tab-stops-orchestrator.ts
+++ b/src/injected/analyzers/tab-stops-orchestrator.ts
@@ -3,18 +3,16 @@
 
 import { WindowUtils } from 'common/window-utils';
 import { AllFrameRunnerTarget } from 'injected/all-frame-runner';
-import {
-    TabStopRequirementResult,
-    TabStopsRequirementEvaluator,
-} from 'injected/tab-stops-requirement-evaluator';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
+import { TabStopsRequirementEvaluator } from 'injected/tab-stops-requirement-evaluator';
 import { TabbableElementGetter } from 'injected/tabbable-element-getter';
 import { FocusableElement } from 'tabbable';
 
 export class TabStopRequirementOrchestrator
-    implements AllFrameRunnerTarget<TabStopRequirementResult>
+    implements AllFrameRunnerTarget<AutomatedTabStopRequirementResult>
 {
     public readonly commandSuffix: string = 'TabStopRequirementOrchestrator';
-    private reportResults: (payload: TabStopRequirementResult) => Promise<void>;
+    private reportResults: (payload: AutomatedTabStopRequirementResult) => Promise<void>;
 
     private tabbableTabStops: FocusableElement[];
     private actualTabStops: Set<HTMLElement> = new Set();
@@ -60,15 +58,15 @@ export class TabStopRequirementOrchestrator
     };
 
     public setResultCallback = (
-        reportResultCallback: (payload: TabStopRequirementResult) => Promise<void>,
+        reportResultCallback: (payload: AutomatedTabStopRequirementResult) => Promise<void>,
     ) => {
         this.reportResults = reportResultCallback;
     };
 
     public transformChildResultForParent = (
-        result: TabStopRequirementResult,
+        result: AutomatedTabStopRequirementResult,
         messageSourceFrame: HTMLIFrameElement,
-    ): TabStopRequirementResult => {
+    ): AutomatedTabStopRequirementResult => {
         const frameSelector = this.getUniqueSelector(messageSourceFrame);
         result.selector = [frameSelector, ...result.selector];
         return result;

--- a/src/injected/tab-stop-requirement-result.ts
+++ b/src/injected/tab-stop-requirement-result.ts
@@ -1,0 +1,13 @@
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
+
+export type TabStopRequirementResult = {
+    requirementId: TabStopRequirementId;
+    description: string;
+    selector?: string[];
+    html?: string;
+};
+
+export type AutomatedTabStopRequirementResult = TabStopRequirementResult & {
+    selector: string[];
+    html: string;
+};

--- a/src/injected/tab-stop-requirement-result.ts
+++ b/src/injected/tab-stop-requirement-result.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 
 export type TabStopRequirementResult = {

--- a/src/injected/tab-stops-requirement-evaluator.ts
+++ b/src/injected/tab-stops-requirement-evaluator.ts
@@ -15,7 +15,9 @@ export interface TabStopsRequirementEvaluator {
         lastTabStop: HTMLElement,
         currentTabStop: HTMLElement,
     ): AutomatedTabStopRequirementResult | null;
-    getTabbableFocusOrderResults(tabbableTabStops: FocusableElement[]): AutomatedTabStopRequirementResult[];
+    getTabbableFocusOrderResults(
+        tabbableTabStops: FocusableElement[],
+    ): AutomatedTabStopRequirementResult[];
     getKeyboardTrapResults(
         oldActiveElement: Element,
         newActiveElement: Element,
@@ -58,11 +60,7 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
     public getFocusOrderResult(
         lastTabStop: HTMLElement,
         currentTabStop: HTMLElement,
-<<<<<<< HEAD
-    ): AutomatedTabStopRequirementResult {
-=======
-    ): TabStopRequirementResult | null {
->>>>>>> eea488041ecde61d6a562c32911224fbe0e02b98
+    ): AutomatedTabStopRequirementResult | null {
         if (this.htmlElementUtils.precedesInDOM(currentTabStop, lastTabStop)) {
             const lastSelector = this.generateSelector(lastTabStop);
             const currSelector = this.generateSelector(currentTabStop);
@@ -98,11 +96,7 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
     public getKeyboardTrapResults(
         oldActiveElement: Element,
         newActiveElement: Element,
-<<<<<<< HEAD
-    ): AutomatedTabStopRequirementResult {
-=======
-    ): TabStopRequirementResult | null {
->>>>>>> eea488041ecde61d6a562c32911224fbe0e02b98
+    ): AutomatedTabStopRequirementResult | null {
         if (oldActiveElement === newActiveElement) {
             const selector = this.generateSelector(oldActiveElement as HTMLElement);
             return {

--- a/src/injected/tab-stops-requirement-evaluator.ts
+++ b/src/injected/tab-stops-requirement-evaluator.ts
@@ -4,29 +4,24 @@
 import { HTMLElementUtils } from 'common/html-element-utils';
 import { getUniqueSelector } from 'scanner/axe-utils';
 import { FocusableElement } from 'tabbable';
-import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
-
-export type TabStopRequirementResult = {
-    requirementId: TabStopRequirementId;
-    description: string;
-    selector: string[];
-    html: string;
-};
+import { AutomatedTabStopRequirementResult } from './tab-stop-requirement-result';
 
 export interface TabStopsRequirementEvaluator {
     getKeyboardNavigationResults(
         tabbableTabStops: FocusableElement[],
         actualTabStops: Set<HTMLElement>,
-    ): TabStopRequirementResult[];
+    ): AutomatedTabStopRequirementResult[];
     getFocusOrderResult(
         lastTabStop: HTMLElement,
         currentTabStop: HTMLElement,
-    ): TabStopRequirementResult;
-    getTabbableFocusOrderResults(tabbableTabStops: FocusableElement[]): TabStopRequirementResult[];
+    ): AutomatedTabStopRequirementResult;
+    getTabbableFocusOrderResults(
+        tabbableTabStops: FocusableElement[],
+    ): AutomatedTabStopRequirementResult[];
     getKeyboardTrapResults(
         oldActiveElement: Element,
         newActiveElement: Element,
-    ): TabStopRequirementResult;
+    ): AutomatedTabStopRequirementResult;
 }
 
 export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementEvaluator {
@@ -46,8 +41,8 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
     public getKeyboardNavigationResults(
         tabbableTabStops: FocusableElement[],
         actualTabStops: Set<HTMLElement>,
-    ): TabStopRequirementResult[] {
-        const requirementResults: TabStopRequirementResult[] = [];
+    ): AutomatedTabStopRequirementResult[] {
+        const requirementResults: AutomatedTabStopRequirementResult[] = [];
         (tabbableTabStops as HTMLElement[]).forEach(expectedTabStop => {
             if (!actualTabStops.has(expectedTabStop)) {
                 const selector = this.generateSelector(expectedTabStop);
@@ -65,7 +60,7 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
     public getFocusOrderResult(
         lastTabStop: HTMLElement,
         currentTabStop: HTMLElement,
-    ): TabStopRequirementResult {
+    ): AutomatedTabStopRequirementResult {
         if (this.htmlElementUtils.precedesInDOM(currentTabStop, lastTabStop)) {
             const lastSelector = this.generateSelector(lastTabStop);
             const currSelector = this.generateSelector(currentTabStop);
@@ -81,8 +76,8 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
 
     public getTabbableFocusOrderResults(
         tabbableTabStops: FocusableElement[],
-    ): TabStopRequirementResult[] {
-        const requirementResults: TabStopRequirementResult[] = [];
+    ): AutomatedTabStopRequirementResult[] {
+        const requirementResults: AutomatedTabStopRequirementResult[] = [];
         const tabStops = tabbableTabStops as HTMLElement[];
         tabStops.forEach((expectedTabStop, index) => {
             if (index > 0) {
@@ -101,7 +96,7 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
     public getKeyboardTrapResults(
         oldActiveElement: Element,
         newActiveElement: Element,
-    ): TabStopRequirementResult {
+    ): AutomatedTabStopRequirementResult {
         if (oldActiveElement === newActiveElement) {
             const selector = this.generateSelector(oldActiveElement as HTMLElement);
             return {

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -16,10 +16,8 @@ import { BrowserBackchannelWindowMessagePoster } from 'injected/frameCommunicato
 import { FrameMessenger } from 'injected/frameCommunicators/frame-messenger';
 import { RespondableCommandMessageCommunicator } from 'injected/frameCommunicators/respondable-command-message-communicator';
 import { SingleFrameTabStopListener } from 'injected/single-frame-tab-stop-listener';
-import {
-    DefaultTabStopsRequirementEvaluator,
-    TabStopRequirementResult,
-} from 'injected/tab-stops-requirement-evaluator';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
+import { DefaultTabStopsRequirementEvaluator } from 'injected/tab-stops-requirement-evaluator';
 import { TabbableElementGetter } from 'injected/tabbable-element-getter';
 import { getUniqueSelector } from 'scanner/axe-utils';
 import { tabbable } from 'tabbable';
@@ -60,7 +58,7 @@ export class WindowInitializer {
     protected drawingController: DrawingController;
     protected scrollingController: ScrollingController;
     protected manualTabStopListener: AllFrameRunner<TabStopEvent>;
-    protected tabStopRequirementRunner: AllFrameRunner<TabStopRequirementResult>;
+    protected tabStopRequirementRunner: AllFrameRunner<AutomatedTabStopRequirementResult>;
     protected frameUrlFinder: FrameUrlFinder;
     protected elementFinderByPosition: ElementFinderByPosition;
     protected elementFinderByPath: ElementFinderByPath;
@@ -151,7 +149,7 @@ export class WindowInitializer {
             tabStopRequirementEvaluator,
             getUniqueSelector,
         );
-        this.tabStopRequirementRunner = new AllFrameRunner<TabStopRequirementResult>(
+        this.tabStopRequirementRunner = new AllFrameRunner<AutomatedTabStopRequirementResult>(
             this.frameMessenger,
             htmlElementUtils,
             this.windowUtils,

--- a/src/tests/unit/tests/DetailsView/actions/tab-stop-requirement-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/tab-stop-requirement-action-message-creator.test.ts
@@ -4,13 +4,13 @@
 // Licensed under the MIT License.
 import {
     AddTabStopInstancePayload,
-    UpdateTabStopRequirementStatusPayload,
-    UpdateTabStopInstancePayload,
     RemoveTabStopInstancePayload,
     ToggleTabStopRequirementExpandPayload,
+    UpdateTabStopInstancePayload,
+    UpdateTabStopRequirementStatusPayload,
 } from 'background/actions/action-payloads';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
-import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
 import {
@@ -249,7 +249,7 @@ describe('TabStopRequirementActionMessageCreatorTest', () => {
     });
 
     test('automatedTabbingResultsCompleted', () => {
-        const tabbingResults: TabStopRequirementResult[] = [
+        const tabbingResults: AutomatedTabStopRequirementResult[] = [
             { requirementId: 'tab-order', html: null, selector: null, description: null },
             { requirementId: 'tab-order', html: null, selector: null, description: null },
         ];

--- a/src/tests/unit/tests/common/telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/common/telemetry-data-factory.test.ts
@@ -28,8 +28,7 @@ import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationType } from 'common/types/visualization-type';
-import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
-
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 import { EventStubFactory } from './../../common/event-stub-factory';
 
 describe('TelemetryDataFactoryTest', () => {
@@ -753,7 +752,7 @@ describe('TelemetryDataFactoryTest', () => {
     });
 
     test('forAutomatedTabStopsResults', () => {
-        const tabbingResults: TabStopRequirementResult[] = [
+        const tabbingResults: AutomatedTabStopRequirementResult[] = [
             { requirementId: 'tab-order', html: null, selector: null, description: null },
             { requirementId: 'tab-order', html: null, selector: null, description: null },
             { requirementId: 'keyboard-traps', html: null, selector: null, description: null },

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -7,7 +7,7 @@ import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-
 import { AllFrameRunner } from 'injected/all-frame-runner';
 import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
-import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, Mock } from 'typemoq';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
@@ -41,7 +41,7 @@ describe('AnalyzerProviderTests', () => {
     let sendConvertedResultsMock: IMock<PostResolveCallback>;
     let sendNeedsReviewResultsMock: IMock<PostResolveCallback>;
     let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
-    let tabStopRequirementRunnerMock: IMock<AllFrameRunner<TabStopRequirementResult>>;
+    let tabStopRequirementRunnerMock: IMock<AllFrameRunner<AutomatedTabStopRequirementResult>>;
     let tabStopRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
     let tabStopsDoneAnalyzingTrackerMock: IMock<TabStopsDoneAnalyzingTracker>;
     let featureFlagStoreMock: IMock<FeatureFlagStore>;
@@ -61,7 +61,8 @@ describe('AnalyzerProviderTests', () => {
         sendConvertedResultsMock = Mock.ofInstance(() => null);
         sendNeedsReviewResultsMock = Mock.ofInstance(() => null);
         scanIncompleteWarningDetectorMock = Mock.ofType<ScanIncompleteWarningDetector>();
-        tabStopRequirementRunnerMock = Mock.ofType<AllFrameRunner<TabStopRequirementResult>>();
+        tabStopRequirementRunnerMock =
+            Mock.ofType<AllFrameRunner<AutomatedTabStopRequirementResult>>();
         tabStopRequirementActionMessageCreatorMock =
             Mock.ofType<TabStopRequirementActionMessageCreator>();
         tabStopsDoneAnalyzingTrackerMock = Mock.ofType<TabStopsDoneAnalyzingTracker>();

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -12,7 +12,7 @@ import { FocusAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { TabStopsAnalyzer } from 'injected/analyzers/tab-stops-analyzer';
 import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
-import { TabStopRequirementResult } from 'injected/tab-stops-requirement-evaluator';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { DebounceFaker } from 'tests/unit/common/debounce-faker';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
@@ -24,7 +24,7 @@ describe('TabStopsAnalyzer', () => {
     let visualizationTypeStub: VisualizationType;
     let testSubject: TabStopsAnalyzer;
     let tabStopsListenerMock: IMock<AllFrameRunner<TabStopEvent>>;
-    let tabStopRequirementRunnerMock: IMock<AllFrameRunner<TabStopRequirementResult>>;
+    let tabStopRequirementRunnerMock: IMock<AllFrameRunner<AutomatedTabStopRequirementResult>>;
     let simulateTabEvent: (tabEvent: TabStopEvent) => void;
     let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
     let emptyScanCompleteMessage: Message;
@@ -32,7 +32,9 @@ describe('TabStopsAnalyzer', () => {
     let featureFlagStoreMock: IMock<FeatureFlagStore>;
     let tabStopRequirementActionMessageCreatorMock: IMock<TabStopRequirementActionMessageCreator>;
     let tabStopsDoneAnalyzingTrackerMock: IMock<TabStopsDoneAnalyzingTracker>;
-    let requirementResultRunnerCallback: (requirementResult: TabStopRequirementResult) => void;
+    let requirementResultRunnerCallback: (
+        requirementResult: AutomatedTabStopRequirementResult,
+    ) => void;
 
     const tabEventStub1: TabStopEvent = {
         target: ['selector1'],
@@ -68,7 +70,7 @@ describe('TabStopsAnalyzer', () => {
             start: () => {},
             stop: () => {},
             initialize: () => {},
-        } as AllFrameRunner<TabStopRequirementResult>);
+        } as AllFrameRunner<AutomatedTabStopRequirementResult>);
         tabStopsDoneAnalyzingTrackerMock = Mock.ofType<TabStopsDoneAnalyzingTracker>(
             null,
             MockBehavior.Strict,
@@ -120,10 +122,10 @@ describe('TabStopsAnalyzer', () => {
         });
 
         it('adds unique tab stop instances when processing tab stops requirement result', async () => {
-            const requirementResult: TabStopRequirementResult = {
+            const requirementResult: AutomatedTabStopRequirementResult = {
                 requirementId: 'keyboard-navigation',
                 description: 'some description',
-            } as TabStopRequirementResult;
+            } as AutomatedTabStopRequirementResult;
 
             setTabStopsAutomationFeatureFlag(true);
             setupTabStopsListenerForStartTabStops();

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-orchestrator.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-orchestrator.test.ts
@@ -3,10 +3,8 @@
 
 import { WindowUtils } from 'common/window-utils';
 import { TabStopRequirementOrchestrator } from 'injected/analyzers/tab-stops-orchestrator';
-import {
-    TabStopRequirementResult,
-    TabStopsRequirementEvaluator,
-} from 'injected/tab-stops-requirement-evaluator';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
+import { TabStopsRequirementEvaluator } from 'injected/tab-stops-requirement-evaluator';
 import { TabbableElementGetter } from 'injected/tabbable-element-getter';
 import { FocusableElement } from 'tabbable';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -17,12 +15,12 @@ describe('TabStopRequirementOrchestrator', () => {
     let windowUtilsMock: IMock<WindowUtils>;
     let tabStopsRequirementEvaluatorMock: IMock<TabStopsRequirementEvaluator>;
     let getUniqueSelectorMock: IMock<(e: HTMLElement) => string>;
-    let reportResultsMock: IMock<(payload: TabStopRequirementResult) => Promise<void>>;
+    let reportResultsMock: IMock<(payload: AutomatedTabStopRequirementResult) => Promise<void>>;
 
     let focusableElementsStub: FocusableElement[];
     let elementStub: HTMLElement;
     let newElementStub: HTMLElement;
-    let tabStopRequirementResultStub: TabStopRequirementResult;
+    let tabStopRequirementResultStub: AutomatedTabStopRequirementResult;
 
     let focusInCallback: (event: Event) => void;
     let keydownCallback: (event: Event) => void;
@@ -35,7 +33,8 @@ describe('TabStopRequirementOrchestrator', () => {
         windowUtilsMock = Mock.ofType<WindowUtils>();
         tabStopsRequirementEvaluatorMock = Mock.ofType<TabStopsRequirementEvaluator>();
         getUniqueSelectorMock = Mock.ofType<(e: HTMLElement) => string>();
-        reportResultsMock = Mock.ofType<(payload: TabStopRequirementResult) => Promise<void>>();
+        reportResultsMock =
+            Mock.ofType<(payload: AutomatedTabStopRequirementResult) => Promise<void>>();
 
         testSubject = new TabStopRequirementOrchestrator(
             domMock.object,
@@ -59,7 +58,7 @@ describe('TabStopRequirementOrchestrator', () => {
         } as HTMLElement;
         tabStopRequirementResultStub = {
             html: 'some html',
-        } as TabStopRequirementResult;
+        } as AutomatedTabStopRequirementResult;
     });
 
     test('transformChildResultForParent', () => {
@@ -68,7 +67,7 @@ describe('TabStopRequirementOrchestrator', () => {
         const anotherSelectorStub = 'some other selector';
         const result = {
             selector: [anotherSelectorStub],
-        } as TabStopRequirementResult;
+        } as AutomatedTabStopRequirementResult;
         const expectedResult = {
             selector: [selectorStub, anotherSelectorStub],
         };
@@ -207,7 +206,7 @@ describe('TabStopRequirementOrchestrator', () => {
     });
 
     function testOnkeydownForFocusTrapsWithResult(
-        givenTabStopRequirementResult: TabStopRequirementResult,
+        givenTabStopRequirementResult: AutomatedTabStopRequirementResult,
         givenTimes: Times,
     ) {
         const eventStub = {
@@ -295,7 +294,7 @@ describe('TabStopRequirementOrchestrator', () => {
         });
     }
 
-    function getTabStopRequirementResultStubs(): TabStopRequirementResult[] {
+    function getTabStopRequirementResultStubs(): AutomatedTabStopRequirementResult[] {
         return [
             {
                 html: 'result 1',
@@ -303,6 +302,6 @@ describe('TabStopRequirementOrchestrator', () => {
             {
                 html: 'result 2',
             },
-        ] as TabStopRequirementResult[];
+        ] as AutomatedTabStopRequirementResult[];
     }
 });

--- a/src/tests/unit/tests/injected/tab-stops-requirement-evaluator.test.ts
+++ b/src/tests/unit/tests/injected/tab-stops-requirement-evaluator.test.ts
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 import { HTMLElementUtils } from 'common/html-element-utils';
-import {
-    DefaultTabStopsRequirementEvaluator,
-    TabStopRequirementResult,
-} from 'injected/tab-stops-requirement-evaluator';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
+import { DefaultTabStopsRequirementEvaluator } from 'injected/tab-stops-requirement-evaluator';
 import { getUniqueSelector } from 'scanner/axe-utils';
 import { FocusableElement } from 'tabbable';
 import { IMock, It, Mock } from 'typemoq';
@@ -34,7 +32,7 @@ describe('TabStopsRequirementEvaluator', () => {
             tabStopElement2 as FocusableElement,
         ];
         const incorrectTabStops = new Set<HTMLElement>([tabStopElement2]);
-        const expectedResult: TabStopRequirementResult = {
+        const expectedResult: AutomatedTabStopRequirementResult = {
             description: 'Element element1 was expected, but not reached in tab order',
             selector: ['element1'],
             html: 'html1',
@@ -57,7 +55,7 @@ describe('TabStopsRequirementEvaluator', () => {
     });
 
     test('addFocusOrderResults returns violations', () => {
-        const expectedResult: TabStopRequirementResult = {
+        const expectedResult: AutomatedTabStopRequirementResult = {
             description:
                 'Element element1 precedes element2 but element2 was visited first in tab order',
             selector: ['element1'],
@@ -86,7 +84,7 @@ describe('TabStopsRequirementEvaluator', () => {
     });
 
     test('addTabbableFocusOrderResults returns violations', () => {
-        const expectedResult: TabStopRequirementResult = {
+        const expectedResult: AutomatedTabStopRequirementResult = {
             description:
                 'Element element1 precedes element2 but element2 was visited first in tab order',
             selector: ['element1'],
@@ -117,7 +115,7 @@ describe('TabStopsRequirementEvaluator', () => {
     });
 
     test('onKeydownForFocusTraps returns violations', () => {
-        const expectedResult: TabStopRequirementResult = {
+        const expectedResult: AutomatedTabStopRequirementResult = {
             description: 'Focus is still on element element1 500ms after pressing tab',
             selector: ['element1'],
             html: 'html1',


### PR DESCRIPTION
#### Details

Just a rename PR so future PRs are easier to review.

##### Motivation

feature work.

##### Context

Will be differentiating instances where we are given an aligning element's information and where we are not (i.e. automated vs manual instances). 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
