### PR TITLE
feat(tabstops-auto-target-page-vis): Add tab stops auto detected failures pop up dialog

### DIFF
--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -16,6 +16,7 @@ import { VisualizationStoreData } from 'common/types/store-data/visualization-st
 import { VisualizationType } from 'common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import * as styles from 'DetailsView/components/adhoc-tab-stops-test-view.scss';
+import { AutoDetectedFailuresDialog } from 'DetailsView/components/auto-detected-failures-dialog';
 import * as requirementInstructionStyles from 'DetailsView/components/requirement-instructions.scss';
 import {
     TabStopsFailedInstanceSection,
@@ -192,6 +193,15 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                     featureFlagStoreData={props.featureFlagStoreData}
                     enableJSXElement={
                         <FocusComponent deps={props.deps} tabbingEnabled={scanData.enabled} />
+                    }
+                />
+                <FlaggedComponent
+                    featureFlag={FeatureFlags.tabStopsAutomation}
+                    featureFlagStoreData={props.featureFlagStoreData}
+                    enableJSXElement={
+                        <AutoDetectedFailuresDialog
+                            visualizationScanResultData={props.visualizationScanResultData}
+                        />
                     }
                 />
             </>

--- a/src/DetailsView/components/auto-detected-failures-dialog.tsx
+++ b/src/DetailsView/components/auto-detected-failures-dialog.tsx
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BlockingDialog } from 'common/components/blocking-dialog';
+import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
+import * as styles from 'DetailsView/components/common-dialog-styles.scss';
+import { DialogFooter, DialogType, PrimaryButton } from 'office-ui-fabric-react';
+import * as React from 'react';
+
+export type AutoDetectedFailuresDialogState = {
+    dialogEnabled: boolean;
+};
+
+export interface AutoDetectedFailuresDialogProps {
+    visualizationScanResultData: VisualizationScanResultData;
+}
+
+export class AutoDetectedFailuresDialog extends React.Component<
+    AutoDetectedFailuresDialogProps,
+    AutoDetectedFailuresDialogState
+> {
+    public constructor(props) {
+        super(props);
+        this.state = {
+            dialogEnabled: false,
+        };
+    }
+
+    private showAutoDetectedFailuresDialog = () => this.setState({ dialogEnabled: true });
+
+    private dismissAutoDetectedFailuresDialog = () => this.setState({ dialogEnabled: false });
+
+    public componentDidUpdate(prevProps, prevState): void {
+        const tabbingJustFinished =
+            this.props.visualizationScanResultData.tabStops.tabbingCompleted &&
+            !prevProps.visualizationScanResultData.tabStops.tabbingCompleted;
+        const autoDetectedFailuresExist =
+            this.props.visualizationScanResultData.tabStops.requirements &&
+            Object.entries(this.props.visualizationScanResultData.tabStops.requirements).some(
+                ([_, data]) => data.instances.length > 0 && data.status === 'fail',
+            );
+        if (tabbingJustFinished && autoDetectedFailuresExist && !prevState.dialogEnabled) {
+            this.showAutoDetectedFailuresDialog();
+        }
+    }
+
+    public render(): JSX.Element {
+        if (!this.state.dialogEnabled) {
+            return null;
+        }
+
+        return (
+            <BlockingDialog
+                hidden={false}
+                dialogContentProps={{
+                    type: DialogType.normal,
+                    title: 'Possible failures auto-detected',
+                }}
+                modalProps={{
+                    containerClassName: styles.insightsDialogMainOverride,
+                }}
+            >
+                <div className={styles.dialogBody}>
+                    <ul>
+                        <li>Review each finding to be sure it's valid</li>
+                        <li>Add any more failures you discovered manually</li>
+                    </ul>
+                </div>
+                <DialogFooter>
+                    <PrimaryButton
+                        onClick={this.dismissAutoDetectedFailuresDialog}
+                        text={'Got it'}
+                    />
+                </DialogFooter>
+            </BlockingDialog>
+        );
+    }
+}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -109,6 +109,19 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
           featureFlag="tabStopsAutomation"
           featureFlagStoreData={Object {}}
         />
+        <FlaggedComponent
+          enableJSXElement={
+            <AutoDetectedFailuresDialog
+              visualizationScanResultData={
+                Object {
+                  "tabStops": Object {},
+                }
+              }
+            />
+          }
+          featureFlag="tabStopsAutomation"
+          featureFlagStoreData={Object {}}
+        />
       </React.Fragment>
     </ThemeCustomizer>
   </div>
@@ -218,6 +231,19 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
             <FocusComponent
               deps="stub-deps"
               tabbingEnabled={true}
+            />
+          }
+          featureFlag="tabStopsAutomation"
+          featureFlagStoreData={Object {}}
+        />
+        <FlaggedComponent
+          enableJSXElement={
+            <AutoDetectedFailuresDialog
+              visualizationScanResultData={
+                Object {
+                  "tabStops": Object {},
+                }
+              }
             />
           }
           featureFlag="tabStopsAutomation"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/auto-detected-failures-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/auto-detected-failures-dialog.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AutoDetectedFailuresDialog on dialog enabled is dismissed when "got it" button is clicked 1`] = `null`;
+
+exports[`AutoDetectedFailuresDialog on dialog enabled renders when dialog is enabled 1`] = `
+<BlockingDialog
+  dialogContentProps={
+    Object {
+      "title": "Possible failures auto-detected",
+      "type": 0,
+    }
+  }
+  hidden={false}
+  modalProps={
+    Object {
+      "containerClassName": "insightsDialogMainOverride",
+    }
+  }
+>
+  <div
+    className="dialogBody"
+  >
+    <ul>
+      <li>
+        Review each finding to be sure it's valid
+      </li>
+      <li>
+        Add any more failures you discovered manually
+      </li>
+    </ul>
+  </div>
+  <StyledDialogFooterBase>
+    <CustomizedPrimaryButton
+      onClick={[Function]}
+      text="Got it"
+    />
+  </StyledDialogFooterBase>
+</BlockingDialog>
+`;
+
+exports[`AutoDetectedFailuresDialog renders when dialog is not enabled 1`] = `null`;

--- a/src/tests/unit/tests/DetailsView/components/auto-detected-failures-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/auto-detected-failures-dialog.test.tsx
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    TabStopRequirementState,
+    VisualizationScanResultData,
+} from 'common/types/store-data/visualization-scan-result-data';
+import {
+    AutoDetectedFailuresDialog,
+    AutoDetectedFailuresDialogProps,
+} from 'DetailsView/components/auto-detected-failures-dialog';
+import { shallow } from 'enzyme';
+import { PrimaryButton } from 'office-ui-fabric-react';
+import * as React from 'react';
+
+describe('AutoDetectedFailuresDialog', () => {
+    let props: AutoDetectedFailuresDialogProps;
+    let visualizationScanResultData: VisualizationScanResultData;
+    const prevState = { autoDetectedFailuresDialogEnabled: false };
+    const prevProps = {
+        visualizationScanResultData: { tabStops: { tabbingCompleted: false } },
+    };
+
+    beforeEach(() => {
+        const requirements: TabStopRequirementState = {
+            'input-focus': {
+                instances: [
+                    { id: 'test-id-1', description: 'test desc 1' },
+                    { id: 'test-id-2', description: 'test desc 2' },
+                ],
+                status: 'fail',
+                isExpanded: false,
+            },
+        };
+        visualizationScanResultData = {
+            tabStops: { tabbingCompleted: true, requirements },
+        } as VisualizationScanResultData;
+        props = {
+            visualizationScanResultData,
+        } as AutoDetectedFailuresDialogProps;
+    });
+
+    it('renders when dialog is not enabled', () => {
+        const wrapper = shallow(<AutoDetectedFailuresDialog {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    describe('on dialog enabled', () => {
+        let wrapper;
+        beforeEach(() => {
+            wrapper = shallow(<AutoDetectedFailuresDialog {...props} />);
+            wrapper.instance().componentDidUpdate(prevProps, prevState);
+        });
+
+        it('renders when dialog is enabled', () => {
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
+
+        it('is dismissed when "got it" button is clicked', () => {
+            wrapper.find(PrimaryButton).simulate('click');
+
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
+    });
+
+    describe('on componentDidUpdate', () => {
+        it('displays dialog on tabbing completed', () => {
+            const wrapper = shallow(<AutoDetectedFailuresDialog {...props} />);
+            expect(wrapper.state('dialogEnabled')).toBe(false);
+            wrapper.instance().componentDidUpdate(prevProps, prevState);
+            expect(wrapper.state('dialogEnabled')).toBe(true);
+        });
+
+        it('does not display dialog with no results', () => {
+            visualizationScanResultData.tabStops.requirements = null;
+
+            const wrapper = shallow(<AutoDetectedFailuresDialog {...props} />);
+            expect(wrapper.state('dialogEnabled')).toBe(false);
+            wrapper.instance().componentDidUpdate(prevProps, prevState);
+            expect(wrapper.state('dialogEnabled')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
#### Details

Add pop up to tab stops page when automatic failures are detected.

![AutoDetectedPopUpTabStops](https://user-images.githubusercontent.com/16010855/153076302-40ea37d6-2cc4-409d-a173-9cf5962532ea.png)
(screenshot of tab stops details view page with popup in front. Popup text is: 'Possible failures auto-detected. Review each finding to be sure it's valid. Add any more failures you discovered manually')

##### Motivation

Feature work.

##### Context

Pop up is behind `tabStopsAutomation` feature flag and only displays when failures have been auto detected. Ideally we will add a `Don't show again` checkbox later in this feature, but this is a stretch goal.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
