### PR TITLE
feat(tabstops-auto-target-page-vis): process both tabbed elements and requirement instances before data is visualized.

### DIFF
--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -186,11 +186,13 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
     };
 
     private onAddTabStopInstance = (payload: AddTabStopInstancePayload): void => {
-        const { requirementId, description } = payload;
+        const { requirementId, description, selector, html } = payload;
         this.state.tabStops.requirements[requirementId].status = 'fail';
         this.state.tabStops.requirements[requirementId].instances.push({
             description,
             id: this.generateUID(),
+            selector,
+            html,
         });
         this.emitChanged();
     };

--- a/src/common/types/store-data/visualization-scan-result-data.ts
+++ b/src/common/types/store-data/visualization-scan-result-data.ts
@@ -33,12 +33,14 @@ export type TabStopRequirementInstance = {
     html?: string;
 };
 
+export type SingleTabStopRequirementState = {
+    status: TabStopRequirementStatus;
+    instances: TabStopRequirementInstance[];
+    isExpanded: boolean;
+};
+
 export type TabStopRequirementState = {
-    [requirementId: string]: {
-        status: TabStopRequirementStatus;
-        instances: TabStopRequirementInstance[];
-        isExpanded: boolean;
-    };
+    [requirementId: string]: SingleTabStopRequirementState;
 };
 
 export interface TabStopsScanResultData {

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -29,6 +29,7 @@ import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-
 import { TargetPageVisualizationUpdater } from 'injected/target-page-visualization-updater';
 import { visualizationNeedsUpdate } from 'injected/visualization-needs-update';
 import { VisualizationStateChangeHandler } from 'injected/visualization-state-change-handler';
+import { GetVisualizationInstancesForTabStops } from 'injected/visualization/get-visualization-instances-for-tab-stops';
 import { AxeInfo } from '../common/axe-info';
 import { InspectConfigurationFactory } from '../common/configs/inspect-configuration-factory';
 import { DateProvider } from '../common/date-provider';
@@ -246,6 +247,7 @@ export class MainWindowInitializer extends WindowInitializer {
         const selectorMapHelper = new SelectorMapHelper(
             Assessments,
             elementBasedViewModelCreator.getElementBasedViewModel,
+            GetVisualizationInstancesForTabStops,
         );
 
         const storeHub = new BaseClientStoresHub<TargetPageStoreData>([

--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
 import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { TargetPageStoreData } from 'injected/client-store-listener';
 import { GetElementBasedViewModelCallback } from 'injected/element-based-view-model-creator';
 import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
+import { GetVisualizationInstancesForTabStops } from 'injected/visualization/get-visualization-instances-for-tab-stops';
 import { includes } from 'lodash';
-
 import { ManualTestStatus } from '../common/types/manual-test-status';
 import { GeneratedAssessmentInstance } from '../common/types/store-data/assessment-result-data';
 import { VisualizationScanResultData } from '../common/types/store-data/visualization-scan-result-data';
@@ -24,12 +25,14 @@ export type VisualizationRelatedStoreData = Pick<
     | 'cardSelectionStoreData'
     | 'needsReviewCardSelectionStoreData'
     | 'needsReviewScanResultStoreData'
+    | 'featureFlagStoreData'
 >;
 
 export class SelectorMapHelper {
     constructor(
         private assessmentsProvider: AssessmentsProvider,
         private getElementBasedViewModel: GetElementBasedViewModelCallback,
+        private getVisualizationInstancesForTabStops: typeof GetVisualizationInstancesForTabStops,
     ) {}
 
     public getSelectorMap(
@@ -45,6 +48,7 @@ export class SelectorMapHelper {
             cardSelectionStoreData,
             needsReviewScanResultStoreData,
             needsReviewCardSelectionStoreData,
+            featureFlagStoreData,
         } = visualizationRelatedStoreData;
 
         if (this.isAdHocVisualization(visualizationType)) {
@@ -55,6 +59,7 @@ export class SelectorMapHelper {
                 cardSelectionStoreData,
                 needsReviewScanResultStoreData,
                 needsReviewCardSelectionStoreData,
+                featureFlagStoreData,
             );
         }
 
@@ -90,6 +95,7 @@ export class SelectorMapHelper {
         cardSelectionStoreData: CardSelectionStoreData,
         needsReviewScanData: NeedsReviewScanResultStoreData,
         needsReviewCardSelectionStoreData: NeedsReviewCardSelectionStoreData,
+        featureFlagStoreData: FeatureFlagStoreData,
     ): SelectorToVisualizationMap {
         let selectorMap = {};
         switch (visualizationType) {
@@ -112,7 +118,10 @@ export class SelectorMapHelper {
                 selectorMap = visualizationScanResultData.landmarks.fullAxeResultsMap;
                 break;
             case VisualizationType.TabStops:
-                selectorMap = visualizationScanResultData.tabStops.tabbedElements;
+                selectorMap = this.getVisualizationInstancesForTabStops(
+                    visualizationScanResultData.tabStops,
+                    featureFlagStoreData,
+                );
                 break;
             default:
                 selectorMap = visualizationScanResultData.color.fullAxeResultsMap;

--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { FeatureFlags } from 'common/feature-flags';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
@@ -118,10 +119,12 @@ export class SelectorMapHelper {
                 selectorMap = visualizationScanResultData.landmarks.fullAxeResultsMap;
                 break;
             case VisualizationType.TabStops:
-                selectorMap = this.getVisualizationInstancesForTabStops(
-                    visualizationScanResultData.tabStops,
-                    featureFlagStoreData,
-                );
+                selectorMap = visualizationScanResultData.tabStops.tabbedElements;
+                if (featureFlagStoreData[FeatureFlags.tabStopsAutomation] === true) {
+                    selectorMap = this.getVisualizationInstancesForTabStops(
+                        visualizationScanResultData.tabStops,
+                    );
+                }
                 break;
             default:
                 selectorMap = visualizationScanResultData.color.fullAxeResultsMap;

--- a/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
+++ b/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FeatureFlags } from 'common/feature-flags';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { TabStopsScanResultData } from 'common/types/store-data/visualization-scan-result-data';
+import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
+import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
+import { forOwn } from 'lodash';
+
+export const GetVisualizationInstancesForTabStops = (
+    tabStopScanResultData: TabStopsScanResultData,
+    featureFlagData: FeatureFlagStoreData,
+): SelectorToVisualizationMap => {
+    const ret = {};
+
+    tabStopScanResultData.tabbedElements.forEach(element => {
+        const instance = {
+            isFailure: false,
+            isVisualizationEnabled: true,
+            ruleResults: null,
+            target: element.target,
+            propertyBag: {
+                tabOrder: element.tabOrder,
+                timestamp: element.timestamp,
+            },
+        } as AssessmentVisualizationInstance;
+
+        ret[element.target.join(';')] = instance;
+    });
+
+    if (featureFlagData[FeatureFlags.tabStopsAutomation] === true) {
+        forOwn(tabStopScanResultData.requirements, obj => {
+            obj.instances.forEach(instance => {
+                const newInstance = {
+                    isFailure: true,
+                    isVisualizationEnabled: true,
+                    ruleResults: null,
+                    target: instance.selector,
+                    propertyBag: {},
+                };
+                ret[newInstance.target.join(';')] = newInstance;
+            });
+        });
+    }
+
+    return ret;
+};

--- a/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
+++ b/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { FeatureFlags } from 'common/feature-flags';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStopsScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
 import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
@@ -10,9 +8,8 @@ import { forOwn } from 'lodash';
 
 export const GetVisualizationInstancesForTabStops = (
     tabStopScanResultData: TabStopsScanResultData,
-    featureFlagData: FeatureFlagStoreData,
 ): SelectorToVisualizationMap => {
-    const ret = {};
+    const selectorToVisualizationInstanceMap: SelectorToVisualizationMap = {};
 
     tabStopScanResultData.tabbedElements.forEach(element => {
         const instance = {
@@ -26,23 +23,26 @@ export const GetVisualizationInstancesForTabStops = (
             },
         } as AssessmentVisualizationInstance;
 
-        ret[element.target.join(';')] = instance;
+        selectorToVisualizationInstanceMap[element.target.join(';')] = instance;
     });
 
-    if (featureFlagData[FeatureFlags.tabStopsAutomation] === true) {
-        forOwn(tabStopScanResultData.requirements, obj => {
-            obj.instances.forEach(instance => {
-                const newInstance = {
-                    isFailure: true,
-                    isVisualizationEnabled: true,
-                    ruleResults: null,
-                    target: instance.selector,
-                    propertyBag: {},
-                };
-                ret[newInstance.target.join(';')] = newInstance;
-            });
-        });
-    }
+    forOwn(tabStopScanResultData.requirements, obj => {
+        obj.instances.forEach(instance => {
+            if (instance.selector == null) {
+                return;
+            }
 
-    return ret;
+            const newInstance = {
+                isFailure: true,
+                isVisualizationEnabled: true,
+                ruleResults: null,
+                target: instance.selector,
+                propertyBag: {},
+            };
+
+            selectorToVisualizationInstanceMap[newInstance.target.join(';')] = newInstance;
+        });
+    });
+
+    return selectorToVisualizationInstanceMap;
 };

--- a/src/injected/visualization/svg-shape-factory.ts
+++ b/src/injected/visualization/svg-shape-factory.ts
@@ -95,7 +95,9 @@ export class SVGShapeFactory {
         text.setAttributeNS(null, 'fill', textConfig.fontColor);
         text.setAttributeNS(null, 'text-anchor', textConfig.textAnchor);
 
-        text.innerHTML = tabOrder.toString();
+        if (tabOrder != null) {
+            text.innerHTML = tabOrder.toString();
+        }
 
         return text;
     }

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -429,12 +429,21 @@ describe('VisualizationScanResultStoreTest', () => {
         const payload: AddTabStopInstancePayload = {
             requirementId: 'keyboard-navigation',
             description: 'test1',
+            selector: ['some-selector'],
+            html: 'some html',
         };
 
         const requirement: TabStopRequirementState = {
             'keyboard-navigation': {
                 status: 'unknown',
-                instances: [{ description: 'test1', id: 'abc' }],
+                instances: [
+                    {
+                        description: 'test1',
+                        id: 'abc',
+                        selector: ['some-selector'],
+                        html: 'some html',
+                    },
+                ],
                 isExpanded: false,
             },
         };

--- a/src/tests/unit/tests/injected/selector-map-helper.test.ts
+++ b/src/tests/unit/tests/injected/selector-map-helper.test.ts
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { FeatureFlags } from 'common/feature-flags';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
 import { GetElementBasedViewModelCallback } from 'injected/element-based-view-model-creator';
 import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
+import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
 import { GetVisualizationInstancesForTabStops } from 'injected/visualization/get-visualization-instances-for-tab-stops';
 import { exampleUnifiedResult } from 'tests/unit/tests/common/components/cards/sample-view-model-data';
 import { IMock, Mock } from 'typemoq';
@@ -21,9 +24,6 @@ import {
 } from '../../../../injected/selector-map-helper';
 import { CreateTestAssessmentProvider } from '../../common/test-assessment-provider';
 import { VisualizationScanResultStoreDataBuilder } from '../../common/visualization-scan-result-store-data-builder';
-import { FeatureFlags } from 'common/feature-flags';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
 
 describe('SelectorMapHelperTest', () => {
     let assessmentsProvider: AssessmentsProvider;

--- a/src/tests/unit/tests/injected/selector-map-helper.test.ts
+++ b/src/tests/unit/tests/injected/selector-map-helper.test.ts
@@ -4,9 +4,9 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
 import { GetElementBasedViewModelCallback } from 'injected/element-based-view-model-creator';
 import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
+import { GetVisualizationInstancesForTabStops } from 'injected/visualization/get-visualization-instances-for-tab-stops';
 import { exampleUnifiedResult } from 'tests/unit/tests/common/components/cards/sample-view-model-data';
 import { IMock, Mock } from 'typemoq';
-
 import { ManualTestStatus } from '../../../../common/types/manual-test-status';
 import {
     AssessmentStoreData,
@@ -21,11 +21,16 @@ import {
 } from '../../../../injected/selector-map-helper';
 import { CreateTestAssessmentProvider } from '../../common/test-assessment-provider';
 import { VisualizationScanResultStoreDataBuilder } from '../../common/visualization-scan-result-store-data-builder';
+import { FeatureFlags } from 'common/feature-flags';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 
 describe('SelectorMapHelperTest', () => {
     let assessmentsProvider: AssessmentsProvider;
     let testSubject: SelectorMapHelper;
     let getElementBasedViewModelMock: IMock<GetElementBasedViewModelCallback>;
+    let getVisualizationInstancesForTabStopsMock: IMock<
+        typeof GetVisualizationInstancesForTabStops
+    >;
 
     const adHocVisualizationTypes = [
         VisualizationType.Headings,
@@ -40,14 +45,17 @@ describe('SelectorMapHelperTest', () => {
     beforeEach(() => {
         assessmentsProvider = CreateTestAssessmentProvider();
         getElementBasedViewModelMock = Mock.ofType<GetElementBasedViewModelCallback>();
+        getVisualizationInstancesForTabStopsMock =
+            Mock.ofType<typeof GetVisualizationInstancesForTabStops>();
         testSubject = new SelectorMapHelper(
             assessmentsProvider,
             getElementBasedViewModelMock.object,
+            getVisualizationInstancesForTabStopsMock.object,
         );
     });
 
     test('constructor', () => {
-        expect(new SelectorMapHelper(null, null)).toBeDefined();
+        expect(new SelectorMapHelper(null, null, null)).toBeDefined();
     });
 
     adHocVisualizationTypes.forEach(visualizationType => {
@@ -102,12 +110,27 @@ describe('SelectorMapHelperTest', () => {
     test('getState: tabStops', () => {
         const visualizationType = VisualizationType.TabStops;
         const state = new VisualizationScanResultStoreDataBuilder().build();
-
         state.tabStops.tabbedElements = [];
+        const expectedInstances = [
+            {
+                target: ['some', 'target'],
+            },
+        ] as AssessmentVisualizationInstance[];
+        const featureFlagStoreData = {
+            ['some-feature-flag']: true,
+        } as FeatureFlagStoreData;
         const storeData: VisualizationRelatedStoreData = {
             visualizationScanResultStoreData: state,
+            featureFlagStoreData: featureFlagStoreData,
         } as VisualizationRelatedStoreData;
-        expect(testSubject.getSelectorMap(visualizationType, null, storeData)).toEqual([]);
+
+        getVisualizationInstancesForTabStopsMock
+            .setup(m => m(state.tabStops, featureFlagStoreData))
+            .returns(() => expectedInstances);
+
+        expect(testSubject.getSelectorMap(visualizationType, null, storeData)).toEqual(
+            expectedInstances,
+        );
     });
 
     test('getState for assessment, selector map is not null', () => {

--- a/src/tests/unit/tests/injected/visualization/get-visualization-for-tab-stops.test.ts
+++ b/src/tests/unit/tests/injected/visualization/get-visualization-for-tab-stops.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FeatureFlags } from 'common/feature-flags';
+import {
+    SingleTabStopRequirementState,
+    TabbedElementData,
+    TabStopRequirementInstance,
+    TabStopRequirementState,
+    TabStopsScanResultData,
+} from 'common/types/store-data/visualization-scan-result-data';
+import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
+import { GetVisualizationInstancesForTabStops } from 'injected/visualization/get-visualization-instances-for-tab-stops';
+
+describe('GetVisualizationInstancesForTabStops', () => {
+    let tabbedElements: TabbedElementData[];
+    let expectedResults: SelectorToVisualizationMap;
+
+    beforeEach(() => {
+        tabbedElements = [
+            {
+                target: ['some', 'target'],
+                tabOrder: 1,
+                timestamp: 123,
+            },
+            {
+                target: ['another', 'target'],
+                tabOrder: 2,
+                timestamp: 124,
+            },
+        ] as TabbedElementData[];
+        expectedResults = {
+            'some;target': buildVisualizationInstance(tabbedElements[0].target, false, {
+                tabOrder: tabbedElements[0].tabOrder,
+                timestamp: tabbedElements[0].timestamp,
+            }),
+            'another;target': buildVisualizationInstance(tabbedElements[1].target, false, {
+                tabOrder: tabbedElements[1].tabOrder,
+                timestamp: tabbedElements[1].timestamp,
+            }),
+        } as SelectorToVisualizationMap;
+    });
+
+    test('GetVisualizationInstancesForTabStops: without requirement instances with feature flag off', () => {
+        const tabStopScanResultData: TabStopsScanResultData = {
+            tabbedElements: tabbedElements,
+        } as TabStopsScanResultData;
+
+        expect(GetVisualizationInstancesForTabStops(tabStopScanResultData, {})).toEqual(
+            expectedResults,
+        );
+    });
+
+    test('GetVisualizationInstancesForTabStops: with requirement instances with feature flag on', () => {
+        const firstRequirementResults = [
+            {
+                selector: ['some', 'requirement result selector'],
+            },
+        ] as TabStopRequirementInstance[];
+
+        const secondRequirementResults = [
+            {
+                selector: ['another', 'requirement result selector'],
+            },
+        ] as TabStopRequirementInstance[];
+
+        const tabStopRequirementState = {
+            'some-requirement': {
+                instances: firstRequirementResults,
+            } as SingleTabStopRequirementState,
+            'another-requirement': {
+                instances: secondRequirementResults,
+            } as SingleTabStopRequirementState,
+        } as TabStopRequirementState;
+
+        const tabStopScanResultData: TabStopsScanResultData = {
+            tabbedElements: tabbedElements,
+            requirements: tabStopRequirementState,
+        } as TabStopsScanResultData;
+
+        expectedResults['some;requirement result selector'] = buildVisualizationInstance(
+            firstRequirementResults[0].selector,
+            true,
+            {},
+        );
+
+        expectedResults['another;requirement result selector'] = buildVisualizationInstance(
+            secondRequirementResults[0].selector,
+            true,
+            {},
+        );
+
+        expect(
+            GetVisualizationInstancesForTabStops(tabStopScanResultData, {
+                [FeatureFlags.tabStopsAutomation]: true,
+            }),
+        ).toEqual(expectedResults);
+    });
+
+    function buildVisualizationInstance(
+        target: string[],
+        isFailure: boolean,
+        propertyBag: { tabOrder?: number; timestamp?: number },
+    ) {
+        return {
+            isFailure,
+            isVisualizationEnabled: true,
+            target,
+            ruleResults: null,
+            propertyBag,
+        };
+    }
+});

--- a/src/tests/unit/tests/injected/visualization/get-visualization-instances-for-tab-stops.test.ts
+++ b/src/tests/unit/tests/injected/visualization/get-visualization-instances-for-tab-stops.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { FeatureFlags } from 'common/feature-flags';
 import {
     SingleTabStopRequirementState,
     TabbedElementData,
@@ -41,20 +40,13 @@ describe('GetVisualizationInstancesForTabStops', () => {
         } as SelectorToVisualizationMap;
     });
 
-    test('GetVisualizationInstancesForTabStops: without requirement instances with feature flag off', () => {
-        const tabStopScanResultData: TabStopsScanResultData = {
-            tabbedElements: tabbedElements,
-        } as TabStopsScanResultData;
-
-        expect(GetVisualizationInstancesForTabStops(tabStopScanResultData, {})).toEqual(
-            expectedResults,
-        );
-    });
-
-    test('GetVisualizationInstancesForTabStops: with requirement instances with feature flag on', () => {
+    test('GetVisualizationInstancesForTabStops', () => {
         const firstRequirementResults = [
             {
                 selector: ['some', 'requirement result selector'],
+            },
+            {
+                description: 'instance without a selector',
             },
         ] as TabStopRequirementInstance[];
 
@@ -90,11 +82,9 @@ describe('GetVisualizationInstancesForTabStops', () => {
             {},
         );
 
-        expect(
-            GetVisualizationInstancesForTabStops(tabStopScanResultData, {
-                [FeatureFlags.tabStopsAutomation]: true,
-            }),
-        ).toEqual(expectedResults);
+        expect(GetVisualizationInstancesForTabStops(tabStopScanResultData)).toEqual(
+            expectedResults,
+        );
     });
 
     function buildVisualizationInstance(

--- a/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
@@ -365,14 +365,33 @@ describe('SVGShapeFactory', () => {
             x: 100,
             y: 100,
         };
+        const tabOrder = 10;
 
         const textConfig: TextConfiguration = {
             textAnchor: 'textAnchor',
             fontColor: 'fontColor',
         };
 
-        const label = testObject.createTabIndexLabel(center, textConfig, 10);
-        verifyTabIndexLabelParams(label, textConfig, center, 10);
+        const label = testObject.createTabIndexLabel(center, textConfig, tabOrder);
+        verifyTabIndexLabelParams(label, textConfig, center, tabOrder);
+        expect(label.innerHTML).toEqual(tabOrder.toString());
+    });
+
+    test('create label with null tab order', () => {
+        const center: Point = {
+            x: 100,
+            y: 100,
+        };
+        const tabOrder = null;
+
+        const textConfig: TextConfiguration = {
+            textAnchor: 'textAnchor',
+            fontColor: 'fontColor',
+        };
+
+        const label = testObject.createTabIndexLabel(center, textConfig, tabOrder);
+        verifyTabIndexLabelParams(label, textConfig, center, tabOrder);
+        expect(label.innerHTML).toEqual('');
     });
 
     function verifyTabIndexLabelParams(
@@ -387,7 +406,6 @@ describe('SVGShapeFactory', () => {
         expect(label.getAttributeNS(null, 'y')).toEqual((center.y + 5).toString());
         expect(label.getAttributeNS(null, 'fill')).toEqual(configuration.fontColor);
         expect(label.getAttributeNS(null, 'text-anchor')).toEqual(configuration.textAnchor);
-        expect(label.innerHTML).toEqual(tabOrder.toString());
     }
 
     function verifyCircleParams(


### PR DESCRIPTION
#### Details

The data from the store needs to be normalized to minimize changes to the drawer layer. This PR does that.

##### Motivation

Feature work.

##### Context

Problems not solved in this PR:
- What about automated instances that share selectors? We don't have a way to represent that information currently.
- We need to include information about type of failure in these instances to visualize them differently.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
