### PR TITLE
refactor(mv3-part-2): Add persistent store

### DIFF
--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -3,6 +3,7 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { PersistentStore } from 'common/flux/persistent-store';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Logger } from 'common/logging/logger';
 import { StoreNames } from 'common/stores/store-names';
@@ -44,50 +45,32 @@ import {
 } from './../actions/action-payloads';
 import { AssessmentActions } from './../actions/assessment-actions';
 import { AssessmentDataRemover } from './../assessment-data-remover';
-import { BaseStoreImpl } from './base-store-impl';
 
-export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
+export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
     constructor(
         private readonly browserAdapter: BrowserAdapter,
         private readonly assessmentActions: AssessmentActions,
         private readonly assessmentDataConverter: AssessmentDataConverter,
         private readonly assessmentDataRemover: AssessmentDataRemover,
         private readonly assessmentsProvider: AssessmentsProvider,
-        private readonly idbInstance: IndexedDBAPI,
-        private readonly persistedData: AssessmentStoreData,
+        idbInstance: IndexedDBAPI,
+        persistedData: AssessmentStoreData,
         private readonly initialAssessmentStoreDataGenerator: InitialAssessmentStoreDataGenerator,
-        private readonly logger: Logger,
+        logger: Logger,
     ) {
-        super(StoreNames.AssessmentStore);
-    }
-
-    private generateDefaultState(persistedData: AssessmentStoreData = null): AssessmentStoreData {
-        return this.initialAssessmentStoreDataGenerator.generateInitialState(persistedData);
-    }
-
-    public getDefaultState(): AssessmentStoreData {
-        return this.generateDefaultState(this.persistedData);
-    }
-
-    private async persistAssessmentData(
-        assessmentStoreData: AssessmentStoreData,
-    ): Promise<boolean> {
-        return await this.idbInstance.setItem(
+        super(
+            StoreNames.AssessmentStore,
+            persistedData,
+            idbInstance,
             IndexedDBDataKeys.assessmentStore,
-            assessmentStoreData,
+            logger,
         );
     }
 
-    /**
-     * overriding emitChanged to persist assessment store
-     * into indexedDB
-     */
-    protected emitChanged(): void {
-        const assessmentStoreData = this.getState();
-
-        this.persistAssessmentData(assessmentStoreData).catch(this.logger.error);
-
-        super.emitChanged();
+    protected override generateDefaultState(
+        persistedData: AssessmentStoreData,
+    ): AssessmentStoreData {
+        return this.initialAssessmentStoreDataGenerator.generateInitialState(persistedData);
     }
 
     protected addActionListeners(): void {
@@ -425,16 +408,14 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
     private onResetData = (payload: ToggleActionPayload): void => {
         const test = this.assessmentsProvider.forType(payload.test);
         const config = test.getVisualizationConfiguration();
-        const defaultTestStatus: AssessmentData = config.getAssessmentData(
-            this.generateDefaultState(),
-        );
+        const defaultTestStatus: AssessmentData = config.getAssessmentData(this.getDefaultState());
         this.state.assessments[test.key] = defaultTestStatus;
         this.state.assessmentNavState.selectedTestSubview = test.requirements[0].key;
         this.emitChanged();
     };
 
     private onResetAllAssessmentsData = (targetTabId: number): void => {
-        this.state = this.generateDefaultState();
+        this.state = this.getDefaultState();
         this.updateTargetTabWithId(targetTabId);
     };
 

--- a/src/background/stores/global/user-configuration-store.ts
+++ b/src/background/stores/global/user-configuration-store.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { PersistentStore } from 'common/flux/persistent-store';
 import { Logger } from 'common/logging/logger';
 import { cloneDeep, isPlainObject } from 'lodash';
 import { IndexedDBAPI } from '../../../common/indexedDB/indexedDB';
@@ -16,9 +17,8 @@ import {
 } from '../../actions/action-payloads';
 import { UserConfigurationActions } from '../../actions/user-configuration-actions';
 import { IndexedDBDataKeys } from '../../IndexedDBDataKeys';
-import { BaseStoreImpl } from '../base-store-impl';
 
-export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStoreData> {
+export class UserConfigurationStore extends PersistentStore<UserConfigurationStoreData> {
     public static readonly defaultState: UserConfigurationStoreData = {
         isFirstTime: true,
         enableTelemetry: false,
@@ -33,24 +33,26 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
     };
 
     constructor(
-        private readonly persistedState: UserConfigurationStoreData,
+        persistedState: UserConfigurationStoreData,
         private readonly userConfigActions: UserConfigurationActions,
-        private readonly indexDbApi: IndexedDBAPI,
-        private readonly logger: Logger,
+        indexDbApi: IndexedDBAPI,
+        logger: Logger,
     ) {
-        super(StoreNames.UserConfigurationStore);
+        super(
+            StoreNames.UserConfigurationStore,
+            persistedState,
+            indexDbApi,
+            IndexedDBDataKeys.userConfiguration,
+            logger,
+        );
     }
 
-    private generateDefaultState(
-        persisted: UserConfigurationStoreData,
+    protected override generateDefaultState(
+        persistedData: UserConfigurationStoreData,
     ): UserConfigurationStoreData {
-        const persistedState = cloneDeep(persisted);
+        const persistedState = cloneDeep(persistedData);
         const defaultState = cloneDeep(UserConfigurationStore.defaultState);
         return Object.assign(defaultState, persistedState);
-    }
-
-    public getDefaultState(): UserConfigurationStoreData {
-        return this.generateDefaultState(this.persistedState);
     }
 
     public getState(): UserConfigurationStoreData {
@@ -78,31 +80,31 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
 
     private onSetAdbLocation = (location: string): void => {
         this.state.adbLocation = location;
-        this.saveAndEmitChanged();
+        this.emitChanged();
     };
 
     private onSetTelemetryState = (enableTelemetry: boolean): void => {
         this.state.isFirstTime = false;
         this.state.enableTelemetry = enableTelemetry;
-        this.saveAndEmitChanged();
+        this.emitChanged();
     };
 
     private onSetHighContrastMode = (payload: SetHighContrastModePayload): void => {
         this.state.enableHighContrast = payload.enableHighContrast;
         this.state.lastSelectedHighContrast = payload.enableHighContrast;
-        this.saveAndEmitChanged();
+        this.emitChanged();
     };
 
     private onSetNativeHighContrastMode = (payload: SetNativeHighContrastModePayload): void => {
         this.state.enableHighContrast = payload.enableHighContrast
             ? true
             : this.state.lastSelectedHighContrast;
-        this.saveAndEmitChanged();
+        this.emitChanged();
     };
 
     private onSetIssueFilingService = (payload: SetIssueFilingServicePayload): void => {
         this.state.bugService = payload.issueFilingServiceName;
-        this.saveAndEmitChanged();
+        this.emitChanged();
     };
 
     private onSetIssueFilingServiceProperty = (
@@ -118,14 +120,14 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
         this.state.bugServicePropertiesMap[payload.issueFilingServiceName][payload.propertyName] =
             payload.propertyValue;
 
-        this.saveAndEmitChanged();
+        this.emitChanged();
     };
 
     private onSaveIssueSettings = (payload: SaveIssueFilingSettingsPayload): void => {
         const bugService = payload.issueFilingServiceName;
         this.state.bugService = bugService;
         this.state.bugServicePropertiesMap[bugService] = payload.issueFilingSettings;
-        this.saveAndEmitChanged();
+        this.emitChanged();
     };
 
     private onSaveLastWindowBounds = (payload: SaveWindowBoundsPayload): void => {
@@ -136,7 +138,7 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
             this.state.lastWindowBounds = payload.windowBounds;
         }
 
-        this.saveAndEmitChanged();
+        this.emitChanged();
     };
 
     private onSetAutoDetectedFailuresDialogState = (
@@ -144,14 +146,6 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
     ): void => {
         this.state.showAutoDetectedFailuresDialog = payload.enabled;
 
-        this.saveAndEmitChanged();
-    };
-
-    private saveAndEmitChanged(): void {
-        this.indexDbApi
-            .setItem(IndexedDBDataKeys.userConfiguration, this.state)
-            .catch(this.logger.error);
-
         this.emitChanged();
-    }
+    };
 }

--- a/src/common/flux/persistent-store.ts
+++ b/src/common/flux/persistent-store.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BaseStoreImpl } from 'background/stores/base-store-impl';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
+import { StoreNames } from 'common/stores/store-names';
+
+export abstract class PersistentStore<TState> extends BaseStoreImpl<TState> {
+    constructor(
+        storeName: StoreNames,
+        protected readonly persistedState: TState,
+        protected readonly idbInstance: IndexedDBAPI,
+        protected readonly indexedDBDataKey: string,
+        protected readonly logger: Logger,
+    ) {
+        super(storeName);
+    }
+
+    protected async persistData(storeData: any): Promise<boolean> {
+        return await this.idbInstance.setItem(this.indexedDBDataKey, storeData);
+    }
+
+    public getDefaultState(): TState {
+        return this.generateDefaultState(this.persistedState);
+    }
+
+    // Allow specific stores to override default state behavior
+    protected generateDefaultState(persistedData: TState): TState {
+        return persistedData;
+    }
+
+    protected emitChanged(): void {
+        const storeData = this.getState();
+
+        this.persistData(storeData).catch(this.logger.error);
+
+        super.emitChanged();
+    }
+}

--- a/src/tests/unit/tests/background/stores/persistent-store.test.ts
+++ b/src/tests/unit/tests/background/stores/persistent-store.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
+import { IMock, Mock, Times } from 'typemoq';
+import { StoreNames } from '../../../../../common/stores/store-names';
+
+describe('PersistentStoreTest', () => {
+    const storeName: StoreNames = -1;
+    const persistedState: TestData = { value: 'persistedState' };
+    const idbInstanceMock: IMock<IndexedDBAPI> = Mock.ofType<IndexedDBAPI>();
+    const indexedDBDataKey: string = 'indexedDBDataKey';
+    const loggerMock: IMock<Logger> = Mock.ofType<Logger>();
+
+    test('getDefaultState', () => {
+        const testObject = new TestStore();
+
+        expect(testObject.getDefaultState()).toEqual(persistedState);
+    });
+
+    test('persistData', async () => {
+        const testObject = new TestStore();
+        const newData = { value: 'newData' };
+        idbInstanceMock
+            .setup(db => db.setItem(indexedDBDataKey, newData))
+            .returns(() => Promise.resolve(true))
+            .verifiable(Times.once());
+
+        await testObject.callPersistData(newData);
+
+        idbInstanceMock.verifyAll();
+    });
+
+    test('emitChanged', async () => {
+        const testObject = new TestStore();
+        testObject.initialize();
+        idbInstanceMock
+            .setup(db => db.setItem(indexedDBDataKey, persistedState))
+            .returns(() => Promise.resolve(true))
+            .verifiable(Times.once());
+
+        testObject.callEmitChanged();
+
+        idbInstanceMock.verifyAll();
+    });
+
+    interface TestData {
+        value: string;
+    }
+
+    class TestStore extends PersistentStore<TestData> {
+        constructor() {
+            super(
+                storeName,
+                persistedState,
+                idbInstanceMock.object,
+                indexedDBDataKey,
+                loggerMock.object,
+            );
+        }
+
+        protected addActionListeners(): void {
+            // Tested in base-store.tests.ts
+        }
+
+        public callEmitChanged() {
+            this.emitChanged();
+        }
+
+        public async callPersistData(data: TestData) {
+            await this.persistData(data);
+        }
+    }
+});


### PR DESCRIPTION
#### Details

Factor `PersistentStore` out of `AssessmentStore` and `UserConfigurationStore`. `PersistentStore` manages persisting store data using the indexed database API. 

##### Motivation

Feature work.

##### Context

This PR aims to refactor only and not make any behavioral changes. In future PRs, we will take advantage of the new `PersistentStore` class to make sure all other store data is persisted as well. This will be necessary when we convert to manifest v3 because we will no longer be able to depend on the background for persisting data, since it is being depreciated in favor of service workers which can potentially stop and lose store data. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
