### PR TITLE
fix: synchronize ExtensionDetailsViewController tabs with browser tabs

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -203,6 +203,7 @@ async function initialize(): Promise<void> {
         tabContextManager.interpretMessageForTab,
         persistData,
     );
+    await detailsViewController.initialize();
 
     const tabContextFactory = new TabContextFactory(
         visualizationConfigurationFactory,

--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -17,6 +17,18 @@ export class ExtensionDetailsViewController implements DetailsViewController {
         private readonly persistStoreData: boolean,
     ) {}
 
+    public async initialize(): Promise<void> {
+        const tabIds = (await this.browserAdapter.tabsQuery({})).map(tab => tab.id);
+
+        const knownTabIds = Object.keys(this.tabIdToDetailsViewMap).flatMap(targetTabId => [
+            parseInt(targetTabId),
+            this.tabIdToDetailsViewMap[targetTabId],
+        ]);
+
+        const removedTabs = knownTabIds.filter(tabId => !tabIds.includes(tabId));
+        await Promise.all(removedTabs.map(tabId => this.onRemoveTab(tabId)));
+    }
+
     public async onUpdateTab(tabId: number, changeInfo: chrome.tabs.TabChangeInfo): Promise<void> {
         const targetTabId = this.getTargetTabIdForDetailsTabId(tabId);
 

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -181,6 +181,7 @@ async function initialize(): Promise<void> {
         tabContextManager.interpretMessageForTab,
         true,
     );
+    await detailsViewController.initialize();
 
     const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter, logger);
     const tabContextFactory = new TabContextFactory(

--- a/src/tests/unit/tests/background/extension-details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/extension-details-view-controller.test.ts
@@ -5,6 +5,7 @@ import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Message } from 'common/message';
 import { Messages } from 'common/messages';
+import { isEmpty } from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DictionaryStringTo } from 'types/common-types';
 import { Tabs } from 'webextension-polyfill';
@@ -25,15 +26,101 @@ describe('ExtensionDetailsViewController', () => {
         idbInstanceMock.reset();
     });
 
+    describe('initialize()', () => {
+        const existingBrowserTabs = [{ id: 1 }, { id: 2 }, { id: 3 }] as Tabs.Tab[];
+
+        beforeEach(() => {
+            browserAdapterMock.setup(b => b.tabsQuery({})).returns(async () => existingBrowserTabs);
+        });
+
+        it('Does nothing when tabIdToDetailsViewMap is empty', async () => {
+            interpretMessageForTabMock
+                .setup(i => i(It.isAny(), It.isAny()))
+                .verifiable(Times.never());
+            setupDatabaseInstance(null, Times.never());
+
+            testSubject = createTestSubject(true);
+            await testSubject.initialize();
+
+            expect(isEmpty(tabIdToDetailsViewMap)).toBe(true);
+            interpretMessageForTabMock.verifyAll();
+            idbInstanceMock.verifyAll();
+        });
+
+        it('Does nothing when tabIdToDetailsViewMap only contains tabs still in browser', async () => {
+            tabIdToDetailsViewMap['1'] = 2;
+            interpretMessageForTabMock
+                .setup(i => i(It.isAny(), It.isAny()))
+                .verifiable(Times.never());
+            setupDatabaseInstance(null, Times.never());
+
+            testSubject = createTestSubject(true);
+            await testSubject.initialize();
+
+            expect(Object.keys(tabIdToDetailsViewMap)).toEqual(['1']);
+            expect(tabIdToDetailsViewMap['1']).toBe(2);
+            interpretMessageForTabMock.verifyAll();
+            idbInstanceMock.verifyAll();
+        });
+
+        it.each([true, false])(
+            'Removes details view tab id if it does not exist in browser with persistData=%s',
+            async persistData => {
+                tabIdToDetailsViewMap['1'] = 2;
+                tabIdToDetailsViewMap['3'] = 33;
+                interpretMessageForTabMock
+                    .setup(i =>
+                        i(3, {
+                            messageType: Messages.Visualizations.DetailsView.Close,
+                            payload: null,
+                            tabId: 3,
+                        }),
+                    )
+                    .verifiable(Times.once());
+
+                if (persistData) {
+                    setupDatabaseInstance({ '1': 2 }, Times.once());
+                } else {
+                    setupDatabaseInstance(null, Times.never());
+                }
+
+                testSubject = createTestSubject(persistData);
+                await testSubject.initialize();
+
+                expect(Object.keys(tabIdToDetailsViewMap)).toEqual(['1']);
+                interpretMessageForTabMock.verifyAll();
+                idbInstanceMock.verifyAll();
+            },
+        );
+
+        it.each([true, false])(
+            'Removes target tab id if it does not exist in browser with persistData=%s',
+            async persistData => {
+                tabIdToDetailsViewMap['1'] = 2;
+                tabIdToDetailsViewMap['33'] = 3;
+                interpretMessageForTabMock
+                    .setup(i => i(It.isAny(), It.isAny()))
+                    .verifiable(Times.never());
+
+                if (persistData) {
+                    setupDatabaseInstance({ '1': 2 }, Times.once());
+                } else {
+                    setupDatabaseInstance(null, Times.never());
+                }
+
+                testSubject = createTestSubject(persistData);
+                await testSubject.initialize();
+
+                expect(Object.keys(tabIdToDetailsViewMap)).toEqual(['1']);
+                interpretMessageForTabMock.verifyAll();
+                idbInstanceMock.verifyAll();
+            },
+        );
+    });
+
     describe('No Persisted Data', () => {
         beforeEach(() => {
-            testSubject = new ExtensionDetailsViewController(
-                browserAdapterMock.object,
-                tabIdToDetailsViewMap,
-                idbInstanceMock.object,
-                interpretMessageForTabMock.object,
-                false,
-            );
+            testSubject = createTestSubject(false);
 
             setupDatabaseInstance(null, Times.never());
         });
@@ -100,13 +187,7 @@ describe('ExtensionDetailsViewController', () => {
 
     describe('Persisted Data', () => {
         beforeEach(() => {
-            testSubject = new ExtensionDetailsViewController(
-                browserAdapterMock.object,
-                tabIdToDetailsViewMap,
-                idbInstanceMock.object,
-                interpretMessageForTabMock.object,
-                true,
-            );
+            testSubject = createTestSubject(true);
         });
 
         describe('showDetailsView', () => {
@@ -586,5 +667,15 @@ describe('ExtensionDetailsViewController', () => {
         } else {
             idbInstanceMock.setup(db => db.setItem(indexedDBDataKey, It.isAny())).verifiable(times);
         }
+    };
+
+    const createTestSubject = (persistData: boolean): ExtensionDetailsViewController => {
+        return new ExtensionDetailsViewController(
+            browserAdapterMock.object,
+            tabIdToDetailsViewMap,
+            idbInstanceMock.object,
+            interpretMessageForTabMock.object,
+            persistData,
+        );
     };
 });


### PR DESCRIPTION
#### Details

After ExtensionDetailsViewController is created, make sure tabIdToDetailsViewMap only contains valid tab ids.

##### Motivation

Fixes a bug currently in canary. Currently, if the extension is reloaded while a details view tab is open, that tab closes, but the persisted tabIdToDetailsViewMap in ExtensionDetailsViewController still contains the closed details view tab id. After a reload, if the user tries to open a details view against the same tab, the extension tries to switch to the nonexistant tab and throws an error. This PR ensures that tabIdToDetailsViewMap only contains valid tab ids after a reload.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
