### PR TITLE
feat(mv3-part-3): TabEventDistributor

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -4,6 +4,7 @@ import { Assessments } from 'assessments/assessments';
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { PostMessageContentRepository } from 'background/post-message-content-repository';
 import { TabContextManager } from 'background/tab-context-manager';
+import { TabEventDistributor } from 'background/tab-event-distributor';
 import { ConsoleTelemetryClient } from 'background/telemetry/console-telemetry-client';
 import { DebugToolsTelemetryClient } from 'background/telemetry/debug-tools-telemetry-client';
 import { createToolData } from 'common/application-properties-provider';
@@ -226,6 +227,13 @@ async function initialize(): Promise<void> {
     );
 
     await targetPageController.initialize();
+
+    const tabEventDistributor = new TabEventDistributor(
+        browserAdapter,
+        targetPageController,
+        detailsViewController,
+    );
+    tabEventDistributor.initialize();
 
     const devToolsBackgroundListener = new DevToolsListener(tabContextManager, browserAdapter);
     devToolsBackgroundListener.initialize();

--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -15,9 +15,34 @@ export class ExtensionDetailsViewController implements DetailsViewController {
         private readonly idbInstance: IndexedDBAPI,
         private readonly interpretMessageForTab: (tabId: number, message: Message) => void,
         private persistStoreData = false,
-    ) {
-        // this.browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
-        // this.browserAdapter.addListenerToTabsOnUpdated(this.onUpdateTab);
+    ) {}
+
+    public async onUpdateTab(tabId: number, changeInfo: chrome.tabs.TabChangeInfo): Promise<void> {
+        const targetTabId = this.getTargetTabIdForDetailsTabId(tabId);
+
+        if (targetTabId == null) {
+            return;
+        }
+
+        if (this.hasUrlChange(changeInfo, targetTabId)) {
+            delete this.tabIdToDetailsViewMap[targetTabId];
+            this.onDetailsViewTabRemoved(targetTabId);
+            await this.persistTabIdToDetailsViewMap();
+        }
+    }
+
+    public async onRemoveTab(tabId: number): Promise<void> {
+        if (this.tabIdToDetailsViewMap[tabId]) {
+            delete this.tabIdToDetailsViewMap[tabId];
+        } else {
+            const targetTabId = this.getTargetTabIdForDetailsTabId(tabId);
+            if (targetTabId) {
+                delete this.tabIdToDetailsViewMap[targetTabId];
+                this.onDetailsViewTabRemoved(targetTabId);
+            }
+        }
+
+        await this.persistTabIdToDetailsViewMap();
     }
 
     private persistTabIdToDetailsViewMap = async () => {
@@ -46,24 +71,6 @@ export class ExtensionDetailsViewController implements DetailsViewController {
             await this.persistTabIdToDetailsViewMap();
         }
     }
-
-    private onUpdateTab = async (
-        tabId: number,
-        changeInfo: chrome.tabs.TabChangeInfo,
-        tab: chrome.tabs.Tab,
-    ): Promise<void> => {
-        const targetTabId = this.getTargetTabIdForDetailsTabId(tabId);
-
-        if (targetTabId == null) {
-            return;
-        }
-
-        if (this.hasUrlChange(changeInfo, targetTabId)) {
-            delete this.tabIdToDetailsViewMap[targetTabId];
-            this.onDetailsViewTabRemoved(targetTabId);
-            await this.persistTabIdToDetailsViewMap();
-        }
-    };
 
     private hasUrlChange(changeInfo: chrome.tabs.TabChangeInfo, targetTabId): boolean {
         if (changeInfo.url == null) {
@@ -95,23 +102,6 @@ export class ExtensionDetailsViewController implements DetailsViewController {
         }
         return null;
     }
-
-    private onRemoveTab = async (
-        tabId: number,
-        removeInfo: chrome.tabs.TabRemoveInfo,
-    ): Promise<void> => {
-        if (this.tabIdToDetailsViewMap[tabId]) {
-            delete this.tabIdToDetailsViewMap[tabId];
-        } else {
-            const targetTabId = this.getTargetTabIdForDetailsTabId(tabId);
-            if (targetTabId) {
-                delete this.tabIdToDetailsViewMap[targetTabId];
-                this.onDetailsViewTabRemoved(targetTabId);
-            }
-        }
-
-        await this.persistTabIdToDetailsViewMap();
-    };
 
     private onDetailsViewTabRemoved(targetTabId: number): void {
         this.interpretMessageForTab(targetTabId, {

--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -16,8 +16,8 @@ export class ExtensionDetailsViewController implements DetailsViewController {
         private readonly interpretMessageForTab: (tabId: number, message: Message) => void,
         private persistStoreData = false,
     ) {
-        this.browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
-        this.browserAdapter.addListenerToTabsOnUpdated(this.onUpdateTab);
+        // this.browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
+        // this.browserAdapter.addListenerToTabsOnUpdated(this.onUpdateTab);
     }
 
     private persistTabIdToDetailsViewMap = async () => {

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -12,6 +12,7 @@ import { PostMessageContentHandler } from 'background/post-message-content-handl
 import { PostMessageContentRepository } from 'background/post-message-content-repository';
 import { TabContextFactory } from 'background/tab-context-factory';
 import { TabContextManager } from 'background/tab-context-manager';
+import { TabEventDistributor } from 'background/tab-event-distributor';
 import { TargetPageController } from 'background/target-page-controller';
 import { TargetTabController } from 'background/target-tab-controller';
 import { ConsoleTelemetryClient } from 'background/telemetry/console-telemetry-client';
@@ -209,8 +210,14 @@ async function initialize(): Promise<void> {
         indexedDBInstance,
         true,
     );
-
     await targetPageController.initialize();
+
+    const tabEventDistributor = new TabEventDistributor(
+        browserAdapter,
+        targetPageController,
+        detailsViewController,
+    );
+    tabEventDistributor.initialize();
 
     const devToolsBackgroundListener = new DevToolsListener(tabContextManager, browserAdapter);
     devToolsBackgroundListener.initialize();

--- a/src/background/tab-event-distributor.ts
+++ b/src/background/tab-event-distributor.ts
@@ -27,28 +27,28 @@ export class TabEventDistributor {
     private onTabNavigated = async (
         details: chrome.webNavigation.WebNavigationFramedCallbackDetails,
     ): Promise<void> => {
-        //TODO: implement
+        await this.targetPageController.onTabNavigated(details);
     };
 
     private onTabRemoved = async (
         tabId: number,
         removeInfo: chrome.tabs.TabRemoveInfo,
     ): Promise<void> => {
-        //TODO: implement
+        this.targetPageController.onTargetTabRemoved(tabId);
     };
 
     private onWindowFocusChanged = async (windowId: number): Promise<void> => {
-        //TODO: implement
+        await this.targetPageController.onWindowFocusChanged();
     };
 
     private onTabActivated = async (activeInfo: chrome.tabs.TabActiveInfo): Promise<void> => {
-        //TODO: implement
+        await this.targetPageController.onTabActivated(activeInfo);
     };
 
     private onTabUpdated = async (
         tabId: number,
         changeInfo: chrome.tabs.TabChangeInfo,
     ): Promise<void> => {
-        //TODO: implement
+        await this.targetPageController.onTabUpdated(tabId, changeInfo);
     };
 }

--- a/src/background/tab-event-distributor.ts
+++ b/src/background/tab-event-distributor.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
+import { TargetPageController } from 'background/target-page-controller';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+
+export class TabEventDistributor {
+    constructor(
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly targetPageController: TargetPageController,
+        private readonly detailsViewController: ExtensionDetailsViewController,
+    ) {}
+
+    public initialize() {
+        this.browserAdapter.addListenerOnConnect(port => {
+            // do not remove this. We need this to detect if the extension is reloaded from the content scripts
+        });
+
+        this.browserAdapter.addListenerToWebNavigationUpdated(this.onTabNavigated);
+        this.browserAdapter.addListenerToTabsOnRemoved(this.onTabRemoved);
+        this.browserAdapter.addListenerOnWindowsFocusChanged(this.onWindowFocusChanged);
+        this.browserAdapter.addListenerToTabsOnActivated(this.onTabActivated);
+        this.browserAdapter.addListenerToTabsOnUpdated(this.onTabUpdated);
+    }
+
+    private onTabNavigated = async (
+        details: chrome.webNavigation.WebNavigationFramedCallbackDetails,
+    ): Promise<void> => {
+        //TODO: implement
+    };
+
+    private onTabRemoved = async (
+        tabId: number,
+        removeInfo: chrome.tabs.TabRemoveInfo,
+    ): Promise<void> => {
+        //TODO: implement
+    };
+
+    private onWindowFocusChanged = async (windowId: number): Promise<void> => {
+        //TODO: implement
+    };
+
+    private onTabActivated = async (activeInfo: chrome.tabs.TabActiveInfo): Promise<void> => {
+        //TODO: implement
+    };
+
+    private onTabUpdated = async (
+        tabId: number,
+        changeInfo: chrome.tabs.TabChangeInfo,
+    ): Promise<void> => {
+        //TODO: implement
+    };
+}

--- a/src/background/tab-event-distributor.ts
+++ b/src/background/tab-event-distributor.ts
@@ -35,6 +35,7 @@ export class TabEventDistributor {
         removeInfo: chrome.tabs.TabRemoveInfo,
     ): Promise<void> => {
         this.targetPageController.onTargetTabRemoved(tabId);
+        await this.detailsViewController.onRemoveTab(tabId);
     };
 
     private onWindowFocusChanged = async (windowId: number): Promise<void> => {
@@ -48,7 +49,9 @@ export class TabEventDistributor {
     private onTabUpdated = async (
         tabId: number,
         changeInfo: chrome.tabs.TabChangeInfo,
+        tab: chrome.tabs.Tab,
     ): Promise<void> => {
         await this.targetPageController.onTabUpdated(tabId, changeInfo);
+        await this.detailsViewController.onUpdateTab(tabId, changeInfo);
     };
 }

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -50,16 +50,65 @@ export class TargetPageController {
         for (const tab of newTabs) {
             await this.handleTabUrlUpdate(tab.id);
         }
+    }
 
-        this.browserAdapter.addListenerOnConnect(port => {
-            // do not remove this. We need this to detect if the extension is reloaded from the content scripts
+    public async onTabNavigated(
+        details: chrome.webNavigation.WebNavigationFramedCallbackDetails,
+    ): Promise<void> {
+        if (details.frameId === 0) {
+            await this.handleTabUrlUpdate(details.tabId);
+        }
+    }
+
+    public async onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo): Promise<void> {
+        if (changeInfo.url) {
+            await this.handleTabUrlUpdate(tabId);
+        }
+    }
+
+    public async onTabActivated(activeInfo: chrome.tabs.TabActiveInfo): Promise<void> {
+        const activeTabId = activeInfo.tabId;
+        const windowId = activeInfo.windowId;
+
+        this.sendTabVisibilityChangeAction(activeTabId, false);
+
+        const tabs = await this.browserAdapter.tabsQuery({ windowId });
+        tabs.forEach(tab => {
+            if (!tab.active) {
+                this.sendTabVisibilityChangeAction(tab.id, true);
+            }
+        });
+    }
+
+    public async onWindowFocusChanged(): Promise<void> {
+        const chromeWindows = await this.browserAdapter.getAllWindows({
+            populate: false,
+            windowTypes: ['normal', 'popup'],
         });
 
-        this.browserAdapter.addListenerToWebNavigationUpdated(this.onTabNavigated);
-        this.browserAdapter.addListenerToTabsOnRemoved(this.onTargetTabRemoved);
-        this.browserAdapter.addListenerOnWindowsFocusChanged(this.onWindowFocusChanged);
-        this.browserAdapter.addListenerToTabsOnActivated(this.onTabActivated);
-        this.browserAdapter.addListenerToTabsOnUpdated(this.onTabUpdated);
+        chromeWindows.forEach(async chromeWindow => {
+            const activeTabs = await this.browserAdapter.tabsQuery({
+                active: true,
+                windowId: chromeWindow.id,
+            });
+
+            for (const activeTab of activeTabs) {
+                this.sendTabVisibilityChangeAction(
+                    activeTab.id,
+                    chromeWindow.state === 'minimized',
+                );
+            }
+        });
+    }
+
+    public onTargetTabRemoved(tabId: number): void {
+        this.tabContextManager.interpretMessageForTab(tabId, {
+            messageType: Messages.Tab.Remove,
+            payload: null,
+            tabId: tabId,
+        });
+        this.removeKnownTabId(tabId);
+        this.tabContextManager.deleteTabContext(tabId);
     }
 
     private getUrl = async (tabId: number): Promise<string> => {
@@ -89,58 +138,6 @@ export class TargetPageController {
                 await this.idbInstance.setItem(IndexedDBDataKeys.knownTabIds, this.knownTabs);
             }
         }
-    };
-
-    private onTabNavigated = async (
-        details: chrome.webNavigation.WebNavigationFramedCallbackDetails,
-    ): Promise<void> => {
-        if (details.frameId === 0) {
-            await this.handleTabUrlUpdate(details.tabId);
-        }
-    };
-
-    private onTabUpdated = async (
-        tabId: number,
-        changeInfo: chrome.tabs.TabChangeInfo,
-    ): Promise<void> => {
-        if (changeInfo.url) {
-            await this.handleTabUrlUpdate(tabId);
-        }
-    };
-
-    private onTabActivated = async (activeInfo: chrome.tabs.TabActiveInfo): Promise<void> => {
-        const activeTabId = activeInfo.tabId;
-        const windowId = activeInfo.windowId;
-
-        this.sendTabVisibilityChangeAction(activeTabId, false);
-
-        const tabs = await this.browserAdapter.tabsQuery({ windowId });
-        tabs.forEach(tab => {
-            if (!tab.active) {
-                this.sendTabVisibilityChangeAction(tab.id, true);
-            }
-        });
-    };
-
-    private onWindowFocusChanged = async (windowId: number): Promise<void> => {
-        const chromeWindows = await this.browserAdapter.getAllWindows({
-            populate: false,
-            windowTypes: ['normal', 'popup'],
-        });
-
-        chromeWindows.forEach(async chromeWindow => {
-            const activeTabs = await this.browserAdapter.tabsQuery({
-                active: true,
-                windowId: chromeWindow.id,
-            });
-
-            for (const activeTab of activeTabs) {
-                this.sendTabVisibilityChangeAction(
-                    activeTab.id,
-                    chromeWindow.state === 'minimized',
-                );
-            }
-        });
     };
 
     private handleTabUrlUpdate = async (tabId: number): Promise<void> => {
@@ -178,14 +175,4 @@ export class TargetPageController {
         };
         this.tabContextManager.interpretMessageForTab(tabId, message);
     }
-
-    private onTargetTabRemoved = (tabId: number): void => {
-        this.tabContextManager.interpretMessageForTab(tabId, {
-            messageType: Messages.Tab.Remove,
-            payload: null,
-            tabId: tabId,
-        });
-        this.removeKnownTabId(tabId);
-        this.tabContextManager.deleteTabContext(tabId);
-    };
 }

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -105,18 +105,22 @@ export function createSimulatedBrowserAdapter(
         return Promise.resolve(result as Tabs.Tab[]);
     });
 
-    mock.updateTab = (tabId, changeInfo) => {
-        mock.tabs!.filter(tab => tab.id === tabId).forEach((tab, index) => {
-            mock.tabs![index] = { ...tab, ...changeInfo };
-            mock.notifyTabsOnUpdated!(tabId, changeInfo, mock.tabs![index]);
-        });
+    mock.updateTab = async (tabId, changeInfo) => {
+        await Promise.all(
+            mock
+                .tabs!.filter(tab => tab.id === tabId)
+                .map(async (tab, index) => {
+                    mock.tabs![index] = { ...tab, ...changeInfo };
+                    await mock.notifyTabsOnUpdated!(tabId, changeInfo, mock.tabs![index]);
+                }),
+        );
     };
-    mock.activateTab = tabToActivate => {
+    mock.activateTab = async tabToActivate => {
         mock.tabs!.filter(tab => tab.windowId === tabToActivate.windowId).forEach((tab, index) => {
             mock.tabs![index] = { ...tab, active: tabToActivate.id === tab.id };
         });
         if (tabToActivate.id != null) {
-            mock.notifyTabsOnActivated!({
+            await mock.notifyTabsOnActivated!({
                 windowId: tabToActivate.windowId,
                 tabId: tabToActivate.id,
             });

--- a/src/tests/unit/tests/background/tab-event-distributor.test.ts
+++ b/src/tests/unit/tests/background/tab-event-distributor.test.ts
@@ -41,7 +41,7 @@ describe(TabEventDistributor, () => {
 
     afterEach(() => {
         targetPageControllerMock.verifyAll();
-        // detailsViewControllerMock.verifyAll();
+        detailsViewControllerMock.verifyAll();
     });
 
     it('webNavigationUpdated event', async () => {
@@ -57,6 +57,7 @@ describe(TabEventDistributor, () => {
 
     it('tabsOnRemoved event', async () => {
         targetPageControllerMock.setup(t => t.onTargetTabRemoved(tab.id)).verifiable();
+        detailsViewControllerMock.setup(d => d.onRemoveTab(tab.id)).verifiable();
 
         await browserAdapterMock.notifyTabsOnRemoved(tab.id, {} as chrome.tabs.TabRemoveInfo);
     });
@@ -81,6 +82,7 @@ describe(TabEventDistributor, () => {
         const changeInfo: chrome.tabs.TabChangeInfo = {};
 
         targetPageControllerMock.setup(t => t.onTabUpdated(tab.id, changeInfo)).verifiable();
+        detailsViewControllerMock.setup(d => d.onUpdateTab(tab.id, changeInfo)).verifiable();
 
         await browserAdapterMock.updateTab(tab.id, changeInfo);
     });

--- a/src/tests/unit/tests/background/tab-event-distributor.test.ts
+++ b/src/tests/unit/tests/background/tab-event-distributor.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
+import { TabEventDistributor } from 'background/tab-event-distributor';
+import { TargetPageController } from 'background/target-page-controller';
+import {
+    createSimulatedBrowserAdapter,
+    SimulatedBrowserAdapter,
+} from 'tests/unit/common/simulated-browser-adapter';
+import { IMock, Mock, MockBehavior } from 'typemoq';
+
+describe(TabEventDistributor, () => {
+    const existingWindow = { id: 101 } as chrome.windows.Window;
+
+    const existingActiveTab = {
+        id: 1,
+        windowId: existingWindow.id,
+        active: true,
+    } as chrome.tabs.Tab;
+
+    const existingInactiveTab = {
+        id: 2,
+        windowId: existingWindow.id,
+        active: false,
+    } as chrome.tabs.Tab;
+
+    const newTab = {
+        id: 3,
+        windowId: existingWindow.id,
+        active: true,
+    } as chrome.tabs.Tab;
+
+    let browserAdapterMock: SimulatedBrowserAdapter;
+    let targetPageControllerMock: IMock<TargetPageController>;
+    let detailsViewControllerMock: IMock<ExtensionDetailsViewController>;
+
+    let testSubject: TabEventDistributor;
+
+    beforeEach(() => {
+        browserAdapterMock = createSimulatedBrowserAdapter(
+            [existingActiveTab, existingInactiveTab],
+            [existingWindow],
+        );
+        targetPageControllerMock = Mock.ofType(TargetPageController, MockBehavior.Strict);
+        detailsViewControllerMock = Mock.ofType(
+            ExtensionDetailsViewController,
+            MockBehavior.Strict,
+        );
+
+        testSubject = new TabEventDistributor(
+            browserAdapterMock.object,
+            targetPageControllerMock.object,
+            detailsViewControllerMock.object,
+        );
+    });
+
+    it('webNavigationUpdated event', async () => {
+        await browserAdapterMock.notifyWebNavigationUpdated({
+            frameId: 0,
+            tabId: newTab.id,
+        } as chrome.webNavigation.WebNavigationFramedCallbackDetails);
+    });
+
+    it('tabsOnRemoved event', async () => {
+        const removeInfo = {} as chrome.tabs.TabRemoveInfo;
+        await browserAdapterMock.notifyTabsOnRemoved(existingActiveTab.id, removeInfo);
+    });
+
+    it('onWindowsFocusChanged event', async () => {
+        const otherWindowId = 202;
+        await browserAdapterMock.notifyWindowsFocusChanged(otherWindowId);
+    });
+
+    it('onTabActivated event', async () => {
+        await browserAdapterMock.activateTab(existingInactiveTab);
+    });
+
+    it('onTabUpdated event', async () => {
+        const changeInfo: chrome.tabs.TabChangeInfo = {};
+        await browserAdapterMock.updateTab(existingActiveTab.id, changeInfo);
+    });
+});


### PR DESCRIPTION
#### Details

Move tab event listeners in TargetPageController and ExtensionDetailsViewController into a new TabEventDistributor object, which will be the central handler for tab-related events.

##### Motivation

This continues work in #5407, and #5415 to combine event handling into one event listener per event per context. Currently, TargetPageController and ExtensionDetailsViewController both register listeners for some of the same tab events. This PR moves those registrations into a central listener that distributes events to the appropriate functions in those controllers, similar to MessageDistributor.

After this PR, all browser events will have only one registered listener except for onConnect, which we plan to replace with onMessage as part of the move to Manifest V3.

##### Context

The need for this change was identified in a comment on #5396. See #5407 and #5415 for more information.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
