### PR TITLE
fix: unset heading margin under heading element for level component

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -791,6 +791,10 @@
         margin-bottom: unset;
       }</style
     ><style>
+      .heading-element-for-level--OfRDW {
+        margin-block-start: unset;
+        margin-block-end: unset;
+      }
       .failed-instances-container--FqWV6 .collapsible-content {
         margin-left: 24px;
       }
@@ -1803,7 +1807,7 @@
           ><div
             class="failed-instances-container--FqWV6 result-section--j6fYr"
             data-automation-id="result-section"
-            ><h2
+            ><h2 class="heading-element-for-level--OfRDW"
               ><span class="result-section-title--qv3MK"
                 ><span class="screen-reader-only">Failed instances 26</span
                 ><span class="title--neMma" aria-hidden="true"
@@ -1841,7 +1845,7 @@
               data-automation-id="rule-details-group"
               ><div
                 class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="title-container"
+                ><h3 class="heading-element-for-level--OfRDW title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
@@ -1971,7 +1975,7 @@
                 ></div
               ><div
                 class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="title-container"
+                ><h3 class="heading-element-for-level--OfRDW title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
@@ -2512,7 +2516,7 @@
                 ></div
               ><div
                 class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="title-container"
+                ><h3 class="heading-element-for-level--OfRDW title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
@@ -2639,7 +2643,7 @@
                 ></div
               ><div
                 class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="title-container"
+                ><h3 class="heading-element-for-level--OfRDW title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
@@ -2967,7 +2971,7 @@
                 ></div
               ><div
                 class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="title-container"
+                ><h3 class="heading-element-for-level--OfRDW title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
@@ -3775,7 +3779,7 @@
                 ></div
               ><div
                 class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="title-container"
+                ><h3 class="heading-element-for-level--OfRDW title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
@@ -3902,7 +3906,7 @@
                 ></div
               ><div
                 class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="title-container"
+                ><h3 class="heading-element-for-level--OfRDW title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
@@ -4028,7 +4032,7 @@
                 ></div
               ><div
                 class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="title-container"
+                ><h3 class="heading-element-for-level--OfRDW title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
@@ -4156,7 +4160,7 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="title-container"
+              ><h2 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -4705,7 +4709,7 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="title-container"
+              ><h2 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -791,6 +791,10 @@
         margin-bottom: unset;
       }</style
     ><style>
+      .heading-element-for-level--OfRDW {
+        margin-block-start: unset;
+        margin-block-end: unset;
+      }
       .failed-instances-container--FqWV6 .collapsible-content {
         margin-left: 24px;
       }
@@ -1803,7 +1807,7 @@
           ><div
             class="failed-instances-container--FqWV6 result-section--j6fYr"
             data-automation-id="result-section"
-            ><h2
+            ><h2 class="heading-element-for-level--OfRDW"
               ><span class="result-section-title--qv3MK"
                 ><span class="screen-reader-only">Failed instances 0</span
                 ><span class="title--neMma" aria-hidden="true"
@@ -1837,7 +1841,7 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="title-container"
+              ><h2 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -3024,7 +3028,7 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="title-container"
+              ><h2 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -791,6 +791,10 @@
         margin-bottom: unset;
       }</style
     ><style>
+      .heading-element-for-level--OfRDW {
+        margin-block-start: unset;
+        margin-block-end: unset;
+      }
       .failed-instances-container--FqWV6 .collapsible-content {
         margin-left: 24px;
       }
@@ -1792,7 +1796,7 @@
           ><div class="results-heading--pyS7R"><h2>Rules</h2></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -1813,7 +1817,8 @@
                   data-automation-id="rule-details-group"
                   ><div
                     class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                    ><h4 class="title-container"
+                    ><h4
+                      class="heading-element-for-level--OfRDW title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -2171,7 +2176,8 @@
                     ></div
                   ><div
                     class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                    ><h4 class="title-container"
+                    ><h4
+                      class="heading-element-for-level--OfRDW title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -2482,7 +2488,7 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -2641,7 +2647,7 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -791,6 +791,10 @@
         margin-bottom: unset;
       }</style
     ><style>
+      .heading-element-for-level--OfRDW {
+        margin-block-start: unset;
+        margin-block-end: unset;
+      }
       .failed-instances-container--FqWV6 .collapsible-content {
         margin-left: 24px;
       }
@@ -1792,7 +1796,7 @@
           ><div class="results-heading--pyS7R"><h2>Rules</h2></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -1813,7 +1817,8 @@
                   data-automation-id="rule-details-group"
                   ><div
                     class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                    ><h4 class="title-container"
+                    ><h4
+                      class="heading-element-for-level--OfRDW title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -2165,7 +2170,8 @@
                     ></div
                   ><div
                     class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                    ><h4 class="title-container"
+                    ><h4
+                      class="heading-element-for-level--OfRDW title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -2470,7 +2476,7 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -2629,7 +2635,7 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -791,6 +791,10 @@
         margin-bottom: unset;
       }</style
     ><style>
+      .heading-element-for-level--OfRDW {
+        margin-block-start: unset;
+        margin-block-end: unset;
+      }
       .failed-instances-container--FqWV6 .collapsible-content {
         margin-left: 24px;
       }
@@ -1792,7 +1796,7 @@
           ><div class="results-heading--pyS7R"><h2>Rules</h2></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -1811,7 +1815,7 @@
               ></div></div></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -1970,7 +1974,7 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -791,6 +791,10 @@
         margin-bottom: unset;
       }</style
     ><style>
+      .heading-element-for-level--OfRDW {
+        margin-block-start: unset;
+        margin-block-end: unset;
+      }
       .failed-instances-container--FqWV6 .collapsible-content {
         margin-left: 24px;
       }
@@ -1792,7 +1796,7 @@
           ><div class="results-heading--D3Qtr"><h2>Results by URL</h2></div
           ><div class="url-result-section--PmEoY"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -1911,7 +1915,7 @@
             ></div
           ><div class="url-result-section--PmEoY"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -2010,7 +2014,7 @@
             ></div
           ><div class="url-result-section--PmEoY"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -791,6 +791,10 @@
         margin-bottom: unset;
       }</style
     ><style>
+      .heading-element-for-level--OfRDW {
+        margin-block-start: unset;
+        margin-block-end: unset;
+      }
       .failed-instances-container--FqWV6 .collapsible-content {
         margin-left: 24px;
       }
@@ -1792,7 +1796,7 @@
           ><div class="results-heading--D3Qtr"><h2>Results by URL</h2></div
           ><div class="url-result-section--PmEoY"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -1856,7 +1860,7 @@
                   ><tbody></tbody></table></div></div></div
           ><div class="url-result-section--PmEoY"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
@@ -1926,7 +1930,7 @@
                   ><tbody></tbody></table></div></div></div
           ><div class="url-result-section--PmEoY"
             ><div class="collapsible-container collapsed"
-              ><h3 class="title-container"
+              ><h3 class="heading-element-for-level--OfRDW title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"

--- a/src/common/components/heading-element-for-level.scss
+++ b/src/common/components/heading-element-for-level.scss
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+.heading-element-for-level {
+    margin-block-start: unset;
+    margin-block-end: unset;
+}

--- a/src/common/components/heading-element-for-level.tsx
+++ b/src/common/components/heading-element-for-level.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
+import * as styles from './heading-element-for-level.scss';
 
 export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 export type HeadingElementForLevelProps = React.DetailedHTMLProps<
@@ -13,7 +14,13 @@ export type HeadingElementForLevelProps = React.DetailedHTMLProps<
 
 export const HeadingElementForLevel = NamedFC<HeadingElementForLevelProps>(
     'HeadingElementForLevel',
-    ({ headingLevel, ...props }) => React.createElement(`h${headingLevel}`, props),
+    ({ headingLevel, ...props }) => {
+        const newProps = {
+            className: styles.headingElementForLevel,
+            ...props,
+        };
+        return React.createElement(`h${headingLevel}`, newProps);
+    },
 );
 
 export const GetNextHeadingLevel = (headingLevel: HeadingLevel) => {

--- a/src/common/components/heading-element-for-level.tsx
+++ b/src/common/components/heading-element-for-level.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { css } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import * as styles from './heading-element-for-level.scss';
@@ -16,8 +17,8 @@ export const HeadingElementForLevel = NamedFC<HeadingElementForLevelProps>(
     'HeadingElementForLevel',
     ({ headingLevel, ...props }) => {
         const newProps = {
-            className: styles.headingElementForLevel,
             ...props,
+            className: css(styles.headingElementForLevel, props.className),
         };
         return React.createElement(`h${headingLevel}`, newProps);
     },

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -1034,7 +1034,9 @@ exports[`Guidance Content pages adhoc/tabstops/guidance matches the snapshot 1`]
           Note: this test requires you to use a keyboard and to visually identify interactive elements.
         </em>
       </p>
-      <h2>
+      <h2
+        class="heading-element-for-level--{{CSS_MODULE_HASH}}"
+      >
         How to test
       </h2>
       <ol>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/heading-element-for-level.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/heading-element-for-level.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`HeadingElementForLevel should render a h1 1`] = `
 <h1
-  className="a class"
+  className="headingElementForLevel a class"
 >
   A Heading
 </h1>
@@ -10,7 +10,7 @@ exports[`HeadingElementForLevel should render a h1 1`] = `
 
 exports[`HeadingElementForLevel should render a h2 1`] = `
 <h2
-  className="a class"
+  className="headingElementForLevel a class"
 >
   A Heading
 </h2>
@@ -18,7 +18,7 @@ exports[`HeadingElementForLevel should render a h2 1`] = `
 
 exports[`HeadingElementForLevel should render a h3 1`] = `
 <h3
-  className="a class"
+  className="headingElementForLevel a class"
 >
   A Heading
 </h3>
@@ -26,7 +26,7 @@ exports[`HeadingElementForLevel should render a h3 1`] = `
 
 exports[`HeadingElementForLevel should render a h4 1`] = `
 <h4
-  className="a class"
+  className="headingElementForLevel a class"
 >
   A Heading
 </h4>
@@ -34,7 +34,7 @@ exports[`HeadingElementForLevel should render a h4 1`] = `
 
 exports[`HeadingElementForLevel should render a h5 1`] = `
 <h5
-  className="a class"
+  className="headingElementForLevel a class"
 >
   A Heading
 </h5>
@@ -42,7 +42,7 @@ exports[`HeadingElementForLevel should render a h5 1`] = `
 
 exports[`HeadingElementForLevel should render a h6 1`] = `
 <h6
-  className="a class"
+  className="headingElementForLevel a class"
 >
   A Heading
 </h6>


### PR DESCRIPTION
#### Details

unset the margin for the new heading element.

##### Motivation

Fix for visual bug.

##### Context

Many components/products use this component so it made sense to make this a default behavior as this is what was previously expected. In the future we can manage this by passing through CSS classes if we wish to get these margins again.

Verified the fix worked in: automated checks (unified, web), needs review (unified, web) and tab stops (web).

Example of difference below.
Before:
![image](https://user-images.githubusercontent.com/32555133/162822849-2c7d5524-3727-4cde-80fc-7007de345575.png)

After:
![image](https://user-images.githubusercontent.com/32555133/162822708-c32be9e2-500b-40e7-b2d5-a72125619bf0.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5355 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
