### PR TITLE
feat(mv3-part-2): Consolidate store proxy message handling

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -102,6 +102,7 @@ import { NavigatorUtils } from '../common/navigator-utils';
 import { getCardViewData } from '../common/rule-based-view-model-provider';
 import { SelfFastPass, SelfFastPassContainer } from '../common/self-fast-pass';
 import { StoreProxy } from '../common/store-proxy';
+import { StoreUpdateMessageDistributor } from '../common/store-update-message-distributor';
 import { BaseClientStoresHub } from '../common/stores/base-client-stores-hub';
 import { StoreNames } from '../common/stores/store-names';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
@@ -163,75 +164,69 @@ if (tabId != null) {
         (tab: Tab): void => {
             const telemetryFactory = new TelemetryDataFactory();
 
+            const logger = createDefaultLogger();
+            const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(
+                browserAdapter,
+                logger,
+                tab.id,
+            );
+            storeUpdateMessageDistributor.initialize();
+
             const visualizationStore = new StoreProxy<VisualizationStoreData>(
                 StoreNames[StoreNames.VisualizationStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const permissionsStateStore = new StoreProxy<PermissionsStateStoreData>(
                 StoreNames[StoreNames.PermissionsStateStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const tabStore = new StoreProxy<TabStoreData>(
                 StoreNames[StoreNames.TabStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const visualizationScanResultStore = new StoreProxy<VisualizationScanResultData>(
                 StoreNames[StoreNames.VisualizationScanResultStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const unifiedScanResultStore = new StoreProxy<UnifiedScanResultStoreData>(
                 StoreNames[StoreNames.UnifiedScanResultStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const cardSelectionStore = new StoreProxy<CardSelectionStoreData>(
                 StoreNames[StoreNames.CardSelectionStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const needsReviewScanResultStore = new StoreProxy<NeedsReviewScanResultStoreData>(
                 StoreNames[StoreNames.NeedsReviewScanResultStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const needsReviewCardSelectionStore = new StoreProxy<NeedsReviewCardSelectionStoreData>(
                 StoreNames[StoreNames.NeedsReviewCardSelectionStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const pathSnippetStore = new StoreProxy<PathSnippetStoreData>(
                 StoreNames[StoreNames.PathSnippetStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const detailsViewStore = new StoreProxy<DetailsViewStoreData>(
                 StoreNames[StoreNames.DetailsViewStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const assessmentStore = new StoreProxy<AssessmentStoreData>(
                 StoreNames[StoreNames.AssessmentStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const featureFlagStore = new StoreProxy<DictionaryStringTo<boolean>>(
                 StoreNames[StoreNames.FeatureFlagStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const scopingStore = new StoreProxy<ScopingStoreData>(
                 StoreNames[StoreNames.ScopingPanelStateStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
             const userConfigStore = new StoreProxy<UserConfigurationStoreData>(
                 StoreNames[StoreNames.UserConfigurationStore],
-                browserAdapter,
-                tab.id,
+                storeUpdateMessageDistributor,
             );
 
             const tabStopsViewActions = new TabStopsViewActions();
@@ -257,7 +252,6 @@ if (tabId != null) {
                 tabStopsViewStore,
             ]);
 
-            const logger = createDefaultLogger();
             const actionMessageDispatcher = new RemoteActionMessageDispatcher(
                 browserAdapter.sendMessageToFrames,
                 tab.id,

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -164,10 +164,8 @@ if (tabId != null) {
         (tab: Tab): void => {
             const telemetryFactory = new TelemetryDataFactory();
 
-            const logger = createDefaultLogger();
             const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(
                 browserAdapter,
-                logger,
                 tab.id,
             );
             storeUpdateMessageDistributor.initialize();
@@ -252,6 +250,7 @@ if (tabId != null) {
                 tabStopsViewStore,
             ]);
 
+            const logger = createDefaultLogger();
             const actionMessageDispatcher = new RemoteActionMessageDispatcher(
                 browserAdapter.sendMessageToFrames,
                 tab.id,

--- a/src/Devtools/dev-tool-init.ts
+++ b/src/Devtools/dev-tool-init.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapterFactory } from 'common/browser-adapters/browser-adapter-factory';
+import { createDefaultLogger } from 'common/logging/default-logger';
 import { TargetPageInspector } from 'Devtools/target-page-inspector';
 import * as UAParser from 'ua-parser-js';
 import { DevToolInitializer } from './dev-tool-initializer';
@@ -8,11 +9,13 @@ import { DevToolInitializer } from './dev-tool-initializer';
 const userAgentParser = new UAParser(window.navigator.userAgent);
 const browserAdapterFactory = new BrowserAdapterFactory(userAgentParser);
 const browserAdapter = browserAdapterFactory.makeFromUserAgent();
+const logger = createDefaultLogger();
 
 const targetPageInspector = new TargetPageInspector(chrome.devtools.inspectedWindow);
 
 const devToolInitializer: DevToolInitializer = new DevToolInitializer(
     browserAdapter,
     targetPageInspector,
+    logger,
 );
 devToolInitializer.initialize();

--- a/src/Devtools/dev-tool-init.ts
+++ b/src/Devtools/dev-tool-init.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapterFactory } from 'common/browser-adapters/browser-adapter-factory';
-import { createDefaultLogger } from 'common/logging/default-logger';
 import { TargetPageInspector } from 'Devtools/target-page-inspector';
 import * as UAParser from 'ua-parser-js';
 import { DevToolInitializer } from './dev-tool-initializer';
@@ -9,13 +8,11 @@ import { DevToolInitializer } from './dev-tool-initializer';
 const userAgentParser = new UAParser(window.navigator.userAgent);
 const browserAdapterFactory = new BrowserAdapterFactory(userAgentParser);
 const browserAdapter = browserAdapterFactory.makeFromUserAgent();
-const logger = createDefaultLogger();
 
 const targetPageInspector = new TargetPageInspector(chrome.devtools.inspectedWindow);
 
 const devToolInitializer: DevToolInitializer = new DevToolInitializer(
     browserAdapter,
     targetPageInspector,
-    logger,
 );
 devToolInitializer.initialize();

--- a/src/Devtools/dev-tool-initializer.ts
+++ b/src/Devtools/dev-tool-initializer.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { Logger } from 'common/logging/logger';
+import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
 import { TargetPageInspector } from 'Devtools/target-page-inspector';
 import { StoreProxy } from '../common/store-proxy';
 import { StoreNames } from '../common/stores/store-names';
@@ -11,12 +13,19 @@ export class DevToolInitializer {
     constructor(
         private readonly browserAdapter: BrowserAdapter,
         private readonly targetPageInspector: TargetPageInspector,
+        private readonly logger: Logger,
     ) {}
 
     public initialize(): void {
+        const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(
+            this.browserAdapter,
+            this.logger,
+        );
+        storeUpdateMessageDistributor.initialize();
+
         const devtoolsStore = new StoreProxy<DevToolStoreData>(
             StoreNames[StoreNames.DevToolsStore],
-            this.browserAdapter,
+            storeUpdateMessageDistributor,
         );
 
         const inspectHandler = new InspectHandler(

--- a/src/Devtools/dev-tool-initializer.ts
+++ b/src/Devtools/dev-tool-initializer.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { Logger } from 'common/logging/logger';
 import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
 import { TargetPageInspector } from 'Devtools/target-page-inspector';
 import { StoreProxy } from '../common/store-proxy';
@@ -13,13 +12,11 @@ export class DevToolInitializer {
     constructor(
         private readonly browserAdapter: BrowserAdapter,
         private readonly targetPageInspector: TargetPageInspector,
-        private readonly logger: Logger,
     ) {}
 
     public initialize(): void {
         const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(
             this.browserAdapter,
-            this.logger,
         );
         storeUpdateMessageDistributor.initialize();
 

--- a/src/common/constants/generic-store-messages-types.ts
+++ b/src/common/constants/generic-store-messages-types.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-export class GenericStoreMessageTypes {
-    public static readonly storeStateChanged: string = 'STORE_CHANGED';
+export enum GenericStoreMessageTypes {
+    storeStateChanged = 'STORE_CHANGED',
 }

--- a/src/common/constants/generic-store-messages-types.ts
+++ b/src/common/constants/generic-store-messages-types.ts
@@ -1,5 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-export enum GenericStoreMessageTypes {
-    storeStateChanged = 'STORE_CHANGED',
-}

--- a/src/common/state-dispatcher.ts
+++ b/src/common/state-dispatcher.ts
@@ -3,8 +3,7 @@
 import { StoreHub } from 'background/stores/store-hub';
 import { Logger } from 'common/logging/logger';
 import { BaseStore } from './base-store';
-import { GenericStoreMessageTypes } from './constants/generic-store-messages-types';
-import { StoreUpdateMessage } from './types/store-update-message';
+import { StoreUpdateMessage, storeUpdateMessageType } from './types/store-update-message';
 
 export class StateDispatcher {
     constructor(
@@ -28,7 +27,7 @@ export class StateDispatcher {
             this.broadcastMessage({
                 isStoreUpdateMessage: true,
                 storeId: store.getId(),
-                messageType: GenericStoreMessageTypes.storeStateChanged,
+                messageType: storeUpdateMessageType,
                 storeType: this.stores.getStoreType(),
                 payload: store.getState(),
             }).catch(this.logger.error);

--- a/src/common/state-dispatcher.ts
+++ b/src/common/state-dispatcher.ts
@@ -25,7 +25,6 @@ export class StateDispatcher {
     private getDispatchStateUpdateEvent = (store: BaseStore<any>): (() => void) => {
         return () => {
             this.broadcastMessage({
-                isStoreUpdateMessage: true,
                 storeId: store.getId(),
                 messageType: storeUpdateMessageType,
                 storeType: this.stores.getStoreType(),

--- a/src/common/store-proxy.ts
+++ b/src/common/store-proxy.ts
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
 import { isEqual } from 'lodash';
-
 import { BaseStore } from './base-store';
-import { GenericStoreMessageTypes } from './constants/generic-store-messages-types';
 import { Store } from './flux/store';
 import { StoreUpdateMessage } from './types/store-update-message';
 
@@ -20,10 +18,7 @@ export class StoreProxy<TState> extends Store implements BaseStore<TState> {
     }
 
     private onChange = (message: StoreUpdateMessage<TState>): void => {
-        if (
-            message.messageType === GenericStoreMessageTypes.storeStateChanged &&
-            !isEqual(this.state, message.payload)
-        ) {
+        if (!isEqual(this.state, message.payload)) {
             this.state = message.payload;
             this.emitChanged();
         }

--- a/src/common/store-proxy.ts
+++ b/src/common/store-proxy.ts
@@ -1,33 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
 import { isEqual } from 'lodash';
 
 import { BaseStore } from './base-store';
-import { BrowserAdapter } from './browser-adapters/browser-adapter';
 import { GenericStoreMessageTypes } from './constants/generic-store-messages-types';
 import { Store } from './flux/store';
-import { StoreType } from './types/store-type';
 import { StoreUpdateMessage } from './types/store-update-message';
 
 export class StoreProxy<TState> extends Store implements BaseStore<TState> {
     private state: TState;
-    private storeId: string;
-    private tabId?: number;
-    private browserAdapter: BrowserAdapter;
 
-    constructor(storeId: string, browserAdapter: BrowserAdapter, tabId?: number) {
+    constructor(
+        private readonly storeId: string,
+        private readonly messageDistributor: StoreUpdateMessageDistributor,
+    ) {
         super();
-        this.storeId = storeId;
-        this.browserAdapter = browserAdapter;
-        this.tabId = tabId;
-        this.browserAdapter.addListenerOnMessage(this.onChange);
+        this.messageDistributor.registerStoreUpdateListener(storeId, this.onChange);
     }
 
     private onChange = (message: StoreUpdateMessage<TState>): void => {
-        if (!this.isValidMessage(message)) {
-            return;
-        }
-
         if (
             message.messageType === GenericStoreMessageTypes.storeStateChanged &&
             !isEqual(this.state, message.payload)
@@ -37,33 +29,11 @@ export class StoreProxy<TState> extends Store implements BaseStore<TState> {
         }
     };
 
-    private isValidMessage(message: StoreUpdateMessage<TState>): boolean {
-        return (
-            message.isStoreUpdateMessage &&
-            this.isMessageForCurrentStore(message) &&
-            (this.isMessageForCurrentTab(message) || message.storeType === StoreType.GlobalStore)
-        );
-    }
-
-    private isMessageForCurrentTab(message: StoreUpdateMessage<TState>): boolean {
-        return (
-            this.tabId == null || message.tabId === this.tabId // tabid will be null on inital state in content script of target page
-        );
-    }
-
-    private isMessageForCurrentStore(message: StoreUpdateMessage<TState>): boolean {
-        return message.payload && message.storeId === this.getId();
-    }
-
     public getState = (): TState => {
         return this.state;
     };
 
     public getId(): string {
         return this.storeId;
-    }
-
-    public dispose(): void {
-        this.browserAdapter.removeListenerOnMessage(this.onChange);
     }
 }

--- a/src/common/store-update-message-distributor.ts
+++ b/src/common/store-update-message-distributor.ts
@@ -5,6 +5,7 @@ import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import _ from 'lodash';
 import { StoreType } from './types/store-type';
 import { StoreUpdateMessage } from './types/store-update-message';
+import { GenericStoreMessageTypes } from './constants/generic-store-messages-types';
 
 type StoreUpdateMessageListener = (message: StoreUpdateMessage<any>) => void;
 
@@ -44,7 +45,7 @@ export class StoreUpdateMessageDistributor {
 
     private isValidMessage(message: StoreUpdateMessage<any>): boolean {
         return (
-            message.isStoreUpdateMessage &&
+            message.messageType === GenericStoreMessageTypes.storeStateChanged &&
             message.storeId &&
             message.payload &&
             (this.isMessageForCurrentTab(message) || message.storeType === StoreType.GlobalStore)

--- a/src/common/store-update-message-distributor.ts
+++ b/src/common/store-update-message-distributor.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { Logger } from './logging/logger';
 import { StoreType } from './types/store-type';
 import { StoreUpdateMessage } from './types/store-update-message';
 
@@ -11,11 +10,7 @@ type StoreUpdateMessageListener = (message: StoreUpdateMessage<any>) => void;
 export class StoreUpdateMessageDistributor {
     private readonly registeredUpdateListeners: { [key: string]: StoreUpdateMessageListener } = {};
 
-    constructor(
-        private readonly browserAdapter: BrowserAdapter,
-        private readonly logger: Logger,
-        private readonly tabId?: number,
-    ) {}
+    constructor(private readonly browserAdapter: BrowserAdapter, private readonly tabId?: number) {}
 
     public initialize(): void {
         this.browserAdapter.addListenerOnMessage(this.handleMessage);
@@ -37,16 +32,12 @@ export class StoreUpdateMessageDistributor {
 
     private handleMessage = (message: StoreUpdateMessage<any>): void => {
         if (!this.isValidMessage(message)) {
-            this.logger.log('Unable to interpret message - ', message);
-
             return;
         }
 
         const listener = this.registeredUpdateListeners[message.storeId];
         if (listener) {
             listener(message);
-        } else {
-            this.logger.log('No listeners registered for message - ', message);
         }
     };
 

--- a/src/common/store-update-message-distributor.ts
+++ b/src/common/store-update-message-distributor.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import _ from 'lodash';
 import { StoreType } from './types/store-type';
 import { StoreUpdateMessage } from './types/store-update-message';
 
@@ -51,8 +52,6 @@ export class StoreUpdateMessageDistributor {
     }
 
     private isMessageForCurrentTab(message: StoreUpdateMessage<any>): boolean {
-        return (
-            this.tabId == null || message.tabId === this.tabId // tabid will be null on inital state in content script of target page
-        );
+        return _.isEmpty(this.tabId) || message.tabId === this.tabId;
     }
 }

--- a/src/common/store-update-message-distributor.ts
+++ b/src/common/store-update-message-distributor.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { Logger } from './logging/logger';
+import { StoreType } from './types/store-type';
+import { StoreUpdateMessage } from './types/store-update-message';
+
+type StoreUpdateMessageListener = (message: StoreUpdateMessage<any>) => void;
+
+export class StoreUpdateMessageDistributor {
+    private readonly registeredUpdateListeners: { [key: string]: StoreUpdateMessageListener } = {};
+
+    constructor(
+        private readonly tabId: number,
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly logger: Logger,
+    ) {}
+
+    public initialize(): void {
+        this.browserAdapter.addListenerOnMessage(this.handleMessage);
+    }
+
+    public dispose(): void {
+        this.browserAdapter.removeListenerOnMessage(this.handleMessage);
+    }
+
+    public registerStoreUpdateListener(
+        storeId: string,
+        listener: StoreUpdateMessageListener,
+    ): void {
+        if (this.registeredUpdateListeners[storeId]) {
+            throw new Error(`An update listener for store ${storeId} is already registered`);
+        }
+        this.registeredUpdateListeners[storeId] = listener;
+    }
+
+    private handleMessage = (message: StoreUpdateMessage<any>): void => {
+        if (!this.isValidMessage(message)) {
+            this.logger.log('Unable to interpret message - ', message);
+
+            return;
+        }
+
+        const listener = this.registeredUpdateListeners[message.storeId];
+        if (listener) {
+            listener(message);
+        } else {
+            this.logger.log('No listeners registered for message - ', message);
+        }
+    };
+
+    private isValidMessage(message: StoreUpdateMessage<any>): boolean {
+        return (
+            message.isStoreUpdateMessage &&
+            message.storeId &&
+            message.payload &&
+            (this.isMessageForCurrentTab(message) || message.storeType === StoreType.GlobalStore)
+        );
+    }
+
+    private isMessageForCurrentTab(message: StoreUpdateMessage<any>): boolean {
+        return (
+            this.tabId == null || message.tabId === this.tabId // tabid will be null on inital state in content script of target page
+        );
+    }
+}

--- a/src/common/store-update-message-distributor.ts
+++ b/src/common/store-update-message-distributor.ts
@@ -3,9 +3,9 @@
 
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import _ from 'lodash';
+import { GenericStoreMessageTypes } from './constants/generic-store-messages-types';
 import { StoreType } from './types/store-type';
 import { StoreUpdateMessage } from './types/store-update-message';
-import { GenericStoreMessageTypes } from './constants/generic-store-messages-types';
 
 type StoreUpdateMessageListener = (message: StoreUpdateMessage<any>) => void;
 

--- a/src/common/store-update-message-distributor.ts
+++ b/src/common/store-update-message-distributor.ts
@@ -3,9 +3,8 @@
 
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import _ from 'lodash';
-import { GenericStoreMessageTypes } from './constants/generic-store-messages-types';
 import { StoreType } from './types/store-type';
-import { StoreUpdateMessage } from './types/store-update-message';
+import { StoreUpdateMessage, storeUpdateMessageType } from './types/store-update-message';
 
 type StoreUpdateMessageListener = (message: StoreUpdateMessage<any>) => void;
 
@@ -45,7 +44,7 @@ export class StoreUpdateMessageDistributor {
 
     private isValidMessage(message: StoreUpdateMessage<any>): boolean {
         return (
-            message.messageType === GenericStoreMessageTypes.storeStateChanged &&
+            message.messageType === storeUpdateMessageType &&
             message.storeId &&
             message.payload &&
             (this.isMessageForCurrentTab(message) || message.storeType === StoreType.GlobalStore)
@@ -53,6 +52,6 @@ export class StoreUpdateMessageDistributor {
     }
 
     private isMessageForCurrentTab(message: StoreUpdateMessage<any>): boolean {
-        return _.isEmpty(this.tabId) || message.tabId === this.tabId;
+        return _.isNil(this.tabId) || message.tabId === this.tabId;
     }
 }

--- a/src/common/store-update-message-distributor.ts
+++ b/src/common/store-update-message-distributor.ts
@@ -12,9 +12,9 @@ export class StoreUpdateMessageDistributor {
     private readonly registeredUpdateListeners: { [key: string]: StoreUpdateMessageListener } = {};
 
     constructor(
-        private readonly tabId: number,
         private readonly browserAdapter: BrowserAdapter,
         private readonly logger: Logger,
+        private readonly tabId?: number,
     ) {}
 
     public initialize(): void {

--- a/src/common/types/store-update-message.ts
+++ b/src/common/types/store-update-message.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { GenericStoreMessageTypes } from 'common/constants/generic-store-messages-types';
 import { StoreType } from './store-type';
 
 export interface StoreUpdateMessage<TPayloadType> {
-    isStoreUpdateMessage: boolean;
-    messageType: string;
+    messageType: GenericStoreMessageTypes.storeStateChanged;
     storeType: StoreType;
     storeId: string;
     payload: TPayloadType;

--- a/src/common/types/store-update-message.ts
+++ b/src/common/types/store-update-message.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { GenericStoreMessageTypes } from 'common/constants/generic-store-messages-types';
 import { StoreType } from './store-type';
 
+export const storeUpdateMessageType = 'STORE_CHANGED';
+
 export interface StoreUpdateMessage<TPayloadType> {
-    messageType: GenericStoreMessageTypes.storeStateChanged;
+    messageType: typeof storeUpdateMessageType;
     storeType: StoreType;
     storeId: string;
     payload: TPayloadType;

--- a/src/debug-tools/initializer/debug-tools-init.tsx
+++ b/src/debug-tools/initializer/debug-tools-init.tsx
@@ -6,7 +6,6 @@ import { BrowserAdapterFactory } from 'common/browser-adapters/browser-adapter-f
 import { DateProvider } from 'common/date-provider';
 import { initializeFabricIcons } from 'common/fabric-icons';
 import { createDefaultLogger } from 'common/logging/default-logger';
-import { Logger } from 'common/logging/logger';
 import { RemoteActionMessageDispatcher } from 'common/message-creators/remote-action-message-dispatcher';
 import { StoreActionMessageCreatorFactory } from 'common/message-creators/store-action-message-creator-factory';
 import { getNarrowModeThresholdsForWeb } from 'common/narrow-mode-thresholds';
@@ -38,9 +37,8 @@ export const initializeDebugTools = () => {
     const userAgentParser = new UAParser(window.navigator.userAgent);
     const browserAdapterFactory = new BrowserAdapterFactory(userAgentParser);
     const browserAdapter = browserAdapterFactory.makeFromUserAgent();
-    const logger = createDefaultLogger();
 
-    const storeProxies = createStoreProxies(browserAdapter, logger);
+    const storeProxies = createStoreProxies(browserAdapter);
     const storeActionMessageCreator = getStoreActionMessageCreator(browserAdapter, storeProxies);
 
     const debugToolsNavActions = new DebugToolsNavActions();
@@ -68,8 +66,8 @@ export const initializeDebugTools = () => {
     render(props);
 };
 
-const createStoreProxies = (browserAdapter: BrowserAdapter, logger: Logger) => {
-    const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(browserAdapter, logger);
+const createStoreProxies = (browserAdapter: BrowserAdapter) => {
+    const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(browserAdapter);
     storeUpdateMessageDistributor.initialize();
 
     const featureFlagStore = new StoreProxy<FeatureFlagStoreData>(

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -6,6 +6,7 @@ import { EnumHelper } from 'common/enum-helper';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unavailable';
 import { createDefaultLogger } from 'common/logging/default-logger';
+import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
 import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
@@ -84,6 +85,7 @@ export class MainWindowInitializer extends WindowInitializer {
     private analyzerController: AnalyzerController;
     private inspectController: InspectController;
     private pathSnippetController: PathSnippetController;
+    private storeUpdateMessageDistributor: StoreUpdateMessageDistributor;
     private visualizationStoreProxy: StoreProxy<VisualizationStoreData>;
     private assessmentStoreProxy: StoreProxy<AssessmentStoreData>;
     private featureFlagStoreProxy: StoreProxy<FeatureFlagStoreData>;
@@ -100,72 +102,82 @@ export class MainWindowInitializer extends WindowInitializer {
     private needsReviewCardSelectionStoreProxy: StoreProxy<NeedsReviewCardSelectionStoreData>;
     private permissionsStateStoreProxy: StoreProxy<PermissionsStateStoreData>;
 
+    constructor() {
+        super();
+    }
+
     public async initialize(): Promise<void> {
         const asyncInitializationSteps: Promise<void>[] = [];
         asyncInitializationSteps.push(super.initialize());
 
+        const logger = createDefaultLogger();
+
+        this.storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(
+            this.browserAdapter,
+            logger,
+        );
+        this.storeUpdateMessageDistributor.initialize();
+
         this.visualizationStoreProxy = new StoreProxy<VisualizationStoreData>(
             StoreNames[StoreNames.VisualizationStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.scopingStoreProxy = new StoreProxy<ScopingStoreData>(
             StoreNames[StoreNames.ScopingPanelStateStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.featureFlagStoreProxy = new StoreProxy<FeatureFlagStoreData>(
             StoreNames[StoreNames.FeatureFlagStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.userConfigStoreProxy = new StoreProxy<UserConfigurationStoreData>(
             StoreNames[StoreNames.UserConfigurationStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.visualizationScanResultStoreProxy = new StoreProxy<VisualizationScanResultData>(
             StoreNames[StoreNames.VisualizationScanResultStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.assessmentStoreProxy = new StoreProxy<AssessmentStoreData>(
             StoreNames[StoreNames.AssessmentStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.tabStoreProxy = new StoreProxy<TabStoreData>(
             StoreNames[StoreNames.TabStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.devToolStoreProxy = new StoreProxy<DevToolStoreData>(
             StoreNames[StoreNames.DevToolsStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.inspectStoreProxy = new StoreProxy<InspectStoreData>(
             StoreNames[StoreNames.InspectStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.pathSnippetStoreProxy = new StoreProxy<PathSnippetStoreData>(
             StoreNames[StoreNames.PathSnippetStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.unifiedScanResultStoreProxy = new StoreProxy<UnifiedScanResultStoreData>(
             StoreNames[StoreNames.UnifiedScanResultStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.cardSelectionStoreProxy = new StoreProxy<CardSelectionStoreData>(
             StoreNames[StoreNames.CardSelectionStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.needsReviewScanResultStoreProxy = new StoreProxy<NeedsReviewScanResultStoreData>(
             StoreNames[StoreNames.NeedsReviewScanResultStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.needsReviewCardSelectionStoreProxy = new StoreProxy<NeedsReviewCardSelectionStoreData>(
             StoreNames[StoreNames.NeedsReviewCardSelectionStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
         this.permissionsStateStoreProxy = new StoreProxy<PermissionsStateStoreData>(
             StoreNames[StoreNames.PermissionsStateStore],
-            this.browserAdapter,
+            this.storeUpdateMessageDistributor,
         );
-
-        const logger = createDefaultLogger();
 
         const actionMessageDispatcher = new RemoteActionMessageDispatcher(
             this.browserAdapter.sendMessageToFrames,
@@ -419,9 +431,6 @@ export class MainWindowInitializer extends WindowInitializer {
     protected dispose(): void {
         super.dispose();
 
-        this.tabStoreProxy.dispose();
-        this.visualizationScanResultStoreProxy.dispose();
-        this.visualizationStoreProxy.dispose();
-        this.devToolStoreProxy.dispose();
+        this.storeUpdateMessageDistributor.dispose();
     }
 }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -102,20 +102,11 @@ export class MainWindowInitializer extends WindowInitializer {
     private needsReviewCardSelectionStoreProxy: StoreProxy<NeedsReviewCardSelectionStoreData>;
     private permissionsStateStoreProxy: StoreProxy<PermissionsStateStoreData>;
 
-    constructor() {
-        super();
-    }
-
     public async initialize(): Promise<void> {
         const asyncInitializationSteps: Promise<void>[] = [];
         asyncInitializationSteps.push(super.initialize());
 
-        const logger = createDefaultLogger();
-
-        this.storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(
-            this.browserAdapter,
-            logger,
-        );
+        this.storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(this.browserAdapter);
         this.storeUpdateMessageDistributor.initialize();
 
         this.visualizationStoreProxy = new StoreProxy<VisualizationStoreData>(
@@ -178,6 +169,8 @@ export class MainWindowInitializer extends WindowInitializer {
             StoreNames[StoreNames.PermissionsStateStore],
             this.storeUpdateMessageDistributor,
         );
+
+        const logger = createDefaultLogger();
 
         const actionMessageDispatcher = new RemoteActionMessageDispatcher(
             this.browserAdapter.sendMessageToFrames,

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -3,6 +3,7 @@
 import { loadTheme } from '@fluentui/react';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { DocumentManipulator } from 'common/document-manipulator';
+import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
 import * as ReactDOM from 'react-dom';
 import { AxeInfo } from '../common/axe-info';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
@@ -118,6 +119,13 @@ export class PopupInitializer {
             actionMessageDispatcher,
         );
 
+        const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(
+            this.browserAdapter,
+            this.logger,
+            tab.id,
+        );
+        storeUpdateMessageDistributor.initialize();
+
         const visualizationStoreName = StoreNames[StoreNames.VisualizationStore];
         const commandStoreName = StoreNames[StoreNames.CommandStore];
         const featureFlagStoreName = StoreNames[StoreNames.FeatureFlagStore];
@@ -126,28 +134,23 @@ export class PopupInitializer {
 
         const visualizationStore = new StoreProxy<VisualizationStoreData>(
             visualizationStoreName,
-            this.browserAdapter,
-            tab.id,
+            storeUpdateMessageDistributor,
         );
         const launchPanelStateStore = new StoreProxy<LaunchPanelStoreData>(
             launchPanelStateStoreName,
-            this.browserAdapter,
-            tab.id,
+            storeUpdateMessageDistributor,
         );
         const commandStore = new StoreProxy<CommandStoreData>(
             commandStoreName,
-            this.browserAdapter,
-            tab.id,
+            storeUpdateMessageDistributor,
         );
         const featureFlagStore = new StoreProxy<FeatureFlagStoreData>(
             featureFlagStoreName,
-            this.browserAdapter,
-            tab.id,
+            storeUpdateMessageDistributor,
         );
         const userConfigurationStore = new StoreProxy<UserConfigurationStoreData>(
             userConfigurationStoreName,
-            this.browserAdapter,
-            tab.id,
+            storeUpdateMessageDistributor,
         );
 
         const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -121,7 +121,6 @@ export class PopupInitializer {
 
         const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(
             this.browserAdapter,
-            this.logger,
             tab.id,
         );
         storeUpdateMessageDistributor.initialize();

--- a/src/tests/unit/tests/common/state-dispatcher.test.ts
+++ b/src/tests/unit/tests/common/state-dispatcher.test.ts
@@ -16,7 +16,6 @@ describe('StateDispatcherTest', () => {
     test('fire changed event on initialize', () => {
         const newstoreData: StoreStubData = { value: 'testValue' };
         const expectedMessage: StoreUpdateMessage<StoreStubData> = {
-            isStoreUpdateMessage: true,
             messageType: storeUpdateMessageType,
             storeId: 'testStoreId',
             storeType: StoreType.TabContextStore,
@@ -64,7 +63,6 @@ describe('StateDispatcherTest', () => {
     test('fire changed event from store', () => {
         const newstoreData: StoreStubData = { value: 'testValue' };
         const expectedMessage: StoreUpdateMessage<StoreStubData> = {
-            isStoreUpdateMessage: true,
             messageType: storeUpdateMessageType,
             storeId: 'testStoreId',
             storeType: StoreType.TabContextStore,
@@ -116,7 +114,6 @@ describe('StateDispatcherTest', () => {
     test('propagate exceptions in broadcasting changes to logger.error', async () => {
         const newstoreData: StoreStubData = { value: 'testValue' };
         const expectedMessage: StoreUpdateMessage<StoreStubData> = {
-            isStoreUpdateMessage: true,
             messageType: storeUpdateMessageType,
             storeId: 'testStoreId',
             storeType: StoreType.TabContextStore,

--- a/src/tests/unit/tests/common/state-dispatcher.test.ts
+++ b/src/tests/unit/tests/common/state-dispatcher.test.ts
@@ -5,17 +5,19 @@ import { Logger } from 'common/logging/logger';
 import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { BaseStore } from '../../../../common/base-store';
-import { GenericStoreMessageTypes } from '../../../../common/constants/generic-store-messages-types';
 import { StateDispatcher } from '../../../../common/state-dispatcher';
 import { StoreType } from '../../../../common/types/store-type';
-import { StoreUpdateMessage } from '../../../../common/types/store-update-message';
+import {
+    StoreUpdateMessage,
+    storeUpdateMessageType,
+} from '../../../../common/types/store-update-message';
 
 describe('StateDispatcherTest', () => {
     test('fire changed event on initialize', () => {
         const newstoreData: StoreStubData = { value: 'testValue' };
         const expectedMessage: StoreUpdateMessage<StoreStubData> = {
             isStoreUpdateMessage: true,
-            messageType: GenericStoreMessageTypes.storeStateChanged,
+            messageType: storeUpdateMessageType,
             storeId: 'testStoreId',
             storeType: StoreType.TabContextStore,
             payload: newstoreData,
@@ -63,7 +65,7 @@ describe('StateDispatcherTest', () => {
         const newstoreData: StoreStubData = { value: 'testValue' };
         const expectedMessage: StoreUpdateMessage<StoreStubData> = {
             isStoreUpdateMessage: true,
-            messageType: GenericStoreMessageTypes.storeStateChanged,
+            messageType: storeUpdateMessageType,
             storeId: 'testStoreId',
             storeType: StoreType.TabContextStore,
             payload: newstoreData,
@@ -115,7 +117,7 @@ describe('StateDispatcherTest', () => {
         const newstoreData: StoreStubData = { value: 'testValue' };
         const expectedMessage: StoreUpdateMessage<StoreStubData> = {
             isStoreUpdateMessage: true,
-            messageType: GenericStoreMessageTypes.storeStateChanged,
+            messageType: storeUpdateMessageType,
             storeId: 'testStoreId',
             storeType: StoreType.TabContextStore,
             payload: newstoreData,

--- a/src/tests/unit/tests/common/store-proxy.test.ts
+++ b/src/tests/unit/tests/common/store-proxy.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { It, Mock } from 'typemoq';
+import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
+import { IMock, It, Mock } from 'typemoq';
 
-import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { GenericStoreMessageTypes } from '../../../../common/constants/generic-store-messages-types';
 import { StoreProxy } from '../../../../common/store-proxy';
 import { StoreType } from '../../../../common/types/store-type';
@@ -17,20 +17,29 @@ class TestableStoreProxy<TState> extends StoreProxy<TState> {
 }
 
 describe('StoreProxyTest', () => {
-    test('onChange for this proxy', () => {
-        const expectedData = 'test';
-        let onChange: (message: StoreUpdateMessage<string>) => void;
-        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
-        browserAdapterMock
-            .setup(it => it.addListenerOnMessage(It.isAny()))
-            .callback(callback => {
-                onChange = callback;
-            })
+    const expectedData = 'test';
+    const storeId = 'TestStore';
+    let onChange: (message: StoreUpdateMessage<string>) => void;
+    let messageDistributorMock: IMock<StoreUpdateMessageDistributor>;
+
+    let testSubject: TestableStoreProxy<string>;
+
+    beforeEach(() => {
+        messageDistributorMock = Mock.ofType<StoreUpdateMessageDistributor>();
+        messageDistributorMock
+            .setup(m => m.registerStoreUpdateListener(storeId, It.isAny()))
+            .callback((storeId, callback) => (onChange = callback))
             .verifiable();
 
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
+        testSubject = new TestableStoreProxy('TestStore', messageDistributorMock.object);
+    });
 
-        onChange.call(storeProxy, {
+    afterEach(() => {
+        messageDistributorMock.verifyAll();
+    });
+
+    test('onChange when state is different', () => {
+        onChange.call(testSubject, {
             messageType: GenericStoreMessageTypes.storeStateChanged,
             tabId: 1,
             storeId: 'TestStore',
@@ -39,25 +48,11 @@ describe('StoreProxyTest', () => {
             payload: 'test',
         } as StoreUpdateMessage<string>);
 
-        expect(storeProxy.getState()).toEqual(expectedData);
-        expect(storeProxy.emitChangedCallCount).toBe(1);
-        browserAdapterMock.verifyAll();
+        expect(testSubject.getState()).toEqual(expectedData);
+        expect(testSubject.emitChangedCallCount).toBe(1);
     });
 
-    test('onChange for this proxy, when state is same', () => {
-        const expectedData = 'test';
-        let onChange: () => void;
-        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
-
-        browserAdapterMock
-            .setup(it => it.addListenerOnMessage(It.isAny()))
-            .callback(callback => {
-                onChange = callback;
-            })
-            .verifiable();
-
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
-
+    test('onChange when state is same', () => {
         const stateUpdateMessage: StoreUpdateMessage<string> = {
             messageType: GenericStoreMessageTypes.storeStateChanged,
             tabId: 1,
@@ -67,135 +62,18 @@ describe('StoreProxyTest', () => {
             payload: 'test',
         };
 
-        onChange.call(storeProxy, stateUpdateMessage);
-        storeProxy.emitChangedCallCount = 0;
+        onChange.call(testSubject, stateUpdateMessage);
+        testSubject.emitChangedCallCount = 0;
 
         // calling store update event again with same data
-        onChange.call(storeProxy, stateUpdateMessage);
+        onChange.call(testSubject, stateUpdateMessage);
 
-        expect(storeProxy.getState()).toEqual(expectedData);
-        expect(storeProxy.emitChangedCallCount).toBe(0);
-        browserAdapterMock.verifyAll();
-    });
-
-    test('onChange for this proxy when tab id is null in storeProxy', () => {
-        const expectedData = 'test';
-        let onChange: (message: StoreUpdateMessage<string>) => void;
-        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
-        browserAdapterMock
-            .setup(it => it.addListenerOnMessage(It.isAny()))
-            .callback(callback => {
-                onChange = callback;
-            })
-            .verifiable();
-
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object);
-
-        onChange.call(storeProxy, {
-            messageType: GenericStoreMessageTypes.storeStateChanged,
-            tabId: 1,
-            storeId: 'TestStore',
-            storeType: StoreType.TabContextStore,
-            isStoreUpdateMessage: true,
-            payload: 'test',
-        } as StoreUpdateMessage<string>);
-
-        expect(storeProxy.getState()).toEqual(expectedData);
-        expect(storeProxy.emitChangedCallCount).toBe(1);
-        browserAdapterMock.verifyAll();
-    });
-
-    test('onChange for another proxy', () => {
-        let onChange: (message: StoreUpdateMessage<string>) => void;
-        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
-        browserAdapterMock
-            .setup(it => it.addListenerOnMessage(It.isAny()))
-            .callback(callback => {
-                onChange = callback;
-            })
-            .verifiable();
-
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
-
-        onChange.call(storeProxy, {
-            messageType: GenericStoreMessageTypes.storeStateChanged,
-            tabId: 1,
-            storeId: 'AnotherProxy',
-            storeType: StoreType.TabContextStore,
-            isStoreUpdateMessage: true,
-            payload: 'this value should not affect TestStoreProxy',
-        } as StoreUpdateMessage<string>);
-
-        expect(storeProxy.getState()).not.toBeDefined();
-        expect(storeProxy.emitChangedCallCount).toBe(0);
-        browserAdapterMock.verifyAll();
-    });
-
-    test('onChange message is for global store', () => {
-        let onChange: (message: StoreUpdateMessage<string>) => void;
-        const expectedData = 'test';
-        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
-        browserAdapterMock
-            .setup(it => it.addListenerOnMessage(It.isAny()))
-            .callback(callback => {
-                onChange = callback;
-            })
-            .verifiable();
-
-        const storeProxy = new TestableStoreProxy('GlobalStoreProxy', browserAdapterMock.object, 1);
-
-        onChange.call(storeProxy, {
-            messageType: GenericStoreMessageTypes.storeStateChanged,
-            storeType: StoreType.GlobalStore,
-            storeId: 'GlobalStoreProxy',
-            isStoreUpdateMessage: true,
-            payload: expectedData,
-        } as StoreUpdateMessage<string>);
-
-        expect(storeProxy.getState()).toEqual(expectedData);
-        expect(storeProxy.emitChangedCallCount).toBe(1);
-        browserAdapterMock.verifyAll();
-    });
-
-    test('onChange for another tab', () => {
-        let onChange: (message: StoreUpdateMessage<string>) => void;
-        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
-        browserAdapterMock
-            .setup(it => it.addListenerOnMessage(It.isAny()))
-            .callback(callback => {
-                onChange = callback;
-            })
-            .verifiable();
-
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
-
-        onChange.call(storeProxy, {
-            messageType: GenericStoreMessageTypes.storeStateChanged,
-            tabId: 2,
-            storeType: StoreType.TabContextStore,
-            storeId: 'TestStore',
-            isStoreUpdateMessage: true,
-            payload: 'another store state',
-        } as StoreUpdateMessage<string>);
-
-        expect(storeProxy.getState()).not.toBeDefined();
-        expect(storeProxy.emitChangedCallCount).toBe(0);
-        browserAdapterMock.verifyAll();
+        expect(testSubject.getState()).toEqual(expectedData);
+        expect(testSubject.emitChangedCallCount).toBe(0);
     });
 
     test('onChange message type is not GenericStoreMessageTypes.storeChanged', () => {
-        let onChange: (message: StoreUpdateMessage<string>) => void;
-        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
-        browserAdapterMock
-            .setup(it => it.addListenerOnMessage(It.isAny()))
-            .callback(callback => {
-                onChange = callback;
-            })
-            .verifiable();
-
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
-
-        onChange.call(storeProxy, {
+        onChange.call(testSubject, {
             messageType: 'ANOTHER_KIND_OF_MESSAGE',
             tabId: 1,
             storeType: StoreType.TabContextStore,
@@ -204,24 +82,12 @@ describe('StoreProxyTest', () => {
             payload: 'store state',
         } as StoreUpdateMessage<string>);
 
-        expect(storeProxy.getState()).not.toBeDefined();
-        expect(storeProxy.emitChangedCallCount).toBe(0);
-        browserAdapterMock.verifyAll();
+        expect(testSubject.getState()).not.toBeDefined();
+        expect(testSubject.emitChangedCallCount).toBe(0);
     });
 
     test('onChange message is store update message', () => {
-        let onChange: (message: StoreUpdateMessage<string>) => void;
-        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
-        browserAdapterMock
-            .setup(it => it.addListenerOnMessage(It.isAny()))
-            .callback(callback => {
-                onChange = callback;
-            })
-            .verifiable();
-
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
-
-        onChange.call(storeProxy, {
+        onChange.call(testSubject, {
             messageType: 'STORE_UPDATED',
             tabId: 1,
             storeType: StoreType.TabContextStore,
@@ -229,8 +95,7 @@ describe('StoreProxyTest', () => {
             payload: 'store state',
         } as StoreUpdateMessage<string>);
 
-        expect(storeProxy.getState()).not.toBeDefined();
-        expect(storeProxy.emitChangedCallCount).toBe(0);
-        browserAdapterMock.verifyAll();
+        expect(testSubject.getState()).not.toBeDefined();
+        expect(testSubject.emitChangedCallCount).toBe(0);
     });
 });

--- a/src/tests/unit/tests/common/store-proxy.test.ts
+++ b/src/tests/unit/tests/common/store-proxy.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
 import { IMock, It, Mock } from 'typemoq';
-
 import { GenericStoreMessageTypes } from '../../../../common/constants/generic-store-messages-types';
 import { StoreProxy } from '../../../../common/store-proxy';
 import { StoreType } from '../../../../common/types/store-type';
@@ -78,9 +77,8 @@ describe('StoreProxyTest', () => {
             tabId: 1,
             storeType: StoreType.TabContextStore,
             storeId: 'TestStore',
-            isStoreUpdateMessage: true,
             payload: 'store state',
-        } as StoreUpdateMessage<string>);
+        } as unknown as StoreUpdateMessage<string>);
 
         expect(testSubject.getState()).not.toBeDefined();
         expect(testSubject.emitChangedCallCount).toBe(0);
@@ -88,7 +86,7 @@ describe('StoreProxyTest', () => {
 
     test('onChange message is store update message', () => {
         onChange.call(testSubject, {
-            messageType: 'STORE_UPDATED',
+            messageType: GenericStoreMessageTypes.storeStateChanged,
             tabId: 1,
             storeType: StoreType.TabContextStore,
             storeId: 'TestStore',

--- a/src/tests/unit/tests/common/store-proxy.test.ts
+++ b/src/tests/unit/tests/common/store-proxy.test.ts
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
 import { IMock, It, Mock } from 'typemoq';
-import { GenericStoreMessageTypes } from '../../../../common/constants/generic-store-messages-types';
 import { StoreProxy } from '../../../../common/store-proxy';
 import { StoreType } from '../../../../common/types/store-type';
-import { StoreUpdateMessage } from '../../../../common/types/store-update-message';
+import {
+    StoreUpdateMessage,
+    storeUpdateMessageType,
+} from '../../../../common/types/store-update-message';
 
 class TestableStoreProxy<TState> extends StoreProxy<TState> {
     public emitChangedCallCount: number = 0;
@@ -39,7 +41,7 @@ describe('StoreProxyTest', () => {
 
     test('onChange when state is different', () => {
         onChange.call(testSubject, {
-            messageType: GenericStoreMessageTypes.storeStateChanged,
+            messageType: storeUpdateMessageType,
             tabId: 1,
             storeId: 'TestStore',
             storeType: StoreType.TabContextStore,
@@ -53,7 +55,7 @@ describe('StoreProxyTest', () => {
 
     test('onChange when state is same', () => {
         const stateUpdateMessage: StoreUpdateMessage<string> = {
-            messageType: GenericStoreMessageTypes.storeStateChanged,
+            messageType: storeUpdateMessageType,
             tabId: 1,
             storeId: 'TestStore',
             isStoreUpdateMessage: true,

--- a/src/tests/unit/tests/common/store-proxy.test.ts
+++ b/src/tests/unit/tests/common/store-proxy.test.ts
@@ -45,7 +45,6 @@ describe('StoreProxyTest', () => {
             tabId: 1,
             storeId: 'TestStore',
             storeType: StoreType.TabContextStore,
-            isStoreUpdateMessage: true,
             payload: 'test',
         } as StoreUpdateMessage<string>);
 
@@ -58,7 +57,6 @@ describe('StoreProxyTest', () => {
             messageType: storeUpdateMessageType,
             tabId: 1,
             storeId: 'TestStore',
-            isStoreUpdateMessage: true,
             storeType: StoreType.TabContextStore,
             payload: 'test',
         };

--- a/src/tests/unit/tests/common/store-proxy.test.ts
+++ b/src/tests/unit/tests/common/store-proxy.test.ts
@@ -70,30 +70,4 @@ describe('StoreProxyTest', () => {
         expect(testSubject.getState()).toEqual(expectedData);
         expect(testSubject.emitChangedCallCount).toBe(0);
     });
-
-    test('onChange message type is not GenericStoreMessageTypes.storeChanged', () => {
-        onChange.call(testSubject, {
-            messageType: 'ANOTHER_KIND_OF_MESSAGE',
-            tabId: 1,
-            storeType: StoreType.TabContextStore,
-            storeId: 'TestStore',
-            payload: 'store state',
-        } as unknown as StoreUpdateMessage<string>);
-
-        expect(testSubject.getState()).not.toBeDefined();
-        expect(testSubject.emitChangedCallCount).toBe(0);
-    });
-
-    test('onChange message is store update message', () => {
-        onChange.call(testSubject, {
-            messageType: GenericStoreMessageTypes.storeStateChanged,
-            tabId: 1,
-            storeType: StoreType.TabContextStore,
-            storeId: 'TestStore',
-            payload: 'store state',
-        } as StoreUpdateMessage<string>);
-
-        expect(testSubject.getState()).not.toBeDefined();
-        expect(testSubject.emitChangedCallCount).toBe(0);
-    });
 });

--- a/src/tests/unit/tests/common/store-update-message-distributor.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-distributor.test.ts
@@ -48,9 +48,9 @@ describe(StoreUpdateMessageDistributor, () => {
         } as StoreUpdateMessage<string>;
 
         testSubject = new StoreUpdateMessageDistributor(
-            tabId,
             browserAdapterMock.object,
             loggerMock.object,
+            tabId,
         );
 
         testSubject.initialize();

--- a/src/tests/unit/tests/common/store-update-message-distributor.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-distributor.test.ts
@@ -3,6 +3,7 @@
 
 import { IMock, It, Mock } from 'typemoq';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
+import { GenericStoreMessageTypes } from '../../../../common/constants/generic-store-messages-types';
 import { StoreUpdateMessageDistributor } from '../../../../common/store-update-message-distributor';
 import { StoreType } from '../../../../common/types/store-type';
 import { StoreUpdateMessage } from '../../../../common/types/store-update-message';
@@ -28,7 +29,7 @@ describe(StoreUpdateMessageDistributor, () => {
         registeredListener = jest.fn();
 
         tabContextMessage = {
-            isStoreUpdateMessage: true,
+            messageType: GenericStoreMessageTypes.storeStateChanged,
             storeId,
             payload: 'store update payload',
             tabId,
@@ -36,7 +37,7 @@ describe(StoreUpdateMessageDistributor, () => {
         } as StoreUpdateMessage<string>;
 
         globalStoreMessage = {
-            isStoreUpdateMessage: true,
+            messageType: GenericStoreMessageTypes.storeStateChanged,
             storeId,
             payload: 'store update payload',
             tabId: null,
@@ -54,7 +55,10 @@ describe(StoreUpdateMessageDistributor, () => {
     });
 
     const invalidMessages: StoreUpdateMessage<string>[] = [
-        { ...tabContextMessage, isStoreUpdateMessage: false },
+        {
+            ...tabContextMessage,
+            messageType: 'something else',
+        } as unknown as StoreUpdateMessage<string>,
         { ...tabContextMessage, payload: undefined },
         { ...tabContextMessage, storeId: undefined },
         { ...tabContextMessage, tabId: tabId + 10 },

--- a/src/tests/unit/tests/common/store-update-message-distributor.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-distributor.test.ts
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { IMock, It, Mock } from 'typemoq';
+import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
+import { Logger } from '../../../../common/logging/logger';
+import { StoreUpdateMessageDistributor } from '../../../../common/store-update-message-distributor';
+import { StoreType } from '../../../../common/types/store-type';
+import { StoreUpdateMessage } from '../../../../common/types/store-update-message';
+
+describe(StoreUpdateMessageDistributor, () => {
+    const tabId = 1;
+    const storeId = 'TestStore';
+    let browserAdapterMock: IMock<BrowserAdapter>;
+    let loggerMock: IMock<Logger>;
+    let onMessage: (message: StoreUpdateMessage<any>, sender?: any) => void;
+    let registeredListener: jest.Mock;
+
+    let tabContextMessage: StoreUpdateMessage<string>;
+    let globalStoreMessage: StoreUpdateMessage<string>;
+
+    let testSubject: StoreUpdateMessageDistributor;
+
+    beforeEach(() => {
+        browserAdapterMock = Mock.ofType<BrowserAdapter>();
+        browserAdapterMock
+            .setup(b => b.addListenerOnMessage(It.isAny()))
+            .callback(listener => (onMessage = listener));
+
+        loggerMock = Mock.ofType<Logger>();
+
+        registeredListener = jest.fn();
+
+        tabContextMessage = {
+            isStoreUpdateMessage: true,
+            storeId,
+            payload: 'store update payload',
+            tabId,
+            storeType: StoreType.TabContextStore,
+        } as StoreUpdateMessage<string>;
+
+        globalStoreMessage = {
+            isStoreUpdateMessage: true,
+            storeId,
+            payload: 'store update payload',
+            tabId: null,
+            storeType: StoreType.GlobalStore,
+        } as StoreUpdateMessage<string>;
+
+        testSubject = new StoreUpdateMessageDistributor(
+            tabId,
+            browserAdapterMock.object,
+            loggerMock.object,
+        );
+
+        testSubject.initialize();
+        testSubject.registerStoreUpdateListener(storeId, registeredListener);
+    });
+
+    afterEach(() => {
+        browserAdapterMock.verifyAll();
+        loggerMock.verifyAll();
+    });
+
+    const invalidMessages: StoreUpdateMessage<string>[] = [
+        { ...tabContextMessage, isStoreUpdateMessage: false },
+        { ...tabContextMessage, payload: undefined },
+        { ...tabContextMessage, storeId: undefined },
+        { ...tabContextMessage, tabId: tabId + 10 },
+    ];
+    it.each(invalidMessages)('logs and ignores invalid message: %o', message => {
+        loggerMock
+            .setup(l =>
+                l.log(
+                    It.is(x => x.includes('Unable to interpret message')),
+                    It.isAny(),
+                ),
+            )
+            .verifiable();
+
+        onMessage(message);
+
+        expect(registeredListener).toBeCalledTimes(0);
+    });
+
+    it('logs and ignores if no listener is registered for this message', () => {
+        const message = {
+            ...tabContextMessage,
+            storeId: 'AnotherStore',
+        };
+
+        loggerMock
+            .setup(l =>
+                l.log(
+                    It.is(x => x.includes('No listeners registered for message')),
+                    It.isAny(),
+                ),
+            )
+            .verifiable();
+
+        onMessage(message);
+
+        expect(registeredListener).toBeCalledTimes(0);
+    });
+
+    it('Calls registered listener for tab context store message', () => {
+        onMessage(tabContextMessage);
+
+        expect(registeredListener).toBeCalledWith(tabContextMessage);
+    });
+
+    it('Calls registered listener for global store message', () => {
+        onMessage(globalStoreMessage);
+
+        expect(registeredListener).toBeCalledWith(globalStoreMessage);
+    });
+
+    it('Does not overwrite listeners for the same store', () => {
+        expect(() => testSubject.registerStoreUpdateListener(storeId, () => null)).toThrow();
+    });
+
+    it('Registers multiple listeners and distributes messages correctly', () => {
+        const anotherStoreId = 'AnotherStore';
+        const anotherListener = jest.fn();
+
+        const messageForStore = { ...tabContextMessage };
+        const messageForAnotherStore = { ...tabContextMessage, storeId: anotherStoreId };
+
+        testSubject.registerStoreUpdateListener(anotherStoreId, anotherListener);
+
+        onMessage(messageForStore);
+        onMessage(messageForAnotherStore);
+
+        expect(registeredListener).toBeCalledWith(messageForStore);
+        expect(anotherListener).toBeCalledWith(messageForAnotherStore);
+    });
+
+    it('dispose removes message listener', () => {
+        browserAdapterMock.setup(o => o.removeListenerOnMessage(onMessage)).verifiable();
+
+        testSubject.dispose();
+    });
+});

--- a/src/tests/unit/tests/common/store-update-message-distributor.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-distributor.test.ts
@@ -94,6 +94,16 @@ describe(StoreUpdateMessageDistributor, () => {
         expect(registeredListener).toBeCalledWith(globalStoreMessage);
     });
 
+    it('Calls registered listener if not created with a tab id', () => {
+        testSubject = new StoreUpdateMessageDistributor(browserAdapterMock.object);
+        testSubject.initialize();
+        testSubject.registerStoreUpdateListener(storeId, registeredListener);
+
+        onMessage(tabContextMessage);
+
+        expect(registeredListener).toBeCalledWith(tabContextMessage);
+    });
+
     it('Does not overwrite listeners for the same store', () => {
         expect(() => testSubject.registerStoreUpdateListener(storeId, () => null)).toThrow();
     });

--- a/src/tests/unit/tests/common/store-update-message-distributor.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-distributor.test.ts
@@ -3,10 +3,12 @@
 
 import { IMock, It, Mock } from 'typemoq';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
-import { GenericStoreMessageTypes } from '../../../../common/constants/generic-store-messages-types';
 import { StoreUpdateMessageDistributor } from '../../../../common/store-update-message-distributor';
 import { StoreType } from '../../../../common/types/store-type';
-import { StoreUpdateMessage } from '../../../../common/types/store-update-message';
+import {
+    StoreUpdateMessage,
+    storeUpdateMessageType,
+} from '../../../../common/types/store-update-message';
 
 describe(StoreUpdateMessageDistributor, () => {
     const tabId = 1;
@@ -29,7 +31,7 @@ describe(StoreUpdateMessageDistributor, () => {
         registeredListener = jest.fn();
 
         tabContextMessage = {
-            messageType: GenericStoreMessageTypes.storeStateChanged,
+            messageType: storeUpdateMessageType,
             storeId,
             payload: 'store update payload',
             tabId,
@@ -37,7 +39,7 @@ describe(StoreUpdateMessageDistributor, () => {
         } as StoreUpdateMessage<string>;
 
         globalStoreMessage = {
-            messageType: GenericStoreMessageTypes.storeStateChanged,
+            messageType: storeUpdateMessageType,
             storeId,
             payload: 'store update payload',
             tabId: null,

--- a/src/views/insights/dependencies.ts
+++ b/src/views/insights/dependencies.ts
@@ -4,6 +4,7 @@ import { loadTheme } from '@fluentui/react';
 import { DocumentManipulator } from 'common/document-manipulator';
 import { Logger } from 'common/logging/logger';
 import { getNarrowModeThresholdsForWeb } from 'common/narrow-mode-thresholds';
+import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
 import { textContent } from 'content/strings/text-content';
 import * as ReactDOM from 'react-dom';
 import { Content } from 'views/content/content';
@@ -39,9 +40,12 @@ export const rendererDependencies: (
         actionMessageDispatcher,
     );
 
+    const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(browserAdapter, logger);
+    storeUpdateMessageDistributor.initialize();
+
     const store = new StoreProxy<UserConfigurationStoreData>(
         StoreNames[StoreNames.UserConfigurationStore],
-        browserAdapter,
+        storeUpdateMessageDistributor,
     );
     const storesHub = new BaseClientStoresHub<any>([store]);
     const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(

--- a/src/views/insights/dependencies.ts
+++ b/src/views/insights/dependencies.ts
@@ -40,7 +40,7 @@ export const rendererDependencies: (
         actionMessageDispatcher,
     );
 
-    const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(browserAdapter, logger);
+    const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(browserAdapter);
     storeUpdateMessageDistributor.initialize();
 
     const store = new StoreProxy<UserConfigurationStoreData>(


### PR DESCRIPTION
#### Details

Creates StoreUpdateMesssageDistributor to distribute update messages to the appropriate StoreProxy, if one is registered.

##### Motivation

As mentioned in #5396 and #5407, we will eventually need to combine message handling into one event listener (per context) that distributes messages to their respective handlers. Currently, each StoreProxy registers its own separate onMessage handler. This change creates one central message listener that distributes store update messages to the appropriate StoreProxy.

##### Context

This continues a change from #5407. After this PR, all contexts will have only one registered onMessage listener at the browser level.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
