### PR TITLE
feat(tabstops-auto-target-page-vis): fix start over tab stops issue

### DIFF
--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -187,16 +187,14 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
 
     private onAddTabStopInstance = (payload: AddTabStopInstancePayload): void => {
         const { requirementId, description, selector, html } = payload;
-        if (this.state.tabStops.needToCollectTabbingResults) {
-            this.state.tabStops.requirements[requirementId].status = 'fail';
-            this.state.tabStops.requirements[requirementId].instances.push({
-                description,
-                id: this.generateUID(),
-                selector,
-                html,
-            });
-            this.emitChanged();
-        }
+        this.state.tabStops.requirements[requirementId].status = 'fail';
+        this.state.tabStops.requirements[requirementId].instances.push({
+            description,
+            id: this.generateUID(),
+            selector,
+            html,
+        });
+        this.emitChanged();
     };
 
     private onUpdateTabStopInstance = (payload: UpdateTabStopInstancePayload): void => {

--- a/src/injected/analyzers/tab-stops-requirement-result-processor.ts
+++ b/src/injected/analyzers/tab-stops-requirement-result-processor.ts
@@ -19,7 +19,9 @@ export class TabStopsRequirementResultProcessor {
     ) {}
 
     public start = (): void => {
-        if (!this.isStopped) {
+        const state = this.visualizationResultsStore.getState();
+
+        if (!this.isStopped || !state.tabStops.needToCollectTabbingResults) {
             return;
         }
 

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -458,23 +458,6 @@ describe('VisualizationScanResultStoreTest', () => {
                 .withActionParam(payload)
                 .testListenerToBeCalledOnce(initialState, expectedState);
         });
-
-        test('does not add instance when needToCollectTabbingResults is false', () => {
-            initialState.tabStops.needToCollectTabbingResults = false;
-
-            expectedState.tabStops.needToCollectTabbingResults = false;
-
-            const unsavedInstancePayload: AddTabStopInstancePayload = {
-                requirementId: 'keyboard-navigation',
-                description: 'test2',
-                selector: ['selector should not be saved'],
-                html: 'html should not be saved',
-            };
-
-            createStoreTesterForTabStopRequirementActions('addTabStopInstance')
-                .withActionParam(unsavedInstancePayload)
-                .testListenerToNeverBeCalled(initialState, expectedState);
-        });
     });
 
     test('onUpdateTabStopInstance', () => {

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-requirement-result-processor.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-requirement-result-processor.test.ts
@@ -57,6 +57,38 @@ describe('TabStopsRequirementResultProcessor', () => {
         visualizationScanResultsStoreMock
             .setup(m => m.addChangedListener(It.is(isFunction)))
             .verifiable(Times.once());
+        setupVisualizationScanResultStoreMock({
+            tabStops: { needToCollectTabbingResults: true },
+        } as VisualizationScanResultData);
+
+        testSubject.start();
+
+        verifyAll();
+    });
+
+    it('start does not do anything when already started', () => {
+        visualizationScanResultsStoreMock
+            .setup(m => m.addChangedListener(It.is(isFunction)))
+            .verifiable(Times.once());
+        tabStopRequirementRunnerMock.setup(m => m.start()).verifiable(Times.once());
+        setupVisualizationScanResultStoreMock({
+            tabStops: { needToCollectTabbingResults: true },
+        } as VisualizationScanResultData);
+
+        testSubject.start();
+        testSubject.start();
+
+        verifyAll();
+    });
+
+    it('start does not do anything when needToCollectTabbingResults is false', () => {
+        visualizationScanResultsStoreMock
+            .setup(m => m.addChangedListener(It.is(isFunction)))
+            .verifiable(Times.never());
+        tabStopRequirementRunnerMock.setup(m => m.start()).verifiable(Times.never());
+        setupVisualizationScanResultStoreMock({
+            tabStops: { needToCollectTabbingResults: false },
+        } as VisualizationScanResultData);
 
         testSubject.start();
 
@@ -82,6 +114,9 @@ describe('TabStopsRequirementResultProcessor', () => {
         tabStopRequirementActionMessageCreatorMock
             .setup(m => m.addTabStopInstance(It.isValue(secondRequirementResult)))
             .verifiable(Times.once());
+        setupVisualizationScanResultStoreMock({
+            tabStops: { needToCollectTabbingResults: true },
+        } as VisualizationScanResultData);
 
         testSubject.start();
 
@@ -119,11 +154,6 @@ describe('TabStopsRequirementResultProcessor', () => {
         });
 
         it('does not send message when tabbing is not completed', () => {
-            const visualizationScanResultsStoreState = {
-                tabStops: { tabbingCompleted: false, needToCollectTabbingResults: false },
-            } as VisualizationScanResultData;
-
-            setupVisualizationScanResultStoreMock(visualizationScanResultsStoreState);
             tabStopRequirementActionMessageCreatorMock
                 .setup(m => m.updateNeedToCollectTabbingResults(It.isAny()))
                 .verifiable(Times.never());
@@ -136,7 +166,17 @@ describe('TabStopsRequirementResultProcessor', () => {
                 })
                 .verifiable(Times.once());
 
+            setupVisualizationScanResultStoreMock({
+                tabStops: { needToCollectTabbingResults: true },
+            } as VisualizationScanResultData);
             testSubject.start();
+            visualizationScanResultsStoreMock.reset();
+
+            const visualizationScanResultsStoreState = {
+                tabStops: { tabbingCompleted: false, needToCollectTabbingResults: false },
+            } as VisualizationScanResultData;
+            setupVisualizationScanResultStoreMock(visualizationScanResultsStoreState);
+
             visualizationResultsListener();
 
             verifyAll();
@@ -154,6 +194,9 @@ describe('TabStopsRequirementResultProcessor', () => {
         visualizationScanResultsStoreMock
             .setup(m => m.removeChangedListener(It.is(isFunction)))
             .verifiable(Times.once());
+        setupVisualizationScanResultStoreMock({
+            tabStops: { needToCollectTabbingResults: true },
+        } as VisualizationScanResultData);
 
         testSubject.start();
         testSubject.stop();


### PR DESCRIPTION
#### Details

Changes the tab stop requirement result processor to not start when tab results are already collected.

##### Motivation

feature work.

##### Context

Previously, we were depending on the store check to see if we already have completed collecting results for tab stops and then not doing anything if we had. This is an alternative to that: no results are created (since the requirement runner is never started) if that's the case.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
