### PR TITLE
feat(mv3-part-2): Convert background stores data to be persistent

### DIFF
--- a/src/background/IndexedDBDataKeys.ts
+++ b/src/background/IndexedDBDataKeys.ts
@@ -5,4 +5,19 @@ export class IndexedDBDataKeys {
     public static readonly userConfiguration: string = 'userConfiguration';
     public static readonly installation: string = 'installationData';
     public static readonly unifiedFeatureFlags: string = 'featureFlags';
+    public static readonly cardSelectionStore: string = 'cardSelectionStore';
+    public static readonly detailsViewStore: string = 'detailsViewStore';
+    public static readonly devToolStore: string = 'devToolStore';
+    public static readonly commandStore: string = 'commandStore';
+    public static readonly launchPanelStore: string = 'launchPanelStore';
+    public static readonly permissionsStateStore: string = 'permissionsStateStore';
+    public static readonly inspectStore: string = 'inspectStore';
+    public static readonly scopingStore: string = 'scopingStore';
+    public static readonly tabStore: string = 'tabStore';
+    public static readonly pathSnippetStore: string = 'pathSnippetStore';
+    public static readonly needsReviewScanResultsStore: string = 'needsReviewScanResultsStore';
+    public static readonly needsReviewCardSelectionStore: string = 'needsReviewCardSelectionStore';
+    public static readonly visualizationStore: string = 'visualizationStore';
+    public static readonly visualizationScanResultStore: string = 'visualizationScanResultStore';
+    public static readonly unifiedScanResultStore: string = 'unifiedScanResultStore';
 }

--- a/src/background/IndexedDBDataKeys.ts
+++ b/src/background/IndexedDBDataKeys.ts
@@ -9,7 +9,6 @@ export class IndexedDBDataKeys {
     public static readonly detailsViewStore: string = 'detailsViewStore';
     public static readonly devToolStore: string = 'devToolStore';
     public static readonly commandStore: string = 'commandStore';
-    public static readonly launchPanelStore: string = 'launchPanelStore';
     public static readonly permissionsStateStore: string = 'permissionsStateStore';
     public static readonly inspectStore: string = 'inspectStore';
     public static readonly scopingStore: string = 'scopingStore';

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -70,7 +70,6 @@ async function initialize(): Promise<void> {
         IndexedDBDataKeys.detailsViewStore,
         IndexedDBDataKeys.devToolStore,
         IndexedDBDataKeys.commandStore,
-        IndexedDBDataKeys.launchPanelStore,
         IndexedDBDataKeys.permissionsStateStore,
         IndexedDBDataKeys.inspectStore,
         IndexedDBDataKeys.scopingStore,

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -191,6 +191,8 @@ async function initialize(): Promise<void> {
         logger,
         usageLogger,
         windowUtils,
+        persistedData,
+        indexedDBInstance,
     );
 
     const targetPageController = new TargetPageController(

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -66,6 +66,21 @@ async function initialize(): Promise<void> {
     const indexedDBDataKeysToFetch = [
         IndexedDBDataKeys.assessmentStore,
         IndexedDBDataKeys.userConfiguration,
+        IndexedDBDataKeys.cardSelectionStore,
+        IndexedDBDataKeys.detailsViewStore,
+        IndexedDBDataKeys.devToolStore,
+        IndexedDBDataKeys.commandStore,
+        IndexedDBDataKeys.launchPanelStore,
+        IndexedDBDataKeys.permissionsStateStore,
+        IndexedDBDataKeys.inspectStore,
+        IndexedDBDataKeys.scopingStore,
+        IndexedDBDataKeys.tabStore,
+        IndexedDBDataKeys.pathSnippetStore,
+        IndexedDBDataKeys.needsReviewScanResultsStore,
+        IndexedDBDataKeys.needsReviewCardSelectionStore,
+        IndexedDBDataKeys.visualizationStore,
+        IndexedDBDataKeys.visualizationScanResultStore,
+        IndexedDBDataKeys.unifiedScanResultStore,
     ];
 
     // These can run concurrently, both because they are read-only and because they use different types of underlying storage

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -1,6 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { CommandStoreData } from 'common/types/store-data/command-store-data';
+import { DetailsViewStoreData } from 'common/types/store-data/details-view-store-data';
+import { DevToolStoreData } from 'common/types/store-data/dev-tool-store-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { InspectStoreData } from 'common/types/store-data/inspect-store-data';
+import { LaunchPanelStoreData } from 'common/types/store-data/launch-panel-store-data';
+import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
+import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
+import { PathSnippetStoreData } from 'common/types/store-data/path-snippet-store-data';
+import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
+import { ScopingStoreData } from 'common/types/store-data/scoping-store-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { IndexedDBAPI } from '../common/indexedDB/indexedDB';
 import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
 import { UserConfigurationStoreData } from '../common/types/store-data/user-configuration-store';
@@ -12,6 +27,21 @@ export interface PersistedData {
     userConfigurationData: UserConfigurationStoreData;
     installationData: InstallationData;
     featureFlags: FeatureFlagStoreData;
+    cardSelectionStoreData: CardSelectionStoreData;
+    detailsViewStoreData: DetailsViewStoreData;
+    devToolStoreData: DevToolStoreData;
+    commandStoreData: CommandStoreData;
+    launchPanelStoreData: LaunchPanelStoreData;
+    permissionsStateStoreData: PermissionsStateStoreData;
+    inspectStoreData: InspectStoreData;
+    scopingStoreData: ScopingStoreData;
+    tabStoreData: TabStoreData;
+    pathSnippetStoreData: PathSnippetStoreData;
+    needsReviewScanResultsStoreData: NeedsReviewScanResultStoreData;
+    needsReviewCardSelectionStoreData: NeedsReviewCardSelectionStoreData;
+    visualizationStoreData: VisualizationStoreData;
+    visualizationScanResultStoreData: VisualizationScanResultData;
+    unifiedScanResultStoreData: UnifiedScanResultStoreData;
 }
 
 const keyToPersistedDataMapping = {

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -6,7 +6,6 @@ import { DetailsViewStoreData } from 'common/types/store-data/details-view-store
 import { DevToolStoreData } from 'common/types/store-data/dev-tool-store-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { InspectStoreData } from 'common/types/store-data/inspect-store-data';
-import { LaunchPanelStoreData } from 'common/types/store-data/launch-panel-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
 import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
 import { PathSnippetStoreData } from 'common/types/store-data/path-snippet-store-data';
@@ -31,7 +30,6 @@ export interface PersistedData {
     detailsViewStoreData: DetailsViewStoreData;
     devToolStoreData: DevToolStoreData;
     commandStoreData: CommandStoreData;
-    launchPanelStoreData: LaunchPanelStoreData;
     permissionsStateStoreData: PermissionsStateStoreData;
     inspectStoreData: InspectStoreData;
     scopingStoreData: ScopingStoreData;

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -44,9 +44,8 @@ export interface PersistedData {
     unifiedScanResultStoreData: UnifiedScanResultStoreData;
 }
 
-const keyToPersistedDataMapping = {
+const keyToPersistedDataMappingOverrides = {
     [IndexedDBDataKeys.assessmentStore]: 'assessmentStoreData',
-    [IndexedDBDataKeys.userConfiguration]: 'userConfigurationData',
     [IndexedDBDataKeys.installation]: 'installationData',
     [IndexedDBDataKeys.unifiedFeatureFlags]: 'featureFlags',
 };
@@ -63,7 +62,8 @@ export function getPersistedData(
 
     const promises: Array<Promise<any>> = dataKeysToFetch.map(key => {
         return indexedDBInstance.getItem(key).then(data => {
-            persistedData[keyToPersistedDataMapping[key]] = data;
+            const persistedDataKey = keyToPersistedDataMappingOverrides[key] ?? `${key}Data`;
+            persistedData[persistedDataKey] = data;
         });
     });
 

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -1,5 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { forOwn, isEmpty } from 'lodash';
 import { StoreNames } from '../../common/stores/store-names';
 import {
@@ -13,14 +17,22 @@ import {
 } from '../actions/action-payloads';
 import { CardSelectionActions } from '../actions/card-selection-actions';
 import { UnifiedScanResultActions } from '../actions/unified-scan-result-actions';
-import { BaseStoreImpl } from './base-store-impl';
 
-export class CardSelectionStore extends BaseStoreImpl<CardSelectionStoreData> {
+export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> {
     constructor(
         private readonly cardSelectionActions: CardSelectionActions,
         private readonly unifiedScanResultActions: UnifiedScanResultActions,
+        persistedState: CardSelectionStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
     ) {
-        super(StoreNames.CardSelectionStore);
+        super(
+            StoreNames.CardSelectionStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.cardSelectionStore,
+            logger,
+        );
     }
 
     protected addActionListeners(): void {

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -1,26 +1,38 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { SidePanelActions } from 'background/actions/side-panel-actions';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { SidePanel } from 'background/stores/side-panel';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { StoreNames } from 'common/stores/store-names';
 import { CurrentPanel } from 'common/types/store-data/current-panel';
 import { DetailsViewStoreData } from 'common/types/store-data/details-view-store-data';
 import { DetailsViewRightContentPanelType } from 'DetailsView/components/left-nav/details-view-right-content-panel-type';
 import { ContentActions } from '../actions/content-actions';
 import { DetailsViewActions } from '../actions/details-view-actions';
-import { BaseStoreImpl } from './base-store-impl';
 
 type SidePanelToStoreKey = {
     [P in SidePanel]: keyof DetailsViewStoreData['currentPanel'];
 };
 
-export class DetailsViewStore extends BaseStoreImpl<DetailsViewStoreData> {
+export class DetailsViewStore extends PersistentStore<DetailsViewStoreData> {
     constructor(
         private contentActions: ContentActions,
         private detailsViewActions: DetailsViewActions,
         private sidePanelActions: SidePanelActions,
+        persistedState: DetailsViewStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
     ) {
-        super(StoreNames.DetailsViewStore);
+        super(
+            StoreNames.DetailsViewStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.detailsViewStore,
+            logger,
+        );
     }
 
     public getDefaultState(): DetailsViewStoreData {

--- a/src/background/stores/dev-tools-store.ts
+++ b/src/background/stores/dev-tools-store.ts
@@ -1,15 +1,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { StoreNames } from '../../common/stores/store-names';
 import { DevToolStoreData } from '../../common/types/store-data/dev-tool-store-data';
 import { DevToolActions } from '../actions/dev-tools-actions';
-import { BaseStoreImpl } from './base-store-impl';
 
-export class DevToolStore extends BaseStoreImpl<DevToolStoreData> {
+export class DevToolStore extends PersistentStore<DevToolStoreData> {
     private devToolActions: DevToolActions;
 
-    constructor(devToolActions: DevToolActions) {
-        super(StoreNames.DevToolsStore);
+    constructor(
+        devToolActions: DevToolActions,
+        persistedState: DevToolStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
+    ) {
+        super(
+            StoreNames.DevToolsStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.devToolStore,
+            logger,
+        );
 
         this.devToolActions = devToolActions;
     }

--- a/src/background/stores/global/command-store.ts
+++ b/src/background/stores/global/command-store.ts
@@ -1,5 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import {
     ModifiedCommandsTelemetryData,
     SHORTCUT_MODIFIED,
@@ -8,14 +12,25 @@ import { StoreNames } from '../../../common/stores/store-names';
 import { CommandStoreData } from '../../../common/types/store-data/command-store-data';
 import { CommandActions, GetCommandsPayload } from '../../actions/command-actions';
 import { TelemetryEventHandler } from '../../telemetry/telemetry-event-handler';
-import { BaseStoreImpl } from '../base-store-impl';
 
-export class CommandStore extends BaseStoreImpl<CommandStoreData> {
+export class CommandStore extends PersistentStore<CommandStoreData> {
     private commandActions: CommandActions;
     private telemetryEventHandler: TelemetryEventHandler;
 
-    constructor(commandActions: CommandActions, telemetryEventHandler: TelemetryEventHandler) {
-        super(StoreNames.CommandStore);
+    constructor(
+        commandActions: CommandActions,
+        telemetryEventHandler: TelemetryEventHandler,
+        persistedState: CommandStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
+    ) {
+        super(
+            StoreNames.CommandStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.commandStore,
+            logger,
+        );
 
         this.commandActions = commandActions;
         this.telemetryEventHandler = telemetryEventHandler;

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -63,9 +63,6 @@ export class GlobalStoreHub implements StoreHub {
             globalActionHub.launchPanelStateActions,
             storageAdapter,
             userData,
-            persistedData.launchPanelStoreData,
-            indexedDbInstance,
-            logger,
         );
         this.scopingStore = new ScopingStore(
             globalActionHub.scopingActions,

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -46,7 +46,13 @@ export class GlobalStoreHub implements StoreHub {
         storageAdapter: StorageAdapter,
         logger: Logger,
     ) {
-        this.commandStore = new CommandStore(globalActionHub.commandActions, telemetryEventHandler);
+        this.commandStore = new CommandStore(
+            globalActionHub.commandActions,
+            telemetryEventHandler,
+            persistedData.commandStoreData,
+            indexedDbInstance,
+            logger,
+        );
         this.featureFlagStore = new FeatureFlagStore(
             globalActionHub.featureFlagActions,
             storageAdapter,
@@ -57,8 +63,16 @@ export class GlobalStoreHub implements StoreHub {
             globalActionHub.launchPanelStateActions,
             storageAdapter,
             userData,
+            persistedData.launchPanelStoreData,
+            indexedDbInstance,
+            logger,
         );
-        this.scopingStore = new ScopingStore(globalActionHub.scopingActions);
+        this.scopingStore = new ScopingStore(
+            globalActionHub.scopingActions,
+            persistedData.scopingStoreData,
+            indexedDbInstance,
+            logger,
+        );
         this.assessmentStore = new AssessmentStore(
             browserAdapter,
             globalActionHub.assessmentActions,
@@ -78,6 +92,9 @@ export class GlobalStoreHub implements StoreHub {
         );
         this.permissionsStateStore = new PermissionsStateStore(
             globalActionHub.permissionsStateActions,
+            persistedData.permissionsStateStoreData,
+            indexedDbInstance,
+            logger,
         );
     }
 

--- a/src/background/stores/global/launch-panel-store.ts
+++ b/src/background/stores/global/launch-panel-store.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { StorageAdapter } from 'common/browser-adapters/storage-adapter';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { StoreNames } from 'common/stores/store-names';
 import {
     LaunchPanelStoreData,
@@ -8,16 +12,24 @@ import {
 } from 'common/types/store-data/launch-panel-store-data';
 import { LocalStorageDataKeys } from '../../local-storage-data-keys';
 import { LocalStorageData } from '../../storage-data';
-import { BaseStoreImpl } from '../base-store-impl';
 import { LaunchPanelStateActions } from './../../actions/launch-panel-state-action';
 
-export class LaunchPanelStore extends BaseStoreImpl<LaunchPanelStoreData> {
+export class LaunchPanelStore extends PersistentStore<LaunchPanelStoreData> {
     constructor(
         private readonly launchPanelStateActions: LaunchPanelStateActions,
         private readonly storageAdapter: StorageAdapter,
         private readonly userData: LocalStorageData,
+        persistedState: LaunchPanelStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
     ) {
-        super(StoreNames.LaunchPanelStateStore);
+        super(
+            StoreNames.LaunchPanelStateStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.launchPanelStore,
+            logger,
+        );
     }
 
     public getDefaultState(): LaunchPanelStoreData {

--- a/src/background/stores/global/launch-panel-store.ts
+++ b/src/background/stores/global/launch-panel-store.ts
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { BaseStoreImpl } from 'background/stores/base-store-impl';
 import { StorageAdapter } from 'common/browser-adapters/storage-adapter';
-import { PersistentStore } from 'common/flux/persistent-store';
-import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
-import { Logger } from 'common/logging/logger';
 import { StoreNames } from 'common/stores/store-names';
 import {
     LaunchPanelStoreData,
@@ -14,22 +11,13 @@ import { LocalStorageDataKeys } from '../../local-storage-data-keys';
 import { LocalStorageData } from '../../storage-data';
 import { LaunchPanelStateActions } from './../../actions/launch-panel-state-action';
 
-export class LaunchPanelStore extends PersistentStore<LaunchPanelStoreData> {
+export class LaunchPanelStore extends BaseStoreImpl<LaunchPanelStoreData> {
     constructor(
         private readonly launchPanelStateActions: LaunchPanelStateActions,
         private readonly storageAdapter: StorageAdapter,
         private readonly userData: LocalStorageData,
-        persistedState: LaunchPanelStoreData,
-        idbInstance: IndexedDBAPI,
-        logger: Logger,
     ) {
-        super(
-            StoreNames.LaunchPanelStateStore,
-            persistedState,
-            idbInstance,
-            IndexedDBDataKeys.launchPanelStore,
-            logger,
-        );
+        super(StoreNames.LaunchPanelStateStore);
     }
 
     public getDefaultState(): LaunchPanelStoreData {

--- a/src/background/stores/global/permissions-state-store.ts
+++ b/src/background/stores/global/permissions-state-store.ts
@@ -2,13 +2,27 @@
 // Licensed under the MIT License.
 import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 import { PermissionsStateActions } from 'background/actions/permissions-state-actions';
-import { BaseStoreImpl } from 'background/stores/base-store-impl';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { StoreNames } from 'common/stores/store-names';
 import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 
-export class PermissionsStateStore extends BaseStoreImpl<PermissionsStateStoreData> {
-    constructor(private readonly permissionsStateActions: PermissionsStateActions) {
-        super(StoreNames.PermissionsStateStore);
+export class PermissionsStateStore extends PersistentStore<PermissionsStateStoreData> {
+    constructor(
+        private readonly permissionsStateActions: PermissionsStateActions,
+        protected readonly persistedState: PermissionsStateStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
+    ) {
+        super(
+            StoreNames.PermissionsStateStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.permissionsStateStore,
+            logger,
+        );
     }
 
     public getDefaultState(): PermissionsStateStoreData {

--- a/src/background/stores/global/scoping-store.ts
+++ b/src/background/stores/global/scoping-store.ts
@@ -1,18 +1,32 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import * as _ from 'lodash/index';
 
 import { StoreNames } from '../../../common/stores/store-names';
 import { ScopingStoreData } from '../../../common/types/store-data/scoping-store-data';
-import { BaseStoreImpl } from '../base-store-impl';
 import { ScopingActions, ScopingPayload } from './../../actions/scoping-actions';
 import { ScopingInputTypes } from './../../scoping-input-types';
 
-export class ScopingStore extends BaseStoreImpl<ScopingStoreData> {
+export class ScopingStore extends PersistentStore<ScopingStoreData> {
     private scopingActions: ScopingActions;
 
-    constructor(scopingActions: ScopingActions) {
-        super(StoreNames.ScopingPanelStateStore);
+    constructor(
+        scopingActions: ScopingActions,
+        persistedState: ScopingStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
+    ) {
+        super(
+            StoreNames.ScopingPanelStateStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.scopingStore,
+            logger,
+        );
 
         this.scopingActions = scopingActions;
     }

--- a/src/background/stores/inspect-store.ts
+++ b/src/background/stores/inspect-store.ts
@@ -1,18 +1,33 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { StoreNames } from '../../common/stores/store-names';
 import { InspectStoreData } from '../../common/types/store-data/inspect-store-data';
 import { InspectActions, InspectPayload } from '../actions/inspect-actions';
 import { TabActions } from '../actions/tab-actions';
 import { InspectMode } from '../inspect-modes';
-import { BaseStoreImpl } from './base-store-impl';
 
-export class InspectStore extends BaseStoreImpl<InspectStoreData> {
+export class InspectStore extends PersistentStore<InspectStoreData> {
     private inspectActions: InspectActions;
     private tabActions: TabActions;
 
-    constructor(inspectActions: InspectActions, tabActions: TabActions) {
-        super(StoreNames.InspectStore);
+    constructor(
+        inspectActions: InspectActions,
+        tabActions: TabActions,
+        persistedState: InspectStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
+    ) {
+        super(
+            StoreNames.InspectStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.inspectStore,
+            logger,
+        );
 
         this.inspectActions = inspectActions;
         this.tabActions = tabActions;

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
 import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { RuleExpandCollapseData } from 'common/types/store-data/card-selection-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
 import { forOwn, isEmpty } from 'lodash';
@@ -11,14 +15,22 @@ import {
     RuleExpandCollapsePayload,
     UnifiedScanCompletedPayload,
 } from '../actions/action-payloads';
-import { BaseStoreImpl } from './base-store-impl';
 
-export class NeedsReviewCardSelectionStore extends BaseStoreImpl<NeedsReviewCardSelectionStoreData> {
+export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCardSelectionStoreData> {
     constructor(
         private readonly needsReviewCardSelectionActions: NeedsReviewCardSelectionActions,
         private readonly needsReviewScanResultActions: NeedsReviewScanResultActions,
+        persistedState: NeedsReviewCardSelectionStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
     ) {
-        super(StoreNames.NeedsReviewCardSelectionStore);
+        super(
+            StoreNames.NeedsReviewCardSelectionStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.needsReviewCardSelectionStore,
+            logger,
+        );
     }
 
     protected addActionListeners(): void {

--- a/src/background/stores/needs-review-scan-result-store.ts
+++ b/src/background/stores/needs-review-scan-result-store.ts
@@ -2,17 +2,29 @@
 // Licensed under the MIT License.
 import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
 import { TabActions } from 'background/actions/tab-actions';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
 import { StoreNames } from '../../common/stores/store-names';
 import { UnifiedScanCompletedPayload } from '../actions/action-payloads';
-import { BaseStoreImpl } from './base-store-impl';
 
-export class NeedsReviewScanResultStore extends BaseStoreImpl<NeedsReviewScanResultStoreData> {
+export class NeedsReviewScanResultStore extends PersistentStore<NeedsReviewScanResultStoreData> {
     constructor(
         private readonly needsReviewScanResultActions: NeedsReviewScanResultActions,
         private readonly tabActions: TabActions,
+        persistedState: NeedsReviewScanResultStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
     ) {
-        super(StoreNames.NeedsReviewScanResultStore);
+        super(
+            StoreNames.NeedsReviewScanResultStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.needsReviewScanResultsStore,
+            logger,
+        );
     }
 
     public getDefaultState(): NeedsReviewScanResultStoreData {

--- a/src/background/stores/path-snippet-store.ts
+++ b/src/background/stores/path-snippet-store.ts
@@ -1,13 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { StoreNames } from '../../common/stores/store-names';
 import { PathSnippetStoreData } from '../../common/types/store-data/path-snippet-store-data';
 import { PathSnippetActions } from '../actions/path-snippet-actions';
-import { BaseStoreImpl } from './base-store-impl';
 
-export class PathSnippetStore extends BaseStoreImpl<PathSnippetStoreData> {
-    constructor(private readonly pathSnippetActions: PathSnippetActions) {
-        super(StoreNames.PathSnippetStore);
+export class PathSnippetStore extends PersistentStore<PathSnippetStoreData> {
+    constructor(
+        private readonly pathSnippetActions: PathSnippetActions,
+        persistedState: PathSnippetStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
+    ) {
+        super(
+            StoreNames.PathSnippetStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.pathSnippetStore,
+            logger,
+        );
     }
 
     public getDefaultState(): PathSnippetStoreData {

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { PersistedData } from 'background/get-persisted-data';
 import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { NeedsReviewCardSelectionStore } from 'background/stores/needs-review-card-selection-store';
 import { NeedsReviewScanResultStore } from 'background/stores/needs-review-scan-result-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { BaseStore } from '../../common/base-store';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { StoreType } from '../../common/types/store-type';
@@ -34,12 +37,18 @@ export class TabContextStoreHub implements StoreHub {
     constructor(
         actionHub: ActionHub,
         visualizationConfigurationFactory: VisualizationConfigurationFactory,
+        persistedData: PersistedData,
+        indexedDBInstance: IndexedDBAPI,
+        logger: Logger,
     ) {
         this.visualizationStore = new VisualizationStore(
             actionHub.visualizationActions,
             actionHub.tabActions,
             actionHub.injectionActions,
             visualizationConfigurationFactory,
+            persistedData.visualizationStoreData,
+            indexedDBInstance,
+            logger,
         );
         this.visualizationStore.initialize();
 
@@ -50,49 +59,89 @@ export class TabContextStoreHub implements StoreHub {
             actionHub.visualizationActions,
             generateUID,
             visualizationConfigurationFactory,
+            persistedData.visualizationScanResultStoreData,
+            indexedDBInstance,
+            logger,
         );
         this.visualizationScanResultStore.initialize();
 
-        this.tabStore = new TabStore(actionHub.tabActions, actionHub.visualizationActions);
+        this.tabStore = new TabStore(
+            actionHub.tabActions,
+            actionHub.visualizationActions,
+            persistedData.tabStoreData,
+            indexedDBInstance,
+            logger,
+        );
         this.tabStore.initialize();
 
-        this.devToolStore = new DevToolStore(actionHub.devToolActions);
+        this.devToolStore = new DevToolStore(
+            actionHub.devToolActions,
+            persistedData.devToolStoreData,
+            indexedDBInstance,
+            logger,
+        );
         this.devToolStore.initialize();
 
         this.detailsViewStore = new DetailsViewStore(
             actionHub.contentActions,
             actionHub.detailsViewActions,
             actionHub.sidePanelActions,
+            persistedData.detailsViewStoreData,
+            indexedDBInstance,
+            logger,
         );
         this.detailsViewStore.initialize();
 
-        this.inspectStore = new InspectStore(actionHub.inspectActions, actionHub.tabActions);
+        this.inspectStore = new InspectStore(
+            actionHub.inspectActions,
+            actionHub.tabActions,
+            persistedData.inspectStoreData,
+            indexedDBInstance,
+            logger,
+        );
         this.inspectStore.initialize();
 
-        this.pathSnippetStore = new PathSnippetStore(actionHub.pathSnippetActions);
+        this.pathSnippetStore = new PathSnippetStore(
+            actionHub.pathSnippetActions,
+            persistedData.pathSnippetStoreData,
+            indexedDBInstance,
+            logger,
+        );
         this.pathSnippetStore.initialize();
 
         this.unifiedScanResultStore = new UnifiedScanResultStore(
             actionHub.unifiedScanResultActions,
             actionHub.tabActions,
+            persistedData.unifiedScanResultStoreData,
+            indexedDBInstance,
+            logger,
         );
         this.unifiedScanResultStore.initialize();
 
         this.cardSelectionStore = new CardSelectionStore(
             actionHub.cardSelectionActions,
             actionHub.unifiedScanResultActions,
+            persistedData.cardSelectionStoreData,
+            indexedDBInstance,
+            logger,
         );
         this.cardSelectionStore.initialize();
 
         this.needsReviewScanResultStore = new NeedsReviewScanResultStore(
             actionHub.needsReviewScanResultActions,
             actionHub.tabActions,
+            persistedData.needsReviewScanResultsStoreData,
+            indexedDBInstance,
+            logger,
         );
         this.needsReviewScanResultStore.initialize();
 
         this.needsReviewCardSelectionStore = new NeedsReviewCardSelectionStore(
             actionHub.needsReviewCardSelectionActions,
             actionHub.needsReviewScanResultActions,
+            persistedData.needsReviewCardSelectionStoreData,
+            indexedDBInstance,
+            logger,
         );
         this.needsReviewCardSelectionStore.initialize();
     }

--- a/src/background/stores/tab-store.ts
+++ b/src/background/stores/tab-store.ts
@@ -1,18 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Tab } from 'common/itab';
+import { Logger } from 'common/logging/logger';
 import { StoreNames } from 'common/stores/store-names';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { TabActions } from '../actions/tab-actions';
 import { VisualizationActions } from '../actions/visualization-actions';
-import { BaseStoreImpl } from './base-store-impl';
 
-export class TabStore extends BaseStoreImpl<TabStoreData> {
+export class TabStore extends PersistentStore<TabStoreData> {
     private tabActions: TabActions;
     private visualizationActions: VisualizationActions;
 
-    constructor(tabActions: TabActions, visualizationActions: VisualizationActions) {
-        super(StoreNames.TabStore);
+    constructor(
+        tabActions: TabActions,
+        visualizationActions: VisualizationActions,
+        persistedState: TabStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
+    ) {
+        super(StoreNames.TabStore, persistedState, idbInstance, IndexedDBDataKeys.tabStore, logger);
 
         this.tabActions = tabActions;
         this.visualizationActions = visualizationActions;

--- a/src/background/stores/unified-scan-result-store.ts
+++ b/src/background/stores/unified-scan-result-store.ts
@@ -1,18 +1,30 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TabActions } from 'background/actions/tab-actions';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { StoreNames } from '../../common/stores/store-names';
 import { UnifiedScanResultStoreData } from '../../common/types/store-data/unified-data-interface';
 import { UnifiedScanCompletedPayload } from '../actions/action-payloads';
 import { UnifiedScanResultActions } from '../actions/unified-scan-result-actions';
-import { BaseStoreImpl } from './base-store-impl';
 
-export class UnifiedScanResultStore extends BaseStoreImpl<UnifiedScanResultStoreData> {
+export class UnifiedScanResultStore extends PersistentStore<UnifiedScanResultStoreData> {
     constructor(
         private readonly unifiedScanResultActions: UnifiedScanResultActions,
         private readonly tabActions: TabActions,
+        persistedState: UnifiedScanResultStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
     ) {
-        super(StoreNames.UnifiedScanResultStore);
+        super(
+            StoreNames.UnifiedScanResultStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.unifiedScanResultStore,
+            logger,
+        );
     }
 
     public getDefaultState(): UnifiedScanResultStoreData {

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -3,8 +3,12 @@
 
 import { TabStopRequirementActions } from 'background/actions/tab-stop-requirement-actions';
 import { VisualizationActions } from 'background/actions/visualization-actions';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { AdHocTestkeys } from 'common/configs/adhoc-test-keys';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Logger } from 'common/logging/logger';
 import { StoreNames } from 'common/stores/store-names';
 import {
     TabStopRequirementStatuses,
@@ -29,8 +33,7 @@ import {
 } from '../actions/action-payloads';
 import { TabActions } from '../actions/tab-actions';
 import { VisualizationScanResultActions } from '../actions/visualization-scan-result-actions';
-import { BaseStoreImpl } from './base-store-impl';
-export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationScanResultData> {
+export class VisualizationScanResultStore extends PersistentStore<VisualizationScanResultData> {
     constructor(
         private visualizationScanResultActions: VisualizationScanResultActions,
         private tabActions: TabActions,
@@ -38,8 +41,17 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         private visualizationActions: VisualizationActions,
         private generateUID: () => string,
         private visualizationConfigurationFactory: VisualizationConfigurationFactory,
+        persistedState: VisualizationScanResultData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
     ) {
-        super(StoreNames.VisualizationScanResultStore);
+        super(
+            StoreNames.VisualizationScanResultStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.visualizationScanResultStore,
+            logger,
+        );
     }
 
     public getDefaultState(): VisualizationScanResultData {

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { InjectionActions } from 'background/actions/injection-actions';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { TestMode } from 'common/configs/test-mode';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { EnumHelper } from 'common/enum-helper';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Tab } from 'common/itab';
+import { Logger } from 'common/logging/logger';
 import { StoreNames } from 'common/stores/store-names';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import {
@@ -23,9 +27,8 @@ import {
 } from '../actions/action-payloads';
 import { TabActions } from '../actions/tab-actions';
 import { VisualizationActions } from '../actions/visualization-actions';
-import { BaseStoreImpl } from './base-store-impl';
 
-export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
+export class VisualizationStore extends PersistentStore<VisualizationStoreData> {
     private visualizationActions: VisualizationActions;
     private tabActions: TabActions;
     private injectionActions: InjectionActions;
@@ -36,8 +39,17 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
         tabActions: TabActions,
         injectionActions: InjectionActions,
         visualizationConfigurationFactory: VisualizationConfigurationFactory,
+        persistedState: VisualizationStoreData,
+        idbInstance: IndexedDBAPI,
+        logger: Logger,
     ) {
-        super(StoreNames.VisualizationStore);
+        super(
+            StoreNames.VisualizationStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.visualizationStore,
+            logger,
+        );
 
         this.visualizationActions = visualizationActions;
         this.tabActions = tabActions;

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -3,8 +3,10 @@
 import { NeedsReviewCardSelectionActionCreator } from 'background/actions/needs-review-card-selection-action-creator';
 import { NeedsReviewScanResultActionCreator } from 'background/actions/needs-review-scan-result-action-creator';
 import { TabStopRequirementActionCreator } from 'background/actions/tab-stop-requirement-action-creator';
+import { PersistedData } from 'background/get-persisted-data';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Logger } from 'common/logging/logger';
 import { NotificationCreator } from 'common/notification-creator';
 import { PromiseFactory } from 'common/promises/promise-factory';
@@ -44,6 +46,8 @@ export class TabContextFactory {
         private readonly logger: Logger,
         private readonly usageLogger: UsageLogger,
         private readonly windowUtils: WindowUtils,
+        private readonly persistedData: PersistedData,
+        private readonly indexedDBInstance: IndexedDBAPI,
     ) {}
 
     public createTabContext(
@@ -53,7 +57,13 @@ export class TabContextFactory {
     ): TabContext {
         const interpreter = new Interpreter();
         const actionsHub = new ActionHub();
-        const storeHub = new TabContextStoreHub(actionsHub, this.visualizationConfigurationFactory);
+        const storeHub = new TabContextStoreHub(
+            actionsHub,
+            this.visualizationConfigurationFactory,
+            this.persistedData,
+            this.indexedDBInstance,
+            this.logger,
+        );
         const notificationCreator = new NotificationCreator(
             browserAdapter,
             this.visualizationConfigurationFactory,

--- a/src/common/flux/persistent-store.ts
+++ b/src/common/flux/persistent-store.ts
@@ -32,7 +32,9 @@ export abstract class PersistentStore<TState> extends BaseStoreImpl<TState> {
     protected emitChanged(): void {
         const storeData = this.getState();
 
-        this.persistData(storeData).catch(this.logger.error);
+        if (this.idbInstance && this.logger) {
+            this.persistData(storeData).catch(this.logger.error);
+        }
 
         super.emitChanged();
     }

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -253,6 +253,9 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
         const unifiedScanResultStore = new UnifiedScanResultStore(
             unifiedScanResultActions,
             tabActions,
+            persistedData.unifiedScanResultStoreData,
+            indexedDBInstance,
+            logger,
         );
         unifiedScanResultStore.initialize();
 
@@ -265,6 +268,9 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
         const cardSelectionStore = new CardSelectionStore(
             cardSelectionActions,
             unifiedScanResultActions,
+            persistedData.cardSelectionStoreData,
+            indexedDBInstance,
+            logger,
         );
         cardSelectionStore.initialize();
 
@@ -272,6 +278,9 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
             contentActions,
             detailsViewActions,
             sidePanelActions,
+            persistedData.detailsViewStoreData,
+            indexedDBInstance,
+            logger,
         );
         detailsViewStore.initialize();
 

--- a/src/tests/unit/common/details-view-store-data-builder.ts
+++ b/src/tests/unit/common/details-view-store-data-builder.ts
@@ -8,7 +8,14 @@ import { BaseDataBuilder } from './base-data-builder';
 export class DetailsViewStoreDataBuilder extends BaseDataBuilder<DetailsViewStoreData> {
     constructor() {
         super();
-        this.data = new DetailsViewStore(null!, null!, null!).getDefaultState();
+        this.data = new DetailsViewStore(
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+        ).getDefaultState();
     }
 
     public withPreviewFeaturesOpen(isPreviewFeaturesOpen: boolean): DetailsViewStoreDataBuilder {

--- a/src/tests/unit/common/scoping-store-data-builder.ts
+++ b/src/tests/unit/common/scoping-store-data-builder.ts
@@ -7,6 +7,6 @@ import { BaseDataBuilder } from './base-data-builder';
 export class ScopingStoreDataBuilder extends BaseDataBuilder<ScopingStoreData> {
     constructor() {
         super();
-        this.data = new ScopingStore(null!).getDefaultState();
+        this.data = new ScopingStore(null!, null!, null!, null!).getDefaultState();
     }
 }

--- a/src/tests/unit/common/tab-store-data-builder.ts
+++ b/src/tests/unit/common/tab-store-data-builder.ts
@@ -7,6 +7,6 @@ import { BaseDataBuilder } from './base-data-builder';
 export class TabStoreDataBuilder extends BaseDataBuilder<TabStoreData> {
     constructor() {
         super();
-        this.data = new TabStore(null, null).getDefaultState();
+        this.data = new TabStore(null, null, null, null, null).getDefaultState();
     }
 }

--- a/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
@@ -19,6 +19,9 @@ export class VisualizationScanResultStoreDataBuilder extends BaseDataBuilder<Vis
             null,
             generateUID,
             null,
+            null,
+            null,
+            null,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/common/visualization-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-store-data-builder.ts
@@ -19,6 +19,9 @@ export class VisualizationStoreDataBuilder extends BaseDataBuilder<Visualization
             null,
             null,
             new WebVisualizationConfigurationFactory(),
+            null,
+            null,
+            null,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -81,18 +81,27 @@ export class StoreMocks {
         isPageHidden: false,
         isOriginChanged: false,
     };
-    public commandStoreData = new CommandStore(null, null).getDefaultState();
+    public commandStoreData = new CommandStore(null, null, null, null, null).getDefaultState();
     public userConfigurationStoreData = new UserConfigurationStore(
         null,
         null,
         null,
         null,
     ).getDefaultState();
-    public scopingStoreData = new ScopingStore(null).getDefaultState();
-    public inspectStoreData = new InspectStore(null, null).getDefaultState();
-    public pathSnippetStoreData = new PathSnippetStore(null).getDefaultState();
-    public unifiedScanResultStoreData = new UnifiedScanResultStore(null, null).getDefaultState();
+    public scopingStoreData = new ScopingStore(null, null, null, null).getDefaultState();
+    public inspectStoreData = new InspectStore(null, null, null, null, null).getDefaultState();
+    public pathSnippetStoreData = new PathSnippetStore(null, null, null, null).getDefaultState();
+    public unifiedScanResultStoreData = new UnifiedScanResultStore(
+        null,
+        null,
+        null,
+        null,
+        null,
+    ).getDefaultState();
     public needsReviewScanResultStoreData = new NeedsReviewScanResultStore(
+        null,
+        null,
+        null,
         null,
         null,
     ).getDefaultState();
@@ -101,10 +110,24 @@ export class StoreMocks {
         [FeatureFlags[FeatureFlags.logTelemetryToConsole]]: false,
     };
     public assessmentStoreData: AssessmentStoreData;
-    public permissionsStateStoreData = new PermissionsStateStore(null).getDefaultState();
+    public permissionsStateStoreData = new PermissionsStateStore(
+        null,
+        null,
+        null,
+        null,
+    ).getDefaultState();
     public tabStopsViewStoreData = new TabStopsViewStore(null).getDefaultState();
-    public cardSelectionStoreData = new CardSelectionStore(null, null).getDefaultState();
+    public cardSelectionStoreData = new CardSelectionStore(
+        null,
+        null,
+        null,
+        null,
+        null,
+    ).getDefaultState();
     public needsReviewCardSelectionStoreData = new NeedsReviewCardSelectionStore(
+        null,
+        null,
+        null,
         null,
         null,
     ).getDefaultState();

--- a/src/tests/unit/tests/background/get-persisted-data.test.ts
+++ b/src/tests/unit/tests/background/get-persisted-data.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { getPersistedData, PersistedData } from 'background/get-persisted-data';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { IMock, Mock } from 'typemoq';
 
 import { InstallationData } from '../../../../background/installation-data';
@@ -17,6 +18,7 @@ describe('GetPersistedDataTest', () => {
     let assessmentStoreData: AssessmentStoreData;
     let userConfigurationData: UserConfigurationStoreData;
     let installationData: InstallationData;
+    let permissionsStateStoreData: PermissionsStateStoreData;
 
     beforeEach(() => {
         assessmentStoreData = {
@@ -42,6 +44,7 @@ describe('GetPersistedDataTest', () => {
             month: 0,
             year: 0,
         };
+        permissionsStateStoreData = { hasAllUrlAndFilePermissions: true };
         indexedDBInstanceStrictMock = Mock.ofType<IndexedDBAPI>();
     });
 
@@ -73,6 +76,7 @@ describe('GetPersistedDataTest', () => {
         const indexedDataKeysToFetch = [
             IndexedDBDataKeys.userConfiguration,
             IndexedDBDataKeys.installation,
+            IndexedDBDataKeys.permissionsStateStore,
         ];
 
         indexedDBInstanceStrictMock
@@ -81,6 +85,9 @@ describe('GetPersistedDataTest', () => {
         indexedDBInstanceStrictMock
             .setup(i => i.getItem(IndexedDBDataKeys.installation))
             .returns(async () => installationData);
+        indexedDBInstanceStrictMock
+            .setup(i => i.getItem(IndexedDBDataKeys.permissionsStateStore))
+            .returns(async () => permissionsStateStoreData);
 
         const data = await getPersistedData(
             indexedDBInstanceStrictMock.object,
@@ -90,6 +97,7 @@ describe('GetPersistedDataTest', () => {
         expect(data).toEqual({
             userConfigurationData: userConfigurationData,
             installationData: installationData,
+            permissionsStateStoreData: permissionsStateStoreData,
         } as Partial<PersistedData>);
     });
 });

--- a/src/tests/unit/tests/background/inspect-store.test.ts
+++ b/src/tests/unit/tests/background/inspect-store.test.ts
@@ -75,7 +75,8 @@ describe('InspectStoreTest', () => {
         actionName: keyof InspectActions,
     ): StoreTester<InspectStoreData, InspectActions> {
         const tabActions = new TabActions();
-        const factory = (actions: InspectActions) => new InspectStore(actions, tabActions);
+        const factory = (actions: InspectActions) =>
+            new InspectStore(actions, tabActions, null, null, null);
 
         return new StoreTester(InspectActions, actionName, factory);
     }
@@ -83,7 +84,8 @@ describe('InspectStoreTest', () => {
     function createStoreForTabActions(
         actionName: keyof TabActions,
     ): StoreTester<InspectStoreData, TabActions> {
-        const factory = (actions: TabActions) => new InspectStore(new InspectActions(), actions);
+        const factory = (actions: TabActions) =>
+            new InspectStore(new InspectActions(), actions, null, null, null);
         return new StoreTester(TabActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -87,7 +87,7 @@ describe('CardSelectionStore Test', () => {
         actionName: keyof UnifiedScanResultActions,
     ): StoreTester<CardSelectionStoreData, UnifiedScanResultActions> {
         const factory = (actions: UnifiedScanResultActions) =>
-            new CardSelectionStore(new CardSelectionActions(), actions);
+            new CardSelectionStore(new CardSelectionActions(), actions, null, null, null);
 
         return new StoreTester(UnifiedScanResultActions, actionName, factory);
     }
@@ -388,7 +388,7 @@ describe('CardSelectionStore Test', () => {
         actionName: keyof CardSelectionActions,
     ): StoreTester<CardSelectionStoreData, CardSelectionActions> {
         const factory = (actions: CardSelectionActions) =>
-            new CardSelectionStore(actions, new UnifiedScanResultActions());
+            new CardSelectionStore(actions, new UnifiedScanResultActions(), null, null, null);
 
         return new StoreTester(CardSelectionActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/details-view-store.test.ts
+++ b/src/tests/unit/tests/background/stores/details-view-store.test.ts
@@ -11,7 +11,7 @@ import { StoreTester } from '../../../common/store-tester';
 
 describe('DetailsViewStoreTest', () => {
     test('getId', () => {
-        const testObject = new DetailsViewStore(null, null, null);
+        const testObject = new DetailsViewStore(null, null, null, null, null, null);
         expect(testObject.getId()).toBe(StoreNames[StoreNames.DetailsViewStore]);
     });
 
@@ -128,7 +128,14 @@ describe('DetailsViewStoreTest', () => {
         actionName: keyof ContentActions,
     ): StoreTester<DetailsViewStoreData, ContentActions> {
         const factory = (actions: ContentActions) =>
-            new DetailsViewStore(actions, new DetailsViewActions(), new SidePanelActions());
+            new DetailsViewStore(
+                actions,
+                new DetailsViewActions(),
+                new SidePanelActions(),
+                null,
+                null,
+                null,
+            );
 
         return new StoreTester(ContentActions, actionName, factory);
     }
@@ -137,7 +144,14 @@ describe('DetailsViewStoreTest', () => {
         actionName: keyof DetailsViewActions,
     ): StoreTester<DetailsViewStoreData, DetailsViewActions> {
         const factory = (actions: DetailsViewActions) =>
-            new DetailsViewStore(new ContentActions(), actions, new SidePanelActions());
+            new DetailsViewStore(
+                new ContentActions(),
+                actions,
+                new SidePanelActions(),
+                null,
+                null,
+                null,
+            );
 
         return new StoreTester(DetailsViewActions, actionName, factory);
     }
@@ -146,7 +160,14 @@ describe('DetailsViewStoreTest', () => {
         actionName: keyof SidePanelActions,
     ): StoreTester<DetailsViewStoreData, SidePanelActions> {
         const factory = (actions: SidePanelActions) =>
-            new DetailsViewStore(new ContentActions(), new DetailsViewActions(), actions);
+            new DetailsViewStore(
+                new ContentActions(),
+                new DetailsViewActions(),
+                actions,
+                null,
+                null,
+                null,
+            );
 
         return new StoreTester(SidePanelActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
+++ b/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
@@ -81,13 +81,13 @@ describe('DevToolsStoreTest', () => {
     });
 
     function getDefaultState(): DevToolStoreData {
-        return new DevToolStore(null).getDefaultState();
+        return new DevToolStore(null, null, null, null).getDefaultState();
     }
 
     function createStoreTesterForDevToolsActions(
         actionName: keyof DevToolActions,
     ): StoreTester<DevToolStoreData, DevToolActions> {
-        const factory = (actions: DevToolActions) => new DevToolStore(actions);
+        const factory = (actions: DevToolActions) => new DevToolStore(actions, null, null, null);
 
         return new StoreTester(DevToolActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/global/command-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/command-store.test.ts
@@ -31,7 +31,7 @@ describe('CommandStoreTest', () => {
     });
 
     test('on getCommands: no command modification', () => {
-        const prototype = new CommandStore(null, null);
+        const prototype = new CommandStore(null, null, null, null, null);
         const initialState: CommandStoreData = prototype.getDefaultState();
         const expectedState: CommandStoreData = prototype.getDefaultState();
 
@@ -90,7 +90,13 @@ describe('CommandStoreTest', () => {
     });
 
     test("handling weird case: amount of commands change on runtime (this should not happen but we're handling it anyway)", () => {
-        const initialState: CommandStoreData = new CommandStore(null, null).getDefaultState();
+        const initialState: CommandStoreData = new CommandStore(
+            null,
+            null,
+            null,
+            null,
+            null,
+        ).getDefaultState();
 
         const command: chrome.commands.Command = {
             description: 'Toggle Headings',
@@ -123,7 +129,7 @@ describe('CommandStoreTest', () => {
         actionName: keyof CommandActions,
     ): StoreTester<CommandStoreData, CommandActions> {
         const factory = (actions: CommandActions) =>
-            new CommandStore(actions, telemetryEventHandlerMock.object);
+            new CommandStore(actions, telemetryEventHandlerMock.object, null, null, null);
 
         return new StoreTester(CommandActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
@@ -21,7 +21,12 @@ describe('PermissionsStateStoreTest', () => {
     });
 
     test('getDefaultState returns expected default store state', () => {
-        const testSubject = new PermissionsStateStore(new PermissionsStateActions());
+        const testSubject = new PermissionsStateStore(
+            new PermissionsStateActions(),
+            null,
+            null,
+            null,
+        );
         testSubject.initialize();
 
         expect(testSubject.getDefaultState()).toMatchSnapshot();
@@ -71,12 +76,13 @@ describe('PermissionsStateStoreTest', () => {
     function createStoreTesterForPermissionsStateActions(
         actionName: keyof PermissionsStateActions,
     ): StoreTester<PermissionsStateStoreData, PermissionsStateActions> {
-        const factory = (actions: PermissionsStateActions) => new PermissionsStateStore(actions);
+        const factory = (actions: PermissionsStateActions) =>
+            new PermissionsStateStore(actions, null, null, null);
 
         return new StoreTester(PermissionsStateActions, actionName, factory);
     }
 
     function createPermissionsState(): PermissionsStateStoreData {
-        return new PermissionsStateStore(null).getDefaultState();
+        return new PermissionsStateStore(null, null, null, null).getDefaultState();
     }
 });

--- a/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
@@ -106,7 +106,7 @@ describe('ScopingStoreTest', () => {
     function createStoreForScopingActions(
         actionName: keyof ScopingActions,
     ): StoreTester<ScopingStoreData, ScopingActions> {
-        const factory = (actions: ScopingActions) => new ScopingStore(actions);
+        const factory = (actions: ScopingActions) => new ScopingStore(actions, null, null, null);
 
         return new StoreTester(ScopingActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
@@ -85,7 +85,13 @@ describe('NeedsReviewCardSelectionStore Test', () => {
         actionName: keyof NeedsReviewScanResultActions,
     ): StoreTester<NeedsReviewCardSelectionStoreData, NeedsReviewScanResultActions> {
         const factory = (actions: NeedsReviewScanResultActions) =>
-            new NeedsReviewCardSelectionStore(new NeedsReviewCardSelectionActions(), actions);
+            new NeedsReviewCardSelectionStore(
+                new NeedsReviewCardSelectionActions(),
+                actions,
+                null,
+                null,
+                null,
+            );
 
         return new StoreTester(NeedsReviewScanResultActions, actionName, factory);
     }
@@ -379,7 +385,13 @@ describe('NeedsReviewCardSelectionStore Test', () => {
         actionName: keyof NeedsReviewCardSelectionActions,
     ): StoreTester<NeedsReviewCardSelectionStoreData, NeedsReviewCardSelectionActions> {
         const factory = (actions: NeedsReviewCardSelectionActions) =>
-            new NeedsReviewCardSelectionStore(actions, new NeedsReviewScanResultActions());
+            new NeedsReviewCardSelectionStore(
+                actions,
+                new NeedsReviewScanResultActions(),
+                null,
+                null,
+                null,
+            );
 
         return new StoreTester(NeedsReviewCardSelectionActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
@@ -133,7 +133,7 @@ describe('NeedsReviewScanResultStore Test', () => {
         actionName: keyof NeedsReviewScanResultActions,
     ): StoreTester<NeedsReviewScanResultStoreData, NeedsReviewScanResultActions> {
         const factory = (actions: NeedsReviewScanResultActions) =>
-            new NeedsReviewScanResultStore(actions, new TabActions());
+            new NeedsReviewScanResultStore(actions, new TabActions(), null, null, null);
 
         return new StoreTester(NeedsReviewScanResultActions, actionName, factory);
     }
@@ -142,7 +142,13 @@ describe('NeedsReviewScanResultStore Test', () => {
         actionName: keyof TabActions,
     ): StoreTester<NeedsReviewScanResultStoreData, TabActions> {
         const factory = (tabActions: TabActions) =>
-            new NeedsReviewScanResultStore(new NeedsReviewScanResultActions(), tabActions);
+            new NeedsReviewScanResultStore(
+                new NeedsReviewScanResultActions(),
+                tabActions,
+                null,
+                null,
+                null,
+            );
 
         return new StoreTester(TabActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
+++ b/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
@@ -75,7 +75,8 @@ describe('PathSnippetStoreTest', () => {
     function createStoreForPathSnippetActions(
         actionName: keyof PathSnippetActions,
     ): StoreTester<PathSnippetStoreData, PathSnippetActions> {
-        const factory = (actions: PathSnippetActions) => new PathSnippetStore(actions);
+        const factory = (actions: PathSnippetActions) =>
+            new PathSnippetStore(actions, null, null, null);
         return new StoreTester(PathSnippetActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/persistent-store.test.ts
+++ b/src/tests/unit/tests/background/stores/persistent-store.test.ts
@@ -45,19 +45,36 @@ describe('PersistentStoreTest', () => {
         idbInstanceMock.verifyAll();
     });
 
+    test('emitChanged with null parameters', async () => {
+        const testObject = new TestStore(false);
+        testObject.initialize();
+        idbInstanceMock
+            .setup(db => db.setItem(indexedDBDataKey, persistedState))
+            .returns(() => Promise.resolve(true))
+            .verifiable(Times.once());
+
+        testObject.callEmitChanged();
+
+        idbInstanceMock.verifyAll();
+    });
+
     interface TestData {
         value: string;
     }
 
     class TestStore extends PersistentStore<TestData> {
-        constructor() {
-            super(
-                storeName,
-                persistedState,
-                idbInstanceMock.object,
-                indexedDBDataKey,
-                loggerMock.object,
-            );
+        constructor(passNonNullParams = true) {
+            if (passNonNullParams) {
+                super(
+                    storeName,
+                    persistedState,
+                    idbInstanceMock.object,
+                    indexedDBDataKey,
+                    loggerMock.object,
+                );
+            } else {
+                super(null, null, null, null, null);
+            }
         }
 
         protected addActionListeners(): void {

--- a/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
@@ -1,13 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ActionHub } from 'background/actions/action-hub';
+import { PersistedData } from 'background/get-persisted-data';
 import { TabContextStoreHub } from 'background/stores/tab-context-store-hub';
 import { StoreType } from '../../../../../common/types/store-type';
 
 describe('TabContextStoreHubTest', () => {
     let testSubject: TabContextStoreHub;
     beforeAll(() => {
-        testSubject = new TabContextStoreHub(new ActionHub(), null);
+        testSubject = new TabContextStoreHub(
+            new ActionHub(),
+            null,
+            {} as PersistedData,
+            null,
+            null,
+        );
     });
 
     it('verify getAllStores', () => {

--- a/src/tests/unit/tests/background/stores/tab-store.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-store.test.ts
@@ -237,14 +237,16 @@ describe('TabStoreTest', () => {
     function createStoreTesterForTabActions(
         actionName: keyof TabActions,
     ): StoreTester<TabStoreData, TabActions> {
-        const factory = (actions: TabActions) => new TabStore(actions, new VisualizationActions());
+        const factory = (actions: TabActions) =>
+            new TabStore(actions, new VisualizationActions(), null, null, null);
         return new StoreTester(TabActions, actionName, factory);
     }
 
     function createStoreTesterForVisualizationActions(
         actionName: keyof VisualizationActions,
     ): StoreTester<TabStoreData, VisualizationActions> {
-        const factory = (actions: VisualizationActions) => new TabStore(new TabActions(), actions);
+        const factory = (actions: VisualizationActions) =>
+            new TabStore(new TabActions(), actions, null, null, null);
         return new StoreTester(VisualizationActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
@@ -133,7 +133,13 @@ describe('UnifiedScanResultStore Test', () => {
         actionName: keyof UnifiedScanResultActions,
     ): StoreTester<UnifiedScanResultStoreData, UnifiedScanResultActions> {
         const factory = (unifiedScanResultActions: UnifiedScanResultActions) =>
-            new UnifiedScanResultStore(unifiedScanResultActions, new TabActions());
+            new UnifiedScanResultStore(
+                unifiedScanResultActions,
+                new TabActions(),
+                null,
+                null,
+                null,
+            );
 
         return new StoreTester(UnifiedScanResultActions, actionName, factory);
     }
@@ -142,7 +148,13 @@ describe('UnifiedScanResultStore Test', () => {
         actionName: keyof TabActions,
     ): StoreTester<UnifiedScanResultStoreData, TabActions> {
         const factory = (tabActions: TabActions) =>
-            new UnifiedScanResultStore(new UnifiedScanResultActions(), tabActions);
+            new UnifiedScanResultStore(
+                new UnifiedScanResultActions(),
+                tabActions,
+                null,
+                null,
+                null,
+            );
 
         return new StoreTester(TabActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -564,6 +564,9 @@ describe('VisualizationScanResultStoreTest', () => {
                 new VisualizationActions(),
                 generateUIDStub,
                 visualizationConfigurationFactoryMock.object,
+                null,
+                null,
+                null,
             );
 
         return new StoreTester(VisualizationScanResultActions, actionName, factory);
@@ -580,6 +583,9 @@ describe('VisualizationScanResultStoreTest', () => {
                 new VisualizationActions(),
                 generateUIDStub,
                 visualizationConfigurationFactoryMock.object,
+                null,
+                null,
+                null,
             );
 
         return new StoreTester(TabActions, actionName, factory);
@@ -596,6 +602,9 @@ describe('VisualizationScanResultStoreTest', () => {
                 new VisualizationActions(),
                 generateUIDStub,
                 visualizationConfigurationFactoryMock.object,
+                null,
+                null,
+                null,
             );
 
         return new StoreTester(TabStopRequirementActions, actionName, factory);
@@ -612,6 +621,9 @@ describe('VisualizationScanResultStoreTest', () => {
                 actions,
                 generateUIDStub,
                 visualizationConfigurationFactoryMock.object,
+                null,
+                null,
+                null,
             );
 
         return new StoreTester(VisualizationActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -835,6 +835,9 @@ describe('VisualizationStoreTest ', () => {
                 actions,
                 new InjectionActions(),
                 new WebVisualizationConfigurationFactory(),
+                null,
+                null,
+                null,
             );
 
         return new StoreTester(TabActions, actionName, factory);
@@ -849,6 +852,9 @@ describe('VisualizationStoreTest ', () => {
                 new TabActions(),
                 new InjectionActions(),
                 new WebVisualizationConfigurationFactory(),
+                null,
+                null,
+                null,
             );
 
         return new StoreTester(VisualizationActions, actionName, factory);
@@ -863,6 +869,9 @@ describe('VisualizationStoreTest ', () => {
                 new TabActions(),
                 actions,
                 new WebVisualizationConfigurationFactory(),
+                null,
+                null,
+                null,
             );
 
         return new StoreTester(InjectionActions, actionName, factory);

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
+import { PersistedData } from 'background/get-persisted-data';
 import { Interpreter } from 'background/interpreter';
 import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { DetailsViewStore } from 'background/stores/details-view-store';
@@ -17,6 +18,7 @@ import { TargetTabController } from 'background/target-tab-controller';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Logger } from 'common/logging/logger';
 import { NotificationCreator } from 'common/notification-creator';
 import { WindowUtils } from 'common/window-utils';
@@ -42,6 +44,8 @@ describe('TabContextFactoryTest', () => {
     let mockUsageLogger: IMock<UsageLogger>;
     let mockNotificationCreator: IMock<NotificationCreator>;
     let mockWindowUtils: IMock<WindowUtils>;
+    let mockDBInstance: IMock<IndexedDBAPI>;
+    let persistedDataStub: PersistedData;
 
     beforeEach(() => {
         mockBrowserAdapter = Mock.ofType<BrowserAdapter>();
@@ -50,6 +54,8 @@ describe('TabContextFactoryTest', () => {
         mockDetailsViewController = Mock.ofType<ExtensionDetailsViewController>();
         mockNotificationCreator = Mock.ofType<NotificationCreator>();
         mockWindowUtils = Mock.ofType<WindowUtils>();
+        mockDBInstance = Mock.ofType<IndexedDBAPI>();
+        persistedDataStub = {} as PersistedData;
     });
 
     it('createInterpreter', () => {
@@ -106,6 +112,8 @@ describe('TabContextFactoryTest', () => {
             mockLogger.object,
             mockUsageLogger.object,
             mockWindowUtils.object,
+            persistedDataStub,
+            mockDBInstance.object,
         );
 
         const tabContext = testObject.createTabContext(


### PR DESCRIPTION
#### Details

Convert background stores to extend `PersistentStore` instead of `BaseStore` so that the store data will be backed up in the indexed database. This will be necessary when we convert to manifest v3, which replaces the background with service workers which don't allow us to rely on store data to persist without being backed up. 

##### Motivation

Feature work.

##### Context

This PR converts all background stores that do not have an existing way to persist data. This does not include stores that already persist their data (the feature flag and launch panel stores) or stores that are not in the background (the tab stops view store). For consistency it might make sense to convert the stores that have their own custom methods for persisting data to use this new standard approach, but for now leaving them as is. 

Note that with these change the store data is only backed up, it is never read except in the assessment and user configuration stores (see https://github.com/microsoft/accessibility-insights-web/pull/5337). In a future PR we will need to add logic to either initialize stores with their default data (the results of `getDefaultState`, which is used now) or initialize with the persisted data when the service worker stopped and is restarting. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
