### PR TITLE
fix: Unblock unified build failures

### DIFF
--- a/pipeline/scripts/download-electron-mirror-binaries.js
+++ b/pipeline/scripts/download-electron-mirror-binaries.js
@@ -5,10 +5,6 @@ const core = require('./download-electron-mirror-core');
 
 const downloadMirrorBinaries = async () => {
     await core.downloadAndExtractElectronArtifact('electron', 'node_modules/electron/dist');
-    await core.downloadAndExtractElectronArtifact(
-        'chromedriver',
-        'node_modules/electron-chromedriver/bin',
-    );
 };
 
 downloadMirrorBinaries().catch(err => {

--- a/pipeline/scripts/download-electron-mirror-core.js
+++ b/pipeline/scripts/download-electron-mirror-core.js
@@ -34,8 +34,9 @@ const clearAndExtract = async (zipFilePath, destinationPath) => {
 
     console.log(`extracting to ${destinationPath}`);
 
-    fs.rmdirSync(destinationPath, { recursive: true });
-
+    if (fs.existsSync(destinationPath)) {
+        fs.rmdirSync(destinationPath, { recursive: true });
+    }
     await extract(zipFilePath, { dir: destinationPath });
 };
 


### PR DESCRIPTION
#### Details

Our build is failing because our "download custom electron binaries" step is failing. The failure occurs because we're trying to replace the default version of electron-chromedriver with an internal version. We haven't used electron-chromedriver ourselves since #4673, and it must have recently disappeared as a transitive dependency. This PR does 2 things:
1. Since we don't install the basic electron-chromedriver, don't try to replace it.
2. When extracting a zip file, be resilient if the target folder doesn't already exist. This addresses [this build failure](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=33482&view=logs&j=f0eeb669-1911-5f7c-38db-4be22817cbf3&t=d82a6554-0045-5a6d-be8e-f336c8b7f784&l=19)

Validation build [here](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=33484&view=results)

##### Motivation

Get the build pipeline working

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
1. In theory, some transitive dependency could reintroduce the public version of electron-chromedriver, and we would then use the public version instead of the internal version during our validation. Is that a problem?
2. In the `clearAndExtract` method, I could have just removed the call to `rmdirSync`, but I wanted to reduce the probability of needing to change this file if it's passed in with other parameters. Happy to rework it if full removal seems to make more sense.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
