### PR TITLE
feat(mv3-part-2): Persist target page and details view controllers data

### DIFF
--- a/src/background/IndexedDBDataKeys.ts
+++ b/src/background/IndexedDBDataKeys.ts
@@ -19,4 +19,6 @@ export class IndexedDBDataKeys {
     public static readonly visualizationStore: string = 'visualizationStore';
     public static readonly visualizationScanResultStore: string = 'visualizationScanResultStore';
     public static readonly unifiedScanResultStore: string = 'unifiedScanResultStore';
+    public static readonly knownTabIds: string = 'knownTabIds';
+    public static readonly tabIdToDetailsViewMap: string = 'tabIdToDetailsViewMap';
 }

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -80,6 +80,8 @@ async function initialize(): Promise<void> {
         IndexedDBDataKeys.visualizationStore,
         IndexedDBDataKeys.visualizationScanResultStore,
         IndexedDBDataKeys.unifiedScanResultStore,
+        IndexedDBDataKeys.knownTabIds,
+        IndexedDBDataKeys.tabIdToDetailsViewMap,
     ];
 
     // These can run concurrently, both because they are read-only and because they use different types of underlying storage
@@ -156,7 +158,11 @@ async function initialize(): Promise<void> {
     telemetryStateListener.initialize();
 
     const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter, logger);
-    const detailsViewController = new ExtensionDetailsViewController(browserAdapter);
+    const detailsViewController = new ExtensionDetailsViewController(
+        browserAdapter,
+        persistedData.tabIdToDetailsViewMap ?? {},
+        indexedDBInstance,
+    );
 
     const tabToContextMap: TabToContextMap = {};
 
@@ -216,6 +222,8 @@ async function initialize(): Promise<void> {
         detailsViewController,
         tabContextFactory,
         logger,
+        persistedData.knownTabIds ?? [],
+        indexedDBInstance,
     );
 
     await targetPageController.initialize();

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -15,6 +15,7 @@ import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { DictionaryStringTo } from 'types/common-types';
 import { IndexedDBAPI } from '../common/indexedDB/indexedDB';
 import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
 import { UserConfigurationStoreData } from '../common/types/store-data/user-configuration-store';
@@ -40,6 +41,8 @@ export interface PersistedData {
     visualizationStoreData: VisualizationStoreData;
     visualizationScanResultStoreData: VisualizationScanResultData;
     unifiedScanResultStoreData: UnifiedScanResultStoreData;
+    knownTabIds: number[];
+    tabIdToDetailsViewMap: DictionaryStringTo<number>;
 }
 
 const keyToPersistedDataMappingOverrides = {

--- a/src/tests/unit/tests/background/extension-details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/extension-details-view-controller.test.ts
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { DictionaryStringTo } from 'types/common-types';
 import { Tabs } from 'webextension-polyfill-ts';
 
 describe('ExtensionDetailsViewController', () => {
@@ -13,7 +15,10 @@ describe('ExtensionDetailsViewController', () => {
         tabId: number,
         changeInfo: chrome.tabs.TabChangeInfo,
         tab: chrome.tabs.Tab,
-    ) => void;
+    ) => Promise<void>;
+    let tabIdToDetailsViewMap: DictionaryStringTo<number>;
+    const indexedDBDataKey: string = 'tabIdToDetailsViewMap';
+    const idbInstanceMock: IMock<IndexedDBAPI> = Mock.ofType<IndexedDBAPI>();
 
     beforeEach(() => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
@@ -32,7 +37,14 @@ describe('ExtensionDetailsViewController', () => {
             })
             .verifiable();
 
-        testSubject = new ExtensionDetailsViewController(browserAdapterMock.object);
+        tabIdToDetailsViewMap = {};
+        idbInstanceMock.reset();
+
+        testSubject = new ExtensionDetailsViewController(
+            browserAdapterMock.object,
+            tabIdToDetailsViewMap,
+            idbInstanceMock.object,
+        );
     });
 
     describe('showDetailsView', () => {
@@ -42,9 +54,34 @@ describe('ExtensionDetailsViewController', () => {
 
             setupCreateDetailsView(targetTabId, detailsViewTabId).verifiable(Times.once());
 
+            setupDatabaseInstance({ '12': detailsViewTabId }, Times.once());
+
             await testSubject.showDetailsView(targetTabId);
 
             browserAdapterMock.verifyAll();
+            idbInstanceMock.verifyAll();
+        });
+
+        it('creates a details view the first time with persisted items', async () => {
+            tabIdToDetailsViewMap['9'] = 99;
+
+            const targetTabId = 12;
+            const detailsViewTabId = 10;
+
+            setupCreateDetailsView(targetTabId, detailsViewTabId).verifiable(Times.once());
+
+            setupDatabaseInstance(
+                {
+                    '12': detailsViewTabId,
+                    '9': 99,
+                },
+                Times.once(),
+            );
+
+            await testSubject.showDetailsView(targetTabId);
+
+            browserAdapterMock.verifyAll();
+            idbInstanceMock.verifyAll();
         });
 
         it('switch to existing tab the second time', async () => {
@@ -52,6 +89,8 @@ describe('ExtensionDetailsViewController', () => {
             const detailsViewTabId = 10;
 
             setupCreateDetailsView(targetTabId, detailsViewTabId).verifiable(Times.once());
+
+            setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
 
             await testSubject.showDetailsView(targetTabId);
 
@@ -64,6 +103,7 @@ describe('ExtensionDetailsViewController', () => {
             await testSubject.showDetailsView(targetTabId);
 
             browserAdapterMock.verifyAll();
+            idbInstanceMock.verifyAll();
         });
 
         it('propagates error from failing browser adapter call to switch to tab', async () => {
@@ -71,6 +111,8 @@ describe('ExtensionDetailsViewController', () => {
             const detailsViewTabId = 10;
 
             setupCreateDetailsView(targetTabId, detailsViewTabId).verifiable(Times.once());
+
+            setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
 
             await testSubject.showDetailsView(targetTabId);
 
@@ -84,11 +126,14 @@ describe('ExtensionDetailsViewController', () => {
             await expect(testSubject.showDetailsView(targetTabId)).rejects.toEqual(errorMessage);
 
             browserAdapterMock.verifyAll();
+            idbInstanceMock.verifyAll();
         });
 
         it('propagates error from failing browser adapter call to create tab', async () => {
             const targetTabId = 5;
             const errorMessage = 'error creating new window (from browser adapter)';
+
+            setupDatabaseInstance(null, Times.never());
 
             browserAdapterMock
                 .setup(adapter =>
@@ -102,6 +147,7 @@ describe('ExtensionDetailsViewController', () => {
             await expect(testSubject.showDetailsView(targetTabId)).rejects.toEqual(errorMessage);
 
             browserAdapterMock.verifyAll();
+            idbInstanceMock.verifyAll();
         });
     });
 
@@ -111,13 +157,15 @@ describe('ExtensionDetailsViewController', () => {
 
         setupCreateDetailsView(targetTabId, detailsViewTabId);
 
+        setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
+
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.reset();
 
         // update target tab
-        onUpdateTabCallback(targetTabId, null, null);
+        await onUpdateTabCallback(targetTabId, null, null);
 
         setupCreateDetailsViewForAnyUrl(Times.never());
         setupSwitchToTab(detailsViewTabId);
@@ -126,11 +174,16 @@ describe('ExtensionDetailsViewController', () => {
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.verifyAll();
+        idbInstanceMock.verifyAll();
     });
 
     test('showDetailsView after details tab navigated to another page', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
+
+        setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
+        setupDatabaseInstance({}, Times.once());
+        setupDatabaseInstance({ '5': -1 }, Times.once());
 
         const detailsViewRemovedHandlerMock = Mock.ofInstance((tabId: number) => {});
         detailsViewRemovedHandlerMock
@@ -151,7 +204,7 @@ describe('ExtensionDetailsViewController', () => {
             .setup(adapter => adapter.getUrl(It.isAny()))
             .returns(suffix => `browser://mock_ext_id${suffix}`);
 
-        onUpdateTabCallback(
+        await onUpdateTabCallback(
             detailsViewTabId,
             { url: 'www.bing.com/DetailsView/detailsView.html?tabId=' + targetTabId },
             null,
@@ -164,6 +217,7 @@ describe('ExtensionDetailsViewController', () => {
 
         browserAdapterMock.verifyAll();
         detailsViewRemovedHandlerMock.verifyAll();
+        idbInstanceMock.verifyAll();
     });
 
     test('showDetailsView after details tab navigated to different details page', async () => {
@@ -171,6 +225,10 @@ describe('ExtensionDetailsViewController', () => {
         const detailsViewTabId = 10;
 
         setupCreateDetailsView(targetTabId, detailsViewTabId);
+
+        setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
+        setupDatabaseInstance({}, Times.once());
+        setupDatabaseInstance({ '5': -1 }, Times.once());
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
@@ -182,7 +240,7 @@ describe('ExtensionDetailsViewController', () => {
             .setup(adapter => adapter.getUrl(It.isAny()))
             .returns(suffix => `browser://mock_ext_id${suffix}`);
 
-        onUpdateTabCallback(
+        await onUpdateTabCallback(
             detailsViewTabId,
             { url: 'chromeExt://ext_id/DetailsView/detailsView.html?tabId=90' },
             null,
@@ -194,6 +252,7 @@ describe('ExtensionDetailsViewController', () => {
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.verifyAll();
+        idbInstanceMock.verifyAll();
     });
 
     test('showDetailsView after details tab refresh', async () => {
@@ -201,6 +260,8 @@ describe('ExtensionDetailsViewController', () => {
         const detailsViewTabId = 10;
 
         setupCreateDetailsView(targetTabId, detailsViewTabId);
+
+        setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
@@ -212,7 +273,7 @@ describe('ExtensionDetailsViewController', () => {
             .setup(adapter => adapter.getUrl(It.isAny()))
             .returns(suffix => `browser://mock_ext_id${suffix}`);
 
-        onUpdateTabCallback(
+        await onUpdateTabCallback(
             detailsViewTabId,
             { url: 'browser://MOCK_EXT_ID/detailsView/detailsView.html?tabId=' + targetTabId },
             null,
@@ -225,6 +286,7 @@ describe('ExtensionDetailsViewController', () => {
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.verifyAll();
+        idbInstanceMock.verifyAll();
     });
 
     test('showDetailsView after details tab has # at end', async () => {
@@ -232,6 +294,8 @@ describe('ExtensionDetailsViewController', () => {
         const detailsViewTabId = 10;
 
         setupCreateDetailsView(targetTabId, detailsViewTabId);
+
+        setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
@@ -243,7 +307,7 @@ describe('ExtensionDetailsViewController', () => {
             .setup(adapter => adapter.getUrl(It.isAny()))
             .returns(suffix => `browser://mock_ext_id${suffix}`);
 
-        onUpdateTabCallback(
+        await onUpdateTabCallback(
             detailsViewTabId,
             {
                 url:
@@ -259,6 +323,7 @@ describe('ExtensionDetailsViewController', () => {
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.verifyAll();
+        idbInstanceMock.verifyAll();
     });
 
     test('showDetailsView after details tab title update', async () => {
@@ -267,13 +332,15 @@ describe('ExtensionDetailsViewController', () => {
 
         setupCreateDetailsView(targetTabId, detailsViewTabId);
 
+        setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
+
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.reset();
 
         // update details tab
-        onUpdateTabCallback(detailsViewTabId, { title: 'issues' }, null);
+        await onUpdateTabCallback(detailsViewTabId, { title: 'issues' }, null);
 
         setupCreateDetailsViewForAnyUrl(Times.never());
         setupSwitchToTab(detailsViewTabId);
@@ -282,6 +349,7 @@ describe('ExtensionDetailsViewController', () => {
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.verifyAll();
+        idbInstanceMock.verifyAll();
     });
 
     test('showDetailsView after random tab updated', async () => {
@@ -290,13 +358,15 @@ describe('ExtensionDetailsViewController', () => {
 
         setupCreateDetailsView(targetTabId, detailsViewTabId);
 
+        setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
+
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.reset();
 
         // remove details tab
-        onUpdateTabCallback(123, { title: 'issues' }, null);
+        await onUpdateTabCallback(123, { title: 'issues' }, null);
 
         setupCreateDetailsViewForAnyUrl(Times.never());
         setupSwitchToTab(detailsViewTabId);
@@ -305,6 +375,7 @@ describe('ExtensionDetailsViewController', () => {
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.verifyAll();
+        idbInstanceMock.verifyAll();
     });
 
     test('showDetailsView after target tab removed', async () => {
@@ -312,6 +383,10 @@ describe('ExtensionDetailsViewController', () => {
         const detailsViewTabId = 10;
 
         setupCreateDetailsView(targetTabId, detailsViewTabId);
+
+        setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
+        setupDatabaseInstance({}, Times.once());
+        setupDatabaseInstance({ '5': -1 }, Times.once());
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
@@ -327,6 +402,7 @@ describe('ExtensionDetailsViewController', () => {
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.verifyAll();
+        idbInstanceMock.verifyAll();
     });
 
     test('showDetailsView after details tab removed', async () => {
@@ -334,6 +410,10 @@ describe('ExtensionDetailsViewController', () => {
         const detailsViewTabId = 10;
 
         setupCreateDetailsView(targetTabId, detailsViewTabId);
+
+        setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
+        setupDatabaseInstance({}, Times.once());
+        setupDatabaseInstance({ '5': -1 }, Times.once());
 
         const detailsViewRemovedHandlerMock = Mock.ofInstance((tabId: number) => {});
         detailsViewRemovedHandlerMock
@@ -356,6 +436,7 @@ describe('ExtensionDetailsViewController', () => {
 
         browserAdapterMock.verifyAll();
         detailsViewRemovedHandlerMock.verifyAll();
+        idbInstanceMock.verifyAll();
     });
 
     test('showDetailsView after details tab removed, remove handler not set', async () => {
@@ -363,6 +444,10 @@ describe('ExtensionDetailsViewController', () => {
         const detailsViewTabId = 10;
 
         setupCreateDetailsView(targetTabId, detailsViewTabId);
+
+        setupDatabaseInstance({ '5': detailsViewTabId }, Times.once());
+        setupDatabaseInstance({}, Times.once());
+        setupDatabaseInstance({ '5': -1 }, Times.once());
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
@@ -378,6 +463,7 @@ describe('ExtensionDetailsViewController', () => {
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.verifyAll();
+        idbInstanceMock.verifyAll();
     });
 
     test('showDetailsView after random tab removed', async () => {
@@ -385,6 +471,8 @@ describe('ExtensionDetailsViewController', () => {
         const detailsViewTabId = 10;
 
         setupCreateDetailsView(targetTabId, detailsViewTabId);
+
+        setupDatabaseInstance({ '5': detailsViewTabId }, Times.exactly(2));
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
@@ -401,6 +489,7 @@ describe('ExtensionDetailsViewController', () => {
         await testSubject.showDetailsView(targetTabId);
 
         browserAdapterMock.verifyAll();
+        idbInstanceMock.verifyAll();
     });
 
     const setupSwitchToTab = (tabId: number) => {
@@ -422,5 +511,16 @@ describe('ExtensionDetailsViewController', () => {
             .setup(adapter => adapter.createTabInNewWindow(It.isAny()))
             .returns(() => Promise.resolve({ id: -1 } as Tabs.Tab))
             .verifiable(times);
+    };
+
+    const setupDatabaseInstance = (expectedMap: DictionaryStringTo<number>, times: Times) => {
+        if (expectedMap) {
+            idbInstanceMock
+                .setup(db => db.setItem(indexedDBDataKey, expectedMap))
+                .returns(() => Promise.resolve(true))
+                .verifiable(times);
+        } else {
+            idbInstanceMock.setup(db => db.setItem(indexedDBDataKey, It.isAny())).verifiable(times);
+        }
     };
 });


### PR DESCRIPTION
#### Details

Adding logic to persist target page and details view controller backing data. This change has no effect on the manifest v2 version of the extension but will be necessary for the manifest v3 version.

##### Motivation

Feature work.

##### Context

The target page controller actually deals with a map from known tab IDs to tab context objects, which could not be saved in the indexed database as is. As a result, this PR adds logic to save a list of the known tab IDs so that, when the service worker restarts, it knows to only instantiate a new context object to replace the lost one and not to broadcast a `ExistingTabUpdated` message when the url remains the same.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
