### PR TITLE
feat(mv3-part-4): Fix tab message errors

### DIFF
--- a/src/common/components/with-store-subscription.tsx
+++ b/src/common/components/with-store-subscription.tsx
@@ -17,16 +17,16 @@ export type WithStoreSubscriptionDeps<T> = {
 
 export function withStoreSubscription<P extends WithStoreSubscriptionProps<S>, S>(
     WrappedComponent: React.ComponentType<P>,
-): React.ComponentClass<Pick<P, Exclude<keyof P, keyof { storeState: S }>>, S> & {
+): React.ComponentClass<Pick<P, Exclude<keyof P, keyof { storeState: S }>>, Partial<S>> & {
     displayName: string;
 } {
-    return class extends React.Component<P, S> {
+    return class extends React.Component<P, Partial<S>> {
         public static readonly displayName = `WithStoreSubscriptionFor${WrappedComponent.displayName}`;
 
         constructor(props: P) {
             super(props);
             if (this.hasStores()) {
-                this.state = this.props.deps.storesHub.getAllStoreData()!;
+                this.state = this.props.deps.storesHub.getAllStoreData()! as S;
             } else {
                 this.state = {} as S;
             }

--- a/src/common/components/with-store-subscription.tsx
+++ b/src/common/components/with-store-subscription.tsx
@@ -26,9 +26,9 @@ export function withStoreSubscription<P extends WithStoreSubscriptionProps<S>, S
         constructor(props: P) {
             super(props);
             if (this.hasStores()) {
-                this.state = this.props.deps.storesHub.getAllStoreData()! as S;
+                this.state = this.props.deps.storesHub.getAllStoreData()!;
             } else {
-                this.state = {} as S;
+                this.state = {} as Partial<S>;
             }
         }
 

--- a/src/common/stores/base-client-stores-hub.ts
+++ b/src/common/stores/base-client-stores-hub.ts
@@ -46,16 +46,15 @@ export class BaseClientStoresHub<T> implements ClientStoresHub<T> {
         });
     }
 
-    public getAllStoreData(): T | null {
+    public getAllStoreData(): Partial<T> | null {
         if (!this.hasStores()) {
             return null;
         }
 
-        const state: Partial<T> = this.stores.reduce((builtState: Partial<T>, store) => {
+        return this.stores.reduce((builtState: Partial<T>, store) => {
             const key = `${lowerFirst(store.getId())}Data`;
             builtState[key as keyof T] = store.getState();
             return builtState;
         }, {} as Partial<T>);
-        return state as T;
     }
 }

--- a/src/common/stores/client-stores-hub.ts
+++ b/src/common/stores/client-stores-hub.ts
@@ -8,5 +8,5 @@ export interface ClientStoresHub<T> {
     removeChangedListenerFromAllStores(listener: () => void): void;
     hasStores(): boolean;
     hasStoreData(): boolean;
-    getAllStoreData(): T | null;
+    getAllStoreData(): Partial<T> | null;
 }

--- a/src/injected/client-store-listener.ts
+++ b/src/injected/client-store-listener.ts
@@ -28,13 +28,15 @@ export interface TargetPageStoreData {
 }
 
 export class ClientStoreListener {
-    private onReadyToExecuteVisualizationUpdates: ((storeData: TargetPageStoreData) => void)[] = [];
+    private onReadyToExecuteVisualizationUpdates: ((
+        storeData: Partial<TargetPageStoreData>,
+    ) => void)[] = [];
     constructor(private storeHub: BaseClientStoresHub<TargetPageStoreData>) {
         this.storeHub.addChangedListenerToAllStores(this.onChangedState);
     }
 
     public registerOnReadyToExecuteVisualizationCallback = (
-        callback: (storeData: TargetPageStoreData) => void,
+        callback: (storeData: Partial<TargetPageStoreData>) => void,
     ) => {
         this.onReadyToExecuteVisualizationUpdates.push(callback);
     };
@@ -45,7 +47,7 @@ export class ClientStoreListener {
             return;
         }
 
-        if (storeData.visualizationStoreData.scanning != null) {
+        if (storeData.visualizationStoreData?.scanning != null) {
             return;
         }
 

--- a/src/injected/client-store-listener.ts
+++ b/src/injected/client-store-listener.ts
@@ -28,25 +28,23 @@ export interface TargetPageStoreData {
 }
 
 export class ClientStoreListener {
-    private onReadyToExecuteVisualizationUpdates: ((
-        storeData: Partial<TargetPageStoreData>,
-    ) => void)[] = [];
+    private onReadyToExecuteVisualizationUpdates: ((storeData: TargetPageStoreData) => void)[] = [];
     constructor(private storeHub: BaseClientStoresHub<TargetPageStoreData>) {
         this.storeHub.addChangedListenerToAllStores(this.onChangedState);
     }
 
     public registerOnReadyToExecuteVisualizationCallback = (
-        callback: (storeData: Partial<TargetPageStoreData>) => void,
+        callback: (storeData: TargetPageStoreData) => void,
     ) => {
         this.onReadyToExecuteVisualizationUpdates.push(callback);
     };
 
     private onChangedState = (): void => {
-        const storeData = this.storeHub.getAllStoreData();
-        if (storeData == null) {
+        if (!this.storeHub.hasStores() || !this.storeHub.hasStoreData()) {
             return;
         }
 
+        const storeData = this.storeHub.getAllStoreData() as TargetPageStoreData;
         if (storeData.visualizationStoreData?.scanning != null) {
             return;
         }

--- a/src/injected/client-store-listener.ts
+++ b/src/injected/client-store-listener.ts
@@ -45,7 +45,7 @@ export class ClientStoreListener {
         }
 
         const storeData = this.storeHub.getAllStoreData() as TargetPageStoreData;
-        if (storeData.visualizationStoreData?.scanning != null) {
+        if (storeData.visualizationStoreData.scanning != null) {
             return;
         }
 

--- a/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
+++ b/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
@@ -14,6 +14,7 @@ import { VisualizationStoreData } from 'common/types/store-data/visualization-st
 import {
     DetailsViewContainerDeps,
     DetailsViewContainerProps,
+    DetailsViewContainerState,
 } from 'DetailsView/details-view-container';
 import { DictionaryStringTo } from 'types/common-types';
 import { StoreMocks } from './store-mocks';
@@ -96,7 +97,7 @@ export class DetailsViewContainerPropsBuilder {
 
         const props: DetailsViewContainerProps = {
             deps: this.deps,
-            storeState: storeState,
+            storeState: storeState as DetailsViewContainerState,
         };
 
         return props;

--- a/src/tests/unit/tests/injected/client-store-listener.test.ts
+++ b/src/tests/unit/tests/injected/client-store-listener.test.ts
@@ -35,8 +35,18 @@ describe('ClientStoreListener', () => {
             );
         });
 
+        test('registerOnReadyToExecuteVisualizationCallback: no stores', () => {
+            storeHubMock.setup(shm => shm.hasStores()).returns(() => false);
+            triggerOnChange();
+            onReadyToExecuteVisualizationUpdatesMock.verify(
+                callback => callback(It.isAny()),
+                Times.never(),
+            );
+        });
+
         test('registerOnReadyToExecuteVisualizationCallback: no store data', () => {
-            storeHubMock.setup(shm => shm.getAllStoreData()).returns(() => null);
+            storeHubMock.setup(shm => shm.hasStores()).returns(() => true);
+            storeHubMock.setup(shm => shm.hasStoreData()).returns(() => false);
             triggerOnChange();
             onReadyToExecuteVisualizationUpdatesMock.verify(
                 callback => callback(It.isAny()),
@@ -51,6 +61,8 @@ describe('ClientStoreListener', () => {
                 },
             } as TargetPageStoreData;
 
+            storeHubMock.setup(shm => shm.hasStores()).returns(() => true);
+            storeHubMock.setup(shm => shm.hasStoreData()).returns(() => true);
             storeHubMock.setup(shm => shm.getAllStoreData()).returns(() => storeDataMock);
 
             triggerOnChange();
@@ -68,6 +80,8 @@ describe('ClientStoreListener', () => {
                 },
             } as TargetPageStoreData;
 
+            storeHubMock.setup(shm => shm.hasStores()).returns(() => true);
+            storeHubMock.setup(shm => shm.hasStoreData()).returns(() => true);
             storeHubMock.setup(shm => shm.getAllStoreData()).returns(() => storeDataMock);
 
             triggerOnChange();


### PR DESCRIPTION
#### Details

- In injected scripts, handle a scenario where the storeHub contains stores, but not all stores have their state initialized
- Change the signature of getAllStoreData() to return a Partial instead of assuming all storeData are present

##### Motivation

This fixes frequent error messages in the MV3 extension when a scan is started. The same error occurs silently in the MV2 extension, but does not affect the functionality of the extension.

##### Context

The cause of this bug is that the injected content scripts register some store update listeners that assume the store's state already exists, which isn't the case when the scripts are first initialized, so the initial store update message throws an error. This PR assumes that none of the listeners registered by ClientStoreListener need to be called before the store state is initialized (the listener that updates the StoreProxy state is called separately).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
