### PR TITLE
fix(tabstops-auto-target-page-vis): Fix auto detected failures dialog update logic

### DIFF
--- a/src/DetailsView/components/auto-detected-failures-dialog.tsx
+++ b/src/DetailsView/components/auto-detected-failures-dialog.tsx
@@ -33,7 +33,8 @@ export class AutoDetectedFailuresDialog extends React.Component<
     public componentDidUpdate(prevProps, prevState): void {
         const tabbingJustFinished =
             this.props.visualizationScanResultData.tabStops.tabbingCompleted &&
-            !prevProps.visualizationScanResultData.tabStops.tabbingCompleted;
+            !this.props.visualizationScanResultData.tabStops.needToCollectTabbingResults &&
+            prevProps.visualizationScanResultData.tabStops.needToCollectTabbingResults;
         const autoDetectedFailuresExist =
             this.props.visualizationScanResultData.tabStops.requirements &&
             Object.entries(this.props.visualizationScanResultData.tabStops.requirements).some(

--- a/src/tests/unit/tests/DetailsView/components/auto-detected-failures-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/auto-detected-failures-dialog.test.tsx
@@ -18,7 +18,9 @@ describe('AutoDetectedFailuresDialog', () => {
     let visualizationScanResultData: VisualizationScanResultData;
     const prevState = { autoDetectedFailuresDialogEnabled: false };
     const prevProps = {
-        visualizationScanResultData: { tabStops: { tabbingCompleted: false } },
+        visualizationScanResultData: {
+            tabStops: { tabbingCompleted: false, needToCollectTabbingResults: true },
+        },
     };
 
     beforeEach(() => {
@@ -33,7 +35,7 @@ describe('AutoDetectedFailuresDialog', () => {
             },
         };
         visualizationScanResultData = {
-            tabStops: { tabbingCompleted: true, requirements },
+            tabStops: { tabbingCompleted: true, needToCollectTabbingResults: false, requirements },
         } as VisualizationScanResultData;
         props = {
             visualizationScanResultData,


### PR DESCRIPTION
#### Details

Fix bug in which the tab stops auto detected failures dialog did not pop up when the only failures were missing item failures. 

##### Motivation

Fix bug introduced by feature work.

##### Context

Prior to this change, the dialog appeared when `tabbingCompleted` was changed from `false` to `true` and there were requirement results in the data store. This did not work when the only failures were missing elements, because missing element failures are added to the store after `tabbingCompleted` is true. To fix this, we switched to checking for requirement results when `needToCollectTabbingResults` changes from `true` to `false`, as this marks when all results have been collected and are in the data store. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
