### PR TITLE
fix: Add emphasis tags to bolded requirement ids in details view results

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -1159,6 +1159,9 @@
         font-weight: 600;
         color: var(--primary-text) !important;
       }
+      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+        font-weight: 600;
+      }
       .rule-details-group--U69fz .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
@@ -1875,7 +1878,7 @@
                         ><span
                           data-automation-id="cards-rule-id"
                           class="rule-details-id"
-                          >bypass</span
+                          ><strong>bypass</strong></span
                         >:
                         <span class="rule-details-description"
                           >Ensures each page has at least one mechanism for a
@@ -2005,7 +2008,7 @@
                         ><span
                           data-automation-id="cards-rule-id"
                           class="rule-details-id"
-                          >color-contrast</span
+                          ><strong>color-contrast</strong></span
                         >:
                         <span class="rule-details-description"
                           >Ensures the contrast between foreground and
@@ -2546,7 +2549,7 @@
                         ><span
                           data-automation-id="cards-rule-id"
                           class="rule-details-id"
-                          >html-has-lang</span
+                          ><strong>html-has-lang</strong></span
                         >:
                         <span class="rule-details-description"
                           >Ensures every HTML document has a lang
@@ -2673,7 +2676,7 @@
                         ><span
                           data-automation-id="cards-rule-id"
                           class="rule-details-id"
-                          >image-alt</span
+                          ><strong>image-alt</strong></span
                         >:
                         <span class="rule-details-description"
                           >Ensures &lt;img&gt; elements have alternate text or a
@@ -3001,7 +3004,7 @@
                         ><span
                           data-automation-id="cards-rule-id"
                           class="rule-details-id"
-                          >label</span
+                          ><strong>label</strong></span
                         >:
                         <span class="rule-details-description"
                           >Ensures every form element has a label</span
@@ -3809,7 +3812,7 @@
                         ><span
                           data-automation-id="cards-rule-id"
                           class="rule-details-id"
-                          >landmark-one-main</span
+                          ><strong>landmark-one-main</strong></span
                         >:
                         <span class="rule-details-description"
                           >Ensures the document has only one main landmark and
@@ -3936,7 +3939,7 @@
                         ><span
                           data-automation-id="cards-rule-id"
                           class="rule-details-id"
-                          >page-has-heading-one</span
+                          ><strong>page-has-heading-one</strong></span
                         >:
                         <span class="rule-details-description"
                           >Ensure that the page, or at least one of its frames
@@ -4062,7 +4065,7 @@
                         ><span
                           data-automation-id="cards-rule-id"
                           class="rule-details-id"
-                          >region</span
+                          ><strong>region</strong></span
                         >:
                         <span class="rule-details-description"
                           >Ensures all page content is contained by

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -1159,6 +1159,9 @@
         font-weight: 600;
         color: var(--primary-text) !important;
       }
+      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+        font-weight: 600;
+      }
       .rule-details-group--U69fz .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -1159,6 +1159,9 @@
         font-weight: 600;
         color: var(--primary-text) !important;
       }
+      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+        font-weight: 600;
+      }
       .rule-details-group--U69fz .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
@@ -1849,7 +1852,7 @@
                             ><span
                               data-automation-id="cards-rule-id"
                               class="rule-details-id"
-                              >bypass</span
+                              ><strong>bypass</strong></span
                             >:
                             <span class="rule-details-description"
                               >Ensures each page has at least one mechanism for
@@ -2200,7 +2203,7 @@
                             ><span
                               data-automation-id="cards-rule-id"
                               class="rule-details-id"
-                              >color-contrast</span
+                              ><strong>color-contrast</strong></span
                             >:
                             <span class="rule-details-description"
                               >Ensures the contrast between foreground and

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -1159,6 +1159,9 @@
         font-weight: 600;
         color: var(--primary-text) !important;
       }
+      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+        font-weight: 600;
+      }
       .rule-details-group--U69fz .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
@@ -1849,7 +1852,7 @@
                             ><span
                               data-automation-id="cards-rule-id"
                               class="rule-details-id"
-                              >bypass</span
+                              ><strong>bypass</strong></span
                             >:
                             <span class="rule-details-description"
                               >Ensures each page has at least one mechanism for
@@ -2194,7 +2197,7 @@
                             ><span
                               data-automation-id="cards-rule-id"
                               class="rule-details-id"
-                              >color-contrast</span
+                              ><strong>color-contrast</strong></span
                             >:
                             <span class="rule-details-description"
                               >Ensures the contrast between foreground and

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -1159,6 +1159,9 @@
         font-weight: 600;
         color: var(--primary-text) !important;
       }
+      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+        font-weight: 600;
+      }
       .rule-details-group--U69fz .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -1159,6 +1159,9 @@
         font-weight: 600;
         color: var(--primary-text) !important;
       }
+      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+        font-weight: 600;
+      }
       .rule-details-group--U69fz .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -1159,6 +1159,9 @@
         font-weight: 600;
         color: var(--primary-text) !important;
       }
+      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+        font-weight: 600;
+      }
       .rule-details-group--U69fz .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;

--- a/src/DetailsView/tab-stops-minimal-requirement-header.scss
+++ b/src/DetailsView/tab-stops-minimal-requirement-header.scss
@@ -9,6 +9,9 @@
     display: flex;
     align-items: baseline;
     text-align: left;
+    strong {
+        font-weight: $fontWeightSemiBold;
+    }
 
     :global(.outcome-chip) {
         vertical-align: middle;

--- a/src/DetailsView/tab-stops-minimal-requirement-header.tsx
+++ b/src/DetailsView/tab-stops-minimal-requirement-header.tsx
@@ -35,7 +35,9 @@ export const TabStopsMinimalRequirementHeader = NamedFC<TabStopsMinimalRequireme
         };
 
         const renderRuleName = () => (
-            <span className={styles.requirementDetailsId}>{requirement.name}</span>
+            <span className={styles.requirementDetailsId}>
+                <strong>{requirement.name}</strong>
+            </span>
         );
 
         const renderDescription = () => (

--- a/src/common/components/cards/rules-with-instances.scss
+++ b/src/common/components/cards/rules-with-instances.scss
@@ -27,6 +27,10 @@
                 font-weight: $fontWeightSemiBold;
                 color: $primary-text !important;
             }
+
+            strong {
+                font-weight: $fontWeightSemiBold;
+            }
         }
 
         :global(.rule-detail-description) {

--- a/src/reports/components/report-sections/minimal-rule-header.tsx
+++ b/src/reports/components/report-sections/minimal-rule-header.tsx
@@ -40,7 +40,7 @@ export const MinimalRuleHeader = NamedFC<MinimalRuleHeaderProps>('MinimalRuleHea
 
     const renderRuleName = () => (
         <span data-automation-id={cardsRuleIdAutomationId} className="rule-details-id">
-            {rule.id}
+            <strong>{rule.id}</strong>
         </span>
     );
 

--- a/src/tests/end-to-end/tests/details-view/cross-origin-iframe.test.ts
+++ b/src/tests/end-to-end/tests/details-view/cross-origin-iframe.test.ts
@@ -119,10 +119,12 @@ describe('scanning', () => {
             const ruleNameElement = await ruleDetail.$(
                 fastPassAutomatedChecksSelectors.cardsRuleId,
             );
-            const ruleName = await fastPassAutomatedChecks.evaluate(
+            let ruleName = await fastPassAutomatedChecks.evaluate(
                 element => element.innerHTML,
                 ruleNameElement,
             );
+            ruleName = ruleName.replace('<strong>', '');
+            ruleName = ruleName.replace('</strong>', '');
 
             const expectedCount = expectedCounts[ruleName];
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-minimal-requirement-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-minimal-requirement-header.test.tsx.snap
@@ -20,7 +20,9 @@ exports[`TabStopsMinimalRequirementHeader renders 1`] = `
     <span
       className="requirementDetailsId"
     >
-      test requirement name
+      <strong>
+        test requirement name
+      </strong>
     </span>
     : 
     <span

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/minimal-rule-header.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/minimal-rule-header.test.tsx.snap
@@ -22,7 +22,9 @@ exports[`MinimalRuleHeader renders, outcomeType = fail 1`] = `
       className="rule-details-id"
       data-automation-id="cards-rule-id"
     >
-      rule id
+      <strong>
+        rule id
+      </strong>
     </span>
     : 
     <span
@@ -47,7 +49,9 @@ exports[`MinimalRuleHeader renders, outcomeType = inapplicable 1`] = `
       className="rule-details-id"
       data-automation-id="cards-rule-id"
     >
-      rule id
+      <strong>
+        rule id
+      </strong>
     </span>
     : 
     <span
@@ -72,7 +76,9 @@ exports[`MinimalRuleHeader renders, outcomeType = incomplete 1`] = `
       className="rule-details-id"
       data-automation-id="cards-rule-id"
     >
-      rule id
+      <strong>
+        rule id
+      </strong>
     </span>
     : 
     <span
@@ -97,7 +103,9 @@ exports[`MinimalRuleHeader renders, outcomeType = pass 1`] = `
       className="rule-details-id"
       data-automation-id="cards-rule-id"
     >
-      rule id
+      <strong>
+        rule id
+      </strong>
     </span>
     : 
     <span
@@ -131,7 +139,9 @@ exports[`MinimalRuleHeader renders, outcomeType = review 1`] = `
       className="rule-details-id"
       data-automation-id="cards-rule-id"
     >
-      rule id
+      <strong>
+        rule id
+      </strong>
     </span>
     : 
     <span


### PR DESCRIPTION
#### Details

Fix emphasis bug found in latest accessibility pass. Requirement names listed in details view requirement failures list appears to be visually bolded but is not surrounded by emphasis tags. 

##### Motivation

Addresses issue #5247.

##### Context

No visual changes, changes only to backing html. 

[Screenshot of details view requirement failure results with requirement name bolded followed by failure details which are not bolded.]
![boldedReqName](https://user-images.githubusercontent.com/16010855/157490096-02e3f9e4-26fd-452b-9c72-77b8d063626b.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5247
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
