### PR TITLE
feat(tabstops-auto-target-page-vis): error circles are transparent

### DIFF
--- a/src/injected/visualization/tab-stops-formatter.ts
+++ b/src/injected/visualization/tab-stops-formatter.ts
@@ -46,7 +46,7 @@ export class TabStopsFormatter implements Formatter {
             erroredCircle: {
                 stroke: '#E81123',
                 strokeWidth: '2',
-                fill: '#ffffff',
+                fill: 'transparent',
                 ellipseRy: '16',
                 ellipseRx: ellipseRx.toString(),
             },

--- a/src/tests/end-to-end/tests/details-view/automated-tabstops.test.ts
+++ b/src/tests/end-to-end/tests/details-view/automated-tabstops.test.ts
@@ -163,12 +163,12 @@ describe('Automated TabStops Results', () => {
         const opaqueEllipses = await targetPage.getSelectorElements(
             TabStopShadowDomSelectors.opaqueEllipse,
         );
-        expect(opaqueEllipses.length).toBe(regularCount + missingCount + errorCount);
+        expect(opaqueEllipses.length).toBe(regularCount + missingCount);
 
         const transparentEllipses = await targetPage.getSelectorElements(
             TabStopShadowDomSelectors.transparentEllipse,
         );
-        expect(transparentEllipses.length).toBe(focusCount);
+        expect(transparentEllipses.length).toBe(focusCount + errorCount);
 
         const dottedEllipses = await targetPage.getSelectorElements(
             TabStopShadowDomSelectors.dottedEllipse,

--- a/src/tests/unit/tests/injected/visualization/tab-stops-formatter.test.ts
+++ b/src/tests/unit/tests/injected/visualization/tab-stops-formatter.test.ts
@@ -30,7 +30,7 @@ describe('TabStopsFormatterTests', () => {
             erroredCircle: {
                 stroke: '#E81123',
                 strokeWidth: '2',
-                fill: '#ffffff',
+                fill: 'transparent',
                 ellipseRy: '16',
                 ellipseRx: '16',
             },


### PR DESCRIPTION
#### Details

Makes error circles for tab stop requirements transparent, allowing for tab index underneath to be shown.

##### Motivation

feature work

##### Context

Due to how visualizations work, this can result in the line drawn to be visible in the circle if there is an overlap between elements and where the user has tabbed from. We are moving forward with this bug in mind.

Example:

![image](https://user-images.githubusercontent.com/32555133/157316974-34123352-57fb-4bd4-95e9-dca9014b2718.png)

![image](https://user-images.githubusercontent.com/32555133/157317052-046bbb2a-9c3f-4cf3-ab8b-0b78517d4a23.png)



#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
