### PR TITLE
feat(tabstops-auto-target-page-vis): Add errored and missing tab stops visualizations

### DIFF
--- a/src/injected/frameCommunicators/html-element-axe-results-helper.ts
+++ b/src/injected/frameCommunicators/html-element-axe-results-helper.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TabbedItemType } from 'injected/visualization/tabbed-item';
 import { forOwn } from 'lodash';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 import { HTMLElementUtils } from '../../common/html-element-utils';
@@ -30,6 +31,7 @@ export type TabStopVisualizationRequirementResults = Partial<{
 
 export interface TabStopVisualizationInstance extends AssessmentVisualizationInstance {
     requirementResults: TabStopVisualizationRequirementResults;
+    itemType?: TabbedItemType;
 }
 
 export class HtmlElementAxeResultsHelper {

--- a/src/injected/visualization/formatter.ts
+++ b/src/injected/visualization/formatter.ts
@@ -68,6 +68,7 @@ export interface SVGDrawerConfiguration {
     erroredCircle: CircleConfiguration;
     missingCircle: CircleConfiguration;
     tabIndexLabel: TextConfiguration;
+    erroredTabIndexLabel: TextConfiguration;
     line: LineConfiguration;
     focusedLine: LineConfiguration;
     failureBoxConfig: FailureBoxConfig;

--- a/src/injected/visualization/svg-drawer.ts
+++ b/src/injected/visualization/svg-drawer.ts
@@ -286,7 +286,7 @@ export class SVGDrawer extends BaseDrawer {
         const newCircle = this.svgShapeFactory.createCircle(centerPosition, circleConfiguration);
         const newLabel = this.svgShapeFactory.createTabIndexLabel(
             centerPosition,
-            drawerConfig.tabIndexLabel,
+            drawerConfig.erroredTabIndexLabel,
             item.tabOrder,
             missingItem ? 'X' : null,
         );

--- a/src/injected/visualization/svg-drawer.ts
+++ b/src/injected/visualization/svg-drawer.ts
@@ -294,7 +294,7 @@ export class SVGDrawer extends BaseDrawer {
 
         let newLine: Element;
         if (!missingItem) {
-            this.createLinesInTabOrderVisualization(
+            newLine = this.createLinesInTabOrderVisualization(
                 curElementIndex,
                 false,
                 drawerConfig,

--- a/src/injected/visualization/svg-drawer.ts
+++ b/src/injected/visualization/svg-drawer.ts
@@ -109,6 +109,7 @@ export class SVGDrawer extends BaseDrawer {
             tabOrder: this.getTabOrder(newStateElement),
             shouldRedraw: true,
             focusIndicator: oldStateElement ? oldStateElement.focusIndicator : null,
+            itemType: (newStateElement as TabStopVisualizationInstance)?.itemType,
         };
     }
 

--- a/src/injected/visualization/svg-shape-factory.ts
+++ b/src/injected/visualization/svg-shape-factory.ts
@@ -84,6 +84,7 @@ export class SVGShapeFactory {
         center: Point,
         textConfig: TextConfiguration,
         tabOrder: number,
+        innerText: string = null,
     ): Element {
         const myDocument = this.drawerUtils.getDocumentElement();
         const text = myDocument.createElementNS(SVGNamespaceUrl, 'text');
@@ -96,8 +97,10 @@ export class SVGShapeFactory {
         text.setAttributeNS(null, 'fill', textConfig.fontColor);
         text.setAttributeNS(null, 'text-anchor', textConfig.textAnchor);
 
-        if (tabOrder != null) {
+        if (tabOrder != null && !innerText) {
             text.innerHTML = tabOrder.toString();
+        } else if (innerText) {
+            text.innerHTML = innerText;
         }
 
         return text;

--- a/src/injected/visualization/svg-shape-factory.ts
+++ b/src/injected/visualization/svg-shape-factory.ts
@@ -96,7 +96,7 @@ export class SVGShapeFactory {
 
         text.setAttributeNS(null, 'fill', textConfig.fontColor);
         text.setAttributeNS(null, 'text-anchor', textConfig.textAnchor);
-        
+
         if (innerText) {
             text.innerHTML = innerText;
         } else if (tabOrder != null) {

--- a/src/injected/visualization/svg-shape-factory.ts
+++ b/src/injected/visualization/svg-shape-factory.ts
@@ -96,11 +96,11 @@ export class SVGShapeFactory {
 
         text.setAttributeNS(null, 'fill', textConfig.fontColor);
         text.setAttributeNS(null, 'text-anchor', textConfig.textAnchor);
-
-        if (tabOrder != null && !innerText) {
-            text.innerHTML = tabOrder.toString();
-        } else if (innerText) {
+        
+        if (innerText) {
             text.innerHTML = innerText;
+        } else if (tabOrder != null) {
+            text.innerHTML = tabOrder.toString();
         }
 
         return text;

--- a/src/injected/visualization/tab-stops-formatter.ts
+++ b/src/injected/visualization/tab-stops-formatter.ts
@@ -63,6 +63,11 @@ export class TabStopsFormatter implements Formatter {
                 textAnchor: 'middle',
                 showTabIndexedLabel: true,
             },
+            erroredTabIndexLabel: {
+                fontColor: '#E81123',
+                textAnchor: 'middle',
+                showTabIndexedLabel: true,
+            },
             line: {
                 stroke: '#777777',
                 strokeWidth: '2',

--- a/src/injected/visualization/tabbed-item.ts
+++ b/src/injected/visualization/tabbed-item.ts
@@ -8,4 +8,11 @@ export interface TabbedItem {
     focusIndicator?: FocusIndicator;
     tabOrder: number;
     shouldRedraw?: boolean;
+    itemType?: TabbedItemType;
+}
+
+export enum TabbedItemType {
+    RegularItem,
+    MissingItem,
+    ErroredItem,
 }

--- a/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
@@ -954,6 +954,11 @@ describe('SVGDrawer', () => {
                 textAnchor: 'middle',
                 showTabIndexedLabel: showTabIndexedLabel,
             },
+            erroredTabIndexLabel: {
+                fontColor: '#E81123',
+                textAnchor: 'middle',
+                showTabIndexedLabel: true,
+            },
             line: {
                 stroke: '#777777',
                 strokeWidth: '2',

--- a/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-shape-factory.test.ts
@@ -378,6 +378,24 @@ describe('SVGShapeFactory', () => {
         expect(label.innerHTML).toEqual(tabOrder.toString());
     });
 
+    test('create label with inner text specified', () => {
+        const center: Point = {
+            x: 100,
+            y: 100,
+        };
+        const tabOrder = 10;
+        const text = 'X';
+
+        const textConfig: TextConfiguration = {
+            textAnchor: 'textAnchor',
+            fontColor: 'fontColor',
+        };
+
+        const label = testObject.createTabIndexLabel(center, textConfig, tabOrder, text);
+        verifyTabIndexLabelParams(label, textConfig, center, tabOrder);
+        expect(label.innerHTML).toEqual(text);
+    });
+
     test('create label with null tab order', () => {
         const center: Point = {
             x: 100,

--- a/src/tests/unit/tests/injected/visualization/tab-stops-formatter.test.ts
+++ b/src/tests/unit/tests/injected/visualization/tab-stops-formatter.test.ts
@@ -47,6 +47,11 @@ describe('TabStopsFormatterTests', () => {
                 textAnchor: 'middle',
                 showTabIndexedLabel: showTabIndexedLabel,
             },
+            erroredTabIndexLabel: {
+                fontColor: '#E81123',
+                textAnchor: 'middle',
+                showTabIndexedLabel: true,
+            },
             line: {
                 stroke: '#777777',
                 strokeWidth: '2',


### PR DESCRIPTION
#### Details

Add svg-drawer logic to display different types of focus indicators depending on the item type (regular, missing, or errored). The regular circle is the same as the existing focus indicator and the missing/ errored circles are added in this PR and shown below. Note that the screenshots below are generated when testing and these visualizations are not yet included in any production visualizations.

Missing circle (screenshot of red circle with dotted line, red 'x' in the center, and red '!' in the top right corner):
![MissingCircle](https://user-images.githubusercontent.com/16010855/155368866-ddc6ffa6-52df-4969-8dca-83272edd0ba7.png)

Errored circle (screenshot of red circle with solid line, red '1' in the center, and red '!' in the top right corner):
![ErrorCircle](https://user-images.githubusercontent.com/16010855/155368878-db9cb54c-083f-41da-9d7e-fd356db866fa.png)

##### Motivation

Feature work.

##### Context

At the moment the itemType property is not populated. This means that it will always be undefined and as a result we will have the same behavior as before (createErrorCircle will not be called). A follow up PR will add logic to populate the itemType property. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ not yet included in real UI ] (UI changes only) Verified usability with NVDA/JAWS
