### PR TITLE
feat(mv3-part-2): Add missing key to persisted data mapping overrides

### DIFF
--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -49,6 +49,8 @@ const keyToPersistedDataMappingOverrides = {
     [IndexedDBDataKeys.assessmentStore]: 'assessmentStoreData',
     [IndexedDBDataKeys.installation]: 'installationData',
     [IndexedDBDataKeys.unifiedFeatureFlags]: 'featureFlags',
+    [IndexedDBDataKeys.knownTabIds]: 'knownTabIds',
+    [IndexedDBDataKeys.tabIdToDetailsViewMap]: 'tabIdToDetailsViewMap',
 };
 
 export function getPersistedData(

--- a/src/tests/unit/tests/background/get-persisted-data.test.ts
+++ b/src/tests/unit/tests/background/get-persisted-data.test.ts
@@ -4,6 +4,7 @@ import { getPersistedData, PersistedData } from 'background/get-persisted-data';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { IMock, Mock } from 'typemoq';
+import { DictionaryStringTo } from 'types/common-types';
 
 import { InstallationData } from '../../../../background/installation-data';
 import { IndexedDBAPI } from '../../../../common/indexedDB/indexedDB';
@@ -19,6 +20,8 @@ describe('GetPersistedDataTest', () => {
     let userConfigurationData: UserConfigurationStoreData;
     let installationData: InstallationData;
     let permissionsStateStoreData: PermissionsStateStoreData;
+    let knownTabIds: number[];
+    let tabIdToDetailsViewMap: DictionaryStringTo<number>;
 
     beforeEach(() => {
         assessmentStoreData = {
@@ -45,6 +48,8 @@ describe('GetPersistedDataTest', () => {
             year: 0,
         };
         permissionsStateStoreData = { hasAllUrlAndFilePermissions: true };
+        knownTabIds = [0, 9];
+        tabIdToDetailsViewMap = { key: 9 };
         indexedDBInstanceStrictMock = Mock.ofType<IndexedDBAPI>();
     });
 
@@ -77,6 +82,8 @@ describe('GetPersistedDataTest', () => {
             IndexedDBDataKeys.userConfiguration,
             IndexedDBDataKeys.installation,
             IndexedDBDataKeys.permissionsStateStore,
+            IndexedDBDataKeys.knownTabIds,
+            IndexedDBDataKeys.tabIdToDetailsViewMap,
         ];
 
         indexedDBInstanceStrictMock
@@ -88,6 +95,12 @@ describe('GetPersistedDataTest', () => {
         indexedDBInstanceStrictMock
             .setup(i => i.getItem(IndexedDBDataKeys.permissionsStateStore))
             .returns(async () => permissionsStateStoreData);
+        indexedDBInstanceStrictMock
+            .setup(i => i.getItem(IndexedDBDataKeys.knownTabIds))
+            .returns(async () => knownTabIds);
+        indexedDBInstanceStrictMock
+            .setup(i => i.getItem(IndexedDBDataKeys.tabIdToDetailsViewMap))
+            .returns(async () => tabIdToDetailsViewMap);
 
         const data = await getPersistedData(
             indexedDBInstanceStrictMock.object,
@@ -98,6 +111,8 @@ describe('GetPersistedDataTest', () => {
             userConfigurationData: userConfigurationData,
             installationData: installationData,
             permissionsStateStoreData: permissionsStateStoreData,
+            knownTabIds: knownTabIds,
+            tabIdToDetailsViewMap: tabIdToDetailsViewMap,
         } as Partial<PersistedData>);
     });
 });


### PR DESCRIPTION
#### Details

Follow up to https://github.com/microsoft/accessibility-insights-web/pull/5370, which added logic to persist controllers data. That PR missed updating `keyToPersistedDataMappingOverrides` with the new keys introduced by those changes. Without this change, the controllers will always be initialized with empty objects, instead of persisted data, if any exists. 

##### Motivation

Feature work.

##### Context

This change does not have an effect on the manifest v2 extension because it will always be initialized with empty objects anyways. This change is necessary for the manifest v3 extension, which will need to be initialized with persisted data after a service worker restarts. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
