### PR TITLE
fix(tabstops-auto-target-page-vis): Fix bug in assessment tab stops visualization

### DIFF
--- a/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
+++ b/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
@@ -16,23 +16,25 @@ export const GetVisualizationInstancesForTabStops = (
 ): SelectorToVisualizationMap => {
     const selectorToVisualizationInstanceMap: SelectorToTabStopVisualizationMap = {};
 
-    if (tabStopScanResultData.tabbedElements) {
-        tabStopScanResultData.tabbedElements.forEach(element => {
-            const instance: TabStopVisualizationInstance = {
-                isFailure: false,
-                isVisualizationEnabled: true,
-                ruleResults: null,
-                target: element.target,
-                propertyBag: {
-                    tabOrder: element.tabOrder,
-                    timestamp: element.timestamp,
-                },
-                requirementResults: {},
-            };
-
-            selectorToVisualizationInstanceMap[element.target.join(';')] = instance;
-        });
+    if (!tabStopScanResultData.tabbedElements) {
+        return selectorToVisualizationInstanceMap;
     }
+
+    tabStopScanResultData.tabbedElements.forEach(element => {
+        const instance: TabStopVisualizationInstance = {
+            isFailure: false,
+            isVisualizationEnabled: true,
+            ruleResults: null,
+            target: element.target,
+            propertyBag: {
+                tabOrder: element.tabOrder,
+                timestamp: element.timestamp,
+            },
+            requirementResults: {},
+        };
+
+        selectorToVisualizationInstanceMap[element.target.join(';')] = instance;
+    });
 
     forOwn(tabStopScanResultData.requirements, (obj, requirementId: TabStopRequirementId) => {
         obj.instances.forEach(instance => {

--- a/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
+++ b/src/injected/visualization/get-visualization-instances-for-tab-stops.ts
@@ -16,21 +16,23 @@ export const GetVisualizationInstancesForTabStops = (
 ): SelectorToVisualizationMap => {
     const selectorToVisualizationInstanceMap: SelectorToTabStopVisualizationMap = {};
 
-    tabStopScanResultData.tabbedElements.forEach(element => {
-        const instance: TabStopVisualizationInstance = {
-            isFailure: false,
-            isVisualizationEnabled: true,
-            ruleResults: null,
-            target: element.target,
-            propertyBag: {
-                tabOrder: element.tabOrder,
-                timestamp: element.timestamp,
-            },
-            requirementResults: {},
-        };
+    if (tabStopScanResultData.tabbedElements) {
+        tabStopScanResultData.tabbedElements.forEach(element => {
+            const instance: TabStopVisualizationInstance = {
+                isFailure: false,
+                isVisualizationEnabled: true,
+                ruleResults: null,
+                target: element.target,
+                propertyBag: {
+                    tabOrder: element.tabOrder,
+                    timestamp: element.timestamp,
+                },
+                requirementResults: {},
+            };
 
-        selectorToVisualizationInstanceMap[element.target.join(';')] = instance;
-    });
+            selectorToVisualizationInstanceMap[element.target.join(';')] = instance;
+        });
+    }
 
     forOwn(tabStopScanResultData.requirements, (obj, requirementId: TabStopRequirementId) => {
         obj.instances.forEach(instance => {

--- a/src/tests/unit/tests/injected/visualization/get-visualization-instances-for-tab-stops.test.ts
+++ b/src/tests/unit/tests/injected/visualization/get-visualization-instances-for-tab-stops.test.ts
@@ -111,6 +111,17 @@ describe('GetVisualizationInstancesForTabStops', () => {
         );
     });
 
+    test('GetVisualizationInstancesForTabStops: null tabbedElements', () => {
+        const tabStopRequirementState = {} as TabStopRequirementState;
+
+        const tabStopScanResultData: TabStopsScanResultData = {
+            tabbedElements: null,
+            requirements: tabStopRequirementState,
+        } as TabStopsScanResultData;
+
+        expect(GetVisualizationInstancesForTabStops(tabStopScanResultData)).toEqual({});
+    });
+
     test('GetVisualizationInstancesForTabStops: multiple requirement instances for one element', () => {
         const duplicateSelector = ['some', 'requirement result selector'];
         const firstRequirementResults = [


### PR DESCRIPTION
#### Details

Fixing a bug in which target page visualization does not display for tab stop/focus tracking requirements in assessment when 
`TabStopsAutomation` feature flag is enabled.

##### Motivation

Fix bug introduced by feature work.

##### Context

For some assessments we call `GetVisualizationInstancesForTabStops` with `tabbedElements` null, which prior to this change results in an error.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
