### PR TITLE
feat(mv3-part-3): Add mv3 canary drop config

### DIFF
--- a/targets.config.js
+++ b/targets.config.js
@@ -86,6 +86,20 @@ module.exports = {
         bundleFolder: 'devBundle',
         mustExistFile: 'background.bundle.js',
     },
+    'canary-mv3': {
+        release: true,
+        config: {
+            options: {
+                ...commonExtensionOptions,
+                ...icons.canary,
+                manifestVersion: 3,
+                fullName: 'Accessibility Insights for Web - Canary (Manifest 3)',
+                telemetryBuildName: 'CanaryMV3',
+            },
+        },
+        bundleFolder: 'devMv3Bundle',
+        mustExistFile: 'serviceWorker.bundle.js',
+    },
     insider: {
         release: true,
         config: {


### PR DESCRIPTION
#### Details

Add config for manifest version 3 canary release.

##### Motivation

Feature work.

##### Context

At the moment the only manifest version 3 extension we are producing is a dev build. Now that we have a working prototype of the mv3 extension, we want to create a canary release pipeline so we can start publishing to the extension store. This change adds the config so that there will be a mv3 canary version built in the drop, but note that there is not yet an accompanying release pipeline so for now the build will not be published anywhere.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
