### PR TITLE
fix: update .NET core version for mac ESRP signing

### DIFF
--- a/pipeline/unified/channel/sign-release-package-mac.yaml
+++ b/pipeline/unified/channel/sign-release-package-mac.yaml
@@ -22,6 +22,13 @@ jobs:
                 artifact: ${{ parameters.unsignedArtifactName }}
                 path: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core 2.1.0 for ESRP mac mitigation'
+            inputs:
+                packageType: sdk
+                version: 2.1.0
+                installationPath: $(Agent.ToolsDirectory)/dotnet
+
           - template: sign-release-package.yaml
             parameters:
                 filePattern: '*.dmg, *.zip'

--- a/pipeline/unified/channel/sign-release-package-mac.yaml
+++ b/pipeline/unified/channel/sign-release-package-mac.yaml
@@ -26,7 +26,7 @@ jobs:
             displayName: 'Use .NET Core 2.1.0 for ESRP mac mitigation'
             inputs:
                 packageType: sdk
-                version: 2.1.0
+                version: 2.1.x
                 installationPath: $(Agent.ToolsDirectory)/dotnet
 
           - template: sign-release-package.yaml


### PR DESCRIPTION
#### Details

This PR fixes the failed canary build. The build was failing for mac signing because [.NET core 2.1 has reached end of life](https://github.com/actions/virtual-environments/issues/4871) but [ESRP requires the mac signing task to use 2.1](https://marketplace.visualstudio.com/items?itemName=SFP.build-tasks&targetId=465e99f0-a0f9-4257-95e0-04c716327b00). This installs the 2.1.x version for mac. 

This fix was validated by introducing the fix on a separate branch, running the pipeline against the new branch and confirming the build passed. 
