### PR TITLE
feat(tabstops-auto-target-page-vis): fix svg drawer should redraw

### DIFF
--- a/src/injected/visualization/svg-drawer.ts
+++ b/src/injected/visualization/svg-drawer.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { TabbedElementData } from 'common/types/store-data/visualization-scan-result-data';
 import { TabStopVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
-import { chain, each } from 'lodash';
+import { chain, each, isMatch } from 'lodash';
 import { WindowUtils } from '../../common/window-utils';
 import { ShadowUtils } from '../shadow-utils';
 import { BaseDrawer } from './base-drawer';
@@ -40,6 +40,8 @@ export class SVGDrawer extends BaseDrawer {
     ) {
         super(dom, containerClass, windowUtils, shadowUtils, drawerUtils, formatter);
         this.allVisualizedItems = [];
+        this.tabOrderedItems = [];
+        this.failureItems = [];
         this.filterFactory = filterFactory;
         this.svgShapeFactory = svgShapeFactory;
         this.centerPositionCalculator = centerPositionCalculator;
@@ -68,37 +70,24 @@ export class SVGDrawer extends BaseDrawer {
         const dom: Document = this.drawerUtils.getDocumentElement();
 
         for (let pos = 0; pos < visualizationInstances.length; pos++) {
-            const newStateElement: TabStopVisualizationInstance = visualizationInstances[pos];
-            const oldStateElement: TabbedItem = this.allVisualizedItems[pos];
+            const instance = visualizationInstances[pos];
+            const oldStateElement = this.allVisualizedItems[pos];
+            const updatedItem = this.createUpdatedTabbedItem(oldStateElement, instance, dom);
+            this.allVisualizedItems[pos] = updatedItem;
 
-            if (diffFound || this.shouldRedraw(oldStateElement, newStateElement, pos)) {
+            if (diffFound || this.shouldRedraw(oldStateElement, updatedItem)) {
                 diffFound = true;
-                this.allVisualizedItems[pos] = this.createUpdatedTabbedItem(
-                    oldStateElement,
-                    newStateElement,
-                    dom,
-                );
+                updatedItem.shouldRedraw = true;
             } else {
-                this.allVisualizedItems[pos].shouldRedraw = false;
+                updatedItem.shouldRedraw = false;
             }
         }
     }
 
-    private shouldRedraw(
-        oldStateElement: TabbedItem,
-        newStateElement: TabStopVisualizationInstance,
-        pos: number,
-    ): boolean {
-        const elementsInSvgCount: number = this.allVisualizedItems.length;
-        const isLastElementInSvg: boolean = pos === elementsInSvgCount - 1;
-
-        return (
-            oldStateElement == null ||
-            newStateElement.target[newStateElement.target.length - 1] !==
-                oldStateElement.selector ||
-            newStateElement.propertyBag.tabOrder !== oldStateElement.tabOrder ||
-            isLastElementInSvg
-        );
+    private shouldRedraw(oldStateElement: TabbedItem, newStateElement: TabbedItem): boolean {
+        const isLastElementInSvg: boolean =
+            oldStateElement === this.tabOrderedItems[this.tabOrderedItems.length - 1];
+        return !isMatch(oldStateElement, newStateElement) || isLastElementInSvg;
     }
 
     private createUpdatedTabbedItem(
@@ -112,7 +101,6 @@ export class SVGDrawer extends BaseDrawer {
             element: dom.querySelector(selector),
             selector: selector,
             tabOrder: newStateElement.propertyBag.tabOrder,
-            shouldRedraw: true,
             focusIndicator: oldStateElement ? oldStateElement.focusIndicator : null,
             isFailure: newStateElement.isFailure,
             itemType: newStateElement.itemType,


### PR DESCRIPTION
#### Details

Changes how shouldRedraw logic is done.

##### Motivation

feature work

##### Context

The 'isMatch' is not absolutely necessary but feels better than the previous method of checking individual properties.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ x Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
