### PR TITLE
fix(tabstops-auto-target-page-vis): keyboard navigation errors not adding to store

### DIFF
--- a/src/injected/analyzer-controller.ts
+++ b/src/injected/analyzer-controller.ts
@@ -72,8 +72,8 @@ export class AnalyzerController {
     private onResultsChangedState = (): void => {
         const state = this.visualizationResultsStore.getState();
         if (state.tabStops.tabbingCompleted && state.tabStops.needToCollectTabbingResults) {
-            this.tabStopRequirementActionMessageCreator.updateNeedToCollectTabbingResults(false);
             this.teardown(AdHocTestkeys.TabStops);
+            this.tabStopRequirementActionMessageCreator.updateNeedToCollectTabbingResults(false);
         }
     };
 


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Automatically detected keyboard navigation failure instances were not being added to the visualization-scan-result-store because the needToCollectTabbingResults flag was set to false before teardown. This PR sets the flag after teardown, so the keyboard navigation instances are added to the store and show up in the failure instance list.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Part of feature work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
