### PR TITLE
fix: Show full focus on target page link

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -656,19 +656,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar .target-page a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1269,19 +1263,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -653,16 +653,21 @@
       }
       .report-header-command-bar .target-page {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar .target-page a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1260,16 +1265,21 @@
       }
       .report-header-command-bar--wDg1t .target-page--giudb {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar--wDg1t .target-page--giudb a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -656,19 +656,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar .target-page a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1269,19 +1263,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -653,16 +653,21 @@
       }
       .report-header-command-bar .target-page {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar .target-page a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1260,16 +1265,21 @@
       }
       .report-header-command-bar--wDg1t .target-page--giudb {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar--wDg1t .target-page--giudb a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -656,19 +656,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar .target-page a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1269,19 +1263,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -653,16 +653,21 @@
       }
       .report-header-command-bar .target-page {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar .target-page a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1260,16 +1265,21 @@
       }
       .report-header-command-bar--wDg1t .target-page--giudb {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar--wDg1t .target-page--giudb a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -656,19 +656,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar .target-page a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1269,19 +1263,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -653,16 +653,21 @@
       }
       .report-header-command-bar .target-page {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar .target-page a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1260,16 +1265,21 @@
       }
       .report-header-command-bar--wDg1t .target-page--giudb {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar--wDg1t .target-page--giudb a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -656,19 +656,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar .target-page a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1269,19 +1263,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -653,16 +653,21 @@
       }
       .report-header-command-bar .target-page {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar .target-page a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1260,16 +1265,21 @@
       }
       .report-header-command-bar--wDg1t .target-page--giudb {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar--wDg1t .target-page--giudb a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -656,19 +656,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar .target-page a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1269,19 +1263,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -653,16 +653,21 @@
       }
       .report-header-command-bar .target-page {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar .target-page a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1260,16 +1265,21 @@
       }
       .report-header-command-bar--wDg1t .target-page--giudb {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar--wDg1t .target-page--giudb a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -656,19 +656,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar .target-page a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1269,19 +1263,13 @@
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
-        display: inherit;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-      }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -653,16 +653,21 @@
       }
       .report-header-command-bar .target-page {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar .target-page a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .report-congrats-message {
         word-break: break-word;
@@ -1260,16 +1265,21 @@
       }
       .report-header-command-bar--wDg1t .target-page--giudb {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: var(--primary-text);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
           sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+      }
+      .report-header-command-bar--wDg1t .target-page--giudb a {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .combined-report-result-section-title--XUDDo {
         display: flex;

--- a/src/reports/components/report-sections/header-section.scss
+++ b/src/reports/components/report-sections/header-section.scss
@@ -15,13 +15,18 @@
     box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
 
     .target-page {
-        @include ellipsedText();
-
+        white-space: nowrap;
         margin: 0px 0px 0px 16px;
+        display: flex;
         color: $primary-text;
         font-family: $fontFamily;
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
         font-weight: normal;
+        min-width: 0;
+
+        a {
+            @include ellipsedText();
+        }
     }
 }

--- a/src/reports/components/report-sections/header-section.scss
+++ b/src/reports/components/report-sections/header-section.scss
@@ -18,16 +18,10 @@
         @include ellipsedText();
 
         margin: 0px 0px 0px 16px;
-        display: inherit;
-
         color: $primary-text;
         font-family: $fontFamily;
         font-size: 14px;
-        line-height: 20px;
+        line-height: 24px;
         font-weight: normal;
-
-        a {
-            @include ellipsedText();
-        }
     }
 }


### PR DESCRIPTION
#### Details

This PR fixes the focus on the target link in the FastPass and Assessment report. The focus was getting clipped due to the parent's `overflow: hidden`. 

- Replace `@include ellipsedText();` on parent element (`.target-page`) with `white-space: nowrap;`. This will keep the content on one line, but not clip the overflow. The CSS already sets the ellipsed text include on the anchor element and that's the only content we want to be truncated.
- Replace `display: inherit` with `display: flex`, while these values are the same, from a readability perspective, it may be helpful to be explicit with this value and help make the code modular. Using flex is important here so that only the link is truncated.
- Set `min-width: 0` on `.target-page`. I found this to be the best option to avoid using `overflow: hidden` on `.target-page` since hiding the overflow clips the focus. By setting `min-width` the element will contain the contents. This post on [flebox and truncated text](https://css-tricks.com/flexbox-truncated-text/#aa-the-solution-is-min-width-0-on-the-flex-child) explains more about using min-width on a flex child. An alternative would be to set `max-width: calc(100% -16px)` -- this accounts for the margin-left, but this option feels a little more brittle since it could break if `margin` changes.

Current | Proposed
---|---
<img src="https://user-images.githubusercontent.com/2180540/153942194-70911d1f-581c-4b45-b094-7cd9e3c70fdb.png" width="400" alt="screenshot of fast pass results, the target link focus does not complete enclose the link"> | <img src="https://user-images.githubusercontent.com/2180540/153942160-9847916d-35b2-48a0-82b4-4315a3936f33.png" width="400" alt="screenshot of fast pass result, the target link focus, which is a black border, completely surrounds the link">


On smaller width devices, the target link continues to truncate the text:
<img src="https://user-images.githubusercontent.com/2180540/154091033-af4944d9-ebf1-49c6-a919-98515002b3d5.png" width="500" alt="screenshot showing the target link is truncated">



##### Motivation

Addresses #5067

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

In my initial solution, I had made `.target-page` a block element (removed flexbox), increased the line-height, and remove the ellipsed text include from the anchor element, see commit [e664889](https://github.com/microsoft/accessibility-insights-web/pull/5175/commits/e664889c589688a048907f1dbaf96ed43f2fee6a). While this technically worked, on smaller devices the truncated ellipses use the text color, not the link color. Ultimately, we should truncate the link itself, not the parent element.


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5067
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
