### PR TITLE
feat(mv3-part-2): Remove tab IDs that were closed when service worker is down

### DIFF
--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -28,6 +28,12 @@ export class TargetPageController {
         this.knownTabIds.forEach(tabId => this.addTabContext(tabId));
 
         const tabs = await this.browserAdapter.tabsQuery({});
+
+        const removedTabs = this.knownTabIds.filter(
+            knownTab => !tabs.map(tab => tab.id).includes(knownTab),
+        );
+        removedTabs.forEach(removedTabId => this.onTargetTabRemoved(removedTabId));
+
         const newTabs = tabs.filter(tab => !this.knownTabIds.includes(tab.id));
         if (newTabs) {
             newTabs.forEach(tab => {


### PR DESCRIPTION
#### Details

Ensure that storage is cleaned up for any tabs removed when the service worker is down by checking that all `knownTabIds` still exist upon the service worker restarting and, for any tab that no longer exists, tearing down its storage.

##### Motivation

Feature work.

##### Context

These changes will not have any effect on the mv2 extension, since `knownTabIds` is always an empty list. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
