### PR TITLE
fix: Ignore hidden elements when determining tabbable elements

### DIFF
--- a/src/injected/tabbable-element-getter.ts
+++ b/src/injected/tabbable-element-getter.ts
@@ -23,11 +23,11 @@ export class TabbableElementGetter {
     ) => {
         const hiddenSelectors = ['div[aria-hidden="true"]', 'div[aria-modal="true"]'];
         hiddenSelectors.forEach(selector => {
-            const hiddenElements = this.doc.querySelectorAll<FocusableElement>(
-                `${selector}, ${selector} *`,
-            );
+            const hiddenElements = this.doc.querySelectorAll(selector);
             if (hiddenElements) {
-                elements = elements.filter(e => !Array.from(hiddenElements).includes(e));
+                elements = elements.filter(
+                    e => !Array.from(hiddenElements).some(hidden => hidden.contains(e)),
+                );
             }
         });
         return elements;

--- a/src/injected/tabbable-element-getter.ts
+++ b/src/injected/tabbable-element-getter.ts
@@ -18,7 +18,7 @@ export class TabbableElementGetter {
     ) {}
 
     public get: () => TabbableElementInfo[] = () => {
-        return this.getTabbableElements(this.doc.documentElement).map((elem, index) => ({
+        return this.getRawElements().map((elem, index) => ({
             html: elem.outerHTML,
             selector: this.generateSelector(elem as HTMLElement),
             order: index,
@@ -26,6 +26,23 @@ export class TabbableElementGetter {
     };
 
     public getRawElements: () => FocusableElement[] = () => {
-        return this.getTabbableElements(this.doc.documentElement);
+        const tabbableElements = this.getTabbableElements(this.doc.documentElement);
+        const filteredElements = this.filterHiddenElements(tabbableElements);
+        return filteredElements;
+    };
+
+    private filterHiddenElements: (elements: FocusableElement[]) => FocusableElement[] = (
+        elements: FocusableElement[],
+    ) => {
+        const hiddenSelectors = ['div[aria-hidden="true"]', 'div[aria-modal="true"]'];
+        hiddenSelectors.forEach(selector => {
+            const hiddenElements = this.doc.querySelectorAll<FocusableElement>(
+                `${selector}, ${selector} *`,
+            );
+            if (hiddenElements) {
+                elements = elements.filter(e => !Array.from(hiddenElements).includes(e));
+            }
+        });
+        return elements;
     };
 }

--- a/src/injected/tabbable-element-getter.ts
+++ b/src/injected/tabbable-element-getter.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { getUniqueSelector } from 'scanner/axe-utils';
 import { FocusableElement, tabbable } from 'tabbable';
 
 export interface TabbableElementInfo {
@@ -11,19 +10,7 @@ export interface TabbableElementInfo {
 }
 
 export class TabbableElementGetter {
-    constructor(
-        private doc: Document,
-        private generateSelector: typeof getUniqueSelector,
-        private getTabbableElements: typeof tabbable,
-    ) {}
-
-    public get: () => TabbableElementInfo[] = () => {
-        return this.getRawElements().map((elem, index) => ({
-            html: elem.outerHTML,
-            selector: this.generateSelector(elem as HTMLElement),
-            order: index,
-        }));
-    };
+    constructor(private doc: Document, private getTabbableElements: typeof tabbable) {}
 
     public getRawElements: () => FocusableElement[] = () => {
         const tabbableElements = this.getTabbableElements(this.doc.documentElement);

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -133,11 +133,7 @@ export class WindowInitializer {
         );
         this.manualTabStopListener.initialize();
 
-        const tabbableElementGetter = new TabbableElementGetter(
-            document,
-            getUniqueSelector,
-            tabbable,
-        );
+        const tabbableElementGetter = new TabbableElementGetter(document, tabbable);
         const tabStopRequirementEvaluator = new DefaultTabStopsRequirementEvaluator(
             htmlElementUtils,
             getUniqueSelector,

--- a/src/tests/unit/tests/injected/tabbable-element-getter.test.ts
+++ b/src/tests/unit/tests/injected/tabbable-element-getter.test.ts
@@ -1,20 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { TabbableElementGetter, TabbableElementInfo } from 'injected/tabbable-element-getter';
-import { getUniqueSelector } from 'scanner/axe-utils';
+import { TabbableElementGetter } from 'injected/tabbable-element-getter';
 import { tabbable, FocusableElement } from 'tabbable';
 import { TestDocumentCreator } from 'tests/unit/common/test-document-creator';
 import { IMock, Mock } from 'typemoq';
 
 describe('TabbableElementGetter', () => {
-    let generateSelectorMock: IMock<typeof getUniqueSelector>;
     let getTabbableElementsMock: IMock<typeof tabbable>;
     let testSubject: TabbableElementGetter;
     let documentElementStub: HTMLElement;
 
     beforeEach(() => {
-        generateSelectorMock = Mock.ofType<typeof getUniqueSelector>();
         getTabbableElementsMock = Mock.ofType<typeof tabbable>();
     });
 
@@ -39,38 +36,7 @@ describe('TabbableElementGetter', () => {
                 .setup(m => m(documentElementStub))
                 .returns(() => focusableElementsStub);
 
-            testSubject = new TabbableElementGetter(
-                docMock.object,
-                generateSelectorMock.object,
-                getTabbableElementsMock.object,
-            );
-        });
-
-        test('get', () => {
-            docMock.setup(m => m.documentElement).returns(() => documentElementStub);
-
-            generateSelectorMock
-                .setup(m => m(focusableElementsStub[0] as HTMLElement))
-                .returns(() => 'some selector');
-
-            generateSelectorMock
-                .setup(m => m(focusableElementsStub[1] as HTMLElement))
-                .returns(() => 'some other selector');
-
-            const expectedTabbleElementInfo: TabbableElementInfo[] = [
-                {
-                    html: 'some outer html',
-                    selector: 'some selector',
-                    order: 0,
-                },
-                {
-                    html: 'some other outer html',
-                    selector: 'some other selector',
-                    order: 1,
-                },
-            ];
-
-            expect(testSubject.get()).toEqual(expectedTabbleElementInfo);
+            testSubject = new TabbableElementGetter(docMock.object, getTabbableElementsMock.object);
         });
 
         test('getRawElements', () => {
@@ -100,11 +66,7 @@ describe('TabbableElementGetter', () => {
                     Array.from(doc.querySelectorAll<FocusableElement>('div')),
                 );
 
-            testSubject = new TabbableElementGetter(
-                fakeDocument,
-                generateSelectorMock.object,
-                getTabbableElementsMock.object,
-            );
+            testSubject = new TabbableElementGetter(fakeDocument, getTabbableElementsMock.object);
         });
 
         test('hidden elements are ignored', () => {

--- a/src/tests/unit/tests/injected/tabbable-element-getter.test.ts
+++ b/src/tests/unit/tests/injected/tabbable-element-getter.test.ts
@@ -4,72 +4,111 @@
 import { TabbableElementGetter, TabbableElementInfo } from 'injected/tabbable-element-getter';
 import { getUniqueSelector } from 'scanner/axe-utils';
 import { tabbable, FocusableElement } from 'tabbable';
+import { TestDocumentCreator } from 'tests/unit/common/test-document-creator';
 import { IMock, Mock } from 'typemoq';
 
 describe('TabbableElementGetter', () => {
-    let docMock: IMock<Document>;
     let generateSelectorMock: IMock<typeof getUniqueSelector>;
     let getTabbableElementsMock: IMock<typeof tabbable>;
     let testSubject: TabbableElementGetter;
     let documentElementStub: HTMLElement;
-    let focusableElementsStub: FocusableElement[];
 
     beforeEach(() => {
-        docMock = Mock.ofType<Document>();
         generateSelectorMock = Mock.ofType<typeof getUniqueSelector>();
         getTabbableElementsMock = Mock.ofType<typeof tabbable>();
-        documentElementStub = {} as HTMLElement;
-
-        focusableElementsStub = [
-            {
-                outerHTML: 'some outer html',
-            },
-            {
-                outerHTML: 'some other outer html',
-            },
-        ] as FocusableElement[];
-
-        getTabbableElementsMock
-            .setup(m => m(documentElementStub))
-            .returns(() => focusableElementsStub);
-
-        testSubject = new TabbableElementGetter(
-            docMock.object,
-            generateSelectorMock.object,
-            getTabbableElementsMock.object,
-        );
     });
 
-    test('get', () => {
-        docMock.setup(m => m.documentElement).returns(() => documentElementStub);
+    describe('mock document', () => {
+        let docMock: IMock<Document>;
+        let focusableElementsStub: FocusableElement[];
 
-        generateSelectorMock
-            .setup(m => m(focusableElementsStub[0] as HTMLElement))
-            .returns(() => 'some selector');
+        beforeEach(() => {
+            docMock = Mock.ofType<Document>();
+            documentElementStub = {} as HTMLElement;
 
-        generateSelectorMock
-            .setup(m => m(focusableElementsStub[1] as HTMLElement))
-            .returns(() => 'some other selector');
+            focusableElementsStub = [
+                {
+                    outerHTML: 'some outer html',
+                },
+                {
+                    outerHTML: 'some other outer html',
+                },
+            ] as FocusableElement[];
 
-        const expectedTabbleElementInfo: TabbableElementInfo[] = [
-            {
-                html: 'some outer html',
-                selector: 'some selector',
-                order: 0,
-            },
-            {
-                html: 'some other outer html',
-                selector: 'some other selector',
-                order: 1,
-            },
-        ];
+            getTabbableElementsMock
+                .setup(m => m(documentElementStub))
+                .returns(() => focusableElementsStub);
 
-        expect(testSubject.get()).toEqual(expectedTabbleElementInfo);
+            testSubject = new TabbableElementGetter(
+                docMock.object,
+                generateSelectorMock.object,
+                getTabbableElementsMock.object,
+            );
+        });
+
+        test('get', () => {
+            docMock.setup(m => m.documentElement).returns(() => documentElementStub);
+
+            generateSelectorMock
+                .setup(m => m(focusableElementsStub[0] as HTMLElement))
+                .returns(() => 'some selector');
+
+            generateSelectorMock
+                .setup(m => m(focusableElementsStub[1] as HTMLElement))
+                .returns(() => 'some other selector');
+
+            const expectedTabbleElementInfo: TabbableElementInfo[] = [
+                {
+                    html: 'some outer html',
+                    selector: 'some selector',
+                    order: 0,
+                },
+                {
+                    html: 'some other outer html',
+                    selector: 'some other selector',
+                    order: 1,
+                },
+            ];
+
+            expect(testSubject.get()).toEqual(expectedTabbleElementInfo);
+        });
+
+        test('getRawElements', () => {
+            docMock.setup(m => m.documentElement).returns(() => documentElementStub);
+
+            expect(testSubject.getRawElements()).toEqual(focusableElementsStub);
+        });
     });
 
-    test('getRawElements', () => {
-        docMock.setup(m => m.documentElement).returns(() => documentElementStub);
+    describe('fake document', () => {
+        let fakeDocument: Document;
+        let shownElement: HTMLElement;
 
-        expect(testSubject.getRawElements()).toEqual(focusableElementsStub);
+        beforeEach(() => {
+            fakeDocument = TestDocumentCreator.createTestDocument(`
+                <div id='id1' aria-hidden='true'></div>
+                <div id='id2'></div>
+                <div id='id3' aria-modal='true'></div>
+                <div aria-hidden='true'><div id='id4'></div></div>
+            `);
+            shownElement = fakeDocument.getElementById('id2');
+            documentElementStub = {} as HTMLElement;
+
+            getTabbableElementsMock
+                .setup(m => m(fakeDocument.documentElement))
+                .returns((doc: Document) =>
+                    Array.from(doc.querySelectorAll<FocusableElement>('div')),
+                );
+
+            testSubject = new TabbableElementGetter(
+                fakeDocument,
+                generateSelectorMock.object,
+                getTabbableElementsMock.object,
+            );
+        });
+
+        test('hidden elements are ignored', () => {
+            expect(testSubject.getRawElements()).toEqual([shownElement]);
+        });
     });
 });


### PR DESCRIPTION
#### Details

Fix automated tab stops bug so that elements behind an open modal are not marked as missing failures. 

[Screenshot of site with modal open and no missing tab stops marked in background]
<img width="752" alt="ModalWithoutMissingTabs" src="https://user-images.githubusercontent.com/16010855/160879632-31735558-9437-491c-8138-8efc76b918f3.png">

##### Motivation

Addresses issue #5305.

##### Context

Tabbable does not take `aria-hidden` or `aria-modal` into account when determining which elements are tabbable, meaning before this change we were marking them as missing since the user can't tab to them. This PR adds logic to filter out these elements from the tabbable results so they are not considered when determining missing elements.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5305
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
