### PR TITLE
refactor: Replace `util.inspect` with `JSON.stringify`

### DIFF
--- a/src/background/browser-message-broadcaster-factory.ts
+++ b/src/background/browser-message-broadcaster-factory.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { inspect } from 'util';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { Logger } from 'common/logging/logger';
 
@@ -64,7 +63,7 @@ export class BrowserMessageBroadcasterFactory {
             return;
         }
 
-        const msg = `${operationDescription} failed for message ${inspect(
+        const msg = `${operationDescription} failed for message ${JSON.stringify(
             message,
         )} with browser error message: ${chromeError.message}`;
         this.logger.error(msg);

--- a/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
+++ b/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
@@ -53,7 +53,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const testMessage = { someData: 'test data' } as any;
             const testError = { message: 'test error' };
             const expectedMessage =
-                "sendMessageToFrames failed for message { someData: 'test data' } with browser error message: test error";
+                'sendMessageToFrames failed for message {"someData":"test data"} with browser error message: test error';
 
             browserAdapterMock
                 .setup(ba => ba.tabsQuery({}))
@@ -76,7 +76,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const testMessage = { someData: 'test data' } as any;
             const testError = { message: 'test error' };
             const expectedMessage =
-                "sendMessageToTab(1) failed for message { someData: 'test data' } with browser error message: test error";
+                'sendMessageToTab(1) failed for message {"someData":"test data"} with browser error message: test error';
 
             browserAdapterMock
                 .setup(ba => ba.tabsQuery({}))
@@ -141,7 +141,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const testMessage = { someData: 'test data' } as any;
             const testError = { message: 'test error' };
             const expectedMessage =
-                "sendMessageToFrames failed for message { someData: 'test data', tabId: 1 } with browser error message: test error";
+                'sendMessageToFrames failed for message {"someData":"test data","tabId":1} with browser error message: test error';
 
             browserAdapterMock
                 .setup(ba => ba.sendMessageToFrames(It.isAny()))
@@ -161,7 +161,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const testMessage = { someData: 'test data' } as any;
             const testError = { message: 'test error' };
             const expectedMessage =
-                "sendMessageToTab(1) failed for message { someData: 'test data', tabId: 1 } with browser error message: test error";
+                'sendMessageToTab(1) failed for message {"someData":"test data","tabId":1} with browser error message: test error';
 
             browserAdapterMock
                 .setup(ba => ba.sendMessageToFrames(It.isAny()))


### PR DESCRIPTION
#### Details

In https://github.com/microsoft/accessibility-insights-web/pull/5188, we learned that a `yargs` module resolution hid that we are using a Node core module `util`. In Webpack 5, [automatic Node.js polyfills were removed](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed) with preference to use frontend-compatible modules. There is only one file that's processed by Wepback that uses `util`, so this PR will repalce `util.inspect` with `JSON.stringify`.

##### Motivation

Supports https://github.com/microsoft/accessibility-insights-web/pull/5188 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

You can find a more detailed description of this decision in https://github.com/microsoft/accessibility-insights-web/pull/5188#issuecomment-1050142256.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
