### PR TITLE
feat(mv3-part-2): Do not persist data for mv2 extension

### DIFF
--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -13,16 +13,19 @@ export class ExtensionDetailsViewController implements DetailsViewController {
         private readonly browserAdapter: BrowserAdapter,
         private readonly tabIdToDetailsViewMap: DictionaryStringTo<number>,
         private readonly idbInstance: IndexedDBAPI,
+        private persistStoreData = false,
     ) {
         this.browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
         this.browserAdapter.addListenerToTabsOnUpdated(this.onUpdateTab);
     }
 
     private persistTabIdToDetailsViewMap = async () => {
-        await this.idbInstance.setItem(
-            IndexedDBDataKeys.tabIdToDetailsViewMap,
-            this.tabIdToDetailsViewMap,
-        );
+        if (this.persistStoreData) {
+            await this.idbInstance.setItem(
+                IndexedDBDataKeys.tabIdToDetailsViewMap,
+                this.tabIdToDetailsViewMap,
+            );
+        }
     };
 
     public setupDetailsViewTabRemovedHandler(handler: (tabId: number) => void): void {

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -67,8 +67,8 @@ export class TargetPageController {
     private removeKnownTabId = async (tabId: number, context: TabContext) => {
         if (this.knownTabIds.includes(tabId)) {
             this.knownTabIds.splice(this.knownTabIds.indexOf(tabId, 0), 1);
+            context.teardown();
             if (this.persistStoreData) {
-                context.teardown();
                 await this.idbInstance.setItem(IndexedDBDataKeys.knownTabIds, this.knownTabIds);
             }
         }

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -22,6 +22,7 @@ export class TargetPageController {
         private readonly logger: Logger,
         private readonly knownTabIds: number[],
         private readonly idbInstance: IndexedDBAPI,
+        private persistStoreData = false,
     ) {}
 
     public async initialize(): Promise<void> {
@@ -57,15 +58,19 @@ export class TargetPageController {
     private addKnownTabId = async (tabId: number) => {
         if (!this.knownTabIds.includes(tabId)) {
             this.knownTabIds.push(tabId);
-            await this.idbInstance.setItem(IndexedDBDataKeys.knownTabIds, this.knownTabIds);
+            if (this.persistStoreData) {
+                await this.idbInstance.setItem(IndexedDBDataKeys.knownTabIds, this.knownTabIds);
+            }
         }
     };
 
     private removeKnownTabId = async (tabId: number, context: TabContext) => {
         if (this.knownTabIds.includes(tabId)) {
             this.knownTabIds.splice(this.knownTabIds.indexOf(tabId, 0), 1);
-            context.teardown();
-            await this.idbInstance.setItem(IndexedDBDataKeys.knownTabIds, this.knownTabIds);
+            if (this.persistStoreData) {
+                context.teardown();
+                await this.idbInstance.setItem(IndexedDBDataKeys.knownTabIds, this.knownTabIds);
+            }
         }
     };
 

--- a/src/common/flux/persistent-store.ts
+++ b/src/common/flux/persistent-store.ts
@@ -21,7 +21,7 @@ export abstract class PersistentStore<TState> extends BaseStoreImpl<TState> {
         if (this.persistStoreData) {
             return await this.idbInstance.setItem(this.indexedDBDataKey, storeData);
         }
-        return Promise.resolve(true);
+        return true;
     }
 
     // Allow specific stores to override default state behavior

--- a/src/tests/unit/tests/background/stores/persistent-store.test.ts
+++ b/src/tests/unit/tests/background/stores/persistent-store.test.ts
@@ -3,7 +3,7 @@
 import { PersistentStore } from 'common/flux/persistent-store';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Logger } from 'common/logging/logger';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 import { StoreNames } from '../../../../../common/stores/store-names';
 
 describe('PersistentStoreTest', () => {
@@ -15,64 +15,7 @@ describe('PersistentStoreTest', () => {
     const indexedDBDataKey: string = 'indexedDBDataKey';
     const loggerMock: IMock<Logger> = Mock.ofType<Logger>();
 
-    test('getDefaultState', () => {
-        const testObject = new TestStore();
-
-        expect(testObject.getDefaultState()).toEqual(defaultState);
-    });
-
-    test('persistData', async () => {
-        const testObject = new TestStore();
-        const newData = { value: 'newData' };
-        idbInstanceMock
-            .setup(db => db.setItem(indexedDBDataKey, newData))
-            .returns(() => Promise.resolve(true))
-            .verifiable(Times.once());
-
-        await testObject.callPersistData(newData);
-
-        idbInstanceMock.verifyAll();
-    });
-
-    test('emitChanged', async () => {
-        const testObject = new TestStore();
-        testObject.initialize();
-        idbInstanceMock
-            .setup(db => db.setItem(indexedDBDataKey, persistedState))
-            .returns(() => Promise.resolve(true))
-            .verifiable(Times.once());
-
-        testObject.callEmitChanged();
-
-        idbInstanceMock.verifyAll();
-    });
-
-    test('emitChanged with null parameters', async () => {
-        const testObject = new TestStore(false);
-        testObject.initialize();
-        idbInstanceMock
-            .setup(db => db.setItem(indexedDBDataKey, persistedState))
-            .returns(() => Promise.resolve(true))
-            .verifiable(Times.once());
-
-        testObject.callEmitChanged();
-
-        idbInstanceMock.verifyAll();
-    });
-
-    test('Teardown', async () => {
-        const testObject = new TestStore();
-        idbInstanceMock
-            .setup(db => db.removeItem(indexedDBDataKey))
-            .returns(() => Promise.resolve(true))
-            .verifiable(Times.once());
-
-        await testObject.teardown();
-
-        idbInstanceMock.verifyAll();
-    });
-
-    describe('Initialize with store data', () => {
+    describe('Persist store data', () => {
         test('Initialize with initial state', async () => {
             const testObject = new TestStore();
 
@@ -113,9 +56,75 @@ describe('PersistentStoreTest', () => {
 
             expect(testObject.getState()).toBe(generatedState);
         });
+
+        test('getDefaultState', () => {
+            const testObject = new TestStore();
+
+            expect(testObject.getDefaultState()).toEqual(defaultState);
+        });
+
+        test('persistData', async () => {
+            const testObject = new TestStore();
+            const newData = { value: 'newData' };
+            idbInstanceMock
+                .setup(db => db.setItem(indexedDBDataKey, newData))
+                .returns(() => Promise.resolve(true))
+                .verifiable(Times.once());
+
+            await testObject.callPersistData(newData);
+
+            idbInstanceMock.verifyAll();
+        });
+
+        test('emitChanged', async () => {
+            const testObject = new TestStore();
+            testObject.initialize();
+            idbInstanceMock
+                .setup(db => db.setItem(indexedDBDataKey, persistedState))
+                .returns(() => Promise.resolve(true))
+                .verifiable(Times.once());
+
+            testObject.callEmitChanged();
+
+            idbInstanceMock.verifyAll();
+        });
+
+        test('emitChanged with null parameters', async () => {
+            const testObject = new TestStore(false);
+            testObject.initialize();
+            idbInstanceMock
+                .setup(db => db.setItem(indexedDBDataKey, persistedState))
+                .returns(() => Promise.resolve(true))
+                .verifiable(Times.once());
+
+            testObject.callEmitChanged();
+
+            idbInstanceMock.verifyAll();
+        });
+
+        test('Teardown', async () => {
+            const testObject = new TestStore();
+            idbInstanceMock
+                .setup(db => db.removeItem(indexedDBDataKey))
+                .returns(() => Promise.resolve(true))
+                .verifiable(Times.once());
+
+            await testObject.teardown();
+
+            idbInstanceMock.verifyAll();
+        });
     });
 
-    describe('Initialize without store data', () => {
+    describe('Do not persist store data', () => {
+        beforeEach(() => {
+            idbInstanceMock.reset();
+
+            idbInstanceMock
+                .setup(db => db.setItem(It.isAny(), It.isAny()))
+                .verifiable(Times.never());
+            idbInstanceMock.setup(db => db.removeItem(It.isAny())).verifiable(Times.never());
+        });
+
         test('Initialize with initial state', async () => {
             const testObject = new TestStore(true, false);
 
@@ -132,6 +141,47 @@ describe('PersistentStoreTest', () => {
 
             expect(testObject.getState()).toBe(defaultState);
         });
+
+        test('getDefaultState', () => {
+            const testObject = new TestStore(true, false);
+
+            expect(testObject.getDefaultState()).toEqual(defaultState);
+        });
+
+        test('persistData', async () => {
+            const testObject = new TestStore(true, false);
+            const newData = { value: 'newData' };
+
+            await testObject.callPersistData(newData);
+
+            idbInstanceMock.verifyAll();
+        });
+
+        test('emitChanged', async () => {
+            const testObject = new TestStore(true, false);
+            testObject.initialize();
+
+            testObject.callEmitChanged();
+
+            idbInstanceMock.verifyAll();
+        });
+
+        test('emitChanged with null parameters', async () => {
+            const testObject = new TestStore(false, false);
+            testObject.initialize();
+
+            testObject.callEmitChanged();
+
+            idbInstanceMock.verifyAll();
+        });
+
+        test('Teardown', async () => {
+            const testObject = new TestStore(true, false);
+
+            await testObject.teardown();
+
+            idbInstanceMock.verifyAll();
+        });
     });
 
     interface TestData {
@@ -139,7 +189,7 @@ describe('PersistentStoreTest', () => {
     }
 
     class TestStore extends PersistentStore<TestData> {
-        constructor(passNonNullParams = true, initializeWithStoreData = true) {
+        constructor(passNonNullParams = true, persistStoreData = true) {
             if (passNonNullParams) {
                 super(
                     storeName,
@@ -147,10 +197,10 @@ describe('PersistentStoreTest', () => {
                     idbInstanceMock.object,
                     indexedDBDataKey,
                     loggerMock.object,
-                    initializeWithStoreData,
+                    persistStoreData,
                 );
             } else {
-                super(null, null, null, null, null, initializeWithStoreData);
+                super(null, null, null, null, null, persistStoreData);
             }
         }
 

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -187,9 +187,6 @@ describe('TargetPageController', () => {
         });
 
         it('should remove tabs that no longer exist', async () => {
-            setupDatabaseInstance([EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID], Times.once());
-            setupTeardownInstance(Times.once());
-
             knownTabIds.push(EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID, NEW_TAB_ID);
 
             await testSubject.initialize();

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -103,7 +103,6 @@ describe('TargetPageController', () => {
             resetInterpreterMocks(mockTabInterpreters);
 
             setupDatabaseInstance(null, Times.never());
-            setupTeardownInstance(Times.never());
         });
 
         it('should not persist data on init', async () => {

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -83,55 +83,30 @@ describe('TargetPageController', () => {
         idbInstanceMock.reset();
         knownTabIds = [];
         tabContextTeardownMock = Mock.ofInstance(() => Promise.resolve());
-
-        testSubject = new TargetPageController(
-            tabToContextMap,
-            mockBroadcasterFactoryStrictMock.object,
-            mockBrowserAdapter.object,
-            mockDetailsViewController.object,
-            mockTabContextFactory.object,
-            mockLogger.object,
-            knownTabIds,
-            idbInstanceMock.object,
-        );
     });
 
-    describe('initialize', () => {
-        it('should register the expected listeners', async () => {
-            setupDatabaseInstance([EXISTING_ACTIVE_TAB_ID], Times.once());
-            setupDatabaseInstance([EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID], Times.once());
+    describe('No Persisted Data', () => {
+        beforeEach(() => {
+            testSubject = new TargetPageController(
+                tabToContextMap,
+                mockBroadcasterFactoryStrictMock.object,
+                mockBrowserAdapter.object,
+                mockDetailsViewController.object,
+                mockTabContextFactory.object,
+                mockLogger.object,
+                knownTabIds,
+                idbInstanceMock.object,
+                false,
+            );
+
+            idbInstanceMock.reset();
+            resetInterpreterMocks(mockTabInterpreters);
+
+            setupDatabaseInstance(null, Times.never());
             setupTeardownInstance(Times.never());
-
-            await testSubject.initialize();
-
-            mockBrowserAdapter.verify(m => m.addListenerOnConnect(It.isAny()), Times.once());
-            mockBrowserAdapter.verify(
-                m => m.addListenerOnWindowsFocusChanged(It.isAny()),
-                Times.once(),
-            );
-            mockBrowserAdapter.verify(
-                m => m.addListenerToTabsOnActivated(It.isAny()),
-                Times.once(),
-            );
-            mockBrowserAdapter.verify(m => m.addListenerToTabsOnRemoved(It.isAny()), Times.once());
-            mockBrowserAdapter.verify(m => m.addListenerToTabsOnUpdated(It.isAny()), Times.once());
-            mockBrowserAdapter.verify(
-                m => m.addListenerToWebNavigationUpdated(It.isAny()),
-                Times.once(),
-            );
-
-            mockDetailsViewController.verify(
-                m => m.setupDetailsViewTabRemovedHandler(It.isAny()),
-                Times.once(),
-            );
-
-            idbInstanceMock.verifyAll();
         });
 
-        it('should create a tab context for each pre-existing tab', async () => {
-            setupDatabaseInstance([EXISTING_ACTIVE_TAB_ID], Times.once());
-            setupDatabaseInstance([EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID], Times.once());
-
+        it('should not persist data on init', async () => {
             await testSubject.initialize();
 
             mockTabContextFactory.verify(
@@ -179,43 +154,13 @@ describe('TargetPageController', () => {
             idbInstanceMock.verifyAll();
         });
 
-        it('should create a tab context for each persisted tab', async () => {
-            setupDatabaseInstance(null, Times.never());
-
-            knownTabIds.push(EXISTING_INACTIVE_TAB_ID);
-            knownTabIds.push(EXISTING_ACTIVE_TAB_ID);
-
+        it('should not persist data for new tabs', async () => {
             await testSubject.initialize();
 
-            mockTabContextFactory.verify(
-                f =>
-                    f.createTabContext(
-                        itIsFakeBroadcasterForTabId(EXISTING_ACTIVE_TAB_ID),
-                        It.isAny(),
-                        It.isAny(),
-                        EXISTING_ACTIVE_TAB_ID,
-                    ),
-                Times.once(),
-            );
-            expect(tabToContextMap[EXISTING_ACTIVE_TAB_ID]).toHaveProperty(
-                'interpreter',
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].object,
-            );
-
-            mockTabContextFactory.verify(
-                f =>
-                    f.createTabContext(
-                        itIsFakeBroadcasterForTabId(EXISTING_INACTIVE_TAB_ID),
-                        It.isAny(),
-                        It.isAny(),
-                        It.isAny(),
-                    ),
-                Times.once(),
-            );
-            expect(tabToContextMap[EXISTING_INACTIVE_TAB_ID]).toHaveProperty(
-                'interpreter',
-                mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].object,
-            );
+            mockBrowserAdapter.notifyWebNavigationUpdated({
+                frameId: 0,
+                tabId: NEW_TAB_ID,
+            } as chrome.webNavigation.WebNavigationFramedCallbackDetails);
 
             mockTabContextFactory.verify(
                 f =>
@@ -223,76 +168,22 @@ describe('TargetPageController', () => {
                         itIsFakeBroadcasterForTabId(NEW_TAB_ID),
                         It.isAny(),
                         It.isAny(),
-                        It.isAny(),
+                        NEW_TAB_ID,
                     ),
-                Times.never(),
+                Times.once(),
             );
-            expect(tabToContextMap[NEW_TAB_ID]).toBeUndefined();
-
-            idbInstanceMock.verifyAll();
-
-            verifyNoInterpreterMessages(mockTabInterpreters);
+            expect(tabToContextMap[NEW_TAB_ID]).toHaveProperty(
+                'interpreter',
+                mockTabInterpreters[NEW_TAB_ID].object,
+            );
         });
 
-        it('should create a tab context for each persisted and non-persisted tab', async () => {
-            setupDatabaseInstance([EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID], Times.once());
-
-            knownTabIds.push(EXISTING_ACTIVE_TAB_ID);
-
+        it('should not persist data for tabs that are removed', async () => {
             await testSubject.initialize();
 
-            mockTabContextFactory.verify(
-                f =>
-                    f.createTabContext(
-                        itIsFakeBroadcasterForTabId(EXISTING_ACTIVE_TAB_ID),
-                        It.isAny(),
-                        It.isAny(),
-                        EXISTING_ACTIVE_TAB_ID,
-                    ),
-                Times.once(),
-            );
-            expect(tabToContextMap[EXISTING_ACTIVE_TAB_ID]).toHaveProperty(
-                'interpreter',
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].object,
-            );
+            mockBrowserAdapter.notifyTabsOnRemoved(EXISTING_ACTIVE_TAB_ID, null);
 
-            mockTabContextFactory.verify(
-                f =>
-                    f.createTabContext(
-                        itIsFakeBroadcasterForTabId(EXISTING_INACTIVE_TAB_ID),
-                        It.isAny(),
-                        It.isAny(),
-                        It.isAny(),
-                    ),
-                Times.once(),
-            );
-            expect(tabToContextMap[EXISTING_INACTIVE_TAB_ID]).toHaveProperty(
-                'interpreter',
-                mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].object,
-            );
-
-            mockTabContextFactory.verify(
-                f =>
-                    f.createTabContext(
-                        itIsFakeBroadcasterForTabId(NEW_TAB_ID),
-                        It.isAny(),
-                        It.isAny(),
-                        It.isAny(),
-                    ),
-                Times.never(),
-            );
-            expect(tabToContextMap[NEW_TAB_ID]).toBeUndefined();
-
-            idbInstanceMock.verifyAll();
-
-            mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
-                i => i.interpret(It.isAny()),
-                Times.never(),
-            );
-            mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].verify(
-                i => i.interpret(It.isAny()),
-                Times.once(),
-            );
+            expect(tabToContextMap[EXISTING_ACTIVE_TAB_ID]).toBeUndefined();
         });
 
         it('should remove tabs that no longer exist', async () => {
@@ -365,54 +256,100 @@ describe('TargetPageController', () => {
         });
     });
 
-    describe('in initialized state', () => {
-        beforeEach(async () => {
-            await testSubject.initialize();
-            idbInstanceMock.reset();
-            resetInterpreterMocks(mockTabInterpreters);
+    describe('Persisted Data', () => {
+        beforeEach(() => {
+            testSubject = new TargetPageController(
+                tabToContextMap,
+                mockBroadcasterFactoryStrictMock.object,
+                mockBrowserAdapter.object,
+                mockDetailsViewController.object,
+                mockTabContextFactory.object,
+                mockLogger.object,
+                knownTabIds,
+                idbInstanceMock.object,
+                true,
+            );
         });
 
-        afterEach(() => {
-            idbInstanceMock.verifyAll();
-        });
-
-        describe('onConnect', () => {
-            it('should not have any observable effect', () => {
-                setupDatabaseInstance(null, Times.never());
-
-                mockBrowserAdapter.notifyOnConnect({
-                    name: 'irrelevant port',
-                } as chrome.runtime.Port);
-                verifyNoInterpreterMessages(mockTabInterpreters);
-            });
-        });
-
-        describe('onWebNavigationUpdated', () => {
-            const rootFrameId = 0;
-            const nonRootFrameId = 1;
-
-            it('should ignore updates for non-root frames', () => {
-                setupDatabaseInstance(null, Times.never());
+        describe('initialize', () => {
+            it('should register the expected listeners', async () => {
+                setupDatabaseInstance([EXISTING_ACTIVE_TAB_ID], Times.once());
+                setupDatabaseInstance(
+                    [EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID],
+                    Times.once(),
+                );
                 setupTeardownInstance(Times.never());
 
-                mockBrowserAdapter.notifyWebNavigationUpdated({
-                    frameId: nonRootFrameId,
-                    tabId: EXISTING_ACTIVE_TAB_ID,
-                } as chrome.webNavigation.WebNavigationFramedCallbackDetails);
+                await testSubject.initialize();
 
-                verifyNoInterpreterMessages(mockTabInterpreters);
-            });
-
-            it('should initialize a new tab context for root frames in new tabs', () => {
-                setupDatabaseInstance(
-                    [EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID, NEW_TAB_ID],
+                mockBrowserAdapter.verify(m => m.addListenerOnConnect(It.isAny()), Times.once());
+                mockBrowserAdapter.verify(
+                    m => m.addListenerOnWindowsFocusChanged(It.isAny()),
+                    Times.once(),
+                );
+                mockBrowserAdapter.verify(
+                    m => m.addListenerToTabsOnActivated(It.isAny()),
+                    Times.once(),
+                );
+                mockBrowserAdapter.verify(
+                    m => m.addListenerToTabsOnRemoved(It.isAny()),
+                    Times.once(),
+                );
+                mockBrowserAdapter.verify(
+                    m => m.addListenerToTabsOnUpdated(It.isAny()),
+                    Times.once(),
+                );
+                mockBrowserAdapter.verify(
+                    m => m.addListenerToWebNavigationUpdated(It.isAny()),
                     Times.once(),
                 );
 
-                mockBrowserAdapter.notifyWebNavigationUpdated({
-                    frameId: rootFrameId,
-                    tabId: NEW_TAB_ID,
-                } as chrome.webNavigation.WebNavigationFramedCallbackDetails);
+                mockDetailsViewController.verify(
+                    m => m.setupDetailsViewTabRemovedHandler(It.isAny()),
+                    Times.once(),
+                );
+
+                idbInstanceMock.verifyAll();
+            });
+
+            it('should create a tab context for each pre-existing tab', async () => {
+                setupDatabaseInstance([EXISTING_ACTIVE_TAB_ID], Times.once());
+                setupDatabaseInstance(
+                    [EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID],
+                    Times.once(),
+                );
+
+                await testSubject.initialize();
+
+                mockTabContextFactory.verify(
+                    f =>
+                        f.createTabContext(
+                            itIsFakeBroadcasterForTabId(EXISTING_ACTIVE_TAB_ID),
+                            It.isAny(),
+                            It.isAny(),
+                            EXISTING_ACTIVE_TAB_ID,
+                        ),
+                    Times.once(),
+                );
+                expect(tabToContextMap[EXISTING_ACTIVE_TAB_ID]).toHaveProperty(
+                    'interpreter',
+                    mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].object,
+                );
+
+                mockTabContextFactory.verify(
+                    f =>
+                        f.createTabContext(
+                            itIsFakeBroadcasterForTabId(EXISTING_INACTIVE_TAB_ID),
+                            It.isAny(),
+                            It.isAny(),
+                            EXISTING_INACTIVE_TAB_ID,
+                        ),
+                    Times.once(),
+                );
+                expect(tabToContextMap[EXISTING_INACTIVE_TAB_ID]).toHaveProperty(
+                    'interpreter',
+                    mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].object,
+                );
 
                 mockTabContextFactory.verify(
                     f =>
@@ -420,280 +357,475 @@ describe('TargetPageController', () => {
                             itIsFakeBroadcasterForTabId(NEW_TAB_ID),
                             It.isAny(),
                             It.isAny(),
-                            NEW_TAB_ID,
+                            It.isAny(),
+                        ),
+                    Times.never(),
+                );
+                expect(tabToContextMap[NEW_TAB_ID]).toBeUndefined();
+
+                idbInstanceMock.verifyAll();
+            });
+
+            it('should create a tab context for each persisted tab', async () => {
+                setupDatabaseInstance(null, Times.never());
+
+                knownTabIds.push(EXISTING_INACTIVE_TAB_ID);
+                knownTabIds.push(EXISTING_ACTIVE_TAB_ID);
+
+                await testSubject.initialize();
+
+                mockTabContextFactory.verify(
+                    f =>
+                        f.createTabContext(
+                            itIsFakeBroadcasterForTabId(EXISTING_ACTIVE_TAB_ID),
+                            It.isAny(),
+                            It.isAny(),
+                            EXISTING_ACTIVE_TAB_ID,
                         ),
                     Times.once(),
                 );
-                expect(tabToContextMap[NEW_TAB_ID]).toHaveProperty(
+                expect(tabToContextMap[EXISTING_ACTIVE_TAB_ID]).toHaveProperty(
                     'interpreter',
-                    mockTabInterpreters[NEW_TAB_ID].object,
+                    mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].object,
                 );
+
+                mockTabContextFactory.verify(
+                    f =>
+                        f.createTabContext(
+                            itIsFakeBroadcasterForTabId(EXISTING_INACTIVE_TAB_ID),
+                            It.isAny(),
+                            It.isAny(),
+                            It.isAny(),
+                        ),
+                    Times.once(),
+                );
+                expect(tabToContextMap[EXISTING_INACTIVE_TAB_ID]).toHaveProperty(
+                    'interpreter',
+                    mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].object,
+                );
+
+                mockTabContextFactory.verify(
+                    f =>
+                        f.createTabContext(
+                            itIsFakeBroadcasterForTabId(NEW_TAB_ID),
+                            It.isAny(),
+                            It.isAny(),
+                            It.isAny(),
+                        ),
+                    Times.never(),
+                );
+                expect(tabToContextMap[NEW_TAB_ID]).toBeUndefined();
+
+                idbInstanceMock.verifyAll();
+
+                verifyNoInterpreterMessages(mockTabInterpreters);
             });
 
-            it('should send an Tab.ExistingTabUpdated message for root frames in existing tabs', () => {
-                setupDatabaseInstance(null, Times.never());
+            it('should create a tab context for each persisted and non-persisted tab', async () => {
+                setupDatabaseInstance(
+                    [EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID],
+                    Times.once(),
+                );
 
-                mockBrowserAdapter.notifyWebNavigationUpdated({
-                    frameId: rootFrameId,
-                    tabId: EXISTING_ACTIVE_TAB_ID,
-                } as chrome.webNavigation.WebNavigationFramedCallbackDetails);
+                knownTabIds.push(EXISTING_ACTIVE_TAB_ID);
 
-                const expectedMessage = {
-                    messageType: Messages.Tab.ExistingTabUpdated,
-                    payload: { ...EXISTING_ACTIVE_TAB },
-                    tabId: EXISTING_ACTIVE_TAB_ID,
-                };
+                await testSubject.initialize();
+
+                mockTabContextFactory.verify(
+                    f =>
+                        f.createTabContext(
+                            itIsFakeBroadcasterForTabId(EXISTING_ACTIVE_TAB_ID),
+                            It.isAny(),
+                            It.isAny(),
+                            EXISTING_ACTIVE_TAB_ID,
+                        ),
+                    Times.once(),
+                );
+                expect(tabToContextMap[EXISTING_ACTIVE_TAB_ID]).toHaveProperty(
+                    'interpreter',
+                    mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].object,
+                );
+
+                mockTabContextFactory.verify(
+                    f =>
+                        f.createTabContext(
+                            itIsFakeBroadcasterForTabId(EXISTING_INACTIVE_TAB_ID),
+                            It.isAny(),
+                            It.isAny(),
+                            It.isAny(),
+                        ),
+                    Times.once(),
+                );
+                expect(tabToContextMap[EXISTING_INACTIVE_TAB_ID]).toHaveProperty(
+                    'interpreter',
+                    mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].object,
+                );
+
+                mockTabContextFactory.verify(
+                    f =>
+                        f.createTabContext(
+                            itIsFakeBroadcasterForTabId(NEW_TAB_ID),
+                            It.isAny(),
+                            It.isAny(),
+                            It.isAny(),
+                        ),
+                    Times.never(),
+                );
+                expect(tabToContextMap[NEW_TAB_ID]).toBeUndefined();
+
+                idbInstanceMock.verifyAll();
+
                 mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
-                    i => i.interpret(expectedMessage),
+                    i => i.interpret(It.isAny()),
+                    Times.never(),
+                );
+                mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].verify(
+                    i => i.interpret(It.isAny()),
                     Times.once(),
                 );
             });
         });
 
-        describe('onTabRemoved', () => {
-            it('should ignore removals of non-tracked tabs', () => {
-                setupDatabaseInstance(null, Times.never());
-                setupTeardownInstance(Times.once());
-                mockBrowserAdapter.notifyTabsOnRemoved(NEW_TAB_ID, null);
-                verifyNoInterpreterMessages(mockTabInterpreters);
-            });
-
-            it('should send a Tab.Remove message for tracked tabs', () => {
-                setupDatabaseInstance([EXISTING_INACTIVE_TAB_ID], Times.once());
-                setupTeardownInstance(Times.once());
-
-                const expectedMessage = {
-                    messageType: Messages.Tab.Remove,
-                    payload: null,
-                    tabId: EXISTING_ACTIVE_TAB_ID,
-                };
-                mockBrowserAdapter.notifyTabsOnRemoved(EXISTING_ACTIVE_TAB_ID, null);
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
-                    i => i.interpret(expectedMessage),
-                    Times.once(),
-                );
-            });
-
-            it('should remove tabToContextMap entries for tabs that are removed', () => {
-                setupDatabaseInstance([EXISTING_INACTIVE_TAB_ID], Times.once());
-                setupTeardownInstance(Times.once());
-
-                mockBrowserAdapter.notifyTabsOnRemoved(EXISTING_ACTIVE_TAB_ID, null);
-
-                expect(tabToContextMap[EXISTING_ACTIVE_TAB_ID]).toBeUndefined();
-            });
-
-            it('should stop sending future messages after tabs are removed', () => {
-                setupDatabaseInstance([EXISTING_INACTIVE_TAB_ID], Times.once());
-                setupTeardownInstance(Times.once());
-
-                mockBrowserAdapter.notifyTabsOnRemoved(EXISTING_ACTIVE_TAB_ID, null);
+        describe('in initialized state', () => {
+            beforeEach(async () => {
+                await testSubject.initialize();
+                idbInstanceMock.reset();
                 resetInterpreterMocks(mockTabInterpreters);
-                mockBrowserAdapter.notifyTabsOnRemoved(EXISTING_ACTIVE_TAB_ID, null);
-
-                verifyNoInterpreterMessages(mockTabInterpreters);
-            });
-        });
-
-        describe('onDetailsViewTabRemoved', () => {
-            beforeEach(() => {
-                setupDatabaseInstance(null, Times.never());
-                setupTeardownInstance(Times.never());
             });
 
-            it('should ignore removals of non-tracked tabs', () => {
-                mockDetailsViewController.notifyDetailsViewTabRemoved(NEW_TAB_ID);
-                verifyNoInterpreterMessages(mockTabInterpreters);
+            afterEach(() => {
+                idbInstanceMock.verifyAll();
             });
 
-            it('should send a Messages.Visualizations.DetailsView.Close message for tracked tabs', () => {
-                mockDetailsViewController.notifyDetailsViewTabRemoved(EXISTING_ACTIVE_TAB_ID);
+            describe('onConnect', () => {
+                it('should not have any observable effect', () => {
+                    setupDatabaseInstance(null, Times.never());
 
-                const expectedMessage = {
-                    messageType: Messages.Visualizations.DetailsView.Close,
-                    payload: null,
-                    tabId: EXISTING_ACTIVE_TAB_ID,
-                };
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
-                    i => i.interpret(expectedMessage),
-                    Times.once(),
-                );
-            });
-        });
-
-        describe('onWindowsFocusChanged', () => {
-            beforeEach(() => {
-                setupDatabaseInstance(null, Times.never());
-                setupTeardownInstance(Times.never());
+                    mockBrowserAdapter.notifyOnConnect({
+                        name: 'irrelevant port',
+                    } as chrome.runtime.Port);
+                    verifyNoInterpreterMessages(mockTabInterpreters);
+                });
             });
 
-            const irrelevantWindowId = -1;
-            it.each`
-                windowState       | expectedHiddenValue
-                ${'minimized'}    | ${true}
-                ${'maximized'}    | ${false}
-                ${'normal'}       | ${false}
-                ${'unrecognized'} | ${false}
-            `(
-                'should send a Tab.VisibilityChange message with hidden=$expectedHiddenValue for active tabs in windows with state $windowState',
-                async ({ windowState, expectedHiddenValue }) => {
-                    mockBrowserAdapter.windows.forEach(w => {
-                        w.state = windowState;
-                    });
-                    mockBrowserAdapter.notifyWindowsFocusChanged(irrelevantWindowId);
+            describe('onWebNavigationUpdated', () => {
+                const rootFrameId = 0;
+                const nonRootFrameId = 1;
 
-                    await flushSettledPromises();
+                it('should ignore updates for non-root frames', () => {
+                    setupDatabaseInstance(null, Times.never());
+                    setupTeardownInstance(Times.never());
+
+                    mockBrowserAdapter.notifyWebNavigationUpdated({
+                        frameId: nonRootFrameId,
+                        tabId: EXISTING_ACTIVE_TAB_ID,
+                    } as chrome.webNavigation.WebNavigationFramedCallbackDetails);
+
+                    verifyNoInterpreterMessages(mockTabInterpreters);
+                });
+
+                it('should initialize a new tab context for root frames in new tabs', () => {
+                    setupDatabaseInstance(
+                        [EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID, NEW_TAB_ID],
+                        Times.once(),
+                    );
+
+                    mockBrowserAdapter.notifyWebNavigationUpdated({
+                        frameId: rootFrameId,
+                        tabId: NEW_TAB_ID,
+                    } as chrome.webNavigation.WebNavigationFramedCallbackDetails);
+
+                    mockTabContextFactory.verify(
+                        f =>
+                            f.createTabContext(
+                                itIsFakeBroadcasterForTabId(NEW_TAB_ID),
+                                It.isAny(),
+                                It.isAny(),
+                                NEW_TAB_ID,
+                            ),
+                        Times.once(),
+                    );
+                    expect(tabToContextMap[NEW_TAB_ID]).toHaveProperty(
+                        'interpreter',
+                        mockTabInterpreters[NEW_TAB_ID].object,
+                    );
+                });
+
+                it('should send an Tab.ExistingTabUpdated message for root frames in existing tabs', () => {
+                    setupDatabaseInstance(null, Times.never());
+
+                    mockBrowserAdapter.notifyWebNavigationUpdated({
+                        frameId: rootFrameId,
+                        tabId: EXISTING_ACTIVE_TAB_ID,
+                    } as chrome.webNavigation.WebNavigationFramedCallbackDetails);
 
                     const expectedMessage = {
-                        messageType: Messages.Tab.VisibilityChange,
-                        payload: { hidden: expectedHiddenValue },
+                        messageType: Messages.Tab.ExistingTabUpdated,
+                        payload: { ...EXISTING_ACTIVE_TAB },
                         tabId: EXISTING_ACTIVE_TAB_ID,
                     };
                     mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
                         i => i.interpret(expectedMessage),
                         Times.once(),
                     );
-                },
-            );
-
-            it('should ignore untracked tabs', () => {
-                mockBrowserAdapter.notifyWindowsFocusChanged(irrelevantWindowId);
-                mockTabInterpreters[NEW_TAB_ID].verify(i => i.interpret(It.isAny()), Times.never());
+                });
             });
 
-            it('should ignore inactive tabs', () => {
-                mockBrowserAdapter.notifyWindowsFocusChanged(irrelevantWindowId);
-                mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].verify(
-                    i => i.interpret(It.isAny()),
-                    Times.never(),
-                );
+            describe('onTabRemoved', () => {
+                it('should ignore removals of non-tracked tabs', () => {
+                    setupDatabaseInstance(null, Times.never());
+                    setupTeardownInstance(Times.once());
+                    mockBrowserAdapter.notifyTabsOnRemoved(NEW_TAB_ID, null);
+                    verifyNoInterpreterMessages(mockTabInterpreters);
+                });
+
+                it('should send a Tab.Remove message for tracked tabs', () => {
+                    setupDatabaseInstance([EXISTING_INACTIVE_TAB_ID], Times.once());
+                    setupTeardownInstance(Times.once());
+
+                    const expectedMessage = {
+                        messageType: Messages.Tab.Remove,
+                        payload: null,
+                        tabId: EXISTING_ACTIVE_TAB_ID,
+                    };
+                    mockBrowserAdapter.notifyTabsOnRemoved(EXISTING_ACTIVE_TAB_ID, null);
+                    mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                        i => i.interpret(expectedMessage),
+                        Times.once(),
+                    );
+                });
+
+                it('should remove tabToContextMap entries for tabs that are removed', () => {
+                    setupDatabaseInstance([EXISTING_INACTIVE_TAB_ID], Times.once());
+                    setupTeardownInstance(Times.once());
+
+                    mockBrowserAdapter.notifyTabsOnRemoved(EXISTING_ACTIVE_TAB_ID, null);
+
+                    expect(tabToContextMap[EXISTING_ACTIVE_TAB_ID]).toBeUndefined();
+                });
+
+                it('should stop sending future messages after tabs are removed', () => {
+                    setupDatabaseInstance([EXISTING_INACTIVE_TAB_ID], Times.once());
+                    setupTeardownInstance(Times.once());
+
+                    mockBrowserAdapter.notifyTabsOnRemoved(EXISTING_ACTIVE_TAB_ID, null);
+                    resetInterpreterMocks(mockTabInterpreters);
+                    mockBrowserAdapter.notifyTabsOnRemoved(EXISTING_ACTIVE_TAB_ID, null);
+
+                    verifyNoInterpreterMessages(mockTabInterpreters);
+                });
             });
 
-            it('should ignore tabs for windows which result in a runtime error when queried', () => {
-                mockBrowserAdapter.object.getRuntimeLastError(); // clear out the first method setup from setupMockBrowserAdapter()
-                mockBrowserAdapter
-                    .setup(m => m.getRuntimeLastError())
-                    .returns(() => ({ message: 'test error' }));
+            describe('onDetailsViewTabRemoved', () => {
+                beforeEach(() => {
+                    setupDatabaseInstance(null, Times.never());
+                    setupTeardownInstance(Times.never());
+                });
 
-                mockBrowserAdapter.notifyWindowsFocusChanged(irrelevantWindowId);
-                verifyNoInterpreterMessages(mockTabInterpreters);
-            });
-        });
+                it('should ignore removals of non-tracked tabs', () => {
+                    mockDetailsViewController.notifyDetailsViewTabRemoved(NEW_TAB_ID);
+                    verifyNoInterpreterMessages(mockTabInterpreters);
+                });
 
-        describe('onTabActivated', () => {
-            beforeEach(() => {
-                setupDatabaseInstance(null, Times.never());
-            });
+                it('should send a Messages.Visualizations.DetailsView.Close message for tracked tabs', () => {
+                    mockDetailsViewController.notifyDetailsViewTabRemoved(EXISTING_ACTIVE_TAB_ID);
 
-            it('should send a Tab.VisibilityChange message with isHidden=false for activation of known tabs', () => {
-                mockBrowserAdapter.activateTab(EXISTING_INACTIVE_TAB);
-
-                const expectedMessage = {
-                    messageType: Messages.Tab.VisibilityChange,
-                    payload: { hidden: false },
-                    tabId: EXISTING_INACTIVE_TAB_ID,
-                };
-                mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].verify(
-                    i => i.interpret(expectedMessage),
-                    Times.once(),
-                );
+                    const expectedMessage = {
+                        messageType: Messages.Visualizations.DetailsView.Close,
+                        payload: null,
+                        tabId: EXISTING_ACTIVE_TAB_ID,
+                    };
+                    mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                        i => i.interpret(expectedMessage),
+                        Times.once(),
+                    );
+                });
             });
 
-            it('should send a Tab.VisibilityChange message with isHidden=true for other known tabs in the same window when a known tab is activated', async () => {
-                mockBrowserAdapter.activateTab(EXISTING_INACTIVE_TAB);
-                await flushSettledPromises();
+            describe('onWindowsFocusChanged', () => {
+                beforeEach(() => {
+                    setupDatabaseInstance(null, Times.never());
+                    setupTeardownInstance(Times.never());
+                });
 
-                const expectedMessage = {
-                    messageType: Messages.Tab.VisibilityChange,
-                    payload: { hidden: true },
-                    tabId: EXISTING_ACTIVE_TAB_ID,
-                };
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
-                    i => i.interpret(expectedMessage),
-                    Times.once(),
-                );
-            });
+                const irrelevantWindowId = -1;
+                it.each`
+                    windowState       | expectedHiddenValue
+                    ${'minimized'}    | ${true}
+                    ${'maximized'}    | ${false}
+                    ${'normal'}       | ${false}
+                    ${'unrecognized'} | ${false}
+                `(
+                    'should send a Tab.VisibilityChange message with hidden=$expectedHiddenValue for active tabs in windows with state $windowState',
+                    async ({ windowState, expectedHiddenValue }) => {
+                        mockBrowserAdapter.windows.forEach(w => {
+                            w.state = windowState;
+                        });
+                        mockBrowserAdapter.notifyWindowsFocusChanged(irrelevantWindowId);
 
-            it('should send a Tab.VisibilityChange message with isHidden=true for other known tabs in the same window when an untracked tab is activated', async () => {
-                mockBrowserAdapter.activateTab(NEW_TAB);
-                await flushSettledPromises();
+                        await flushSettledPromises();
 
-                const expectedMessage = {
-                    messageType: Messages.Tab.VisibilityChange,
-                    payload: { hidden: true },
-                    tabId: EXISTING_ACTIVE_TAB_ID,
-                };
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
-                    i => i.interpret(expectedMessage),
-                    Times.once(),
-                );
-            });
-
-            it('should not send activation messages for untracked tabs', () => {
-                mockBrowserAdapter.tabs.push(NEW_TAB);
-                mockBrowserAdapter.activateTab(NEW_TAB);
-                mockTabInterpreters[NEW_TAB_ID].verify(i => i.interpret(It.isAny()), Times.never());
-            });
-
-            it('should not send deactivation messages for untracked tabs', () => {
-                mockBrowserAdapter.tabs.push(NEW_TAB);
-                mockBrowserAdapter.activateTab(EXISTING_INACTIVE_TAB);
-                mockTabInterpreters[NEW_TAB_ID].verify(i => i.interpret(It.isAny()), Times.never());
-            });
-        });
-
-        describe('onTabUpdated', () => {
-            const changeInfoWithoutUrl: chrome.tabs.TabChangeInfo = {};
-            const changeInfoWithUrl: chrome.tabs.TabChangeInfo = {
-                url: 'https://new-host/new-page',
-            };
-
-            it("should ignore updates that don't change the url", () => {
-                setupDatabaseInstance(null, Times.never());
-                mockBrowserAdapter.updateTab(EXISTING_ACTIVE_TAB_ID, changeInfoWithoutUrl);
-                verifyNoInterpreterMessages(mockTabInterpreters);
-            });
-
-            it('should initialize a new tab context for url changes in untracked tabs', () => {
-                setupDatabaseInstance(
-                    [EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID, NEW_TAB_ID],
-                    Times.once(),
-                );
-                mockBrowserAdapter.tabs.push(NEW_TAB);
-                mockBrowserAdapter.updateTab(NEW_TAB_ID, changeInfoWithUrl);
-
-                mockTabContextFactory.verify(
-                    f =>
-                        f.createTabContext(
-                            itIsFakeBroadcasterForTabId(NEW_TAB_ID),
-                            It.isAny(),
-                            It.isAny(),
-                            NEW_TAB_ID,
-                        ),
-                    Times.once(),
-                );
-                expect(tabToContextMap[NEW_TAB_ID]).toHaveProperty(
-                    'interpreter',
-                    mockTabInterpreters[NEW_TAB_ID].object,
-                );
-            });
-
-            it('should send a Tab.ExistingTabUpdated message for url changes in tracked tabs', () => {
-                setupDatabaseInstance(null, Times.never());
-                const expectedMessage = {
-                    messageType: Messages.Tab.ExistingTabUpdated,
-                    payload: {
-                        ...EXISTING_ACTIVE_TAB,
-                        url: changeInfoWithUrl.url,
+                        const expectedMessage = {
+                            messageType: Messages.Tab.VisibilityChange,
+                            payload: { hidden: expectedHiddenValue },
+                            tabId: EXISTING_ACTIVE_TAB_ID,
+                        };
+                        mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                            i => i.interpret(expectedMessage),
+                            Times.once(),
+                        );
                     },
-                    tabId: EXISTING_ACTIVE_TAB_ID,
-                };
-                mockBrowserAdapter.updateTab(EXISTING_ACTIVE_TAB_ID, changeInfoWithUrl);
-
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
-                    i => i.interpret(expectedMessage),
-                    Times.once(),
                 );
+
+                it('should ignore untracked tabs', () => {
+                    mockBrowserAdapter.notifyWindowsFocusChanged(irrelevantWindowId);
+                    mockTabInterpreters[NEW_TAB_ID].verify(
+                        i => i.interpret(It.isAny()),
+                        Times.never(),
+                    );
+                });
+
+                it('should ignore inactive tabs', () => {
+                    mockBrowserAdapter.notifyWindowsFocusChanged(irrelevantWindowId);
+                    mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].verify(
+                        i => i.interpret(It.isAny()),
+                        Times.never(),
+                    );
+                });
+
+                it('should ignore tabs for windows which result in a runtime error when queried', () => {
+                    mockBrowserAdapter.object.getRuntimeLastError(); // clear out the first method setup from setupMockBrowserAdapter()
+                    mockBrowserAdapter
+                        .setup(m => m.getRuntimeLastError())
+                        .returns(() => ({ message: 'test error' }));
+
+                    mockBrowserAdapter.notifyWindowsFocusChanged(irrelevantWindowId);
+                    verifyNoInterpreterMessages(mockTabInterpreters);
+                });
+            });
+
+            describe('onTabActivated', () => {
+                beforeEach(() => {
+                    setupDatabaseInstance(null, Times.never());
+                });
+
+                it('should send a Tab.VisibilityChange message with isHidden=false for activation of known tabs', () => {
+                    mockBrowserAdapter.activateTab(EXISTING_INACTIVE_TAB);
+
+                    const expectedMessage = {
+                        messageType: Messages.Tab.VisibilityChange,
+                        payload: { hidden: false },
+                        tabId: EXISTING_INACTIVE_TAB_ID,
+                    };
+                    mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].verify(
+                        i => i.interpret(expectedMessage),
+                        Times.once(),
+                    );
+                });
+
+                it('should send a Tab.VisibilityChange message with isHidden=true for other known tabs in the same window when a known tab is activated', async () => {
+                    mockBrowserAdapter.activateTab(EXISTING_INACTIVE_TAB);
+                    await flushSettledPromises();
+
+                    const expectedMessage = {
+                        messageType: Messages.Tab.VisibilityChange,
+                        payload: { hidden: true },
+                        tabId: EXISTING_ACTIVE_TAB_ID,
+                    };
+                    mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                        i => i.interpret(expectedMessage),
+                        Times.once(),
+                    );
+                });
+
+                it('should send a Tab.VisibilityChange message with isHidden=true for other known tabs in the same window when an untracked tab is activated', async () => {
+                    mockBrowserAdapter.activateTab(NEW_TAB);
+                    await flushSettledPromises();
+
+                    const expectedMessage = {
+                        messageType: Messages.Tab.VisibilityChange,
+                        payload: { hidden: true },
+                        tabId: EXISTING_ACTIVE_TAB_ID,
+                    };
+                    mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                        i => i.interpret(expectedMessage),
+                        Times.once(),
+                    );
+                });
+
+                it('should not send activation messages for untracked tabs', () => {
+                    mockBrowserAdapter.tabs.push(NEW_TAB);
+                    mockBrowserAdapter.activateTab(NEW_TAB);
+                    mockTabInterpreters[NEW_TAB_ID].verify(
+                        i => i.interpret(It.isAny()),
+                        Times.never(),
+                    );
+                });
+
+                it('should not send deactivation messages for untracked tabs', () => {
+                    mockBrowserAdapter.tabs.push(NEW_TAB);
+                    mockBrowserAdapter.activateTab(EXISTING_INACTIVE_TAB);
+                    mockTabInterpreters[NEW_TAB_ID].verify(
+                        i => i.interpret(It.isAny()),
+                        Times.never(),
+                    );
+                });
+            });
+
+            describe('onTabUpdated', () => {
+                const changeInfoWithoutUrl: chrome.tabs.TabChangeInfo = {};
+                const changeInfoWithUrl: chrome.tabs.TabChangeInfo = {
+                    url: 'https://new-host/new-page',
+                };
+
+                it("should ignore updates that don't change the url", () => {
+                    setupDatabaseInstance(null, Times.never());
+                    mockBrowserAdapter.updateTab(EXISTING_ACTIVE_TAB_ID, changeInfoWithoutUrl);
+                    verifyNoInterpreterMessages(mockTabInterpreters);
+                });
+
+                it('should initialize a new tab context for url changes in untracked tabs', () => {
+                    setupDatabaseInstance(
+                        [EXISTING_ACTIVE_TAB_ID, EXISTING_INACTIVE_TAB_ID, NEW_TAB_ID],
+                        Times.once(),
+                    );
+
+                    mockBrowserAdapter.tabs.push(NEW_TAB);
+                    mockBrowserAdapter.updateTab(NEW_TAB_ID, changeInfoWithUrl);
+
+                    mockTabContextFactory.verify(
+                        f =>
+                            f.createTabContext(
+                                itIsFakeBroadcasterForTabId(NEW_TAB_ID),
+                                It.isAny(),
+                                It.isAny(),
+                                NEW_TAB_ID,
+                            ),
+                        Times.once(),
+                    );
+                    expect(tabToContextMap[NEW_TAB_ID]).toHaveProperty(
+                        'interpreter',
+                        mockTabInterpreters[NEW_TAB_ID].object,
+                    );
+                });
+
+                it('should send a Tab.ExistingTabUpdated message for url changes in tracked tabs', () => {
+                    setupDatabaseInstance(null, Times.never());
+                    const expectedMessage = {
+                        messageType: Messages.Tab.ExistingTabUpdated,
+                        payload: {
+                            ...EXISTING_ACTIVE_TAB,
+                            url: changeInfoWithUrl.url,
+                        },
+                        tabId: EXISTING_ACTIVE_TAB_ID,
+                    };
+                    mockBrowserAdapter.updateTab(EXISTING_ACTIVE_TAB_ID, changeInfoWithUrl);
+
+                    mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                        i => i.interpret(expectedMessage),
+                        Times.once(),
+                    );
+                });
             });
         });
     });


### PR DESCRIPTION
#### Details

Previous PRs added logic to persist store/controller data, which will be necessary for the mv3 extension. Those PRs made it so that the mv2 extension also persists data but does not read from the persisted data. @dbjorge suggested that we do not persist data at all in the mv2 extension to avoid backward compat issues in the future, so this PR turns data persist-ing off by default. I will follow up in a future PR to turn data persisting on only for the mv3 extension.

##### Motivation

Feature work.

##### Context

Confirmed by running dev mv2 extension locally that we no longer persist data (other than assessment, user config, etc- which were already persisted prior to this change).

Note that test file diffs look big primarily because of whitespace changes, might be easier to review that code locally. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
