### PR TITLE
feat(mv3-part-3): Replace debug tools telemetry connection with messages

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -102,7 +102,7 @@ import { NavigatorUtils } from '../common/navigator-utils';
 import { getCardViewData } from '../common/rule-based-view-model-provider';
 import { SelfFastPass, SelfFastPassContainer } from '../common/self-fast-pass';
 import { StoreProxy } from '../common/store-proxy';
-import { StoreUpdateMessageDistributor } from '../common/store-update-message-distributor';
+import { StoreUpdateMessageHub } from '../common/store-update-message-hub';
 import { BaseClientStoresHub } from '../common/stores/base-client-stores-hub';
 import { StoreNames } from '../common/stores/store-names';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
@@ -164,67 +164,64 @@ if (tabId != null) {
         (tab: Tab): void => {
             const telemetryFactory = new TelemetryDataFactory();
 
-            const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(
-                browserAdapter,
-                tab.id,
-            );
-            storeUpdateMessageDistributor.initialize();
+            const storeUpdateMessageHub = new StoreUpdateMessageHub(tab.id);
+            browserAdapter.addListenerOnMessage(storeUpdateMessageHub.handleMessage);
 
             const visualizationStore = new StoreProxy<VisualizationStoreData>(
                 StoreNames[StoreNames.VisualizationStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const permissionsStateStore = new StoreProxy<PermissionsStateStoreData>(
                 StoreNames[StoreNames.PermissionsStateStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const tabStore = new StoreProxy<TabStoreData>(
                 StoreNames[StoreNames.TabStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const visualizationScanResultStore = new StoreProxy<VisualizationScanResultData>(
                 StoreNames[StoreNames.VisualizationScanResultStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const unifiedScanResultStore = new StoreProxy<UnifiedScanResultStoreData>(
                 StoreNames[StoreNames.UnifiedScanResultStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const cardSelectionStore = new StoreProxy<CardSelectionStoreData>(
                 StoreNames[StoreNames.CardSelectionStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const needsReviewScanResultStore = new StoreProxy<NeedsReviewScanResultStoreData>(
                 StoreNames[StoreNames.NeedsReviewScanResultStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const needsReviewCardSelectionStore = new StoreProxy<NeedsReviewCardSelectionStoreData>(
                 StoreNames[StoreNames.NeedsReviewCardSelectionStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const pathSnippetStore = new StoreProxy<PathSnippetStoreData>(
                 StoreNames[StoreNames.PathSnippetStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const detailsViewStore = new StoreProxy<DetailsViewStoreData>(
                 StoreNames[StoreNames.DetailsViewStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const assessmentStore = new StoreProxy<AssessmentStoreData>(
                 StoreNames[StoreNames.AssessmentStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const featureFlagStore = new StoreProxy<DictionaryStringTo<boolean>>(
                 StoreNames[StoreNames.FeatureFlagStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const scopingStore = new StoreProxy<ScopingStoreData>(
                 StoreNames[StoreNames.ScopingPanelStateStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
             const userConfigStore = new StoreProxy<UserConfigurationStoreData>(
                 StoreNames[StoreNames.UserConfigurationStore],
-                storeUpdateMessageDistributor,
+                storeUpdateMessageHub,
             );
 
             const tabStopsViewActions = new TabStopsViewActions();

--- a/src/Devtools/dev-tool-initializer.ts
+++ b/src/Devtools/dev-tool-initializer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
+import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { TargetPageInspector } from 'Devtools/target-page-inspector';
 import { StoreProxy } from '../common/store-proxy';
 import { StoreNames } from '../common/stores/store-names';
@@ -15,14 +15,12 @@ export class DevToolInitializer {
     ) {}
 
     public initialize(): void {
-        const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(
-            this.browserAdapter,
-        );
-        storeUpdateMessageDistributor.initialize();
+        const storeUpdateMessageHub = new StoreUpdateMessageHub();
+        this.browserAdapter.addListenerOnMessage(storeUpdateMessageHub.handleMessage);
 
         const devtoolsStore = new StoreProxy<DevToolStoreData>(
             StoreNames[StoreNames.DevToolsStore],
-            storeUpdateMessageDistributor,
+            storeUpdateMessageHub,
         );
 
         const inspectHandler = new InspectHandler(

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -106,7 +106,6 @@ async function initialize(): Promise<void> {
         browserAdapter,
         applicationTelemetryDataFactory,
     );
-    debugToolsTelemetryClient.initialize();
 
     const telemetryClient = getTelemetryClient(applicationTelemetryDataFactory, [
         consoleTelemetryClient,
@@ -143,6 +142,7 @@ async function initialize(): Promise<void> {
         persistData,
     );
     telemetryLogger.initialize(globalContext.featureFlagsController);
+    debugToolsTelemetryClient.initialize(globalContext.featureFlagsController);
 
     const telemetryStateListener = new TelemetryStateListener(
         globalContext.stores.userConfigurationStore,

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -26,6 +26,7 @@ import { TelemetryDataFactory } from '../common/telemetry-data-factory';
 import { UrlValidator } from '../common/url-validator';
 import { title, toolName } from '../content/strings/application';
 import { IssueFilingServiceProviderImpl } from '../issue-filing/issue-filing-service-provider-impl';
+import { BackgroundMessageDistributor } from './background-message-distributor';
 import { BrowserMessageBroadcasterFactory } from './browser-message-broadcaster-factory';
 import { DevToolsListener } from './dev-tools-listener';
 import { ExtensionDetailsViewController } from './extension-details-view-controller';
@@ -33,7 +34,6 @@ import { getAllPersistedData, getGlobalPersistedData } from './get-persisted-dat
 import { GlobalContextFactory } from './global-context-factory';
 import { KeyboardShortcutHandler } from './keyboard-shortcut-handler';
 import { deprecatedStorageDataKeys, storageDataKeys } from './local-storage-data-keys';
-import { BackgroundMessageDistributor } from './background-message-distributor';
 import { TabContextFactory } from './tab-context-factory';
 import { TargetPageController } from './target-page-controller';
 import { TargetTabController } from './target-tab-controller';

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -33,7 +33,7 @@ import { getAllPersistedData, getGlobalPersistedData } from './get-persisted-dat
 import { GlobalContextFactory } from './global-context-factory';
 import { KeyboardShortcutHandler } from './keyboard-shortcut-handler';
 import { deprecatedStorageDataKeys, storageDataKeys } from './local-storage-data-keys';
-import { MessageDistributor } from './message-distributor';
+import { BackgroundMessageDistributor } from './background-message-distributor';
 import { TabContextFactory } from './tab-context-factory';
 import { TargetPageController } from './target-page-controller';
 import { TargetTabController } from './target-tab-controller';
@@ -181,7 +181,7 @@ async function initialize(): Promise<void> {
 
     const postMessageContentHandler = new PostMessageContentHandler(postMessageContentRepository);
 
-    const messageDistributor = new MessageDistributor(
+    const messageDistributor = new BackgroundMessageDistributor(
         globalContext,
         tabContextManager,
         postMessageContentHandler,

--- a/src/background/background-message-distributor.ts
+++ b/src/background/background-message-distributor.ts
@@ -12,7 +12,7 @@ export interface Sender {
     tab?: Tab;
 }
 
-export class MessageDistributor {
+export class BackgroundMessageDistributor {
     constructor(
         private readonly globalContext: GlobalContext,
         private readonly tabContextManager: TabContextManager,

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -7,7 +7,7 @@ import { ExtensionDetailsViewController } from 'background/extension-details-vie
 import { getAllPersistedData } from 'background/get-persisted-data';
 import { GlobalContextFactory } from 'background/global-context-factory';
 import { KeyboardShortcutHandler } from 'background/keyboard-shortcut-handler';
-import { MessageDistributor } from 'background/message-distributor';
+import { BackgroundMessageDistributor } from 'background/background-message-distributor';
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { PostMessageContentRepository } from 'background/post-message-content-repository';
 import { TabContextFactory } from 'background/tab-context-factory';
@@ -160,7 +160,7 @@ async function initialize(): Promise<void> {
 
     const postMessageContentHandler = new PostMessageContentHandler(postMessageContentRepository);
 
-    const messageDistributor = new MessageDistributor(
+    const messageDistributor = new BackgroundMessageDistributor(
         globalContext,
         tabContextManager,
         postMessageContentHandler,

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { BackgroundMessageDistributor } from 'background/background-message-distributor';
 import { BrowserMessageBroadcasterFactory } from 'background/browser-message-broadcaster-factory';
 import { DevToolsListener } from 'background/dev-tools-listener';
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
 import { getAllPersistedData } from 'background/get-persisted-data';
 import { GlobalContextFactory } from 'background/global-context-factory';
 import { KeyboardShortcutHandler } from 'background/keyboard-shortcut-handler';
-import { BackgroundMessageDistributor } from 'background/background-message-distributor';
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { PostMessageContentRepository } from 'background/post-message-content-repository';
 import { TabContextFactory } from 'background/tab-context-factory';

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -86,7 +86,6 @@ async function initialize(): Promise<void> {
         browserAdapter,
         applicationTelemetryDataFactory,
     );
-    debugToolsTelemetryClient.initialize();
 
     const telemetryClient = getTelemetryClient(applicationTelemetryDataFactory, [
         consoleTelemetryClient,
@@ -124,6 +123,7 @@ async function initialize(): Promise<void> {
     );
 
     telemetryLogger.initialize(globalContext.featureFlagsController);
+    debugToolsTelemetryClient.initialize(globalContext.featureFlagsController);
 
     const telemetryStateListener = new TelemetryStateListener(
         globalContext.stores.userConfigurationStore,

--- a/src/background/telemetry/debug-tools-telemetry-client.ts
+++ b/src/background/telemetry/debug-tools-telemetry-client.ts
@@ -1,55 +1,44 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FeatureFlagChecker } from 'background/feature-flag-checker';
 import { ApplicationTelemetryDataFactory } from 'background/telemetry/application-telemetry-data-factory';
 import { TelemetryClient } from 'background/telemetry/telemetry-client';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { ConnectionNames } from 'common/constants/connection-names';
+import { FeatureFlags } from 'common/feature-flags';
+import { Messages } from 'common/messages';
 
 export class DebugToolsTelemetryClient implements TelemetryClient {
-    private connections: chrome.runtime.Port[] = [];
+    private featureFlagChecker: FeatureFlagChecker;
 
     constructor(
         private readonly browserAdapter: BrowserAdapter,
         private readonly telemetryDataFactory: ApplicationTelemetryDataFactory,
     ) {}
 
-    public initialize(): void {
-        this.browserAdapter.addListenerOnConnect((connection: chrome.runtime.Port) => {
-            if (connection.name !== ConnectionNames.debugToolsTelemetry) {
-                return;
-            }
-
-            connection.onDisconnect.addListener(() => {
-                this.connections = this.connections.filter(current => current !== connection);
-            });
-
-            this.connections.push(connection);
-        });
+    public initialize(featureFlagChecker: FeatureFlagChecker): void {
+        this.featureFlagChecker = featureFlagChecker;
     }
 
     public enableTelemetry(): void {
-        // no-op as we always want to send telemetry to the debug tools page (if there is a connection)
+        // no-op as we always want to send telemetry to the debug tools page (if feature flag is enabled)
     }
 
     public disableTelemetry(): void {
-        // no-op as we always want to send telemetry to the debug tools page (if there is a connection)
+        // no-op as we always want to send telemetry to the debug tools page (if feature flag is enabled)
     }
 
     public trackEvent(name: string, properties?: Object): void {
-        if (this.connections.length === 0) {
-            return;
-        }
+        if (this.featureFlagChecker?.isEnabled(FeatureFlags.debugTools)) {
+            const finalProperties = {
+                ...properties,
+                ...this.telemetryDataFactory.getData(),
+            };
 
-        const finalProperties = {
-            ...properties,
-            ...this.telemetryDataFactory.getData(),
-        };
-
-        this.connections.forEach(connection =>
-            connection.postMessage({
+            this.browserAdapter.sendRuntimeMessage({
+                messageType: Messages.DebugTools.Telemetry,
                 name,
                 properties: finalProperties,
-            }),
-        );
+            });
+        }
     }
 }

--- a/src/common/constants/connection-names.ts
+++ b/src/common/constants/connection-names.ts
@@ -2,5 +2,4 @@
 // Licensed under the MIT License.
 export class ConnectionNames {
     public static readonly devTools: string = 'insights-dev-tools';
-    public static readonly debugToolsTelemetry: string = 'insights-debug-tools-telemetry';
 }

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -195,5 +195,6 @@ export const Messages = {
 
     DebugTools: {
         Open: `${messagePrefix}/debugTools/open`,
+        Telemetry: `${messagePrefix}/debugTools/telemetry`,
     },
 };

--- a/src/common/store-proxy.ts
+++ b/src/common/store-proxy.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
+import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { isEqual } from 'lodash';
 import { BaseStore } from './base-store';
 import { Store } from './flux/store';
@@ -11,10 +11,10 @@ export class StoreProxy<TState> extends Store implements BaseStore<TState> {
 
     constructor(
         private readonly storeId: string,
-        private readonly messageDistributor: StoreUpdateMessageDistributor,
+        private readonly messageHub: StoreUpdateMessageHub,
     ) {
         super();
-        this.messageDistributor.registerStoreUpdateListener(storeId, this.onChange);
+        this.messageHub.registerStoreUpdateListener(storeId, this.onChange);
     }
 
     private onChange = (message: StoreUpdateMessage<TState>): void => {

--- a/src/common/store-update-message-hub.ts
+++ b/src/common/store-update-message-hub.ts
@@ -1,25 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import _ from 'lodash';
 import { StoreType } from './types/store-type';
 import { StoreUpdateMessage, storeUpdateMessageType } from './types/store-update-message';
 
 type StoreUpdateMessageListener = (message: StoreUpdateMessage<any>) => void;
 
-export class StoreUpdateMessageDistributor {
+export class StoreUpdateMessageHub {
     private readonly registeredUpdateListeners: { [key: string]: StoreUpdateMessageListener } = {};
 
-    constructor(private readonly browserAdapter: BrowserAdapter, private readonly tabId?: number) {}
-
-    public initialize(): void {
-        this.browserAdapter.addListenerOnMessage(this.handleMessage);
-    }
-
-    public dispose(): void {
-        this.browserAdapter.removeListenerOnMessage(this.handleMessage);
-    }
+    constructor(private readonly tabId?: number) {}
 
     public registerStoreUpdateListener(
         storeId: string,
@@ -31,7 +22,7 @@ export class StoreUpdateMessageDistributor {
         this.registeredUpdateListeners[storeId] = listener;
     }
 
-    private handleMessage = (message: StoreUpdateMessage<any>): void => {
+    public readonly handleMessage = (message: StoreUpdateMessage<any>): void => {
         if (!this.isValidMessage(message)) {
             return;
         }

--- a/src/debug-tools/controllers/telemetry-listener.ts
+++ b/src/debug-tools/controllers/telemetry-listener.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { ConnectionNames } from 'common/constants/connection-names';
+
+import { Messages } from 'common/messages';
 
 export type DebugToolsTelemetryMessage = {
     timestamp: number;
@@ -24,23 +24,15 @@ export type DebugToolsTelemetryMessageListener = (
 type GetDate = () => Date;
 
 export class TelemetryListener {
-    private connection: chrome.runtime.Port;
     private listeners: DebugToolsTelemetryMessageListener[] = [];
 
-    constructor(
-        private readonly browserAdapter: BrowserAdapter,
-        private readonly getDate: GetDate,
-    ) {}
+    constructor(private readonly getDate: GetDate) {}
 
-    public initialize(): void {
-        this.connection = this.browserAdapter.connect({
-            name: ConnectionNames.debugToolsTelemetry,
-        });
+    public readonly onTelemetryMessage = (telemetryMessage: any) => {
+        if (telemetryMessage.messageType !== Messages.DebugTools.Telemetry) {
+            return;
+        }
 
-        this.connection.onMessage.addListener(this.onTelemetryMessage);
-    }
-
-    private onTelemetryMessage = (telemetryMessage: any) => {
         this.listeners.forEach(listener =>
             listener(convertToDebugToolTelemetryMessage(telemetryMessage, this.getDate)),
         );
@@ -48,10 +40,6 @@ export class TelemetryListener {
 
     public addListener(listener: DebugToolsTelemetryMessageListener): void {
         this.listeners.push(listener);
-    }
-
-    public dispose(): void {
-        this.connection.disconnect();
     }
 }
 

--- a/src/debug-tools/debug-tools-message-distributor.ts
+++ b/src/debug-tools/debug-tools-message-distributor.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
+import { StoreUpdateMessage } from 'common/types/store-update-message';
+import { TelemetryListener } from 'debug-tools/controllers/telemetry-listener';
+
+export class DebugToolsMessageDistributor {
+    constructor(
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly storeUpdateMessageHub: StoreUpdateMessageHub,
+        private readonly telemetryListener: TelemetryListener,
+    ) {}
+
+    public initialize() {
+        this.browserAdapter.addListenerOnMessage(this.distributeMessage);
+    }
+
+    private distributeMessage = (message: any) => {
+        this.telemetryListener.onTelemetryMessage(message);
+        this.storeUpdateMessageHub.handleMessage(message as StoreUpdateMessage<unknown>);
+    };
+}

--- a/src/debug-tools/initializer/debug-tools-init.tsx
+++ b/src/debug-tools/initializer/debug-tools-init.tsx
@@ -10,7 +10,7 @@ import { RemoteActionMessageDispatcher } from 'common/message-creators/remote-ac
 import { StoreActionMessageCreatorFactory } from 'common/message-creators/store-action-message-creator-factory';
 import { getNarrowModeThresholdsForWeb } from 'common/narrow-mode-thresholds';
 import { StoreProxy } from 'common/store-proxy';
-import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
+import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { StoreNames } from 'common/stores/store-names';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -67,24 +67,24 @@ export const initializeDebugTools = () => {
 };
 
 const createStoreProxies = (browserAdapter: BrowserAdapter) => {
-    const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(browserAdapter);
-    storeUpdateMessageDistributor.initialize();
+    const storeUpdateMessageHub = new StoreUpdateMessageHub();
+    browserAdapter.addListenerOnMessage(storeUpdateMessageHub.handleMessage);
 
     const featureFlagStore = new StoreProxy<FeatureFlagStoreData>(
         StoreNames[StoreNames.FeatureFlagStore],
-        storeUpdateMessageDistributor,
+        storeUpdateMessageHub,
     );
     const scopingStore = new StoreProxy<ScopingStoreData>(
         StoreNames[StoreNames.ScopingPanelStateStore],
-        storeUpdateMessageDistributor,
+        storeUpdateMessageHub,
     );
     const userConfigurationStore = new StoreProxy<UserConfigurationStoreData>(
         StoreNames[StoreNames.UserConfigurationStore],
-        storeUpdateMessageDistributor,
+        storeUpdateMessageHub,
     );
     const permissionsStore = new StoreProxy<PermissionsStateStoreData>(
         StoreNames[StoreNames.PermissionsStateStore],
-        storeUpdateMessageDistributor,
+        storeUpdateMessageHub,
     );
 
     return [featureFlagStore, scopingStore, userConfigurationStore, permissionsStore];

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -6,7 +6,7 @@ import { EnumHelper } from 'common/enum-helper';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unavailable';
 import { createDefaultLogger } from 'common/logging/default-logger';
-import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
+import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
@@ -85,7 +85,7 @@ export class MainWindowInitializer extends WindowInitializer {
     private analyzerController: AnalyzerController;
     private inspectController: InspectController;
     private pathSnippetController: PathSnippetController;
-    private storeUpdateMessageDistributor: StoreUpdateMessageDistributor;
+    private storeUpdateMessageHub: StoreUpdateMessageHub;
     private visualizationStoreProxy: StoreProxy<VisualizationStoreData>;
     private assessmentStoreProxy: StoreProxy<AssessmentStoreData>;
     private featureFlagStoreProxy: StoreProxy<FeatureFlagStoreData>;
@@ -106,68 +106,68 @@ export class MainWindowInitializer extends WindowInitializer {
         const asyncInitializationSteps: Promise<void>[] = [];
         asyncInitializationSteps.push(super.initialize());
 
-        this.storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(this.browserAdapter);
-        this.storeUpdateMessageDistributor.initialize();
+        this.storeUpdateMessageHub = new StoreUpdateMessageHub();
+        this.browserAdapter.addListenerOnMessage(this.storeUpdateMessageHub.handleMessage);
 
         this.visualizationStoreProxy = new StoreProxy<VisualizationStoreData>(
             StoreNames[StoreNames.VisualizationStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.scopingStoreProxy = new StoreProxy<ScopingStoreData>(
             StoreNames[StoreNames.ScopingPanelStateStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.featureFlagStoreProxy = new StoreProxy<FeatureFlagStoreData>(
             StoreNames[StoreNames.FeatureFlagStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.userConfigStoreProxy = new StoreProxy<UserConfigurationStoreData>(
             StoreNames[StoreNames.UserConfigurationStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.visualizationScanResultStoreProxy = new StoreProxy<VisualizationScanResultData>(
             StoreNames[StoreNames.VisualizationScanResultStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.assessmentStoreProxy = new StoreProxy<AssessmentStoreData>(
             StoreNames[StoreNames.AssessmentStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.tabStoreProxy = new StoreProxy<TabStoreData>(
             StoreNames[StoreNames.TabStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.devToolStoreProxy = new StoreProxy<DevToolStoreData>(
             StoreNames[StoreNames.DevToolsStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.inspectStoreProxy = new StoreProxy<InspectStoreData>(
             StoreNames[StoreNames.InspectStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.pathSnippetStoreProxy = new StoreProxy<PathSnippetStoreData>(
             StoreNames[StoreNames.PathSnippetStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.unifiedScanResultStoreProxy = new StoreProxy<UnifiedScanResultStoreData>(
             StoreNames[StoreNames.UnifiedScanResultStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.cardSelectionStoreProxy = new StoreProxy<CardSelectionStoreData>(
             StoreNames[StoreNames.CardSelectionStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.needsReviewScanResultStoreProxy = new StoreProxy<NeedsReviewScanResultStoreData>(
             StoreNames[StoreNames.NeedsReviewScanResultStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.needsReviewCardSelectionStoreProxy = new StoreProxy<NeedsReviewCardSelectionStoreData>(
             StoreNames[StoreNames.NeedsReviewCardSelectionStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
         this.permissionsStateStoreProxy = new StoreProxy<PermissionsStateStoreData>(
             StoreNames[StoreNames.PermissionsStateStore],
-            this.storeUpdateMessageDistributor,
+            this.storeUpdateMessageHub,
         );
 
         const logger = createDefaultLogger();
@@ -423,6 +423,6 @@ export class MainWindowInitializer extends WindowInitializer {
     protected dispose(): void {
         super.dispose();
 
-        this.storeUpdateMessageDistributor.dispose();
+        this.browserAdapter.removeListenerOnMessage(this.storeUpdateMessageHub.handleMessage);
     }
 }

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -3,7 +3,7 @@
 import { loadTheme } from '@fluentui/react';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { DocumentManipulator } from 'common/document-manipulator';
-import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
+import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import * as ReactDOM from 'react-dom';
 import { AxeInfo } from '../common/axe-info';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
@@ -119,11 +119,8 @@ export class PopupInitializer {
             actionMessageDispatcher,
         );
 
-        const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(
-            this.browserAdapter,
-            tab.id,
-        );
-        storeUpdateMessageDistributor.initialize();
+        const storeUpdateMessageDistributor = new StoreUpdateMessageHub(tab.id);
+        this.browserAdapter.addListenerOnMessage(storeUpdateMessageDistributor.handleMessage);
 
         const visualizationStoreName = StoreNames[StoreNames.VisualizationStore];
         const commandStoreName = StoreNames[StoreNames.CommandStore];

--- a/src/tests/unit/tests/background/background-message-distributor.test.ts
+++ b/src/tests/unit/tests/background/background-message-distributor.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { GlobalContext } from 'background/global-context';
 import { Interpreter } from 'background/interpreter';
-import { MessageDistributor, Sender } from 'background/message-distributor';
+import { BackgroundMessageDistributor, Sender } from 'background/background-message-distributor';
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { TabContextManager } from 'background/tab-context-manager';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -10,7 +10,7 @@ import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adap
 import { Logger } from '../../../../common/logging/logger';
 import { InterpreterMessage } from '../../../../common/message';
 
-describe('MessageDistributorTest', () => {
+describe(BackgroundMessageDistributor, () => {
     const tabId = 1;
 
     let mockBrowserAdapter: IMock<BrowserAdapter>;
@@ -20,7 +20,7 @@ describe('MessageDistributorTest', () => {
     let postMessageContentHandlerMock: IMock<PostMessageContentHandler>;
     let loggerMock: IMock<Logger>;
 
-    let testSubject: MessageDistributor;
+    let testSubject: BackgroundMessageDistributor;
 
     let distributeMessageCallback: (message: any, sender?: Sender) => any;
 
@@ -38,7 +38,7 @@ describe('MessageDistributorTest', () => {
         postMessageContentHandlerMock = Mock.ofType<PostMessageContentHandler>();
 
         loggerMock = Mock.ofType<Logger>();
-        testSubject = new MessageDistributor(
+        testSubject = new BackgroundMessageDistributor(
             globalContextMock.object,
             tabContextManagerMock.object,
             postMessageContentHandlerMock.object,

--- a/src/tests/unit/tests/background/background-message-distributor.test.ts
+++ b/src/tests/unit/tests/background/background-message-distributor.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BackgroundMessageDistributor, Sender } from 'background/background-message-distributor';
 import { GlobalContext } from 'background/global-context';
 import { Interpreter } from 'background/interpreter';
-import { BackgroundMessageDistributor, Sender } from 'background/background-message-distributor';
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { TabContextManager } from 'background/tab-context-manager';
 import { IMock, It, Mock, Times } from 'typemoq';

--- a/src/tests/unit/tests/background/telemetry/debug-tools-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/debug-tools-telemetry-client.test.ts
@@ -1,82 +1,40 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FeatureFlagChecker } from 'background/feature-flag-checker';
 import {
     ApplicationTelemetryData,
     ApplicationTelemetryDataFactory,
 } from 'background/telemetry/application-telemetry-data-factory';
 import { DebugToolsTelemetryClient } from 'background/telemetry/debug-tools-telemetry-client';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { ConnectionNames } from 'common/constants/connection-names';
-import { isFunction, times } from 'lodash';
+import { FeatureFlags } from 'common/feature-flags';
+import { Messages } from 'common/messages';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('DebugToolsTelemetryClient', () => {
-    type Port = chrome.runtime.Port;
-    type OnDisconnect = Port['onDisconnect'];
-
-    const connectionsCountProperty = 'connections.length';
-
+    let debugToolsFeatureFlag: boolean;
     let browserAdapterMock: IMock<BrowserAdapter>;
-    let portMock: IMock<Port>;
     let telemetryDataFactoryMock: IMock<ApplicationTelemetryDataFactory>;
+    const featureFlagChecker: FeatureFlagChecker = {
+        isEnabled: feature => feature === FeatureFlags.debugTools && debugToolsFeatureFlag,
+    };
 
     let testSubject: DebugToolsTelemetryClient;
 
     beforeEach(() => {
+        debugToolsFeatureFlag = true;
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
-        portMock = Mock.ofType<Port>();
         telemetryDataFactoryMock = Mock.ofType<ApplicationTelemetryDataFactory>();
 
         testSubject = new DebugToolsTelemetryClient(
             browserAdapterMock.object,
             telemetryDataFactoryMock.object,
         );
+        testSubject.initialize(featureFlagChecker);
     });
 
-    describe('initialize', () => {
-        it('no op for NON debug tools telemetry connection name', () => {
-            browserAdapterMock
-                .setup(adapter => adapter.addListenerOnConnect(It.is(isFunction)))
-                .callback(listener => listener(portMock.object));
-
-            portMock.setup(port => port.name).returns(() => 'not-the-on-i-am-looking-for');
-
-            testSubject.initialize();
-
-            portMock.verify(port => port.onDisconnect, Times.never());
-
-            expect(testSubject).toHaveProperty(connectionsCountProperty, 0);
-        });
-
-        it.each([1, 3, 4, 7])(
-            'handles new debug tools telemetry connections (total connection count %s)',
-            connectionsCount => {
-                let onConnectListener: Function;
-
-                browserAdapterMock
-                    .setup(adapter => adapter.addListenerOnConnect(It.is(isFunction)))
-                    .callback(listener => (onConnectListener = listener));
-
-                portMock
-                    .setup(port => port.name)
-                    .returns(() => ConnectionNames.debugToolsTelemetry);
-
-                const onDisconnectMock = Mock.ofType<OnDisconnect>();
-
-                portMock.setup(port => port.onDisconnect).returns(() => onDisconnectMock.object);
-
-                testSubject.initialize();
-
-                times(connectionsCount, () => onConnectListener(portMock.object));
-
-                onDisconnectMock.verify(
-                    onDisconnect => onDisconnect.addListener(It.is(isFunction)),
-                    Times.exactly(connectionsCount),
-                );
-
-                expect(testSubject).toHaveProperty(connectionsCountProperty, connectionsCount);
-            },
-        );
+    afterEach(() => {
+        browserAdapterMock.verifyAll();
     });
 
     describe('enableTelemetry', () => {
@@ -107,106 +65,41 @@ describe('DebugToolsTelemetryClient', () => {
         const eventName = 'test-event-name';
         const eventProperties = { testProperty: 'testValue' };
 
-        it('is no op when there are no connections', () => {
+        it('is no op when feature flag is disabled', () => {
+            debugToolsFeatureFlag = false;
+
             testSubject = new DebugToolsTelemetryClient(null, null);
+            testSubject.initialize(featureFlagChecker);
+
+            browserAdapterMock
+                .setup(b => b.sendRuntimeMessage(It.isAny()))
+                .verifiable(Times.never());
 
             const action = () => testSubject.trackEvent(eventName, eventProperties);
 
             expect(action).not.toThrow();
         });
 
-        it('post a message to every tracked connection', () => {
-            const connectionsCount = 3;
-            let onConnectListener: Function;
-
+        it('send runtime message if feature flag is enabled', () => {
             const appData: ApplicationTelemetryData = {
                 applicationBuild: 'test-application-build',
                 applicationName: 'test-application-name',
                 applicationVersion: 'test-application-version',
                 installationId: 'test-installation-id',
             };
+            const expectedMessage = {
+                messageType: Messages.DebugTools.Telemetry,
+                name: eventName,
+                properties: {
+                    ...eventProperties,
+                    ...appData,
+                },
+            };
 
             telemetryDataFactoryMock.setup(factory => factory.getData()).returns(() => appData);
-
-            browserAdapterMock
-                .setup(adapter => adapter.addListenerOnConnect(It.is(isFunction)))
-                .callback(listener => (onConnectListener = listener));
-
-            const onDisconnectMock = Mock.ofType<OnDisconnect>();
-
-            const portMocks: IMock<Port>[] = [];
-
-            for (let portIndex = 0; portIndex < connectionsCount; portIndex++) {
-                const mock = Mock.ofType<Port>();
-                mock.setup(port => port.name).returns(() => ConnectionNames.debugToolsTelemetry);
-                mock.setup(port => port.onDisconnect).returns(() => onDisconnectMock.object);
-
-                portMocks.push(mock);
-            }
-
-            testSubject.initialize();
-
-            times(connectionsCount, callIndex => onConnectListener(portMocks[callIndex].object));
-
-            expect(testSubject).toHaveProperty(connectionsCountProperty, connectionsCount);
+            browserAdapterMock.setup(b => b.sendRuntimeMessage(expectedMessage)).verifiable();
 
             testSubject.trackEvent(eventName, eventProperties);
-
-            portMocks.forEach(mock => {
-                mock.verify(
-                    port =>
-                        port.postMessage(
-                            It.isValue({
-                                name: eventName,
-                                properties: {
-                                    ...eventProperties,
-                                    ...appData,
-                                },
-                            }),
-                        ),
-                    Times.once(),
-                );
-            });
-        });
-    });
-
-    it('handles onDisconnect events for existing, tracked connections', () => {
-        const connectionsCount = 3;
-        let onConnectListener: Function;
-
-        browserAdapterMock
-            .setup(adapter => adapter.addListenerOnConnect(It.is(isFunction)))
-            .callback(listener => (onConnectListener = listener));
-
-        const onDisconnectListeners: Function[] = [];
-        const onDisconnectMock = Mock.ofType<OnDisconnect>();
-        onDisconnectMock
-            .setup(onDisconnect => onDisconnect.addListener(It.is(isFunction)))
-            .callback(listener => onDisconnectListeners.push(listener));
-
-        const portMocks: IMock<Port>[] = [];
-
-        for (let portIndex = 0; portIndex < connectionsCount; portIndex++) {
-            const mock = Mock.ofType<Port>();
-            mock.setup(port => port.name).returns(() => ConnectionNames.debugToolsTelemetry);
-            mock.setup(port => port.onDisconnect).returns(() => onDisconnectMock.object);
-
-            portMocks.push(mock);
-        }
-
-        testSubject.initialize();
-
-        times(connectionsCount, callIndex => onConnectListener(portMocks[callIndex].object));
-
-        expect(testSubject).toHaveProperty(connectionsCountProperty, connectionsCount);
-        expect(onDisconnectListeners).toHaveLength(connectionsCount);
-
-        onDisconnectListeners.forEach((disconnectionListener, disconnectionIndex) => {
-            disconnectionListener();
-            expect(testSubject).toHaveProperty(
-                connectionsCountProperty,
-                connectionsCount - (disconnectionIndex + 1),
-            );
         });
     });
 });

--- a/src/tests/unit/tests/common/store-proxy.test.ts
+++ b/src/tests/unit/tests/common/store-proxy.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
+import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { IMock, It, Mock } from 'typemoq';
 import { StoreProxy } from '../../../../common/store-proxy';
 import { StoreType } from '../../../../common/types/store-type';
@@ -21,22 +21,22 @@ describe('StoreProxyTest', () => {
     const expectedData = 'test';
     const storeId = 'TestStore';
     let onChange: (message: StoreUpdateMessage<string>) => void;
-    let messageDistributorMock: IMock<StoreUpdateMessageDistributor>;
+    let storeUpdateHubMock: IMock<StoreUpdateMessageHub>;
 
     let testSubject: TestableStoreProxy<string>;
 
     beforeEach(() => {
-        messageDistributorMock = Mock.ofType<StoreUpdateMessageDistributor>();
-        messageDistributorMock
+        storeUpdateHubMock = Mock.ofType<StoreUpdateMessageHub>();
+        storeUpdateHubMock
             .setup(m => m.registerStoreUpdateListener(storeId, It.isAny()))
             .callback((storeId, callback) => (onChange = callback))
             .verifiable();
 
-        testSubject = new TestableStoreProxy('TestStore', messageDistributorMock.object);
+        testSubject = new TestableStoreProxy('TestStore', storeUpdateHubMock.object);
     });
 
     afterEach(() => {
-        messageDistributorMock.verifyAll();
+        storeUpdateHubMock.verifyAll();
     });
 
     test('onChange when state is different', () => {

--- a/src/tests/unit/tests/common/store-update-message-hub.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-hub.test.ts
@@ -1,33 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { IMock, It, Mock } from 'typemoq';
-import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
-import { StoreUpdateMessageDistributor } from '../../../../common/store-update-message-distributor';
+import { StoreUpdateMessageHub } from '../../../../common/store-update-message-hub';
 import { StoreType } from '../../../../common/types/store-type';
 import {
     StoreUpdateMessage,
     storeUpdateMessageType,
 } from '../../../../common/types/store-update-message';
 
-describe(StoreUpdateMessageDistributor, () => {
+describe(StoreUpdateMessageHub, () => {
     const tabId = 1;
     const storeId = 'TestStore';
-    let browserAdapterMock: IMock<BrowserAdapter>;
-    let onMessage: (message: StoreUpdateMessage<any>, sender?: any) => void;
     let registeredListener: jest.Mock;
 
     let tabContextMessage: StoreUpdateMessage<string>;
     let globalStoreMessage: StoreUpdateMessage<string>;
 
-    let testSubject: StoreUpdateMessageDistributor;
+    let testSubject: StoreUpdateMessageHub;
 
     beforeEach(() => {
-        browserAdapterMock = Mock.ofType<BrowserAdapter>();
-        browserAdapterMock
-            .setup(b => b.addListenerOnMessage(It.isAny()))
-            .callback(listener => (onMessage = listener));
-
         registeredListener = jest.fn();
 
         tabContextMessage = {
@@ -46,14 +37,9 @@ describe(StoreUpdateMessageDistributor, () => {
             storeType: StoreType.GlobalStore,
         } as StoreUpdateMessage<string>;
 
-        testSubject = new StoreUpdateMessageDistributor(browserAdapterMock.object, tabId);
+        testSubject = new StoreUpdateMessageHub(tabId);
 
-        testSubject.initialize();
         testSubject.registerStoreUpdateListener(storeId, registeredListener);
-    });
-
-    afterEach(() => {
-        browserAdapterMock.verifyAll();
     });
 
     const invalidMessages: StoreUpdateMessage<string>[] = [
@@ -66,7 +52,7 @@ describe(StoreUpdateMessageDistributor, () => {
         { ...tabContextMessage, tabId: tabId + 10 },
     ];
     it.each(invalidMessages)('ignores invalid message: %o', message => {
-        onMessage(message);
+        testSubject.handleMessage(message);
 
         expect(registeredListener).toBeCalledTimes(0);
     });
@@ -77,29 +63,28 @@ describe(StoreUpdateMessageDistributor, () => {
             storeId: 'AnotherStore',
         };
 
-        onMessage(message);
+        testSubject.handleMessage(message);
 
         expect(registeredListener).toBeCalledTimes(0);
     });
 
     it('Calls registered listener for tab context store message', () => {
-        onMessage(tabContextMessage);
+        testSubject.handleMessage(tabContextMessage);
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
     });
 
     it('Calls registered listener for global store message', () => {
-        onMessage(globalStoreMessage);
+        testSubject.handleMessage(globalStoreMessage);
 
         expect(registeredListener).toBeCalledWith(globalStoreMessage);
     });
 
     it('Calls registered listener if not created with a tab id', () => {
-        testSubject = new StoreUpdateMessageDistributor(browserAdapterMock.object);
-        testSubject.initialize();
+        testSubject = new StoreUpdateMessageHub();
         testSubject.registerStoreUpdateListener(storeId, registeredListener);
 
-        onMessage(tabContextMessage);
+        testSubject.handleMessage(tabContextMessage);
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
     });
@@ -117,16 +102,10 @@ describe(StoreUpdateMessageDistributor, () => {
 
         testSubject.registerStoreUpdateListener(anotherStoreId, anotherListener);
 
-        onMessage(messageForStore);
-        onMessage(messageForAnotherStore);
+        testSubject.handleMessage(messageForStore);
+        testSubject.handleMessage(messageForAnotherStore);
 
         expect(registeredListener).toBeCalledWith(messageForStore);
         expect(anotherListener).toBeCalledWith(messageForAnotherStore);
-    });
-
-    it('dispose removes message listener', () => {
-        browserAdapterMock.setup(o => o.removeListenerOnMessage(onMessage)).verifiable();
-
-        testSubject.dispose();
     });
 });

--- a/src/tests/unit/tests/debug-tools/debug-tools-message-distributor.test.ts
+++ b/src/tests/unit/tests/debug-tools/debug-tools-message-distributor.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
+import { StoreUpdateMessage } from 'common/types/store-update-message';
+import { TelemetryListener } from 'debug-tools/controllers/telemetry-listener';
+import { DebugToolsMessageDistributor } from 'debug-tools/debug-tools-message-distributor';
+import { IMock, It, Mock } from 'typemoq';
+
+describe(DebugToolsMessageDistributor, () => {
+    let registeredListener: (message: any) => void;
+    let browserAdapterMock: IMock<BrowserAdapter>;
+    let telemetryListenerMock: IMock<TelemetryListener>;
+    let storeUpdateHubMock: IMock<StoreUpdateMessageHub>;
+
+    let testSubject: DebugToolsMessageDistributor;
+
+    beforeEach(() => {
+        browserAdapterMock = Mock.ofType<BrowserAdapter>();
+        telemetryListenerMock = Mock.ofType<TelemetryListener>();
+        storeUpdateHubMock = Mock.ofType<StoreUpdateMessageHub>();
+
+        browserAdapterMock
+            .setup(b => b.addListenerOnMessage(It.isAny()))
+            .returns(listener => (registeredListener = listener));
+
+        testSubject = new DebugToolsMessageDistributor(
+            browserAdapterMock.object,
+            storeUpdateHubMock.object,
+            telemetryListenerMock.object,
+        );
+    });
+
+    it('registers listener that calls both message handlers', () => {
+        const message = { messageType: 'message type' };
+
+        telemetryListenerMock.setup(t => t.onTelemetryMessage(message)).verifiable();
+        storeUpdateHubMock
+            .setup(s => s.handleMessage(message as StoreUpdateMessage<unknown>))
+            .verifiable();
+
+        testSubject.initialize();
+
+        expect(registeredListener).toBeDefined();
+        registeredListener(message);
+
+        telemetryListenerMock.verifyAll();
+        storeUpdateHubMock.verifyAll();
+    });
+});

--- a/src/views/insights/dependencies.ts
+++ b/src/views/insights/dependencies.ts
@@ -4,7 +4,7 @@ import { loadTheme } from '@fluentui/react';
 import { DocumentManipulator } from 'common/document-manipulator';
 import { Logger } from 'common/logging/logger';
 import { getNarrowModeThresholdsForWeb } from 'common/narrow-mode-thresholds';
-import { StoreUpdateMessageDistributor } from 'common/store-update-message-distributor';
+import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { textContent } from 'content/strings/text-content';
 import * as ReactDOM from 'react-dom';
 import { Content } from 'views/content/content';
@@ -40,12 +40,12 @@ export const rendererDependencies: (
         actionMessageDispatcher,
     );
 
-    const storeUpdateMessageDistributor = new StoreUpdateMessageDistributor(browserAdapter);
-    storeUpdateMessageDistributor.initialize();
+    const storeUpdateMessageHub = new StoreUpdateMessageHub();
+    browserAdapter.addListenerOnMessage(storeUpdateMessageHub.handleMessage);
 
     const store = new StoreProxy<UserConfigurationStoreData>(
         StoreNames[StoreNames.UserConfigurationStore],
-        storeUpdateMessageDistributor,
+        storeUpdateMessageHub,
     );
     const storesHub = new BaseClientStoresHub<any>([store]);
     const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -265,7 +265,7 @@
         "./src/common/platform.ts",
         "./src/common/state-dispatcher.ts",
         "./src/common/store-proxy.ts",
-        "./src/common/store-update-message-distributor.ts",
+        "./src/common/store-update-message-hub.ts",
         "./src/common/tabbable-elements-helper.ts",
         "./src/common/telemetry-data-factory.ts",
         "./src/common/uid-generator.ts",


### PR DESCRIPTION
#### Details

Remove the use of connect() for telemetry in debug tools and use messages instead.

Related, minor refactors in this PR:
- Rename MessageDistributor to BackgroundMessageDistributor (to distinguish it from DebugToolsMessageDistributor)
- Rename StoreUpdateMessageDistributor to StoreUpdateMessageHub and don't have it register its own message listener (because some contexts only use the StoreUpdateMessageHub message listener, but the debug tools context needs to listen for store update messages as well as telemetry messages, and we need to keep one listener per event)

##### Motivation

When we update to MV3, open connections are likely to trigger a watchdog timeout that will kill our service workers after five minutes. Replacing these open connections with messaging will avoid this.

##### Context

Other uses of connect() will be addressed in future PRs.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
