### PR TITLE
fix: allow dyld environment variables for potential fix auto-update on Mac

### DIFF
--- a/src/electron/resources/entitlements.plist
+++ b/src/electron/resources/entitlements.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
#### Details

Adds entitlement for allowing DYLD environment variables.

More info: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-dyld-environment-variables

##### Motivation

Fixing #3942.
##### Context

The error that I'm seeing suggests that we're having trouble accessing the dylib ... so I'm wondering if this is necessary to fix problem (underlying update method could be using these environment variables to access these files). This was a common entitlement for electron projects I found when working on notarization.

The error:

```
Error: ditto: Accessibility Insights for Android - Canary.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libswiftshader_libGLESv2.dylib: No such file or directory
ditto: Couldn't read pkzip signature
```

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3942 
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
