### PR TITLE
chore: make snapshots of typemoq mocks less brittle

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -41,6 +41,7 @@ module.exports = {
         ],
     ],
     setupFilesAfterEnv: [`${__dirname}/src/tests/common/flush-promises-after-each-test.ts`],
+    snapshotSerializers: [`${__dirname}/src/tests/common/typemoq-snapshot-serializer.ts`],
     testEnvironment: 'node',
     testMatch: ['**/*.spec.[tj]s', '**/*.test.[tj]s'],
     testPathIgnorePatterns: ['/dist/', '/out/'],

--- a/src/tests/common/typemoq-snapshot-serializer.ts
+++ b/src/tests/common/typemoq-snapshot-serializer.ts
@@ -15,7 +15,7 @@ import { MockException } from 'typemoq';
 // See https://github.com/florinn/typemoq/blob/master/src/Consts.ts
 const typemoqProxyIdValue = 'BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8';
 
-function readingPropertyThrowsMockException(val: unknown): boolean {
+function readingPropertyThrowsMockException(val: Function): boolean {
     try {
         val['___any_property'];
     } catch (e: any) {

--- a/src/tests/common/typemoq-snapshot-serializer.ts
+++ b/src/tests/common/typemoq-snapshot-serializer.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { MockException } from 'typemoq';
+
 // This file is a Jest Snapshot Serializer which serializes all typemoq mock objects as a
 // constant string, similar to how Jest serializes functions as the constant string "[Function]"
 //
@@ -13,10 +15,35 @@
 // See https://github.com/florinn/typemoq/blob/master/src/Consts.ts
 const typemoqProxyIdValue = 'BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8';
 
-export function test(val: unknown): boolean {
-    return val != null && typeof val === 'object' && val['___id'] === typemoqProxyIdValue;
+function readingPropertyThrowsMockException(val: unknown): boolean {
+    try {
+        val['___any_property'];
+    } catch (e: any) {
+        if (e instanceof MockException) {
+            return true;
+        }
+    }
+    return false;
 }
 
-export function serialize(): string {
-    return '[typemoq mock object]';
+export function test(val: unknown): boolean {
+    if (val == null) {
+        return false;
+    }
+
+    if (typeof val === 'object' && val['___id'] === typemoqProxyIdValue) {
+        // This is a typemoq mock object (eg, Mock.of<Type>().object)
+        return true;
+    }
+
+    if (typeof val === 'function' && readingPropertyThrowsMockException(val)) {
+        // This is a method of a typemoq mock object (eg, Mock.of<Type>().object.someMethod)
+        return true;
+    }
+
+    return false;
+}
+
+export function serialize(val: unknown): string {
+    return `[typemoq mock ${typeof val}]`;
 }

--- a/src/tests/common/typemoq-snapshot-serializer.ts
+++ b/src/tests/common/typemoq-snapshot-serializer.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This file is a Jest Snapshot Serializer which serializes all typemoq mock objects as a
+// constant string, similar to how Jest serializes functions as the constant string "[Function]"
+//
+// References:
+// * https://jestjs.io/docs/expect#expectaddsnapshotserializerserializer
+// * https://jestjs.io/docs/configuration#snapshotserializers-arraystring
+// * https://github.com/facebook/jest/blob/main/packages/pretty-format/README.md#serialize
+
+// This is a hardcoded constant value that typemoq embeds into every Mock proxy object it creates.
+// See https://github.com/florinn/typemoq/blob/master/src/Consts.ts
+const typemoqProxyIdValue = 'BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8';
+
+export function test(val: unknown): boolean {
+    return val != null && typeof val === 'object' && val['___id'] === typemoqProxyIdValue;
+}
+
+export function serialize(): string {
+    return '[typemoq mock object]';
+}

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
@@ -4,40 +4,8 @@ exports[`DetailsViewContainer render content render once; should call details vi
 <DetailsViewContentWithLocalState
   deps={
     Object {
-      "detailsViewActionMessageCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "addPathForValidation": [Function],
-        "cancelStartOver": [Function],
-        "cancelStartOverAllAssessments": [Function],
-        "changeAssessmentVisualizationState": [Function],
-        "changeManualRequirementStatus": [Function],
-        "changeManualTestStatus": [Function],
-        "clearPathSnippetData": [Function],
-        "closePreviewFeaturesPanel": [Function],
-        "closeScopingPanel": [Function],
-        "closeSettingsPanel": [Function],
-        "continuePreviousAssessment": [Function],
-        "copyIssueDetailsClicked": [Function],
-        "dispatcher": undefined,
-        "editFailureInstance": [Function],
-        "leftNavPanelExpanded": [Function],
-        "loadAssessment": [Function],
-        "removeFailureInstance": [Function],
-        "rescanVisualization": [Function],
-        "rescanVisualizationWithoutTelemetry": [Function],
-        "saveAssessment": [Function],
-        "setAllUrlsPermissionState": [Function],
-        "setFeatureFlag": [Function],
-        "startOverAllAssessments": [Function],
-        "switchToTargetTab": [Function],
-        "telemetryFactory": undefined,
-        "undoManualRequirementStatusChange": [Function],
-        "undoManualTestStatusChange": [Function],
-      },
-      "storesHub": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "stores": undefined,
-      },
+      "detailsViewActionMessageCreator": [typemoq mock object],
+      "storesHub": [typemoq mock object],
     }
   }
   storeState={
@@ -61,19 +29,13 @@ exports[`DetailsViewContainer render content show NoContentAvailable when stores
     childrenProps={
       Object {
         "deps": Object {
-          "storesHub": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "stores": undefined,
-          },
+          "storesHub": [typemoq mock object],
         },
       }
     }
     deps={
       Object {
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
-        },
+        "storesHub": [typemoq mock object],
       }
     }
     isNarrowModeEnabled={false}
@@ -89,19 +51,13 @@ exports[`DetailsViewContainer render content show NoContentAvailable when target
     childrenProps={
       Object {
         "deps": Object {
-          "storesHub": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "stores": undefined,
-          },
+          "storesHub": [typemoq mock object],
         },
       }
     }
     deps={
       Object {
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
-        },
+        "storesHub": [typemoq mock object],
       }
     }
     isNarrowModeEnabled={true}
@@ -117,19 +73,13 @@ exports[`DetailsViewContainer render content shows NoContentAvailable when targe
     childrenProps={
       Object {
         "deps": Object {
-          "storesHub": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "stores": undefined,
-          },
+          "storesHub": [typemoq mock object],
         },
       }
     }
     deps={
       Object {
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
-        },
+        "storesHub": [typemoq mock object],
       }
     }
     isNarrowModeEnabled={true}

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -5,45 +5,8 @@ exports[` render renders normally 1`] = `
   <InteractiveHeader
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
-        "dropdownClickHandler": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dropdownActionMessageCreator": undefined,
-          "openDebugTools": [Function],
-          "openPreviewFeaturesPanelHandler": [Function],
-          "openScopingPanelHandler": [Function],
-          "openSettingsPanelHandler": [Function],
-          "source": undefined,
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
+        "dropdownClickHandler": [typemoq mock object],
         "getCardSelectionViewData": [Function],
         "getCardViewData": [Function],
         "getDateFromTimestamp": [Function],
@@ -51,10 +14,7 @@ exports[` render renders normally 1`] = `
         "getDetailsSwitcherNavConfiguration": [Function],
         "isResultHighlightUnavailable": [Function],
         "storeActionMessageCreator": undefined,
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
-        },
+        "storesHub": [typemoq mock object],
       }
     }
     featureFlagStoreData={
@@ -89,45 +49,8 @@ exports[` render renders normally 1`] = `
     automatedChecksCardsViewData={Object {}}
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
-        "dropdownClickHandler": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dropdownActionMessageCreator": undefined,
-          "openDebugTools": [Function],
-          "openPreviewFeaturesPanelHandler": [Function],
-          "openScopingPanelHandler": [Function],
-          "openSettingsPanelHandler": [Function],
-          "source": undefined,
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
+        "dropdownClickHandler": [typemoq mock object],
         "getCardSelectionViewData": [Function],
         "getCardViewData": [Function],
         "getDateFromTimestamp": [Function],
@@ -135,10 +58,7 @@ exports[` render renders normally 1`] = `
         "getDetailsSwitcherNavConfiguration": [Function],
         "isResultHighlightUnavailable": [Function],
         "storeActionMessageCreator": undefined,
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
-        },
+        "storesHub": [typemoq mock object],
       }
     }
     detailsViewStoreData={
@@ -154,17 +74,7 @@ exports[` render renders normally 1`] = `
         "detailsViewRightContentPanel": "TestView",
       }
     }
-    dropdownClickHandler={
-      proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "dropdownActionMessageCreator": undefined,
-        "openDebugTools": [Function],
-        "openPreviewFeaturesPanelHandler": [Function],
-        "openScopingPanelHandler": [Function],
-        "openSettingsPanelHandler": [Function],
-        "source": undefined,
-      }
-    }
+    dropdownClickHandler={[typemoq mock object]}
     featureFlagStoreData={
       Object {
         "logTelemetryToConsole": false,
@@ -473,45 +383,8 @@ exports[` render renders normally 1`] = `
   <DetailsViewOverlay
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
-        "dropdownClickHandler": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dropdownActionMessageCreator": undefined,
-          "openDebugTools": [Function],
-          "openPreviewFeaturesPanelHandler": [Function],
-          "openScopingPanelHandler": [Function],
-          "openSettingsPanelHandler": [Function],
-          "source": undefined,
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
+        "dropdownClickHandler": [typemoq mock object],
         "getCardSelectionViewData": [Function],
         "getCardViewData": [Function],
         "getDateFromTimestamp": [Function],
@@ -519,10 +392,7 @@ exports[` render renders normally 1`] = `
         "getDetailsSwitcherNavConfiguration": [Function],
         "isResultHighlightUnavailable": [Function],
         "storeActionMessageCreator": undefined,
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
-        },
+        "storesHub": [typemoq mock object],
       }
     }
     detailsViewStoreData={

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-issues-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-issues-test-view.test.tsx.snap
@@ -12,13 +12,7 @@ exports[`AdhocIssuesTestView should return DetailsListIssuesView 1`] = `
       warnings={Array []}
     />
     <DetailsListIssuesView
-      clickHandlerFactory={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "actionCreator": undefined,
-          "telemetryFactory": undefined,
-        }
-      }
+      clickHandlerFactory={[typemoq mock object]}
       configuration={
         Object {
           "displayableData": Object {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -78,36 +78,7 @@ exports[`DetailsViewCommandBar renders with export button and start over 1`] = `
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -159,36 +130,7 @@ exports[`DetailsViewCommandBar renders with export button and start over 1`] = `
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -250,36 +192,7 @@ exports[`DetailsViewCommandBar renders with export button and start over 1`] = `
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     dialogState="none"
@@ -377,36 +290,7 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -458,36 +342,7 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -549,36 +404,7 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     dialogState="none"
@@ -670,36 +496,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog hidde
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -751,36 +548,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog hidde
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -842,36 +610,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog hidde
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     dialogState="none"
@@ -963,36 +702,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog open 
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={true}
@@ -1044,36 +754,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog open 
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -1135,36 +816,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog open 
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     dialogState="none"
@@ -1269,36 +921,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog hidden 1`] = 
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -1350,36 +973,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog hidden 1`] = 
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -1441,36 +1035,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog hidden 1`] = 
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     dialogState="none"
@@ -1562,36 +1127,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog open 1`] = `
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -1643,36 +1179,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog open 1`] = `
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={true}
@@ -1734,36 +1241,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog open 1`] = `
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     dialogState="none"
@@ -1855,36 +1333,7 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -1936,36 +1385,7 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -2027,36 +1447,7 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     dialogState="none"
@@ -2207,36 +1598,7 @@ exports[`DetailsViewCommandBar renders without export button and without start o
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -2288,36 +1650,7 @@ exports[`DetailsViewCommandBar renders without export button and without start o
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -2379,36 +1712,7 @@ exports[`DetailsViewCommandBar renders without export button and without start o
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     dialogState="none"
@@ -2505,36 +1809,7 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -2586,36 +1861,7 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     isOpen={false}
@@ -2677,36 +1923,7 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
     }
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     dialogState="none"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
@@ -23,16 +23,8 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have ch
   <IssueFilingSettingsContainer
     deps={
       Object {
-        "issueFilingActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-        },
-        "issueFilingServiceProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "services": undefined,
-        },
+        "issueFilingActionMessageCreator": [typemoq mock object],
+        "issueFilingServiceProvider": [typemoq mock object],
         "toolData": Object {
           "applicationProperties": Object {
             "environmentName": "environmentName",
@@ -44,14 +36,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have ch
             "version": "engine-version",
           },
         },
-        "userConfigMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "saveIssueFilingSettings": [Function],
-          "saveWindowBounds": [Function],
-          "setIssueFilingService": [Function],
-          "setIssueFilingServiceProperty": [Function],
-        },
+        "userConfigMessageCreator": [typemoq mock object],
       }
     }
     onPropertyUpdateCallback={[Function]}
@@ -104,16 +89,8 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have no
   <IssueFilingSettingsContainer
     deps={
       Object {
-        "issueFilingActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-        },
-        "issueFilingServiceProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "services": undefined,
-        },
+        "issueFilingActionMessageCreator": [typemoq mock object],
+        "issueFilingServiceProvider": [typemoq mock object],
         "toolData": Object {
           "applicationProperties": Object {
             "environmentName": "environmentName",
@@ -125,14 +102,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have no
             "version": "engine-version",
           },
         },
-        "userConfigMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "saveIssueFilingSettings": [Function],
-          "saveWindowBounds": [Function],
-          "setIssueFilingService": [Function],
-          "setIssueFilingServiceProperty": [Function],
-        },
+        "userConfigMessageCreator": [typemoq mock object],
       }
     }
     onPropertyUpdateCallback={[Function]}
@@ -185,16 +155,8 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have change
   <IssueFilingSettingsContainer
     deps={
       Object {
-        "issueFilingActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-        },
-        "issueFilingServiceProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "services": undefined,
-        },
+        "issueFilingActionMessageCreator": [typemoq mock object],
+        "issueFilingServiceProvider": [typemoq mock object],
         "toolData": Object {
           "applicationProperties": Object {
             "environmentName": "environmentName",
@@ -206,14 +168,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have change
             "version": "engine-version",
           },
         },
-        "userConfigMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "saveIssueFilingSettings": [Function],
-          "saveWindowBounds": [Function],
-          "setIssueFilingService": [Function],
-          "setIssueFilingServiceProperty": [Function],
-        },
+        "userConfigMessageCreator": [typemoq mock object],
       }
     }
     onPropertyUpdateCallback={[Function]}
@@ -266,16 +221,8 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have not ch
   <IssueFilingSettingsContainer
     deps={
       Object {
-        "issueFilingActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-        },
-        "issueFilingServiceProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "services": undefined,
-        },
+        "issueFilingActionMessageCreator": [typemoq mock object],
+        "issueFilingServiceProvider": [typemoq mock object],
         "toolData": Object {
           "applicationProperties": Object {
             "environmentName": "environmentName",
@@ -287,14 +234,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have not ch
             "version": "engine-version",
           },
         },
-        "userConfigMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "saveIssueFilingSettings": [Function],
-          "saveWindowBounds": [Function],
-          "setIssueFilingService": [Function],
-          "setIssueFilingServiceProperty": [Function],
-        },
+        "userConfigMessageCreator": [typemoq mock object],
       }
     }
     onPropertyUpdateCallback={[Function]}
@@ -347,16 +287,8 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
   <IssueFilingSettingsContainer
     deps={
       Object {
-        "issueFilingActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-        },
-        "issueFilingServiceProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "services": undefined,
-        },
+        "issueFilingActionMessageCreator": [typemoq mock object],
+        "issueFilingServiceProvider": [typemoq mock object],
         "toolData": Object {
           "applicationProperties": Object {
             "environmentName": "environmentName",
@@ -368,14 +300,7 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
             "version": "engine-version",
           },
         },
-        "userConfigMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "saveIssueFilingSettings": [Function],
-          "saveWindowBounds": [Function],
-          "setIssueFilingService": [Function],
-          "setIssueFilingServiceProperty": [Function],
-        },
+        "userConfigMessageCreator": [typemoq mock object],
       }
     }
     onPropertyUpdateCallback={[Function]}
@@ -428,16 +353,8 @@ exports[`IssueFilingDialog render with isSettingsValid: true 1`] = `
   <IssueFilingSettingsContainer
     deps={
       Object {
-        "issueFilingActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-        },
-        "issueFilingServiceProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "services": undefined,
-        },
+        "issueFilingActionMessageCreator": [typemoq mock object],
+        "issueFilingServiceProvider": [typemoq mock object],
         "toolData": Object {
           "applicationProperties": Object {
             "environmentName": "environmentName",
@@ -449,14 +366,7 @@ exports[`IssueFilingDialog render with isSettingsValid: true 1`] = `
             "version": "engine-version",
           },
         },
-        "userConfigMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "saveIssueFilingSettings": [Function],
-          "saveWindowBounds": [Function],
-          "setIssueFilingService": [Function],
-          "setIssueFilingServiceProperty": [Function],
-        },
+        "userConfigMessageCreator": [typemoq mock object],
       }
     }
     onPropertyUpdateCallback={[Function]}
@@ -509,16 +419,8 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
   <IssueFilingSettingsContainer
     deps={
       Object {
-        "issueFilingActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-        },
-        "issueFilingServiceProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "services": undefined,
-        },
+        "issueFilingActionMessageCreator": [typemoq mock object],
+        "issueFilingServiceProvider": [typemoq mock object],
         "toolData": Object {
           "applicationProperties": Object {
             "environmentName": "environmentName",
@@ -530,14 +432,7 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
             "version": "engine-version",
           },
         },
-        "userConfigMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "saveIssueFilingSettings": [Function],
-          "saveWindowBounds": [Function],
-          "setIssueFilingService": [Function],
-          "setIssueFilingServiceProperty": [Function],
-        },
+        "userConfigMessageCreator": [typemoq mock object],
       }
     }
     onPropertyUpdateCallback={[Function]}
@@ -591,16 +486,8 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
   <IssueFilingSettingsContainer
     deps={
       Object {
-        "issueFilingActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-        },
-        "issueFilingServiceProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "services": undefined,
-        },
+        "issueFilingActionMessageCreator": [typemoq mock object],
+        "issueFilingServiceProvider": [typemoq mock object],
         "toolData": Object {
           "applicationProperties": Object {
             "environmentName": "environmentName",
@@ -612,14 +499,7 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
             "version": "engine-version",
           },
         },
-        "userConfigMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "saveIssueFilingSettings": [Function],
-          "saveWindowBounds": [Function],
-          "setIssueFilingService": [Function],
-          "setIssueFilingServiceProperty": [Function],
-        },
+        "userConfigMessageCreator": [typemoq mock object],
       }
     }
     onPropertyUpdateCallback={[Function]}
@@ -672,16 +552,8 @@ exports[`IssueFilingDialog render: validate callback (onSelectedServiceChange) s
   <IssueFilingSettingsContainer
     deps={
       Object {
-        "issueFilingActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-        },
-        "issueFilingServiceProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "services": undefined,
-        },
+        "issueFilingActionMessageCreator": [typemoq mock object],
+        "issueFilingServiceProvider": [typemoq mock object],
         "toolData": Object {
           "applicationProperties": Object {
             "environmentName": "environmentName",
@@ -693,14 +565,7 @@ exports[`IssueFilingDialog render: validate callback (onSelectedServiceChange) s
             "version": "engine-version",
           },
         },
-        "userConfigMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "saveIssueFilingSettings": [Function],
-          "saveWindowBounds": [Function],
-          "setIssueFilingService": [Function],
-          "setIssueFilingServiceProperty": [Function],
-        },
+        "userConfigMessageCreator": [typemoq mock object],
       }
     }
     onPropertyUpdateCallback={[Function]}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
@@ -66,43 +66,9 @@ exports[`IssuesTableTest automated checks disabled 1`] = `
       }
       deps={
         Object {
-          "detailsViewActionMessageCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "addPathForValidation": [Function],
-            "cancelStartOver": [Function],
-            "cancelStartOverAllAssessments": [Function],
-            "changeAssessmentVisualizationState": [Function],
-            "changeManualRequirementStatus": [Function],
-            "changeManualTestStatus": [Function],
-            "clearPathSnippetData": [Function],
-            "closePreviewFeaturesPanel": [Function],
-            "closeScopingPanel": [Function],
-            "closeSettingsPanel": [Function],
-            "continuePreviousAssessment": [Function],
-            "copyIssueDetailsClicked": [Function],
-            "dispatcher": undefined,
-            "editFailureInstance": [Function],
-            "leftNavPanelExpanded": [Function],
-            "loadAssessment": [Function],
-            "removeFailureInstance": [Function],
-            "rescanVisualization": [Function],
-            "rescanVisualizationWithoutTelemetry": [Function],
-            "saveAssessment": [Function],
-            "setAllUrlsPermissionState": [Function],
-            "setFeatureFlag": [Function],
-            "startOverAllAssessments": [Function],
-            "switchToTargetTab": [Function],
-            "telemetryFactory": undefined,
-            "undoManualRequirementStatusChange": [Function],
-            "undoManualTestStatusChange": [Function],
-          },
+          "detailsViewActionMessageCreator": [typemoq mock object],
           "getDateFromTimestamp": [Function],
-          "reportGenerator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "assessmentJsonExportGenerator": undefined,
-            "assessmentReportHtmlGenerator": undefined,
-            "fastPassReportHtmlGenerator": undefined,
-          },
+          "reportGenerator": [typemoq mock object],
         }
       }
       scanMetadata={
@@ -212,43 +178,9 @@ exports[`IssuesTableTest not scanning, issuesEnabled is true 1`] = `
       }
       deps={
         Object {
-          "detailsViewActionMessageCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "addPathForValidation": [Function],
-            "cancelStartOver": [Function],
-            "cancelStartOverAllAssessments": [Function],
-            "changeAssessmentVisualizationState": [Function],
-            "changeManualRequirementStatus": [Function],
-            "changeManualTestStatus": [Function],
-            "clearPathSnippetData": [Function],
-            "closePreviewFeaturesPanel": [Function],
-            "closeScopingPanel": [Function],
-            "closeSettingsPanel": [Function],
-            "continuePreviousAssessment": [Function],
-            "copyIssueDetailsClicked": [Function],
-            "dispatcher": undefined,
-            "editFailureInstance": [Function],
-            "leftNavPanelExpanded": [Function],
-            "loadAssessment": [Function],
-            "removeFailureInstance": [Function],
-            "rescanVisualization": [Function],
-            "rescanVisualizationWithoutTelemetry": [Function],
-            "saveAssessment": [Function],
-            "setAllUrlsPermissionState": [Function],
-            "setFeatureFlag": [Function],
-            "startOverAllAssessments": [Function],
-            "switchToTargetTab": [Function],
-            "telemetryFactory": undefined,
-            "undoManualRequirementStatusChange": [Function],
-            "undoManualTestStatusChange": [Function],
-          },
+          "detailsViewActionMessageCreator": [typemoq mock object],
           "getDateFromTimestamp": [Function],
-          "reportGenerator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "assessmentJsonExportGenerator": undefined,
-            "assessmentReportHtmlGenerator": undefined,
-            "fastPassReportHtmlGenerator": undefined,
-          },
+          "reportGenerator": [typemoq mock object],
         }
       }
       scanMetadata={

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/load-assessment-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/load-assessment-dialog.test.tsx.snap
@@ -4,39 +4,8 @@ exports[`LoadAssessmentDialog should not show when isOpen is set to false 1`] = 
 <ChangeAssessmentDialog
   deps={
     Object {
-      "detailsViewActionMessageCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "addPathForValidation": [Function],
-        "cancelStartOver": [Function],
-        "cancelStartOverAllAssessments": [Function],
-        "changeAssessmentVisualizationState": [Function],
-        "changeManualRequirementStatus": [Function],
-        "changeManualTestStatus": [Function],
-        "clearPathSnippetData": [Function],
-        "closePreviewFeaturesPanel": [Function],
-        "closeScopingPanel": [Function],
-        "closeSettingsPanel": [Function],
-        "continuePreviousAssessment": [Function],
-        "copyIssueDetailsClicked": [Function],
-        "dispatcher": undefined,
-        "editFailureInstance": [Function],
-        "leftNavPanelExpanded": [Function],
-        "loadAssessment": [Function],
-        "removeFailureInstance": [Function],
-        "rescanVisualization": [Function],
-        "rescanVisualizationWithoutTelemetry": [Function],
-        "saveAssessment": [Function],
-        "setAllUrlsPermissionState": [Function],
-        "setFeatureFlag": [Function],
-        "startOverAllAssessments": [Function],
-        "switchToTargetTab": [Function],
-        "telemetryFactory": undefined,
-        "undoManualRequirementStatusChange": [Function],
-        "undoManualTestStatusChange": [Function],
-      },
-      "urlParser": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      },
+      "detailsViewActionMessageCreator": [typemoq mock object],
+      "urlParser": [typemoq mock object],
     }
   }
   dialogContentTitle="Assessment in progress"
@@ -70,39 +39,8 @@ exports[`LoadAssessmentDialog should show when isOpen is set to true 1`] = `
 <ChangeAssessmentDialog
   deps={
     Object {
-      "detailsViewActionMessageCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "addPathForValidation": [Function],
-        "cancelStartOver": [Function],
-        "cancelStartOverAllAssessments": [Function],
-        "changeAssessmentVisualizationState": [Function],
-        "changeManualRequirementStatus": [Function],
-        "changeManualTestStatus": [Function],
-        "clearPathSnippetData": [Function],
-        "closePreviewFeaturesPanel": [Function],
-        "closeScopingPanel": [Function],
-        "closeSettingsPanel": [Function],
-        "continuePreviousAssessment": [Function],
-        "copyIssueDetailsClicked": [Function],
-        "dispatcher": undefined,
-        "editFailureInstance": [Function],
-        "leftNavPanelExpanded": [Function],
-        "loadAssessment": [Function],
-        "removeFailureInstance": [Function],
-        "rescanVisualization": [Function],
-        "rescanVisualizationWithoutTelemetry": [Function],
-        "saveAssessment": [Function],
-        "setAllUrlsPermissionState": [Function],
-        "setFeatureFlag": [Function],
-        "startOverAllAssessments": [Function],
-        "switchToTargetTab": [Function],
-        "telemetryFactory": undefined,
-        "undoManualRequirementStatusChange": [Function],
-        "undoManualTestStatusChange": [Function],
-      },
-      "urlParser": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      },
+      "detailsViewActionMessageCreator": [typemoq mock object],
+      "urlParser": [typemoq mock object],
     }
   }
   dialogContentTitle="Assessment in progress"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
@@ -5,48 +5,11 @@ exports[`ReportExportDialogFactory getReportExportDialogForAssessment expected p
   afterDialogDismissed={[Function]}
   deps={
     Object {
-      "detailsViewActionMessageCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "addPathForValidation": [Function],
-        "cancelStartOver": [Function],
-        "cancelStartOverAllAssessments": [Function],
-        "changeAssessmentVisualizationState": [Function],
-        "changeManualRequirementStatus": [Function],
-        "changeManualTestStatus": [Function],
-        "clearPathSnippetData": [Function],
-        "closePreviewFeaturesPanel": [Function],
-        "closeScopingPanel": [Function],
-        "closeSettingsPanel": [Function],
-        "continuePreviousAssessment": [Function],
-        "copyIssueDetailsClicked": [Function],
-        "dispatcher": undefined,
-        "editFailureInstance": [Function],
-        "leftNavPanelExpanded": [Function],
-        "loadAssessment": [Function],
-        "removeFailureInstance": [Function],
-        "rescanVisualization": [Function],
-        "rescanVisualizationWithoutTelemetry": [Function],
-        "saveAssessment": [Function],
-        "setAllUrlsPermissionState": [Function],
-        "setFeatureFlag": [Function],
-        "startOverAllAssessments": [Function],
-        "switchToTargetTab": [Function],
-        "telemetryFactory": undefined,
-        "undoManualRequirementStatusChange": [Function],
-        "undoManualTestStatusChange": [Function],
-      },
+      "detailsViewActionMessageCreator": [typemoq mock object],
       "getCurrentDate": [Function],
       "getDateFromTimestamp": [Function],
-      "reportExportServiceProvider": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "services": undefined,
-      },
-      "reportGenerator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "assessmentJsonExportGenerator": undefined,
-        "assessmentReportHtmlGenerator": undefined,
-        "fastPassReportHtmlGenerator": undefined,
-      },
+      "reportExportServiceProvider": [typemoq mock object],
+      "reportGenerator": [typemoq mock object],
     }
   }
   dismissExportDialog={[Function]}
@@ -84,48 +47,11 @@ exports[`ReportExportDialogFactory getReportExportDialogForFastPass expected pro
   afterDialogDismissed={[Function]}
   deps={
     Object {
-      "detailsViewActionMessageCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "addPathForValidation": [Function],
-        "cancelStartOver": [Function],
-        "cancelStartOverAllAssessments": [Function],
-        "changeAssessmentVisualizationState": [Function],
-        "changeManualRequirementStatus": [Function],
-        "changeManualTestStatus": [Function],
-        "clearPathSnippetData": [Function],
-        "closePreviewFeaturesPanel": [Function],
-        "closeScopingPanel": [Function],
-        "closeSettingsPanel": [Function],
-        "continuePreviousAssessment": [Function],
-        "copyIssueDetailsClicked": [Function],
-        "dispatcher": undefined,
-        "editFailureInstance": [Function],
-        "leftNavPanelExpanded": [Function],
-        "loadAssessment": [Function],
-        "removeFailureInstance": [Function],
-        "rescanVisualization": [Function],
-        "rescanVisualizationWithoutTelemetry": [Function],
-        "saveAssessment": [Function],
-        "setAllUrlsPermissionState": [Function],
-        "setFeatureFlag": [Function],
-        "startOverAllAssessments": [Function],
-        "switchToTargetTab": [Function],
-        "telemetryFactory": undefined,
-        "undoManualRequirementStatusChange": [Function],
-        "undoManualTestStatusChange": [Function],
-      },
+      "detailsViewActionMessageCreator": [typemoq mock object],
       "getCurrentDate": [Function],
       "getDateFromTimestamp": [Function],
-      "reportExportServiceProvider": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "services": undefined,
-      },
-      "reportGenerator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "assessmentJsonExportGenerator": undefined,
-        "assessmentReportHtmlGenerator": undefined,
-        "fastPassReportHtmlGenerator": undefined,
-      },
+      "reportExportServiceProvider": [typemoq mock object],
+      "reportGenerator": [typemoq mock object],
     }
   }
   dismissExportDialog={[Function]}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-view.test.tsx.snap
@@ -8,12 +8,8 @@ exports[`RequirementViewTest renders with content from props 1`] = `
     <RequirementViewTitle
       deps={
         Object {
-          "assessmentViewUpdateHandler": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          },
-          "assessmentsProvider": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          },
+          "assessmentViewUpdateHandler": [typemoq mock object],
+          "assessmentsProvider": [typemoq mock object],
         }
       }
       name="test-requirement-name"
@@ -46,11 +42,7 @@ exports[`RequirementViewTest renders with content from props 1`] = `
             "selectedTestType": 0,
           }
         }
-        assessmentsProvider={
-          proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          }
-        }
+        assessmentsProvider={[typemoq mock object]}
         featureFlagStoreData={
           Object {
             "some feature flag": true,
@@ -93,12 +85,8 @@ exports[`RequirementViewTest renders with content from props 1`] = `
       currentTest={0}
       deps={
         Object {
-          "assessmentViewUpdateHandler": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          },
-          "assessmentsProvider": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          },
+          "assessmentViewUpdateHandler": [typemoq mock object],
+          "assessmentsProvider": [typemoq mock object],
         }
       }
       nextRequirement={

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-button-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/save-assessment-button-factory.test.tsx.snap
@@ -30,20 +30,9 @@ exports[`SaveAssessmentButtonFactory getSaveButtonForAssessment renders save ass
   }
   deps={
     Object {
-      "assessmentDataFormatter": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "addVersionNumber": [Function],
-        "formatAssessmentData": [Function],
-      },
-      "fileNameBuilder": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      },
-      "fileURLProvider": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "provideBlob": undefined,
-        "provideURL": [Function],
-        "windowUtils": undefined,
-      },
+      "assessmentDataFormatter": [typemoq mock object],
+      "fileNameBuilder": [typemoq mock object],
+      "fileURLProvider": [typemoq mock object],
       "getCurrentDate": [Function],
     }
   }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
@@ -4,39 +4,8 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
 <ChangeAssessmentDialog
   deps={
     Object {
-      "detailsViewActionMessageCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "addPathForValidation": [Function],
-        "cancelStartOver": [Function],
-        "cancelStartOverAllAssessments": [Function],
-        "changeAssessmentVisualizationState": [Function],
-        "changeManualRequirementStatus": [Function],
-        "changeManualTestStatus": [Function],
-        "clearPathSnippetData": [Function],
-        "closePreviewFeaturesPanel": [Function],
-        "closeScopingPanel": [Function],
-        "closeSettingsPanel": [Function],
-        "continuePreviousAssessment": [Function],
-        "copyIssueDetailsClicked": [Function],
-        "dispatcher": undefined,
-        "editFailureInstance": [Function],
-        "leftNavPanelExpanded": [Function],
-        "loadAssessment": [Function],
-        "removeFailureInstance": [Function],
-        "rescanVisualization": [Function],
-        "rescanVisualizationWithoutTelemetry": [Function],
-        "saveAssessment": [Function],
-        "setAllUrlsPermissionState": [Function],
-        "setFeatureFlag": [Function],
-        "startOverAllAssessments": [Function],
-        "switchToTargetTab": [Function],
-        "telemetryFactory": undefined,
-        "undoManualRequirementStatusChange": [Function],
-        "undoManualTestStatusChange": [Function],
-      },
-      "urlParser": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      },
+      "detailsViewActionMessageCreator": [typemoq mock object],
+      "urlParser": [typemoq mock object],
     }
   }
   dialogContentTitle="Assessment in progress"
@@ -89,39 +58,8 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
 <ChangeAssessmentDialog
   deps={
     Object {
-      "detailsViewActionMessageCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "addPathForValidation": [Function],
-        "cancelStartOver": [Function],
-        "cancelStartOverAllAssessments": [Function],
-        "changeAssessmentVisualizationState": [Function],
-        "changeManualRequirementStatus": [Function],
-        "changeManualTestStatus": [Function],
-        "clearPathSnippetData": [Function],
-        "closePreviewFeaturesPanel": [Function],
-        "closeScopingPanel": [Function],
-        "closeSettingsPanel": [Function],
-        "continuePreviousAssessment": [Function],
-        "copyIssueDetailsClicked": [Function],
-        "dispatcher": undefined,
-        "editFailureInstance": [Function],
-        "leftNavPanelExpanded": [Function],
-        "loadAssessment": [Function],
-        "removeFailureInstance": [Function],
-        "rescanVisualization": [Function],
-        "rescanVisualizationWithoutTelemetry": [Function],
-        "saveAssessment": [Function],
-        "setAllUrlsPermissionState": [Function],
-        "setFeatureFlag": [Function],
-        "startOverAllAssessments": [Function],
-        "switchToTargetTab": [Function],
-        "telemetryFactory": undefined,
-        "undoManualRequirementStatusChange": [Function],
-        "undoManualTestStatusChange": [Function],
-      },
-      "urlParser": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      },
+      "detailsViewActionMessageCreator": [typemoq mock object],
+      "urlParser": [typemoq mock object],
     }
   }
   dialogContentTitle="Assessment in progress"
@@ -177,39 +115,8 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
 <ChangeAssessmentDialog
   deps={
     Object {
-      "detailsViewActionMessageCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "addPathForValidation": [Function],
-        "cancelStartOver": [Function],
-        "cancelStartOverAllAssessments": [Function],
-        "changeAssessmentVisualizationState": [Function],
-        "changeManualRequirementStatus": [Function],
-        "changeManualTestStatus": [Function],
-        "clearPathSnippetData": [Function],
-        "closePreviewFeaturesPanel": [Function],
-        "closeScopingPanel": [Function],
-        "closeSettingsPanel": [Function],
-        "continuePreviousAssessment": [Function],
-        "copyIssueDetailsClicked": [Function],
-        "dispatcher": undefined,
-        "editFailureInstance": [Function],
-        "leftNavPanelExpanded": [Function],
-        "loadAssessment": [Function],
-        "removeFailureInstance": [Function],
-        "rescanVisualization": [Function],
-        "rescanVisualizationWithoutTelemetry": [Function],
-        "saveAssessment": [Function],
-        "setAllUrlsPermissionState": [Function],
-        "setFeatureFlag": [Function],
-        "startOverAllAssessments": [Function],
-        "switchToTargetTab": [Function],
-        "telemetryFactory": undefined,
-        "undoManualRequirementStatusChange": [Function],
-        "undoManualTestStatusChange": [Function],
-      },
-      "urlParser": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      },
+      "detailsViewActionMessageCreator": [typemoq mock object],
+      "urlParser": [typemoq mock object],
     }
   }
   dialogContentTitle="Assessment in progress"
@@ -265,39 +172,8 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
 <ChangeAssessmentDialog
   deps={
     Object {
-      "detailsViewActionMessageCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "addPathForValidation": [Function],
-        "cancelStartOver": [Function],
-        "cancelStartOverAllAssessments": [Function],
-        "changeAssessmentVisualizationState": [Function],
-        "changeManualRequirementStatus": [Function],
-        "changeManualTestStatus": [Function],
-        "clearPathSnippetData": [Function],
-        "closePreviewFeaturesPanel": [Function],
-        "closeScopingPanel": [Function],
-        "closeSettingsPanel": [Function],
-        "continuePreviousAssessment": [Function],
-        "copyIssueDetailsClicked": [Function],
-        "dispatcher": undefined,
-        "editFailureInstance": [Function],
-        "leftNavPanelExpanded": [Function],
-        "loadAssessment": [Function],
-        "removeFailureInstance": [Function],
-        "rescanVisualization": [Function],
-        "rescanVisualizationWithoutTelemetry": [Function],
-        "saveAssessment": [Function],
-        "setAllUrlsPermissionState": [Function],
-        "setFeatureFlag": [Function],
-        "startOverAllAssessments": [Function],
-        "switchToTargetTab": [Function],
-        "telemetryFactory": undefined,
-        "undoManualRequirementStatusChange": [Function],
-        "undoManualTestStatusChange": [Function],
-      },
-      "urlParser": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      },
+      "detailsViewActionMessageCreator": [typemoq mock object],
+      "urlParser": [typemoq mock object],
     }
   }
   dialogContentTitle="Assessment in progress"
@@ -353,39 +229,8 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
 <ChangeAssessmentDialog
   deps={
     Object {
-      "detailsViewActionMessageCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "addPathForValidation": [Function],
-        "cancelStartOver": [Function],
-        "cancelStartOverAllAssessments": [Function],
-        "changeAssessmentVisualizationState": [Function],
-        "changeManualRequirementStatus": [Function],
-        "changeManualTestStatus": [Function],
-        "clearPathSnippetData": [Function],
-        "closePreviewFeaturesPanel": [Function],
-        "closeScopingPanel": [Function],
-        "closeSettingsPanel": [Function],
-        "continuePreviousAssessment": [Function],
-        "copyIssueDetailsClicked": [Function],
-        "dispatcher": undefined,
-        "editFailureInstance": [Function],
-        "leftNavPanelExpanded": [Function],
-        "loadAssessment": [Function],
-        "removeFailureInstance": [Function],
-        "rescanVisualization": [Function],
-        "rescanVisualizationWithoutTelemetry": [Function],
-        "saveAssessment": [Function],
-        "setAllUrlsPermissionState": [Function],
-        "setFeatureFlag": [Function],
-        "startOverAllAssessments": [Function],
-        "switchToTargetTab": [Function],
-        "telemetryFactory": undefined,
-        "undoManualRequirementStatusChange": [Function],
-        "undoManualTestStatusChange": [Function],
-      },
-      "urlParser": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      },
+      "detailsViewActionMessageCreator": [typemoq mock object],
+      "urlParser": [typemoq mock object],
     }
   }
   dialogContentTitle="Assessment in progress"

--- a/src/tests/unit/tests/DetailsView/components/details-view-overlay/preview-features-panel/__snapshots__/preview-features-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/details-view-overlay/preview-features-panel/__snapshots__/preview-features-container.test.tsx.snap
@@ -12,36 +12,7 @@ exports[`PreviewFeaturesContainerTest renders all available preview features 1`]
   <PreviewFeaturesToggleList
     deps={
       Object {
-        "detailsViewActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "addPathForValidation": [Function],
-          "cancelStartOver": [Function],
-          "cancelStartOverAllAssessments": [Function],
-          "changeAssessmentVisualizationState": [Function],
-          "changeManualRequirementStatus": [Function],
-          "changeManualTestStatus": [Function],
-          "clearPathSnippetData": [Function],
-          "closePreviewFeaturesPanel": [Function],
-          "closeScopingPanel": [Function],
-          "closeSettingsPanel": [Function],
-          "continuePreviousAssessment": [Function],
-          "copyIssueDetailsClicked": [Function],
-          "dispatcher": undefined,
-          "editFailureInstance": [Function],
-          "leftNavPanelExpanded": [Function],
-          "loadAssessment": [Function],
-          "removeFailureInstance": [Function],
-          "rescanVisualization": [Function],
-          "rescanVisualizationWithoutTelemetry": [Function],
-          "saveAssessment": [Function],
-          "setAllUrlsPermissionState": [Function],
-          "setFeatureFlag": [Function],
-          "startOverAllAssessments": [Function],
-          "switchToTargetTab": [Function],
-          "telemetryFactory": undefined,
-          "undoManualRequirementStatusChange": [Function],
-          "undoManualTestStatusChange": [Function],
-        },
+        "detailsViewActionMessageCreator": [typemoq mock object],
       }
     }
     displayedFeatureFlags={

--- a/src/tests/unit/tests/DetailsView/components/details-view-overlay/settings-panel/settings/issue-filing/__snapshots__/issue-filing-settings.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/details-view-overlay/settings-panel/settings/issue-filing/__snapshots__/issue-filing-settings.test.tsx.snap
@@ -10,18 +10,8 @@ exports[`IssueFilingSettings renders 1`] = `
   <IssueFilingSettingsContainer
     deps={
       Object {
-        "issueFilingServiceProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "services": undefined,
-        },
-        "userConfigMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "saveIssueFilingSettings": [Function],
-          "saveWindowBounds": [Function],
-          "setIssueFilingService": [Function],
-          "setIssueFilingServiceProperty": [Function],
-        },
+        "issueFilingServiceProvider": [typemoq mock object],
+        "userConfigMessageCreator": [typemoq mock object],
       }
     }
     onPropertyUpdateCallback={[Function]}

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-instance-section-props-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/__snapshots__/tab-stops-instance-section-props-factory.test.tsx.snap
@@ -3,24 +3,8 @@
 exports[`TabStopsInstanceSectionPropsFactory for Fastpass creates props as expected 1`] = `
 Object {
   "deps": Object {
-    "tabStopRequirementActionMessageCreator": proxy {
-      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      "automatedTabbingResultsCompleted": [Function],
-      "dispatcher": undefined,
-      "source": undefined,
-      "telemetryFactory": undefined,
-      "toggleTabStopRequirementExpand": [Function],
-      "updateNeedToCollectTabbingResults": [Function],
-      "updateTabbingCompleted": [Function],
-    },
-    "tabStopsTestViewController": proxy {
-      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      "actions": undefined,
-      "createNewFailureInstancePanel": [Function],
-      "dismissPanel": [Function],
-      "editExistingFailureInstance": [Function],
-      "updateDescription": [Function],
-    },
+    "tabStopRequirementActionMessageCreator": [typemoq mock object],
+    "tabStopsTestViewController": [typemoq mock object],
   },
   "getCollapsibleComponentPropsWithInstance": [Function],
   "headingLevel": 3,
@@ -102,46 +86,14 @@ Object {
     requirementId="keyboard-navigation"
   />,
   "deps": Object {
-    "tabStopRequirementActionMessageCreator": proxy {
-      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      "automatedTabbingResultsCompleted": [Function],
-      "dispatcher": undefined,
-      "source": undefined,
-      "telemetryFactory": undefined,
-      "toggleTabStopRequirementExpand": [Function],
-      "updateNeedToCollectTabbingResults": [Function],
-      "updateTabbingCompleted": [Function],
-    },
-    "tabStopsTestViewController": proxy {
-      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      "actions": undefined,
-      "createNewFailureInstancePanel": [Function],
-      "dismissPanel": [Function],
-      "editExistingFailureInstance": [Function],
-      "updateDescription": [Function],
-    },
+    "tabStopRequirementActionMessageCreator": [typemoq mock object],
+    "tabStopsTestViewController": [typemoq mock object],
   },
   "header": <TabStopsMinimalRequirementHeader
     deps={
       Object {
-        "tabStopRequirementActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "automatedTabbingResultsCompleted": [Function],
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-          "toggleTabStopRequirementExpand": [Function],
-          "updateNeedToCollectTabbingResults": [Function],
-          "updateTabbingCompleted": [Function],
-        },
-        "tabStopsTestViewController": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "actions": undefined,
-          "createNewFailureInstancePanel": [Function],
-          "dismissPanel": [Function],
-          "editExistingFailureInstance": [Function],
-          "updateDescription": [Function],
-        },
+        "tabStopRequirementActionMessageCreator": [typemoq mock object],
+        "tabStopsTestViewController": [typemoq mock object],
       }
     }
     requirement={
@@ -174,24 +126,8 @@ Object {
 exports[`TabStopsInstanceSectionPropsFactory for Report creates props as expected 1`] = `
 Object {
   "deps": Object {
-    "tabStopRequirementActionMessageCreator": proxy {
-      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      "automatedTabbingResultsCompleted": [Function],
-      "dispatcher": undefined,
-      "source": undefined,
-      "telemetryFactory": undefined,
-      "toggleTabStopRequirementExpand": [Function],
-      "updateNeedToCollectTabbingResults": [Function],
-      "updateTabbingCompleted": [Function],
-    },
-    "tabStopsTestViewController": proxy {
-      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      "actions": undefined,
-      "createNewFailureInstancePanel": [Function],
-      "dismissPanel": [Function],
-      "editExistingFailureInstance": [Function],
-      "updateDescription": [Function],
-    },
+    "tabStopRequirementActionMessageCreator": [typemoq mock object],
+    "tabStopsTestViewController": [typemoq mock object],
   },
   "getCollapsibleComponentPropsWithInstance": [Function],
   "getCollapsibleComponentPropsWithoutInstance": [Function],
@@ -276,46 +212,14 @@ Object {
     requirementId="keyboard-navigation"
   />,
   "deps": Object {
-    "tabStopRequirementActionMessageCreator": proxy {
-      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      "automatedTabbingResultsCompleted": [Function],
-      "dispatcher": undefined,
-      "source": undefined,
-      "telemetryFactory": undefined,
-      "toggleTabStopRequirementExpand": [Function],
-      "updateNeedToCollectTabbingResults": [Function],
-      "updateTabbingCompleted": [Function],
-    },
-    "tabStopsTestViewController": proxy {
-      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      "actions": undefined,
-      "createNewFailureInstancePanel": [Function],
-      "dismissPanel": [Function],
-      "editExistingFailureInstance": [Function],
-      "updateDescription": [Function],
-    },
+    "tabStopRequirementActionMessageCreator": [typemoq mock object],
+    "tabStopsTestViewController": [typemoq mock object],
   },
   "header": <TabStopsMinimalRequirementHeader
     deps={
       Object {
-        "tabStopRequirementActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "automatedTabbingResultsCompleted": [Function],
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-          "toggleTabStopRequirementExpand": [Function],
-          "updateNeedToCollectTabbingResults": [Function],
-          "updateTabbingCompleted": [Function],
-        },
-        "tabStopsTestViewController": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "actions": undefined,
-          "createNewFailureInstancePanel": [Function],
-          "dismissPanel": [Function],
-          "editExistingFailureInstance": [Function],
-          "updateDescription": [Function],
-        },
+        "tabStopRequirementActionMessageCreator": [typemoq mock object],
+        "tabStopsTestViewController": [typemoq mock object],
       }
     }
     requirement={
@@ -356,46 +260,14 @@ Object {
     This requirement has failed but no comment has been added
   </span>,
   "deps": Object {
-    "tabStopRequirementActionMessageCreator": proxy {
-      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      "automatedTabbingResultsCompleted": [Function],
-      "dispatcher": undefined,
-      "source": undefined,
-      "telemetryFactory": undefined,
-      "toggleTabStopRequirementExpand": [Function],
-      "updateNeedToCollectTabbingResults": [Function],
-      "updateTabbingCompleted": [Function],
-    },
-    "tabStopsTestViewController": proxy {
-      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      "actions": undefined,
-      "createNewFailureInstancePanel": [Function],
-      "dismissPanel": [Function],
-      "editExistingFailureInstance": [Function],
-      "updateDescription": [Function],
-    },
+    "tabStopRequirementActionMessageCreator": [typemoq mock object],
+    "tabStopsTestViewController": [typemoq mock object],
   },
   "header": <TabStopsMinimalRequirementHeader
     deps={
       Object {
-        "tabStopRequirementActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "automatedTabbingResultsCompleted": [Function],
-          "dispatcher": undefined,
-          "source": undefined,
-          "telemetryFactory": undefined,
-          "toggleTabStopRequirementExpand": [Function],
-          "updateNeedToCollectTabbingResults": [Function],
-          "updateTabbingCompleted": [Function],
-        },
-        "tabStopsTestViewController": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "actions": undefined,
-          "createNewFailureInstancePanel": [Function],
-          "dismissPanel": [Function],
-          "editExistingFailureInstance": [Function],
-          "updateDescription": [Function],
-        },
+        "tabStopRequirementActionMessageCreator": [typemoq mock object],
+        "tabStopsTestViewController": [typemoq mock object],
       }
     }
     requirement={

--- a/src/tests/unit/tests/common/components/__snapshots__/theme.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/theme.test.tsx.snap
@@ -9,10 +9,7 @@ exports[`ThemeInner is high contrast mode enabled: false 1`] = `
   }
   deps={
     Object {
-      "documentManipulator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "document": undefined,
-      },
+      "documentManipulator": [typemoq mock object],
       "loadTheme": [MockFunction],
       "storeActionMessageCreator": null,
       "storesHub": null,
@@ -31,10 +28,7 @@ exports[`ThemeInner is high contrast mode enabled: true 1`] = `
   }
   deps={
     Object {
-      "documentManipulator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "document": undefined,
-      },
+      "documentManipulator": [typemoq mock object],
       "loadTheme": [MockFunction],
       "storeActionMessageCreator": null,
       "storesHub": null,

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-fix-card-row.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-fix-card-row.test.tsx.snap
@@ -21,21 +21,7 @@ exports[`HowToFixWebCardRow renders 1`] = `
         deps={
           Object {
             "LinkComponent": Object {},
-            "fixInstructionProcessor": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "backgroundColorText": "background color: ",
-              "backgroundRecommendedColorText": "Use background color: ",
-              "backgroundRecommendedRegExp": /Use background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-              "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-              "colorValueMatcher": "(#[0-9a-f]{6})",
-              "contrastRatioRegExp": /Expected contrast ratio of /i,
-              "contrastRatioText": "Expected contrast ratio of ",
-              "foregroundColorText": "foreground color: ",
-              "foregroundRecommendedColorText": "Use foreground color: ",
-              "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-              "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-              "originalMiddleSentence": " and the original foreground color: ",
-            },
+            "fixInstructionProcessor": [typemoq mock object],
             "recommendColor": Object {},
           }
         }
@@ -53,21 +39,7 @@ exports[`HowToFixWebCardRow renders 1`] = `
         deps={
           Object {
             "LinkComponent": Object {},
-            "fixInstructionProcessor": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "backgroundColorText": "background color: ",
-              "backgroundRecommendedColorText": "Use background color: ",
-              "backgroundRecommendedRegExp": /Use background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-              "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-              "colorValueMatcher": "(#[0-9a-f]{6})",
-              "contrastRatioRegExp": /Expected contrast ratio of /i,
-              "contrastRatioText": "Expected contrast ratio of ",
-              "foregroundColorText": "foreground color: ",
-              "foregroundRecommendedColorText": "Use foreground color: ",
-              "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-              "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-              "originalMiddleSentence": " and the original foreground color: ",
-            },
+            "fixInstructionProcessor": [typemoq mock object],
             "recommendColor": Object {},
           }
         }

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details-footer.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details-footer.test.tsx.snap
@@ -20,9 +20,7 @@ exports[`InstanceDetailsFooter renders per snapshot when all card interactions a
           "supportsHighlighting": true,
           "supportsIssueFiling": true,
         },
-        "unifiedResultToIssueFilingDataConverter": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        },
+        "unifiedResultToIssueFilingDataConverter": [typemoq mock object],
       }
     }
     issueDetailsData={Object {}}
@@ -52,9 +50,7 @@ exports[`InstanceDetailsFooter renders per snapshot when only UserConfig-agnosti
           "supportsHighlighting": true,
           "supportsIssueFiling": false,
         },
-        "unifiedResultToIssueFilingDataConverter": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        },
+        "unifiedResultToIssueFilingDataConverter": [typemoq mock object],
       }
     }
     issueDetailsData={Object {}}
@@ -99,9 +95,7 @@ exports[`InstanceDetailsFooter renders per snapshot with highlightState="hidden"
           "supportsHighlighting": true,
           "supportsIssueFiling": true,
         },
-        "unifiedResultToIssueFilingDataConverter": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        },
+        "unifiedResultToIssueFilingDataConverter": [typemoq mock object],
       }
     }
     issueDetailsData={Object {}}
@@ -131,9 +125,7 @@ exports[`InstanceDetailsFooter renders per snapshot with highlightState="unavail
           "supportsHighlighting": true,
           "supportsIssueFiling": true,
         },
-        "unifiedResultToIssueFilingDataConverter": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        },
+        "unifiedResultToIssueFilingDataConverter": [typemoq mock object],
       }
     }
     issueDetailsData={Object {}}
@@ -163,9 +155,7 @@ exports[`InstanceDetailsFooter renders per snapshot with highlightState="visible
           "supportsHighlighting": true,
           "supportsIssueFiling": true,
         },
-        "unifiedResultToIssueFilingDataConverter": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        },
+        "unifiedResultToIssueFilingDataConverter": [typemoq mock object],
       }
     }
     issueDetailsData={Object {}}

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
@@ -11,41 +11,13 @@ exports[`RulesWithInstances renders 1`] = `
     containerClassName="collapsibleRuleDetailsGroup"
     content={
       <RuleContent
-        cardSelectionMessageCreator={
-          proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "collapseAllRules": [Function],
-            "dispatcher": undefined,
-            "expandAllRules": [Function],
-            "source": undefined,
-            "telemetryFactory": undefined,
-            "toggleCardSelection": [Function],
-            "toggleRuleExpandCollapse": [Function],
-            "toggleVisualHelper": [Function],
-          }
-        }
+        cardSelectionMessageCreator={[typemoq mock object]}
         deps={
           Object {
             "collapsibleControl": [Function],
           }
         }
-        fixInstructionProcessor={
-          proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "backgroundColorText": "background color: ",
-            "backgroundRecommendedColorText": "Use background color: ",
-            "backgroundRecommendedRegExp": /Use background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "colorValueMatcher": "(#[0-9a-f]{6})",
-            "contrastRatioRegExp": /Expected contrast ratio of /i,
-            "contrastRatioText": "Expected contrast ratio of ",
-            "foregroundColorText": "foreground color: ",
-            "foregroundRecommendedColorText": "Use foreground color: ",
-            "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "originalMiddleSentence": " and the original foreground color: ",
-          }
-        }
+        fixInstructionProcessor={[typemoq mock object]}
         rule={
           Object {
             "description": "sample-description",

--- a/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
@@ -16,19 +16,13 @@ exports[`DebugToolsView renders when storesHub.hasStoresData = true 1`] = `
     childrenProps={
       Object {
         "deps": Object {
-          "storesHub": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "stores": undefined,
-          },
+          "storesHub": [typemoq mock object],
         },
       }
     }
     deps={
       Object {
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
-        },
+        "storesHub": [typemoq mock object],
       }
     }
     isNarrowModeEnabled={true}
@@ -37,10 +31,7 @@ exports[`DebugToolsView renders when storesHub.hasStoresData = true 1`] = `
     className="nav"
     deps={
       Object {
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
-        },
+        "storesHub": [typemoq mock object],
       }
     }
     state={
@@ -54,10 +45,7 @@ exports[`DebugToolsView renders when storesHub.hasStoresData = true 1`] = `
   <CurrentView
     deps={
       Object {
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
-        },
+        "storesHub": [typemoq mock object],
       }
     }
     storeState={

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-viewer.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-viewer.test.tsx.snap
@@ -17,13 +17,7 @@ exports[`TelemetryViewer renders when there is at least one telemetry message 1`
   <TelemetryMessagesList
     deps={
       Object {
-        "telemetryListener": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "browserAdapter": undefined,
-          "getDate": undefined,
-          "listeners": Array [],
-          "onTelemetryMessage": [Function],
-        },
+        "telemetryListener": [typemoq mock object],
       }
     }
     items={

--- a/src/tests/unit/tests/electron/views/results/__snapshots__/results-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/results/__snapshots__/results-view.test.tsx.snap
@@ -53,18 +53,8 @@ exports[`ResultsView right content panel info changes when left nav selected key
       "getCardsViewData": [Function],
       "getDateFromTimestamp": [Function],
       "isResultHighlightUnavailable": [Function],
-      "leftNavActionCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "cardSelectionActions": undefined,
-        "itemSelected": [Function],
-        "leftNavActions": undefined,
-        "setLeftNavVisible": [Function],
-      },
-      "scanActionCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "deviceConnectionActions": undefined,
-        "scanActions": undefined,
-      },
+      "leftNavActionCreator": [typemoq mock object],
+      "scanActionCreator": [typemoq mock object],
       "screenshotViewModelProvider": [Function],
       "toolData": Object {
         "applicationProperties": Object {
@@ -136,18 +126,8 @@ exports[`ResultsView right content panel info renders with default/initial value
       "getCardsViewData": [Function],
       "getDateFromTimestamp": [Function],
       "isResultHighlightUnavailable": [Function],
-      "leftNavActionCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "cardSelectionActions": undefined,
-        "itemSelected": [Function],
-        "leftNavActions": undefined,
-        "setLeftNavVisible": [Function],
-      },
-      "scanActionCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "deviceConnectionActions": undefined,
-        "scanActions": undefined,
-      },
+      "leftNavActionCreator": [typemoq mock object],
+      "scanActionCreator": [typemoq mock object],
       "screenshotViewModelProvider": [Function],
       "toolData": Object {
         "applicationProperties": Object {
@@ -200,18 +180,8 @@ exports[`ResultsView when status scan <Completed> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
-        "leftNavActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "cardSelectionActions": undefined,
-          "itemSelected": [Function],
-          "leftNavActions": undefined,
-          "setLeftNavVisible": [Function],
-        },
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceConnectionActions": undefined,
-          "scanActions": undefined,
-        },
+        "leftNavActionCreator": [typemoq mock object],
+        "scanActionCreator": [typemoq mock object],
         "screenshotViewModelProvider": [Function],
         "toolData": Object {
           "applicationProperties": Object {
@@ -254,18 +224,8 @@ exports[`ResultsView when status scan <Completed> 1`] = `
           "getCardsViewData": [Function],
           "getDateFromTimestamp": [Function],
           "isResultHighlightUnavailable": [Function],
-          "leftNavActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "cardSelectionActions": undefined,
-            "itemSelected": [Function],
-            "leftNavActions": undefined,
-            "setLeftNavVisible": [Function],
-          },
-          "scanActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "deviceConnectionActions": undefined,
-            "scanActions": undefined,
-          },
+          "leftNavActionCreator": [typemoq mock object],
+          "scanActionCreator": [typemoq mock object],
           "screenshotViewModelProvider": [Function],
           "toolData": Object {
             "applicationProperties": Object {
@@ -333,18 +293,8 @@ exports[`ResultsView when status scan <Completed> 1`] = `
             "getCardsViewData": [Function],
             "getDateFromTimestamp": [Function],
             "isResultHighlightUnavailable": [Function],
-            "leftNavActionCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "cardSelectionActions": undefined,
-              "itemSelected": [Function],
-              "leftNavActions": undefined,
-              "setLeftNavVisible": [Function],
-            },
-            "scanActionCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "deviceConnectionActions": undefined,
-              "scanActions": undefined,
-            },
+            "leftNavActionCreator": [typemoq mock object],
+            "scanActionCreator": [typemoq mock object],
             "screenshotViewModelProvider": [Function],
             "toolData": Object {
               "applicationProperties": Object {
@@ -436,18 +386,8 @@ exports[`ResultsView when status scan <Completed> 1`] = `
                   "getCardsViewData": [Function],
                   "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
-                  "leftNavActionCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "cardSelectionActions": undefined,
-                    "itemSelected": [Function],
-                    "leftNavActions": undefined,
-                    "setLeftNavVisible": [Function],
-                  },
-                  "scanActionCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "deviceConnectionActions": undefined,
-                    "scanActions": undefined,
-                  },
+                  "leftNavActionCreator": [typemoq mock object],
+                  "scanActionCreator": [typemoq mock object],
                   "screenshotViewModelProvider": [Function],
                   "toolData": Object {
                     "applicationProperties": Object {
@@ -511,18 +451,8 @@ exports[`ResultsView when status scan <Completed> 1`] = `
               "getCardsViewData": [Function],
               "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
-              "leftNavActionCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "cardSelectionActions": undefined,
-                "itemSelected": [Function],
-                "leftNavActions": undefined,
-                "setLeftNavVisible": [Function],
-              },
-              "scanActionCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "deviceConnectionActions": undefined,
-                "scanActions": undefined,
-              },
+              "leftNavActionCreator": [typemoq mock object],
+              "scanActionCreator": [typemoq mock object],
               "screenshotViewModelProvider": [Function],
               "toolData": Object {
                 "applicationProperties": Object {
@@ -572,18 +502,8 @@ exports[`ResultsView when status scan <Completed> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
-        "leftNavActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "cardSelectionActions": undefined,
-          "itemSelected": [Function],
-          "leftNavActions": undefined,
-          "setLeftNavVisible": [Function],
-        },
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceConnectionActions": undefined,
-          "scanActions": undefined,
-        },
+        "leftNavActionCreator": [typemoq mock object],
+        "scanActionCreator": [typemoq mock object],
         "screenshotViewModelProvider": [Function],
         "toolData": Object {
           "applicationProperties": Object {
@@ -637,18 +557,8 @@ exports[`ResultsView when status scan <Failed> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
-        "leftNavActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "cardSelectionActions": undefined,
-          "itemSelected": [Function],
-          "leftNavActions": undefined,
-          "setLeftNavVisible": [Function],
-        },
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceConnectionActions": undefined,
-          "scanActions": undefined,
-        },
+        "leftNavActionCreator": [typemoq mock object],
+        "scanActionCreator": [typemoq mock object],
         "screenshotViewModelProvider": [Function],
         "toolData": Object {
           "applicationProperties": Object {
@@ -691,18 +601,8 @@ exports[`ResultsView when status scan <Failed> 1`] = `
           "getCardsViewData": [Function],
           "getDateFromTimestamp": [Function],
           "isResultHighlightUnavailable": [Function],
-          "leftNavActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "cardSelectionActions": undefined,
-            "itemSelected": [Function],
-            "leftNavActions": undefined,
-            "setLeftNavVisible": [Function],
-          },
-          "scanActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "deviceConnectionActions": undefined,
-            "scanActions": undefined,
-          },
+          "leftNavActionCreator": [typemoq mock object],
+          "scanActionCreator": [typemoq mock object],
           "screenshotViewModelProvider": [Function],
           "toolData": Object {
             "applicationProperties": Object {
@@ -770,18 +670,8 @@ exports[`ResultsView when status scan <Failed> 1`] = `
             "getCardsViewData": [Function],
             "getDateFromTimestamp": [Function],
             "isResultHighlightUnavailable": [Function],
-            "leftNavActionCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "cardSelectionActions": undefined,
-              "itemSelected": [Function],
-              "leftNavActions": undefined,
-              "setLeftNavVisible": [Function],
-            },
-            "scanActionCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "deviceConnectionActions": undefined,
-              "scanActions": undefined,
-            },
+            "leftNavActionCreator": [typemoq mock object],
+            "scanActionCreator": [typemoq mock object],
             "screenshotViewModelProvider": [Function],
             "toolData": Object {
               "applicationProperties": Object {
@@ -858,18 +748,8 @@ exports[`ResultsView when status scan <Failed> 1`] = `
                   "getCardsViewData": [Function],
                   "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
-                  "leftNavActionCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "cardSelectionActions": undefined,
-                    "itemSelected": [Function],
-                    "leftNavActions": undefined,
-                    "setLeftNavVisible": [Function],
-                  },
-                  "scanActionCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "deviceConnectionActions": undefined,
-                    "scanActions": undefined,
-                  },
+                  "leftNavActionCreator": [typemoq mock object],
+                  "scanActionCreator": [typemoq mock object],
                   "screenshotViewModelProvider": [Function],
                   "toolData": Object {
                     "applicationProperties": Object {
@@ -918,18 +798,8 @@ exports[`ResultsView when status scan <Failed> 1`] = `
               "getCardsViewData": [Function],
               "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
-              "leftNavActionCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "cardSelectionActions": undefined,
-                "itemSelected": [Function],
-                "leftNavActions": undefined,
-                "setLeftNavVisible": [Function],
-              },
-              "scanActionCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "deviceConnectionActions": undefined,
-                "scanActions": undefined,
-              },
+              "leftNavActionCreator": [typemoq mock object],
+              "scanActionCreator": [typemoq mock object],
               "screenshotViewModelProvider": [Function],
               "toolData": Object {
                 "applicationProperties": Object {
@@ -982,18 +852,8 @@ exports[`ResultsView when status scan <Failed> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
-        "leftNavActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "cardSelectionActions": undefined,
-          "itemSelected": [Function],
-          "leftNavActions": undefined,
-          "setLeftNavVisible": [Function],
-        },
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceConnectionActions": undefined,
-          "scanActions": undefined,
-        },
+        "leftNavActionCreator": [typemoq mock object],
+        "scanActionCreator": [typemoq mock object],
         "screenshotViewModelProvider": [Function],
         "toolData": Object {
           "applicationProperties": Object {
@@ -1047,18 +907,8 @@ exports[`ResultsView when status scan <Scanning> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
-        "leftNavActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "cardSelectionActions": undefined,
-          "itemSelected": [Function],
-          "leftNavActions": undefined,
-          "setLeftNavVisible": [Function],
-        },
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceConnectionActions": undefined,
-          "scanActions": undefined,
-        },
+        "leftNavActionCreator": [typemoq mock object],
+        "scanActionCreator": [typemoq mock object],
         "screenshotViewModelProvider": [Function],
         "toolData": Object {
           "applicationProperties": Object {
@@ -1101,18 +951,8 @@ exports[`ResultsView when status scan <Scanning> 1`] = `
           "getCardsViewData": [Function],
           "getDateFromTimestamp": [Function],
           "isResultHighlightUnavailable": [Function],
-          "leftNavActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "cardSelectionActions": undefined,
-            "itemSelected": [Function],
-            "leftNavActions": undefined,
-            "setLeftNavVisible": [Function],
-          },
-          "scanActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "deviceConnectionActions": undefined,
-            "scanActions": undefined,
-          },
+          "leftNavActionCreator": [typemoq mock object],
+          "scanActionCreator": [typemoq mock object],
           "screenshotViewModelProvider": [Function],
           "toolData": Object {
             "applicationProperties": Object {
@@ -1180,18 +1020,8 @@ exports[`ResultsView when status scan <Scanning> 1`] = `
             "getCardsViewData": [Function],
             "getDateFromTimestamp": [Function],
             "isResultHighlightUnavailable": [Function],
-            "leftNavActionCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "cardSelectionActions": undefined,
-              "itemSelected": [Function],
-              "leftNavActions": undefined,
-              "setLeftNavVisible": [Function],
-            },
-            "scanActionCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "deviceConnectionActions": undefined,
-              "scanActions": undefined,
-            },
+            "leftNavActionCreator": [typemoq mock object],
+            "scanActionCreator": [typemoq mock object],
             "screenshotViewModelProvider": [Function],
             "toolData": Object {
               "applicationProperties": Object {
@@ -1268,18 +1098,8 @@ exports[`ResultsView when status scan <Scanning> 1`] = `
                   "getCardsViewData": [Function],
                   "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
-                  "leftNavActionCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "cardSelectionActions": undefined,
-                    "itemSelected": [Function],
-                    "leftNavActions": undefined,
-                    "setLeftNavVisible": [Function],
-                  },
-                  "scanActionCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "deviceConnectionActions": undefined,
-                    "scanActions": undefined,
-                  },
+                  "leftNavActionCreator": [typemoq mock object],
+                  "scanActionCreator": [typemoq mock object],
                   "screenshotViewModelProvider": [Function],
                   "toolData": Object {
                     "applicationProperties": Object {
@@ -1328,18 +1148,8 @@ exports[`ResultsView when status scan <Scanning> 1`] = `
               "getCardsViewData": [Function],
               "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
-              "leftNavActionCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "cardSelectionActions": undefined,
-                "itemSelected": [Function],
-                "leftNavActions": undefined,
-                "setLeftNavVisible": [Function],
-              },
-              "scanActionCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "deviceConnectionActions": undefined,
-                "scanActions": undefined,
-              },
+              "leftNavActionCreator": [typemoq mock object],
+              "scanActionCreator": [typemoq mock object],
               "screenshotViewModelProvider": [Function],
               "toolData": Object {
                 "applicationProperties": Object {
@@ -1389,18 +1199,8 @@ exports[`ResultsView when status scan <Scanning> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
-        "leftNavActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "cardSelectionActions": undefined,
-          "itemSelected": [Function],
-          "leftNavActions": undefined,
-          "setLeftNavVisible": [Function],
-        },
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceConnectionActions": undefined,
-          "scanActions": undefined,
-        },
+        "leftNavActionCreator": [typemoq mock object],
+        "scanActionCreator": [typemoq mock object],
         "screenshotViewModelProvider": [Function],
         "toolData": Object {
           "applicationProperties": Object {
@@ -1454,18 +1254,8 @@ exports[`ResultsView when status scan <undefined> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
-        "leftNavActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "cardSelectionActions": undefined,
-          "itemSelected": [Function],
-          "leftNavActions": undefined,
-          "setLeftNavVisible": [Function],
-        },
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceConnectionActions": undefined,
-          "scanActions": undefined,
-        },
+        "leftNavActionCreator": [typemoq mock object],
+        "scanActionCreator": [typemoq mock object],
         "screenshotViewModelProvider": [Function],
         "toolData": Object {
           "applicationProperties": Object {
@@ -1508,18 +1298,8 @@ exports[`ResultsView when status scan <undefined> 1`] = `
           "getCardsViewData": [Function],
           "getDateFromTimestamp": [Function],
           "isResultHighlightUnavailable": [Function],
-          "leftNavActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "cardSelectionActions": undefined,
-            "itemSelected": [Function],
-            "leftNavActions": undefined,
-            "setLeftNavVisible": [Function],
-          },
-          "scanActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "deviceConnectionActions": undefined,
-            "scanActions": undefined,
-          },
+          "leftNavActionCreator": [typemoq mock object],
+          "scanActionCreator": [typemoq mock object],
           "screenshotViewModelProvider": [Function],
           "toolData": Object {
             "applicationProperties": Object {
@@ -1587,18 +1367,8 @@ exports[`ResultsView when status scan <undefined> 1`] = `
             "getCardsViewData": [Function],
             "getDateFromTimestamp": [Function],
             "isResultHighlightUnavailable": [Function],
-            "leftNavActionCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "cardSelectionActions": undefined,
-              "itemSelected": [Function],
-              "leftNavActions": undefined,
-              "setLeftNavVisible": [Function],
-            },
-            "scanActionCreator": proxy {
-              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-              "deviceConnectionActions": undefined,
-              "scanActions": undefined,
-            },
+            "leftNavActionCreator": [typemoq mock object],
+            "scanActionCreator": [typemoq mock object],
             "screenshotViewModelProvider": [Function],
             "toolData": Object {
               "applicationProperties": Object {
@@ -1675,18 +1445,8 @@ exports[`ResultsView when status scan <undefined> 1`] = `
                   "getCardsViewData": [Function],
                   "getDateFromTimestamp": [Function],
                   "isResultHighlightUnavailable": [Function],
-                  "leftNavActionCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "cardSelectionActions": undefined,
-                    "itemSelected": [Function],
-                    "leftNavActions": undefined,
-                    "setLeftNavVisible": [Function],
-                  },
-                  "scanActionCreator": proxy {
-                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                    "deviceConnectionActions": undefined,
-                    "scanActions": undefined,
-                  },
+                  "leftNavActionCreator": [typemoq mock object],
+                  "scanActionCreator": [typemoq mock object],
                   "screenshotViewModelProvider": [Function],
                   "toolData": Object {
                     "applicationProperties": Object {
@@ -1734,18 +1494,8 @@ exports[`ResultsView when status scan <undefined> 1`] = `
               "getCardsViewData": [Function],
               "getDateFromTimestamp": [Function],
               "isResultHighlightUnavailable": [Function],
-              "leftNavActionCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "cardSelectionActions": undefined,
-                "itemSelected": [Function],
-                "leftNavActions": undefined,
-                "setLeftNavVisible": [Function],
-              },
-              "scanActionCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "deviceConnectionActions": undefined,
-                "scanActions": undefined,
-              },
+              "leftNavActionCreator": [typemoq mock object],
+              "scanActionCreator": [typemoq mock object],
               "screenshotViewModelProvider": [Function],
               "toolData": Object {
                 "applicationProperties": Object {
@@ -1795,18 +1545,8 @@ exports[`ResultsView when status scan <undefined> 1`] = `
         "getCardsViewData": [Function],
         "getDateFromTimestamp": [Function],
         "isResultHighlightUnavailable": [Function],
-        "leftNavActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "cardSelectionActions": undefined,
-          "itemSelected": [Function],
-          "leftNavActions": undefined,
-          "setLeftNavVisible": [Function],
-        },
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceConnectionActions": undefined,
-          "scanActions": undefined,
-        },
+        "leftNavActionCreator": [typemoq mock object],
+        "scanActionCreator": [typemoq mock object],
         "screenshotViewModelProvider": [Function],
         "toolData": Object {
           "applicationProperties": Object {

--- a/src/tests/unit/tests/electron/views/results/components/__snapshots__/title-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/results/components/__snapshots__/title-bar.test.tsx.snap
@@ -35,23 +35,10 @@ exports[`TitleBar renders 1`] = `
   className="titleBar"
   deps={
     Object {
-      "platformInfo": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "currentProcess": undefined,
-      },
-      "storeActionMessageCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "dispatcher": undefined,
-        "getStateMessages": undefined,
-      },
-      "storesHub": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "stores": undefined,
-      },
-      "windowFrameActionCreator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "windowFrameActions": undefined,
-      },
+      "platformInfo": [typemoq mock object],
+      "storeActionMessageCreator": [typemoq mock object],
+      "storesHub": [typemoq mock object],
+      "windowFrameActionCreator": [typemoq mock object],
     }
   }
   headerTextClassName="headerText"
@@ -66,23 +53,10 @@ exports[`TitleBar renders 1`] = `
   <WithStoreSubscriptionForHeaderIconComponent
     deps={
       Object {
-        "platformInfo": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "currentProcess": undefined,
-        },
-        "storeActionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-          "getStateMessages": undefined,
-        },
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
-        },
-        "windowFrameActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "windowFrameActions": undefined,
-        },
+        "platformInfo": [typemoq mock object],
+        "storeActionMessageCreator": [typemoq mock object],
+        "storesHub": [typemoq mock object],
+        "windowFrameActionCreator": [typemoq mock object],
       }
     }
   />

--- a/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/platform-body-class-modifier.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/platform-body-class-modifier.test.tsx.snap
@@ -9,14 +9,8 @@ exports[`PlatformInfo Renders per snapshot for mac 1`] = `
   }
   deps={
     Object {
-      "documentManipulator": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "document": undefined,
-      },
-      "platformInfo": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "currentProcess": undefined,
-      },
+      "documentManipulator": [typemoq mock object],
+      "platformInfo": [typemoq mock object],
     }
   }
 />

--- a/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
@@ -9,10 +9,7 @@ exports[`RootContainer renders with routeId = deviceConnectView 1`] = `
   }
   deps={
     Object {
-      "storesHub": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "stores": undefined,
-      },
+      "storesHub": [typemoq mock object],
     }
   }
   scanStoreData={
@@ -48,10 +45,7 @@ exports[`RootContainer renders with routeId = resultsView 1`] = `
         "rules": Object {},
       },
       "deps": Object {
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
-        },
+        "storesHub": [typemoq mock object],
       },
       "scanStoreData": Object {
         "status": 2,
@@ -70,10 +64,7 @@ exports[`RootContainer renders with routeId = resultsView 1`] = `
   }
   deps={
     Object {
-      "storesHub": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "stores": undefined,
-      },
+      "storesHub": [typemoq mock object],
     }
   }
   isNarrowModeEnabled={true}

--- a/src/tests/unit/tests/injected/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/command-bar.test.tsx.snap
@@ -18,10 +18,7 @@ exports[`CommandBar renders renders, shows copy button insecure origin message: 
     <CopyIssueDetailsButton
       deps={
         Object {
-          "axeResultToIssueFilingDataConverter": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "shortenSelector": undefined,
-          },
+          "axeResultToIssueFilingDataConverter": [typemoq mock object],
         }
       }
       issueDetailsData={Object {}}
@@ -29,10 +26,7 @@ exports[`CommandBar renders renders, shows copy button insecure origin message: 
     <IssueFilingButton
       deps={
         Object {
-          "axeResultToIssueFilingDataConverter": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "shortenSelector": undefined,
-          },
+          "axeResultToIssueFilingDataConverter": [typemoq mock object],
         }
       }
       issueDetailsData={Object {}}
@@ -66,10 +60,7 @@ exports[`CommandBar renders renders, shows copy button insecure origin message: 
     <CopyIssueDetailsButton
       deps={
         Object {
-          "axeResultToIssueFilingDataConverter": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "shortenSelector": undefined,
-          },
+          "axeResultToIssueFilingDataConverter": [typemoq mock object],
         }
       }
       issueDetailsData={Object {}}
@@ -77,10 +68,7 @@ exports[`CommandBar renders renders, shows copy button insecure origin message: 
     <IssueFilingButton
       deps={
         Object {
-          "axeResultToIssueFilingDataConverter": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "shortenSelector": undefined,
-          },
+          "axeResultToIssueFilingDataConverter": [typemoq mock object],
         }
       }
       issueDetailsData={Object {}}
@@ -120,10 +108,7 @@ exports[`CommandBar renders renders, shows inspect button message: false 1`] = `
     <CopyIssueDetailsButton
       deps={
         Object {
-          "axeResultToIssueFilingDataConverter": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "shortenSelector": undefined,
-          },
+          "axeResultToIssueFilingDataConverter": [typemoq mock object],
         }
       }
       issueDetailsData={Object {}}
@@ -131,10 +116,7 @@ exports[`CommandBar renders renders, shows inspect button message: false 1`] = `
     <IssueFilingButton
       deps={
         Object {
-          "axeResultToIssueFilingDataConverter": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "shortenSelector": undefined,
-          },
+          "axeResultToIssueFilingDataConverter": [typemoq mock object],
         }
       }
       issueDetailsData={Object {}}
@@ -168,10 +150,7 @@ exports[`CommandBar renders renders, shows inspect button message: true 1`] = `
     <CopyIssueDetailsButton
       deps={
         Object {
-          "axeResultToIssueFilingDataConverter": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "shortenSelector": undefined,
-          },
+          "axeResultToIssueFilingDataConverter": [typemoq mock object],
         }
       }
       issueDetailsData={Object {}}
@@ -179,10 +158,7 @@ exports[`CommandBar renders renders, shows inspect button message: true 1`] = `
     <IssueFilingButton
       deps={
         Object {
-          "axeResultToIssueFilingDataConverter": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "shortenSelector": undefined,
-          },
+          "axeResultToIssueFilingDataConverter": [typemoq mock object],
         }
       }
       issueDetailsData={Object {}}

--- a/src/tests/unit/tests/issue-filing/components/__snapshots__/issue-filing-settings-container.test.tsx.snap
+++ b/src/tests/unit/tests/issue-filing/components/__snapshots__/issue-filing-settings-container.test.tsx.snap
@@ -24,10 +24,7 @@ exports[`IssueFilingSettingsContainerTest render 1`] = `
   <settingsForm
     deps={
       Object {
-        "issueFilingServiceProvider": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "services": undefined,
-        },
+        "issueFilingServiceProvider": [typemoq mock object],
         "userConfigMessageCreator": Object {},
       }
     }

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -85,10 +85,7 @@ exports[`PopupView renderFailureMsgPanelForFileUrl 1`] = `
       "browserAdapter": Object {
         "getManifest": [Function],
       },
-      "storesHub": proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "stores": undefined,
-      },
+      "storesHub": [typemoq mock object],
     }
   }
   header={

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
@@ -56,32 +56,12 @@ exports[`ReportBody renders 1`] = `
     }
     deps={Object {}}
     description="test description"
-    fixInstructionProcessor={
-      proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        "backgroundColorText": "background color: ",
-        "backgroundRecommendedColorText": "Use background color: ",
-        "backgroundRecommendedRegExp": /Use background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-        "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-        "colorValueMatcher": "(#[0-9a-f]{6})",
-        "contrastRatioRegExp": /Expected contrast ratio of /i,
-        "contrastRatioText": "Expected contrast ratio of ",
-        "foregroundColorText": "foreground color: ",
-        "foregroundRecommendedColorText": "Use foreground color: ",
-        "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-        "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-        "originalMiddleSentence": " and the original foreground color: ",
-      }
-    }
+    fixInstructionProcessor={[typemoq mock object]}
     getCollapsibleScript={[Function]}
     getGuidanceTagsFromGuidanceLinks={[Function]}
     pageTitle="page-title"
     pageUrl="url:target-page"
-    recommendColor={
-      proxy {
-        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-      }
-    }
+    recommendColor={[typemoq mock object]}
     scanMetadata={
       Object {
         "targetAppInfo": Object {
@@ -214,32 +194,12 @@ exports[`ReportBody renders 1`] = `
       }
       deps={Object {}}
       description="test description"
-      fixInstructionProcessor={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "backgroundColorText": "background color: ",
-          "backgroundRecommendedColorText": "Use background color: ",
-          "backgroundRecommendedRegExp": /Use background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "colorValueMatcher": "(#[0-9a-f]{6})",
-          "contrastRatioRegExp": /Expected contrast ratio of /i,
-          "contrastRatioText": "Expected contrast ratio of ",
-          "foregroundColorText": "foreground color: ",
-          "foregroundRecommendedColorText": "Use foreground color: ",
-          "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "originalMiddleSentence": " and the original foreground color: ",
-        }
-      }
+      fixInstructionProcessor={[typemoq mock object]}
       getCollapsibleScript={[Function]}
       getGuidanceTagsFromGuidanceLinks={[Function]}
       pageTitle="page-title"
       pageUrl="url:target-page"
-      recommendColor={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        }
-      }
+      recommendColor={[typemoq mock object]}
       scanMetadata={
         Object {
           "targetAppInfo": Object {
@@ -370,32 +330,12 @@ exports[`ReportBody renders 1`] = `
       }
       deps={Object {}}
       description="test description"
-      fixInstructionProcessor={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "backgroundColorText": "background color: ",
-          "backgroundRecommendedColorText": "Use background color: ",
-          "backgroundRecommendedRegExp": /Use background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "colorValueMatcher": "(#[0-9a-f]{6})",
-          "contrastRatioRegExp": /Expected contrast ratio of /i,
-          "contrastRatioText": "Expected contrast ratio of ",
-          "foregroundColorText": "foreground color: ",
-          "foregroundRecommendedColorText": "Use foreground color: ",
-          "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "originalMiddleSentence": " and the original foreground color: ",
-        }
-      }
+      fixInstructionProcessor={[typemoq mock object]}
       getCollapsibleScript={[Function]}
       getGuidanceTagsFromGuidanceLinks={[Function]}
       pageTitle="page-title"
       pageUrl="url:target-page"
-      recommendColor={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        }
-      }
+      recommendColor={[typemoq mock object]}
       scanMetadata={
         Object {
           "targetAppInfo": Object {
@@ -526,32 +466,12 @@ exports[`ReportBody renders 1`] = `
       }
       deps={Object {}}
       description="test description"
-      fixInstructionProcessor={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "backgroundColorText": "background color: ",
-          "backgroundRecommendedColorText": "Use background color: ",
-          "backgroundRecommendedRegExp": /Use background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "colorValueMatcher": "(#[0-9a-f]{6})",
-          "contrastRatioRegExp": /Expected contrast ratio of /i,
-          "contrastRatioText": "Expected contrast ratio of ",
-          "foregroundColorText": "foreground color: ",
-          "foregroundRecommendedColorText": "Use foreground color: ",
-          "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "originalMiddleSentence": " and the original foreground color: ",
-        }
-      }
+      fixInstructionProcessor={[typemoq mock object]}
       getCollapsibleScript={[Function]}
       getGuidanceTagsFromGuidanceLinks={[Function]}
       pageTitle="page-title"
       pageUrl="url:target-page"
-      recommendColor={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        }
-      }
+      recommendColor={[typemoq mock object]}
       scanMetadata={
         Object {
           "targetAppInfo": Object {
@@ -682,32 +602,12 @@ exports[`ReportBody renders 1`] = `
         }
         deps={Object {}}
         description="test description"
-        fixInstructionProcessor={
-          proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "backgroundColorText": "background color: ",
-            "backgroundRecommendedColorText": "Use background color: ",
-            "backgroundRecommendedRegExp": /Use background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "colorValueMatcher": "(#[0-9a-f]{6})",
-            "contrastRatioRegExp": /Expected contrast ratio of /i,
-            "contrastRatioText": "Expected contrast ratio of ",
-            "foregroundColorText": "foreground color: ",
-            "foregroundRecommendedColorText": "Use foreground color: ",
-            "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "originalMiddleSentence": " and the original foreground color: ",
-          }
-        }
+        fixInstructionProcessor={[typemoq mock object]}
         getCollapsibleScript={[Function]}
         getGuidanceTagsFromGuidanceLinks={[Function]}
         pageTitle="page-title"
         pageUrl="url:target-page"
-        recommendColor={
-          proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          }
-        }
+        recommendColor={[typemoq mock object]}
         scanMetadata={
           Object {
             "targetAppInfo": Object {
@@ -838,32 +738,12 @@ exports[`ReportBody renders 1`] = `
         }
         deps={Object {}}
         description="test description"
-        fixInstructionProcessor={
-          proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "backgroundColorText": "background color: ",
-            "backgroundRecommendedColorText": "Use background color: ",
-            "backgroundRecommendedRegExp": /Use background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "colorValueMatcher": "(#[0-9a-f]{6})",
-            "contrastRatioRegExp": /Expected contrast ratio of /i,
-            "contrastRatioText": "Expected contrast ratio of ",
-            "foregroundColorText": "foreground color: ",
-            "foregroundRecommendedColorText": "Use foreground color: ",
-            "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "originalMiddleSentence": " and the original foreground color: ",
-          }
-        }
+        fixInstructionProcessor={[typemoq mock object]}
         getCollapsibleScript={[Function]}
         getGuidanceTagsFromGuidanceLinks={[Function]}
         pageTitle="page-title"
         pageUrl="url:target-page"
-        recommendColor={
-          proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          }
-        }
+        recommendColor={[typemoq mock object]}
         scanMetadata={
           Object {
             "targetAppInfo": Object {
@@ -994,32 +874,12 @@ exports[`ReportBody renders 1`] = `
         }
         deps={Object {}}
         description="test description"
-        fixInstructionProcessor={
-          proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "backgroundColorText": "background color: ",
-            "backgroundRecommendedColorText": "Use background color: ",
-            "backgroundRecommendedRegExp": /Use background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "colorValueMatcher": "(#[0-9a-f]{6})",
-            "contrastRatioRegExp": /Expected contrast ratio of /i,
-            "contrastRatioText": "Expected contrast ratio of ",
-            "foregroundColorText": "foreground color: ",
-            "foregroundRecommendedColorText": "Use foreground color: ",
-            "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "originalMiddleSentence": " and the original foreground color: ",
-          }
-        }
+        fixInstructionProcessor={[typemoq mock object]}
         getCollapsibleScript={[Function]}
         getGuidanceTagsFromGuidanceLinks={[Function]}
         pageTitle="page-title"
         pageUrl="url:target-page"
-        recommendColor={
-          proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          }
-        }
+        recommendColor={[typemoq mock object]}
         scanMetadata={
           Object {
             "targetAppInfo": Object {
@@ -1153,32 +1013,12 @@ exports[`ReportBody renders 1`] = `
       }
       deps={Object {}}
       description="test description"
-      fixInstructionProcessor={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "backgroundColorText": "background color: ",
-          "backgroundRecommendedColorText": "Use background color: ",
-          "backgroundRecommendedRegExp": /Use background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "colorValueMatcher": "(#[0-9a-f]{6})",
-          "contrastRatioRegExp": /Expected contrast ratio of /i,
-          "contrastRatioText": "Expected contrast ratio of ",
-          "foregroundColorText": "foreground color: ",
-          "foregroundRecommendedColorText": "Use foreground color: ",
-          "foregroundRecommendedRegExp": /Use foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "originalMiddleSentence": " and the original foreground color: ",
-        }
-      }
+      fixInstructionProcessor={[typemoq mock object]}
       getCollapsibleScript={[Function]}
       getGuidanceTagsFromGuidanceLinks={[Function]}
       pageTitle="page-title"
       pageUrl="url:target-page"
-      recommendColor={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        }
-      }
+      recommendColor={[typemoq mock object]}
       scanMetadata={
         Object {
           "targetAppInfo": Object {


### PR DESCRIPTION
#### Details

This PR implements and configures a new `typemoq-snapshot-serializer`, a Jest Snapshot Serializer which causes typemoq mock objects that get captured by test snapshots to be serialized as `[typemoq mock object]` instead of as a big blob of all the objects' properties.

Example before:

```
      Object {
        "deps": Object {
          "storesHub": proxy {
            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
            "stores": undefined,
          },
        },
      }
```

Same example after:

```
      Object {
        "deps": Object {
          "storesHub": [typemoq mock object],
        },
      }
```

##### Motivation

1. This makes tests less brittle. In general, we don't want to pin the individual properties of mocked objects in snapshots; from the perspective of the test performing the snapshot, they're implementation details (otherwise it wouldn't be mocked!), so we shouldn't be validating them directly
2. This simplifies work that @katydecorah and I are looking at to upgrade our `@swc/core` dependency (that upgrade would otherwise change how these proxy objects get serialized in a way which is an implementation detail to all these tests, but which would have required we update all these snapshots anyway)
3. Works around a long-standing issue where snapshotting the results of `enzyme.shallow(<Component prop={someMock}/>).getElement()` would fail with a confusing looking `MockException` (the one that the new snapshot serializer catches when trying to detect a mock function)

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
