### PR TITLE
chore: increase the timeout for CI builds to upload e2e test debug logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
         path: |
           test-results/e2e/chrome-logs
           test-results/e2e/failure-screenshots
-      timeout-minutes: 3
+      timeout-minutes: 15 # chrome-logs is several GB, this can take a while
   
   e2e-unified-tests:
     name: e2e-unified-tests (${{ strategy.job-index }}/${{ strategy.job-total }})


### PR DESCRIPTION
#### Details

Recently we've seen a few timeouts in e2e CI jobs which have failed (usually with a test timing out), then additionally failed to upload debug logs (also in a timeout). This PR bumps up the latter timeout to make diagnosing the former timeouts more feasible.

##### Motivation

Improve test debugability

##### Context

Attempt 1 of e2e job 0 in #5386 is an example of the timeouts in question

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
