### PR TITLE
feat(tabstops-auto-target-page-vis): Fix FocusTrackingAnalyzer bug

### DIFF
--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -46,8 +46,7 @@ export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     adhocToolsPanelDisplayOrder: 5,
     analyzerProgressMessageType: Messages.Visualizations.TabStops.TabbedElementAdded,
     analyzerTerminatedMessageType: Messages.Visualizations.TabStops.TerminateScan,
-    getAnalyzer: provider =>
-        provider.createFocusTrackingAnalyzer(tabStopVisualizationConfiguration),
+    getAnalyzer: provider => provider.createTabStopsAnalyzer(tabStopVisualizationConfiguration),
     getIdentifier: () => tabStopsTestKey,
     visualizationInstanceProcessor: () => VisualizationInstanceProcessor.nullProcessor,
     getDrawer: provider => provider.createSVGDrawer(),

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -117,6 +117,20 @@ export class AnalyzerProvider {
             this.scanIncompleteWarningDetector,
             this.logger,
             this.featureFlagStore,
+            null,
+            this.tabStopRequirementActionMessageCreator,
+            this.tabStopsDoneAnalyzingTracker,
+        );
+    }
+
+    public createTabStopsAnalyzer(config: FocusAnalyzerConfiguration): Analyzer {
+        return new TabStopsAnalyzer(
+            config,
+            this.tabStopsListener,
+            this.sendMessageDelegate,
+            this.scanIncompleteWarningDetector,
+            this.logger,
+            this.featureFlagStore,
             this.tabStopsRequirementRunner,
             this.tabStopRequirementActionMessageCreator,
             this.tabStopsDoneAnalyzingTracker,

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -50,7 +50,10 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         };
         this.tabStopListenerRunner.start();
 
-        if (this.featureFlagStore.getState()[FeatureFlags.tabStopsAutomation] === true) {
+        if (
+            this.tabStopRequirementRunner &&
+            this.featureFlagStore.getState()[FeatureFlags.tabStopsAutomation] === true
+        ) {
             this.seenTabStopRequirementResults = [];
             this.tabStopsDoneAnalyzingTracker.reset();
             this.tabStopRequirementRunner.topWindowCallback = this.processTabStopRequirementResults;
@@ -103,7 +106,9 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
     public teardown(): void {
         this.debouncedProcessTabEvents?.cancel();
         this.tabStopListenerRunner.stop();
-        this.tabStopRequirementRunner.stop();
+        if (this.tabStopRequirementRunner) {
+            this.tabStopRequirementRunner.stop();
+        }
         this.tabStopRequirementActionMessageCreator.automatedTabbingResultsCompleted(
             this.seenTabStopRequirementResults,
         );

--- a/src/injected/tab-stops-requirement-evaluator.ts
+++ b/src/injected/tab-stops-requirement-evaluator.ts
@@ -44,7 +44,7 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
         actualTabStops: Set<HTMLElement>,
     ): AutomatedTabStopRequirementResult[] {
         const requirementResults: AutomatedTabStopRequirementResult[] = [];
-        (tabbableTabStops as HTMLElement[]).forEach(expectedTabStop => {
+        ((tabbableTabStops as HTMLElement[]) ?? []).forEach(expectedTabStop => {
             if (!actualTabStops.has(expectedTabStop)) {
                 const selector = this.generateSelector(expectedTabStop);
                 requirementResults.push({

--- a/src/injected/tab-stops-requirement-evaluator.ts
+++ b/src/injected/tab-stops-requirement-evaluator.ts
@@ -43,8 +43,12 @@ export class DefaultTabStopsRequirementEvaluator implements TabStopsRequirementE
         tabbableTabStops: FocusableElement[],
         actualTabStops: Set<HTMLElement>,
     ): AutomatedTabStopRequirementResult[] {
+        if (!tabbableTabStops) {
+            return [];
+        }
+
         const requirementResults: AutomatedTabStopRequirementResult[] = [];
-        ((tabbableTabStops as HTMLElement[]) ?? []).forEach(expectedTabStop => {
+        (tabbableTabStops as HTMLElement[]).forEach(expectedTabStop => {
             if (!actualTabStops.has(expectedTabStop)) {
                 const selector = this.generateSelector(expectedTabStop);
                 requirementResults.push({

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -160,17 +160,24 @@ describe('AnalyzerProviderTests', () => {
         const analyzer = testObject.createFocusTrackingAnalyzer(config);
         const openAnalyzer = analyzer as any;
         expect(analyzer).toBeInstanceOf(BaseAnalyzer);
-        expect(openAnalyzer.tabStopListenerRunner).toEqual(tabStopsListener.object);
+        expect(openAnalyzer.tabStopRequirementRunner).toBeNull();
+        validateFocusTrackingAnalyzer(openAnalyzer, config);
+    });
+
+    test('createTabStopsAnalyzer', () => {
+        const config: FocusAnalyzerConfiguration = {
+            testType: typeStub,
+            analyzerMessageType: analyzerMessageTypeStub,
+            key: keyStub,
+            analyzerProgressMessageType: 'analyzer progress message',
+            analyzerTerminatedMessageType: 'analyzer terminated message',
+        };
+
+        const analyzer = testObject.createTabStopsAnalyzer(config);
+        const openAnalyzer = analyzer as any;
+        expect(analyzer).toBeInstanceOf(BaseAnalyzer);
         expect(openAnalyzer.tabStopRequirementRunner).toEqual(tabStopRequirementRunnerMock.object);
-        expect(openAnalyzer.tabStopRequirementActionMessageCreator).toEqual(
-            tabStopRequirementActionMessageCreatorMock.object,
-        );
-        expect(openAnalyzer.tabStopsDoneAnalyzingTracker).toEqual(
-            tabStopsDoneAnalyzingTrackerMock.object,
-        );
-        expect(openAnalyzer.featureFlagStore).toEqual(featureFlagStoreMock.object);
-        expect(openAnalyzer.config).toEqual(config);
-        expect(openAnalyzer.sendMessage).toEqual(sendMessageMock.object);
+        validateFocusTrackingAnalyzer(openAnalyzer, config);
     });
 
     test('createBaseAnalyzer', () => {
@@ -192,6 +199,19 @@ describe('AnalyzerProviderTests', () => {
         expect(openAnalyzer.scopingStore).toEqual(scopingStoreMock.object);
         expect(openAnalyzer.dateGetter).toEqual(dateGetterMock.object);
         expect(openAnalyzer.telemetryFactory).toEqual(telemetryFactoryMock.object);
+        expect(openAnalyzer.config).toEqual(config);
+        expect(openAnalyzer.sendMessage).toEqual(sendMessageMock.object);
+    }
+
+    function validateFocusTrackingAnalyzer(openAnalyzer, config): void {
+        expect(openAnalyzer.tabStopListenerRunner).toEqual(tabStopsListener.object);
+        expect(openAnalyzer.tabStopRequirementActionMessageCreator).toEqual(
+            tabStopRequirementActionMessageCreatorMock.object,
+        );
+        expect(openAnalyzer.tabStopsDoneAnalyzingTracker).toEqual(
+            tabStopsDoneAnalyzingTrackerMock.object,
+        );
+        expect(openAnalyzer.featureFlagStore).toEqual(featureFlagStoreMock.object);
         expect(openAnalyzer.config).toEqual(config);
         expect(openAnalyzer.sendMessage).toEqual(sendMessageMock.object);
     }

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -264,6 +264,38 @@ describe('TabStopsAnalyzer', () => {
             debounceFaker.flush();
             verifyAll();
         });
+
+        it('runs analyze and teardown with null requirement runner', async () => {
+            testSubject = new TabStopsAnalyzer(
+                configStub,
+                tabStopsListenerMock.object,
+                sendMessageMock.object,
+                scanIncompleteWarningDetectorMock.object,
+                failTestOnErrorLogger,
+                featureFlagStoreMock.object,
+                null,
+                tabStopRequirementActionMessageCreatorMock.object,
+                tabStopsDoneAnalyzingTrackerMock.object,
+                debounceFaker.debounce,
+            );
+
+            setTabStopsAutomationFeatureFlag(true);
+            setupTabStopsListenerForStartTabStops();
+            setupSendMessageMock(emptyScanCompleteMessage);
+
+            testSubject.analyze();
+            await flushSettledPromises();
+
+            verifyAll();
+
+            setupSendMessageMock({
+                messageType: configStub.analyzerTerminatedMessageType,
+                payload: { key: configStub.key, testType: configStub.testType },
+            });
+            testSubject.teardown();
+
+            verifyAll();
+        });
     });
 
     function verifyAll(): void {

--- a/src/tests/unit/tests/injected/tab-stops-requirement-evaluator.test.ts
+++ b/src/tests/unit/tests/injected/tab-stops-requirement-evaluator.test.ts
@@ -43,6 +43,10 @@ describe('TabStopsRequirementEvaluator', () => {
         ).toEqual([expectedResult]);
     });
 
+    test('addKeyboardNavigationResults returns empty set with no tabbed elements', () => {
+        expect(testSubject.getKeyboardNavigationResults(null, null)).toEqual([]);
+    });
+
     test('addKeyboardNavigationResults returns empty set with no violations', () => {
         const tabbableTabStops = [
             tabStopElement1 as FocusableElement,


### PR DESCRIPTION
#### Details

Fixes bug in which automatic tab stops requirement checks are run for any test that uses the FocusTrackingAnalyzer (for example, Keyboard Navigation requirement under Assessment). As a result, extra failure instances will be collected, stored, and displayed when the user switches to the tabstops report. 

##### Motivation

Fix bug introduced by feature work.

##### Context

Added an extra method to `analyzer-provider` to avoid having to condition based on `VisualizationType` in the TabStopsAnalyzer. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
