### PR TITLE
feat(axe-core-4.4): Update axe-core@4.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
         "ajv": "^8.11.0",
         "android-device-list": "^1.2.7",
         "appium-adb": "^9.2.1",
-        "axe-core": "4.3.2",
+        "axe-core": "4.4.1",
         "axios": "^0.26.1",
         "classnames": "^2.3.1",
         "electron": "14.0.0",

--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -19,7 +19,7 @@
     },
     "dependencies": {
         "@fluentui/react": "^8.49.6",
-        "axe-core": "4.3.2",
+        "axe-core": "4.4.1",
         "classnames": "^2.3.1",
         "lodash": "^4.17.21",
         "luxon": "^2.3.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "@fluentui/react": "^8.49.6",
-        "axe-core": "4.2.1",
+        "axe-core": "4.4.1",
         "classnames": "^2.3.1",
         "lodash": "^4.17.21",
         "luxon": "^2.3.2",

--- a/src/content/guideline-metadata.ts
+++ b/src/content/guideline-metadata.ts
@@ -226,6 +226,7 @@ export const guidelineMetadata = {
         link: 'https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html',
         guidanceTags: [],
     },
+    // wcag146: intentionally omitted, AAA
     'WCAG 1.4.10': {
         number: '1.4.10',
         axeTag: 'wcag1410',

--- a/src/injected/frameCommunicators/axe-frame-messenger.ts
+++ b/src/injected/frameCommunicators/axe-frame-messenger.ts
@@ -10,39 +10,15 @@ import {
     CallbackWindowCommandMessageListener,
 } from './respondable-command-message-communicator';
 
-// These are the corrected typings from https://github.com/dequelabs/axe-core/pull/2885, which
-// didn't quite make the axe-core 4.2.1 release. They can be replaced with axe.* typings once
-// https://github.com/dequelabs/axe-core/pull/2885 merges and releases.
-namespace axe2885 {
-    export type FrameMessenger = {
-        open: (topicHandler: TopicHandler) => Close | void;
-        post: (frameWindow: Window, data: TopicData, replyHandler: ReplyHandler) => boolean | void;
-    };
-    export type Close = Function;
-    export type TopicHandler = (data: TopicData, responder: Responder) => void;
-    export type ReplyHandler = (
-        message: any | Error,
-        keepalive: boolean,
-        responder: Responder,
-    ) => void;
-    export type Responder = (
-        message: any | Error,
-        keepalive?: boolean,
-        replyHandler?: ReplyHandler,
-    ) => void;
-    export type TopicData = { topic: String } & ReplyData;
-    export type ReplyData = { channelId: String; message: any; keepalive: boolean };
-}
-
 const postCommand = 'axe.frameMessenger.post';
-type PostCommandRequestPayload = axe2885.TopicData;
+type PostCommandRequestPayload = axe.TopicData;
 type PostCommandResponsePayload =
     | { type: 'success'; message: any; keepalive: boolean }
     | { type: 'error' };
 
 // AxeFrameMessenger is an axe-core axe.frameMessenger-compatible version of our FrameMessenger
-export class AxeFrameMessenger implements axe2885.FrameMessenger {
-    private topicHandlers: axe2885.TopicHandler[] = [];
+export class AxeFrameMessenger implements axe.FrameMessenger {
+    private topicHandlers: axe.TopicHandler[] = [];
 
     constructor(
         private readonly underlyingCommunicator: RespondableCommandMessageCommunicator,
@@ -55,7 +31,7 @@ export class AxeFrameMessenger implements axe2885.FrameMessenger {
         axeInstance.frameMessenger(this as any);
     }
 
-    public open = (topicHandler: axe2885.TopicHandler): axe2885.Close => {
+    public open = (topicHandler: axe.TopicHandler): axe.Close => {
         if (this.topicHandlers.length === 0) {
             this.underlyingCommunicator.addCallbackCommandMessageListener(
                 postCommand,
@@ -66,7 +42,7 @@ export class AxeFrameMessenger implements axe2885.FrameMessenger {
         return () => this.close(topicHandler);
     };
 
-    public close = (topicHandler: axe2885.TopicHandler) => {
+    public close = (topicHandler: axe.TopicHandler) => {
         this.topicHandlers = this.topicHandlers.filter(h => h !== topicHandler);
         if (this.topicHandlers.length === 0) {
             this.underlyingCommunicator.removeCommandMessageListener(postCommand);
@@ -75,13 +51,13 @@ export class AxeFrameMessenger implements axe2885.FrameMessenger {
 
     public post = (
         frameWindow: Window,
-        topicData: axe2885.TopicData,
-        replyHandler: axe2885.ReplyHandler,
+        topicData: axe.TopicData,
+        replyHandler: axe.ReplyHandler,
     ): boolean => {
         const payload: PostCommandRequestPayload = topicData;
         const message: CommandMessage = { command: postCommand, payload };
 
-        const replyToReplyCallback: axe2885.Responder = () => {
+        const replyToReplyCallback: axe.Responder = () => {
             // As of 4.2.1, axe-core is documented as not using replies to replies, and we don't
             // use any axe-core plugins that might require this.
             this.logger.error(
@@ -143,11 +119,11 @@ export class AxeFrameMessenger implements axe2885.FrameMessenger {
         }
 
         const receivedPayload: PostCommandRequestPayload = receivedMessage.payload;
-        const topicData: axe2885.TopicData = receivedPayload;
-        const topicResponder: axe2885.Responder = (
+        const topicData: axe.TopicData = receivedPayload;
+        const topicResponder: axe.Responder = (
             message: any,
             keepalive?: boolean,
-            replyHandler?: axe2885.ReplyHandler,
+            replyHandler?: axe.ReplyHandler,
         ): void => {
             if (replyHandler != null) {
                 // As of 4.2.1, axe-core is documented as not using replies to replies, and we don't

--- a/src/scanner/axe-configurator.ts
+++ b/src/scanner/axe-configurator.ts
@@ -12,7 +12,7 @@ import { localeConfiguration } from './locale-configuration';
 
 export class AxeConfigurator {
     public configureAxe(axe: typeof Axe, configuration: RuleConfiguration[]): void {
-        axe.configure({ branding: { brand: 'axe', application: 'msftAI' } });
+        axe.configure({ branding: 'msftAI' });
         axe.configure(this.createAxeConfigurationFromCustomRules(configuration) as any);
         axe.configure({ locale: localeConfiguration });
     }

--- a/src/scanner/get-rule-inclusions.ts
+++ b/src/scanner/get-rule-inclusions.ts
@@ -78,6 +78,13 @@ function getRuleIncludedConfig(
         };
     }
 
+    if (rule.tags.includes('wcag2aaa')) {
+        return {
+            status: 'excluded',
+            reason: 'rule is tagged wcag2aaa',
+        };
+    }
+
     return {
         status: 'included',
     };

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -242,7 +242,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
                 axe-core
               </a>
             </div>
-             4.3.2
+             4.4.1
           </div>
         </div>
       </div>

--- a/src/tests/unit/tests/scanner/__snapshots__/get-rule-inclusions.test.ts.snap
+++ b/src/tests/unit/tests/scanner/__snapshots__/get-rule-inclusions.test.ts.snap
@@ -170,7 +170,8 @@ Object {
     "status": "included",
   },
   "identical-links-same-purpose": Object {
-    "status": "included",
+    "reason": "rule is tagged wcag2aaa",
+    "status": "excluded",
   },
   "image-alt": Object {
     "status": "included",

--- a/src/tests/unit/tests/scanner/__snapshots__/get-rule-inclusions.test.ts.snap
+++ b/src/tests/unit/tests/scanner/__snapshots__/get-rule-inclusions.test.ts.snap
@@ -95,6 +95,10 @@ Object {
   "color-contrast": Object {
     "status": "included",
   },
+  "color-contrast-enhanced": Object {
+    "reason": "disabled in axe config",
+    "status": "excluded",
+  },
   "css-orientation-lock": Object {
     "reason": "rule is tagged experimental",
     "status": "excluded",
@@ -166,8 +170,7 @@ Object {
     "status": "included",
   },
   "identical-links-same-purpose": Object {
-    "reason": "rule is tagged best-practice",
-    "status": "excluded",
+    "status": "included",
   },
   "image-alt": Object {
     "status": "included",

--- a/src/tests/unit/tests/scanner/axe-configurator.test.ts
+++ b/src/tests/unit/tests/scanner/axe-configurator.test.ts
@@ -74,9 +74,7 @@ describe('AxeConfigurator', () => {
 
             configureMock.setup(cm => cm(It.isValue({ locale: localeConfiguration }))).verifiable();
 
-            configureMock
-                .setup(cm => cm(It.isValue({ branding: { brand: 'axe', application: 'msftAI' } })))
-                .verifiable();
+            configureMock.setup(cm => cm(It.isValue({ branding: 'msftAI' }))).verifiable();
 
             const axeStub = {
                 configure: configureMock.object,

--- a/src/tests/unit/tests/scanner/get-rule-inclusions.test.ts
+++ b/src/tests/unit/tests/scanner/get-rule-inclusions.test.ts
@@ -85,6 +85,24 @@ describe('getRuleInclusions', () => {
         });
     });
 
+    it('excludes rules mapped to wcag2aaa tag and populates reason', () => {
+        const aaaRule = [
+            {
+                id: 'aaa-rule',
+                selector: 'fake-selector',
+                enabled: true,
+                tags: ['wcag2aaa'],
+            },
+        ];
+        const inclusions = getRuleInclusions(aaaRule, {});
+        expect(inclusions).toMatchObject({
+            'aaa-rule': {
+                status: 'excluded',
+                reason: 'rule is tagged wcag2aaa',
+            },
+        });
+    });
+
     it('excludes rules mapped to experimental tag and populates reason', () => {
         const experimentalRule = [
             {

--- a/src/tests/unit/tests/scanner/map-axe-tags-to-guidance-links.test.ts
+++ b/src/tests/unit/tests/scanner/map-axe-tags-to-guidance-links.test.ts
@@ -14,7 +14,7 @@ describe('mapAxeTagsToGuidanceLinks', () => {
         expect(mapAxeTagsToGuidanceLinks(tags)).toEqual([]);
     });
 
-    const wcagAAAtags = ['wcag223', 'wcag224', 'wcag248', 'wcag249', 'wcag325'];
+    const wcagAAAtags = ['wcag146', 'wcag223', 'wcag224', 'wcag248', 'wcag249', 'wcag325'];
     const irrelevantAxeCoreTags = [
         // axe-core specific, not required for our purposes
         'cat.aria',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,9 +100,6 @@ const commonConfig = {
         // We only directly use .tsx and .ts, but some of our transitive dependencies directly
         // require .js or .json files
         extensions: ['.tsx', '.ts', '.js', '.json'],
-        // axe-core invokes require('crypto'), but only in a path we don't use, so we don't need a polyfill
-        // See https://github.com/dequelabs/axe-core/issues/2873
-        fallback: { crypto: false },
     },
     plugins: commonPlugins,
     performance: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3545,15 +3545,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.1.tgz#2e50bcf10ee5b819014f6e342e41e45096239e34"
-  integrity sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA==
-
-axe-core@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.2.tgz#fcf8777b82c62cfc69c7e9f32c0d2226287680e7"
-  integrity sha512-5LMaDRWm8ZFPAEdzTYmgjjEdj1YnQcpfrVajO/sn/LhbpGp0Y0H64c2hLZI1gRMxfA+w1S71Uc/nHaOXgcCvGg==
+axe-core@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
+  integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
 axios@0.26.1, axios@^0.26.1:
   version "0.26.1"


### PR DESCRIPTION
#### Details

This PR will update axe-core to 4.4.1. This new version includes bug fixes, 17 false-positive fixes, 1 rule change, and 1 general improvement.

- Omit [color-contrast-enhanced, wcag146](https://github.com/dequelabs/axe-core/blob/f583c70b191513f5bd116a3ed091e937ea2cd65d/lib/rules/color-contrast-enhanced.json) in tests. Being AAA, this rule is out of scope.
- Update axe config to replace `branding` property value to be a string.
- Remove webpack configuration for fallback of the "crypto" import, the dependency was removed in axe-core.
- Remove manual typings that are now in axe-core.
- Exclude all rules tagged with `wcag2aaa`. The product does not include AAA rules and by filtering them out it will prevent `identical-links-same-purpose` from being included. In 4.4, some [rules were retagged](https://github.com/dequelabs/axe-core/commit/828e526fd06ee596df73f4825e750aad459ca75e), which removed the `best-practices` tag from this rule (the `best-practices` tag previously excluded `identical-links-same-purpose`).


##### To do

- [x] Understand how we should handle identical-links-same-purpose
- [x] Check if we can improve our code from the changes: 
    - [x] include/exclude property for AxeOptions has been enhanced 
    - [x] allow passing a NodeList to ElementContext 

##### Motivation

Feature work

##### Context

axe-core [4.4.0](https://github.com/dequelabs/axe-core/releases/tag/v4.4.0) and [4.4.1](https://github.com/dequelabs/axe-core/releases/tag/v4.4.1) release notes

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
