### PR TITLE
refactor: replacing div with role=heading with native heading element issue #5120

### DIFF
--- a/src/content/adhoc/tabstops/how-to-test.tsx
+++ b/src/content/adhoc/tabstops/how-to-test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { HeadingElementForLevel, HeadingLevel } from 'common/components/heading-element-for-level';
 import { create, React } from '../../common';
 
 export const createHowToTest = (headingLevel: number) => {
@@ -10,9 +11,7 @@ export const createHowToTest = (headingLevel: number) => {
                     Note: this test requires you to use a keyboard and to visually identify interactive elements.
                 </Markup.Emphasis>
             </p>
-            <div role="heading" aria-level={headingLevel}>
-                How to test
-            </div>
+            <HeadingElementForLevel headingLevel={headingLevel as HeadingLevel}>How to test</HeadingElementForLevel>
             <ol>
                 <li>Refresh the target page to put it in its default state.</li>
                 <li>Turn on the Show tab stops toggle. An empty circle will highlight the element with focus.</li>

--- a/src/popup/components/launch-pad.tsx
+++ b/src/popup/components/launch-pad.tsx
@@ -59,13 +59,7 @@ export class LaunchPad extends React.Component<LaunchPadProps, undefined> {
         return (
             <div className="ms-Grid main-section">
                 <main>
-                    <div
-                        role="heading"
-                        aria-level={2}
-                        className="launch-pad-title ms-fontWeight-semibold"
-                    >
-                        Launch pad
-                    </div>
+                    <h2 className="launch-pad-title ms-fontWeight-semibold">Launch pad</h2>
                     <hr className="ms-fontColor-neutralTertiaryAlt launch-pad-hr" />
                     <div className="launch-pad-main-section">
                         {this.renderLaunchPadItemRows(this.props.rowConfigs)}

--- a/src/reports/components/report-sections/report-collapsible-container.tsx
+++ b/src/reports/components/report-sections/report-collapsible-container.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
+import { HeadingElementForLevel, HeadingLevel } from 'common/components/heading-element-for-level';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
@@ -26,7 +27,10 @@ const ReportCollapsibleContainer = NamedFC<ReportCollapsibleContainerProps>(
 
         return (
             <div className={outerDivClassName}>
-                <div className="title-container" role="heading" aria-level={headingLevel}>
+                <HeadingElementForLevel
+                    headingLevel={headingLevel as HeadingLevel}
+                    className="title-container"
+                >
                     <button
                         className="collapsible-control"
                         aria-expanded="false"
@@ -35,7 +39,7 @@ const ReportCollapsibleContainer = NamedFC<ReportCollapsibleContainerProps>(
                     >
                         {header}
                     </button>
-                </div>
+                </HeadingElementForLevel>
                 <div id={contentId} className="collapsible-content" aria-hidden="true">
                     {content}
                 </div>

--- a/src/tests/unit/tests/popup/components/launch-pad.test.tsx
+++ b/src/tests/unit/tests/popup/components/launch-pad.test.tsx
@@ -56,13 +56,7 @@ describe('LaunchPad', () => {
         const expected = (
             <div className="ms-Grid main-section">
                 <main>
-                    <div
-                        role="heading"
-                        aria-level={2}
-                        className="launch-pad-title ms-fontWeight-semibold"
-                    >
-                        Launch pad
-                    </div>
+                    <h2 className="launch-pad-title ms-fontWeight-semibold">Launch pad</h2>
                     <hr className="ms-fontColor-neutralTertiaryAlt launch-pad-hr" />
                     <div className="launch-pad-main-section">
                         <div key="row-item-1">


### PR DESCRIPTION
#### Details

Refactoring the codebase to use native heading elements instead of div elements with role = heading  as per issue #5120 

##### Motivation

addresses issue #5120 

##### Context

I replaced previously hardcoded levels with the corosponding h element directly and the previously dynamic levels with the element HeadingElementForLevel as this elemnt seems to serve the purpose of dynamically creating a native h-element of a given level.

I intentionally left out the tests (both e2e and unit) as I am not certain what the correct action is here. 

#### Pull request checklist

- [x] Addresses an existing issue: #5120 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
