### PR TITLE
feat(mv3-part-3): Persist mv2 store and controller data

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { PostMessageContentRepository } from 'background/post-message-content-repository';
 import { TabContextManager } from 'background/tab-context-manager';
@@ -27,9 +28,8 @@ import { IssueFilingServiceProviderImpl } from '../issue-filing/issue-filing-ser
 import { BrowserMessageBroadcasterFactory } from './browser-message-broadcaster-factory';
 import { DevToolsListener } from './dev-tools-listener';
 import { ExtensionDetailsViewController } from './extension-details-view-controller';
-import { getGlobalPersistedData } from './get-persisted-data';
+import { getAllPersistedData, getGlobalPersistedData } from './get-persisted-data';
 import { GlobalContextFactory } from './global-context-factory';
-import { IndexedDBDataKeys } from './IndexedDBDataKeys';
 import { KeyboardShortcutHandler } from './keyboard-shortcut-handler';
 import { deprecatedStorageDataKeys, storageDataKeys } from './local-storage-data-keys';
 import { MessageDistributor } from './message-distributor';
@@ -49,6 +49,8 @@ import { cleanKeysFromStorage } from './user-stored-data-cleaner';
 declare let window: Window & InsightsWindowExtensions;
 
 async function initialize(): Promise<void> {
+    const persistData = true;
+
     const userAgentParser = new UAParser(window.navigator.userAgent);
     const browserAdapterFactory = new BrowserAdapterFactory(userAgentParser);
     const browserAdapter = browserAdapterFactory.makeFromUserAgent();
@@ -69,10 +71,12 @@ async function initialize(): Promise<void> {
     ];
 
     // These can run concurrently, both because they are read-only and because they use different types of underlying storage
-    const persistedDataPromise = getGlobalPersistedData(
-        indexedDBInstance,
-        indexedDBDataKeysToFetch,
-    );
+    let persistedDataPromise;
+    if (persistData) {
+        persistedDataPromise = getAllPersistedData(indexedDBInstance);
+    } else {
+        persistedDataPromise = getGlobalPersistedData(indexedDBInstance, indexedDBDataKeysToFetch);
+    }
     const userDataPromise = browserAdapter.getUserData(storageDataKeys);
     const persistedData = await persistedDataPromise;
     const userData = await userDataPromise;
@@ -135,7 +139,7 @@ async function initialize(): Promise<void> {
         browserAdapter,
         browserAdapter,
         logger,
-        false,
+        persistData,
     );
     telemetryLogger.initialize(globalContext.featureFlagsController);
 
@@ -194,9 +198,10 @@ async function initialize(): Promise<void> {
 
     const detailsViewController = new ExtensionDetailsViewController(
         browserAdapter,
-        {},
+        persistedData.tabIdToDetailsViewMap ?? {},
         indexedDBInstance,
         tabContextManager.interpretMessageForTab,
+        persistData,
     );
 
     const tabContextFactory = new TabContextFactory(
@@ -213,7 +218,7 @@ async function initialize(): Promise<void> {
         windowUtils.setTimeout,
         persistedData,
         indexedDBInstance,
-        false,
+        persistData,
     );
 
     const targetPageController = new TargetPageController(
@@ -221,8 +226,9 @@ async function initialize(): Promise<void> {
         tabContextFactory,
         browserAdapter,
         logger,
-        {},
+        persistedData.knownTabIds ?? {},
         indexedDBInstance,
+        persistData,
     );
 
     await targetPageController.initialize();

--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -14,7 +14,7 @@ export class ExtensionDetailsViewController implements DetailsViewController {
         private readonly tabIdToDetailsViewMap: DictionaryStringTo<number>,
         private readonly idbInstance: IndexedDBAPI,
         private readonly interpretMessageForTab: (tabId: number, message: Message) => void,
-        private persistStoreData = false,
+        private persistStoreData: boolean,
     ) {
         this.browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
         this.browserAdapter.addListenerToTabsOnUpdated(this.onUpdateTab);

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -19,7 +19,7 @@ export class TargetPageController {
         private readonly logger: Logger,
         private readonly knownTabs: DictionaryNumberTo<string>,
         private readonly idbInstance: IndexedDBAPI,
-        private persistStoreData = false,
+        private persistStoreData: boolean,
     ) {}
 
     public async initialize(): Promise<void> {


### PR DESCRIPTION
#### Details

This PR turns on data persistence in the stores and controllers for the manifest version 2 extension. This behavior is already turned on in the manifest v3 extension. 

##### Motivation

Feature work.

##### Context

In previous PRs we turned data persistence off to ensure that we wouldn't have backwards compat issues/ unnecessary logic in the latest release. Now that the release is finished, we want to turn persistence back on in canary to keep as close to parity as possible between mv2 and mv3 extensions. 

Note that this PR adds a persistData boolean to background-init that controls if this behavior is on or not. For future releases we will likely want to turn this behavior off again by setting persistData to false to avoid future backwards compat issues. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
