### PR TITLE
feat(tabstops-auto-target-page-vis): Convert svg drawer to use TabStopVisualizationInstance

### DIFF
--- a/src/injected/visualization/svg-drawer.ts
+++ b/src/injected/visualization/svg-drawer.ts
@@ -46,7 +46,7 @@ export class SVGDrawer extends BaseDrawer {
         const tabbedElements = drawerInfo.data.map(element => {
             return {
                 ...element,
-                tabOrder: element.propertyBag.tabOrder,
+                tabOrder: element.propertyBag?.tabOrder,
             };
         });
         this.updateTabbedElements(tabbedElements);
@@ -85,7 +85,7 @@ export class SVGDrawer extends BaseDrawer {
             oldStateElement == null ||
             newStateElement.target[newStateElement.target.length - 1] !==
                 oldStateElement.selector ||
-            newStateElement.propertyBag.tabOrder !== oldStateElement.tabOrder ||
+            newStateElement.propertyBag?.tabOrder !== oldStateElement.tabOrder ||
             isLastElementInSvg
         );
     }
@@ -100,7 +100,7 @@ export class SVGDrawer extends BaseDrawer {
         return {
             element: dom.querySelector(selector),
             selector: selector,
-            tabOrder: newStateElement.propertyBag.tabOrder,
+            tabOrder: newStateElement.propertyBag?.tabOrder,
             shouldRedraw: true,
             focusIndicator: oldStateElement ? oldStateElement.focusIndicator : null,
         };

--- a/src/injected/visualization/svg-drawer.ts
+++ b/src/injected/visualization/svg-drawer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TabStopVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
 import { chain, each, size } from 'lodash';
-import { TabbedElementData } from '../../common/types/store-data/visualization-scan-result-data';
 import { WindowUtils } from '../../common/window-utils';
 import { ShadowUtils } from '../shadow-utils';
 import { BaseDrawer } from './base-drawer';
@@ -42,22 +42,22 @@ export class SVGDrawer extends BaseDrawer {
         this.centerPositionCalculator = centerPositionCalculator;
     }
 
-    public initialize(drawerInfo: DrawerInitData<TabbedElementData>): void {
+    public initialize(drawerInfo: DrawerInitData<TabStopVisualizationInstance>): void {
         const tabbedElements = drawerInfo.data.map(element => {
             return {
                 ...element,
-                tabOrder: element.tabOrder || element.propertyBag.tabOrder,
+                tabOrder: element.propertyBag.tabOrder,
             };
         });
         this.updateTabbedElements(tabbedElements);
     }
 
-    private updateTabbedElements(newTabbedElements: TabbedElementData[]): void {
+    private updateTabbedElements(newTabbedElements: TabStopVisualizationInstance[]): void {
         let diffFound = false;
         const dom: Document = this.drawerUtils.getDocumentElement();
 
         for (let pos = 0; pos < newTabbedElements.length; pos++) {
-            const newStateElement: TabbedElementData = newTabbedElements[pos];
+            const newStateElement: TabStopVisualizationInstance = newTabbedElements[pos];
             const oldStateElement: TabbedItem = this.tabbedElements[pos];
 
             if (diffFound || this.shouldRedraw(oldStateElement, newStateElement, pos)) {
@@ -65,7 +65,6 @@ export class SVGDrawer extends BaseDrawer {
                 this.tabbedElements[pos] = this.getNewTabbedElement(
                     oldStateElement,
                     newStateElement,
-                    pos,
                     dom,
                 );
             } else {
@@ -76,7 +75,7 @@ export class SVGDrawer extends BaseDrawer {
 
     private shouldRedraw(
         oldStateElement: TabbedItem,
-        newStateElement: TabbedElementData,
+        newStateElement: TabStopVisualizationInstance,
         pos: number,
     ): boolean {
         const elementsInSvgCount: number = this.tabbedElements.length;
@@ -86,15 +85,14 @@ export class SVGDrawer extends BaseDrawer {
             oldStateElement == null ||
             newStateElement.target[newStateElement.target.length - 1] !==
                 oldStateElement.selector ||
-            newStateElement.tabOrder !== oldStateElement.tabOrder ||
+            newStateElement.propertyBag.tabOrder !== oldStateElement.tabOrder ||
             isLastElementInSvg
         );
     }
 
     private getNewTabbedElement(
         oldStateElement: TabbedItem,
-        newStateElement: TabbedElementData,
-        pos: number,
+        newStateElement: TabStopVisualizationInstance,
         dom: Document,
     ): TabbedItem {
         const selector: string = newStateElement.target[newStateElement.target.length - 1];
@@ -102,7 +100,7 @@ export class SVGDrawer extends BaseDrawer {
         return {
             element: dom.querySelector(selector),
             selector: selector,
-            tabOrder: newStateElement.tabOrder,
+            tabOrder: newStateElement.propertyBag.tabOrder,
             shouldRedraw: true,
             focusIndicator: oldStateElement ? oldStateElement.focusIndicator : null,
         };

--- a/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TabStopVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { getDefaultFeatureFlagsWeb } from '../../../../../common/feature-flags';
-import { TabbedElementData } from '../../../../../common/types/store-data/visualization-scan-result-data';
 import { WindowUtils } from '../../../../../common/window-utils';
 import { ShadowUtils } from '../../../../../injected/shadow-utils';
 import { CenterPositionCalculator } from '../../../../../injected/visualization/center-position-calculator';
@@ -66,12 +66,14 @@ describe('SVGDrawer', () => {
                 selector: '#id1',
             },
         ];
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                tabOrder: 1,
-                timestamp: 60,
-                html: 'test',
                 target: ['#id1'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
         ];
 
@@ -107,16 +109,14 @@ describe('SVGDrawer', () => {
                 selector: '#id1',
             },
         ];
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                propertyBag: {
-                    tabOrder: 1,
-                    timestamp: 0,
-                },
-                tabOrder: null,
-                timestamp: 60,
-                html: 'test',
                 target: ['#id1'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
         ];
 
@@ -176,18 +176,22 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                tabOrder: 1,
-                timestamp: 60,
-                html: 'test',
                 target: ['#id1'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
             {
-                tabOrder: 2,
-                timestamp: 61,
-                html: 'test',
                 target: ['#id2'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 2 },
             },
         ];
 
@@ -249,26 +253,22 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                tabOrder: null,
-                timestamp: 60,
-                html: 'test',
                 target: ['#id1'],
-                propertyBag: {
-                    tabOrder: 1,
-                    timestamp: null,
-                },
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
             {
-                tabOrder: null,
-                timestamp: 61,
-                html: 'test',
                 target: ['#id2'],
-                propertyBag: {
-                    tabOrder: 2,
-                    timestamp: null,
-                },
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 2 },
             },
         ];
 
@@ -361,30 +361,38 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                tabOrder: 1,
-                timestamp: 60,
-                html: 'test',
                 target: ['#id1'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
             {
-                tabOrder: 2,
-                timestamp: 61,
-                html: 'test',
                 target: ['#id2'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 2 },
             },
             {
-                tabOrder: 3,
-                timestamp: 62,
-                html: 'test',
                 target: ['#id3'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 3 },
             },
             {
-                tabOrder: 4,
-                timestamp: 63,
-                html: 'test',
                 target: ['#id4'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 4 },
             },
         ];
 
@@ -445,12 +453,14 @@ describe('SVGDrawer', () => {
         fakeDocument.body.innerHTML = "<div id='id1'></div>";
         const element = fakeDocument.querySelector<HTMLElement>('#id1');
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                tabOrder: 1,
-                timestamp: 60,
-                html: 'test',
                 target: ['#id1'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
         ];
         const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub)
@@ -507,12 +517,14 @@ describe('SVGDrawer', () => {
 
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
         const element = fakeDocument.querySelector<HTMLElement>('#id1');
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                tabOrder: 1,
-                timestamp: 60,
-                html: 'test',
                 target: ['#id1'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
         ];
 
@@ -564,18 +576,22 @@ describe('SVGDrawer', () => {
         `;
 
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig(false, false);
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                tabOrder: 1,
-                timestamp: 60,
                 target: ['#id1'],
-                html: 'test',
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
             {
-                tabOrder: 2,
-                timestamp: 70,
                 target: ['#id2'],
-                html: 'test',
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 2 },
             },
         ];
 
@@ -629,18 +645,22 @@ describe('SVGDrawer', () => {
 
         // pass true or false in createTestDrawingConfig falseto set showDetailedTabOrder parameter in config
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                tabOrder: 1,
-                timestamp: 60,
-                html: 'test',
                 target: ['#id1'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
             {
-                tabOrder: 2,
-                timestamp: 70,
-                html: 'test',
                 target: ['#id2'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 2 },
             },
         ];
 
@@ -694,18 +714,22 @@ describe('SVGDrawer', () => {
 
         // pass true or false in createTestDrawingConfig falseto set showDetailedTabOrder parameter in config
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                tabOrder: 1,
-                timestamp: 60,
-                html: 'test',
                 target: ['#id1'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
             {
-                tabOrder: 2,
-                timestamp: 70,
-                html: 'test',
                 target: ['#id2'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 2 },
             },
         ];
 
@@ -761,18 +785,22 @@ describe('SVGDrawer', () => {
         `;
 
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                tabOrder: 1,
-                timestamp: 60,
-                html: 'test',
                 target: ['#id1'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
             {
-                tabOrder: 3,
-                timestamp: 70,
-                html: 'test',
                 target: ['#id2'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 3 },
             },
         ];
 
@@ -825,18 +853,22 @@ describe('SVGDrawer', () => {
         `;
 
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
-        const tabbedElements: TabbedElementData[] = [
+        const tabbedElements: TabStopVisualizationInstance[] = [
             {
-                tabOrder: 1,
-                timestamp: 60,
-                html: 'test',
                 target: ['#id1'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 1 },
             },
             {
-                tabOrder: 2,
-                timestamp: 70,
-                html: 'test',
                 target: ['#id2'],
+                requirementResults: null,
+                isFailure: false,
+                isVisualizationEnabled: false,
+                ruleResults: null,
+                propertyBag: { tabOrder: 2 },
             },
         ];
 

--- a/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TabbedElementData } from 'common/types/store-data/visualization-scan-result-data';
 import { TabStopVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
 import { IMock, It, Mock, Times } from 'typemoq';
 
@@ -96,7 +97,7 @@ describe('SVGDrawer', () => {
         drawerUtilsMock.verifyAll();
     });
 
-    test('initialize with element having property bag instead of taborder', () => {
+    test('initialize with TabbedElementData element', () => {
         fakeDocument.body.innerHTML = "<div id='id1'></div>";
 
         const element = fakeDocument.querySelector('#id1');
@@ -109,14 +110,12 @@ describe('SVGDrawer', () => {
                 selector: '#id1',
             },
         ];
-        const tabbedElements: TabStopVisualizationInstance[] = [
+        const tabbedElements: TabbedElementData[] = [
             {
+                tabOrder: 1,
+                timestamp: 60,
+                html: 'test',
                 target: ['#id1'],
-                requirementResults: null,
-                isFailure: false,
-                isVisualizationEnabled: false,
-                ruleResults: null,
-                propertyBag: { tabOrder: 1 },
             },
         ];
 


### PR DESCRIPTION
#### Details

Currently `svg-drawer` accepts the data type `TabbedElementData`, which does not contain any of the requirement failure data that will be necessary to show automatic failure visualizations. This PR switches to using the `TabStopVisualizationInstance` data type, which will eventually be populated with automatically failed requirement results. 

##### Motivation

Feature work.

##### Context

At the moment the `requirementResults` property of `TabStopVisualizationInstance` is never populated so failure visualizations are still not shown correctly. This will be fixed in following PRs. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
