### PR TITLE
chore: remove obsolete dependency on axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,6 @@
         "android-device-list": "^1.2.7",
         "appium-adb": "^9.2.1",
         "axe-core": "4.4.1",
-        "axios": "^0.26.1",
         "classnames": "^2.3.1",
         "electron": "14.0.0",
         "electron-log": "^4.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3546,7 +3546,7 @@ axe-core@4.4.1:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
-axios@0.26.1, axios@^0.26.1:
+axios@0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
   integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==


### PR DESCRIPTION
#### Details

web's `axios` dependency was originally introduced in #1077 as part of our implementation to have AI4Android communicate with the android service's webserver. We removed all usages of it when we replaced the android service's webserver with its ContentProvider-based implementation, but missed removing the `axios` dependency.

This doesn't have a huge impact since `appium-adb` still has a transitive dependency on `axios`, but at least it reduces some dependabot noise.

##### Motivation

Remove obsolete code, reduce dependabot noise

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
