### PR TITLE
fix: Do not initialize with persisted data for manifest v2 extension

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -160,7 +160,7 @@ async function initialize(): Promise<void> {
     const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter, logger);
     const detailsViewController = new ExtensionDetailsViewController(
         browserAdapter,
-        persistedData.tabIdToDetailsViewMap ?? {},
+        {},
         indexedDBInstance,
     );
 
@@ -222,7 +222,7 @@ async function initialize(): Promise<void> {
         detailsViewController,
         tabContextFactory,
         logger,
-        persistedData.knownTabIds ?? [],
+        [],
         indexedDBInstance,
     );
 

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -64,6 +64,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
             idbInstance,
             IndexedDBDataKeys.assessmentStore,
             logger,
+            true,
         );
     }
 

--- a/src/background/stores/global/user-configuration-store.ts
+++ b/src/background/stores/global/user-configuration-store.ts
@@ -44,6 +44,7 @@ export class UserConfigurationStore extends PersistentStore<UserConfigurationSto
             indexDbApi,
             IndexedDBDataKeys.userConfiguration,
             logger,
+            true,
         );
     }
 

--- a/src/common/flux/persistent-store.ts
+++ b/src/common/flux/persistent-store.ts
@@ -12,6 +12,7 @@ export abstract class PersistentStore<TState> extends BaseStoreImpl<TState> {
         protected readonly idbInstance: IndexedDBAPI,
         protected readonly indexedDBDataKey: string,
         protected readonly logger: Logger,
+        private initializeWithStoreData = false,
     ) {
         super(storeName);
     }
@@ -26,11 +27,15 @@ export abstract class PersistentStore<TState> extends BaseStoreImpl<TState> {
     }
 
     public override initialize(initialState?: TState): void {
-        const generatedPersistedState = this.generateDefaultState(this.persistedState);
+        if (this.initializeWithStoreData) {
+            const generatedPersistedState = this.generateDefaultState(this.persistedState);
 
-        this.state = initialState || (generatedPersistedState ?? this.getDefaultState());
+            this.state = initialState || (generatedPersistedState ?? this.getDefaultState());
 
-        this.addActionListeners();
+            this.addActionListeners();
+        } else {
+            super.initialize(initialState);
+        }
     }
 
     protected emitChanged(): void {

--- a/src/tests/unit/tests/background/stores/persistent-store.test.ts
+++ b/src/tests/unit/tests/background/stores/persistent-store.test.ts
@@ -60,45 +60,66 @@ describe('PersistentStoreTest', () => {
         idbInstanceMock.verifyAll();
     });
 
-    test('Initialize with initial state', async () => {
-        const testObject = new TestStore();
+    describe('Initialize with store data', () => {
+        test('Initialize with initial state', async () => {
+            const testObject = new TestStore();
 
-        const init = { value: 'value' };
-        testObject.initialize(init);
+            const init = { value: 'value' };
+            testObject.initialize(init);
 
-        expect(testObject.getState()).toBe(init);
+            expect(testObject.getState()).toBe(init);
+        });
+
+        test('Initialize with persisted data', async () => {
+            const testObject = new TestStore();
+
+            testObject.initialize();
+
+            expect(testObject.getState()).toBe(persistedState);
+        });
+
+        test('Initialize without persisted data', async () => {
+            const testObject = new TestStore(false);
+
+            testObject.initialize();
+
+            expect(testObject.getState()).toBe(defaultState);
+        });
+
+        test('Initialize with persisted data and generateDefaultState override', async () => {
+            const testObject = new GenerateDefaultStateTestStore();
+
+            testObject.initialize();
+
+            expect(testObject.getState()).toBe(generatedState);
+        });
+
+        test('Initialize without persisted data and generateDefaultState override', async () => {
+            const testObject = new GenerateDefaultStateTestStore(false);
+
+            testObject.initialize();
+
+            expect(testObject.getState()).toBe(generatedState);
+        });
     });
 
-    test('Initialize with persisted data', async () => {
-        const testObject = new TestStore();
+    describe('Initialize without store data', () => {
+        test('Initialize with initial state', async () => {
+            const testObject = new TestStore(true, false);
 
-        testObject.initialize();
+            const init = { value: 'value' };
+            testObject.initialize(init);
 
-        expect(testObject.getState()).toBe(persistedState);
-    });
+            expect(testObject.getState()).toBe(init);
+        });
 
-    test('Initialize without persisted data', async () => {
-        const testObject = new TestStore(false);
+        test('Initialize without initial state', async () => {
+            const testObject = new TestStore(true, false);
 
-        testObject.initialize();
+            testObject.initialize();
 
-        expect(testObject.getState()).toBe(defaultState);
-    });
-
-    test('Initialize with persisted data and generateDefaultState override', async () => {
-        const testObject = new GenerateDefaultStateTestStore();
-
-        testObject.initialize();
-
-        expect(testObject.getState()).toBe(generatedState);
-    });
-
-    test('Initialize without persisted data and generateDefaultState override', async () => {
-        const testObject = new GenerateDefaultStateTestStore(false);
-
-        testObject.initialize();
-
-        expect(testObject.getState()).toBe(generatedState);
+            expect(testObject.getState()).toBe(defaultState);
+        });
     });
 
     interface TestData {
@@ -106,7 +127,7 @@ describe('PersistentStoreTest', () => {
     }
 
     class TestStore extends PersistentStore<TestData> {
-        constructor(passNonNullParams = true) {
+        constructor(passNonNullParams = true, initializeWithStoreData = true) {
             if (passNonNullParams) {
                 super(
                     storeName,
@@ -114,9 +135,10 @@ describe('PersistentStoreTest', () => {
                     idbInstanceMock.object,
                     indexedDBDataKey,
                     loggerMock.object,
+                    initializeWithStoreData,
                 );
             } else {
-                super(null, null, null, null, null);
+                super(null, null, null, null, null, initializeWithStoreData);
             }
         }
 


### PR DESCRIPTION
#### Details

Fix bug discovered in canary caused by https://github.com/microsoft/accessibility-insights-web/pull/5363.

##### Motivation

Fixes bug in canary.

##### Context

The issue in canary seems to be caused with an underlying bug in the way details view store data is persisted. This PR does not address that issue, but instead it stops initializing stores/ controllers with persisted data for the manifest v2 extension. This will allow us to unblock canary but leave the persisting logic in so that it can be fixed and called from the manifest v3 extension.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
