### PR TITLE
fix: Changing country to country/region, as per TSA Policheck guidance

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.input.ts
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.input.ts
@@ -2456,7 +2456,7 @@ export const axeResultsWithIssues: AxeReportParameters = {
                                 relatedNodes: [],
                             },
                         ],
-                        html: '<div>\n          Country:\n          <input type="text" name="country">\n        </div>',
+                        html: '<div>\n          Country/Region:\n          <input type="text" name="country/region">\n        </div>',
                         impact: null,
                         none: [],
                         target: ['div:nth-child(7)'],
@@ -2480,10 +2480,10 @@ export const axeResultsWithIssues: AxeReportParameters = {
                                 relatedNodes: [],
                             },
                         ],
-                        html: '<input type="text" name="country">',
+                        html: '<input type="text" name="country/region">',
                         impact: null,
                         none: [],
-                        target: ['input[name="country"]'],
+                        target: ['input[name="country/region"]'],
                     },
                     {
                         all: [],
@@ -3294,7 +3294,7 @@ export const axeResultsWithIssues: AxeReportParameters = {
                     {
                         all: [],
                         any: [],
-                        html: '<input type="text" name="country">',
+                        html: '<input type="text" name="country/region">',
                         impact: null,
                         none: [
                             {
@@ -3305,7 +3305,7 @@ export const axeResultsWithIssues: AxeReportParameters = {
                                 relatedNodes: [],
                             },
                         ],
-                        target: ['input[name="country"]'],
+                        target: ['input[name="country/region"]'],
                     },
                     {
                         all: [],
@@ -3860,7 +3860,7 @@ export const axeResultsWithIssues: AxeReportParameters = {
                     {
                         all: [],
                         any: [],
-                        html: '<input type="text" name="country">',
+                        html: '<input type="text" name="country/region">',
                         impact: null,
                         none: [
                             {
@@ -3872,7 +3872,7 @@ export const axeResultsWithIssues: AxeReportParameters = {
                                 relatedNodes: [],
                             },
                         ],
-                        target: ['input[name="country"]'],
+                        target: ['input[name="country/region"]'],
                     },
                     {
                         all: [],
@@ -5354,10 +5354,10 @@ export const axeResultsWithIssues: AxeReportParameters = {
                         ],
                         failureSummary:
                             'Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Form element does not have an implicit (wrapped) <label>\n  Form element does not have an explicit <label>\n  Element has no title attribute or the title attribute is empty',
-                        html: '<input type="text" name="country">',
+                        html: '<input type="text" name="country/region">',
                         impact: 'critical',
                         none: [],
-                        target: ['input[name="country"]'],
+                        target: ['input[name="country/region"]'],
                     },
                     {
                         all: [],
@@ -6106,7 +6106,7 @@ export const axeResultsWithIssues: AxeReportParameters = {
                                         target: ['form > div:nth-child(6)'],
                                     },
                                     {
-                                        html: '<div>\n          Country:\n          <input type="text" name="country">\n        </div>',
+                                        html: '<div>\n          Country/Region:\n          <input type="text" name="country/region">\n        </div>',
                                         target: ['div:nth-child(7)'],
                                     },
                                     {

--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -3345,13 +3345,13 @@
                                 ><tr class="row--m8TLI"
                                   ><th class="row-label--MxfuQ">Path</th
                                   ><td class="row-content--ECKwg"
-                                    >input[name=&quot;country&quot;]</td
+                                    >input[name=&quot;country/region&quot;]</td
                                   ></tr
                                 ><tr class="row--m8TLI"
                                   ><th class="row-label--MxfuQ">Snippet</th
                                   ><td class="row-content--ECKwg snippet--wZrK1"
                                     >&lt;input type=&quot;text&quot;
-                                    name=&quot;country&quot;&gt;</td
+                                    name=&quot;country/region&quot;&gt;</td
                                   ></tr
                                 ><tr class="row--m8TLI"
                                   ><th class="row-label--MxfuQ">How to fix</th

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.input.ts
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.input.ts
@@ -4860,10 +4860,10 @@ export const axeResultsWithoutIssues: AxeReportParameters = {
                                 relatedNodes: [],
                             },
                         ],
-                        html: '<label for="country">Country:</label>',
+                        html: '<label for="country/region">Country/Region:</label>',
                         impact: null,
                         none: [],
-                        target: ['label[for="country"]'],
+                        target: ['label[for="country/region"]'],
                     },
                     {
                         all: [],
@@ -4884,10 +4884,10 @@ export const axeResultsWithoutIssues: AxeReportParameters = {
                                 relatedNodes: [],
                             },
                         ],
-                        html: '<input type="text" name="country" id="country">',
+                        html: '<input type="text" name="country/region" id="country/region">',
                         impact: null,
                         none: [],
-                        target: ['#country'],
+                        target: ['#country/region'],
                     },
                     {
                         all: [],
@@ -5592,7 +5592,7 @@ export const axeResultsWithoutIssues: AxeReportParameters = {
                         all: [],
                         any: [
                             {
-                                data: 'country',
+                                data: 'country/region',
                                 id: 'duplicate-id-aria',
                                 impact: 'critical',
                                 message:
@@ -5600,10 +5600,10 @@ export const axeResultsWithoutIssues: AxeReportParameters = {
                                 relatedNodes: [],
                             },
                         ],
-                        html: '<input type="text" name="country" id="country">',
+                        html: '<input type="text" name="country/region" id="country/region">',
                         impact: null,
                         none: [],
-                        target: ['#country'],
+                        target: ['#country/region'],
                     },
                     {
                         all: [],
@@ -6622,7 +6622,7 @@ export const axeResultsWithoutIssues: AxeReportParameters = {
                     {
                         all: [],
                         any: [],
-                        html: '<input type="text" name="country" id="country">',
+                        html: '<input type="text" name="country/region" id="country/region">',
                         impact: null,
                         none: [
                             {
@@ -6632,13 +6632,13 @@ export const axeResultsWithoutIssues: AxeReportParameters = {
                                 message: 'Form field does not have multiple label elements',
                                 relatedNodes: [
                                     {
-                                        html: '<label for="country">Country:</label>',
-                                        target: ['label[for="country"]'],
+                                        html: '<label for="country/region">Country/Region:</label>',
+                                        target: ['label[for="country/region"]'],
                                     },
                                 ],
                             },
                         ],
-                        target: ['#country'],
+                        target: ['#country/region'],
                     },
                     {
                         all: [],
@@ -7391,7 +7391,7 @@ export const axeResultsWithoutIssues: AxeReportParameters = {
                     {
                         all: [],
                         any: [],
-                        html: '<input type="text" name="country" id="country">',
+                        html: '<input type="text" name="country/region" id="country/region">',
                         impact: null,
                         none: [
                             {
@@ -7403,7 +7403,7 @@ export const axeResultsWithoutIssues: AxeReportParameters = {
                                 relatedNodes: [],
                             },
                         ],
-                        target: ['#country'],
+                        target: ['#country/region'],
                     },
                     {
                         all: [],
@@ -7665,7 +7665,7 @@ export const axeResultsWithoutIssues: AxeReportParameters = {
                                 relatedNodes: [],
                             },
                         ],
-                        html: '<input type="text" name="country" id="country">',
+                        html: '<input type="text" name="country/region" id="country/region">',
                         impact: null,
                         none: [
                             {
@@ -7676,7 +7676,7 @@ export const axeResultsWithoutIssues: AxeReportParameters = {
                                 relatedNodes: [],
                             },
                         ],
-                        target: ['#country'],
+                        target: ['#country/region'],
                     },
                     {
                         all: [],


### PR DESCRIPTION
#### Details

Addressing TSA bugs; changing language in our test cases to be in line with Policheck requirements. 
More specifically, for the report end to end tests, our example cases of axe results with and without issues used the word "country" and it is recommended to use "country/region" instead. 

##### Motivation

Compliance/bug fix. 

##### Context

Since this is not user-facing, priority of this change is low; however, making this change could prevent TSA from catching this and flagging it as a bug again in the future, which will save us engineering time. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
