### PR TITLE
feat(tabstops-auto-target-page-vis): dismiss tabstops dialog via escape

### DIFF
--- a/src/DetailsView/components/auto-detected-failures-dialog.tsx
+++ b/src/DetailsView/components/auto-detected-failures-dialog.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { DialogFooter, DialogType, PrimaryButton } from '@fluentui/react';
-import { BlockingDialog } from 'common/components/blocking-dialog';
+import { Dialog, DialogFooter, DialogType, PrimaryButton } from '@fluentui/react';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import * as styles from 'DetailsView/components/common-dialog-styles.scss';
 import * as React from 'react';
@@ -51,7 +50,7 @@ export class AutoDetectedFailuresDialog extends React.Component<
         }
 
         return (
-            <BlockingDialog
+            <Dialog
                 hidden={false}
                 dialogContentProps={{
                     type: DialogType.normal,
@@ -60,6 +59,7 @@ export class AutoDetectedFailuresDialog extends React.Component<
                 modalProps={{
                     containerClassName: styles.insightsDialogMainOverride,
                 }}
+                onDismiss={this.dismissAutoDetectedFailuresDialog}
             >
                 <div className={styles.dialogBody}>
                     <ul>
@@ -73,7 +73,7 @@ export class AutoDetectedFailuresDialog extends React.Component<
                         text={'Got it'}
                     />
                 </DialogFooter>
-            </BlockingDialog>
+            </Dialog>
         );
     }
 }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/auto-detected-failures-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/auto-detected-failures-dialog.test.tsx.snap
@@ -2,8 +2,10 @@
 
 exports[`AutoDetectedFailuresDialog on dialog enabled is dismissed when "got it" button is clicked 1`] = `null`;
 
+exports[`AutoDetectedFailuresDialog on dialog enabled is dismissed when onDismiss is called 1`] = `null`;
+
 exports[`AutoDetectedFailuresDialog on dialog enabled renders when dialog is enabled 1`] = `
-<BlockingDialog
+<Dialog
   dialogContentProps={
     Object {
       "title": "Possible failures auto-detected",
@@ -16,6 +18,7 @@ exports[`AutoDetectedFailuresDialog on dialog enabled renders when dialog is ena
       "containerClassName": "insightsDialogMainOverride",
     }
   }
+  onDismiss={[Function]}
 >
   <div
     className="dialogBody"
@@ -35,7 +38,7 @@ exports[`AutoDetectedFailuresDialog on dialog enabled renders when dialog is ena
       text="Got it"
     />
   </StyledDialogFooterBase>
-</BlockingDialog>
+</Dialog>
 `;
 
 exports[`AutoDetectedFailuresDialog renders when dialog is not enabled 1`] = `null`;

--- a/src/tests/unit/tests/DetailsView/components/auto-detected-failures-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/auto-detected-failures-dialog.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { PrimaryButton } from '@fluentui/react';
+import { Dialog, PrimaryButton } from '@fluentui/react';
 import {
     TabStopRequirementState,
     VisualizationScanResultData,
@@ -10,7 +10,7 @@ import {
     AutoDetectedFailuresDialog,
     AutoDetectedFailuresDialogProps,
 } from 'DetailsView/components/auto-detected-failures-dialog';
-import { shallow } from 'enzyme';
+import { shallow, ShallowWrapper } from 'enzyme';
 import * as React from 'react';
 
 describe('AutoDetectedFailuresDialog', () => {
@@ -49,7 +49,8 @@ describe('AutoDetectedFailuresDialog', () => {
     });
 
     describe('on dialog enabled', () => {
-        let wrapper;
+        let wrapper: ShallowWrapper;
+
         beforeEach(() => {
             wrapper = shallow(<AutoDetectedFailuresDialog {...props} />);
             wrapper.instance().componentDidUpdate(prevProps, prevState);
@@ -62,6 +63,11 @@ describe('AutoDetectedFailuresDialog', () => {
         it('is dismissed when "got it" button is clicked', () => {
             wrapper.find(PrimaryButton).simulate('click');
 
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
+
+        it('is dismissed when onDismiss is called', () => {
+            wrapper.find(Dialog).prop('onDismiss')();
             expect(wrapper.getElement()).toMatchSnapshot();
         });
     });


### PR DESCRIPTION
#### Details

Uses the default fluent UI dialog to allow us to light dismiss (escape/click away) from the auto-detected failures dialog.

##### Motivation

feature work

##### Context

N/A

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
