### PR TITLE
chore: Enable and fix stylelint rules for global function names, imports, and extends

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -12,8 +12,6 @@ module.exports = {
         // TO BE ENABLED: Recommended fixes
         'scss/at-extend-no-missing-placeholder': null,
         'no-duplicate-selectors': null,
-        'no-invalid-position-at-import-rule': null,
-        'no-duplicate-at-import-rules': null,
         'scss/comment-no-empty': null,
         'no-descending-specificity': null,
 

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -14,7 +14,6 @@ module.exports = {
         'no-duplicate-selectors': null,
         'no-invalid-position-at-import-rule': null,
         'no-duplicate-at-import-rules': null,
-        'scss/no-global-function-names': null,
         'scss/comment-no-empty': null,
         'no-descending-specificity': null,
 

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -10,7 +10,6 @@ module.exports = {
         'shorthand-property-no-redundant-values': null, // Prefer longhand to improve readability
 
         // TO BE ENABLED: Recommended fixes
-        'scss/at-extend-no-missing-placeholder': null,
         'no-duplicate-selectors': null,
         'scss/comment-no-empty': null,
         'no-descending-specificity': null,

--- a/src/common/styles/fonts.scss
+++ b/src/common/styles/fonts.scss
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+@use 'sass:string';
 
 // This file is @imported by many SCSS modules, which means it *must not* contain any actual style
 // definitions; it may *only* contain SCSS directives (eg, $variable, @function, and @mixin).
@@ -9,7 +10,7 @@
     $family: '';
     @each $font in $fonts {
         $font: if(
-            str-index($font, ' ') == null and str-index($font, '-') != 1,
+            string.index($font, ' ') == null and string.index($font, '-') != 1,
             $font,
             "'#{$font}'"
         );

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 @import '../../common/styles/root-level-only/color-definitions.scss';
 @import '../../common/styles/colors.scss';
+@import '../../common/styles/common.scss';
 
 #accessibility-insights-root-container {
     visibility: hidden !important;
@@ -30,10 +31,6 @@
 
 #accessibility-insights-root-container,
 #insights-shadow-container {
-    @import '../../common/styles/colors.scss';
-    @import '../../common/styles/common.scss';
-    @import '../../common/components/toast.scss';
-
     @mixin max-z-index-1 {
         z-index: 2147483646 !important;
     }

--- a/src/reports/assessment-report.scss
+++ b/src/reports/assessment-report.scss
@@ -117,7 +117,8 @@ header {
     white-space: pre-line;
 }
 
-.instance-key {
+.instance-key,
+%instance-key {
     font-size: 12px;
     font-weight: $fontWeightSemiBold;
     vertical-align: top;
@@ -126,13 +127,13 @@ header {
 }
 
 .instance-subsection-header {
-    @extend .instance-key;
+    @extend %instance-key;
 
     text-align: left;
 }
 
 .instance-key-indented {
-    @extend .instance-key;
+    @extend %instance-key;
 
     padding-left: 30px;
 }

--- a/src/reports/components/outcome-summary-bar.scss
+++ b/src/reports/components/outcome-summary-bar.scss
@@ -30,7 +30,8 @@ $outcome-not-applicable-color: $neutral-outcome;
     font-weight: 600;
     white-space: pre-wrap;
 
-    .block {
+    .block,
+    %block {
         font-family: $fontFamily;
         line-height: 20px;
         font-size: 16px;
@@ -47,7 +48,7 @@ $outcome-not-applicable-color: $neutral-outcome;
     }
 
     .fail {
-        @extend .block;
+        @extend %block;
         @include cross-icon-styles($outcome-summary-icon-size, 0, $outcome-fail-color);
 
         .check-container {
@@ -59,7 +60,7 @@ $outcome-not-applicable-color: $neutral-outcome;
     }
 
     .pass {
-        @extend .block;
+        @extend %block;
         @include check-icon-styles($outcome-summary-icon-size, 0, $outcome-pass-color);
 
         .check-container {
@@ -73,7 +74,7 @@ $outcome-not-applicable-color: $neutral-outcome;
 
     .inapplicable,
     .unscannable {
-        @extend .block;
+        @extend %block;
         @include inapplicable-icon-styles(
             $outcome-summary-icon-size,
             0,
@@ -90,7 +91,7 @@ $outcome-not-applicable-color: $neutral-outcome;
     }
 
     .incomplete {
-        @extend .block;
+        @extend %block;
         @include incomplete-icon-styles(14px, 3px);
 
         .check-container {


### PR DESCRIPTION
#### Details

This PR will enable and fix the following stylelint rules (bundled these together as there were few fixes for each):

- [`scss/no-global-function-names`](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/no-global-function-names/README.md) disallows the use of global function names, as these global functions are now located inside built-in Sass modules.
- [`no-invalid-position-at-import-rule`](https://stylelint.io/user-guide/rules/list/no-invalid-position-at-import-rule/) disallows invalid position `@import` rules within a stylesheet (for example, not at the top of the file).
- [`no-duplicate-at-import-rule`](https://stylelint.io/user-guide/rules/list/no-duplicate-at-import-rules/) sisallows duplicate `@import` rules within a stylesheet.
- [`scss/at-extend-no-missing-placeholder`](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-extend-no-missing-placeholder/README.md) disallow at-extends (`@extend`) with missing placeholders (a placeholder begins with `%`).



##### Motivation

Part of https://github.com/microsoft/accessibility-insights-web/issues/5187 as an incremental task to enable stylelint rules.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5187 
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
