### PR TITLE
feat(tabstops-auto-target-page-vis): Add automatically failed tab stops target page visualization elements

### DIFF
--- a/src/injected/visualization/focus-indicator.ts
+++ b/src/injected/visualization/focus-indicator.ts
@@ -4,4 +4,5 @@ export interface FocusIndicator {
     circle: Element;
     tabIndexLabel?: Element;
     line?: Element;
+    failureLabel?: Element;
 }

--- a/src/injected/visualization/formatter.ts
+++ b/src/injected/visualization/formatter.ts
@@ -28,6 +28,7 @@ export interface TextBoxConfig extends BoxConfig {
 
 export interface FailureBoxConfig extends BoxConfig {
     hasDialogView?: boolean;
+    cornerRadius?: string;
 }
 
 export interface BoxConfig {

--- a/src/injected/visualization/formatter.ts
+++ b/src/injected/visualization/formatter.ts
@@ -64,9 +64,12 @@ export type LineConfiguration = StrokeConfiguration;
 export interface SVGDrawerConfiguration {
     circle: CircleConfiguration;
     focusedCircle: CircleConfiguration;
+    erroredCircle: CircleConfiguration;
+    missingCircle: CircleConfiguration;
     tabIndexLabel: TextConfiguration;
     line: LineConfiguration;
     focusedLine: LineConfiguration;
+    failureBoxConfig: FailureBoxConfig;
 }
 
 export interface SingleTargetDrawerConfiguration {

--- a/src/injected/visualization/svg-shape-factory.ts
+++ b/src/injected/visualization/svg-shape-factory.ts
@@ -3,6 +3,7 @@
 import { DrawerUtils } from './drawer-utils';
 import {
     CircleConfiguration,
+    FailureBoxConfig,
     LineConfiguration,
     StrokeConfiguration,
     TextConfiguration,
@@ -97,9 +98,40 @@ export class SVGShapeFactory {
 
         if (tabOrder != null) {
             text.innerHTML = tabOrder.toString();
+        } else {
+            text.innerHTML = 'X';
         }
 
         return text;
+    }
+
+    public createFailureLabel(center: Point, failureBoxConfig: FailureBoxConfig): Element {
+        const myDocument = this.drawerUtils.getDocumentElement();
+
+        const box = myDocument.createElementNS(SVGNamespaceUrl, 'rect');
+        box.classList.add('insights-highlight-text');
+        box.classList.add('failure-label');
+        box.setAttributeNS(null, 'x', (center.x + 10).toString());
+        box.setAttributeNS(null, 'y', (center.y - 20).toString());
+        box.setAttributeNS(null, 'width', failureBoxConfig.boxWidth);
+        box.setAttributeNS(null, 'height', failureBoxConfig.boxWidth);
+        box.setAttributeNS(null, 'fill', failureBoxConfig.background);
+
+        const text = myDocument.createElementNS(SVGNamespaceUrl, 'text');
+        text.classList.add('insights-highlight-text');
+        text.classList.add('failure-label');
+        text.setAttributeNS(null, 'x', (center.x + 13).toString());
+        text.setAttributeNS(null, 'y', (center.y - 12).toString());
+        text.setAttributeNS(null, 'fill', failureBoxConfig.fontColor);
+        text.setAttributeNS(null, 'font-size', failureBoxConfig.fontSize);
+        text.setAttributeNS(null, 'font-weight', failureBoxConfig.fontWeight);
+        text.innerHTML = failureBoxConfig.text;
+
+        const group = myDocument.createElementNS(SVGNamespaceUrl, 'g');
+        group.appendChild(box);
+        group.appendChild(text);
+
+        return group;
     }
 
     private applyCircleConfiguration(element: Element, configuration: CircleConfiguration): void {

--- a/src/injected/visualization/svg-shape-factory.ts
+++ b/src/injected/visualization/svg-shape-factory.ts
@@ -98,8 +98,6 @@ export class SVGShapeFactory {
 
         if (tabOrder != null) {
             text.innerHTML = tabOrder.toString();
-        } else {
-            text.innerHTML = 'X';
         }
 
         return text;
@@ -116,6 +114,7 @@ export class SVGShapeFactory {
         box.setAttributeNS(null, 'width', failureBoxConfig.boxWidth);
         box.setAttributeNS(null, 'height', failureBoxConfig.boxWidth);
         box.setAttributeNS(null, 'fill', failureBoxConfig.background);
+        box.setAttributeNS(null, 'rx', failureBoxConfig.cornerRadius);
 
         const text = myDocument.createElementNS(SVGNamespaceUrl, 'text');
         text.classList.add('insights-highlight-text');

--- a/src/injected/visualization/svg-shape-factory.ts
+++ b/src/injected/visualization/svg-shape-factory.ts
@@ -119,7 +119,7 @@ export class SVGShapeFactory {
         const text = myDocument.createElementNS(SVGNamespaceUrl, 'text');
         text.classList.add('insights-highlight-text');
         text.classList.add('failure-label');
-        text.setAttributeNS(null, 'x', (center.x + 13).toString());
+        text.setAttributeNS(null, 'x', (center.x + 13.5).toString());
         text.setAttributeNS(null, 'y', (center.y - 12).toString());
         text.setAttributeNS(null, 'fill', failureBoxConfig.fontColor);
         text.setAttributeNS(null, 'font-size', failureBoxConfig.fontSize);

--- a/src/injected/visualization/tab-stops-formatter.ts
+++ b/src/injected/visualization/tab-stops-formatter.ts
@@ -43,6 +43,21 @@ export class TabStopsFormatter implements Formatter {
                 ellipseRy: '16',
                 ellipseRx: ellipseRx.toString(),
             },
+            erroredCircle: {
+                stroke: '#E81123',
+                strokeWidth: '2',
+                fill: '#ffffff',
+                ellipseRy: '16',
+                ellipseRx: ellipseRx.toString(),
+            },
+            missingCircle: {
+                stroke: '#E81123',
+                strokeWidth: '2',
+                fill: '#ffffff',
+                ellipseRy: '16',
+                ellipseRx: ellipseRx.toString(),
+                strokeDasharray: '2 2',
+            },
             tabIndexLabel: {
                 fontColor: '#000000',
                 textAnchor: 'middle',
@@ -57,6 +72,13 @@ export class TabStopsFormatter implements Formatter {
                 stroke: '#C71585',
                 strokeWidth: '3',
                 strokeDasharray: '7 2',
+            },
+            failureBoxConfig: {
+                background: '#E81123',
+                fontColor: '#FFFFFF',
+                text: '!',
+                boxWidth: '10px',
+                fontSize: '10',
             },
         };
 

--- a/src/injected/visualization/tab-stops-formatter.ts
+++ b/src/injected/visualization/tab-stops-formatter.ts
@@ -79,6 +79,7 @@ export class TabStopsFormatter implements Formatter {
                 text: '!',
                 boxWidth: '10px',
                 fontSize: '10',
+                cornerRadius: '3px',
             },
         };
 

--- a/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
@@ -934,6 +934,21 @@ describe('SVGDrawer', () => {
                 ellipseRy: '16',
                 ellipseRx: '16',
             },
+            erroredCircle: {
+                stroke: '#E81123',
+                strokeWidth: '2',
+                fill: '#ffffff',
+                ellipseRy: '16',
+                ellipseRx: '16',
+            },
+            missingCircle: {
+                stroke: '#E81123',
+                strokeWidth: '2',
+                fill: '#ffffff',
+                ellipseRy: '16',
+                ellipseRx: '16',
+                strokeDasharray: '2 2',
+            },
             tabIndexLabel: {
                 fontColor: '#000000',
                 textAnchor: 'middle',
@@ -948,6 +963,13 @@ describe('SVGDrawer', () => {
                 stroke: '#C71585',
                 strokeWidth: '3',
                 strokeDasharray: '7 3',
+            },
+            failureBoxConfig: {
+                background: '#E81123',
+                fontColor: '#FFFFFF',
+                text: '!',
+                boxWidth: '10px',
+                fontSize: '10',
             },
         };
 

--- a/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
@@ -3,6 +3,7 @@
 import { DrawerUtils } from 'injected/visualization/drawer-utils';
 import {
     CircleConfiguration,
+    FailureBoxConfig,
     LineConfiguration,
     TextConfiguration,
 } from 'injected/visualization/formatter';
@@ -391,7 +392,26 @@ describe('SVGShapeFactory', () => {
 
         const label = testObject.createTabIndexLabel(center, textConfig, tabOrder);
         verifyTabIndexLabelParams(label, textConfig, center, tabOrder);
-        expect(label.innerHTML).toEqual('');
+        expect(label.innerHTML).toEqual('X');
+    });
+
+    test('create failure label', () => {
+        const center: Point = {
+            x: 100,
+            y: 100,
+        };
+
+        const failureBoxConfig: FailureBoxConfig = {
+            background: '#E81123',
+            fontColor: '#FFFFFF',
+            text: '!',
+            boxWidth: '10px',
+            fontSize: '10',
+            fontWeight: '1',
+        };
+
+        const label = testObject.createFailureLabel(center, failureBoxConfig);
+        verifyFailureLabelParams(label, failureBoxConfig, center);
     });
 
     function verifyTabIndexLabelParams(
@@ -422,6 +442,33 @@ describe('SVGShapeFactory', () => {
         expect(circle.getAttributeNS(null, 'class')).toEqual('insights-svg-focus-indicator');
         expect(circle.getAttributeNS(null, 'cx')).toEqual(center.x.toString());
         expect(circle.getAttributeNS(null, 'cy')).toEqual(center.y.toString());
+    }
+
+    function verifyFailureLabelParams(
+        box: Element,
+        configuration: FailureBoxConfig,
+        center: Point,
+    ): void {
+        expect(box.tagName).toEqual('g');
+
+        const rect = box.getElementsByTagName('rect')[0];
+
+        expect(rect.classList.value).toBe('insights-highlight-text failure-label');
+        expect(rect.getAttributeNS(null, 'x')).toBe((center.x + 10).toString());
+        expect(rect.getAttributeNS(null, 'y')).toBe((center.y - 20).toString());
+        expect(rect.getAttributeNS(null, 'width')).toBe(configuration.boxWidth);
+        expect(rect.getAttributeNS(null, 'height')).toBe(configuration.boxWidth);
+        expect(rect.getAttributeNS(null, 'fill')).toBe(configuration.background);
+
+        const text = box.getElementsByTagName('text')[0];
+
+        expect(text.classList.value).toBe('insights-highlight-text failure-label');
+        expect(text.getAttributeNS(null, 'x')).toBe((center.x + 13).toString());
+        expect(text.getAttributeNS(null, 'y')).toBe((center.x - 12).toString());
+        expect(text.getAttributeNS(null, 'fill')).toBe(configuration.fontColor);
+        expect(text.getAttributeNS(null, 'font-size')).toBe(configuration.fontSize);
+        expect(text.getAttributeNS(null, 'font-weight')).toBe(configuration.fontWeight);
+        expect(text.innerHTML).toBe(configuration.text);
     }
 
     function verifyLineParams(

--- a/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
@@ -465,7 +465,7 @@ describe('SVGShapeFactory', () => {
         const text = box.getElementsByTagName('text')[0];
 
         expect(text.classList.value).toBe('insights-highlight-text failure-label');
-        expect(text.getAttributeNS(null, 'x')).toBe((center.x + 13).toString());
+        expect(text.getAttributeNS(null, 'x')).toBe((center.x + 13.5).toString());
         expect(text.getAttributeNS(null, 'y')).toBe((center.x - 12).toString());
         expect(text.getAttributeNS(null, 'fill')).toBe(configuration.fontColor);
         expect(text.getAttributeNS(null, 'font-size')).toBe(configuration.fontSize);

--- a/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
@@ -392,7 +392,7 @@ describe('SVGShapeFactory', () => {
 
         const label = testObject.createTabIndexLabel(center, textConfig, tabOrder);
         verifyTabIndexLabelParams(label, textConfig, center, tabOrder);
-        expect(label.innerHTML).toEqual('X');
+        expect(label.innerHTML).toEqual('');
     });
 
     test('create failure label', () => {
@@ -408,6 +408,7 @@ describe('SVGShapeFactory', () => {
             boxWidth: '10px',
             fontSize: '10',
             fontWeight: '1',
+            cornerRadius: '3px',
         };
 
         const label = testObject.createFailureLabel(center, failureBoxConfig);
@@ -459,6 +460,7 @@ describe('SVGShapeFactory', () => {
         expect(rect.getAttributeNS(null, 'width')).toBe(configuration.boxWidth);
         expect(rect.getAttributeNS(null, 'height')).toBe(configuration.boxWidth);
         expect(rect.getAttributeNS(null, 'fill')).toBe(configuration.background);
+        expect(rect.getAttributeNS(null, 'rx')).toBe(configuration.cornerRadius);
 
         const text = box.getElementsByTagName('text')[0];
 

--- a/src/tests/unit/tests/injected/visualization/tab-stops-formatter.test.ts
+++ b/src/tests/unit/tests/injected/visualization/tab-stops-formatter.test.ts
@@ -27,6 +27,21 @@ describe('TabStopsFormatterTests', () => {
                 ellipseRy: '16',
                 ellipseRx: '16',
             },
+            erroredCircle: {
+                stroke: '#E81123',
+                strokeWidth: '2',
+                fill: '#ffffff',
+                ellipseRy: '16',
+                ellipseRx: '16',
+            },
+            missingCircle: {
+                stroke: '#E81123',
+                strokeWidth: '2',
+                fill: '#ffffff',
+                ellipseRy: '16',
+                ellipseRx: '16',
+                strokeDasharray: '2 2',
+            },
             tabIndexLabel: {
                 fontColor: '#000000',
                 textAnchor: 'middle',
@@ -41,6 +56,13 @@ describe('TabStopsFormatterTests', () => {
                 stroke: '#C71585',
                 strokeWidth: '3',
                 strokeDasharray: '7 2',
+            },
+            failureBoxConfig: {
+                background: '#E81123',
+                fontColor: '#FFFFFF',
+                text: '!',
+                boxWidth: '10px',
+                fontSize: '10',
             },
         };
     }
@@ -69,6 +91,8 @@ describe('TabStopsFormatterTests', () => {
         const expectedConfig = createTestDrawerConfig();
         expectedConfig.circle.ellipseRx = '39.1';
         expectedConfig.focusedCircle.ellipseRx = '39.1';
+        expectedConfig.erroredCircle.ellipseRx = '39.1';
+        expectedConfig.missingCircle.ellipseRx = '39.1';
         expect(config).toEqual(expectedConfig);
         element.remove();
     });

--- a/src/tests/unit/tests/injected/visualization/tab-stops-formatter.test.ts
+++ b/src/tests/unit/tests/injected/visualization/tab-stops-formatter.test.ts
@@ -63,6 +63,7 @@ describe('TabStopsFormatterTests', () => {
                 text: '!',
                 boxWidth: '10px',
                 fontSize: '10',
+                cornerRadius: '3px',
             },
         };
     }


### PR DESCRIPTION
#### Details

Add visualization elements that will be leveraged for automated tab stops failure visualization in target page. Note that screenshots below were generated during tested and do not show up in any real visualizations. 

Missing element visualization: dotted red circle with red '!' in right upper corner. Once logic is added to differentiate between types of tabstops visualization elements, the tab order number will be replaced with a red 'X'. 
![MissingElementsFailureVis](https://user-images.githubusercontent.com/16010855/154315939-18de61e9-4df1-4688-8583-1cad8b0bb8df.png)
(screenshot of missing element visualization described above)

Failed element visualization: solid red circle with red '!' in right upper corner. This visualization will represent any automatically detected tab stop failure besides a missing element. Once logic is added to differentiate between types of tabstops visualization elements, the tab order text will be red. 
![FailedElementVis](https://user-images.githubusercontent.com/16010855/154315935-45c4bb5e-649c-49c4-847e-154df84e6b2f.png)
(screenshot of failed element visualization described above)

##### Motivation

Feature work.

##### Context

This PR only adds the elements themselves, they are not yet leveraged in the target page visualization. A follow up PR will add the logic to determine which failure elements need to be displayed. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ not yet included in visualization ] (UI changes only) Verified usability with NVDA/JAWS
