### PR TITLE
feat(tabstops-auto-target-page-vis): Add and populate tabbed item type for automated tabbing results

### DIFF
--- a/src/injected/frameCommunicators/html-element-axe-results-helper.ts
+++ b/src/injected/frameCommunicators/html-element-axe-results-helper.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TabbedItemType } from 'injected/visualization/tabbed-item';
 import { forOwn } from 'lodash';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 import { HTMLElementUtils } from '../../common/html-element-utils';
@@ -30,6 +31,7 @@ export type TabStopVisualizationRequirementResults = Partial<{
 
 export interface TabStopVisualizationInstance extends AssessmentVisualizationInstance {
     requirementResults: TabStopVisualizationRequirementResults;
+    itemType?: TabbedItemType;
 }
 
 export class HtmlElementAxeResultsHelper {

--- a/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
+++ b/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
@@ -45,6 +45,10 @@ export const GetVisualizationInstancesForTabStops = (
                 selectorToVisualizationInstanceMap[selector].requirementResults[requirementId] = {
                     instanceId: instance.id,
                 };
+                selectorToVisualizationInstanceMap[selector].itemType =
+                    requirementId === 'keyboard-navigation'
+                        ? TabbedItemType.MissingItem
+                        : TabbedItemType.ErroredItem;
                 return;
             }
 
@@ -59,29 +63,15 @@ export const GetVisualizationInstancesForTabStops = (
                         instanceId: instance.id,
                     },
                 },
+                itemType:
+                    requirementId === 'keyboard-navigation'
+                        ? TabbedItemType.MissingItem
+                        : TabbedItemType.ErroredItem,
             };
 
             selectorToVisualizationInstanceMap[selector] = newInstance;
         });
     });
-
-    forOwn(
-        selectorToVisualizationInstanceMap,
-        (visualizationInstance: TabStopVisualizationInstance) => {
-            const isMissing =
-                visualizationInstance.requirementResults &&
-                visualizationInstance.requirementResults['keyboard-navigation'] !== undefined;
-            const isErrored =
-                visualizationInstance.requirementResults &&
-                (visualizationInstance.requirementResults['tab-order'] !== undefined ||
-                    visualizationInstance.requirementResults['keyboard-traps'] !== undefined);
-            visualizationInstance.itemType = isMissing
-                ? TabbedItemType.MissingItem
-                : isErrored
-                ? TabbedItemType.ErroredItem
-                : TabbedItemType.RegularItem;
-        },
-    );
 
     return selectorToVisualizationInstanceMap;
 };

--- a/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
+++ b/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
@@ -7,6 +7,7 @@ import {
     SelectorToTabStopVisualizationMap,
     SelectorToVisualizationMap,
 } from 'injected/selector-to-visualization-map';
+import { TabbedItemType } from 'injected/visualization/tabbed-item';
 import { forOwn } from 'lodash';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 
@@ -63,6 +64,24 @@ export const GetVisualizationInstancesForTabStops = (
             selectorToVisualizationInstanceMap[selector] = newInstance;
         });
     });
+
+    forOwn(
+        selectorToVisualizationInstanceMap,
+        (visualizationInstance: TabStopVisualizationInstance) => {
+            const isMissing =
+                visualizationInstance.requirementResults &&
+                visualizationInstance.requirementResults['keyboard-navigation'] !== undefined;
+            const isErrored =
+                visualizationInstance.requirementResults &&
+                (visualizationInstance.requirementResults['tab-order'] !== undefined ||
+                    visualizationInstance.requirementResults['keyboard-traps'] !== undefined);
+            visualizationInstance.itemType = isMissing
+                ? TabbedItemType.MissingItem
+                : isErrored
+                ? TabbedItemType.ErroredItem
+                : TabbedItemType.RegularItem;
+        },
+    );
 
     return selectorToVisualizationInstanceMap;
 };

--- a/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
+++ b/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
@@ -38,6 +38,11 @@ export const GetVisualizationInstancesForTabStops = (
                 return;
             }
 
+            const itemType =
+                requirementId === 'keyboard-navigation'
+                    ? TabbedItemType.MissingItem
+                    : TabbedItemType.ErroredItem;
+
             const selector = instance.selector.join(';');
 
             if (selectorToVisualizationInstanceMap[selector] != null) {
@@ -45,10 +50,8 @@ export const GetVisualizationInstancesForTabStops = (
                 selectorToVisualizationInstanceMap[selector].requirementResults[requirementId] = {
                     instanceId: instance.id,
                 };
-                selectorToVisualizationInstanceMap[selector].itemType =
-                    requirementId === 'keyboard-navigation'
-                        ? TabbedItemType.MissingItem
-                        : TabbedItemType.ErroredItem;
+                selectorToVisualizationInstanceMap[selector].itemType = itemType;
+
                 return;
             }
 
@@ -63,10 +66,7 @@ export const GetVisualizationInstancesForTabStops = (
                         instanceId: instance.id,
                     },
                 },
-                itemType:
-                    requirementId === 'keyboard-navigation'
-                        ? TabbedItemType.MissingItem
-                        : TabbedItemType.ErroredItem,
+                itemType,
             };
 
             selectorToVisualizationInstanceMap[selector] = newInstance;

--- a/src/injected/visualization/tabbed-item.ts
+++ b/src/injected/visualization/tabbed-item.ts
@@ -12,7 +12,6 @@ export interface TabbedItem {
 }
 
 export enum TabbedItemType {
-    RegularItem,
-    MissingItem,
-    ErroredItem,
+    MissingItem = 'MissingItem',
+    ErroredItem = 'ErroredItem',
 }

--- a/src/injected/visualization/tabbed-item.ts
+++ b/src/injected/visualization/tabbed-item.ts
@@ -8,4 +8,11 @@ export interface TabbedItem {
     focusIndicator?: FocusIndicator;
     tabOrder: number;
     shouldRedraw?: boolean;
+    itemType?: TabbedItemType;
+}
+
+export enum TabbedItemType {
+    RegularItem,
+    MissingItem,
+    ErroredItem,
 }

--- a/src/tests/unit/tests/injected/visualization/get-visualization-instances-for-tab-stops.test.ts
+++ b/src/tests/unit/tests/injected/visualization/get-visualization-instances-for-tab-stops.test.ts
@@ -14,6 +14,7 @@ import {
 } from 'injected/frameCommunicators/html-element-axe-results-helper';
 import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
 import { GetVisualizationInstancesForTabStops } from 'injected/visualization/get-visualization-instances-for-tab-stops';
+import { TabbedItemType } from 'injected/visualization/tabbed-item';
 
 describe('GetVisualizationInstancesForTabStops', () => {
     let tabbedElements: TabbedElementData[];
@@ -41,6 +42,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
                     timestamp: tabbedElements[0].timestamp,
                 },
                 {},
+                TabbedItemType.RegularItem,
             ),
             'another;target': buildVisualizationInstance(
                 tabbedElements[1].target,
@@ -50,6 +52,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
                     timestamp: tabbedElements[1].timestamp,
                 },
                 {},
+                TabbedItemType.RegularItem,
             ),
         } as SelectorToVisualizationMap;
     });
@@ -92,6 +95,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
             true,
             {},
             { ['keyboard-navigation']: { instanceId: firstRequirementResults[0].id } },
+            TabbedItemType.MissingItem,
         );
 
         expectedResults['another;requirement result selector'] = buildVisualizationInstance(
@@ -99,6 +103,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
             true,
             {},
             { ['keyboard-traps']: { instanceId: secondRequirementResults[0].id } },
+            TabbedItemType.ErroredItem,
         );
 
         expect(GetVisualizationInstancesForTabStops(tabStopScanResultData)).toEqual(
@@ -147,6 +152,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
                 'keyboard-navigation': { instanceId: firstRequirementResults[0].id },
                 'keyboard-traps': { instanceId: secondRequirementResults[0].id },
             },
+            TabbedItemType.MissingItem,
         );
 
         expect(GetVisualizationInstancesForTabStops(tabStopScanResultData)).toEqual(
@@ -159,6 +165,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
         isFailure: boolean,
         propertyBag: { tabOrder?: number; timestamp?: number },
         requirementResults: TabStopVisualizationRequirementResults,
+        itemType: TabbedItemType,
     ): TabStopVisualizationInstance {
         return {
             isFailure,
@@ -167,6 +174,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
             ruleResults: null,
             propertyBag,
             requirementResults,
+            itemType,
         };
     }
 });

--- a/src/tests/unit/tests/injected/visualization/get-visualization-instances-for-tab-stops.test.ts
+++ b/src/tests/unit/tests/injected/visualization/get-visualization-instances-for-tab-stops.test.ts
@@ -42,7 +42,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
                     timestamp: tabbedElements[0].timestamp,
                 },
                 {},
-                TabbedItemType.RegularItem,
+                undefined,
             ),
             'another;target': buildVisualizationInstance(
                 tabbedElements[1].target,
@@ -52,7 +52,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
                     timestamp: tabbedElements[1].timestamp,
                 },
                 {},
-                TabbedItemType.RegularItem,
+                undefined,
             ),
         } as SelectorToVisualizationMap;
     });
@@ -152,7 +152,7 @@ describe('GetVisualizationInstancesForTabStops', () => {
                 'keyboard-navigation': { instanceId: firstRequirementResults[0].id },
                 'keyboard-traps': { instanceId: secondRequirementResults[0].id },
             },
-            TabbedItemType.MissingItem,
+            TabbedItemType.ErroredItem,
         );
 
         expect(GetVisualizationInstancesForTabStops(tabStopScanResultData)).toEqual(


### PR DESCRIPTION
#### Details

Add the `itemType` property to `TabStopVisualizationInstance` and `TabbedItem`. This property differentiates between the different types of elements/failures that are passed to the svg-drawer to visualize and is populated based off the content of the `requirementResults`. 

##### Motivation

Feature work.

##### Context

A future PR will take advantage of the new itemType property in the svg-drawer for tab stops failure visualization. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
