### PR TITLE
(feat: mv3-part-2): Consolidate background message distribution logic

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -174,9 +174,16 @@ async function initialize(): Promise<void> {
     );
     keyboardShortcutHandler.initialize();
 
+    const postMessageContentRepository = new PostMessageContentRepository(
+        DateProvider.getCurrentDate,
+    );
+
+    const postMessageContentHandler = new PostMessageContentHandler(postMessageContentRepository);
+
     const messageDistributor = new MessageDistributor(
         globalContext,
         tabToContextMap,
+        postMessageContentHandler,
         browserAdapter,
         logger,
     );
@@ -217,17 +224,6 @@ async function initialize(): Promise<void> {
 
     const devToolsBackgroundListener = new DevToolsListener(tabToContextMap, browserAdapter);
     devToolsBackgroundListener.initialize();
-
-    const postMessageContentRepository = new PostMessageContentRepository(
-        DateProvider.getCurrentDate,
-    );
-
-    const postMessageContentHandler = new PostMessageContentHandler(
-        postMessageContentRepository,
-        browserAdapter,
-    );
-
-    postMessageContentHandler.initialize();
 
     window.insightsFeatureFlags = globalContext.featureFlagsController;
     window.insightsUserConfiguration = globalContext.userConfigurationController;

--- a/src/background/message-distributor.ts
+++ b/src/background/message-distributor.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { Tab } from '../common/itab';
 import { Logger } from '../common/logging/logger';
 import { InterpreterMessage } from '../common/message';
 import { GlobalContext } from './global-context';
+import { PostMessageContentHandler } from './post-message-content-handler';
 import { TabToContextMap } from './tab-context';
 
 export interface Sender {
@@ -15,6 +16,7 @@ export class MessageDistributor {
     constructor(
         private readonly globalContext: GlobalContext,
         private readonly tabToContextMap: TabToContextMap,
+        private readonly postMessageContentHandler: PostMessageContentHandler,
         private readonly browserAdapter: BrowserAdapter,
         private readonly logger: Logger,
     ) {}
@@ -23,14 +25,13 @@ export class MessageDistributor {
         this.browserAdapter.addListenerOnMessage(this.distributeMessage);
     }
 
-    private distributeMessage = (message: InterpreterMessage, sender?: Sender): void => {
+    private distributeMessage = (message: InterpreterMessage, sender?: Sender): any => {
         message.tabId = this.getTabId(message, sender);
 
         const isInterpretedUsingGlobalContext = this.globalContext.interpreter.interpret(message);
         const isInterpretedUsingTabContext = this.tryInterpretUsingTabContext(message);
-        const isInterpretedAsBackchannelWindowMessage = message.messageType?.startsWith(
-            'backchannel_window_message',
-        );
+        const { success: isInterpretedAsBackchannelWindowMessage, response } =
+            this.postMessageContentHandler.handleMessage(message);
 
         if (
             !isInterpretedUsingGlobalContext &&
@@ -39,9 +40,13 @@ export class MessageDistributor {
         ) {
             this.logger.log('Unable to interpret message - ', message);
         }
+
+        if (response) {
+            return response;
+        }
     };
 
-    private getTabId(message: InterpreterMessage, sender?: Sender): number {
+    private getTabId(message: InterpreterMessage, sender?: Sender): number | null {
         if (message != null && message.tabId != null) {
             return message.tabId;
         } else if (sender != null && sender.tab != null && sender.tab.id != null) {

--- a/src/background/post-message-content-handler.ts
+++ b/src/background/post-message-content-handler.ts
@@ -1,45 +1,36 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { PostMessageContentRepository } from 'background/post-message-content-repository';
-import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { InterpreterMessage } from '../common/message';
 import {
-    BackchannelRetrieveRequestMessage,
-    BackchannelRetrieveResponseMessage,
+    BackchannelRequestMessage,
+    BackchannelRequestMessageType,
     BackchannelStoreRequestMessage,
-} from 'common/types/backchannel-message-type';
+    BackchannelRetrieveResponseMessage,
+} from '../common/types/backchannel-message-type';
+import { PostMessageContentRepository } from './post-message-content-repository';
+
+export type BackchannelMessageResponse = {
+    success: boolean;
+    response?: any;
+};
 
 export class PostMessageContentHandler {
-    constructor(
-        private readonly postMessageContentRepository: PostMessageContentRepository,
-        private readonly browserAdapter: BrowserAdapter,
-    ) {}
+    constructor(private readonly postMessageContentRepository: PostMessageContentRepository) {}
 
-    public initialize = (): void => {
-        this.browserAdapter.addListenerOnMessage(this.storeContentOnMessageReceived);
-        this.browserAdapter.addListenerOnMessage(this.retrieveContentOnMessageReceived);
-    };
-
-    private storeContentOnMessageReceived = (message: BackchannelStoreRequestMessage): void => {
-        if (message.messageType !== 'backchannel_window_message.store_request') {
-            return;
-        }
-
+    private storeContentOnMessageReceived = (message: BackchannelRequestMessage): void => {
+        const storeRequestMessage = message as BackchannelStoreRequestMessage;
         this.postMessageContentRepository.storeContent(
-            message.messageId,
-            message.stringifiedMessageData,
+            storeRequestMessage.messageId,
+            storeRequestMessage.stringifiedMessageData,
         );
     };
 
     // It's important that this is NOT an async function. See
     // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/Runtime/onMessage
     private retrieveContentOnMessageReceived = (
-        message: BackchannelRetrieveRequestMessage,
+        message: BackchannelRequestMessage,
     ): Promise<BackchannelRetrieveResponseMessage> | void => {
-        if (message.messageType !== 'backchannel_window_message.retrieve_request') {
-            return;
-        }
-
         let content: string;
         try {
             content = this.postMessageContentRepository.popContent(message.messageId);
@@ -55,4 +46,27 @@ export class PostMessageContentHandler {
 
         return Promise.resolve(responseMessage);
     };
+
+    // Map enforces that every BackchannelRequestMessageType has a handler
+    private readonly messageHandlers: {
+        [key in BackchannelRequestMessageType]: (
+            message: BackchannelRequestMessage,
+        ) => void | Promise<BackchannelRetrieveResponseMessage>;
+    } = {
+        'backchannel_window_message.retrieve_request': this.retrieveContentOnMessageReceived,
+        'backchannel_window_message.store_request': this.storeContentOnMessageReceived,
+    };
+
+    public handleMessage(message: InterpreterMessage): BackchannelMessageResponse {
+        if (Object.keys(this.messageHandlers).includes(message.messageType)) {
+            return {
+                success: true,
+                response: this.messageHandlers[message.messageType](
+                    message as BackchannelRequestMessage,
+                ),
+            };
+        }
+
+        return { success: false };
+    }
 }

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -158,9 +158,16 @@ async function initialize(): Promise<void> {
     );
     keyboardShortcutHandler.initialize();
 
+    const postMessageContentRepository = new PostMessageContentRepository(
+        DateProvider.getCurrentDate,
+    );
+
+    const postMessageContentHandler = new PostMessageContentHandler(postMessageContentRepository);
+
     const messageDistributor = new MessageDistributor(
         globalContext,
         tabToContextMap,
+        postMessageContentHandler,
         browserAdapter,
         logger,
     );
@@ -200,17 +207,6 @@ async function initialize(): Promise<void> {
 
     const devToolsBackgroundListener = new DevToolsListener(tabToContextMap, browserAdapter);
     devToolsBackgroundListener.initialize();
-
-    const postMessageContentRepository = new PostMessageContentRepository(
-        DateProvider.getCurrentDate,
-    );
-
-    const postMessageContentHandler = new PostMessageContentHandler(
-        postMessageContentRepository,
-        browserAdapter,
-    );
-
-    postMessageContentHandler.initialize();
 
     await cleanKeysFromStoragePromise;
 

--- a/src/common/types/backchannel-message-type.ts
+++ b/src/common/types/backchannel-message-type.ts
@@ -1,19 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export type BackchannelStoreRequestMessage = {
+export type BackchannelRequestMessageType =
+    | 'backchannel_window_message.store_request'
+    | 'backchannel_window_message.retrieve_request';
+
+export interface BackchannelRequestMessage {
+    messageId: string;
+    messageType: BackchannelRequestMessageType;
+}
+
+export interface BackchannelStoreRequestMessage extends BackchannelRequestMessage {
     messageId: string; // same as WindowMessage
     messageType: 'backchannel_window_message.store_request';
     stringifiedMessageData: string; // JSON.stringify(originalMessage)
-};
+}
 
-export type BackchannelRetrieveRequestMessage = {
+export interface BackchannelRetrieveRequestMessage extends BackchannelRequestMessage {
     messageId: string; // same as WindowMessage
     messageType: 'backchannel_window_message.retrieve_request';
-};
+}
 
-export type BackchannelRetrieveResponseMessage = {
+export interface BackchannelRetrieveResponseMessage {
     messageId: string; // same as WindowMessage
     messageType: 'backchannel_window_message.retrieve_response';
     stringifiedMessageData: string;
-};
+}

--- a/src/tests/unit/tests/background/message-distributor.test.ts
+++ b/src/tests/unit/tests/background/message-distributor.test.ts
@@ -3,6 +3,7 @@
 import { GlobalContext } from 'background/global-context';
 import { Interpreter } from 'background/interpreter';
 import { MessageDistributor, Sender } from 'background/message-distributor';
+import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { TabContext, TabToContextMap } from 'background/tab-context';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
@@ -10,26 +11,40 @@ import { Logger } from '../../../../common/logging/logger';
 import { InterpreterMessage } from '../../../../common/message';
 
 describe('MessageDistributorTest', () => {
+    const tabId = 1;
+
     let mockBrowserAdapter: IMock<BrowserAdapter>;
     let testSubject: MessageDistributor;
     let tabToInterpreterMap: TabToContextMap;
     let globalContextMock: IMock<GlobalContext>;
-    let globalInterpreter: Interpreter;
+    let globalInterpreterMock: IMock<Interpreter>;
+    let tabContextInterpreterMock: IMock<Interpreter>;
+    let postMessageContentHandlerMock: IMock<PostMessageContentHandler>;
     let loggerMock: IMock<Logger>;
 
-    let distributeMessageCallback: (message: any, sender?: Sender) => void;
+    let distributeMessageCallback: (message: any, sender?: Sender) => any;
 
     beforeEach(() => {
         mockBrowserAdapter = Mock.ofType<BrowserAdapter>();
+
+        globalInterpreterMock = Mock.ofType(Interpreter);
+        setupInterpreterMockWithInteraction(globalInterpreterMock, false);
+
+        tabContextInterpreterMock = Mock.ofType(Interpreter);
+
         tabToInterpreterMap = {};
+        tabToInterpreterMap[tabId] = new TabContext(tabContextInterpreterMock.object as any, null);
 
         globalContextMock = Mock.ofType(GlobalContext);
-        globalContextMock.setup(x => x.interpreter).returns(() => globalInterpreter);
+        globalContextMock.setup(x => x.interpreter).returns(() => globalInterpreterMock.object);
+
+        postMessageContentHandlerMock = Mock.ofType<PostMessageContentHandler>();
 
         loggerMock = Mock.ofType<Logger>();
         testSubject = new MessageDistributor(
             globalContextMock.object,
             tabToInterpreterMap,
+            postMessageContentHandlerMock.object,
             mockBrowserAdapter.object,
             loggerMock.object,
         );
@@ -42,108 +57,135 @@ describe('MessageDistributorTest', () => {
             .verifiable();
     });
 
-    test('distribute message to both global & tabcontext', () => {
-        const tabId = 1;
+    afterEach(() => {
+        tabContextInterpreterMock.verifyAll();
+        globalInterpreterMock.verifyAll();
+        postMessageContentHandlerMock.verifyAll();
+        loggerMock.verifyAll();
+    });
 
-        const globalInterpreterMock = createInterpreterMockWithInteraction();
-        globalInterpreter = globalInterpreterMock.object;
-        const tabContextInterpreterMock = createInterpreterMockWithInteraction();
-        tabToInterpreterMap[tabId] = new TabContext(tabContextInterpreterMock.object as any, null);
+    test('distribute message to both global & tabcontext', () => {
         const message = { tabId: tabId, payload: {} };
+
+        setupInterpreterMockWithInteraction(tabContextInterpreterMock, true);
+        setupBackchannelIgnoreMessage(message);
+        setupNeverLogFailure();
 
         testSubject.initialize();
 
         distributeMessageCallback(message);
-
-        tabContextInterpreterMock.verifyAll();
-        globalInterpreterMock.verifyAll();
     });
 
     test('should not distribute message, when tabid is not set', () => {
-        const tabId = 1;
-
-        const globalInterpreterMock = createInterpreterMockWithInteraction();
-        globalInterpreter = globalInterpreterMock.object;
-        const tabContextInterpreterMock = createInterpreterMockWithoutInteraction();
-        tabToInterpreterMap[tabId] = new TabContext(tabContextInterpreterMock.object as any, null);
-
-        testSubject.initialize();
         const message = { payload: {} };
 
-        distributeMessageCallback(message);
+        setupInterpreterMockWithoutInteraction(tabContextInterpreterMock);
+        setupBackchannelIgnoreMessage(message);
+        setupLogFailure();
 
-        tabContextInterpreterMock.verifyAll();
-        globalInterpreterMock.verifyAll();
+        testSubject.initialize();
+
+        distributeMessageCallback(message);
     });
 
     test('should not distribute message, when tabid is not set & sender tab is null ', () => {
-        const tabId = 1;
-
-        const globalInterpreterMock = createInterpreterMockWithInteraction();
-        globalInterpreter = globalInterpreterMock.object;
-        const tabContextInterpreterMock = createInterpreterMockWithoutInteraction();
-        tabToInterpreterMap[tabId] = new TabContext(tabContextInterpreterMock.object as any, null);
-
-        testSubject.initialize();
         const message = { payload: {} };
         const sender: Sender = {};
 
-        distributeMessageCallback(message, sender);
+        setupInterpreterMockWithoutInteraction(tabContextInterpreterMock);
+        setupBackchannelIgnoreMessage(message);
+        setupLogFailure();
 
-        tabContextInterpreterMock.verifyAll();
-        globalInterpreterMock.verifyAll();
+        testSubject.initialize();
+
+        distributeMessageCallback(message, sender);
     });
 
     test('should distribute message, when sender has tab id', () => {
-        const tabId = 1;
         const message = { payload: {} } as InterpreterMessage;
+        const sender: Sender = { tab: { id: 1 } };
 
-        const globalInterpreterMock = createInterpreterMockWithInteraction();
-        globalInterpreter = globalInterpreterMock.object;
-        const tabContextInterpreterMock = createInterpreterMockWithInteraction();
-        tabToInterpreterMap[tabId] = new TabContext(tabContextInterpreterMock.object as any, null);
+        setupInterpreterMockWithInteraction(tabContextInterpreterMock, true);
+        setupBackchannelIgnoreMessage(message);
+        setupNeverLogFailure();
 
         testSubject.initialize();
-        const sender: Sender = { tab: { id: 1 } };
 
         distributeMessageCallback(message, sender);
 
-        tabContextInterpreterMock.verifyAll();
-        globalInterpreterMock.verifyAll();
         expect(message.tabId).toBe(tabId);
     });
 
     test('should not distribute message, when interpreter is not available', () => {
         const anotherTabId = 10;
-
-        const globalInterpreterMock = createInterpreterMockWithInteraction();
-        globalInterpreter = globalInterpreterMock.object;
-
-        const tabContextInterpreterMock = createInterpreterMockWithoutInteraction();
-        tabToInterpreterMap[1] = new TabContext(tabContextInterpreterMock.object as any, null);
-
-        testSubject.initialize();
         const message = { tabId: anotherTabId, payload: {} };
 
-        distributeMessageCallback(message);
+        setupInterpreterMockWithoutInteraction(tabContextInterpreterMock);
+        setupBackchannelIgnoreMessage(message);
+        setupLogFailure();
 
-        tabContextInterpreterMock.verifyAll();
-        globalInterpreterMock.verifyAll();
+        testSubject.initialize();
+
+        distributeMessageCallback(message);
     });
 
-    function createInterpreterMockWithoutInteraction(): IMock<Interpreter> {
-        const interpreterMock = Mock.ofType(Interpreter);
+    test.each(['response obj', undefined])(
+        'should distribute backchannel message and return %s',
+        response => {
+            const message = { payload: {} };
 
+            setupInterpreterMockWithoutInteraction(tabContextInterpreterMock);
+            setupInterpretBackchannelMessage(message as InterpreterMessage, response);
+            setupNeverLogFailure();
+
+            testSubject.initialize();
+
+            const actualResponse = distributeMessageCallback(message);
+
+            expect(actualResponse).toEqual(response);
+        },
+    );
+
+    function setupInterpreterMockWithoutInteraction(interpreterMock: IMock<Interpreter>): void {
         interpreterMock.setup(x => x.interpret(It.isAny())).verifiable(Times.never());
-
-        return interpreterMock;
     }
 
-    function createInterpreterMockWithInteraction(): IMock<Interpreter> {
-        const interpreterMock = Mock.ofType(Interpreter);
+    function setupInterpreterMockWithInteraction(
+        interpreterMock: IMock<Interpreter>,
+        success: boolean,
+    ): void {
+        interpreterMock
+            .setup(x => x.interpret(It.isAny()))
+            .returns(() => success)
+            .verifiable(Times.once());
+    }
 
-        interpreterMock.setup(x => x.interpret(It.isAny())).verifiable(Times.once());
+    function setupBackchannelIgnoreMessage(message: any): void {
+        postMessageContentHandlerMock
+            .setup(o => o.handleMessage(It.isObjectWith(message)))
+            .returns(() => ({ success: false }))
+            .verifiable();
+    }
 
-        return interpreterMock;
+    function setupInterpretBackchannelMessage(message: InterpreterMessage, response?: any): void {
+        postMessageContentHandlerMock
+            .setup(o => o.handleMessage(It.isObjectWith(message)))
+            .returns(() => ({ success: true, response }))
+            .verifiable();
+    }
+
+    function setupLogFailure() {
+        loggerMock
+            .setup(l =>
+                l.log(
+                    It.is(message => (message as string).includes('Unable to interpret message')),
+                    It.isAny(),
+                ),
+            )
+            .verifiable();
+    }
+
+    function setupNeverLogFailure() {
+        loggerMock.setup(l => l.log(It.isAny(), It.isAny())).verifiable(Times.never());
     }
 });


### PR DESCRIPTION
#### Details

Currently, we register separate onMessage event handlers in MessageDistributor and PostMessageContentHandler. This PR combines these into one onMessage handler in MessageDistributor.

##### Motivation

As noted in #5396, BrowserAdapterEventManager only allows one event handler per event, so we will need to combine message distribution logic into one ApplicationHandler. Most of it is already consolidated into MessageDistributor, so this PR moves the remaining onMessage registrations in the background context into MessageDistributor.

##### Context

Multiple onMessage handlers are also registered by StoreProxies. However, StoreProxies are only created in contexts that don't have a MessageDistributor (i.e. non-background contexts), so those event handlers will be consolidated in a different class and a different PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
