### PR TITLE
feat(mv3-part-2): Only use persisted tab info if tabs are still valid after service worker restart

### DIFF
--- a/src/background/IndexedDBDataKeys.ts
+++ b/src/background/IndexedDBDataKeys.ts
@@ -13,24 +13,26 @@ export class IndexedDBDataKeys {
     public static readonly tabIdToDetailsViewMap: string = 'tabIdToDetailsViewMap';
 
     // Tab specific keys- there may be multiple instances of these stores for each tab
-    public static readonly cardSelectionStore: (tabId) => string = tabId =>
+    public static readonly cardSelectionStore: (tabId: number) => string = tabId =>
         'cardSelectionStore' + tabId;
-    public static readonly detailsViewStore: (tabId) => string = tabId =>
+    public static readonly detailsViewStore: (tabId: number) => string = tabId =>
         'detailsViewStore' + tabId;
-    public static readonly devToolStore: (tabId) => string = tabId => 'devToolStore' + tabId;
-    public static readonly inspectStore: (tabId) => string = tabId => 'inspectStore' + tabId;
-    public static readonly tabStore: (tabId) => string = tabId => 'tabStore' + tabId;
-    public static readonly pathSnippetStore: (tabId) => string = tabId =>
+    public static readonly devToolStore: (tabId: number) => string = tabId =>
+        'devToolStore' + tabId;
+    public static readonly inspectStore: (tabId: number) => string = tabId =>
+        'inspectStore' + tabId;
+    public static readonly tabStore: (tabId: number) => string = tabId => 'tabStore' + tabId;
+    public static readonly pathSnippetStore: (tabId: number) => string = tabId =>
         'pathSnippetStore' + tabId;
-    public static readonly needsReviewScanResultsStore: (tabId) => string = tabId =>
+    public static readonly needsReviewScanResultsStore: (tabId: number) => string = tabId =>
         'needsReviewScanResultsStore' + tabId;
-    public static readonly needsReviewCardSelectionStore: (tabId) => string = tabId =>
+    public static readonly needsReviewCardSelectionStore: (tabId: number) => string = tabId =>
         'needsReviewCardSelectionStore' + tabId;
-    public static readonly visualizationStore: (tabId) => string = tabId =>
+    public static readonly visualizationStore: (tabId: number) => string = tabId =>
         'visualizationStore' + tabId;
-    public static readonly visualizationScanResultStore: (tabId) => string = tabId =>
+    public static readonly visualizationScanResultStore: (tabId: number) => string = tabId =>
         'visualizationScanResultStore' + tabId;
-    public static readonly unifiedScanResultStore: (tabId) => string = tabId =>
+    public static readonly unifiedScanResultStore: (tabId: number) => string = tabId =>
         'unifiedScanResultStore' + tabId;
 
     public static readonly globalKeys: string[] = [
@@ -45,7 +47,7 @@ export class IndexedDBDataKeys {
         IndexedDBDataKeys.tabIdToDetailsViewMap,
     ];
 
-    public static readonly tabSpecificKeys: ((tabId) => string)[] = [
+    public static readonly tabSpecificKeys: ((tabId: number) => string)[] = [
         IndexedDBDataKeys.cardSelectionStore,
         IndexedDBDataKeys.detailsViewStore,
         IndexedDBDataKeys.devToolStore,

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -217,7 +217,7 @@ async function initialize(): Promise<void> {
         detailsViewController,
         tabContextFactory,
         logger,
-        [],
+        {},
         indexedDBInstance,
     );
 

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -15,7 +15,7 @@ import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
-import { DictionaryStringTo } from 'types/common-types';
+import { DictionaryNumberTo, DictionaryStringTo } from 'types/common-types';
 import { IndexedDBAPI } from '../common/indexedDB/indexedDB';
 import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
 import { UserConfigurationStoreData } from '../common/types/store-data/user-configuration-store';
@@ -33,7 +33,7 @@ export interface PersistedData {
     commandStoreData: CommandStoreData;
     permissionsStateStoreData: PermissionsStateStoreData;
     scopingStoreData: ScopingStoreData;
-    knownTabIds: number[];
+    knownTabIds: DictionaryNumberTo<string>;
     tabIdToDetailsViewMap: DictionaryStringTo<number>;
 }
 
@@ -129,11 +129,13 @@ export async function getAllPersistedData(indexedDBInstance: IndexedDBAPI): Prom
         persistedData,
     );
 
-    const knownTabIds: number[] = await indexedDBInstance.getItem(IndexedDBDataKeys.knownTabIds);
-    if (knownTabIds && knownTabIds.length > 0) {
-        knownTabIds.forEach(tabId => {
+    const knownTabIds: DictionaryNumberTo<string> = await indexedDBInstance.getItem(
+        IndexedDBDataKeys.knownTabIds,
+    );
+    if (knownTabIds && Object.keys(knownTabIds).length > 0) {
+        Object.keys(knownTabIds).forEach(tabId => {
             const tabSpecificPromises = getAllTabSpecificPersistedPromises(
-                tabId,
+                parseInt(tabId),
                 indexedDBInstance,
                 persistedData,
             );

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -201,7 +201,7 @@ async function initialize(): Promise<void> {
         detailsViewController,
         tabContextFactory,
         logger,
-        persistedData.knownTabIds ?? [],
+        persistedData.knownTabIds ?? {},
         indexedDBInstance,
         true,
     );

--- a/src/tests/unit/tests/background/get-persisted-data.test.ts
+++ b/src/tests/unit/tests/background/get-persisted-data.test.ts
@@ -9,7 +9,7 @@ import {
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { IMock, Mock } from 'typemoq';
-import { DictionaryStringTo } from 'types/common-types';
+import { DictionaryNumberTo, DictionaryStringTo } from 'types/common-types';
 
 import { InstallationData } from '../../../../background/installation-data';
 import { IndexedDBAPI } from '../../../../common/indexedDB/indexedDB';
@@ -25,7 +25,7 @@ describe('GetPersistedDataTest', () => {
     let userConfigurationData: UserConfigurationStoreData;
     let installationData: InstallationData;
     let permissionsStateStoreData: PermissionsStateStoreData;
-    let knownTabIds: number[];
+    let knownTabIds: DictionaryNumberTo<string>;
     let tabIdToDetailsViewMap: DictionaryStringTo<number>;
 
     beforeEach(() => {
@@ -53,7 +53,7 @@ describe('GetPersistedDataTest', () => {
             year: 0,
         };
         permissionsStateStoreData = { hasAllUrlAndFilePermissions: true };
-        knownTabIds = [0, 9];
+        knownTabIds = { 0: 'url0', 9: 'url9' };
         tabIdToDetailsViewMap = { key: 9 };
         indexedDBInstanceStrictMock = Mock.ofType<IndexedDBAPI>();
     });
@@ -127,14 +127,14 @@ describe('GetPersistedDataTest', () => {
         it('returns global data when no known tabs exist', async () => {
             indexedDBInstanceStrictMock
                 .setup(i => i.getItem(IndexedDBDataKeys.knownTabIds))
-                .returns(() => Promise.resolve([]));
+                .returns(() => Promise.resolve({}));
             setupGlobalData();
 
             const data = await getAllPersistedData(indexedDBInstanceStrictMock.object);
 
             expect(data).toEqual({
                 assessmentStoreData: assessmentStoreData,
-                knownTabIds: [],
+                knownTabIds: {},
                 userConfigurationData: {},
                 commandStoreData: {},
                 featureFlags: {},
@@ -203,10 +203,10 @@ describe('GetPersistedDataTest', () => {
         }
 
         function setupTabData() {
-            knownTabIds.forEach(tabId => {
+            Object.keys(knownTabIds).forEach(tabId => {
                 IndexedDBDataKeys.tabSpecificKeys.forEach(key => {
                     indexedDBInstanceStrictMock
-                        .setup(i => i.getItem(key(tabId)))
+                        .setup(i => i.getItem(key(parseInt(tabId))))
                         .returns(async () => Promise.resolve({}));
                 });
             });

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -592,7 +592,6 @@ describe('TargetPageController', () => {
 
             describe('onConnect', () => {
                 it('should not have any observable effect', () => {
-                    idbInstanceMock.reset();
                     setupDatabaseInstance(Times.never());
 
                     mockBrowserAdapter.notifyOnConnect({
@@ -672,10 +671,6 @@ describe('TargetPageController', () => {
             });
 
             describe('onTabRemoved', () => {
-                beforeEach(() => {
-                    idbInstanceMock.reset();
-                });
-
                 it('should ignore removals of non-tracked tabs', () => {
                     setupDatabaseInstance(Times.never());
                     setupTeardownInstance(Times.once());
@@ -749,7 +744,6 @@ describe('TargetPageController', () => {
 
             describe('onWindowsFocusChanged', () => {
                 beforeEach(() => {
-                    idbInstanceMock.reset();
                     setupDatabaseInstance(Times.never());
                     setupTeardownInstance(Times.never());
                 });


### PR DESCRIPTION
#### Details

Adds logic to determine if a tab url has changed between service worker shut down and restart. This ensures that we correctly handle url changes even if they happen with the service worker was down.

##### Motivation

Feature work.

##### Context

This change required us to restructure knownTabIds such that it now stores and persists both the tab ID and url. This allows us to check that the urls haven't changed between service worker shut down and restart.

This change does not effect the mv2 extension because it does not persist any data and therefore it never has any known tabs on target page controller initialization.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
