### PR TITLE
feat(tabstops-auto-target-page-vis): enable tab stops automation feature flag

### DIFF
--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -100,10 +100,10 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
         },
         {
             id: FeatureFlags.tabStopsAutomation,
-            defaultValue: false,
+            defaultValue: true,
             displayableName: 'Tab Stops Automation',
             displayableDescription: 'Enables the new tab stops automation',
-            isPreviewFeature: false,
+            isPreviewFeature: true,
             forceDefault: false,
         },
     ];

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
@@ -130,6 +130,53 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
                     Enables exporting reports to external services
                   </div>
                 </div>
+                <div
+                  class="generic-toggle-component--{{CSS_MODULE_HASH}}"
+                >
+                  <div
+                    class="toggle-container--{{CSS_MODULE_HASH}}"
+                  >
+                    <div
+                      class="toggle-name--{{CSS_MODULE_HASH}}"
+                    >
+                      Tab Stops Automation
+                    </div>
+                    <div
+                      class="ms-Toggle is-checked is-enabled toggle--{{CSS_MODULE_HASH}} root-000"
+                    >
+                      <div
+                        class="ms-Toggle-innerContainer container-000"
+                      >
+                        <button
+                          aria-checked="true"
+                          aria-label="Tab Stops Automation"
+                          class="ms-Toggle-background pill-000"
+                          data-is-focusable="true"
+                          data-ktp-target="true"
+                          id="tabStopsAutomation"
+                          role="switch"
+                          type="button"
+                        >
+                          <span
+                            class="ms-Toggle-thumb thumb-000"
+                          />
+                        </button>
+                        <label
+                          class="ms-Label ms-Toggle-stateText text-000"
+                          for="tabStopsAutomation"
+                          id="tabStopsAutomation-stateText"
+                        >
+                          On
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="toggle-description--{{CSS_MODULE_HASH}}"
+                  >
+                    Enables the new tab stops automation
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -25,7 +25,7 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.manualInstanceDetails]: false,
             [FeatureFlags.debugTools]: false,
             [FeatureFlags.exportReportOptions]: false,
-            [FeatureFlags.tabStopsAutomation]: false,
+            [FeatureFlags.tabStopsAutomation]: true,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Enable Tab Stops Automation feature flag by default and show it as a preview feature for release.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Turn on new tab stops automation feature for users.

##### Context

![image](https://user-images.githubusercontent.com/48259897/157638672-aae12f39-d4d6-4a34-9d75-d0856deb6f70.png)
(Screenshot of Preview features panel, with Tab Stops Automation toggled on)

This feature flag will be removed in a future release.
<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
