### PR TITLE
feat(mv3-part-2): Include tab ID in tab specific persisted data keys

### DIFF
--- a/src/background/IndexedDBDataKeys.ts
+++ b/src/background/IndexedDBDataKeys.ts
@@ -1,24 +1,61 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 export class IndexedDBDataKeys {
+    // Global keys
     public static readonly assessmentStore: string = 'assessmentStoreData';
     public static readonly userConfiguration: string = 'userConfiguration';
     public static readonly installation: string = 'installationData';
     public static readonly unifiedFeatureFlags: string = 'featureFlags';
-    public static readonly cardSelectionStore: string = 'cardSelectionStore';
-    public static readonly detailsViewStore: string = 'detailsViewStore';
-    public static readonly devToolStore: string = 'devToolStore';
     public static readonly commandStore: string = 'commandStore';
     public static readonly permissionsStateStore: string = 'permissionsStateStore';
-    public static readonly inspectStore: string = 'inspectStore';
     public static readonly scopingStore: string = 'scopingStore';
-    public static readonly tabStore: string = 'tabStore';
-    public static readonly pathSnippetStore: string = 'pathSnippetStore';
-    public static readonly needsReviewScanResultsStore: string = 'needsReviewScanResultsStore';
-    public static readonly needsReviewCardSelectionStore: string = 'needsReviewCardSelectionStore';
-    public static readonly visualizationStore: string = 'visualizationStore';
-    public static readonly visualizationScanResultStore: string = 'visualizationScanResultStore';
-    public static readonly unifiedScanResultStore: string = 'unifiedScanResultStore';
     public static readonly knownTabIds: string = 'knownTabIds';
     public static readonly tabIdToDetailsViewMap: string = 'tabIdToDetailsViewMap';
+
+    // Tab specific keys- there may be multiple instances of these stores for each tab
+    public static readonly cardSelectionStore: (tabId) => string = tabId =>
+        'cardSelectionStore' + tabId;
+    public static readonly detailsViewStore: (tabId) => string = tabId =>
+        'detailsViewStore' + tabId;
+    public static readonly devToolStore: (tabId) => string = tabId => 'devToolStore' + tabId;
+    public static readonly inspectStore: (tabId) => string = tabId => 'inspectStore' + tabId;
+    public static readonly tabStore: (tabId) => string = tabId => 'tabStore' + tabId;
+    public static readonly pathSnippetStore: (tabId) => string = tabId =>
+        'pathSnippetStore' + tabId;
+    public static readonly needsReviewScanResultsStore: (tabId) => string = tabId =>
+        'needsReviewScanResultsStore' + tabId;
+    public static readonly needsReviewCardSelectionStore: (tabId) => string = tabId =>
+        'needsReviewCardSelectionStore' + tabId;
+    public static readonly visualizationStore: (tabId) => string = tabId =>
+        'visualizationStore' + tabId;
+    public static readonly visualizationScanResultStore: (tabId) => string = tabId =>
+        'visualizationScanResultStore' + tabId;
+    public static readonly unifiedScanResultStore: (tabId) => string = tabId =>
+        'unifiedScanResultStore' + tabId;
+
+    public static readonly globalKeys: string[] = [
+        IndexedDBDataKeys.assessmentStore,
+        IndexedDBDataKeys.userConfiguration,
+        IndexedDBDataKeys.installation,
+        IndexedDBDataKeys.unifiedFeatureFlags,
+        IndexedDBDataKeys.commandStore,
+        IndexedDBDataKeys.permissionsStateStore,
+        IndexedDBDataKeys.scopingStore,
+        IndexedDBDataKeys.knownTabIds,
+        IndexedDBDataKeys.tabIdToDetailsViewMap,
+    ];
+
+    public static readonly tabSpecificKeys: ((tabId) => string)[] = [
+        IndexedDBDataKeys.cardSelectionStore,
+        IndexedDBDataKeys.detailsViewStore,
+        IndexedDBDataKeys.devToolStore,
+        IndexedDBDataKeys.inspectStore,
+        IndexedDBDataKeys.tabStore,
+        IndexedDBDataKeys.pathSnippetStore,
+        IndexedDBDataKeys.needsReviewScanResultsStore,
+        IndexedDBDataKeys.needsReviewCardSelectionStore,
+        IndexedDBDataKeys.visualizationStore,
+        IndexedDBDataKeys.visualizationScanResultStore,
+        IndexedDBDataKeys.unifiedScanResultStore,
+    ];
 }

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -26,7 +26,7 @@ import { IssueFilingServiceProviderImpl } from '../issue-filing/issue-filing-ser
 import { BrowserMessageBroadcasterFactory } from './browser-message-broadcaster-factory';
 import { DevToolsListener } from './dev-tools-listener';
 import { ExtensionDetailsViewController } from './extension-details-view-controller';
-import { getPersistedData } from './get-persisted-data';
+import { getGlobalPersistedData } from './get-persisted-data';
 import { GlobalContextFactory } from './global-context-factory';
 import { IndexedDBDataKeys } from './IndexedDBDataKeys';
 import { KeyboardShortcutHandler } from './keyboard-shortcut-handler';
@@ -66,26 +66,13 @@ async function initialize(): Promise<void> {
     const indexedDBDataKeysToFetch = [
         IndexedDBDataKeys.assessmentStore,
         IndexedDBDataKeys.userConfiguration,
-        IndexedDBDataKeys.cardSelectionStore,
-        IndexedDBDataKeys.detailsViewStore,
-        IndexedDBDataKeys.devToolStore,
-        IndexedDBDataKeys.commandStore,
-        IndexedDBDataKeys.permissionsStateStore,
-        IndexedDBDataKeys.inspectStore,
-        IndexedDBDataKeys.scopingStore,
-        IndexedDBDataKeys.tabStore,
-        IndexedDBDataKeys.pathSnippetStore,
-        IndexedDBDataKeys.needsReviewScanResultsStore,
-        IndexedDBDataKeys.needsReviewCardSelectionStore,
-        IndexedDBDataKeys.visualizationStore,
-        IndexedDBDataKeys.visualizationScanResultStore,
-        IndexedDBDataKeys.unifiedScanResultStore,
-        IndexedDBDataKeys.knownTabIds,
-        IndexedDBDataKeys.tabIdToDetailsViewMap,
     ];
 
     // These can run concurrently, both because they are read-only and because they use different types of underlying storage
-    const persistedDataPromise = getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch);
+    const persistedDataPromise = getGlobalPersistedData(
+        indexedDBInstance,
+        indexedDBDataKeysToFetch,
+    );
     const userDataPromise = browserAdapter.getUserData(storageDataKeys);
     const persistedData = await persistedDataPromise;
     const userData = await userDataPromise;

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -23,26 +23,32 @@ import { IndexedDBDataKeys } from './IndexedDBDataKeys';
 import { InstallationData } from './installation-data';
 
 export interface PersistedData {
+    tabData: {
+        [tabId: number]: TabSpecificPersistedData;
+    };
     assessmentStoreData: AssessmentStoreData;
     userConfigurationData: UserConfigurationStoreData;
     installationData: InstallationData;
     featureFlags: FeatureFlagStoreData;
+    commandStoreData: CommandStoreData;
+    permissionsStateStoreData: PermissionsStateStoreData;
+    scopingStoreData: ScopingStoreData;
+    knownTabIds: number[];
+    tabIdToDetailsViewMap: DictionaryStringTo<number>;
+}
+
+export interface TabSpecificPersistedData {
     cardSelectionStoreData: CardSelectionStoreData;
     detailsViewStoreData: DetailsViewStoreData;
     devToolStoreData: DevToolStoreData;
-    commandStoreData: CommandStoreData;
-    permissionsStateStoreData: PermissionsStateStoreData;
     inspectStoreData: InspectStoreData;
-    scopingStoreData: ScopingStoreData;
-    tabStoreData: TabStoreData;
-    pathSnippetStoreData: PathSnippetStoreData;
     needsReviewScanResultsStoreData: NeedsReviewScanResultStoreData;
     needsReviewCardSelectionStoreData: NeedsReviewCardSelectionStoreData;
-    visualizationStoreData: VisualizationStoreData;
-    visualizationScanResultStoreData: VisualizationScanResultData;
+    pathSnippetStoreData: PathSnippetStoreData;
+    tabStoreData: TabStoreData;
     unifiedScanResultStoreData: UnifiedScanResultStoreData;
-    knownTabIds: number[];
-    tabIdToDetailsViewMap: DictionaryStringTo<number>;
+    visualizationScanResultStoreData: VisualizationScanResultData;
+    visualizationStoreData: VisualizationStoreData;
 }
 
 const keyToPersistedDataMappingOverrides = {
@@ -53,7 +59,26 @@ const keyToPersistedDataMappingOverrides = {
     [IndexedDBDataKeys.tabIdToDetailsViewMap]: 'tabIdToDetailsViewMap',
 };
 
-export function getPersistedData(
+function getPersistedDataKey(key: string): string {
+    return keyToPersistedDataMappingOverrides[key] ?? `${key}Data`;
+}
+
+function getGlobalPersistedPromises(
+    dataKeysToFetch: string[],
+    indexedDBInstance: IndexedDBAPI,
+    persistedData: PersistedData,
+): Promise<any>[] {
+    const promises: Array<Promise<any>> = dataKeysToFetch.map(key => {
+        return indexedDBInstance.getItem(key).then(data => {
+            const persistedDataKey = getPersistedDataKey(key);
+            persistedData[persistedDataKey] = data;
+        });
+    });
+
+    return promises;
+}
+
+export function getGlobalPersistedData(
     indexedDBInstance: IndexedDBAPI,
     dataKeysToFetch: string[],
     options?: { ignorePersistedData: boolean }, // this option is for tests to ensure they can use mock-adb
@@ -63,12 +88,35 @@ export function getPersistedData(
         return Promise.resolve(persistedData); //empty object
     }
 
-    const promises: Array<Promise<any>> = dataKeysToFetch.map(key => {
-        return indexedDBInstance.getItem(key).then(data => {
-            const persistedDataKey = keyToPersistedDataMappingOverrides[key] ?? `${key}Data`;
-            persistedData[persistedDataKey] = data;
+    const promises = getGlobalPersistedPromises(dataKeysToFetch, indexedDBInstance, persistedData);
+
+    return Promise.all(promises).then(() => persistedData);
+}
+
+export async function getAllPersistedData(indexedDBInstance: IndexedDBAPI): Promise<PersistedData> {
+    const persistedData = { tabData: {} } as PersistedData;
+
+    let promises = getGlobalPersistedPromises(
+        IndexedDBDataKeys.globalKeys,
+        indexedDBInstance,
+        persistedData,
+    );
+
+    const knownTabIds: number[] = await indexedDBInstance.getItem(IndexedDBDataKeys.knownTabIds);
+    if (knownTabIds && knownTabIds.length > 0) {
+        knownTabIds.forEach(tabId => {
+            persistedData.tabData[tabId] = {} as TabSpecificPersistedData;
+            promises = promises.concat(
+                IndexedDBDataKeys.tabSpecificKeys.map(keyFunc => {
+                    const key = keyFunc(tabId);
+                    return indexedDBInstance.getItem(key).then(data => {
+                        const persistedDataKey = getPersistedDataKey(keyFunc(''));
+                        persistedData.tabData[tabId][persistedDataKey] = data;
+                    });
+                }),
+            );
         });
-    });
+    }
 
     return Promise.all(promises).then(() => persistedData);
 }

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -25,12 +25,13 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         persistedState: CardSelectionStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
         super(
             StoreNames.CardSelectionStore,
             persistedState,
             idbInstance,
-            IndexedDBDataKeys.cardSelectionStore,
+            IndexedDBDataKeys.cardSelectionStore(tabId),
             logger,
         );
     }

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -25,12 +25,13 @@ export class DetailsViewStore extends PersistentStore<DetailsViewStoreData> {
         persistedState: DetailsViewStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
         super(
             StoreNames.DetailsViewStore,
             persistedState,
             idbInstance,
-            IndexedDBDataKeys.detailsViewStore,
+            IndexedDBDataKeys.detailsViewStore(tabId),
             logger,
         );
     }

--- a/src/background/stores/dev-tools-store.ts
+++ b/src/background/stores/dev-tools-store.ts
@@ -16,12 +16,13 @@ export class DevToolStore extends PersistentStore<DevToolStoreData> {
         persistedState: DevToolStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
         super(
             StoreNames.DevToolsStore,
             persistedState,
             idbInstance,
-            IndexedDBDataKeys.devToolStore,
+            IndexedDBDataKeys.devToolStore(tabId),
             logger,
         );
 

--- a/src/background/stores/inspect-store.ts
+++ b/src/background/stores/inspect-store.ts
@@ -20,12 +20,13 @@ export class InspectStore extends PersistentStore<InspectStoreData> {
         persistedState: InspectStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
         super(
             StoreNames.InspectStore,
             persistedState,
             idbInstance,
-            IndexedDBDataKeys.inspectStore,
+            IndexedDBDataKeys.inspectStore(tabId),
             logger,
         );
 

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -23,12 +23,13 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         persistedState: NeedsReviewCardSelectionStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
         super(
             StoreNames.NeedsReviewCardSelectionStore,
             persistedState,
             idbInstance,
-            IndexedDBDataKeys.needsReviewCardSelectionStore,
+            IndexedDBDataKeys.needsReviewCardSelectionStore(tabId),
             logger,
         );
     }

--- a/src/background/stores/needs-review-scan-result-store.ts
+++ b/src/background/stores/needs-review-scan-result-store.ts
@@ -17,12 +17,13 @@ export class NeedsReviewScanResultStore extends PersistentStore<NeedsReviewScanR
         persistedState: NeedsReviewScanResultStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
         super(
             StoreNames.NeedsReviewScanResultStore,
             persistedState,
             idbInstance,
-            IndexedDBDataKeys.needsReviewScanResultsStore,
+            IndexedDBDataKeys.needsReviewScanResultsStore(tabId),
             logger,
         );
     }

--- a/src/background/stores/path-snippet-store.ts
+++ b/src/background/stores/path-snippet-store.ts
@@ -14,12 +14,13 @@ export class PathSnippetStore extends PersistentStore<PathSnippetStoreData> {
         persistedState: PathSnippetStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
         super(
             StoreNames.PathSnippetStore,
             persistedState,
             idbInstance,
-            IndexedDBDataKeys.pathSnippetStore,
+            IndexedDBDataKeys.pathSnippetStore(tabId),
             logger,
         );
     }

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -4,9 +4,9 @@ import { PersistedData } from 'background/get-persisted-data';
 import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { NeedsReviewCardSelectionStore } from 'background/stores/needs-review-card-selection-store';
 import { NeedsReviewScanResultStore } from 'background/stores/needs-review-scan-result-store';
+import { PersistentStore } from 'common/flux/persistent-store';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Logger } from 'common/logging/logger';
-import { BaseStore } from '../../common/base-store';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { StoreType } from '../../common/types/store-type';
 import { generateUID } from '../../common/uid-generator';
@@ -40,15 +40,19 @@ export class TabContextStoreHub implements StoreHub {
         persistedData: PersistedData,
         indexedDBInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
+        const persistedTabData = persistedData.tabData ? persistedData.tabData[tabId] : null;
+
         this.visualizationStore = new VisualizationStore(
             actionHub.visualizationActions,
             actionHub.tabActions,
             actionHub.injectionActions,
             visualizationConfigurationFactory,
-            persistedData.visualizationStoreData,
+            persistedTabData?.visualizationStoreData,
             indexedDBInstance,
             logger,
+            tabId,
         );
         this.visualizationStore.initialize();
 
@@ -59,26 +63,29 @@ export class TabContextStoreHub implements StoreHub {
             actionHub.visualizationActions,
             generateUID,
             visualizationConfigurationFactory,
-            persistedData.visualizationScanResultStoreData,
+            persistedTabData?.visualizationScanResultStoreData,
             indexedDBInstance,
             logger,
+            tabId,
         );
         this.visualizationScanResultStore.initialize();
 
         this.tabStore = new TabStore(
             actionHub.tabActions,
             actionHub.visualizationActions,
-            persistedData.tabStoreData,
+            persistedTabData?.tabStoreData,
             indexedDBInstance,
             logger,
+            tabId,
         );
         this.tabStore.initialize();
 
         this.devToolStore = new DevToolStore(
             actionHub.devToolActions,
-            persistedData.devToolStoreData,
+            persistedTabData?.devToolStoreData,
             indexedDBInstance,
             logger,
+            tabId,
         );
         this.devToolStore.initialize();
 
@@ -86,67 +93,74 @@ export class TabContextStoreHub implements StoreHub {
             actionHub.contentActions,
             actionHub.detailsViewActions,
             actionHub.sidePanelActions,
-            persistedData.detailsViewStoreData,
+            persistedTabData?.detailsViewStoreData,
             indexedDBInstance,
             logger,
+            tabId,
         );
         this.detailsViewStore.initialize();
 
         this.inspectStore = new InspectStore(
             actionHub.inspectActions,
             actionHub.tabActions,
-            persistedData.inspectStoreData,
+            persistedTabData?.inspectStoreData,
             indexedDBInstance,
             logger,
+            tabId,
         );
         this.inspectStore.initialize();
 
         this.pathSnippetStore = new PathSnippetStore(
             actionHub.pathSnippetActions,
-            persistedData.pathSnippetStoreData,
+            persistedTabData?.pathSnippetStoreData,
             indexedDBInstance,
             logger,
+            tabId,
         );
         this.pathSnippetStore.initialize();
 
         this.unifiedScanResultStore = new UnifiedScanResultStore(
             actionHub.unifiedScanResultActions,
             actionHub.tabActions,
-            persistedData.unifiedScanResultStoreData,
+            persistedTabData?.unifiedScanResultStoreData,
             indexedDBInstance,
             logger,
+            tabId,
         );
         this.unifiedScanResultStore.initialize();
 
         this.cardSelectionStore = new CardSelectionStore(
             actionHub.cardSelectionActions,
             actionHub.unifiedScanResultActions,
-            persistedData.cardSelectionStoreData,
+            persistedTabData?.cardSelectionStoreData,
             indexedDBInstance,
             logger,
+            tabId,
         );
         this.cardSelectionStore.initialize();
 
         this.needsReviewScanResultStore = new NeedsReviewScanResultStore(
             actionHub.needsReviewScanResultActions,
             actionHub.tabActions,
-            persistedData.needsReviewScanResultsStoreData,
+            persistedTabData?.needsReviewScanResultsStoreData,
             indexedDBInstance,
             logger,
+            tabId,
         );
         this.needsReviewScanResultStore.initialize();
 
         this.needsReviewCardSelectionStore = new NeedsReviewCardSelectionStore(
             actionHub.needsReviewCardSelectionActions,
             actionHub.needsReviewScanResultActions,
-            persistedData.needsReviewCardSelectionStoreData,
+            persistedTabData?.needsReviewCardSelectionStoreData,
             indexedDBInstance,
             logger,
+            tabId,
         );
         this.needsReviewCardSelectionStore.initialize();
     }
 
-    public getAllStores(): BaseStore<any>[] {
+    public getAllStores(): PersistentStore<any>[] {
         return [
             this.tabStore,
             this.visualizationStore,

--- a/src/background/stores/tab-store.ts
+++ b/src/background/stores/tab-store.ts
@@ -20,8 +20,15 @@ export class TabStore extends PersistentStore<TabStoreData> {
         persistedState: TabStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
-        super(StoreNames.TabStore, persistedState, idbInstance, IndexedDBDataKeys.tabStore, logger);
+        super(
+            StoreNames.TabStore,
+            persistedState,
+            idbInstance,
+            IndexedDBDataKeys.tabStore(tabId),
+            logger,
+        );
 
         this.tabActions = tabActions;
         this.visualizationActions = visualizationActions;

--- a/src/background/stores/unified-scan-result-store.ts
+++ b/src/background/stores/unified-scan-result-store.ts
@@ -17,12 +17,13 @@ export class UnifiedScanResultStore extends PersistentStore<UnifiedScanResultSto
         persistedState: UnifiedScanResultStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
         super(
             StoreNames.UnifiedScanResultStore,
             persistedState,
             idbInstance,
-            IndexedDBDataKeys.unifiedScanResultStore,
+            IndexedDBDataKeys.unifiedScanResultStore(tabId),
             logger,
         );
     }

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -44,12 +44,13 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         persistedState: VisualizationScanResultData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
         super(
             StoreNames.VisualizationScanResultStore,
             persistedState,
             idbInstance,
-            IndexedDBDataKeys.visualizationScanResultStore,
+            IndexedDBDataKeys.visualizationScanResultStore(tabId),
             logger,
         );
     }

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -42,12 +42,13 @@ export class VisualizationStore extends PersistentStore<VisualizationStoreData> 
         persistedState: VisualizationStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        tabId: number,
     ) {
         super(
             StoreNames.VisualizationStore,
             persistedState,
             idbInstance,
-            IndexedDBDataKeys.visualizationStore,
+            IndexedDBDataKeys.visualizationStore(tabId),
             logger,
         );
 

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -54,6 +54,7 @@ export class TabContextFactory {
         broadcastMessage: (message) => Promise<void>,
         browserAdapter: BrowserAdapter,
         detailsViewController: ExtensionDetailsViewController,
+        tabId: number,
     ): TabContext {
         const interpreter = new Interpreter();
         const actionsHub = new ActionHub();
@@ -63,6 +64,7 @@ export class TabContextFactory {
             this.persistedData,
             this.indexedDBInstance,
             this.logger,
+            tabId,
         );
         const notificationCreator = new NotificationCreator(
             browserAdapter,

--- a/src/background/tab-context.ts
+++ b/src/background/tab-context.ts
@@ -13,6 +13,11 @@ export class TabContext {
 
     public devToolsConnection?: chrome.runtime.Port;
 
+    public teardown = async () => {
+        const promises = this.stores.getAllStores().map(store => store.teardown());
+        await Promise.all(promises);
+    };
+
     constructor(interpreter: Interpreter, storeHub: TabContextStoreHub) {
         this.interpreter = interpreter;
         this.stores = storeHub;

--- a/src/common/flux/persistent-store.ts
+++ b/src/common/flux/persistent-store.ts
@@ -38,6 +38,10 @@ export abstract class PersistentStore<TState> extends BaseStoreImpl<TState> {
         }
     }
 
+    public async teardown(): Promise<void> {
+        await this.idbInstance.removeItem(this.indexedDBDataKey);
+    }
+
     protected emitChanged(): void {
         const storeData = this.getState();
 

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -123,7 +123,7 @@ import { getDefaultAddListenerForCollapsibleSection } from 'reports/components/r
 import { ReactStaticRenderer } from 'reports/react-static-renderer';
 import { ReportHtmlGenerator } from 'reports/report-html-generator';
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
-import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
+import { getGlobalPersistedData, PersistedData } from '../../background/get-persisted-data';
 import { IndexedDBDataKeys } from '../../background/IndexedDBDataKeys';
 import { InstallationData } from '../../background/installation-data';
 import { UserConfigurationStore } from '../../background/stores/global/user-configuration-store';
@@ -188,7 +188,7 @@ const indexedDBDataKeysToFetch = [
 
 const logger = createDefaultLogger();
 
-getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
+getGlobalPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
     ignorePersistedData: process.env.ACCESSIBILITY_INSIGHTS_ELECTRON_CLEAR_DATA === 'true', // this option is for tests to ensure they can use mock-adb
 })
     .then((persistedData: Partial<PersistedData>) => {
@@ -253,9 +253,10 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
         const unifiedScanResultStore = new UnifiedScanResultStore(
             unifiedScanResultActions,
             tabActions,
-            persistedData.unifiedScanResultStoreData,
+            null,
             indexedDBInstance,
             logger,
+            null,
         );
         unifiedScanResultStore.initialize();
 
@@ -268,9 +269,10 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
         const cardSelectionStore = new CardSelectionStore(
             cardSelectionActions,
             unifiedScanResultActions,
-            persistedData.cardSelectionStoreData,
+            null,
             indexedDBInstance,
             logger,
+            null,
         );
         cardSelectionStore.initialize();
 
@@ -278,9 +280,10 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
             contentActions,
             detailsViewActions,
             sidePanelActions,
-            persistedData.detailsViewStoreData,
+            null,
             indexedDBInstance,
             logger,
+            null,
         );
         detailsViewStore.initialize();
 

--- a/src/tests/unit/common/details-view-store-data-builder.ts
+++ b/src/tests/unit/common/details-view-store-data-builder.ts
@@ -15,6 +15,7 @@ export class DetailsViewStoreDataBuilder extends BaseDataBuilder<DetailsViewStor
             null!,
             null!,
             null!,
+            null!,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/common/tab-store-data-builder.ts
+++ b/src/tests/unit/common/tab-store-data-builder.ts
@@ -7,6 +7,6 @@ import { BaseDataBuilder } from './base-data-builder';
 export class TabStoreDataBuilder extends BaseDataBuilder<TabStoreData> {
     constructor() {
         super();
-        this.data = new TabStore(null, null, null, null, null).getDefaultState();
+        this.data = new TabStore(null, null, null, null, null, null).getDefaultState();
     }
 }

--- a/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
@@ -22,6 +22,7 @@ export class VisualizationScanResultStoreDataBuilder extends BaseDataBuilder<Vis
             null,
             null,
             null,
+            null,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/common/visualization-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-store-data-builder.ts
@@ -22,6 +22,7 @@ export class VisualizationStoreDataBuilder extends BaseDataBuilder<Visualization
             null,
             null,
             null,
+            null,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -89,9 +89,23 @@ export class StoreMocks {
         null,
     ).getDefaultState();
     public scopingStoreData = new ScopingStore(null, null, null, null).getDefaultState();
-    public inspectStoreData = new InspectStore(null, null, null, null, null).getDefaultState();
-    public pathSnippetStoreData = new PathSnippetStore(null, null, null, null).getDefaultState();
+    public inspectStoreData = new InspectStore(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+    ).getDefaultState();
+    public pathSnippetStoreData = new PathSnippetStore(
+        null,
+        null,
+        null,
+        null,
+        null,
+    ).getDefaultState();
     public unifiedScanResultStoreData = new UnifiedScanResultStore(
+        null,
         null,
         null,
         null,
@@ -99,6 +113,7 @@ export class StoreMocks {
         null,
     ).getDefaultState();
     public needsReviewScanResultStoreData = new NeedsReviewScanResultStore(
+        null,
         null,
         null,
         null,
@@ -123,8 +138,10 @@ export class StoreMocks {
         null,
         null,
         null,
+        null,
     ).getDefaultState();
     public needsReviewCardSelectionStoreData = new NeedsReviewCardSelectionStore(
+        null,
         null,
         null,
         null,

--- a/src/tests/unit/tests/background/get-persisted-data.test.ts
+++ b/src/tests/unit/tests/background/get-persisted-data.test.ts
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getPersistedData, PersistedData } from 'background/get-persisted-data';
+import {
+    getAllPersistedData,
+    getGlobalPersistedData,
+    PersistedData,
+    TabSpecificPersistedData,
+} from 'background/get-persisted-data';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { IMock, Mock } from 'typemoq';
@@ -53,66 +58,158 @@ describe('GetPersistedDataTest', () => {
         indexedDBInstanceStrictMock = Mock.ofType<IndexedDBAPI>();
     });
 
-    it('propagates the results of IndexedDBAPI.getItem for the appropriate keys', async () => {
-        const indexedDataKeysToFetch = [
-            IndexedDBDataKeys.assessmentStore,
-            IndexedDBDataKeys.userConfiguration,
-        ];
+    describe('getGlobalPersistedData', () => {
+        it('propagates the results of IndexedDBAPI.getItem for the appropriate keys', async () => {
+            const indexedDataKeysToFetch = [
+                IndexedDBDataKeys.assessmentStore,
+                IndexedDBDataKeys.userConfiguration,
+            ];
 
-        indexedDBInstanceStrictMock
-            .setup(i => i.getItem(IndexedDBDataKeys.assessmentStore))
-            .returns(async () => assessmentStoreData);
-        indexedDBInstanceStrictMock
-            .setup(i => i.getItem(IndexedDBDataKeys.userConfiguration))
-            .returns(async () => userConfigurationData);
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.assessmentStore))
+                .returns(async () => assessmentStoreData);
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.userConfiguration))
+                .returns(async () => userConfigurationData);
 
-        const data = await getPersistedData(
-            indexedDBInstanceStrictMock.object,
-            indexedDataKeysToFetch,
-        );
+            const data = await getGlobalPersistedData(
+                indexedDBInstanceStrictMock.object,
+                indexedDataKeysToFetch,
+            );
 
-        expect(data).toEqual({
-            assessmentStoreData: assessmentStoreData,
-            userConfigurationData: userConfigurationData,
-        } as PersistedData);
+            expect(data).toEqual({
+                assessmentStoreData: assessmentStoreData,
+                userConfigurationData: userConfigurationData,
+            } as PersistedData);
+        });
+
+        it('uses specified data keys to read persisted data', async () => {
+            const indexedDataKeysToFetch = [
+                IndexedDBDataKeys.userConfiguration,
+                IndexedDBDataKeys.installation,
+                IndexedDBDataKeys.permissionsStateStore,
+                IndexedDBDataKeys.knownTabIds,
+                IndexedDBDataKeys.tabIdToDetailsViewMap,
+            ];
+
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.userConfiguration))
+                .returns(async () => userConfigurationData);
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.installation))
+                .returns(async () => installationData);
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.permissionsStateStore))
+                .returns(async () => permissionsStateStoreData);
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.knownTabIds))
+                .returns(async () => knownTabIds);
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.tabIdToDetailsViewMap))
+                .returns(async () => tabIdToDetailsViewMap);
+
+            const data = await getGlobalPersistedData(
+                indexedDBInstanceStrictMock.object,
+                indexedDataKeysToFetch,
+            );
+
+            expect(data).toEqual({
+                userConfigurationData: userConfigurationData,
+                installationData: installationData,
+                permissionsStateStoreData: permissionsStateStoreData,
+                knownTabIds: knownTabIds,
+                tabIdToDetailsViewMap: tabIdToDetailsViewMap,
+            } as Partial<PersistedData>);
+        });
     });
 
-    it('uses specified data keys to read persisted data', async () => {
-        const indexedDataKeysToFetch = [
-            IndexedDBDataKeys.userConfiguration,
-            IndexedDBDataKeys.installation,
-            IndexedDBDataKeys.permissionsStateStore,
-            IndexedDBDataKeys.knownTabIds,
-            IndexedDBDataKeys.tabIdToDetailsViewMap,
-        ];
+    describe('getAllPersistedData', () => {
+        it('returns global data when no known tabs exist', async () => {
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.knownTabIds))
+                .returns(() => Promise.resolve([]));
+            setupGlobalData();
 
-        indexedDBInstanceStrictMock
-            .setup(i => i.getItem(IndexedDBDataKeys.userConfiguration))
-            .returns(async () => userConfigurationData);
-        indexedDBInstanceStrictMock
-            .setup(i => i.getItem(IndexedDBDataKeys.installation))
-            .returns(async () => installationData);
-        indexedDBInstanceStrictMock
-            .setup(i => i.getItem(IndexedDBDataKeys.permissionsStateStore))
-            .returns(async () => permissionsStateStoreData);
-        indexedDBInstanceStrictMock
-            .setup(i => i.getItem(IndexedDBDataKeys.knownTabIds))
-            .returns(async () => knownTabIds);
-        indexedDBInstanceStrictMock
-            .setup(i => i.getItem(IndexedDBDataKeys.tabIdToDetailsViewMap))
-            .returns(async () => tabIdToDetailsViewMap);
+            const data = await getAllPersistedData(indexedDBInstanceStrictMock.object);
 
-        const data = await getPersistedData(
-            indexedDBInstanceStrictMock.object,
-            indexedDataKeysToFetch,
-        );
+            expect(data).toEqual({
+                assessmentStoreData: assessmentStoreData,
+                knownTabIds: [],
+                userConfigurationData: {},
+                commandStoreData: {},
+                featureFlags: {},
+                installationData: {},
+                permissionsStateStoreData: {},
+                scopingStoreData: {},
+                tabIdToDetailsViewMap: {},
+                tabData: {},
+            } as PersistedData);
+        });
 
-        expect(data).toEqual({
-            userConfigurationData: userConfigurationData,
-            installationData: installationData,
-            permissionsStateStoreData: permissionsStateStoreData,
-            knownTabIds: knownTabIds,
-            tabIdToDetailsViewMap: tabIdToDetailsViewMap,
-        } as Partial<PersistedData>);
+        it('returns all data', async () => {
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.knownTabIds))
+                .returns(() => Promise.resolve(knownTabIds));
+            setupGlobalData();
+            setupTabData();
+
+            const data = await getAllPersistedData(indexedDBInstanceStrictMock.object);
+
+            const expectedTabData = {
+                cardSelectionStoreData: {},
+                detailsViewStoreData: {},
+                devToolStoreData: {},
+                inspectStoreData: {},
+                needsReviewCardSelectionStoreData: {},
+                needsReviewScanResultsStoreData: {},
+                pathSnippetStoreData: {},
+                tabStoreData: {},
+                unifiedScanResultStoreData: {},
+                visualizationScanResultStoreData: {},
+                visualizationStoreData: {},
+            } as TabSpecificPersistedData;
+            const tabData: { [tabId: number]: TabSpecificPersistedData } = {
+                0: expectedTabData,
+                9: expectedTabData,
+            };
+            expect(data).toEqual({
+                assessmentStoreData: assessmentStoreData,
+                knownTabIds: knownTabIds,
+                userConfigurationData: {},
+                commandStoreData: {},
+                featureFlags: {},
+                installationData: {},
+                permissionsStateStoreData: {},
+                scopingStoreData: {},
+                tabIdToDetailsViewMap: {},
+                tabData,
+            } as PersistedData);
+        });
+
+        function setupGlobalData() {
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.assessmentStore))
+                .returns(async () => assessmentStoreData);
+            IndexedDBDataKeys.globalKeys.forEach(key => {
+                if (
+                    key !== IndexedDBDataKeys.knownTabIds &&
+                    key !== IndexedDBDataKeys.assessmentStore
+                ) {
+                    indexedDBInstanceStrictMock
+                        .setup(i => i.getItem(key))
+                        .returns(async () => Promise.resolve({}));
+                }
+            });
+        }
+
+        function setupTabData() {
+            knownTabIds.forEach(tabId => {
+                IndexedDBDataKeys.tabSpecificKeys.forEach(key => {
+                    indexedDBInstanceStrictMock
+                        .setup(i => i.getItem(key(tabId)))
+                        .returns(async () => Promise.resolve({}));
+                });
+            });
+        }
     });
 });

--- a/src/tests/unit/tests/background/inspect-store.test.ts
+++ b/src/tests/unit/tests/background/inspect-store.test.ts
@@ -76,7 +76,7 @@ describe('InspectStoreTest', () => {
     ): StoreTester<InspectStoreData, InspectActions> {
         const tabActions = new TabActions();
         const factory = (actions: InspectActions) =>
-            new InspectStore(actions, tabActions, null, null, null);
+            new InspectStore(actions, tabActions, null, null, null, null);
 
         return new StoreTester(InspectActions, actionName, factory);
     }
@@ -85,7 +85,7 @@ describe('InspectStoreTest', () => {
         actionName: keyof TabActions,
     ): StoreTester<InspectStoreData, TabActions> {
         const factory = (actions: TabActions) =>
-            new InspectStore(new InspectActions(), actions, null, null, null);
+            new InspectStore(new InspectActions(), actions, null, null, null, null);
         return new StoreTester(TabActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -87,7 +87,7 @@ describe('CardSelectionStore Test', () => {
         actionName: keyof UnifiedScanResultActions,
     ): StoreTester<CardSelectionStoreData, UnifiedScanResultActions> {
         const factory = (actions: UnifiedScanResultActions) =>
-            new CardSelectionStore(new CardSelectionActions(), actions, null, null, null);
+            new CardSelectionStore(new CardSelectionActions(), actions, null, null, null, null);
 
         return new StoreTester(UnifiedScanResultActions, actionName, factory);
     }
@@ -388,7 +388,7 @@ describe('CardSelectionStore Test', () => {
         actionName: keyof CardSelectionActions,
     ): StoreTester<CardSelectionStoreData, CardSelectionActions> {
         const factory = (actions: CardSelectionActions) =>
-            new CardSelectionStore(actions, new UnifiedScanResultActions(), null, null, null);
+            new CardSelectionStore(actions, new UnifiedScanResultActions(), null, null, null, null);
 
         return new StoreTester(CardSelectionActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/details-view-store.test.ts
+++ b/src/tests/unit/tests/background/stores/details-view-store.test.ts
@@ -11,7 +11,7 @@ import { StoreTester } from '../../../common/store-tester';
 
 describe('DetailsViewStoreTest', () => {
     test('getId', () => {
-        const testObject = new DetailsViewStore(null, null, null, null, null, null);
+        const testObject = new DetailsViewStore(null, null, null, null, null, null, null);
         expect(testObject.getId()).toBe(StoreNames[StoreNames.DetailsViewStore]);
     });
 
@@ -135,6 +135,7 @@ describe('DetailsViewStoreTest', () => {
                 null,
                 null,
                 null,
+                null,
             );
 
         return new StoreTester(ContentActions, actionName, factory);
@@ -151,6 +152,7 @@ describe('DetailsViewStoreTest', () => {
                 null,
                 null,
                 null,
+                null,
             );
 
         return new StoreTester(DetailsViewActions, actionName, factory);
@@ -164,6 +166,7 @@ describe('DetailsViewStoreTest', () => {
                 new ContentActions(),
                 new DetailsViewActions(),
                 actions,
+                null,
                 null,
                 null,
                 null,

--- a/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
+++ b/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
@@ -81,13 +81,14 @@ describe('DevToolsStoreTest', () => {
     });
 
     function getDefaultState(): DevToolStoreData {
-        return new DevToolStore(null, null, null, null).getDefaultState();
+        return new DevToolStore(null, null, null, null, null).getDefaultState();
     }
 
     function createStoreTesterForDevToolsActions(
         actionName: keyof DevToolActions,
     ): StoreTester<DevToolStoreData, DevToolActions> {
-        const factory = (actions: DevToolActions) => new DevToolStore(actions, null, null, null);
+        const factory = (actions: DevToolActions) =>
+            new DevToolStore(actions, null, null, null, null);
 
         return new StoreTester(DevToolActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
@@ -91,6 +91,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
                 null,
                 null,
                 null,
+                null,
             );
 
         return new StoreTester(NeedsReviewScanResultActions, actionName, factory);
@@ -388,6 +389,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
             new NeedsReviewCardSelectionStore(
                 actions,
                 new NeedsReviewScanResultActions(),
+                null,
                 null,
                 null,
                 null,

--- a/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
@@ -133,7 +133,7 @@ describe('NeedsReviewScanResultStore Test', () => {
         actionName: keyof NeedsReviewScanResultActions,
     ): StoreTester<NeedsReviewScanResultStoreData, NeedsReviewScanResultActions> {
         const factory = (actions: NeedsReviewScanResultActions) =>
-            new NeedsReviewScanResultStore(actions, new TabActions(), null, null, null);
+            new NeedsReviewScanResultStore(actions, new TabActions(), null, null, null, null);
 
         return new StoreTester(NeedsReviewScanResultActions, actionName, factory);
     }
@@ -145,6 +145,7 @@ describe('NeedsReviewScanResultStore Test', () => {
             new NeedsReviewScanResultStore(
                 new NeedsReviewScanResultActions(),
                 tabActions,
+                null,
                 null,
                 null,
                 null,

--- a/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
+++ b/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
@@ -76,7 +76,7 @@ describe('PathSnippetStoreTest', () => {
         actionName: keyof PathSnippetActions,
     ): StoreTester<PathSnippetStoreData, PathSnippetActions> {
         const factory = (actions: PathSnippetActions) =>
-            new PathSnippetStore(actions, null, null, null);
+            new PathSnippetStore(actions, null, null, null, null);
         return new StoreTester(PathSnippetActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/persistent-store.test.ts
+++ b/src/tests/unit/tests/background/stores/persistent-store.test.ts
@@ -60,6 +60,18 @@ describe('PersistentStoreTest', () => {
         idbInstanceMock.verifyAll();
     });
 
+    test('Teardown', async () => {
+        const testObject = new TestStore();
+        idbInstanceMock
+            .setup(db => db.removeItem(indexedDBDataKey))
+            .returns(() => Promise.resolve(true))
+            .verifiable(Times.once());
+
+        await testObject.teardown();
+
+        idbInstanceMock.verifyAll();
+    });
+
     describe('Initialize with store data', () => {
         test('Initialize with initial state', async () => {
             const testObject = new TestStore();

--- a/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
@@ -14,6 +14,7 @@ describe('TabContextStoreHubTest', () => {
             {} as PersistedData,
             null,
             null,
+            null,
         );
     });
 

--- a/src/tests/unit/tests/background/stores/tab-store.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-store.test.ts
@@ -238,7 +238,7 @@ describe('TabStoreTest', () => {
         actionName: keyof TabActions,
     ): StoreTester<TabStoreData, TabActions> {
         const factory = (actions: TabActions) =>
-            new TabStore(actions, new VisualizationActions(), null, null, null);
+            new TabStore(actions, new VisualizationActions(), null, null, null, null);
         return new StoreTester(TabActions, actionName, factory);
     }
 
@@ -246,7 +246,7 @@ describe('TabStoreTest', () => {
         actionName: keyof VisualizationActions,
     ): StoreTester<TabStoreData, VisualizationActions> {
         const factory = (actions: VisualizationActions) =>
-            new TabStore(new TabActions(), actions, null, null, null);
+            new TabStore(new TabActions(), actions, null, null, null, null);
         return new StoreTester(VisualizationActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
@@ -139,6 +139,7 @@ describe('UnifiedScanResultStore Test', () => {
                 null,
                 null,
                 null,
+                null,
             );
 
         return new StoreTester(UnifiedScanResultActions, actionName, factory);
@@ -151,6 +152,7 @@ describe('UnifiedScanResultStore Test', () => {
             new UnifiedScanResultStore(
                 new UnifiedScanResultActions(),
                 tabActions,
+                null,
                 null,
                 null,
                 null,

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -567,6 +567,7 @@ describe('VisualizationScanResultStoreTest', () => {
                 null,
                 null,
                 null,
+                null,
             );
 
         return new StoreTester(VisualizationScanResultActions, actionName, factory);
@@ -583,6 +584,7 @@ describe('VisualizationScanResultStoreTest', () => {
                 new VisualizationActions(),
                 generateUIDStub,
                 visualizationConfigurationFactoryMock.object,
+                null,
                 null,
                 null,
                 null,
@@ -605,6 +607,7 @@ describe('VisualizationScanResultStoreTest', () => {
                 null,
                 null,
                 null,
+                null,
             );
 
         return new StoreTester(TabStopRequirementActions, actionName, factory);
@@ -621,6 +624,7 @@ describe('VisualizationScanResultStoreTest', () => {
                 actions,
                 generateUIDStub,
                 visualizationConfigurationFactoryMock.object,
+                null,
                 null,
                 null,
                 null,

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -838,6 +838,7 @@ describe('VisualizationStoreTest ', () => {
                 null,
                 null,
                 null,
+                null,
             );
 
         return new StoreTester(TabActions, actionName, factory);
@@ -855,6 +856,7 @@ describe('VisualizationStoreTest ', () => {
                 null,
                 null,
                 null,
+                null,
             );
 
         return new StoreTester(VisualizationActions, actionName, factory);
@@ -869,6 +871,7 @@ describe('VisualizationStoreTest ', () => {
                 new TabActions(),
                 actions,
                 new WebVisualizationConfigurationFactory(),
+                null,
                 null,
                 null,
                 null,

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -120,6 +120,7 @@ describe('TabContextFactoryTest', () => {
             broadcastMock.object,
             mockBrowserAdapter.object,
             mockDetailsViewController.object,
+            null,
         );
 
         broadcastMock.verifyAll();

--- a/src/tests/unit/tests/background/tab-context.test.ts
+++ b/src/tests/unit/tests/background/tab-context.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Interpreter } from 'background/interpreter';
+import { TabContextStoreHub } from 'background/stores/tab-context-store-hub';
+import { TabContext } from 'background/tab-context';
+import { PersistentStore } from 'common/flux/persistent-store';
+import { IMock, Mock, Times } from 'typemoq';
+
+describe('TabContextTests', () => {
+    let interpreterMock: IMock<Interpreter>;
+    let storeHubMock: IMock<TabContextStoreHub>;
+    let testSubject: TabContext;
+    let storeMocks: IMock<PersistentStore<any>>[];
+
+    beforeEach(() => {
+        interpreterMock = Mock.ofType<Interpreter>();
+        storeHubMock = Mock.ofType<TabContextStoreHub>();
+        storeMocks = [Mock.ofType<PersistentStore<any>>(), Mock.ofType<PersistentStore<any>>()];
+        testSubject = new TabContext(interpreterMock.object, storeHubMock.object);
+    });
+
+    it('teardown', async () => {
+        storeHubMock
+            .setup(storeHub => storeHub.getAllStores())
+            .returns(() => storeMocks.map(storeMock => storeMock.object))
+            .verifiable(Times.once());
+
+        storeMocks.forEach(storeMock => setupStoreMock(storeMock));
+
+        await testSubject.teardown();
+
+        storeHubMock.verifyAll();
+        storeMocks.forEach(storeMock => storeMock.verifyAll());
+    });
+
+    function setupStoreMock(storeMock: IMock<PersistentStore<any>>): void {
+        storeMock
+            .setup(store => store.teardown())
+            .returns(() => Promise.resolve())
+            .verifiable(Times.once());
+    }
+});


### PR DESCRIPTION
#### Details

Add logic to include the tab ID in the indexed database key for stores that have multiple instances for each tab. These changes fix the bug that #5381 worked around. 

##### Motivation

Feature work.

##### Context

This PR leaves the workaround from #5381 in so that these changes do not effect the manifest v2 extension. 

Including the tab ID in the database key caused the following changes to be necessary:

- Update the keys to be functions that accept the tabID- see changes in IndexedDBDataKeys 
- Pass tab ID through to each store- see the changes in the stores, TabContextFactory, TargetPageController, and TabContextStoreHub
- Add logic to teardown stores to ensure that when tabs are closed we clean up the storage associated with them- see the changes in PersistentStore, TabContext, and TargetPageController
- Update get-persisted-data so that it knows how to read tab specific data from the database
- Update background and renderer init so that they only get the global persisted data that they will actually use.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
