### PR TITLE
feat(mv3-part-3): Fix assessment store start over logic

### DIFF
--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -413,14 +413,16 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
     private onResetData = (payload: ToggleActionPayload): void => {
         const test = this.assessmentsProvider.forType(payload.test);
         const config = test.getVisualizationConfiguration();
-        const defaultTestStatus: AssessmentData = config.getAssessmentData(this.getDefaultState());
+        const defaultTestStatus: AssessmentData = config.getAssessmentData(
+            this.generateDefaultState(null),
+        );
         this.state.assessments[test.key] = defaultTestStatus;
         this.state.assessmentNavState.selectedTestSubview = test.requirements[0].key;
         this.emitChanged();
     };
 
     private onResetAllAssessmentsData = (targetTabId: number): void => {
-        this.state = this.getDefaultState();
+        this.state = this.generateDefaultState(null);
         this.updateTargetTabWithId(targetTabId);
     };
 

--- a/src/tests/unit/tests/background/stores/__snapshots__/assessment-store.test.ts.snap
+++ b/src/tests/unit/tests/background/stores/__snapshots__/assessment-store.test.ts.snap
@@ -2,4 +2,6 @@
 
 exports[`AssessmentStore onResetAllAssessmentsData 1`] = `"tab with Id 1000 not found"`;
 
+exports[`AssessmentStore onResetAllAssessmentsData with persisted data 1`] = `"tab with Id 1000 not found"`;
+
 exports[`AssessmentStore onUpdateTargetTabId 1`] = `"tab with Id 1000 not found"`;


### PR DESCRIPTION
#### Details

Fix a bug in the way the assessment store handles resetting data when the user starts over. 

##### Motivation

Feature work.

##### Context

Moving to use the PersistentStore introduced a bug where we use the persisted data to calculate the default store data all the time. This PR makes it so that we don't use the persisted data when resetting the assessment store data.

Note that this bug only repros in the mv3 extension because the mv2 extension does not persist data at the moment.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
