### PR TITLE
feat(mv3-part-2): Turn on persisting data stores in mv3

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -135,6 +135,7 @@ async function initialize(): Promise<void> {
         browserAdapter,
         browserAdapter,
         logger,
+        false,
     );
     telemetryLogger.initialize(globalContext.featureFlagsController);
 

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -48,6 +48,7 @@ export class GlobalContextFactory {
         storageAdapter: StorageAdapter,
         commandsAdapter: CommandsAdapter,
         logger: Logger,
+        persistStoreData: boolean,
     ): Promise<GlobalContext> {
         const interpreter = new Interpreter();
 
@@ -62,6 +63,7 @@ export class GlobalContextFactory {
             persistedData,
             storageAdapter,
             logger,
+            persistStoreData,
         );
 
         const featureFlagsController = new FeatureFlagsController(

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -119,6 +119,7 @@ async function initialize(): Promise<void> {
         browserAdapter,
         browserAdapter,
         logger,
+        true,
     );
 
     telemetryLogger.initialize(globalContext.featureFlagsController);
@@ -134,6 +135,7 @@ async function initialize(): Promise<void> {
         browserAdapter,
         persistedData.tabIdToDetailsViewMap ?? {},
         indexedDBInstance,
+        true,
     );
     const tabToContextMap: TabToContextMap = {};
 
@@ -201,6 +203,7 @@ async function initialize(): Promise<void> {
         logger,
         persistedData.knownTabIds ?? [],
         indexedDBInstance,
+        true,
     );
 
     await targetPageController.initialize();

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -26,6 +26,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.CardSelectionStore,
@@ -33,6 +34,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
             idbInstance,
             IndexedDBDataKeys.cardSelectionStore(tabId),
             logger,
+            persistStoreData,
         );
     }
 

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -26,6 +26,7 @@ export class DetailsViewStore extends PersistentStore<DetailsViewStoreData> {
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.DetailsViewStore,
@@ -33,6 +34,7 @@ export class DetailsViewStore extends PersistentStore<DetailsViewStoreData> {
             idbInstance,
             IndexedDBDataKeys.detailsViewStore(tabId),
             logger,
+            persistStoreData,
         );
     }
 

--- a/src/background/stores/dev-tools-store.ts
+++ b/src/background/stores/dev-tools-store.ts
@@ -17,6 +17,7 @@ export class DevToolStore extends PersistentStore<DevToolStoreData> {
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.DevToolsStore,
@@ -24,6 +25,7 @@ export class DevToolStore extends PersistentStore<DevToolStoreData> {
             idbInstance,
             IndexedDBDataKeys.devToolStore(tabId),
             logger,
+            persistStoreData,
         );
 
         this.devToolActions = devToolActions;

--- a/src/background/stores/global/command-store.ts
+++ b/src/background/stores/global/command-store.ts
@@ -23,6 +23,7 @@ export class CommandStore extends PersistentStore<CommandStoreData> {
         persistedState: CommandStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.CommandStore,
@@ -30,6 +31,7 @@ export class CommandStore extends PersistentStore<CommandStoreData> {
             idbInstance,
             IndexedDBDataKeys.commandStore,
             logger,
+            persistStoreData,
         );
 
         this.commandActions = commandActions;

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -45,6 +45,7 @@ export class GlobalStoreHub implements StoreHub {
         persistedData: PersistedData,
         storageAdapter: StorageAdapter,
         logger: Logger,
+        persistStoreData: boolean,
     ) {
         this.commandStore = new CommandStore(
             globalActionHub.commandActions,
@@ -52,6 +53,7 @@ export class GlobalStoreHub implements StoreHub {
             persistedData.commandStoreData,
             indexedDbInstance,
             logger,
+            persistStoreData,
         );
         this.featureFlagStore = new FeatureFlagStore(
             globalActionHub.featureFlagActions,
@@ -69,6 +71,7 @@ export class GlobalStoreHub implements StoreHub {
             persistedData.scopingStoreData,
             indexedDbInstance,
             logger,
+            persistStoreData,
         );
         this.assessmentStore = new AssessmentStore(
             browserAdapter,
@@ -92,6 +95,7 @@ export class GlobalStoreHub implements StoreHub {
             persistedData.permissionsStateStoreData,
             indexedDbInstance,
             logger,
+            persistStoreData,
         );
     }
 

--- a/src/background/stores/global/permissions-state-store.ts
+++ b/src/background/stores/global/permissions-state-store.ts
@@ -15,6 +15,7 @@ export class PermissionsStateStore extends PersistentStore<PermissionsStateStore
         protected readonly persistedState: PermissionsStateStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.PermissionsStateStore,
@@ -22,6 +23,7 @@ export class PermissionsStateStore extends PersistentStore<PermissionsStateStore
             idbInstance,
             IndexedDBDataKeys.permissionsStateStore,
             logger,
+            persistStoreData,
         );
     }
 

--- a/src/background/stores/global/scoping-store.ts
+++ b/src/background/stores/global/scoping-store.ts
@@ -19,6 +19,7 @@ export class ScopingStore extends PersistentStore<ScopingStoreData> {
         persistedState: ScopingStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.ScopingPanelStateStore,
@@ -26,6 +27,7 @@ export class ScopingStore extends PersistentStore<ScopingStoreData> {
             idbInstance,
             IndexedDBDataKeys.scopingStore,
             logger,
+            persistStoreData,
         );
 
         this.scopingActions = scopingActions;

--- a/src/background/stores/inspect-store.ts
+++ b/src/background/stores/inspect-store.ts
@@ -21,6 +21,7 @@ export class InspectStore extends PersistentStore<InspectStoreData> {
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.InspectStore,
@@ -28,6 +29,7 @@ export class InspectStore extends PersistentStore<InspectStoreData> {
             idbInstance,
             IndexedDBDataKeys.inspectStore(tabId),
             logger,
+            persistStoreData,
         );
 
         this.inspectActions = inspectActions;

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -24,6 +24,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.NeedsReviewCardSelectionStore,
@@ -31,6 +32,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
             idbInstance,
             IndexedDBDataKeys.needsReviewCardSelectionStore(tabId),
             logger,
+            persistStoreData,
         );
     }
 

--- a/src/background/stores/needs-review-scan-result-store.ts
+++ b/src/background/stores/needs-review-scan-result-store.ts
@@ -18,6 +18,7 @@ export class NeedsReviewScanResultStore extends PersistentStore<NeedsReviewScanR
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.NeedsReviewScanResultStore,
@@ -25,6 +26,7 @@ export class NeedsReviewScanResultStore extends PersistentStore<NeedsReviewScanR
             idbInstance,
             IndexedDBDataKeys.needsReviewScanResultsStore(tabId),
             logger,
+            persistStoreData,
         );
     }
 

--- a/src/background/stores/path-snippet-store.ts
+++ b/src/background/stores/path-snippet-store.ts
@@ -15,6 +15,7 @@ export class PathSnippetStore extends PersistentStore<PathSnippetStoreData> {
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.PathSnippetStore,
@@ -22,6 +23,7 @@ export class PathSnippetStore extends PersistentStore<PathSnippetStoreData> {
             idbInstance,
             IndexedDBDataKeys.pathSnippetStore(tabId),
             logger,
+            persistStoreData,
         );
     }
 

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -41,6 +41,7 @@ export class TabContextStoreHub implements StoreHub {
         indexedDBInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         const persistedTabData = persistedData.tabData ? persistedData.tabData[tabId] : null;
 
@@ -53,6 +54,7 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
+            persistStoreData,
         );
         this.visualizationStore.initialize();
 
@@ -67,6 +69,7 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
+            persistStoreData,
         );
         this.visualizationScanResultStore.initialize();
 
@@ -77,6 +80,7 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
+            persistStoreData,
         );
         this.tabStore.initialize();
 
@@ -86,6 +90,7 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
+            persistStoreData,
         );
         this.devToolStore.initialize();
 
@@ -97,6 +102,7 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
+            persistStoreData,
         );
         this.detailsViewStore.initialize();
 
@@ -107,6 +113,7 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
+            persistStoreData,
         );
         this.inspectStore.initialize();
 
@@ -116,6 +123,7 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
+            persistStoreData,
         );
         this.pathSnippetStore.initialize();
 
@@ -126,6 +134,7 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
+            persistStoreData,
         );
         this.unifiedScanResultStore.initialize();
 
@@ -136,6 +145,7 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
+            persistStoreData,
         );
         this.cardSelectionStore.initialize();
 
@@ -146,6 +156,7 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
+            persistStoreData,
         );
         this.needsReviewScanResultStore.initialize();
 
@@ -156,6 +167,7 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
+            persistStoreData,
         );
         this.needsReviewCardSelectionStore.initialize();
     }

--- a/src/background/stores/tab-store.ts
+++ b/src/background/stores/tab-store.ts
@@ -21,6 +21,7 @@ export class TabStore extends PersistentStore<TabStoreData> {
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.TabStore,
@@ -28,6 +29,7 @@ export class TabStore extends PersistentStore<TabStoreData> {
             idbInstance,
             IndexedDBDataKeys.tabStore(tabId),
             logger,
+            persistStoreData,
         );
 
         this.tabActions = tabActions;

--- a/src/background/stores/unified-scan-result-store.ts
+++ b/src/background/stores/unified-scan-result-store.ts
@@ -18,6 +18,7 @@ export class UnifiedScanResultStore extends PersistentStore<UnifiedScanResultSto
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.UnifiedScanResultStore,
@@ -25,6 +26,7 @@ export class UnifiedScanResultStore extends PersistentStore<UnifiedScanResultSto
             idbInstance,
             IndexedDBDataKeys.unifiedScanResultStore(tabId),
             logger,
+            persistStoreData,
         );
     }
 

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -45,6 +45,7 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.VisualizationScanResultStore,
@@ -52,6 +53,7 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
             idbInstance,
             IndexedDBDataKeys.visualizationScanResultStore(tabId),
             logger,
+            persistStoreData,
         );
     }
 

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -43,6 +43,7 @@ export class VisualizationStore extends PersistentStore<VisualizationStoreData> 
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
+        persistStoreData: boolean,
     ) {
         super(
             StoreNames.VisualizationStore,
@@ -50,6 +51,7 @@ export class VisualizationStore extends PersistentStore<VisualizationStoreData> 
             idbInstance,
             IndexedDBDataKeys.visualizationStore(tabId),
             logger,
+            persistStoreData,
         );
 
         this.visualizationActions = visualizationActions;

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -54,6 +54,7 @@ export class TabContextFactory {
         browserAdapter: BrowserAdapter,
         detailsViewController: ExtensionDetailsViewController,
         tabId: number,
+        persistStoreData: boolean,
     ): TabContext {
         const interpreter = new Interpreter();
         const actionsHub = new ActionHub();
@@ -64,6 +65,7 @@ export class TabContextFactory {
             this.indexedDBInstance,
             this.logger,
             tabId,
+            persistStoreData,
         );
         const notificationCreator = new NotificationCreator(
             browserAdapter,

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -142,6 +142,7 @@ export class TargetPageController {
             this.browserAdapter,
             this.detailsViewController,
             tabId,
+            this.persistStoreData,
         );
     }
 

--- a/src/common/flux/persistent-store.ts
+++ b/src/common/flux/persistent-store.ts
@@ -12,7 +12,7 @@ export abstract class PersistentStore<TState> extends BaseStoreImpl<TState> {
         protected readonly idbInstance: IndexedDBAPI,
         protected readonly indexedDBDataKey: string,
         protected readonly logger: Logger,
-        private persistStoreData = false,
+        private persistStoreData: boolean,
     ) {
         super(storeName);
     }

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -257,6 +257,7 @@ getGlobalPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
             indexedDBInstance,
             logger,
             null,
+            false,
         );
         unifiedScanResultStore.initialize();
 
@@ -273,6 +274,7 @@ getGlobalPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
             indexedDBInstance,
             logger,
             null,
+            false,
         );
         cardSelectionStore.initialize();
 
@@ -284,6 +286,7 @@ getGlobalPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
             indexedDBInstance,
             logger,
             null,
+            false,
         );
         detailsViewStore.initialize();
 

--- a/src/tests/unit/common/details-view-store-data-builder.ts
+++ b/src/tests/unit/common/details-view-store-data-builder.ts
@@ -16,6 +16,7 @@ export class DetailsViewStoreDataBuilder extends BaseDataBuilder<DetailsViewStor
             null!,
             null!,
             null!,
+            null!,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/common/scoping-store-data-builder.ts
+++ b/src/tests/unit/common/scoping-store-data-builder.ts
@@ -7,6 +7,6 @@ import { BaseDataBuilder } from './base-data-builder';
 export class ScopingStoreDataBuilder extends BaseDataBuilder<ScopingStoreData> {
     constructor() {
         super();
-        this.data = new ScopingStore(null!, null!, null!, null!).getDefaultState();
+        this.data = new ScopingStore(null!, null!, null!, null!, null!).getDefaultState();
     }
 }

--- a/src/tests/unit/common/tab-store-data-builder.ts
+++ b/src/tests/unit/common/tab-store-data-builder.ts
@@ -7,6 +7,6 @@ import { BaseDataBuilder } from './base-data-builder';
 export class TabStoreDataBuilder extends BaseDataBuilder<TabStoreData> {
     constructor() {
         super();
-        this.data = new TabStore(null, null, null, null, null, null).getDefaultState();
+        this.data = new TabStore(null, null, null, null, null, null, null).getDefaultState();
     }
 }

--- a/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
@@ -23,6 +23,7 @@ export class VisualizationScanResultStoreDataBuilder extends BaseDataBuilder<Vis
             null,
             null,
             null,
+            null,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/common/visualization-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-store-data-builder.ts
@@ -23,6 +23,7 @@ export class VisualizationStoreDataBuilder extends BaseDataBuilder<Visualization
             null,
             null,
             null,
+            true,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -81,15 +81,23 @@ export class StoreMocks {
         isPageHidden: false,
         isOriginChanged: false,
     };
-    public commandStoreData = new CommandStore(null, null, null, null, null).getDefaultState();
+    public commandStoreData = new CommandStore(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+    ).getDefaultState();
     public userConfigurationStoreData = new UserConfigurationStore(
         null,
         null,
         null,
         null,
     ).getDefaultState();
-    public scopingStoreData = new ScopingStore(null, null, null, null).getDefaultState();
+    public scopingStoreData = new ScopingStore(null, null, null, null, null).getDefaultState();
     public inspectStoreData = new InspectStore(
+        null,
         null,
         null,
         null,
@@ -103,6 +111,7 @@ export class StoreMocks {
         null,
         null,
         null,
+        null,
     ).getDefaultState();
     public unifiedScanResultStoreData = new UnifiedScanResultStore(
         null,
@@ -111,8 +120,10 @@ export class StoreMocks {
         null,
         null,
         null,
+        null,
     ).getDefaultState();
     public needsReviewScanResultStoreData = new NeedsReviewScanResultStore(
+        null,
         null,
         null,
         null,
@@ -130,6 +141,7 @@ export class StoreMocks {
         null,
         null,
         null,
+        null,
     ).getDefaultState();
     public tabStopsViewStoreData = new TabStopsViewStore(null).getDefaultState();
     public cardSelectionStoreData = new CardSelectionStore(
@@ -139,8 +151,10 @@ export class StoreMocks {
         null,
         null,
         null,
+        null,
     ).getDefaultState();
     public needsReviewCardSelectionStoreData = new NeedsReviewCardSelectionStore(
+        null,
         null,
         null,
         null,

--- a/src/tests/unit/tests/background/global-context-factory.test.ts
+++ b/src/tests/unit/tests/background/global-context-factory.test.ts
@@ -69,6 +69,7 @@ describe('GlobalContextFactoryTest', () => {
             storageAdapterMock.object,
             commandsAdapterMock.object,
             loggerMock.object,
+            true,
         );
 
         expect(globalContext).toBeInstanceOf(GlobalContext);

--- a/src/tests/unit/tests/background/inspect-store.test.ts
+++ b/src/tests/unit/tests/background/inspect-store.test.ts
@@ -76,7 +76,7 @@ describe('InspectStoreTest', () => {
     ): StoreTester<InspectStoreData, InspectActions> {
         const tabActions = new TabActions();
         const factory = (actions: InspectActions) =>
-            new InspectStore(actions, tabActions, null, null, null, null);
+            new InspectStore(actions, tabActions, null, null, null, null, true);
 
         return new StoreTester(InspectActions, actionName, factory);
     }
@@ -85,7 +85,7 @@ describe('InspectStoreTest', () => {
         actionName: keyof TabActions,
     ): StoreTester<InspectStoreData, TabActions> {
         const factory = (actions: TabActions) =>
-            new InspectStore(new InspectActions(), actions, null, null, null, null);
+            new InspectStore(new InspectActions(), actions, null, null, null, null, true);
         return new StoreTester(TabActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -87,7 +87,15 @@ describe('CardSelectionStore Test', () => {
         actionName: keyof UnifiedScanResultActions,
     ): StoreTester<CardSelectionStoreData, UnifiedScanResultActions> {
         const factory = (actions: UnifiedScanResultActions) =>
-            new CardSelectionStore(new CardSelectionActions(), actions, null, null, null, null);
+            new CardSelectionStore(
+                new CardSelectionActions(),
+                actions,
+                null,
+                null,
+                null,
+                null,
+                true,
+            );
 
         return new StoreTester(UnifiedScanResultActions, actionName, factory);
     }
@@ -388,7 +396,15 @@ describe('CardSelectionStore Test', () => {
         actionName: keyof CardSelectionActions,
     ): StoreTester<CardSelectionStoreData, CardSelectionActions> {
         const factory = (actions: CardSelectionActions) =>
-            new CardSelectionStore(actions, new UnifiedScanResultActions(), null, null, null, null);
+            new CardSelectionStore(
+                actions,
+                new UnifiedScanResultActions(),
+                null,
+                null,
+                null,
+                null,
+                true,
+            );
 
         return new StoreTester(CardSelectionActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/details-view-store.test.ts
+++ b/src/tests/unit/tests/background/stores/details-view-store.test.ts
@@ -11,7 +11,7 @@ import { StoreTester } from '../../../common/store-tester';
 
 describe('DetailsViewStoreTest', () => {
     test('getId', () => {
-        const testObject = new DetailsViewStore(null, null, null, null, null, null, null);
+        const testObject = new DetailsViewStore(null, null, null, null, null, null, null, true);
         expect(testObject.getId()).toBe(StoreNames[StoreNames.DetailsViewStore]);
     });
 
@@ -136,6 +136,7 @@ describe('DetailsViewStoreTest', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(ContentActions, actionName, factory);
@@ -153,6 +154,7 @@ describe('DetailsViewStoreTest', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(DetailsViewActions, actionName, factory);
@@ -170,6 +172,7 @@ describe('DetailsViewStoreTest', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(SidePanelActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
+++ b/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
@@ -81,14 +81,14 @@ describe('DevToolsStoreTest', () => {
     });
 
     function getDefaultState(): DevToolStoreData {
-        return new DevToolStore(null, null, null, null, null).getDefaultState();
+        return new DevToolStore(null, null, null, null, null, null).getDefaultState();
     }
 
     function createStoreTesterForDevToolsActions(
         actionName: keyof DevToolActions,
     ): StoreTester<DevToolStoreData, DevToolActions> {
         const factory = (actions: DevToolActions) =>
-            new DevToolStore(actions, null, null, null, null);
+            new DevToolStore(actions, null, null, null, null, true);
 
         return new StoreTester(DevToolActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/global/command-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/command-store.test.ts
@@ -31,7 +31,7 @@ describe('CommandStoreTest', () => {
     });
 
     test('on getCommands: no command modification', () => {
-        const prototype = new CommandStore(null, null, null, null, null);
+        const prototype = new CommandStore(null, null, null, null, null, null);
         const initialState: CommandStoreData = prototype.getDefaultState();
         const expectedState: CommandStoreData = prototype.getDefaultState();
 
@@ -96,6 +96,7 @@ describe('CommandStoreTest', () => {
             null,
             null,
             null,
+            null,
         ).getDefaultState();
 
         const command: chrome.commands.Command = {
@@ -129,7 +130,7 @@ describe('CommandStoreTest', () => {
         actionName: keyof CommandActions,
     ): StoreTester<CommandStoreData, CommandActions> {
         const factory = (actions: CommandActions) =>
-            new CommandStore(actions, telemetryEventHandlerMock.object, null, null, null);
+            new CommandStore(actions, telemetryEventHandlerMock.object, null, null, null, true);
 
         return new StoreTester(CommandActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
@@ -62,6 +62,7 @@ describe('GlobalStoreHubTest', () => {
             cloneDeep(persistedDataStub),
             null,
             failTestOnErrorLogger,
+            true,
         );
         const allStores = testSubject.getAllStores();
 
@@ -87,6 +88,7 @@ describe('GlobalStoreHubTest', () => {
             cloneDeep(persistedDataStub),
             null,
             failTestOnErrorLogger,
+            true,
         );
         const allStores = testSubject.getAllStores() as BaseStoreImpl<any>[];
         const initializeMocks: Array<IMock<Function>> = [];

--- a/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
@@ -26,6 +26,7 @@ describe('PermissionsStateStoreTest', () => {
             null,
             null,
             null,
+            true,
         );
         testSubject.initialize();
 
@@ -77,12 +78,12 @@ describe('PermissionsStateStoreTest', () => {
         actionName: keyof PermissionsStateActions,
     ): StoreTester<PermissionsStateStoreData, PermissionsStateActions> {
         const factory = (actions: PermissionsStateActions) =>
-            new PermissionsStateStore(actions, null, null, null);
+            new PermissionsStateStore(actions, null, null, null, true);
 
         return new StoreTester(PermissionsStateActions, actionName, factory);
     }
 
     function createPermissionsState(): PermissionsStateStoreData {
-        return new PermissionsStateStore(null, null, null, null).getDefaultState();
+        return new PermissionsStateStore(null, null, null, null, null).getDefaultState();
     }
 });

--- a/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
@@ -106,7 +106,8 @@ describe('ScopingStoreTest', () => {
     function createStoreForScopingActions(
         actionName: keyof ScopingActions,
     ): StoreTester<ScopingStoreData, ScopingActions> {
-        const factory = (actions: ScopingActions) => new ScopingStore(actions, null, null, null);
+        const factory = (actions: ScopingActions) =>
+            new ScopingStore(actions, null, null, null, true);
 
         return new StoreTester(ScopingActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
@@ -92,6 +92,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(NeedsReviewScanResultActions, actionName, factory);
@@ -393,6 +394,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(NeedsReviewCardSelectionActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
@@ -133,7 +133,7 @@ describe('NeedsReviewScanResultStore Test', () => {
         actionName: keyof NeedsReviewScanResultActions,
     ): StoreTester<NeedsReviewScanResultStoreData, NeedsReviewScanResultActions> {
         const factory = (actions: NeedsReviewScanResultActions) =>
-            new NeedsReviewScanResultStore(actions, new TabActions(), null, null, null, null);
+            new NeedsReviewScanResultStore(actions, new TabActions(), null, null, null, null, true);
 
         return new StoreTester(NeedsReviewScanResultActions, actionName, factory);
     }
@@ -149,6 +149,7 @@ describe('NeedsReviewScanResultStore Test', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(TabActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
+++ b/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
@@ -76,7 +76,7 @@ describe('PathSnippetStoreTest', () => {
         actionName: keyof PathSnippetActions,
     ): StoreTester<PathSnippetStoreData, PathSnippetActions> {
         const factory = (actions: PathSnippetActions) =>
-            new PathSnippetStore(actions, null, null, null, null);
+            new PathSnippetStore(actions, null, null, null, null, true);
         return new StoreTester(PathSnippetActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
@@ -15,6 +15,7 @@ describe('TabContextStoreHubTest', () => {
             null,
             null,
             null,
+            true,
         );
     });
 

--- a/src/tests/unit/tests/background/stores/tab-store.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-store.test.ts
@@ -238,7 +238,7 @@ describe('TabStoreTest', () => {
         actionName: keyof TabActions,
     ): StoreTester<TabStoreData, TabActions> {
         const factory = (actions: TabActions) =>
-            new TabStore(actions, new VisualizationActions(), null, null, null, null);
+            new TabStore(actions, new VisualizationActions(), null, null, null, null, true);
         return new StoreTester(TabActions, actionName, factory);
     }
 
@@ -246,7 +246,7 @@ describe('TabStoreTest', () => {
         actionName: keyof VisualizationActions,
     ): StoreTester<TabStoreData, VisualizationActions> {
         const factory = (actions: VisualizationActions) =>
-            new TabStore(new TabActions(), actions, null, null, null, null);
+            new TabStore(new TabActions(), actions, null, null, null, null, true);
         return new StoreTester(VisualizationActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
@@ -140,6 +140,7 @@ describe('UnifiedScanResultStore Test', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(UnifiedScanResultActions, actionName, factory);
@@ -156,6 +157,7 @@ describe('UnifiedScanResultStore Test', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(TabActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -568,6 +568,7 @@ describe('VisualizationScanResultStoreTest', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(VisualizationScanResultActions, actionName, factory);
@@ -588,6 +589,7 @@ describe('VisualizationScanResultStoreTest', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(TabActions, actionName, factory);
@@ -608,6 +610,7 @@ describe('VisualizationScanResultStoreTest', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(TabStopRequirementActions, actionName, factory);
@@ -628,6 +631,7 @@ describe('VisualizationScanResultStoreTest', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(VisualizationActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -839,6 +839,7 @@ describe('VisualizationStoreTest ', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(TabActions, actionName, factory);
@@ -857,6 +858,7 @@ describe('VisualizationStoreTest ', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(VisualizationActions, actionName, factory);
@@ -875,6 +877,7 @@ describe('VisualizationStoreTest ', () => {
                 null,
                 null,
                 null,
+                true,
             );
 
         return new StoreTester(InjectionActions, actionName, factory);

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -120,6 +120,7 @@ describe('TabContextFactoryTest', () => {
             mockBrowserAdapter.object,
             mockDetailsViewController.object,
             null,
+            true,
         );
 
         broadcastMock.verifyAll();

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -115,6 +115,7 @@ describe('TargetPageController', () => {
                         It.isAny(),
                         It.isAny(),
                         EXISTING_ACTIVE_TAB_ID,
+                        false,
                     ),
                 Times.once(),
             );
@@ -130,6 +131,7 @@ describe('TargetPageController', () => {
                         It.isAny(),
                         It.isAny(),
                         EXISTING_INACTIVE_TAB_ID,
+                        false,
                     ),
                 Times.once(),
             );
@@ -145,6 +147,7 @@ describe('TargetPageController', () => {
                         It.isAny(),
                         It.isAny(),
                         It.isAny(),
+                        false,
                     ),
                 Times.never(),
             );
@@ -168,6 +171,7 @@ describe('TargetPageController', () => {
                         It.isAny(),
                         It.isAny(),
                         NEW_TAB_ID,
+                        false,
                     ),
                 Times.once(),
             );
@@ -197,6 +201,7 @@ describe('TargetPageController', () => {
                         It.isAny(),
                         It.isAny(),
                         EXISTING_ACTIVE_TAB_ID,
+                        false,
                     ),
                 Times.once(),
             );
@@ -212,6 +217,7 @@ describe('TargetPageController', () => {
                         It.isAny(),
                         It.isAny(),
                         It.isAny(),
+                        false,
                     ),
                 Times.once(),
             );
@@ -227,6 +233,7 @@ describe('TargetPageController', () => {
                         It.isAny(),
                         It.isAny(),
                         It.isAny(),
+                        false,
                     ),
                 Times.once(),
             );
@@ -324,6 +331,7 @@ describe('TargetPageController', () => {
                             It.isAny(),
                             It.isAny(),
                             EXISTING_ACTIVE_TAB_ID,
+                            true,
                         ),
                     Times.once(),
                 );
@@ -339,9 +347,11 @@ describe('TargetPageController', () => {
                             It.isAny(),
                             It.isAny(),
                             EXISTING_INACTIVE_TAB_ID,
+                            true,
                         ),
                     Times.once(),
                 );
+
                 expect(tabToContextMap[EXISTING_INACTIVE_TAB_ID]).toHaveProperty(
                     'interpreter',
                     mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].object,
@@ -354,6 +364,7 @@ describe('TargetPageController', () => {
                             It.isAny(),
                             It.isAny(),
                             It.isAny(),
+                            true,
                         ),
                     Times.never(),
                 );
@@ -377,6 +388,7 @@ describe('TargetPageController', () => {
                             It.isAny(),
                             It.isAny(),
                             EXISTING_ACTIVE_TAB_ID,
+                            true,
                         ),
                     Times.once(),
                 );
@@ -392,6 +404,7 @@ describe('TargetPageController', () => {
                             It.isAny(),
                             It.isAny(),
                             It.isAny(),
+                            true,
                         ),
                     Times.once(),
                 );
@@ -407,6 +420,7 @@ describe('TargetPageController', () => {
                             It.isAny(),
                             It.isAny(),
                             It.isAny(),
+                            true,
                         ),
                     Times.never(),
                 );
@@ -434,6 +448,7 @@ describe('TargetPageController', () => {
                             It.isAny(),
                             It.isAny(),
                             EXISTING_ACTIVE_TAB_ID,
+                            true,
                         ),
                     Times.once(),
                 );
@@ -449,6 +464,7 @@ describe('TargetPageController', () => {
                             It.isAny(),
                             It.isAny(),
                             It.isAny(),
+                            true,
                         ),
                     Times.once(),
                 );
@@ -461,6 +477,7 @@ describe('TargetPageController', () => {
                     f =>
                         f.createTabContext(
                             itIsFakeBroadcasterForTabId(NEW_TAB_ID),
+                            It.isAny(),
                             It.isAny(),
                             It.isAny(),
                             It.isAny(),
@@ -538,6 +555,7 @@ describe('TargetPageController', () => {
                                 It.isAny(),
                                 It.isAny(),
                                 NEW_TAB_ID,
+                                true,
                             ),
                         Times.once(),
                     );
@@ -796,6 +814,7 @@ describe('TargetPageController', () => {
                                 It.isAny(),
                                 It.isAny(),
                                 NEW_TAB_ID,
+                                true,
                             ),
                         Times.once(),
                     );
@@ -871,6 +890,7 @@ describe('TargetPageController', () => {
                 It.isAny(),
                 mockBrowserAdapter.object,
                 mockDetailsViewController.object,
+                It.isAny(),
                 It.isAny(),
             ),
         ).returns((fakeBroadcaster, _2, _3) => ({


### PR DESCRIPTION
#### Details

Turn on flag so that store/controller data is persisted in the mv3 extension (but not the mv2 extension).

##### Motivation

Feature work.

##### Context

#5381 and #5410 added a flag in the persistent store and controllers to determine if they persist data in the indexed database or not. Prior to this PR, this flag is turned off by default to avoid persisting data in the mv2 extension. This PR turns the flag on for the mv3 extension.

Confirmed locally that with this change the mv2 extension still does not persist data and mv3 extension does.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
