### PR TITLE
feat(mv3-part-3): DevToolsMonitor

### DIFF
--- a/src/Devtools/dev-tool-initializer.ts
+++ b/src/Devtools/dev-tool-initializer.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
+import { DevToolsMessageDistributor } from 'Devtools/dev-tool-message-distributor';
 import { TargetPageInspector } from 'Devtools/target-page-inspector';
 import { StoreProxy } from '../common/store-proxy';
 import { StoreNames } from '../common/stores/store-names';
@@ -16,12 +17,17 @@ export class DevToolInitializer {
 
     public initialize(): void {
         const storeUpdateMessageHub = new StoreUpdateMessageHub();
-        this.browserAdapter.addListenerOnMessage(storeUpdateMessageHub.handleMessage);
 
         const devtoolsStore = new StoreProxy<DevToolStoreData>(
             StoreNames[StoreNames.DevToolsStore],
             storeUpdateMessageHub,
         );
+
+        const messageDistributor = new DevToolsMessageDistributor(
+            this.browserAdapter,
+            storeUpdateMessageHub,
+        );
+        messageDistributor.initialize();
 
         const inspectHandler = new InspectHandler(
             devtoolsStore,

--- a/src/Devtools/dev-tool-message-distributor.ts
+++ b/src/Devtools/dev-tool-message-distributor.ts
@@ -18,9 +18,9 @@ export class DevToolsMessageDistributor {
         this.browserAdapter.addListenerOnMessage(this.distributeMessage);
     }
 
-    // Must return a promise for the response to send correctly
     private distributeMessage = (message: Message): void | Promise<DevToolsStatusResponse> => {
         if (this.isStatusRequestForTab(message)) {
+            // Must return a promise for the response to send correctly
             return Promise.resolve({ isActive: true });
         } else {
             this.storeUpdateHub.handleMessage(message as StoreUpdateMessage<unknown>);

--- a/src/Devtools/dev-tool-message-distributor.ts
+++ b/src/Devtools/dev-tool-message-distributor.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { Message } from 'common/message';
+import { Messages } from 'common/messages';
+import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
+import { DevToolsStatusRequest, DevToolsStatusResponse } from 'common/types/dev-tools-messages';
+import { StoreUpdateMessage } from 'common/types/store-update-message';
+
+export class DevToolsMessageDistributor {
+    constructor(
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly storeUpdateHub: StoreUpdateMessageHub,
+    ) {}
+
+    public initialize() {
+        this.browserAdapter.addListenerOnMessage(this.distributeMessage);
+    }
+
+    // Must return a promise for the response to send correctly
+    private distributeMessage = (message: Message): void | Promise<DevToolsStatusResponse> => {
+        if (this.isStatusRequestForTab(message)) {
+            return Promise.resolve({ isActive: true });
+        } else {
+            this.storeUpdateHub.handleMessage(message as StoreUpdateMessage<unknown>);
+        }
+    };
+
+    private isStatusRequestForTab(message: Message): boolean {
+        return (
+            message.messageType === Messages.DevTools.StatusRequest &&
+            (message as DevToolsStatusRequest).tabId ===
+                this.browserAdapter.getInspectedWindowTabId()
+        );
+    }
+}

--- a/src/Devtools/inspect-handler.ts
+++ b/src/Devtools/inspect-handler.ts
@@ -29,23 +29,6 @@ export class InspectHandler {
             }
         });
 
-        // TODO: create a new DevToolsMessageDistributor to handle these messages
-        this.browserAdapter.addListenerOnMessage(
-            (message): void | Promise<DevToolsStatusResponse> => {
-                console.log(
-                    `Tab ${this.browserAdapter.getInspectedWindowTabId()} Received message ${JSON.stringify(
-                        message,
-                    )}`,
-                );
-                if (
-                    message.messageType === Messages.DevTools.StatusRequest &&
-                    message.tabId === this.browserAdapter.getInspectedWindowTabId()
-                ) {
-                    return Promise.resolve({ isActive: true, tabId: message.tabId });
-                }
-            },
-        );
-
         const backgroundPageConnection = this.browserAdapter.connect({
             name: ConnectionNames.devTools,
         });

--- a/src/Devtools/inspect-handler.ts
+++ b/src/Devtools/inspect-handler.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { Messages } from 'common/messages';
 import { TargetPageInspector } from 'Devtools/target-page-inspector';
 import { BaseStore } from '../common/base-store';
 import { ConnectionNames } from '../common/constants/connection-names';
-import { DevToolsOpenMessage, DevToolsStatusResponse } from '../common/types/dev-tools-messages';
+import { DevToolsOpenMessage } from '../common/types/dev-tools-messages';
 import { DevToolStoreData } from '../common/types/store-data/dev-tool-store-data';
 
 export class InspectHandler {

--- a/src/Devtools/inspect-handler.ts
+++ b/src/Devtools/inspect-handler.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { Messages } from 'common/messages';
 import { TargetPageInspector } from 'Devtools/target-page-inspector';
 import { BaseStore } from '../common/base-store';
 import { ConnectionNames } from '../common/constants/connection-names';
-import { DevToolsOpenMessage } from '../common/types/dev-tools-messages';
+import { DevToolsOpenMessage, DevToolsStatusResponse } from '../common/types/dev-tools-messages';
 import { DevToolStoreData } from '../common/types/store-data/dev-tool-store-data';
 
 export class InspectHandler {

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -167,7 +167,7 @@ export interface SetLaunchPanelState extends BaseActionPayload {
     launchPanelType: LaunchPanelType;
 }
 
-export interface OnDevToolOpenPayload extends BaseActionPayload {
+export interface OnDevToolStatusPayload extends BaseActionPayload {
     status: boolean;
 }
 

--- a/src/background/actions/dev-tools-action-creator.ts
+++ b/src/background/actions/dev-tools-action-creator.ts
@@ -9,7 +9,7 @@ import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import {
     InspectElementPayload,
     InspectFrameUrlPayload,
-    OnDevToolOpenPayload,
+    OnDevToolStatusPayload,
 } from './action-payloads';
 import { DevToolActions } from './dev-tools-actions';
 
@@ -22,8 +22,16 @@ export class DevToolsActionCreator {
 
     public registerCallbacks(): void {
         this.interpreter.registerTypeToPayloadCallback(
-            Messages.DevTools.DevtoolStatus,
+            Messages.DevTools.Open,
             this.onDevToolOpened,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.DevTools.Close,
+            this.onDevToolClosed,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.DevTools.DevtoolStatus,
+            this.onDevToolStatusChanged,
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.DevTools.InspectElement,
@@ -39,7 +47,15 @@ export class DevToolsActionCreator {
         );
     }
 
-    private onDevToolOpened = (payload: OnDevToolOpenPayload): void => {
+    private onDevToolOpened = (): void => {
+        this.devToolActions.openDevTools.invoke();
+    };
+
+    private onDevToolClosed = (): void => {
+        this.devToolActions.closeDevTools.invoke();
+    };
+
+    private onDevToolStatusChanged = (payload: OnDevToolStatusPayload): void => {
         this.devToolActions.setDevToolState.invoke(payload.status);
     };
 

--- a/src/background/actions/dev-tools-action-creator.ts
+++ b/src/background/actions/dev-tools-action-creator.ts
@@ -22,14 +22,6 @@ export class DevToolsActionCreator {
 
     public registerCallbacks(): void {
         this.interpreter.registerTypeToPayloadCallback(
-            Messages.DevTools.Open,
-            this.onDevToolOpened,
-        );
-        this.interpreter.registerTypeToPayloadCallback(
-            Messages.DevTools.Close,
-            this.onDevToolClosed,
-        );
-        this.interpreter.registerTypeToPayloadCallback(
             Messages.DevTools.DevtoolStatus,
             this.onDevToolStatusChanged,
         );
@@ -46,14 +38,6 @@ export class DevToolsActionCreator {
             this.onDevToolGetCurrentState,
         );
     }
-
-    private onDevToolOpened = (): void => {
-        this.devToolActions.openDevTools.invoke();
-    };
-
-    private onDevToolClosed = (): void => {
-        this.devToolActions.closeDevTools.invoke();
-    };
 
     private onDevToolStatusChanged = (payload: OnDevToolStatusPayload): void => {
         this.devToolActions.setDevToolState.invoke(payload.status);

--- a/src/background/actions/dev-tools-actions.ts
+++ b/src/background/actions/dev-tools-actions.ts
@@ -3,9 +3,7 @@
 import { Action } from 'common/flux/action';
 
 export class DevToolActions {
-    public readonly setDevToolState = new Action<boolean>(); // TODO: remove
-    public readonly openDevTools = new Action<void>();
-    public readonly closeDevTools = new Action<void>();
+    public readonly setDevToolState = new Action<boolean>();
     public readonly setInspectElement = new Action<string[]>();
     public readonly setFrameUrl = new Action<string>();
     public readonly getCurrentState = new Action();

--- a/src/background/actions/dev-tools-actions.ts
+++ b/src/background/actions/dev-tools-actions.ts
@@ -3,7 +3,9 @@
 import { Action } from 'common/flux/action';
 
 export class DevToolActions {
-    public readonly setDevToolState = new Action<boolean>();
+    public readonly setDevToolState = new Action<boolean>(); // TODO: remove
+    public readonly openDevTools = new Action<void>();
+    public readonly closeDevTools = new Action<void>();
     public readonly setInspectElement = new Action<string[]>();
     public readonly setFrameUrl = new Action<string>();
     public readonly getCurrentState = new Action();

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -242,7 +242,12 @@ async function initialize(): Promise<void> {
     );
     tabEventDistributor.initialize();
 
-    const devToolsMonitor = new DevToolsMonitor(browserAdapter, promiseFactory, [], tabContextManager);
+    const devToolsMonitor = new DevToolsMonitor(
+        browserAdapter,
+        promiseFactory,
+        [],
+        tabContextManager,
+    );
     const devToolsBackgroundListener = new DevToolsListener(
         tabContextManager,
         browserAdapter,

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -242,7 +242,7 @@ async function initialize(): Promise<void> {
     );
     tabEventDistributor.initialize();
 
-    const devToolsMonitor = new DevToolsMonitor(browserAdapter, promiseFactory, []);
+    const devToolsMonitor = new DevToolsMonitor(browserAdapter, promiseFactory, [], tabContextManager);
     const devToolsBackgroundListener = new DevToolsListener(
         tabContextManager,
         browserAdapter,

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { DevToolsMonitor } from 'background/dev-tools-monitor';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { PostMessageContentRepository } from 'background/post-message-content-repository';
@@ -241,7 +242,12 @@ async function initialize(): Promise<void> {
     );
     tabEventDistributor.initialize();
 
-    const devToolsBackgroundListener = new DevToolsListener(tabContextManager, browserAdapter);
+    const devToolsMonitor = new DevToolsMonitor(browserAdapter, promiseFactory, []);
+    const devToolsBackgroundListener = new DevToolsListener(
+        tabContextManager,
+        browserAdapter,
+        devToolsMonitor,
+    );
     devToolsBackgroundListener.initialize();
 
     window.insightsFeatureFlags = globalContext.featureFlagsController;

--- a/src/background/dev-tools-listener.ts
+++ b/src/background/dev-tools-listener.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DevToolsMonitor } from 'background/dev-tools-monitor';
 import { TabContextManager } from 'background/tab-context-manager';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { ConnectionNames } from '../common/constants/connection-names';
 import { Messages } from '../common/messages';
-import { DevToolsOpenMessage } from '../common/types/dev-tools-open-message';
-import { OnDevToolOpenPayload } from './actions/action-payloads';
+import { DevToolsOpenMessage } from '../common/types/dev-tools-messages';
+import { OnDevToolStatusPayload } from './actions/action-payloads';
 
 export interface PortWithTabId extends chrome.runtime.Port {
     targetPageTabId: number;
@@ -15,6 +16,7 @@ export class DevToolsListener {
     constructor(
         private readonly tabContextManager: TabContextManager,
         private readonly browserAdapter: BrowserAdapter,
+        private readonly devToolsMonitor: DevToolsMonitor,
     ) {}
 
     public initialize(): void {
@@ -26,6 +28,7 @@ export class DevToolsListener {
                 ) => {
                     devToolsConnection.targetPageTabId = message.tabId;
                     this.sendDevToolStatus(devToolsConnection, true);
+                    this.devToolsMonitor.monitorActiveDevtool(message.tabId);
                 };
 
                 devToolsConnection.onMessage.addListener(devToolsListener);
@@ -44,7 +47,7 @@ export class DevToolsListener {
         this.tabContextManager.interpretMessageForTab(tabId, {
             payload: {
                 status: status,
-            } as OnDevToolOpenPayload,
+            } as OnDevToolStatusPayload,
             tabId: tabId,
             messageType: Messages.DevTools.DevtoolStatus,
         });

--- a/src/background/dev-tools-listener.ts
+++ b/src/background/dev-tools-listener.ts
@@ -28,7 +28,7 @@ export class DevToolsListener {
                 ) => {
                     devToolsConnection.targetPageTabId = message.tabId;
                     this.sendDevToolStatus(devToolsConnection, true);
-                    this.devToolsMonitor.monitorActiveDevtool(message.tabId);
+                    this.devToolsMonitor.startMonitoringDevtool(message.tabId);
                 };
 
                 devToolsConnection.onMessage.addListener(devToolsListener);

--- a/src/background/dev-tools-monitor.ts
+++ b/src/background/dev-tools-monitor.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { Messages } from 'common/messages';
+import { PromiseFactory, TimeoutError } from 'common/promises/promise-factory';
+import { DevToolsStatusResponse } from 'common/types/dev-tools-messages';
+import _ from 'lodash';
+
+export class DevToolsMonitor {
+    constructor(
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly promiseFactory: PromiseFactory,
+        private readonly activeDevtoolTabIds: number[],
+        private readonly messageTimeoutMilliseconds = 5000,
+        private readonly pollIntervalMilliseconds = 1000,
+    ) {}
+
+    public initialize() {
+        // TODO: initialize with persisted activeDevtoolTabIds, start monitor if needed
+    }
+
+    public monitorActiveDevtool(tabId: number): void {
+        this.addActiveDevtool(tabId);
+
+        if (this.activeDevtoolTabIds.length === 1) {
+            // Do not await, we want to continue running other synchronous code
+            this.waitForAllDevtoolsClosed();
+        }
+    }
+
+    private addActiveDevtool(tabId: number): void {
+        if (!_.isNil(tabId) && !this.activeDevtoolTabIds.includes(tabId)) {
+            this.activeDevtoolTabIds.push(tabId);
+        }
+        // TODO: persist activeDevtoolTabIds
+    }
+
+    private removeActiveDevtool(tabId: number): void {
+        const index = this.activeDevtoolTabIds.indexOf(tabId);
+        if (index >= 0) {
+            this.activeDevtoolTabIds.splice(index, 1);
+        }
+        // TODO: persist activeDevtoolTabIds
+    }
+
+    private async waitForAllDevtoolsClosed(): Promise<void> {
+        while (this.activeDevtoolTabIds.length > 0) {
+            await this.promiseFactory.delay(null, this.pollIntervalMilliseconds);
+            await this.removeInactiveDevtools();
+        }
+    }
+
+    private async removeInactiveDevtools(): Promise<void> {
+        const idsToRemove: number[] = [];
+
+        await Promise.all(
+            this.activeDevtoolTabIds.map(async tabId => {
+                const isOpen = await this.isDevtoolOpen(tabId);
+                if (!isOpen) {
+                    idsToRemove.push(tabId);
+                }
+            }),
+        );
+
+        idsToRemove.forEach(tabId => {
+            this.removeActiveDevtool(tabId);
+            this.onDevtoolsClosed(tabId);
+        });
+    }
+
+    private async isDevtoolOpen(tabId: number): Promise<boolean> {
+        const devtoolStatusPromise = await this.browserAdapter.sendRuntimeMessage({
+            messageType: Messages.DevTools.StatusRequest,
+            tabId: tabId,
+        });
+
+        try {
+            const statusResponse: DevToolsStatusResponse = await this.promiseFactory.timeout(
+                devtoolStatusPromise,
+                this.messageTimeoutMilliseconds,
+            );
+
+            return statusResponse?.isActive === true;
+        } catch (e) {
+            if (e instanceof TimeoutError) {
+                return false;
+            }
+            throw e;
+        }
+    }
+
+    private onDevtoolsClosed(tabId: number): void {
+        // TODO
+    }
+}

--- a/src/background/dev-tools-monitor.ts
+++ b/src/background/dev-tools-monitor.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { OnDevToolStatusPayload } from 'background/actions/action-payloads';
+import { TabContextManager } from 'background/tab-context-manager';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { Messages } from 'common/messages';
 import { PromiseFactory, TimeoutError } from 'common/promises/promise-factory';
@@ -12,13 +14,10 @@ export class DevToolsMonitor {
         private readonly browserAdapter: BrowserAdapter,
         private readonly promiseFactory: PromiseFactory,
         protected readonly activeDevtoolTabIds: number[],
+        private readonly tabContextManager: TabContextManager,
         private readonly messageTimeoutMilliseconds = 5000,
         private readonly pollIntervalMilliseconds = 1000,
     ) {}
-
-    public initialize() {
-        // TODO: initialize with persisted activeDevtoolTabIds, start monitor if needed
-    }
 
     public startMonitoringDevtool(tabId: number): void {
         this.addActiveDevtool(tabId);
@@ -33,7 +32,6 @@ export class DevToolsMonitor {
         if (!_.isNil(tabId) && !this.activeDevtoolTabIds.includes(tabId)) {
             this.activeDevtoolTabIds.push(tabId);
         }
-        // TODO: persist activeDevtoolTabIds
     }
 
     private removeActiveDevtool(tabId: number): void {
@@ -41,7 +39,6 @@ export class DevToolsMonitor {
         if (index >= 0) {
             this.activeDevtoolTabIds.splice(index, 1);
         }
-        // TODO: persist activeDevtoolTabIds
     }
 
     protected async monitorActiveDevtools(): Promise<void> {
@@ -89,6 +86,12 @@ export class DevToolsMonitor {
     }
 
     private onDevtoolsClosed(tabId: number): void {
-        // TODO
+        this.tabContextManager.interpretMessageForTab(tabId, {
+            payload: {
+                status: false,
+            } as OnDevToolStatusPayload,
+            tabId: tabId,
+            messageType: Messages.DevTools.DevtoolStatus,
+        });
     }
 }

--- a/src/background/dev-tools-monitor.ts
+++ b/src/background/dev-tools-monitor.ts
@@ -78,7 +78,7 @@ export class DevToolsMonitor {
 
             return statusResponse?.isActive === true;
         } catch (e) {
-            if (e instanceof TimeoutError) {
+            if (e instanceof TimeoutError || e.message.includes('Could not establish connection')) {
                 return false;
             }
             throw e;

--- a/src/background/dev-tools-monitor.ts
+++ b/src/background/dev-tools-monitor.ts
@@ -7,7 +7,7 @@ import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { Messages } from 'common/messages';
 import { PromiseFactory, TimeoutError } from 'common/promises/promise-factory';
 import { DevToolsStatusResponse } from 'common/types/dev-tools-messages';
-import _ from 'lodash';
+import { isNil } from 'lodash';
 
 export class DevToolsMonitor {
     constructor(
@@ -15,8 +15,8 @@ export class DevToolsMonitor {
         private readonly promiseFactory: PromiseFactory,
         protected readonly activeDevtoolTabIds: number[],
         private readonly tabContextManager: TabContextManager,
-        private readonly messageTimeoutMilliseconds = 5000,
-        private readonly pollIntervalMilliseconds = 1000,
+        private readonly messageTimeoutMilliseconds = 500,
+        private readonly pollIntervalMilliseconds = 500,
     ) {}
 
     public startMonitoringDevtool(tabId: number): void {
@@ -29,7 +29,7 @@ export class DevToolsMonitor {
     }
 
     private addActiveDevtool(tabId: number): void {
-        if (!_.isNil(tabId) && !this.activeDevtoolTabIds.includes(tabId)) {
+        if (!isNil(tabId) && !this.activeDevtoolTabIds.includes(tabId)) {
             this.activeDevtoolTabIds.push(tabId);
         }
     }

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -4,6 +4,7 @@ import { Assessments } from 'assessments/assessments';
 import { BackgroundMessageDistributor } from 'background/background-message-distributor';
 import { BrowserMessageBroadcasterFactory } from 'background/browser-message-broadcaster-factory';
 import { DevToolsListener } from 'background/dev-tools-listener';
+import { DevToolsMonitor } from 'background/dev-tools-monitor';
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
 import { getAllPersistedData } from 'background/get-persisted-data';
 import { GlobalContextFactory } from 'background/global-context-factory';
@@ -219,7 +220,12 @@ async function initialize(): Promise<void> {
     );
     tabEventDistributor.initialize();
 
-    const devToolsBackgroundListener = new DevToolsListener(tabContextManager, browserAdapter);
+    const devToolsMonitor = new DevToolsMonitor(browserAdapter, promiseFactory, []);
+    const devToolsBackgroundListener = new DevToolsListener(
+        tabContextManager,
+        browserAdapter,
+        devToolsMonitor,
+    );
     devToolsBackgroundListener.initialize();
 
     await cleanKeysFromStoragePromise;

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -220,7 +220,7 @@ async function initialize(): Promise<void> {
     );
     tabEventDistributor.initialize();
 
-    const devToolsMonitor = new DevToolsMonitor(browserAdapter, promiseFactory, []);
+    const devToolsMonitor = new DevToolsMonitor(browserAdapter, promiseFactory, [], tabContextManager);
     const devToolsBackgroundListener = new DevToolsListener(
         tabContextManager,
         browserAdapter,

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -220,7 +220,12 @@ async function initialize(): Promise<void> {
     );
     tabEventDistributor.initialize();
 
-    const devToolsMonitor = new DevToolsMonitor(browserAdapter, promiseFactory, [], tabContextManager);
+    const devToolsMonitor = new DevToolsMonitor(
+        browserAdapter,
+        promiseFactory,
+        [],
+        tabContextManager,
+    );
     const devToolsBackgroundListener = new DevToolsListener(
         tabContextManager,
         browserAdapter,

--- a/src/background/stores/dev-tools-store.ts
+++ b/src/background/stores/dev-tools-store.ts
@@ -43,12 +43,22 @@ export class DevToolStore extends PersistentStore<DevToolStoreData> {
     }
 
     protected addActionListeners(): void {
-        this.devToolActions.setDevToolState.addListener(this.onDevToolStatusChanged);
+        this.devToolActions.setDevToolState.addListener(this.onDevToolStatusChanged); // TODO: remove
+        this.devToolActions.openDevTools.addListener(this.onDevToolOpened);
+        this.devToolActions.openDevTools.addListener(this.onDevToolClosed);
         this.devToolActions.setInspectElement.addListener(this.onInspectElement);
         this.devToolActions.setFrameUrl.addListener(this.onSetFrameUrl);
 
         this.devToolActions.getCurrentState.addListener(this.onGetCurrentState);
     }
+
+    private onDevToolOpened = (): void => {
+        this.onDevToolStatusChanged(true);
+    };
+
+    private onDevToolClosed = (): void => {
+        this.onDevToolStatusChanged(false);
+    };
 
     private onDevToolStatusChanged = (status: boolean): void => {
         if (this.state.isOpen !== status) {

--- a/src/background/stores/dev-tools-store.ts
+++ b/src/background/stores/dev-tools-store.ts
@@ -43,22 +43,12 @@ export class DevToolStore extends PersistentStore<DevToolStoreData> {
     }
 
     protected addActionListeners(): void {
-        this.devToolActions.setDevToolState.addListener(this.onDevToolStatusChanged); // TODO: remove
-        this.devToolActions.openDevTools.addListener(this.onDevToolOpened);
-        this.devToolActions.openDevTools.addListener(this.onDevToolClosed);
+        this.devToolActions.setDevToolState.addListener(this.onDevToolStatusChanged);
         this.devToolActions.setInspectElement.addListener(this.onInspectElement);
         this.devToolActions.setFrameUrl.addListener(this.onSetFrameUrl);
 
         this.devToolActions.getCurrentState.addListener(this.onGetCurrentState);
     }
-
-    private onDevToolOpened = (): void => {
-        this.onDevToolStatusChanged(true);
-    };
-
-    private onDevToolClosed = (): void => {
-        this.onDevToolStatusChanged(false);
-    };
 
     private onDevToolStatusChanged = (status: boolean): void => {
         if (this.state.isOpen !== status) {

--- a/src/common/message-creators/dev-tool-action-message-creator.ts
+++ b/src/common/message-creators/dev-tool-action-message-creator.ts
@@ -3,7 +3,7 @@
 import {
     InspectElementPayload,
     InspectFrameUrlPayload,
-    OnDevToolOpenPayload,
+    OnDevToolStatusPayload,
 } from 'background/actions/action-payloads';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 
@@ -22,7 +22,7 @@ export class DevToolActionMessageCreator {
             messageType: Messages.DevTools.DevtoolStatus,
             payload: {
                 status: status,
-            } as OnDevToolOpenPayload,
+            } as OnDevToolStatusPayload,
         };
 
         this.dispatcher.dispatchMessage(message);

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -47,10 +47,8 @@ export const Messages = {
     },
 
     DevTools: {
-        Open: `${messagePrefix}/devtools/open`,
-        Close: `${messagePrefix}/devtools/close`,
         StatusRequest: `${messagePrefix}/devtools/getStatus`,
-        DevtoolStatus: `${messagePrefix}/devtools/status`, // TODO: remove this, replace with Open
+        DevtoolStatus: `${messagePrefix}/devtools/status`,
         InspectElement: `${messagePrefix}/devtools/inspect`,
         InspectFrameUrl: `${messagePrefix}/devtools/inspectFrameUrl`,
     },

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -47,7 +47,10 @@ export const Messages = {
     },
 
     DevTools: {
-        DevtoolStatus: `${messagePrefix}/devtools/status`,
+        Open: `${messagePrefix}/devtools/open`,
+        Close: `${messagePrefix}/devtools/close`,
+        StatusRequest: `${messagePrefix}/devtools/getStatus`,
+        DevtoolStatus: `${messagePrefix}/devtools/status`, // TODO: remove this, replace with Open
         InspectElement: `${messagePrefix}/devtools/inspect`,
         InspectFrameUrl: `${messagePrefix}/devtools/inspectFrameUrl`,
     },

--- a/src/common/promises/promise-factory.ts
+++ b/src/common/promises/promise-factory.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-type TimeoutCreator = <T>(promise: Promise<T>, delayInMilliseconds: number) => Promise<T>;
-type DelayCreator = (result: any, delayInMs: number) => Promise<any>;
+export type TimeoutCreator = <T>(promise: Promise<T>, delayInMilliseconds: number) => Promise<T>;
+export type DelayCreator = (result: any, delayInMs: number) => Promise<any>;
 
 export type ExternalResolutionPromise = {
     promise: Promise<any>;

--- a/src/common/types/dev-tools-messages.ts
+++ b/src/common/types/dev-tools-messages.ts
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+
+import { Message } from 'common/message';
+
 // Licensed under the MIT License.
 export interface DevToolsOpenMessage {
+    tabId: number;
+}
+
+export interface DevToolsStatusRequest extends Message {
     tabId: number;
 }
 

--- a/src/common/types/dev-tools-messages.ts
+++ b/src/common/types/dev-tools-messages.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 import { Message } from 'common/message';
 
-// Licensed under the MIT License.
 export interface DevToolsOpenMessage {
     tabId: number;
 }

--- a/src/common/types/dev-tools-messages.ts
+++ b/src/common/types/dev-tools-messages.ts
@@ -3,3 +3,7 @@
 export interface DevToolsOpenMessage {
     tabId: number;
 }
+
+export interface DevToolsStatusResponse {
+    isActive: boolean;
+}

--- a/src/tests/unit/tests/DevTools/dev-tool-message-distributor.test.ts
+++ b/src/tests/unit/tests/DevTools/dev-tool-message-distributor.test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { Message } from 'common/message';
+import { Messages } from 'common/messages';
+import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
+import { DevToolsStatusResponse } from 'common/types/dev-tools-messages';
+import { StoreUpdateMessage } from 'common/types/store-update-message';
+import { DevToolsMessageDistributor } from 'Devtools/dev-tool-message-distributor';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+describe(DevToolsMessageDistributor, () => {
+    const inspectedTabId = 10;
+    let browserAdapterMock: IMock<BrowserAdapter>;
+    let storeUpdateHubMock: IMock<StoreUpdateMessageHub>;
+    let distributeMessage: (message: Message) => void | Promise<DevToolsStatusResponse>;
+
+    let testSubject: DevToolsMessageDistributor;
+
+    beforeEach(() => {
+        browserAdapterMock = Mock.ofType<BrowserAdapter>();
+        browserAdapterMock
+            .setup(b => b.addListenerOnMessage(It.isAny()))
+            .callback(listener => (distributeMessage = listener))
+            .verifiable(Times.once());
+        browserAdapterMock.setup(b => b.getInspectedWindowTabId()).returns(() => inspectedTabId);
+        storeUpdateHubMock = Mock.ofType<StoreUpdateMessageHub>();
+
+        testSubject = new DevToolsMessageDistributor(
+            browserAdapterMock.object,
+            storeUpdateHubMock.object,
+        );
+    });
+
+    afterEach(() => {
+        browserAdapterMock.verifyAll();
+        storeUpdateHubMock.verifyAll();
+    });
+
+    it('initialize registers message listener', () => {
+        testSubject.initialize();
+    });
+
+    describe('initialized', () => {
+        beforeEach(() => {
+            testSubject.initialize();
+        });
+
+        it('Sends a status response to status request message for this tab', async () => {
+            const message = {
+                messageType: Messages.DevTools.StatusRequest,
+                tabId: inspectedTabId,
+            };
+            const expectedResponse = {
+                isActive: true,
+            };
+
+            const responsePromise = distributeMessage(message);
+
+            expect(responsePromise).toBeInstanceOf(Promise);
+
+            const response = await responsePromise;
+
+            expect(response).toEqual(expectedResponse);
+        });
+
+        it('Does not send response to status request for a different tab', () => {
+            const message = {
+                messageType: Messages.DevTools.StatusRequest,
+                tabId: inspectedTabId + 10,
+            };
+
+            const response = distributeMessage(message);
+
+            expect(response).toBeUndefined();
+        });
+
+        it('Passes messages that are not status requests to storeUpdateMessageHub', () => {
+            const message = {
+                messageType: 'another message type',
+            };
+            storeUpdateHubMock
+                .setup(s => s.handleMessage(message as StoreUpdateMessage<unknown>))
+                .verifiable(Times.once());
+
+            const response = distributeMessage(message);
+
+            expect(response).toBeUndefined();
+        });
+    });
+});

--- a/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
@@ -3,7 +3,7 @@
 import {
     InspectElementPayload,
     InspectFrameUrlPayload,
-    OnDevToolOpenPayload,
+    OnDevToolStatusPayload,
 } from 'background/actions/action-payloads';
 import { DevToolsActionCreator } from 'background/actions/dev-tools-action-creator';
 import { DevToolActions } from 'background/actions/dev-tools-actions';
@@ -27,7 +27,7 @@ describe('DevToolsActionCreatorTest', () => {
     });
 
     it('handles DevToolStatus message', () => {
-        const payload: OnDevToolOpenPayload = {
+        const payload: OnDevToolStatusPayload = {
             status: true,
         };
 

--- a/src/tests/unit/tests/background/dev-tools-listener.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-listener.test.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DevToolsListener } from 'background/dev-tools-listener';
+import { DevToolsMonitor } from 'background/dev-tools-monitor';
 import { TabContextManager } from 'background/tab-context-manager';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { ConnectionNames } from '../../../../common/constants/connection-names';
 import { Messages } from '../../../../common/messages';
-import { DevToolsOpenMessage } from '../../../../common/types/dev-tools-open-message';
+import { DevToolsOpenMessage } from '../../../../common/types/dev-tools-messages';
 import {
     DevToolsBrowserAdapterMock,
     PortWithTabTabIdStub,
@@ -17,13 +18,16 @@ describe('DevToolsListenerTests', () => {
     let testSubject: DevToolsListener;
     let browserAdapterMock: DevToolsBrowserAdapterMock;
     let tabContextManagerMock: IMock<TabContextManager>;
+    let devToolsMonitorMock: IMock<DevToolsMonitor>;
 
     beforeEach(() => {
         tabContextManagerMock = Mock.ofType<TabContextManager>();
         browserAdapterMock = new DevToolsBrowserAdapterMock();
+        devToolsMonitorMock = Mock.ofType<DevToolsMonitor>();
         testSubject = new DevToolsListener(
             tabContextManagerMock.object,
             browserAdapterMock.getObject(),
+            devToolsMonitorMock.object,
         );
     });
 
@@ -111,6 +115,8 @@ describe('DevToolsListenerTests', () => {
             )
             .verifiable(Times.once());
 
+        devToolsMonitorMock.setup(d => d.startMonitoringDevtool(2)).verifiable(Times.once());
+
         testSubject.initialize();
         connectListenerCB(portStub);
 
@@ -122,6 +128,8 @@ describe('DevToolsListenerTests', () => {
 
         expect(portStub.targetPageTabId).toBe(2);
         tabContextManagerMock.verifyAll();
+
+        devToolsMonitorMock.verifyAll();
     });
 
     test('initialize - disconnect - call interpreter with status false', () => {

--- a/src/tests/unit/tests/background/dev-tools-monitor.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-monitor.test.ts
@@ -151,6 +151,24 @@ describe(DevToolsMonitor, () => {
         );
     });
 
+    it("Handles 'Could not establish connection' error on message", async () => {
+        const testError = new Error(
+            'Error: Could not establish connection. Receiving end does not exist.',
+        );
+        browserAdapterMock
+            .setup(b =>
+                b.sendRuntimeMessage({ messageType: Messages.DevTools.StatusRequest, tabId }),
+            )
+            .throws(testError);
+        setupTimeoutCreator(Times.never()); // mock call is not verified if return hook throws
+        setupDelayCreator(Times.once());
+        setupDevtoolClosed(tabId);
+
+        testSubject.activeDevtoolTabIds = [tabId];
+
+        await testSubject.testPollLoop();
+    });
+
     it('Throws in loop if a non timeout error occurs', async () => {
         const testError = new Error('Non-timeout error');
         browserAdapterMock

--- a/src/tests/unit/tests/background/dev-tools-monitor.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-monitor.test.ts
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DevToolsMonitor } from 'background/dev-tools-monitor';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { Messages } from 'common/messages';
+import {
+    DelayCreator,
+    PromiseFactory,
+    TimeoutCreator,
+    TimeoutError,
+} from 'common/promises/promise-factory';
+import _ from 'lodash';
+import { flushSettledPromises } from 'tests/common/flush-settled-promises';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { DictionaryNumberTo } from 'types/common-types';
+
+class TestDevToolsMonitor extends DevToolsMonitor {
+    public activeDevtoolTabIds: number[];
+
+    public async testPollLoop(): Promise<void> {
+        await super.monitorActiveDevtools();
+    }
+}
+
+describe(DevToolsMonitor, () => {
+    const messageTimeout = 10;
+    const pollInterval = 20;
+    const tabId = 1;
+    const anotherTabId = 10;
+
+    const messageSuccessResponse = { isActive: true };
+    const mockTimeoutResponse = { isTimeout: true };
+
+    let browserAdapterMock: IMock<BrowserAdapter>;
+    let timeoutMock: IMock<TimeoutCreator>;
+    let delayMock: IMock<DelayCreator>;
+    let promiseFactory: PromiseFactory;
+
+    let testSubject: TestDevToolsMonitor;
+
+    beforeEach(() => {
+        browserAdapterMock = Mock.ofType<BrowserAdapter>();
+        timeoutMock = Mock.ofType<TimeoutCreator>();
+        delayMock = Mock.ofType<DelayCreator>();
+        promiseFactory = {
+            timeout: timeoutMock.object,
+            delay: delayMock.object,
+        } as PromiseFactory;
+
+        testSubject = new TestDevToolsMonitor(
+            browserAdapterMock.object,
+            promiseFactory,
+            [],
+            messageTimeout,
+            pollInterval,
+        );
+    });
+
+    afterEach(() => {
+        browserAdapterMock.verifyAll();
+        timeoutMock.verifyAll();
+        delayMock.verifyAll();
+    });
+
+    it.each([1, 3])(
+        'Start poll loop and run %s times when first devtool tab id is added',
+        async pollCount => {
+            const tabPollCounts: DictionaryNumberTo<number> = {};
+            tabPollCounts[tabId] = pollCount;
+
+            setupPollLoop(tabPollCounts);
+
+            testSubject.startMonitoringDevtool(tabId);
+
+            await flushSettledPromises();
+        },
+    );
+
+    it('Does not start poll loop if another devtool is already being monitored', async () => {
+        testSubject.activeDevtoolTabIds = [anotherTabId];
+
+        timeoutMock.setup(t => t(It.isAny(), It.isAny())).verifiable(Times.never());
+        delayMock.setup(d => d(It.isAny(), It.isAny())).verifiable(Times.never());
+        browserAdapterMock.setup(b => b.sendRuntimeMessage(It.isAny())).verifiable(Times.never());
+
+        testSubject.startMonitoringDevtool(tabId);
+
+        await flushSettledPromises();
+
+        expect(testSubject.activeDevtoolTabIds).toContain(tabId);
+    });
+
+    it('Polls two devtool tabs until both have closed', async () => {
+        testSubject.activeDevtoolTabIds = [tabId, anotherTabId];
+
+        const tabPollCounts: DictionaryNumberTo<number> = {};
+        tabPollCounts[tabId] = 2;
+        tabPollCounts[anotherTabId] = 4;
+
+        setupPollLoop(tabPollCounts);
+
+        await testSubject.testPollLoop();
+    });
+
+    it('Add a devtool tab while monitor loop is running asynchronously', async () => {
+        let firstIteration = true;
+        let stopLoop = false;
+
+        setupDelayCreator(Times.atLeastOnce());
+        setupTimeoutCreator(Times.atLeastOnce());
+
+        browserAdapterMock
+            .setup(b => b.sendRuntimeMessage(It.isAny()))
+            .returns(async message => {
+                // During the first loop, add another tabId to monitor
+                if (firstIteration) {
+                    firstIteration = false;
+                    testSubject.startMonitoringDevtool(anotherTabId);
+                }
+                // stop the loop on the next iteration after the second tab has been messaged
+                if (!stopLoop && message.tabId === anotherTabId) {
+                    stopLoop = true;
+                } else if (stopLoop) {
+                    return mockTimeoutResponse;
+                }
+                return messageSuccessResponse;
+            })
+            .verifiable(Times.atLeastOnce());
+
+        testSubject.startMonitoringDevtool(tabId);
+
+        await flushSettledPromises();
+
+        browserAdapterMock.verify(
+            b => b.sendRuntimeMessage(It.isObjectWith({ tabId: tabId })),
+            Times.atLeastOnce(),
+        );
+        browserAdapterMock.verify(
+            b => b.sendRuntimeMessage(It.isObjectWith({ tabId: anotherTabId })),
+            Times.atLeastOnce(),
+        );
+    });
+
+    it('Throws in loop if a non timeout error occurs', async () => {
+        const testError = new Error('Non-timeout error');
+        browserAdapterMock
+            .setup(b =>
+                b.sendRuntimeMessage({ messageType: Messages.DevTools.StatusRequest, tabId }),
+            )
+            .throws(testError);
+        setupTimeoutCreator(Times.never()); // mock call is not verified if return hook throws
+        setupDelayCreator(Times.once());
+
+        testSubject.activeDevtoolTabIds = [tabId];
+
+        await expect(testSubject.testPollLoop()).rejects.toThrow(testError);
+    });
+
+    function setupPollLoop(expectedTabPollCounts: DictionaryNumberTo<number>): void {
+        let totalMessageCount = 0;
+        let totalLoopCount = 0;
+
+        Object.keys(expectedTabPollCounts).forEach(pollTabId => {
+            const tabPollCount: number = expectedTabPollCounts[pollTabId];
+            totalMessageCount += tabPollCount;
+            totalLoopCount = _.max([totalLoopCount, tabPollCount]);
+
+            setupPollTabTimes(parseInt(pollTabId), tabPollCount);
+        });
+
+        setupDelayCreator(Times.exactly(totalLoopCount));
+        setupTimeoutCreator(Times.exactly(totalMessageCount));
+    }
+
+    function setupPollTabTimes(pollTabId: number, times: number): void {
+        let tabPollCount = 0;
+        const expectedMessage = {
+            messageType: Messages.DevTools.StatusRequest,
+            tabId: pollTabId,
+        };
+
+        browserAdapterMock
+            .setup(b => b.sendRuntimeMessage(expectedMessage))
+            .returns(async message => {
+                tabPollCount += 1;
+                if (tabPollCount < times) {
+                    return messageSuccessResponse;
+                } else {
+                    return mockTimeoutResponse;
+                }
+            })
+            .verifiable(Times.exactly(times));
+    }
+
+    function setupTimeoutCreator(times: Times): void {
+        timeoutMock
+            .setup(t => t(It.isAny(), messageTimeout))
+            .returns(async (promise, timeout) => {
+                const result = await promise;
+                if (_.isEqual(result, mockTimeoutResponse)) {
+                    return Promise.reject(new TimeoutError('Test timeout error'));
+                }
+                return result;
+            })
+            .verifiable(times);
+    }
+
+    function setupDelayCreator(times: Times): void {
+        delayMock.setup(d => d(It.isAny(), pollInterval)).verifiable(times);
+    }
+});

--- a/src/tests/unit/tests/background/dev-tools-monitor.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-monitor.test.ts
@@ -12,7 +12,7 @@ import {
     TimeoutCreator,
     TimeoutError,
 } from 'common/promises/promise-factory';
-import _ from 'lodash';
+import { isEqual, max } from 'lodash';
 import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { DictionaryNumberTo } from 'types/common-types';
@@ -173,7 +173,7 @@ describe(DevToolsMonitor, () => {
         Object.keys(expectedTabPollCounts).forEach(pollTabId => {
             const tabPollCount: number = expectedTabPollCounts[pollTabId];
             totalMessageCount += tabPollCount;
-            totalLoopCount = _.max([totalLoopCount, tabPollCount]);
+            totalLoopCount = max([totalLoopCount, tabPollCount]);
 
             setupPollTabTimes(parseInt(pollTabId), tabPollCount);
         });
@@ -209,7 +209,7 @@ describe(DevToolsMonitor, () => {
             .setup(t => t(It.isAny(), messageTimeout))
             .returns(async (promise, timeout) => {
                 const result = await promise;
-                if (_.isEqual(result, mockTimeoutResponse)) {
+                if (isEqual(result, mockTimeoutResponse)) {
                     return Promise.reject(new TimeoutError('Test timeout error'));
                 }
                 return result;

--- a/src/tests/unit/tests/common/message-creators/dev-tool-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/dev-tool-action-message-creator.test.ts
@@ -3,7 +3,7 @@
 import {
     InspectElementPayload,
     InspectFrameUrlPayload,
-    OnDevToolOpenPayload,
+    OnDevToolStatusPayload,
 } from 'background/actions/action-payloads';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -33,7 +33,7 @@ describe('DevToolActionMessageCreatorTest', () => {
             messageType: Messages.DevTools.DevtoolStatus,
             payload: {
                 status: status,
-            } as OnDevToolOpenPayload,
+            } as OnDevToolStatusPayload,
         };
 
         testSubject.setDevToolStatus(status);


### PR DESCRIPTION
#### Details

Creates DevToolsMonitor to poll active devtools for their status every 500ms until they close. It will only poll if there are active devtools. With this PR, DevToolsMonitor will poll alongside the browser connection that we currently use to detect devtools opening and closing, but the plan is for it to eventually replace that connection.

##### Motivation

Because of the switch to MV3, we will need to replace uses of browser.connect() with message passing. However, since we use the devtools connection to detect when a devtool has closed in addition to when it opened, there isn't an easy 1:1 replacement and we'll need to implement another mechanism to detect when a devtool is no longer open. This PR implements a polling system for that purpose.

##### Context

Future PRs will:
- Persist the list of active devtools in DevToolsMonitor in case the service worker dies unexpectedly
- Remove the browser connection, send a message when a DevTool is initialized, and only use DevToolsMonitor to detect when it closes

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
