### PR TITLE
feat(biz-met-1): Save the last app start time in local storage

### DIFF
--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -22,6 +22,7 @@ import { DetailsViewStore } from 'background/stores/details-view-store';
 import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { UnifiedScanResultStore } from 'background/stores/unified-scan-result-store';
 import { ConsoleTelemetryClient } from 'background/telemetry/console-telemetry-client';
+import { UsageLogger } from 'background/usage-logger';
 import { UserConfigurationController } from 'background/user-configuration-controller';
 import { provideBlob } from 'common/blob-provider';
 import { allCardInteractionsSupported } from 'common/components/cards/card-interaction-support';
@@ -545,6 +546,9 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
         const startTesting = () => {
             windowStateActionCreator.setRoute({ routeId: 'resultsView' });
         };
+
+        const usageLogger = new UsageLogger(storageAdapter, DateProvider.getCurrentDate, logger);
+        usageLogger.record();
 
         const deps: RootContainerRendererDeps = {
             ipcRendererShim: ipcRendererShim,


### PR DESCRIPTION
#### Details

For business metrics, we need to keep track of when the Unified client was last used. We've defined "last used" as starting the application, even if the user then immediately exits without scanning, and simply record the value when the renderer initializes. We leverage the code added in #2446. There's no user-visible impact to this feature, and this data will never appear in our telemetry stream.

##### Motivation

Part of business metrics feature.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1927118](https://mseng.visualstudio.com/1ES/_workitems/edit/1927118)
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
