### PR TITLE
chore(lint): enable no-throw-literal eslint rule

### DIFF
--- a/eslintrc.base.js
+++ b/eslintrc.base.js
@@ -41,6 +41,7 @@ module.exports = {
                 },
             },
         ],
+        'no-throw-literal': 'error',
 
         // Disabled due to high existing-positive count during initial tslint -> eslint migration
         '@typescript-eslint/no-explicit-any': 'off',

--- a/src/tests/unit/tests/scanner/custom-rules-configuration-stub.ts
+++ b/src/tests/unit/tests/scanner/custom-rules-configuration-stub.ts
@@ -9,7 +9,7 @@ const fakeRuleConfigurationA: RuleConfiguration = {
         {
             id: 'fake-check-id',
             evaluate: () => {
-                throw 'unimplemented evaluate stub';
+                throw new Error('unimplemented evaluate stub');
             },
             passMessage: () => passMessageStub,
             failMessage: () => failMessageStub,


### PR DESCRIPTION
#### Details

This is a followup from a PR comment several weeks ago where I suggested to someone that it would be preferable to use `throw new Error('message');` instead of `throw 'message';`, since the former gives a stack trace. This is something that eslint can catch automatically; this PR configures it to do so (and fixes the one existing hit for the rule in a test file).

##### Motivation

Automatically catches an issue that previously required manual review.

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
