### PR TITLE
chore: Enable and fix stylelint rules `no-duplicate-selectors` and `scss/comment-no-empty` 

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -14,7 +14,6 @@ module.exports = {
         'no-invalid-position-at-import-rule': null,
         'no-duplicate-at-import-rules': null,
         'scss/no-global-function-names': null,
-        'scss/comment-no-empty': null,
         'no-descending-specificity': null,
 
         // TO BE CONFIGURED: Limit shorthand for margin, padding

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -11,7 +11,6 @@ module.exports = {
 
         // TO BE ENABLED: Recommended fixes
         'scss/at-extend-no-missing-placeholder': null,
-        'no-duplicate-selectors': null,
         'no-invalid-position-at-import-rule': null,
         'no-duplicate-at-import-rules': null,
         'scss/no-global-function-names': null,

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -39,12 +39,6 @@ body {
     flex-direction: column;
     height: 100%;
 
-    .ms-DetailsRow {
-        .property-bag-div {
-            white-space: normal;
-        }
-    }
-
     .ms-DetailsRow,
     .ms-GroupHeader {
         user-select: text;
@@ -52,6 +46,10 @@ body {
     }
 
     .ms-DetailsRow {
+        .property-bag-div {
+            white-space: normal;
+        }
+
         .content-cell:first-child {
             padding-left: 13px !important;
         }

--- a/src/common/styles/root-level-only/color-definitions.scss
+++ b/src/common/styles/root-level-only/color-definitions.scss
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 // This file should *only* be @imported from root-level SCSS files, *not* individual SCSS modules.
-//
 // SCSS modules should instead use /common/styles/colors.scss.
-//
 // If an SCSS module @imports this, the styles will be repeated once per @importing module in the
 // final packed .css file, which causes perf issues (especially with Chromium's dev tools).
 

--- a/src/common/styles/root-level-only/global-styles.scss
+++ b/src/common/styles/root-level-only/global-styles.scss
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 // This file should *only* be @imported from root-level SCSS files, *not* individual SCSS modules.
-//
 // If an SCSS module @imports this, the styles will be repeated once per @importing module in the
 // final packed .css file, which causes perf issues (especially with Chromium's dev tools).
 

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -258,6 +258,11 @@
         position: absolute !important;
         overflow: hidden !important;
         pointer-events: none !important;
+
+        @include ms-high-contrast-override {
+            forced-color-adjust: none;
+            outline-color: Highlight !important;
+        }
     }
 
     .insights-highlight-container .insights-highlight-box .insights-highlight-text {
@@ -268,13 +273,6 @@
         float: right !important;
         position: relative !important;
         text-align: center !important;
-    }
-
-    .insights-highlight-container .insights-highlight-box {
-        @include ms-high-contrast-override {
-            forced-color-adjust: none;
-            outline-color: Highlight !important;
-        }
     }
 
     .insights-highlight-container .insights-highlight-text {

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -122,11 +122,6 @@ html {
     padding-left: 0;
 }
 
-#popup-container .launch-panel {
-    width: 296px;
-    margin: 10px 0 10px 0;
-}
-
 #popup-container .ad-hoc-tools-panel {
     width: 540px;
     margin: 10px 0 20px 0;
@@ -155,6 +150,40 @@ html {
 #popup-container .main-section {
     margin-left: 14px;
     margin-right: 14px;
+
+    .launch-pad-footer {
+        color: $neutral-60;
+        font-weight: 300;
+        font-size: 11px;
+        margin-bottom: 12px;
+        margin-top: 12px;
+
+        div + div {
+            margin-top: 1vh;
+        }
+
+        a {
+            font-weight: 600;
+        }
+    }
+
+    .launch-pad-hr {
+        margin: 12px 0 0 0;
+        border-width: 1px 0 0 0;
+        padding: 0;
+        border-style: solid;
+        border-color: $neutral-8;
+    }
+
+    .launch-pad-item-title {
+        margin: 5px 0 5px 0;
+        padding: 0;
+        height: 20px;
+
+        .ms-Link {
+            font-weight: 600;
+        }
+    }
 }
 
 #popup-container .main-section label {
@@ -246,42 +275,6 @@ button[disabled]:focus:not(.ms-ContextualMenu-link) {
         font-weight: 600;
         margin-bottom: -4px;
     }
-
-    .main-section {
-        .launch-pad-footer {
-            color: $neutral-60;
-            font-weight: 300;
-            font-size: 11px;
-            margin-bottom: 12px;
-            margin-top: 12px;
-
-            div + div {
-                margin-top: 1vh;
-            }
-
-            a {
-                font-weight: 600;
-            }
-        }
-
-        .launch-pad-hr {
-            margin: 12px 0 0 0;
-            border-width: 1px 0 0 0;
-            padding: 0;
-            border-style: solid;
-            border-color: $neutral-8;
-        }
-
-        .launch-pad-item-title {
-            margin: 5px 0 5px 0;
-            padding: 0;
-            height: 20px;
-
-            .ms-Link {
-                font-weight: 600;
-            }
-        }
-    }
 }
 
 #popup-container #new-launch-pad {
@@ -290,26 +283,12 @@ button[disabled]:focus:not(.ms-ContextualMenu-link) {
 
 #popup-container .launch-panel {
     width: 296px;
+    margin: 10px 0 10px 0;
 
     .launch-pad-main-section {
         width: 100%;
         margin: 0;
-    }
 
-    .launch-pad-item-description {
-        width: 280px;
-    }
-
-    .popup-start-dialog-icon-circle {
-        border-radius: 50%;
-        width: 59px;
-        height: 59px;
-        background-color: $communication-tint-30;
-        margin-top: 12px;
-        padding: 12px 14px 14px 14px;
-    }
-
-    .launch-pad-main-section {
         .ms-Button-icon {
             width: 31px;
             height: 31px;
@@ -327,6 +306,19 @@ button[disabled]:focus:not(.ms-ContextualMenu-link) {
             color: $secondary-text;
             font-style: normal;
         }
+    }
+
+    .launch-pad-item-description {
+        width: 280px;
+    }
+
+    .popup-start-dialog-icon-circle {
+        border-radius: 50%;
+        width: 59px;
+        height: 59px;
+        background-color: $communication-tint-30;
+        margin-top: 12px;
+        padding: 12px 14px 14px 14px;
     }
 
     .launch-pad-item-grid {

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -24,7 +24,6 @@ div.insights-dialog-main-override.telemetry-permission-dialog {
     width: 368px;
 
     // Workaround for issue https://github.com/microsoft/accessibility-insights-web/issues/4178
-    //
     // The bug seems to affect only Chromium 91 (not 90 or 92); the workaround can be removed after
     // Edge/Chrome stable have been on 92 for a few weeks (ie, around September 2021).
     > .ms-Modal-scrollableContent {


### PR DESCRIPTION
#### Details

This PR will enable and fix the following stylelint rules:

- [`no-duplicate-selectors`](https://stylelint.io/user-guide/rules/list/no-duplicate-selectors/) disallows duplicate selectors within a single stylesheet. This rule will improve code legibility and prevent errors.
- [`scss/comment-no-empty`](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/comment-no-empty/README.md) disallows empty comments to enforce code style consistency.

##### Motivation

Part of https://github.com/microsoft/accessibility-insights-web/issues/5187 as an incremental task to enable stylelint rules.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5187 
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
