### PR TITLE
fix: undo electron builder target for mac changes

### DIFF
--- a/src/electron/electron-builder/electron-builder.template.yaml
+++ b/src/electron/electron-builder/electron-builder.template.yaml
@@ -38,14 +38,10 @@ linux:
 appImage:
     license: src/electron/resources/mit_license.txt
 
-# Per: electron-userland/electron-builder#2199:
-# We do not specify target for electron-builder on Mac to produce both dmg and zip files.
-# However, we only use the dmg file produced by electron-builder since the zip is corrupt and create
-# our own zip for auto-update. This is because producing the zip file is necessary for auto-update
-# on Mac regardless of whether you use the zip file produced.
 mac:
     artifactName: ${productName}.${ext}
     icon: TARGET_SPECIFIC
+    target: dmg # we also need zip (electron-userland/electron-builder#2199) & add it in grunt
     identity: null
 
 win:


### PR DESCRIPTION
#### Details

Only builds dmg file.

##### Motivation

See if this fixes/produces different error than the "cannot read pkzip signature" issue.

##### Context

There's a comment suggesting errors that I'm seeing are similar to what happens when we produce a zip from electron-builder (https://github.com/microsoft/accessibility-insights-web/blob/9c25a2d1d4817b71cb7a5f3eb3e814543d2ea5ce/Gruntfile.js#L722-L725) ... and so I want to see whether that remains the case or we see a different error or this fixes the issue last seen for #3942.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3942
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
