### PR TITLE
feat(tabstops-auto-target-page-vis): introduce TabStopVisualizationInstance for multiple failures on one element

### DIFF
--- a/src/injected/frameCommunicators/html-element-axe-results-helper.ts
+++ b/src/injected/frameCommunicators/html-element-axe-results-helper.ts
@@ -24,7 +24,7 @@ export interface AssessmentVisualizationInstance extends AxeResultsWithFrameLeve
 
 export type TabStopVisualizationRequirementResults = Partial<{
     [requirementId in TabStopRequirementId]: {
-        description: string;
+        instanceId: string;
     };
 }>;
 

--- a/src/injected/frameCommunicators/html-element-axe-results-helper.ts
+++ b/src/injected/frameCommunicators/html-element-axe-results-helper.ts
@@ -22,12 +22,14 @@ export interface AssessmentVisualizationInstance extends AxeResultsWithFrameLeve
     propertyBag?: any;
 }
 
-export interface TabStopVisualizationInstance extends AssessmentVisualizationInstance {
-    requirementResults: {
-        [requirementId in TabStopRequirementId]: {
-            description: string;
-        };
+export type TabStopVisualizationRequirementResults = Partial<{
+    [requirementId in TabStopRequirementId]: {
+        description: string;
     };
+}>;
+
+export interface TabStopVisualizationInstance extends AssessmentVisualizationInstance {
+    requirementResults: TabStopVisualizationRequirementResults;
 }
 
 export class HtmlElementAxeResultsHelper {

--- a/src/injected/selector-to-visualization-map.ts
+++ b/src/injected/selector-to-visualization-map.ts
@@ -1,9 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentVisualizationInstance } from './frameCommunicators/html-element-axe-results-helper';
+import {
+    AssessmentVisualizationInstance,
+    TabStopVisualizationInstance,
+} from './frameCommunicators/html-element-axe-results-helper';
 
 // A selectorChain is a semicolon-delimited lists of CSS selectors based on axe-core target
 // properties, eg, of format "#top-frame-iframe;.inner-frame-element"
 export type SelectorToVisualizationMap = {
     [selectorChain: string]: AssessmentVisualizationInstance;
+};
+
+export type SelectorToTabStopVisualizationMap = {
+    [selectorChain: string]: TabStopVisualizationInstance;
 };

--- a/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
+++ b/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
@@ -42,7 +42,7 @@ export const GetVisualizationInstancesForTabStops = (
             if (selectorToVisualizationInstanceMap[selector] != null) {
                 selectorToVisualizationInstanceMap[selector].isFailure = true;
                 selectorToVisualizationInstanceMap[selector].requirementResults[requirementId] = {
-                    description: instance.description,
+                    instanceId: instance.id,
                 };
                 return;
             }
@@ -55,7 +55,7 @@ export const GetVisualizationInstancesForTabStops = (
                 propertyBag: {},
                 requirementResults: {
                     [requirementId]: {
-                        description: instance.description,
+                        instanceId: instance.id,
                     },
                 },
             };

--- a/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
+++ b/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
@@ -2,17 +2,21 @@
 // Licensed under the MIT License.
 
 import { TabStopsScanResultData } from 'common/types/store-data/visualization-scan-result-data';
-import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
-import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
+import { TabStopVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
+import {
+    SelectorToTabStopVisualizationMap,
+    SelectorToVisualizationMap,
+} from 'injected/selector-to-visualization-map';
 import { forOwn } from 'lodash';
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 
 export const GetVisualizationInstancesForTabStops = (
     tabStopScanResultData: TabStopsScanResultData,
 ): SelectorToVisualizationMap => {
-    const selectorToVisualizationInstanceMap: SelectorToVisualizationMap = {};
+    const selectorToVisualizationInstanceMap: SelectorToTabStopVisualizationMap = {};
 
     tabStopScanResultData.tabbedElements.forEach(element => {
-        const instance = {
+        const instance: TabStopVisualizationInstance = {
             isFailure: false,
             isVisualizationEnabled: true,
             ruleResults: null,
@@ -21,26 +25,42 @@ export const GetVisualizationInstancesForTabStops = (
                 tabOrder: element.tabOrder,
                 timestamp: element.timestamp,
             },
-        } as AssessmentVisualizationInstance;
+            requirementResults: {},
+        };
 
         selectorToVisualizationInstanceMap[element.target.join(';')] = instance;
     });
 
-    forOwn(tabStopScanResultData.requirements, obj => {
+    forOwn(tabStopScanResultData.requirements, (obj, requirementId: TabStopRequirementId) => {
         obj.instances.forEach(instance => {
             if (instance.selector == null) {
                 return;
             }
 
-            const newInstance = {
+            const selector = instance.selector.join(';');
+
+            if (selectorToVisualizationInstanceMap[selector] != null) {
+                selectorToVisualizationInstanceMap[selector].isFailure = true;
+                selectorToVisualizationInstanceMap[selector].requirementResults[requirementId] = {
+                    description: instance.description,
+                };
+                return;
+            }
+
+            const newInstance: TabStopVisualizationInstance = {
                 isFailure: true,
                 isVisualizationEnabled: true,
                 ruleResults: null,
                 target: instance.selector,
                 propertyBag: {},
+                requirementResults: {
+                    [requirementId]: {
+                        description: instance.description,
+                    },
+                },
             };
 
-            selectorToVisualizationInstanceMap[newInstance.target.join(';')] = newInstance;
+            selectorToVisualizationInstanceMap[selector] = newInstance;
         });
     });
 

--- a/src/tests/unit/tests/injected/visualization/get-visualization-instances-for-tab-stops.test.ts
+++ b/src/tests/unit/tests/injected/visualization/get-visualization-instances-for-tab-stops.test.ts
@@ -59,6 +59,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
             {
                 selector: ['some', 'requirement result selector'],
                 description: 'instance description 1',
+                id: 'some instance id',
             },
             {
                 description: 'instance without a selector',
@@ -90,14 +91,14 @@ describe('GetVisualizationInstancesForTabStops', () => {
             firstRequirementResults[0].selector,
             true,
             {},
-            { ['keyboard-navigation']: { description: firstRequirementResults[0].description } },
+            { ['keyboard-navigation']: { instanceId: firstRequirementResults[0].id } },
         );
 
         expectedResults['another;requirement result selector'] = buildVisualizationInstance(
             secondRequirementResults[0].selector,
             true,
             {},
-            { ['keyboard-traps']: { description: secondRequirementResults[0].description } },
+            { ['keyboard-traps']: { instanceId: secondRequirementResults[0].id } },
         );
 
         expect(GetVisualizationInstancesForTabStops(tabStopScanResultData)).toEqual(
@@ -111,6 +112,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
             {
                 selector: duplicateSelector,
                 description: 'instance description 1',
+                id: 'some instance id',
             },
         ] as TabStopRequirementInstance[];
 
@@ -118,6 +120,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
             {
                 selector: duplicateSelector,
                 description: 'another instance description',
+                id: 'another instance id',
             },
         ] as TabStopRequirementInstance[];
 
@@ -141,8 +144,8 @@ describe('GetVisualizationInstancesForTabStops', () => {
             true,
             {},
             {
-                'keyboard-navigation': { description: firstRequirementResults[0].description },
-                'keyboard-traps': { description: secondRequirementResults[0].description },
+                'keyboard-navigation': { instanceId: firstRequirementResults[0].id },
+                'keyboard-traps': { instanceId: secondRequirementResults[0].id },
             },
         );
 


### PR DESCRIPTION
#### Details

Allows us to have multiple failures attributed to one element.

##### Motivation
 
feature work

##### Context

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
