### PR TITLE
refactor: use ditto to compress auto-update zip

### DIFF
--- a/pipeline/scripts/zip-mac-folder.js
+++ b/pipeline/scripts/zip-mac-folder.js
@@ -11,18 +11,16 @@
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const sevenBin = require('7zip-bin');
 
 const parentDir = process.argv[2];
 const files = fs.readdirSync(parentDir);
 const existingDmg = files.find(f => path.extname(f) === '.dmg');
 const appName = path.basename(existingDmg, path.extname(existingDmg));
-const cmd = `${sevenBin.path7za}`;
-const args = ['a', `${appName}.zip`, '-r', 'mac'];
+const cmd = `/usr/bin/ditto`;
+const args = ['-c', '-k', '--keepParent', 'mac', `${appName}.zip`];
 
 console.log(`existingDmg: ${existingDmg}`);
 console.log(`appName: ${appName}`);
-console.log(`path to 7z: ${sevenBin.path7za}`);
 
 child_process.execFileSync(cmd, args, {
     cwd: parentDir,


### PR DESCRIPTION
#### Details

Uses ditto to create zip for auto-update.

##### Motivation

Attempted fix for #3942.

##### Context

The error I'm getting upon trying to update seems to imply that this could be a zipping issue.

The error:

```
Error: Error: ditto: Accessibility Insights for Android - Canary.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libswiftshader_libGLESv2.dylib: No such file or directory
ditto: Couldn't read pkzip signature.
```

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3942
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
