### PR TITLE
fix: remove unnecessary changes for auto-update and add comments

### DIFF
--- a/pipeline/scripts/zip-mac-folder.js
+++ b/pipeline/scripts/zip-mac-folder.js
@@ -5,7 +5,7 @@
     The macOS electron-builder update process requires a zip file
     (electron-builder #4230), but the zip file produced by 
     electron-builder is corrupted (electron-builder #3534).
-    We use 7z to create the zip file ourselves.
+    We use ditto to create the zip file ourselves.
 */
 
 const child_process = require('child_process');

--- a/src/electron/electron-builder/electron-builder.template.yaml
+++ b/src/electron/electron-builder/electron-builder.template.yaml
@@ -38,10 +38,14 @@ linux:
 appImage:
     license: src/electron/resources/mit_license.txt
 
+# electron-userland/electron-builder#2199 suggests we should produce a zip using electron-builder
+# even if we do not use it (for auto-update to work) but that actually leads to issues when updating
+# (accessibility-insights-web/3942#issuecomment-1090857396). As such, we only build the dmg with
+# electron-builder and build the zip ourselves.
 mac:
     artifactName: ${productName}.${ext}
     icon: TARGET_SPECIFIC
-    target: dmg # we also need zip (electron-userland/electron-builder#2199) & add it in grunt
+    target: dmg
     identity: null
 
 win:

--- a/src/electron/resources/entitlements.plist
+++ b/src/electron/resources/entitlements.plist
@@ -8,7 +8,5 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
#### Details

Auto-update is now functional per my last PR #5336. I'm removing changes that are not necessary for it to function + adding comments.

##### Motivation

Clean up.

##### Context

Decided to keep using ditto even though that change was made as an (unsuccessful) attempt to fix auto-update, since documentation around notarization on Mac suggests to use ditto.

https://developer.apple.com/forums/thread/701514#701514021

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #3942 
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
