### PR TITLE
feat(mv3-part-3): Move tabIdToContextMap out of TargetPageController

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -203,6 +203,9 @@ async function initialize(): Promise<void> {
         telemetryEventHandler,
         targetTabController,
         notificationCreator,
+        detailsViewController,
+        browserAdapter,
+        messageBroadcasterFactory,
         promiseFactory,
         logger,
         usageLogger,
@@ -211,16 +214,11 @@ async function initialize(): Promise<void> {
         indexedDBInstance,
     );
 
-    const tabContextManager = new TabContextManager(
-        tabToContextMap,
-        messageBroadcasterFactory,
-        browserAdapter,
-        detailsViewController,
-        tabContextFactory,
-    );
+    const tabContextManager = new TabContextManager(tabToContextMap);
 
     const targetPageController = new TargetPageController(
         tabContextManager,
+        tabContextFactory,
         browserAdapter,
         detailsViewController,
         logger,

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -33,7 +33,6 @@ import { IndexedDBDataKeys } from './IndexedDBDataKeys';
 import { KeyboardShortcutHandler } from './keyboard-shortcut-handler';
 import { deprecatedStorageDataKeys, storageDataKeys } from './local-storage-data-keys';
 import { MessageDistributor } from './message-distributor';
-import { TabToContextMap } from './tab-context';
 import { TabContextFactory } from './tab-context-factory';
 import { TargetPageController } from './target-page-controller';
 import { TargetTabController } from './target-tab-controller';
@@ -153,7 +152,7 @@ async function initialize(): Promise<void> {
         indexedDBInstance,
     );
 
-    const tabToContextMap: TabToContextMap = {};
+    const tabContextManager = new TabContextManager();
 
     const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
     const notificationCreator = new NotificationCreator(
@@ -163,7 +162,7 @@ async function initialize(): Promise<void> {
     );
 
     const keyboardShortcutHandler = new KeyboardShortcutHandler(
-        tabToContextMap,
+        tabContextManager,
         browserAdapter,
         urlValidator,
         notificationCreator,
@@ -184,7 +183,7 @@ async function initialize(): Promise<void> {
 
     const messageDistributor = new MessageDistributor(
         globalContext,
-        tabToContextMap,
+        tabContextManager,
         postMessageContentHandler,
         browserAdapter,
         logger,
@@ -215,8 +214,6 @@ async function initialize(): Promise<void> {
         false,
     );
 
-    const tabContextManager = new TabContextManager(tabToContextMap);
-
     const targetPageController = new TargetPageController(
         tabContextManager,
         tabContextFactory,
@@ -229,7 +226,7 @@ async function initialize(): Promise<void> {
 
     await targetPageController.initialize();
 
-    const devToolsBackgroundListener = new DevToolsListener(tabToContextMap, browserAdapter);
+    const devToolsBackgroundListener = new DevToolsListener(tabContextManager, browserAdapter);
     devToolsBackgroundListener.initialize();
 
     window.insightsFeatureFlags = globalContext.featureFlagsController;

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -212,6 +212,7 @@ async function initialize(): Promise<void> {
         windowUtils.setTimeout,
         persistedData,
         indexedDBInstance,
+        false,
     );
 
     const tabContextManager = new TabContextManager(tabToContextMap);

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -3,6 +3,7 @@
 import { Assessments } from 'assessments/assessments';
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { PostMessageContentRepository } from 'background/post-message-content-repository';
+import { TabContextManager } from 'background/tab-context-manager';
 import { ConsoleTelemetryClient } from 'background/telemetry/console-telemetry-client';
 import { DebugToolsTelemetryClient } from 'background/telemetry/debug-tools-telemetry-client';
 import { createToolData } from 'common/application-properties-provider';
@@ -210,12 +211,18 @@ async function initialize(): Promise<void> {
         indexedDBInstance,
     );
 
-    const targetPageController = new TargetPageController(
+    const tabContextManager = new TabContextManager(
         tabToContextMap,
         messageBroadcasterFactory,
         browserAdapter,
         detailsViewController,
         tabContextFactory,
+    );
+
+    const targetPageController = new TargetPageController(
+        tabContextManager,
+        browserAdapter,
+        detailsViewController,
         logger,
         {},
         indexedDBInstance,

--- a/src/background/message-distributor.ts
+++ b/src/background/message-distributor.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TabContextManager } from 'background/tab-context-manager';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { Tab } from '../common/itab';
 import { Logger } from '../common/logging/logger';
 import { InterpreterMessage } from '../common/message';
 import { GlobalContext } from './global-context';
 import { PostMessageContentHandler } from './post-message-content-handler';
-import { TabToContextMap } from './tab-context';
 
 export interface Sender {
     tab?: Tab;
@@ -15,7 +15,7 @@ export interface Sender {
 export class MessageDistributor {
     constructor(
         private readonly globalContext: GlobalContext,
-        private readonly tabToContextMap: TabToContextMap,
+        private readonly tabContextManager: TabContextManager,
         private readonly postMessageContentHandler: PostMessageContentHandler,
         private readonly browserAdapter: BrowserAdapter,
         private readonly logger: Logger,
@@ -57,13 +57,10 @@ export class MessageDistributor {
     }
 
     private tryInterpretUsingTabContext(message: InterpreterMessage): boolean {
-        let hasInterpreted: boolean;
-        const tabContext = this.tabToContextMap[message.tabId];
-
-        if (tabContext != null) {
-            hasInterpreted = tabContext.interpreter.interpret(message);
+        if (message.tabId != null) {
+            return this.tabContextManager.interpretMessageForTab(message.tabId, message);
         }
 
-        return hasInterpreted;
+        return false;
     }
 }

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -187,24 +187,23 @@ async function initialize(): Promise<void> {
         telemetryEventHandler,
         targetTabController,
         notificationCreator,
+        detailsViewController,
+        browserAdapter,
+        messageBroadcasterFactory,
         promiseFactory,
         logger,
         usageLogger,
         globalThis.setTimeout.bind(this),
         persistedData,
         indexedDBInstance,
+        true,
     );
 
-    const tabContextManager = new TabContextManager(
-        tabToContextMap,
-        messageBroadcasterFactory,
-        browserAdapter,
-        detailsViewController,
-        tabContextFactory,
-    );
+    const tabContextManager = new TabContextManager(tabToContextMap);
 
     const targetPageController = new TargetPageController(
         tabContextManager,
+        tabContextFactory,
         browserAdapter,
         detailsViewController,
         logger,

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -10,7 +10,6 @@ import { KeyboardShortcutHandler } from 'background/keyboard-shortcut-handler';
 import { MessageDistributor } from 'background/message-distributor';
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { PostMessageContentRepository } from 'background/post-message-content-repository';
-import { TabToContextMap } from 'background/tab-context';
 import { TabContextFactory } from 'background/tab-context-factory';
 import { TabContextManager } from 'background/tab-context-manager';
 import { TargetPageController } from 'background/target-page-controller';
@@ -138,7 +137,7 @@ async function initialize(): Promise<void> {
         indexedDBInstance,
         true,
     );
-    const tabToContextMap: TabToContextMap = {};
+    const tabContextManager = new TabContextManager();
 
     const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
     const notificationCreator = new NotificationCreator(
@@ -148,7 +147,7 @@ async function initialize(): Promise<void> {
     );
 
     const keyboardShortcutHandler = new KeyboardShortcutHandler(
-        tabToContextMap,
+        tabContextManager,
         browserAdapter,
         urlValidator,
         notificationCreator,
@@ -169,7 +168,7 @@ async function initialize(): Promise<void> {
 
     const messageDistributor = new MessageDistributor(
         globalContext,
-        tabToContextMap,
+        tabContextManager,
         postMessageContentHandler,
         browserAdapter,
         logger,
@@ -199,8 +198,6 @@ async function initialize(): Promise<void> {
         true,
     );
 
-    const tabContextManager = new TabContextManager(tabToContextMap);
-
     const targetPageController = new TargetPageController(
         tabContextManager,
         tabContextFactory,
@@ -214,7 +211,7 @@ async function initialize(): Promise<void> {
 
     await targetPageController.initialize();
 
-    const devToolsBackgroundListener = new DevToolsListener(tabToContextMap, browserAdapter);
+    const devToolsBackgroundListener = new DevToolsListener(tabContextManager, browserAdapter);
     devToolsBackgroundListener.initialize();
 
     await cleanKeysFromStoragePromise;

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -12,6 +12,7 @@ import { PostMessageContentHandler } from 'background/post-message-content-handl
 import { PostMessageContentRepository } from 'background/post-message-content-repository';
 import { TabToContextMap } from 'background/tab-context';
 import { TabContextFactory } from 'background/tab-context-factory';
+import { TabContextManager } from 'background/tab-context-manager';
 import { TargetPageController } from 'background/target-page-controller';
 import { TargetTabController } from 'background/target-tab-controller';
 import { ConsoleTelemetryClient } from 'background/telemetry/console-telemetry-client';
@@ -194,12 +195,18 @@ async function initialize(): Promise<void> {
         indexedDBInstance,
     );
 
-    const targetPageController = new TargetPageController(
+    const tabContextManager = new TabContextManager(
         tabToContextMap,
         messageBroadcasterFactory,
         browserAdapter,
         detailsViewController,
         tabContextFactory,
+    );
+
+    const targetPageController = new TargetPageController(
+        tabContextManager,
+        browserAdapter,
+        detailsViewController,
         logger,
         persistedData.knownTabIds ?? {},
         indexedDBInstance,

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -3,6 +3,7 @@
 import { NeedsReviewCardSelectionActionCreator } from 'background/actions/needs-review-card-selection-action-creator';
 import { NeedsReviewScanResultActionCreator } from 'background/actions/needs-review-scan-result-action-creator';
 import { TabStopRequirementActionCreator } from 'background/actions/tab-stop-requirement-action-creator';
+import { BrowserMessageBroadcasterFactory } from 'background/browser-message-broadcaster-factory';
 import { PersistedData } from 'background/get-persisted-data';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
@@ -41,21 +42,19 @@ export class TabContextFactory {
         private telemetryEventHandler: TelemetryEventHandler,
         private targetTabController: TargetTabController,
         private notificationCreator: NotificationCreator,
+        private detailsViewController: ExtensionDetailsViewController,
+        private browserAdapter: BrowserAdapter,
+        private readonly broadcasterFactory: BrowserMessageBroadcasterFactory,
         private readonly promiseFactory: PromiseFactory,
         private readonly logger: Logger,
         private readonly usageLogger: UsageLogger,
         private readonly setTimeout: (handler: Function, timeout: number) => number,
         private readonly persistedData: PersistedData,
         private readonly indexedDBInstance: IndexedDBAPI,
+        private readonly persistStoreData: boolean = false,
     ) {}
 
-    public createTabContext(
-        broadcastMessage: (message) => Promise<void>,
-        browserAdapter: BrowserAdapter,
-        detailsViewController: ExtensionDetailsViewController,
-        tabId: number,
-        persistStoreData: boolean,
-    ): TabContext {
+    public createTabContext(tabId: number): TabContext {
         const interpreter = new Interpreter();
         const actionsHub = new ActionHub();
         const storeHub = new TabContextStoreHub(
@@ -65,14 +64,14 @@ export class TabContextFactory {
             this.indexedDBInstance,
             this.logger,
             tabId,
-            persistStoreData,
+            this.persistStoreData,
         );
         const notificationCreator = new NotificationCreator(
-            browserAdapter,
+            this.browserAdapter,
             this.visualizationConfigurationFactory,
             this.logger,
         );
-        const shortcutsPageController = new ShortcutsPageController(browserAdapter);
+        const shortcutsPageController = new ShortcutsPageController(this.browserAdapter);
 
         const shortcutsPageActionCreator = new ShortcutsPageActionCreator(
             interpreter,
@@ -84,7 +83,7 @@ export class TabContextFactory {
         const actionCreator = new ActionCreator(
             interpreter,
             actionsHub,
-            detailsViewController,
+            this.detailsViewController,
             this.telemetryEventHandler,
             notificationCreator,
             this.visualizationConfigurationFactory,
@@ -96,7 +95,7 @@ export class TabContextFactory {
             interpreter,
             actionsHub.detailsViewActions,
             actionsHub.sidePanelActions,
-            detailsViewController,
+            this.detailsViewController,
             this.telemetryEventHandler,
         );
 
@@ -109,7 +108,7 @@ export class TabContextFactory {
         const tabActionCreator = new TabActionCreator(
             interpreter,
             actionsHub.tabActions,
-            browserAdapter,
+            this.browserAdapter,
             this.telemetryEventHandler,
             this.logger,
         );
@@ -128,7 +127,7 @@ export class TabContextFactory {
             interpreter,
             actionsHub.inspectActions,
             this.telemetryEventHandler,
-            browserAdapter,
+            this.browserAdapter,
             this.logger,
         );
         const pathSnippetActionCreator = new PathSnippetActionCreator(
@@ -151,7 +150,7 @@ export class TabContextFactory {
             interpreter,
             actionsHub.contentActions,
             this.telemetryEventHandler,
-            detailsViewController,
+            this.detailsViewController,
         );
         const cardSelectionActionCreator = new CardSelectionActionCreator(
             interpreter,
@@ -169,7 +168,7 @@ export class TabContextFactory {
         );
 
         const injectorController = new InjectorController(
-            new ContentScriptInjector(browserAdapter, this.promiseFactory, this.logger),
+            new ContentScriptInjector(this.browserAdapter, this.promiseFactory, this.logger),
             storeHub.visualizationStore,
             interpreter,
             storeHub.tabStore,
@@ -177,6 +176,8 @@ export class TabContextFactory {
             this.setTimeout,
             this.logger,
         );
+
+        const messageBroadcaster = this.broadcasterFactory.createTabSpecificBroadcaster(tabId);
 
         shortcutsPageActionCreator.registerCallbacks();
         actionCreator.registerCallbacks();
@@ -195,7 +196,7 @@ export class TabContextFactory {
         injectionActionCreator.registerCallbacks();
 
         injectorController.initialize();
-        const dispatcher = new StateDispatcher(broadcastMessage, storeHub, this.logger);
+        const dispatcher = new StateDispatcher(messageBroadcaster, storeHub, this.logger);
         dispatcher.initialize();
 
         return new TabContext(interpreter, storeHub);

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -51,7 +51,7 @@ export class TabContextFactory {
         private readonly setTimeout: (handler: Function, timeout: number) => number,
         private readonly persistedData: PersistedData,
         private readonly indexedDBInstance: IndexedDBAPI,
-        private readonly persistStoreData: boolean = false,
+        private readonly persistStoreData: boolean,
     ) {}
 
     public createTabContext(tabId: number): TabContext {

--- a/src/background/tab-context-manager.ts
+++ b/src/background/tab-context-manager.ts
@@ -1,22 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TabContextFactory } from 'background/tab-context-factory';
 import { Message } from '../common/message';
-import { TabContext, TabToContextMap } from './tab-context';
+import { TabToContextMap } from './tab-context';
 
 export class TabContextManager {
     constructor(private readonly targetPageTabIdToContextMap: TabToContextMap) {}
 
-    public addTabContextIfNotExists(tabId: number, tabContext: TabContext): void {
-        if (this.targetPageTabIdToContextMap[tabId] === undefined) {
-            this.targetPageTabIdToContextMap[tabId] = tabContext;
+    public addTabContextIfNotExists(tabId: number, tabContextFactory: TabContextFactory): void {
+        if (!(tabId in this.targetPageTabIdToContextMap)) {
+            this.targetPageTabIdToContextMap[tabId] = tabContextFactory.createTabContext(tabId);
         }
     }
 
     public async deleteTabContext(tabId: number): Promise<void> {
-        const tabContext = this.targetPageTabIdToContextMap[tabId];
-        if (tabContext) {
+        if (tabId in this.targetPageTabIdToContextMap) {
+            const tabContext = this.targetPageTabIdToContextMap[tabId];
             delete this.targetPageTabIdToContextMap[tabId];
-            await tabContext.teardown();
+            await tabContext?.teardown();
         }
     }
 

--- a/src/background/tab-context-manager.ts
+++ b/src/background/tab-context-manager.ts
@@ -33,7 +33,7 @@ export class TabContextManager {
         const tabContext = this.targetPageTabIdToContextMap[tabId];
         if (tabContext) {
             delete this.targetPageTabIdToContextMap[tabId];
-            await tabContext.teardown(); // Make sure this doesn't need to happen in a specific order with removeKnownTab
+            await tabContext.teardown();
         }
     }
 

--- a/src/background/tab-context-manager.ts
+++ b/src/background/tab-context-manager.ts
@@ -1,31 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { Message } from '../common/message';
-import { BrowserMessageBroadcasterFactory } from './browser-message-broadcaster-factory';
-import { ExtensionDetailsViewController } from './extension-details-view-controller';
-import { TabToContextMap } from './tab-context';
-import { TabContextFactory } from './tab-context-factory';
+import { TabContext, TabToContextMap } from './tab-context';
 
 export class TabContextManager {
-    constructor(
-        private readonly targetPageTabIdToContextMap: TabToContextMap,
-        private readonly broadcasterFactory: BrowserMessageBroadcasterFactory,
-        private readonly browserAdapter: BrowserAdapter,
-        private readonly detailsViewController: ExtensionDetailsViewController,
-        private readonly tabContextFactory: TabContextFactory,
-        private persistStoreData = false,
-    ) {}
+    constructor(private readonly targetPageTabIdToContextMap: TabToContextMap) {}
 
-    public addTabContextIfNotExists(tabId: number): void {
+    public addTabContextIfNotExists(tabId: number, tabContext: TabContext): void {
         if (this.targetPageTabIdToContextMap[tabId] === undefined) {
-            this.targetPageTabIdToContextMap[tabId] = this.tabContextFactory.createTabContext(
-                this.broadcasterFactory.createTabSpecificBroadcaster(tabId),
-                this.browserAdapter,
-                this.detailsViewController,
-                tabId,
-                this.persistStoreData,
-            );
+            this.targetPageTabIdToContextMap[tabId] = tabContext;
         }
     }
 

--- a/src/background/tab-context-manager.ts
+++ b/src/background/tab-context-manager.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TabContextStoreHub } from 'background/stores/tab-context-store-hub';
 import { TabContextFactory } from 'background/tab-context-factory';
 import { Message } from '../common/message';
 import { TabToContextMap } from './tab-context';
 
 export class TabContextManager {
-    constructor(private readonly targetPageTabIdToContextMap: TabToContextMap) {}
+    constructor(private readonly targetPageTabIdToContextMap: TabToContextMap = {}) {}
 
     public addTabContextIfNotExists(tabId: number, tabContextFactory: TabContextFactory): void {
         if (!(tabId in this.targetPageTabIdToContextMap)) {
@@ -21,11 +22,18 @@ export class TabContextManager {
         }
     }
 
-    public interpretMessageForTab(tabId: number, message: Message): void {
+    public interpretMessageForTab(tabId: number, message: Message): boolean {
         const tabContext = this.targetPageTabIdToContextMap[tabId];
         if (tabContext) {
             const interpreter = tabContext.interpreter;
-            interpreter.interpret(message);
+
+            return interpreter.interpret(message);
         }
+
+        return false;
+    }
+
+    public getTabContextStores(tabId: number): TabContextStoreHub | undefined {
+        return this.targetPageTabIdToContextMap[tabId]?.stores;
     }
 }

--- a/src/background/tab-context-manager.ts
+++ b/src/background/tab-context-manager.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
+import { Message } from '../common/message';
+import { BrowserMessageBroadcasterFactory } from './browser-message-broadcaster-factory';
+import { ExtensionDetailsViewController } from './extension-details-view-controller';
+import { TabToContextMap } from './tab-context';
+import { TabContextFactory } from './tab-context-factory';
+
+export class TabContextManager {
+    constructor(
+        private readonly targetPageTabIdToContextMap: TabToContextMap,
+        private readonly broadcasterFactory: BrowserMessageBroadcasterFactory,
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly detailsViewController: ExtensionDetailsViewController,
+        private readonly tabContextFactory: TabContextFactory,
+        private persistStoreData = false,
+    ) {}
+
+    public addTabContextIfNotExists(tabId: number): void {
+        if (this.targetPageTabIdToContextMap[tabId] === undefined) {
+            this.targetPageTabIdToContextMap[tabId] = this.tabContextFactory.createTabContext(
+                this.broadcasterFactory.createTabSpecificBroadcaster(tabId),
+                this.browserAdapter,
+                this.detailsViewController,
+                tabId,
+                this.persistStoreData,
+            );
+        }
+    }
+
+    public async deleteTabContext(tabId: number): Promise<void> {
+        const tabContext = this.targetPageTabIdToContextMap[tabId];
+        if (tabContext) {
+            delete this.targetPageTabIdToContextMap[tabId];
+            await tabContext.teardown(); // Make sure this doesn't need to happen in a specific order with removeKnownTab
+        }
+    }
+
+    public interpretMessageForTab(tabId: number, message: Message): void {
+        const tabContext = this.targetPageTabIdToContextMap[tabId];
+        if (tabContext) {
+            const interpreter = tabContext.interpreter;
+            interpreter.interpret(message);
+        }
+    }
+}

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -189,8 +189,8 @@ export class TargetPageController {
 
     private onTargetTabRemoved = (tabId: number): void => {
         this.onTabRemoved(tabId, Messages.Tab.Remove);
-        this.tabContextManager.deleteTabContext(tabId);
         this.removeKnownTabId(tabId);
+        this.tabContextManager.deleteTabContext(tabId);
     };
 
     private onDetailsViewTabRemoved = (tabId: number): void => {

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -8,18 +8,14 @@ import { Message } from 'common/message';
 import { Messages } from 'common/messages';
 import { DictionaryNumberTo } from 'types/common-types';
 import { PageVisibilityChangeTabPayload } from './actions/action-payloads';
-import { BrowserMessageBroadcasterFactory } from './browser-message-broadcaster-factory';
 import { ExtensionDetailsViewController } from './extension-details-view-controller';
-import { TabContext, TabToContextMap } from './tab-context';
-import { TabContextFactory } from './tab-context-factory';
+import { TabContextManager } from './tab-context-manager';
 
 export class TargetPageController {
     constructor(
-        private readonly targetPageTabIdToContextMap: TabToContextMap,
-        private readonly broadcasterFactory: BrowserMessageBroadcasterFactory,
+        private readonly tabContextManager: TabContextManager,
         private readonly browserAdapter: BrowserAdapter,
         private readonly detailsViewController: ExtensionDetailsViewController,
-        private readonly tabContextFactory: TabContextFactory,
         private readonly logger: Logger,
         private readonly knownTabs: DictionaryNumberTo<string>,
         private readonly idbInstance: IndexedDBAPI,
@@ -31,7 +27,7 @@ export class TargetPageController {
             parseInt(knownTab),
         );
 
-        knownTabIds.forEach(tabId => this.addTabContext(tabId));
+        knownTabIds.forEach(tabId => this.tabContextManager.addTabContextIfNotExists(tabId));
 
         const tabs = await this.browserAdapter.tabsQuery({});
 
@@ -86,10 +82,9 @@ export class TargetPageController {
         }
     };
 
-    private removeKnownTabId = async (tabId: number, context: TabContext) => {
+    private removeKnownTabId = async (tabId: number) => {
         if (Object.keys(this.knownTabs).includes(tabId.toString())) {
             delete this.knownTabs[tabId];
-            context.teardown();
             if (this.persistStoreData) {
                 await this.idbInstance.setItem(IndexedDBDataKeys.knownTabIds, this.knownTabs);
             }
@@ -149,41 +144,20 @@ export class TargetPageController {
     };
 
     private handleTabUrlUpdate = async (tabId: number): Promise<void> => {
-        if (!this.hasTabContext(tabId)) {
-            this.addTabContext(tabId);
-        }
-
+        this.tabContextManager.addTabContextIfNotExists(tabId);
         this.sendTabUrlUpdatedAction(tabId);
         await this.addKnownTabId(tabId);
     };
-
-    private hasTabContext(tabId: number): boolean {
-        return tabId in this.targetPageTabIdToContextMap;
-    }
-
-    private addTabContext(tabId: number): void {
-        this.targetPageTabIdToContextMap[tabId] = this.tabContextFactory.createTabContext(
-            this.broadcasterFactory.createTabSpecificBroadcaster(tabId),
-            this.browserAdapter,
-            this.detailsViewController,
-            tabId,
-            this.persistStoreData,
-        );
-    }
 
     private sendTabUrlUpdatedAction(tabId: number): void {
         this.browserAdapter.getTab(
             tabId,
             (tab: chrome.tabs.Tab) => {
-                const tabContext = this.targetPageTabIdToContextMap[tabId];
-                if (tabContext) {
-                    const interpreter = tabContext.interpreter;
-                    interpreter.interpret({
-                        messageType: Messages.Tab.ExistingTabUpdated,
-                        payload: tab,
-                        tabId: tabId,
-                    });
-                }
+                this.tabContextManager.interpretMessageForTab(tabId, {
+                    messageType: Messages.Tab.ExistingTabUpdated,
+                    payload: tab,
+                    tabId: tabId,
+                });
             },
             () => {
                 this.logger.log(
@@ -194,14 +168,6 @@ export class TargetPageController {
     }
 
     private sendTabVisibilityChangeAction(tabId: number, isHidden: boolean): void {
-        if (!this.hasTabContext(tabId)) {
-            return;
-        }
-        const tabContext = this.targetPageTabIdToContextMap[tabId];
-        if (tabContext == null) {
-            return;
-        }
-        const interpreter = tabContext.interpreter;
         const payload: PageVisibilityChangeTabPayload = {
             hidden: isHidden,
         };
@@ -210,26 +176,21 @@ export class TargetPageController {
             payload: payload,
             tabId: tabId,
         };
-        interpreter.interpret(message);
+        this.tabContextManager.interpretMessageForTab(tabId, message);
     }
 
     private onTabRemoved = (tabId: number, messageType: string): void => {
-        const tabContext = this.targetPageTabIdToContextMap[tabId];
-        if (tabContext) {
-            const interpreter = tabContext.interpreter;
-            interpreter.interpret({
-                messageType: messageType,
-                payload: null,
-                tabId: tabId,
-            });
-        }
+        this.tabContextManager.interpretMessageForTab(tabId, {
+            messageType: messageType,
+            payload: null,
+            tabId: tabId,
+        });
     };
 
     private onTargetTabRemoved = (tabId: number): void => {
         this.onTabRemoved(tabId, Messages.Tab.Remove);
-        const context = this.targetPageTabIdToContextMap[tabId];
-        delete this.targetPageTabIdToContextMap[tabId];
-        this.removeKnownTabId(tabId, context);
+        this.tabContextManager.deleteTabContext(tabId);
+        this.removeKnownTabId(tabId);
     };
 
     private onDetailsViewTabRemoved = (tabId: number): void => {

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -29,10 +29,9 @@ export class TargetPageController {
             parseInt(knownTab),
         );
 
-        knownTabIds.forEach(tabId => {
-            const tabContext = this.tabContextFactory.createTabContext(tabId);
-            this.tabContextManager.addTabContextIfNotExists(tabId, tabContext);
-        });
+        knownTabIds.forEach(tabId =>
+            this.tabContextManager.addTabContextIfNotExists(tabId, this.tabContextFactory),
+        );
 
         const tabs = await this.browserAdapter.tabsQuery({});
 
@@ -149,8 +148,7 @@ export class TargetPageController {
     };
 
     private handleTabUrlUpdate = async (tabId: number): Promise<void> => {
-        const tabContext = this.tabContextFactory.createTabContext(tabId);
-        this.tabContextManager.addTabContextIfNotExists(tabId, tabContext);
+        this.tabContextManager.addTabContextIfNotExists(tabId, this.tabContextFactory);
         this.sendTabUrlUpdatedAction(tabId);
         await this.addKnownTabId(tabId);
     };

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -19,22 +19,25 @@ export type SimulatedBrowserAdapter = IMock<BrowserAdapter> & {
     tabs: chrome.tabs.Tab[];
 
     // These are set directly to whichever listener was last registered in the corresponding this.object.addListener* call
-    notifyOnConnect?: (port: chrome.runtime.Port) => void;
-    notifyTabsOnActivated?: (activeInfo: chrome.tabs.TabActiveInfo) => void;
+    notifyOnConnect?: (port: chrome.runtime.Port) => void | Promise<void>;
+    notifyTabsOnActivated?: (activeInfo: chrome.tabs.TabActiveInfo) => void | Promise<void>;
     notifyTabsOnUpdated?: (
         tabId: number,
         changeInfo: chrome.tabs.TabChangeInfo,
         tab: chrome.tabs.Tab,
-    ) => void;
-    notifyTabsOnRemoved?: (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo) => void;
+    ) => void | Promise<void>;
+    notifyTabsOnRemoved?: (
+        tabId: number,
+        removeInfo: chrome.tabs.TabRemoveInfo,
+    ) => void | Promise<void>;
     notifyWebNavigationUpdated?: (
         details: chrome.webNavigation.WebNavigationFramedCallbackDetails,
-    ) => void;
-    notifyWindowsFocusChanged?: (windowId: number) => void;
+    ) => void | Promise<void>;
+    notifyWindowsFocusChanged?: (windowId: number) => void | Promise<void>;
 
     // These simulate real "update"/"activate" events (they update the windows/tabs state and send the notifications)
-    updateTab: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo) => void;
-    activateTab: (tab: chrome.tabs.Tab) => void;
+    updateTab: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo) => void | Promise<void>;
+    activateTab: (tab: chrome.tabs.Tab) => void | Promise<void>;
 
     // This simulates normal browser runtime.onMessage behavior:
     //  - it loops through each listener previously registered with addListenerOnMessage
@@ -81,7 +84,7 @@ export function createSimulatedBrowserAdapter(
     mock.setup(m => m.getAllWindows(It.isAny())).returns(() =>
         Promise.resolve(mock.windows as Windows.Window[]),
     );
-    mock.setup(m => m.getTab(It.isAny(), It.isAny(), It.isAny())).callback(
+    mock.setup(m => m.getTab(It.isAny(), It.isAny(), It.isAny())).returns(
         (tabId, resolve, reject) => {
             const matchingTabs = mock.tabs!.filter(tab => tab.id === tabId);
             if (matchingTabs.length === 1) {

--- a/src/tests/unit/tests/background/dev-tools-listener.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-listener.test.ts
@@ -20,10 +20,6 @@ describe('DevToolsListenerTests', () => {
 
     beforeEach(() => {
         tabContextManagerMock = Mock.ofType<TabContextManager>();
-        // tabIdToContextMap = {
-        //     1: new TabContext(tabId1InterpreterMock.object, null),
-        //     2: new TabContext(tabId2InterpreterMock.object, null),
-        // };
         browserAdapterMock = new DevToolsBrowserAdapterMock();
         testSubject = new DevToolsListener(
             tabContextManagerMock.object,

--- a/src/tests/unit/tests/background/keyboard-shortcut-handler.test.ts
+++ b/src/tests/unit/tests/background/keyboard-shortcut-handler.test.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Interpreter } from 'background/interpreter';
 import { KeyboardShortcutHandler } from 'background/keyboard-shortcut-handler';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
 import { TabContextStoreHub } from 'background/stores/tab-context-store-hub';
 import { VisualizationStore } from 'background/stores/visualization-store';
-import { TabContext, TabToContextMap } from 'background/tab-context';
+import { TabContextManager } from 'background/tab-context-manager';
 import { UsageLogger } from 'background/usage-logger';
 import { BaseStore } from 'common/base-store';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
@@ -28,18 +27,18 @@ import { Tabs } from 'webextension-polyfill';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 
 describe('KeyboardShortcutHandler', () => {
+    const existingTabId = 1;
+
     let testSubject: KeyboardShortcutHandler;
     let browserAdapterMock: IMock<BrowserAdapter>;
     let commandsAdapterMock: IMock<CommandsAdapter>;
     let urlValidatorMock: IMock<UrlValidator>;
-    let tabToContextMap: TabToContextMap;
+    let tabContextManagerMock: IMock<TabContextManager>;
     let visualizationStoreMock: IMock<BaseStore<VisualizationStoreData>>;
-    let interpreterMock: IMock<Interpreter>;
     let loggerMock: IMock<Logger>;
     let usageLoggerMock: IMock<UsageLogger>;
 
     let commandCallback: (commandId: string) => Promise<void>;
-    let existingTabId: number;
     let notificationCreatorMock: IMock<NotificationCreator>;
     let storeState: VisualizationStoreData;
     let simulatedIsFirstTimeUserConfiguration: boolean;
@@ -52,17 +51,16 @@ describe('KeyboardShortcutHandler', () => {
 
     beforeEach(() => {
         visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
-        interpreterMock = Mock.ofType(Interpreter);
 
         visualizationStoreMock = Mock.ofType(VisualizationStore, MockBehavior.Strict);
         visualizationStoreMock.setup(vs => vs.getState()).returns(() => storeState);
 
-        tabToContextMap = {};
-
-        existingTabId = 1;
-        tabToContextMap[existingTabId] = new TabContext(interpreterMock.object, {
-            visualizationStore: visualizationStoreMock.object,
-        } as TabContextStoreHub);
+        tabContextManagerMock = Mock.ofType<TabContextManager>();
+        tabContextManagerMock
+            .setup(t => t.getTabContextStores(existingTabId))
+            .returns(
+                () => ({ visualizationStore: visualizationStoreMock.object } as TabContextStoreHub),
+            );
 
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         browserAdapterMock
@@ -111,7 +109,7 @@ describe('KeyboardShortcutHandler', () => {
         loggerMock = Mock.ofType<Logger>();
         usageLoggerMock = Mock.ofType<UsageLogger>();
         testSubject = new KeyboardShortcutHandler(
-            tabToContextMap,
+            tabContextManagerMock.object,
             browserAdapterMock.object,
             urlValidatorMock.object,
             notificationCreatorMock.object,
@@ -163,9 +161,9 @@ describe('KeyboardShortcutHandler', () => {
                 visualizationConfigurationFactory.getConfiguration(visualizationType);
 
             let receivedMessage: Message;
-            interpreterMock
-                .setup(x => x.interpret(It.isAny()))
-                .returns(message => {
+            tabContextManagerMock
+                .setup(t => t.interpretMessageForTab(existingTabId, It.isAny()))
+                .returns((_tabId, message) => {
                     receivedMessage = message;
                     return true;
                 })
@@ -188,7 +186,7 @@ describe('KeyboardShortcutHandler', () => {
             });
 
             usageLoggerMock.verify(m => m.record(), Times.once());
-            interpreterMock.verifyAll();
+            tabContextManagerMock.verifyAll();
         },
     );
 
@@ -200,9 +198,9 @@ describe('KeyboardShortcutHandler', () => {
                 visualizationConfigurationFactory.getConfiguration(visualizationType);
 
             let receivedMessage: Message;
-            interpreterMock
-                .setup(x => x.interpret(It.isAny()))
-                .returns(message => {
+            tabContextManagerMock
+                .setup(t => t.interpretMessageForTab(existingTabId, It.isAny()))
+                .returns((_tabId, message) => {
                     receivedMessage = message;
                     return true;
                 })
@@ -225,7 +223,7 @@ describe('KeyboardShortcutHandler', () => {
             });
 
             usageLoggerMock.verify(m => m.record(), Times.once());
-            interpreterMock.verifyAll();
+            tabContextManagerMock.verifyAll();
         },
     );
 
@@ -267,35 +265,41 @@ describe('KeyboardShortcutHandler', () => {
     );
 
     it('does not emit toggle messages for unknown command strings', async () => {
-        interpreterMock.setup(x => x.interpret(It.isAny())).verifiable(Times.never());
+        tabContextManagerMock
+            .setup(t => t.interpretMessageForTab(It.isAny(), It.isAny()))
+            .verifiable(Times.never());
 
         await commandCallback('unknown-command');
 
         usageLoggerMock.verify(m => m.record(), Times.once());
-        interpreterMock.verifyAll();
+        tabContextManagerMock.verifyAll();
     });
 
     it('does not emit toggle messages if the first-time dialog has not been dismissed yet', async () => {
         simulatedIsFirstTimeUserConfiguration = true;
 
-        interpreterMock.setup(x => x.interpret(It.isAny())).verifiable(Times.never());
+        tabContextManagerMock
+            .setup(t => t.interpretMessageForTab(It.isAny(), It.isAny()))
+            .verifiable(Times.never());
 
         await commandCallback(getArbitraryValidChromeCommand());
 
         usageLoggerMock.verify(m => m.record(), Times.never());
-        interpreterMock.verifyAll();
+        tabContextManagerMock.verifyAll();
     });
 
     it('does not emit toggle messages when the active/current tab has no known tab context', async () => {
         simulatedActiveTabId = 12;
         expect(simulatedActiveTabId !== existingTabId);
 
-        interpreterMock.setup(x => x.interpret(It.isAny())).verifiable(Times.never());
+        tabContextManagerMock
+            .setup(t => t.interpretMessageForTab(It.isAny(), It.isAny()))
+            .verifiable(Times.never());
 
         await commandCallback(getArbitraryValidChromeCommand());
 
         usageLoggerMock.verify(m => m.record(), Times.once());
-        interpreterMock.verifyAll();
+        tabContextManagerMock.verifyAll();
     });
 
     it('does not emit toggle messages if scanning is in progress already', async () => {
@@ -308,23 +312,27 @@ describe('KeyboardShortcutHandler', () => {
             VisualizationType.Issues,
         );
 
-        interpreterMock.setup(x => x.interpret(It.isAny())).verifiable(Times.never());
+        tabContextManagerMock
+            .setup(t => t.interpretMessageForTab(It.isAny(), It.isAny()))
+            .verifiable(Times.never());
 
         await commandCallback(configuration.chromeCommand);
 
         usageLoggerMock.verify(m => m.record(), Times.once());
-        interpreterMock.verifyAll();
+        tabContextManagerMock.verifyAll();
     });
 
     it("does not emit toggle messages if the active/current tab's URL is not supported", async () => {
         simulatedIsSupportedUrlResponse = false;
 
-        interpreterMock.setup(x => x.interpret(It.isAny())).verifiable(Times.never());
+        tabContextManagerMock
+            .setup(t => t.interpretMessageForTab(It.isAny(), It.isAny()))
+            .verifiable(Times.never());
 
         await commandCallback(getArbitraryValidChromeCommand());
 
         usageLoggerMock.verify(m => m.record(), Times.once());
-        interpreterMock.verifyAll();
+        tabContextManagerMock.verifyAll();
     });
 
     it.each`

--- a/src/tests/unit/tests/background/tab-context-manager.test.ts
+++ b/src/tests/unit/tests/background/tab-context-manager.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Interpreter } from 'background/interpreter';
+import { TabContextStoreHub } from 'background/stores/tab-context-store-hub';
 import { TabContext } from 'background/tab-context';
 import { TabContextFactory } from 'background/tab-context-factory';
 import { TabContextManager } from 'background/tab-context-manager';
@@ -15,6 +16,7 @@ describe(TabContextManager, () => {
     let tabContextFactoryMock: IMock<TabContextFactory>;
     let tabContextMock: IMock<TabContext>;
     let interpreterMock: IMock<Interpreter>;
+    let tabContextStoresMock: IMock<TabContextStoreHub>;
 
     let testSubject: TabContextManager;
 
@@ -24,6 +26,7 @@ describe(TabContextManager, () => {
         tabToContextMap = {};
         tabContextMock = Mock.ofType<TabContext>();
         interpreterMock = Mock.ofType<Interpreter>();
+        tabContextStoresMock = Mock.ofType<TabContextStoreHub>();
 
         testSubject = new TabContextManager(tabToContextMap);
     });
@@ -34,70 +37,102 @@ describe(TabContextManager, () => {
         interpreterMock.verifyAll();
     });
 
-    it('Adds new tab context to map', () => {
-        tabContextFactoryMock
-            .setup(t => t.createTabContext(tabId))
-            .returns(() => tabContextMock.object);
+    describe('addTabContextIfNotExists', () => {
+        it('Adds new tab context to map', () => {
+            tabContextFactoryMock
+                .setup(t => t.createTabContext(tabId))
+                .returns(() => tabContextMock.object);
 
-        testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
+            testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
 
-        expect(tabToContextMap[tabId]).toBe(tabContextMock.object);
+            expect(tabToContextMap[tabId]).toBe(tabContextMock.object);
+        });
+
+        it('Does not recreate tab context if already exists', () => {
+            tabToContextMap[tabId] = tabContextMock.object;
+
+            tabContextFactoryMock.setup(t => t.createTabContext(tabId)).verifiable(Times.never());
+
+            testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
+
+            expect(tabToContextMap[tabId]).toBe(tabContextMock.object);
+        });
+
+        it('Does not overwrite tab context if tab context is undefined', () => {
+            tabToContextMap[tabId] = undefined;
+
+            tabContextFactoryMock.setup(t => t.createTabContext(tabId)).verifiable(Times.never());
+
+            testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
+
+            expect(tabToContextMap[tabId]).toBeUndefined();
+        });
     });
 
-    it('Does not recreate tab context if already exists', () => {
-        tabToContextMap[tabId] = tabContextMock.object;
+    describe('deleteTabContext', () => {
+        it('Deletes tab context and calls teardown', async () => {
+            tabContextMock.setup(t => t.teardown()).verifiable();
 
-        tabContextFactoryMock.setup(t => t.createTabContext(tabId)).verifiable(Times.never());
+            tabToContextMap[tabId] = tabContextMock.object;
 
-        testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
+            await testSubject.deleteTabContext(tabId);
 
-        expect(tabToContextMap[tabId]).toBe(tabContextMock.object);
+            expect(Object.keys(tabToContextMap)).not.toContain(tabId);
+        });
+
+        it('Deletes undefined tab context', async () => {
+            tabToContextMap[tabId] = undefined;
+
+            await testSubject.deleteTabContext(tabId);
+
+            expect(Object.keys(tabToContextMap)).not.toContain(tabId);
+        });
+
+        it('Handles tab id with no context', async () => {
+            await testSubject.deleteTabContext(tabId + 10);
+        });
     });
 
-    it('Does not overwrite tab context if tab context is undefined', () => {
-        tabToContextMap[tabId] = undefined;
+    describe('interpretMessageForTab', () => {
+        it.each([true, false])(
+            'Interpret message with TabContext interpreter and return result=%s',
+            expectedReturnValue => {
+                const message: Message = { messageType: 'test message' };
+                tabToContextMap[tabId] = tabContextMock.object;
 
-        tabContextFactoryMock.setup(t => t.createTabContext(tabId)).verifiable(Times.never());
+                tabContextMock.setup(t => t.interpreter).returns(() => interpreterMock.object);
+                interpreterMock.setup(i => i.interpret(message)).returns(() => expectedReturnValue);
 
-        testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
+                const actualReturnValue = testSubject.interpretMessageForTab(tabId, message);
 
-        expect(tabToContextMap[tabId]).toBeUndefined();
+                expect(actualReturnValue).toEqual(expectedReturnValue);
+            },
+        );
+
+        it('Handles interpretMessageForTab on tab id without context', () => {
+            const message: Message = { messageType: 'test message' };
+
+            const interpreted = testSubject.interpretMessageForTab(tabId, message);
+
+            expect(interpreted).toBeFalsy();
+        });
     });
 
-    it('Deletes tab context and calls teardown', async () => {
-        tabContextMock.setup(t => t.teardown()).verifiable();
+    describe('getTabContextStores', () => {
+        it('Returns storeHub of tab in map', () => {
+            tabToContextMap[tabId] = tabContextMock.object;
 
-        tabToContextMap[tabId] = tabContextMock.object;
+            tabContextMock.setup(t => t.stores).returns(() => tabContextStoresMock.object);
 
-        await testSubject.deleteTabContext(tabId);
+            const stores = testSubject.getTabContextStores(tabId);
 
-        expect(Object.keys(tabToContextMap)).not.toContain(tabId);
-    });
+            expect(stores).toBe(tabContextStoresMock.object);
+        });
 
-    it('Deletes undefined tab context', async () => {
-        tabToContextMap[tabId] = undefined;
+        it('Returns undefined if tab is not in map', () => {
+            const stores = testSubject.getTabContextStores(tabId);
 
-        await testSubject.deleteTabContext(tabId);
-
-        expect(Object.keys(tabToContextMap)).not.toContain(tabId);
-    });
-
-    it('Handles deleteTabContext on tab id with no context', async () => {
-        await testSubject.deleteTabContext(tabId + 10);
-    });
-
-    it('Interpret message with TabContext interpreter', () => {
-        const message: Message = { messageType: 'test message' };
-        tabToContextMap[tabId] = tabContextMock.object;
-
-        tabContextMock.setup(t => t.interpreter).returns(() => interpreterMock.object);
-        interpreterMock.setup(i => i.interpret(message)).verifiable();
-
-        testSubject.interpretMessageForTab(tabId, message);
-    });
-
-    it('Handles interpretMessageForTab on tab id without context', () => {
-        const message: Message = { messageType: 'test message' };
-        testSubject.interpretMessageForTab(tabId, message);
+            expect(stores).toBeUndefined();
+        });
     });
 });

--- a/src/tests/unit/tests/background/tab-context-manager.test.ts
+++ b/src/tests/unit/tests/background/tab-context-manager.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    BrowserMessageBroadcasterFactory,
+    MessageBroadcaster,
+} from 'background/browser-message-broadcaster-factory';
+import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
+import { Interpreter } from 'background/interpreter';
+import { TabContext } from 'background/tab-context';
+import { TabContextFactory } from 'background/tab-context-factory';
+import { TabContextManager } from 'background/tab-context-manager';
+import { Message } from 'common/message';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { DictionaryNumberTo } from 'types/common-types';
+import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
+
+describe(TabContextManager, () => {
+    const tabId = 4;
+    const persistStoreData = false;
+
+    let mockBroadcasterFactoryMock: IMock<BrowserMessageBroadcasterFactory>;
+    let mockTabContextFactory: IMock<TabContextFactory>;
+    let mockBrowserAdapter: IMock<BrowserAdapter>;
+    let mockDetailsViewController: IMock<ExtensionDetailsViewController>;
+    let tabToContextMap: DictionaryNumberTo<TabContext>;
+    let tabContextMock: IMock<TabContext>;
+    let interpreterMock: IMock<Interpreter>;
+
+    let testSubject: TabContextManager;
+
+    beforeEach(() => {
+        mockBroadcasterFactoryMock = Mock.ofType<BrowserMessageBroadcasterFactory>();
+        mockBrowserAdapter = Mock.ofType<BrowserAdapter>();
+        mockDetailsViewController = Mock.ofType<ExtensionDetailsViewController>();
+        tabToContextMap = {};
+        mockTabContextFactory = Mock.ofType<TabContextFactory>();
+        tabContextMock = Mock.ofType<TabContext>();
+        interpreterMock = Mock.ofType<Interpreter>();
+
+        testSubject = new TabContextManager(
+            tabToContextMap,
+            mockBroadcasterFactoryMock.object,
+            mockBrowserAdapter.object,
+            mockDetailsViewController.object,
+            mockTabContextFactory.object,
+            persistStoreData,
+        );
+    });
+
+    afterEach(() => {
+        mockBroadcasterFactoryMock.verifyAll();
+        mockTabContextFactory.verifyAll();
+        tabContextMock.verifyAll();
+        interpreterMock.verifyAll();
+    });
+
+    it('Creates new tab context', () => {
+        const broadcasterMock = Mock.ofType<MessageBroadcaster>();
+        mockBroadcasterFactoryMock
+            .setup(m => m.createTabSpecificBroadcaster(tabId))
+            .returns(() => broadcasterMock.object)
+            .verifiable();
+        mockTabContextFactory
+            .setup(m =>
+                m.createTabContext(
+                    broadcasterMock.object,
+                    mockBrowserAdapter.object,
+                    mockDetailsViewController.object,
+                    tabId,
+                    persistStoreData,
+                ),
+            )
+            .returns(() => tabContextMock.object)
+            .verifiable();
+
+        testSubject.addTabContextIfNotExists(tabId);
+
+        expect(tabToContextMap[tabId]).toBe(tabContextMock.object);
+    });
+
+    it('Does not recreate tab context if already exists', () => {
+        tabToContextMap[tabId] = tabContextMock.object;
+
+        mockTabContextFactory
+            .setup(m =>
+                m.createTabContext(It.isAny(), It.isAny(), It.isAny(), It.isAny(), It.isAny()),
+            )
+            .verifiable(Times.never());
+
+        testSubject.addTabContextIfNotExists(tabId);
+    });
+
+    it('Deletes tab context and calls teardown', async () => {
+        tabContextMock.setup(t => t.teardown()).verifiable();
+
+        tabToContextMap[tabId] = tabContextMock.object;
+
+        await testSubject.deleteTabContext(tabId);
+
+        expect(tabToContextMap[tabId]).toBeUndefined();
+    });
+
+    it('Handles deleteTabContext on tab id with no context', async () => {
+        await testSubject.deleteTabContext(tabId + 10);
+    });
+
+    it('Interpret message with TabContext interpreter', () => {
+        const message: Message = { messageType: 'test message' };
+        tabToContextMap[tabId] = tabContextMock.object;
+
+        tabContextMock.setup(t => t.interpreter).returns(() => interpreterMock.object);
+        interpreterMock.setup(i => i.interpret(message)).verifiable();
+
+        testSubject.interpretMessageForTab(tabId, message);
+    });
+
+    it('Handles interpretMessageForTab on tab id without context', () => {
+        const message: Message = { messageType: 'test message' };
+        testSubject.interpretMessageForTab(tabId, message);
+    });
+});

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
-import { TabContext } from 'background/tab-context';
 import { TabContextFactory } from 'background/tab-context-factory';
 import { TabContextManager } from 'background/tab-context-manager';
 import { TargetPageController } from 'background/target-page-controller';
@@ -504,19 +503,14 @@ describe('TargetPageController', () => {
 
     function setupTryCreateTabContexts(tabIds: number[]) {
         tabIds.forEach(tabId => {
-            const tabContextMock = Mock.ofType<TabContext>();
-            mockTabContextFactory
-                .setup(m => m.createTabContext(tabId))
-                .returns(() => tabContextMock.object);
             mockTabContextManager
-                .setup(m => m.addTabContextIfNotExists(tabId, tabContextMock.object))
+                .setup(m => m.addTabContextIfNotExists(tabId, mockTabContextFactory.object))
                 .verifiable(Times.atLeastOnce());
         });
     }
 
     function setupNeverCreateTabContexts(tabIds: number[]) {
         tabIds.forEach(tabId => {
-            mockTabContextFactory.setup(m => m.createTabContext(tabId)).verifiable(Times.never());
             mockTabContextManager
                 .setup(m => m.addTabContextIfNotExists(tabId, It.isAny()))
                 .verifiable(Times.never());


### PR DESCRIPTION
#### Details

Moves tabIdToContextMap out of TargetPageController and into a new TabContextManager object

##### Motivation

This is part of a larger refactor of TargetPageController and ExtensionDetailsViewController, with the goal of simplifying the tangled dependency between them and removing duplicate tab event listeners that are registered in both.

##### Context

Currently, TargetPageController depends on ExtensionDetailsViewController for the sole purpose of passing ExtensionDetailsViewController a callback function, onDetailsViewTabRemoved. This function is only called from and used by ExtensionDetailsViewController, so it's strange for it to live in TargetPageController as a private method. It's there because it needs access to the TabContext to send a message the target page, and tabIdToContextMap lives in TargetPageController. Its only function is to use that TabContext's interpreter to interpret a message.

This PR moves tabIdToContextMap into another object, TabContextManager, which wraps the current uses of tabIdToContextMap. Currently, TargetPageController has sole access to and responsibility of TabContextManager, but a future PR will add it to ExtensionDetailsViewController so they don't need to depend on each other and pass callbacks back and forth.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
