### PR TITLE
feat(mv3-part-2): minimum changes needed to produce a working MV3 extension

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -437,7 +437,7 @@ module.exports = function (grunt) {
         grunt.file.write(configJSONPath, configJSON);
         const copyrightHeader =
             '// Copyright (c) Microsoft Corporation. All rights reserved.\n// Licensed under the MIT License.\n';
-        const configJS = `${copyrightHeader}window.insights = ${configJSON}`;
+        const configJS = `${copyrightHeader}globalThis.insights = ${configJSON};`;
         grunt.file.write(configJSPath, configJS);
     });
 
@@ -461,15 +461,86 @@ module.exports = function (grunt) {
             // Settings that are specific to MV3
             merge(manifestJSON, {
                 action: {
+                    default_popup: 'popup/popup.html',
                     default_icon: {
                         20: config.options.icon16,
                         40: config.options.icon48,
                     },
                 },
+                permissions: [
+                    'alarms',
+                    'notifications',
+                    'scripting',
+                    'storage',
+                    'tabs',
+                    'webNavigation',
+                ],
                 background: {
                     service_worker: 'bundle/serviceWorker.bundle.js',
                 },
-                host_permissions: [],
+                host_permissions: ['*://*/*'],
+                web_accessible_resources: [
+                    {
+                        resources: [
+                            'insights.html',
+                            'assessments/*',
+                            'injected/*',
+                            'background/*',
+                            'common/*',
+                            'DetailsView/*',
+                            'bundle/*',
+                            'NOTICE.html',
+                        ],
+                        matches: ['<all_urls>'],
+                    },
+                ],
+                commands: {
+                    _execute_browser_action: {
+                        suggested_key: {
+                            windows: 'Alt+Shift+K',
+                            mac: 'Alt+Shift+K',
+                            chromeos: 'Alt+Shift+K',
+                            linux: 'Alt+Shift+K',
+                        },
+                        description: 'Activate the extension',
+                    },
+                    '01_toggle-issues': {
+                        suggested_key: {
+                            windows: 'Alt+Shift+1',
+                            mac: 'Alt+Shift+1',
+                            chromeos: 'Alt+Shift+1',
+                            linux: 'Alt+Shift+1',
+                        },
+                        description: 'Toggle Automated checks',
+                    },
+                    '02_toggle-landmarks': {
+                        suggested_key: {
+                            windows: 'Alt+Shift+2',
+                            mac: 'Alt+Shift+2',
+                            chromeos: 'Alt+Shift+2',
+                            linux: 'Alt+Shift+2',
+                        },
+                        description: 'Toggle Landmarks',
+                    },
+                    '03_toggle-headings': {
+                        suggested_key: {
+                            windows: 'Alt+Shift+3',
+                            mac: 'Alt+Shift+3',
+                            chromeos: 'Alt+Shift+3',
+                            linux: 'Alt+Shift+3',
+                        },
+                        description: 'Toggle Headings',
+                    },
+                    '04_toggle-tabStops': {
+                        description: 'Toggle Tab stops',
+                    },
+                    '05_toggle-color': {
+                        description: 'Toggle Color',
+                    },
+                    '06_toggle-needsReview': {
+                        description: 'Toggle Needs review',
+                    },
+                },
             });
         } else {
             // Settings that are specific to MV2. Note that many of these settings--especially the

--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
         "axe-core": "4.3.2",
         "axios": "^0.26.1",
         "classnames": "^2.3.1",
+        "crypto-browserify": "^3.12.0",
         "electron": "14.0.0",
         "electron-log": "^4.4.6",
         "electron-updater": "^5.0.1",

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -1,20 +1,230 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Assessments } from 'assessments/assessments';
+import { BrowserMessageBroadcasterFactory } from 'background/browser-message-broadcaster-factory';
+import { DevToolsListener } from 'background/dev-tools-listener';
+import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
+import { getPersistedData } from 'background/get-persisted-data';
+import { GlobalContextFactory } from 'background/global-context-factory';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { KeyboardShortcutHandler } from 'background/keyboard-shortcut-handler';
+import { MessageDistributor } from 'background/message-distributor';
+import { PostMessageContentHandler } from 'background/post-message-content-handler';
+import { PostMessageContentRepository } from 'background/post-message-content-repository';
+import { TabToContextMap } from 'background/tab-context';
+import { TabContextFactory } from 'background/tab-context-factory';
+import { TargetPageController } from 'background/target-page-controller';
+import { TargetTabController } from 'background/target-tab-controller';
+import { ConsoleTelemetryClient } from 'background/telemetry/console-telemetry-client';
+import { DebugToolsTelemetryClient } from 'background/telemetry/debug-tools-telemetry-client';
+import {
+    getApplicationTelemetryDataFactory,
+    getTelemetryClient,
+} from 'background/telemetry/telemetry-client-provider';
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { TelemetryLogger } from 'background/telemetry/telemetry-logger';
+import { TelemetryStateListener } from 'background/telemetry/telemetry-state-listener';
+import { UsageLogger } from 'background/usage-logger';
+import { createToolData } from 'common/application-properties-provider';
+import { AxeInfo } from 'common/axe-info';
+import { BrowserAdapterFactory } from 'common/browser-adapters/browser-adapter-factory';
+import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
+import { DateProvider } from 'common/date-provider';
+import { getIndexedDBStore } from 'common/indexedDB/get-indexeddb-store';
+import { IndexedDBAPI, IndexedDBUtil } from 'common/indexedDB/indexedDB';
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { NavigatorUtils } from 'common/navigator-utils';
+import { NotificationCreator } from 'common/notification-creator';
+import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
+import { TelemetryDataFactory } from 'common/telemetry-data-factory';
+import { UrlValidator } from 'common/url-validator';
+import { WindowUtils } from 'common/window-utils';
+import { title, toolName } from 'content/strings/application';
+import { IssueFilingServiceProviderImpl } from 'issue-filing/issue-filing-service-provider-impl';
+import UAParser from 'ua-parser-js';
+import { deprecatedStorageDataKeys, storageDataKeys } from './local-storage-data-keys';
+import { cleanKeysFromStorage } from './user-stored-data-cleaner';
 
-const state = {
-    count: 0,
-    interval: 0,
-};
+async function initialize(): Promise<void> {
+    const userAgentParser = new UAParser(globalThis.navigator.userAgent);
+    const browserAdapterFactory = new BrowserAdapterFactory(userAgentParser);
+    const browserAdapter = browserAdapterFactory.makeFromUserAgent();
 
-chrome.action.onClicked.addListener(onClicked);
-chrome.runtime.onInstalled.addListener(onInstalled);
+    // This only removes keys that are unused by current versions of the extension, so it's okay for it to race with everything else
+    const cleanKeysFromStoragePromise = cleanKeysFromStorage(
+        browserAdapter,
+        deprecatedStorageDataKeys,
+    );
 
-function onInstalled() {
-    state.interval = Math.ceil(5 * Math.random());
-    console.log(`interval = ${state.interval}`);
+    const urlValidator = new UrlValidator(browserAdapter);
+    const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(getIndexedDBStore());
+    const indexedDBDataKeysToFetch = [
+        IndexedDBDataKeys.assessmentStore,
+        IndexedDBDataKeys.userConfiguration,
+    ];
+
+    // // These can run concurrently, both because they are read-only and because they use different types of underlying storage
+    const persistedDataPromise = getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch);
+    const userDataPromise = browserAdapter.getUserData(storageDataKeys); // localStorage
+    const persistedData = await persistedDataPromise; //indexedDB
+    const userData = await userDataPromise;
+    const assessmentsProvider = Assessments;
+    const telemetryDataFactory = new TelemetryDataFactory();
+    const logger = createDefaultLogger();
+    const telemetryLogger = new TelemetryLogger(logger);
+
+    const { installationData } = userData;
+
+    const applicationTelemetryDataFactory = getApplicationTelemetryDataFactory(
+        installationData,
+        browserAdapter,
+        browserAdapter,
+        title,
+    );
+
+    const consoleTelemetryClient = new ConsoleTelemetryClient(
+        applicationTelemetryDataFactory,
+        telemetryLogger,
+    );
+
+    const debugToolsTelemetryClient = new DebugToolsTelemetryClient(
+        browserAdapter,
+        applicationTelemetryDataFactory,
+    );
+    debugToolsTelemetryClient.initialize();
+
+    const telemetryClient = getTelemetryClient(applicationTelemetryDataFactory, [
+        consoleTelemetryClient,
+        debugToolsTelemetryClient,
+    ]);
+
+    const usageLogger = new UsageLogger(browserAdapter, DateProvider.getCurrentDate, logger);
+
+    const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
+
+    const browserSpec = new NavigatorUtils(navigator, logger).getBrowserSpec();
+
+    const toolData = createToolData(
+        'axe-core',
+        AxeInfo.Default.version,
+        toolName,
+        browserAdapter.getVersion(),
+        browserSpec,
+    );
+
+    const globalContext = await GlobalContextFactory.createContext(
+        browserAdapter,
+        telemetryEventHandler,
+        userData,
+        assessmentsProvider,
+        telemetryDataFactory,
+        indexedDBInstance,
+        persistedData,
+        IssueFilingServiceProviderImpl,
+        toolData,
+        browserAdapter,
+        browserAdapter,
+        logger,
+    );
+
+    telemetryLogger.initialize(globalContext.featureFlagsController);
+
+    const telemetryStateListener = new TelemetryStateListener(
+        globalContext.stores.userConfigurationStore,
+        telemetryEventHandler,
+    );
+    telemetryStateListener.initialize();
+
+    const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter, logger);
+    const detailsViewController = new ExtensionDetailsViewController(
+        browserAdapter,
+        persistedData.tabIdToDetailsViewMap ?? {},
+        indexedDBInstance,
+    );
+    const tabToContextMap: TabToContextMap = {};
+
+    const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
+    const notificationCreator = new NotificationCreator(
+        browserAdapter,
+        visualizationConfigurationFactory,
+        logger,
+    );
+
+    const keyboardShortcutHandler = new KeyboardShortcutHandler(
+        tabToContextMap,
+        browserAdapter,
+        urlValidator,
+        notificationCreator,
+        visualizationConfigurationFactory,
+        telemetryDataFactory,
+        globalContext.stores.userConfigurationStore,
+        browserAdapter,
+        logger,
+        usageLogger,
+    );
+    keyboardShortcutHandler.initialize();
+
+    const messageDistributor = new MessageDistributor(
+        globalContext,
+        tabToContextMap,
+        browserAdapter,
+        logger,
+    );
+    messageDistributor.initialize();
+
+    const targetTabController = new TargetTabController(
+        browserAdapter,
+        visualizationConfigurationFactory,
+    );
+    const promiseFactory = createDefaultPromiseFactory();
+    const windowUtils = new WindowUtils();
+
+    const tabContextFactory = new TabContextFactory(
+        visualizationConfigurationFactory,
+        telemetryEventHandler,
+        targetTabController,
+        notificationCreator,
+        promiseFactory,
+        logger,
+        usageLogger,
+        windowUtils,
+        persistedData,
+        indexedDBInstance,
+    );
+
+    const targetPageController = new TargetPageController(
+        tabToContextMap,
+        messageBroadcasterFactory,
+        browserAdapter,
+        detailsViewController,
+        tabContextFactory,
+        logger,
+        persistedData.knownTabIds ?? [],
+        indexedDBInstance,
+    );
+
+    await targetPageController.initialize();
+
+    const devToolsBackgroundListener = new DevToolsListener(tabToContextMap, browserAdapter);
+    devToolsBackgroundListener.initialize();
+
+    const postMessageContentRepository = new PostMessageContentRepository(
+        DateProvider.getCurrentDate,
+    );
+
+    const postMessageContentHandler = new PostMessageContentHandler(
+        postMessageContentRepository,
+        browserAdapter,
+    );
+
+    postMessageContentHandler.initialize();
+
+    await cleanKeysFromStoragePromise;
+
+    globalThis.insightsFeatureFlags = globalContext.featureFlagsController;
+    globalThis.insightsUserConfiguration = globalContext.userConfigurationController;
 }
 
-function onClicked() {
-    console.log(`count = ${state.count}`);
-    state.count += state.interval;
-}
+initialize()
+    .then(() => console.log('Background initialization completed successfully'))
+    .catch((e: Error) => console.error('Background initialization failed: ', e));

--- a/src/common/browser-adapters/webextension-browser-adapter.ts
+++ b/src/common/browser-adapters/webextension-browser-adapter.ts
@@ -91,12 +91,22 @@ export abstract class WebExtensionBrowserAdapter
         details: ExtensionTypes.InjectDetails,
     ): Promise<any[]> {
         this.verifyPathCompatibility(details.file);
-        return browser.tabs.executeScript(tabId, details);
+        return typeof browser.tabs.executeScript === 'function'
+            ? browser.tabs.executeScript(tabId, details)
+            : chrome.scripting.executeScript({
+                  target: { tabId, allFrames: details.allFrames },
+                  files: [details.file],
+              } as chrome.scripting.ScriptInjection);
     }
 
     public insertCSSInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void> {
         this.verifyPathCompatibility(details.file);
-        return browser.tabs.insertCSS(tabId, details);
+        return typeof browser.tabs.insertCSS === 'function'
+            ? browser.tabs.insertCSS(tabId, details)
+            : chrome.scripting.insertCSS({
+                  target: { tabId, allFrames: details.allFrames },
+                  files: [details.file],
+              } as chrome.scripting.CSSInjection);
     }
 
     public createActiveTab(url: string): Promise<Tabs.Tab> {
@@ -206,7 +216,9 @@ export abstract class WebExtensionBrowserAdapter
     }
 
     public getUrl(urlPart: string): string {
-        return chrome.extension.getURL(urlPart);
+        return typeof chrome.extension?.getURL === 'function'
+            ? chrome.extension.getURL(urlPart)
+            : chrome.runtime.getURL(urlPart);
     }
 
     public requestPermissions(permissions: Permissions.Permissions): Promise<boolean> {

--- a/src/common/configuration/global-variable-configuration.ts
+++ b/src/common/configuration/global-variable-configuration.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { cloneDeep, defaultsDeep } from 'lodash';
+
+import { defaults } from './configuration-defaults';
+import {
+    ConfigAccessor,
+    ConfigMutator,
+    InsightsConfiguration,
+    InsightsConfigurationOptions,
+} from './configuration-types';
+
+const globalVariableName = 'insights';
+
+// Appropriate for contexts with a DOM that has pre-loaded insights.config.js in a <script> tag,
+// but without access to the fs module (eg, all extension contexts, electron renderer processes)
+export class GlobalVariableConfiguration implements ConfigAccessor, ConfigMutator {
+    public set config(value: InsightsConfiguration) {
+        globalThis[globalVariableName] = value;
+    }
+    public get config(): InsightsConfiguration {
+        return (globalThis[globalVariableName] = defaultsDeep(
+            globalThis[globalVariableName],
+            defaults,
+        ));
+    }
+
+    public reset(): ConfigMutator {
+        this.config = cloneDeep(defaults);
+        return this;
+    }
+
+    public getOption<K extends keyof InsightsConfigurationOptions>(
+        name: K,
+    ): InsightsConfigurationOptions[K] {
+        return this.config.options[name];
+    }
+
+    public setOption<K extends keyof InsightsConfigurationOptions>(
+        name: K,
+        value: InsightsConfigurationOptions[K],
+    ): GlobalVariableConfiguration {
+        this.config.options[name] = value;
+        return this;
+    }
+}

--- a/src/common/configuration/index.ts
+++ b/src/common/configuration/index.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { GlobalVariableConfiguration } from 'common/configuration/global-variable-configuration';
 import { ConfigAccessor, ConfigMutator } from './configuration-types';
-import { WindowVariableConfiguration } from './window-variable-configuration';
 
-const windowVariableConfig = new WindowVariableConfiguration();
+const globalVariableConfig = new GlobalVariableConfiguration();
 
-export const config = windowVariableConfig as ConfigAccessor;
+export const config = globalVariableConfig as ConfigAccessor;
 
 // This should **only** be used by tests
-export const configMutator = windowVariableConfig as ConfigMutator;
+export const configMutator = globalVariableConfig as ConfigMutator;

--- a/src/common/window-utils.ts
+++ b/src/common/window-utils.ts
@@ -25,7 +25,7 @@ export class WindowUtils {
     }
 
     public setTimeout(handler: Function, timeout: number): number {
-        return window.setTimeout(handler, timeout);
+        return globalThis.setTimeout(handler, timeout);
     }
 
     public setInterval(handler: Function, timeout: number): number {

--- a/src/tests/unit/tests/common/configuration/global-variable-configuration.test.ts
+++ b/src/tests/unit/tests/common/configuration/global-variable-configuration.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { GlobalVariableConfiguration } from 'common/configuration/global-variable-configuration';
+
+describe('GlobalVariableConfiguration', () => {
+    const config = new GlobalVariableConfiguration();
+
+    beforeEach(() => config.reset());
+    afterAll(() => config.reset());
+
+    const defaultTelemetryBuildName = 'unknownBuild';
+    const defaultName = 'Accessibility Insights for Web';
+    const defaultUnifiedAppVersion = '0.0.0';
+    const newName = 'New Extension Name';
+
+    it('reflects the expected default values if none have been set (fullName)', () => {
+        expect(config.getOption('fullName')).toBe(defaultName);
+        expect(config.config.options.fullName).toBe(defaultName);
+    });
+
+    it('reflects the expected default values if none have been set (unifiedAppVersion)', () => {
+        expect(config.getOption('unifiedAppVersion')).toBe(defaultUnifiedAppVersion);
+        expect(config.config.options.unifiedAppVersion).toBe(defaultUnifiedAppVersion);
+    });
+
+    it('reflects the expected default values if none have been set (telemetryBuildName)', () => {
+        expect(config.getOption('telemetryBuildName')).toBe(defaultTelemetryBuildName);
+        expect(config.config.options.telemetryBuildName).toBe(defaultTelemetryBuildName);
+    });
+
+    it('reflects values that have been set explicitly', () => {
+        config.setOption('fullName', newName);
+        expect(config.getOption('fullName')).toBe(newName);
+        expect(config.config.options.fullName).toBe(newName);
+    });
+
+    it('reflects the properties on the window variable', () => {
+        window['insights'] = { options: { fullName: newName } };
+        expect(config.getOption('fullName')).toBe(newName);
+        expect(config.config.options.fullName).toBe(newName);
+    });
+
+    it('prefers explicitly set values to window properties', () => {
+        window['insights'] = { options: { fullName: 'name from window property' } };
+        config.setOption('fullName', newName);
+        expect(config.getOption('fullName')).toBe(newName);
+        expect(config.config.options.fullName).toBe(newName);
+    });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,7 +102,7 @@ const commonConfig = {
         extensions: ['.tsx', '.ts', '.js', '.json'],
         // axe-core invokes require('crypto'), but only in a path we don't use, so we don't need a polyfill
         // See https://github.com/dequelabs/axe-core/issues/2873
-        fallback: { crypto: false },
+        fallback: { crypto: require.resolve('crypto-browserify'), stream: false },
     },
     plugins: commonPlugins,
     performance: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,6 +3470,16 @@ asar@^3.1.0:
   optionalDependencies:
     "@types/glob" "^7.1.1"
 
+asn1.js@^5.2.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
+  integrity sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==
+  dependencies:
+    bn.js "^4.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    safer-buffer "^2.1.0"
+
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -3696,6 +3706,16 @@ bmp-js@^0.1.0:
   resolved "https://registry.yarnpkg.com/bmp-js/-/bmp-js-0.1.0.tgz#e05a63f796a6c1ff25f4771ec7adadc148c07233"
   integrity sha1-4Fpj95amwf8l9Hcex62twUjAcjM=
 
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+
+bn.js@^5.0.0, bn.js@^5.1.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
+  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
+
 body-parser@1.19.2:
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.2.tgz#4714ccd9c157d44797b8b5607d72c0b89952f26e"
@@ -3775,10 +3795,69 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+brorand@^1.0.1, brorand@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
+
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
+
+browserify-aes@^1.0.0, browserify-aes@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
+  integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
+  dependencies:
+    buffer-xor "^1.0.3"
+    cipher-base "^1.0.0"
+    create-hash "^1.1.0"
+    evp_bytestokey "^1.0.3"
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
+browserify-cipher@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
+  integrity sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==
+  dependencies:
+    browserify-aes "^1.0.4"
+    browserify-des "^1.0.0"
+    evp_bytestokey "^1.0.0"
+
+browserify-des@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
+  integrity sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==
+  dependencies:
+    cipher-base "^1.0.1"
+    des.js "^1.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
+
+browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.1.0.tgz#b2fd06b5b75ae297f7ce2dc651f918f5be158c8d"
+  integrity sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==
+  dependencies:
+    bn.js "^5.0.0"
+    randombytes "^2.0.1"
+
+browserify-sign@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.1.tgz#eaf4add46dd54be3bb3b36c0cf15abbeba7956c3"
+  integrity sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==
+  dependencies:
+    bn.js "^5.1.1"
+    browserify-rsa "^4.0.1"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
+    elliptic "^6.5.3"
+    inherits "^2.0.4"
+    parse-asn1 "^5.1.5"
+    readable-stream "^3.6.0"
+    safe-buffer "^5.2.0"
 
 browserslist@^4.14.5, browserslist@^4.16.6:
   version "4.16.6"
@@ -3846,6 +3925,11 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer-xor@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
+  integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
 buffer@^5.1.0, buffer@^5.2.0, buffer@^5.5.0:
   version "5.7.1"
@@ -4139,6 +4223,14 @@ ci-info@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
   integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
+
+cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -4620,6 +4712,37 @@ crc@^3.8.0:
   dependencies:
     buffer "^5.1.0"
 
+create-ecdh@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
+  integrity sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==
+  dependencies:
+    bn.js "^4.1.0"
+    elliptic "^6.5.3"
+
+create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
+  dependencies:
+    cipher-base "^1.0.1"
+    inherits "^2.0.1"
+    md5.js "^1.3.4"
+    ripemd160 "^2.0.1"
+    sha.js "^2.4.0"
+
+create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
+  dependencies:
+    cipher-base "^1.0.3"
+    create-hash "^1.1.0"
+    inherits "^2.0.1"
+    ripemd160 "^2.0.0"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 cross-env@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
@@ -4646,6 +4769,23 @@ cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypto-browserify@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
+  integrity sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
+  dependencies:
+    browserify-cipher "^1.0.0"
+    browserify-sign "^4.0.0"
+    create-ecdh "^4.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.0"
+    diffie-hellman "^5.0.0"
+    inherits "^2.0.1"
+    pbkdf2 "^3.0.3"
+    public-encrypt "^4.0.0"
+    randombytes "^2.0.0"
+    randomfill "^1.0.3"
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -4906,6 +5046,14 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+des.js@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
+  integrity sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==
+  dependencies:
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+
 destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
@@ -4963,6 +5111,15 @@ diff-sequences@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
   integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
+
+diffie-hellman@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
+  integrity sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==
+  dependencies:
+    bn.js "^4.1.0"
+    miller-rabin "^4.0.0"
+    randombytes "^2.0.0"
 
 dir-compare@^2.4.0:
   version "2.4.0"
@@ -5255,6 +5412,19 @@ electron@14.0.0:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
+
+elliptic@^6.5.3:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -5851,6 +6021,14 @@ events@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
   integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
+
+evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
+  integrity sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
+  dependencies:
+    md5.js "^1.3.4"
+    safe-buffer "^5.1.1"
 
 execa@^5.0.0:
   version "5.0.0"
@@ -6987,12 +7165,38 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash-base@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
+  dependencies:
+    inherits "^2.0.4"
+    readable-stream "^3.6.0"
+    safe-buffer "^5.2.0"
+
+hash.js@^1.0.0, hash.js@^1.0.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 history@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/history/-/history-5.2.0.tgz#7cdd31cf9bac3c5d31f09c231c9928fad0007b7c"
   integrity sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==
   dependencies:
     "@babel/runtime" "^7.7.6"
+
+hmac-drbg@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
+  dependencies:
+    hash.js "^1.0.3"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.1"
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"
@@ -8825,6 +9029,15 @@ mathml-tag-names@^2.1.3:
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
   integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
 
+md5.js@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -8910,6 +9123,14 @@ micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+miller-rabin@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
+  integrity sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
+  dependencies:
+    bn.js "^4.0.0"
+    brorand "^1.0.1"
+
 mime-db@1.51.0:
   version "1.51.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
@@ -8970,6 +9191,16 @@ mini-css-extract-plugin@2.6.0:
   integrity sha512-ndG8nxCEnAemsg4FSgS+yNyHKgkTB4nPKqCOgh65j3/30qqC5RaSQQXMm++Y6sb6E1zRSxPkztj9fqxhS1Eo6w==
   dependencies:
     schema-utils "^4.0.0"
+
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
+minimalistic-crypto-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 "minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.4, minimatch@~3.0.2, minimatch@~3.0.4:
   version "3.0.4"
@@ -9867,6 +10098,17 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-asn1@^5.0.0, parse-asn1@^5.1.5:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.6.tgz#385080a3ec13cb62a62d39409cb3e88844cdaed4"
+  integrity sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==
+  dependencies:
+    asn1.js "^5.2.0"
+    browserify-aes "^1.0.0"
+    evp_bytestokey "^1.0.0"
+    pbkdf2 "^3.0.3"
+    safe-buffer "^5.1.1"
+
 parse-bmfont-ascii@^1.0.3:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz#11ac3c3ff58f7c2020ab22769079108d4dfa0285"
@@ -10032,6 +10274,17 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pbkdf2@^3.0.3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
+  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
+  dependencies:
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
 
 pend@~1.2.0:
   version "1.2.0"
@@ -10502,6 +10755,18 @@ psl@^1.1.28, psl@^1.1.33:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
+public-encrypt@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
+  integrity sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==
+  dependencies:
+    bn.js "^4.1.0"
+    browserify-rsa "^4.0.0"
+    create-hash "^1.1.0"
+    parse-asn1 "^5.0.0"
+    randombytes "^2.0.1"
+    safe-buffer "^5.1.2"
+
 pump@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
@@ -10601,11 +10866,19 @@ randexp@0.4.6:
     discontinuous-range "1.0.0"
     ret "~0.1.10"
 
-randombytes@^2.1.0:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
+    safe-buffer "^5.1.0"
+
+randomfill@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
+  integrity sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==
+  dependencies:
+    randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
 range-parser@~1.2.1:
@@ -11130,6 +11403,14 @@ rimraf@~2.4.0:
   dependencies:
     glob "^6.0.1"
 
+ripemd160@^2.0.0, ripemd160@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+
 roarr@^2.15.3:
   version "2.15.4"
   resolved "https://registry.yarnpkg.com/roarr/-/roarr-2.15.4.tgz#f5fe795b7b838ccfe35dc608e0282b9eba2e7afd"
@@ -11172,7 +11453,7 @@ safari-14-idb-fix@^3.0.0:
   resolved "https://registry.yarnpkg.com/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz#450fc049b996ec7f3fd9ca2f89d32e0761583440"
   integrity sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog==
 
-safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -11392,6 +11673,14 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
+sha.js@^2.4.0, sha.js@^2.4.8:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 shallow-clone@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
#### Details

This includes changes required to stand up a working manifest V3 extension:
* include crypto backup in webpack
* replace references to window with references to globalThis
* update deprecated API calls:
  *  chrome.extension.getUrl --> chrome.runtime.getUrl
  * chrome.tabs.insertCSS --> chrome.scripting.insertCSS 
  * chrome.tabs.executeScript --> chrome.scripting.executeScript

##### Motivation

feature work

##### Context

Note that the only place the background script references window is where the InjectionController calls windowUtils.setTimeout. For now, windowUtils.setTimeout has been updated to call globalThis.setTimeout instead of window.setTimeout. This should be made more robust later.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.

