### PR TITLE
feat(mv3-part-3): Refactor ExtensionDetailsViewController and TargetPageController

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -196,7 +196,7 @@ async function initialize(): Promise<void> {
         browserAdapter,
         {},
         indexedDBInstance,
-        tabContextManager,
+        tabContextManager.interpretMessageForTab,
     );
 
     const tabContextFactory = new TabContextFactory(

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -146,11 +146,6 @@ async function initialize(): Promise<void> {
     telemetryStateListener.initialize();
 
     const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter, logger);
-    const detailsViewController = new ExtensionDetailsViewController(
-        browserAdapter,
-        {},
-        indexedDBInstance,
-    );
 
     const tabContextManager = new TabContextManager();
 
@@ -197,6 +192,13 @@ async function initialize(): Promise<void> {
 
     const promiseFactory = createDefaultPromiseFactory();
 
+    const detailsViewController = new ExtensionDetailsViewController(
+        browserAdapter,
+        {},
+        indexedDBInstance,
+        tabContextManager,
+    );
+
     const tabContextFactory = new TabContextFactory(
         visualizationConfigurationFactory,
         telemetryEventHandler,
@@ -218,7 +220,6 @@ async function initialize(): Promise<void> {
         tabContextManager,
         tabContextFactory,
         browserAdapter,
-        detailsViewController,
         logger,
         {},
         indexedDBInstance,

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 export type DetailsViewController = {
-    setupDetailsViewTabRemovedHandler(handler: (tabId: number) => void): void;
     showDetailsView(targetTabId: number): Promise<void>;
 };

--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 import { DetailsViewController } from 'background/details-view-controller';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
-import { TabContextManager } from 'background/tab-context-manager';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Message } from 'common/message';
 import { Messages } from 'common/messages';
 import { DictionaryStringTo } from 'types/common-types';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
@@ -13,7 +13,7 @@ export class ExtensionDetailsViewController implements DetailsViewController {
         private readonly browserAdapter: BrowserAdapter,
         private readonly tabIdToDetailsViewMap: DictionaryStringTo<number>,
         private readonly idbInstance: IndexedDBAPI,
-        private readonly tabContextManager: TabContextManager,
+        private readonly interpretMessageForTab: (tabId: number, message: Message) => void,
         private persistStoreData = false,
     ) {
         this.browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
@@ -114,7 +114,7 @@ export class ExtensionDetailsViewController implements DetailsViewController {
     };
 
     private onDetailsViewTabRemoved(targetTabId: number): void {
-        this.tabContextManager.interpretMessageForTab(targetTabId, {
+        this.interpretMessageForTab(targetTabId, {
             messageType: Messages.Visualizations.DetailsView.Close,
             payload: null,
             tabId: targetTabId,

--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -2,17 +2,18 @@
 // Licensed under the MIT License.
 import { DetailsViewController } from 'background/details-view-controller';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { TabContextManager } from 'background/tab-context-manager';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Messages } from 'common/messages';
 import { DictionaryStringTo } from 'types/common-types';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 
 export class ExtensionDetailsViewController implements DetailsViewController {
-    private detailsViewRemovedHandler: (tabId: number) => void;
-
     constructor(
         private readonly browserAdapter: BrowserAdapter,
         private readonly tabIdToDetailsViewMap: DictionaryStringTo<number>,
         private readonly idbInstance: IndexedDBAPI,
+        private readonly tabContextManager: TabContextManager,
         private persistStoreData = false,
     ) {
         this.browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
@@ -27,10 +28,6 @@ export class ExtensionDetailsViewController implements DetailsViewController {
             );
         }
     };
-
-    public setupDetailsViewTabRemovedHandler(handler: (tabId: number) => void): void {
-        this.detailsViewRemovedHandler = handler;
-    }
 
     public async showDetailsView(targetTabId: number): Promise<void> {
         const detailsViewTabId = this.tabIdToDetailsViewMap[targetTabId];
@@ -63,9 +60,7 @@ export class ExtensionDetailsViewController implements DetailsViewController {
 
         if (this.hasUrlChange(changeInfo, targetTabId)) {
             delete this.tabIdToDetailsViewMap[targetTabId];
-            if (this.detailsViewRemovedHandler != null) {
-                this.detailsViewRemovedHandler(targetTabId);
-            }
+            this.onDetailsViewTabRemoved(targetTabId);
             await this.persistTabIdToDetailsViewMap();
         }
     };
@@ -111,12 +106,18 @@ export class ExtensionDetailsViewController implements DetailsViewController {
             const targetTabId = this.getTargetTabIdForDetailsTabId(tabId);
             if (targetTabId) {
                 delete this.tabIdToDetailsViewMap[targetTabId];
-                if (this.detailsViewRemovedHandler != null) {
-                    this.detailsViewRemovedHandler(targetTabId);
-                }
+                this.onDetailsViewTabRemoved(targetTabId);
             }
         }
 
         await this.persistTabIdToDetailsViewMap();
     };
+
+    private onDetailsViewTabRemoved(targetTabId: number): void {
+        this.tabContextManager.interpretMessageForTab(targetTabId, {
+            messageType: Messages.Visualizations.DetailsView.Close,
+            payload: null,
+            tabId: targetTabId,
+        });
+    }
 }

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -178,7 +178,7 @@ async function initialize(): Promise<void> {
         browserAdapter,
         persistedData.tabIdToDetailsViewMap ?? {},
         indexedDBInstance,
-        tabContextManager,
+        tabContextManager.interpretMessageForTab,
         true,
     );
 

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -130,13 +130,6 @@ async function initialize(): Promise<void> {
     );
     telemetryStateListener.initialize();
 
-    const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter, logger);
-    const detailsViewController = new ExtensionDetailsViewController(
-        browserAdapter,
-        persistedData.tabIdToDetailsViewMap ?? {},
-        indexedDBInstance,
-        true,
-    );
     const tabContextManager = new TabContextManager();
 
     const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
@@ -181,6 +174,15 @@ async function initialize(): Promise<void> {
     );
     const promiseFactory = createDefaultPromiseFactory();
 
+    const detailsViewController = new ExtensionDetailsViewController(
+        browserAdapter,
+        persistedData.tabIdToDetailsViewMap ?? {},
+        indexedDBInstance,
+        tabContextManager,
+        true,
+    );
+
+    const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter, logger);
     const tabContextFactory = new TabContextFactory(
         visualizationConfigurationFactory,
         telemetryEventHandler,
@@ -202,7 +204,6 @@ async function initialize(): Promise<void> {
         tabContextManager,
         tabContextFactory,
         browserAdapter,
-        detailsViewController,
         logger,
         persistedData.knownTabIds ?? {},
         indexedDBInstance,

--- a/src/background/tab-context-manager.ts
+++ b/src/background/tab-context-manager.ts
@@ -22,7 +22,7 @@ export class TabContextManager {
         }
     }
 
-    public interpretMessageForTab(tabId: number, message: Message): boolean {
+    public readonly interpretMessageForTab = (tabId: number, message: Message): boolean => {
         const tabContext = this.targetPageTabIdToContextMap[tabId];
         if (tabContext) {
             const interpreter = tabContext.interpreter;
@@ -31,7 +31,7 @@ export class TabContextManager {
         }
 
         return false;
-    }
+    };
 
     public getTabContextStores(tabId: number): TabContextStoreHub | undefined {
         return this.targetPageTabIdToContextMap[tabId]?.stores;

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { TabContextFactory } from 'background/tab-context-factory';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
@@ -17,7 +16,6 @@ export class TargetPageController {
         private readonly tabContextManager: TabContextManager,
         private readonly tabContextFactory: TabContextFactory,
         private readonly browserAdapter: BrowserAdapter,
-        private readonly detailsViewController: ExtensionDetailsViewController,
         private readonly logger: Logger,
         private readonly knownTabs: DictionaryNumberTo<string>,
         private readonly idbInstance: IndexedDBAPI,
@@ -62,8 +60,6 @@ export class TargetPageController {
         this.browserAdapter.addListenerOnWindowsFocusChanged(this.onWindowFocusChanged);
         this.browserAdapter.addListenerToTabsOnActivated(this.onTabActivated);
         this.browserAdapter.addListenerToTabsOnUpdated(this.onTabUpdated);
-
-        this.detailsViewController.setupDetailsViewTabRemovedHandler(this.onDetailsViewTabRemoved);
     }
 
     private getUrl = async (tabId: number): Promise<string> => {
@@ -183,21 +179,13 @@ export class TargetPageController {
         this.tabContextManager.interpretMessageForTab(tabId, message);
     }
 
-    private onTabRemoved = (tabId: number, messageType: string): void => {
+    private onTargetTabRemoved = (tabId: number): void => {
         this.tabContextManager.interpretMessageForTab(tabId, {
-            messageType: messageType,
+            messageType: Messages.Tab.Remove,
             payload: null,
             tabId: tabId,
         });
-    };
-
-    private onTargetTabRemoved = (tabId: number): void => {
-        this.onTabRemoved(tabId, Messages.Tab.Remove);
         this.removeKnownTabId(tabId);
         this.tabContextManager.deleteTabContext(tabId);
-    };
-
-    private onDetailsViewTabRemoved = (tabId: number): void => {
-        this.onTabRemoved(tabId, Messages.Visualizations.DetailsView.Close);
     };
 }

--- a/src/electron/adapters/null-details-view-controller.ts
+++ b/src/electron/adapters/null-details-view-controller.ts
@@ -3,8 +3,6 @@
 import { DetailsViewController } from 'background/details-view-controller';
 
 export class NullDetailsViewController implements DetailsViewController {
-    public setupDetailsViewTabRemovedHandler(handler: (tabId: number) => void): void {}
-
     public showDetailsView(targetTabId: number): Promise<void> {
         return Promise.resolve();
     }


### PR DESCRIPTION
#### Details

A continuation of the refactor started in #5436. This PR removes the callback that TargetPageController passes to ExtensionDetailsViewController and performs the functionality of the callback function itself.

##### Motivation

Cleans up the tangled dependency between TargetPageController and ExtensionDetailsViewController.

##### Context

See #5436

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
