### PR TITLE
fix(tabstops-auto-target-page-vis): Fix tab stops focus indicator bug

### DIFF
--- a/src/injected/visualization/svg-drawer.ts
+++ b/src/injected/visualization/svg-drawer.ts
@@ -80,8 +80,7 @@ export class SVGDrawer extends BaseDrawer {
 
     private shouldRedraw(oldStateElement: TabbedItem, newStateElement: TabbedItem): boolean {
         const isLastTabbedElement: boolean =
-            oldStateElement != null &&
-            oldStateElement === this.tabOrderedItems[this.tabOrderedItems.length - 1];
+            oldStateElement != null && this.isLastTabbedItem(this.tabOrderedItems, oldStateElement);
         return !isMatch(oldStateElement, newStateElement) || isLastTabbedElement;
     }
 
@@ -323,7 +322,7 @@ export class SVGDrawer extends BaseDrawer {
 
     private getHighlightElements(): HTMLElement[] {
         each(this.tabOrderedItems, (current: TabbedItem, index: number) => {
-            const isLastItem = index === this.tabOrderedItems.length - 1;
+            const isLastItem = this.isLastTabbedItem(this.tabOrderedItems, current);
             if (current.shouldRedraw) {
                 this.removeFocusIndicator(current.focusIndicator);
                 current.focusIndicator = this.createFocusIndicator(
@@ -368,5 +367,10 @@ export class SVGDrawer extends BaseDrawer {
 
     private getTabOrder(element: TabStopVisualizationInstance | TabbedElementData): number {
         return (element as TabbedElementData).tabOrder ?? element.propertyBag?.tabOrder;
+    }
+
+    private isLastTabbedItem(tabOrderedItems: TabbedItem[], current: TabbedItem): boolean {
+        const maxTabOrder = tabOrderedItems.reduce((max, curr) => Math.max(max, curr.tabOrder), 0);
+        return current.tabOrder === maxTabOrder;
     }
 }

--- a/src/tests/end-to-end/tests/details-view/automated-tabstops.test.ts
+++ b/src/tests/end-to-end/tests/details-view/automated-tabstops.test.ts
@@ -85,7 +85,7 @@ describe('Automated TabStops Results', () => {
 
             expect(ruleDetails).toHaveLength(1);
 
-            await verifyTargetPageVisualization(2, 1, 1, 0);
+            await verifyTargetPageVisualization(3, 0, 1, 0);
         },
         longRunningTabStopsTestTimeout,
     );


### PR DESCRIPTION
#### Details

Fix bug in displaying focus indicator circle on tab stops target page visualization. Before this fix, when the user is finished tabbing through the page the focus indicator gets stuck on the last element on the page, even when the tabbing circles back around to the earlier elements. This fix ensures that the focus indicator circle is correct and loops back to the beginning of the page when the user tabs.

##### Motivation

Bug fix in feature work.

##### Context

Previously we were determining the last tabbed element based on the order of the elements in the list we received. With the recent automation changes, this ordering is no longer dependably correct. As a result, we now have to determine the last tabbed element based on the tab order. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
