### PR TITLE
chore: turn on no-floating-promises for most directories

### DIFF
--- a/eslintrc.base.js
+++ b/eslintrc.base.js
@@ -63,7 +63,7 @@ module.exports = {
         '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         '@typescript-eslint/no-misused-promises': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
-        '@typescript-eslint/no-floating-promises': 'off',
+        '@typescript-eslint/no-floating-promises': ['warn'],
         '@typescript-eslint/require-await': 'off',
         '@typescript-eslint/no-implied-eval': 'off',
         '@typescript-eslint/prefer-regexp-exec': 'off',
@@ -93,7 +93,14 @@ module.exports = {
             },
         },
         {
-            files: ['src/tests/**/*'],
+            files: ['./**/*'],
+            excludedFiles: [
+                'src/background/**/*',
+                'src/common/**/*',
+                'src/Devtools/**/*',
+                'src/electron/**/*',
+                'src/injected/**/*',
+            ],
             rules: {
                 '@typescript-eslint/no-floating-promises': ['error'],
             },

--- a/eslintrc.base.js
+++ b/eslintrc.base.js
@@ -63,7 +63,7 @@ module.exports = {
         '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         '@typescript-eslint/no-misused-promises': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
-        '@typescript-eslint/no-floating-promises': ['warn'],
+        '@typescript-eslint/no-floating-promises': ['error'],
         '@typescript-eslint/require-await': 'off',
         '@typescript-eslint/no-implied-eval': 'off',
         '@typescript-eslint/prefer-regexp-exec': 'off',
@@ -93,10 +93,9 @@ module.exports = {
             },
         },
         {
-            files: ['./**/*'],
-            excludedFiles: ['src/background/**/*', 'src/injected/**/*'],
+            files: ['src/background/**/*', 'src/injected/**/*'],
             rules: {
-                '@typescript-eslint/no-floating-promises': ['error'],
+                '@typescript-eslint/no-floating-promises': ['warn'],
             },
         },
     ],

--- a/eslintrc.base.js
+++ b/eslintrc.base.js
@@ -63,7 +63,6 @@ module.exports = {
         '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         '@typescript-eslint/no-misused-promises': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
-        '@typescript-eslint/no-floating-promises': ['error'],
         '@typescript-eslint/require-await': 'off',
         '@typescript-eslint/no-implied-eval': 'off',
         '@typescript-eslint/prefer-regexp-exec': 'off',
@@ -93,9 +92,10 @@ module.exports = {
             },
         },
         {
+            // Temporarily disabling this rule in these directories until the errors are fixed
             files: ['src/background/**/*', 'src/injected/**/*'],
             rules: {
-                '@typescript-eslint/no-floating-promises': ['warn'],
+                '@typescript-eslint/no-floating-promises': 'off',
             },
         },
     ],

--- a/eslintrc.base.js
+++ b/eslintrc.base.js
@@ -92,5 +92,11 @@ module.exports = {
                 'security/detect-eval-with-expression': 'off',
             },
         },
+        {
+            files: ['src/tests/**/*'],
+            rules: {
+                '@typescript-eslint/no-floating-promises': ['error'],
+            },
+        },
     ],
 };

--- a/eslintrc.base.js
+++ b/eslintrc.base.js
@@ -94,12 +94,7 @@ module.exports = {
         },
         {
             files: ['./**/*'],
-            excludedFiles: [
-                'src/background/**/*',
-                'src/common/**/*',
-                'src/electron/**/*',
-                'src/injected/**/*',
-            ],
+            excludedFiles: ['src/background/**/*', 'src/injected/**/*'],
             rules: {
                 '@typescript-eslint/no-floating-promises': ['error'],
             },

--- a/eslintrc.base.js
+++ b/eslintrc.base.js
@@ -97,7 +97,6 @@ module.exports = {
             excludedFiles: [
                 'src/background/**/*',
                 'src/common/**/*',
-                'src/Devtools/**/*',
                 'src/electron/**/*',
                 'src/injected/**/*',
             ],

--- a/src/Devtools/dev-tool-init.ts
+++ b/src/Devtools/dev-tool-init.ts
@@ -26,4 +26,4 @@ const devToolInitializer: DevToolInitializer = new DevToolInitializer(
     browserAdapter,
     targetPageInspector,
 );
-devToolInitializer.initialize();
+void devToolInitializer.initialize();

--- a/src/Devtools/dev-tool-initializer.ts
+++ b/src/Devtools/dev-tool-initializer.ts
@@ -15,7 +15,7 @@ export class DevToolInitializer {
         private readonly targetPageInspector: TargetPageInspector,
     ) {}
 
-    public initialize(): void {
+    public async initialize(): Promise<void> {
         const storeUpdateMessageHub = new StoreUpdateMessageHub();
 
         const devtoolsStore = new StoreProxy<DevToolStoreData>(
@@ -35,6 +35,6 @@ export class DevToolInitializer {
             this.targetPageInspector,
         );
 
-        inspectHandler.initialize();
+        await inspectHandler.initialize();
     }
 }

--- a/src/Devtools/inspect-handler.ts
+++ b/src/Devtools/inspect-handler.ts
@@ -14,7 +14,7 @@ export class InspectHandler {
         private readonly targetPageInspector: TargetPageInspector,
     ) {}
 
-    public initialize(): void {
+    public async initialize(): Promise<void> {
         this.devToolsStore.addChangedListener(() => {
             const state = this.devToolsStore.getState();
 
@@ -28,15 +28,15 @@ export class InspectHandler {
             }
         });
 
-        this.sendDevtoolOpened();
+        await this.sendDevtoolOpened();
     }
 
-    private sendDevtoolOpened(): void {
+    private async sendDevtoolOpened(): Promise<void> {
         const message: InterpreterMessage = {
             messageType: Messages.DevTools.Opened,
             tabId: this.browserAdapter.getInspectedWindowTabId(),
         };
 
-        this.browserAdapter.sendMessageToFrames(message);
+        await this.browserAdapter.sendMessageToFrames(message);
     }
 }

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -121,7 +121,7 @@ export class CardKebabMenuButton extends React.Component<
                     iconName: 'copy',
                 },
                 onClick: event => {
-                    this.copyFailureDetails(event);
+                    void this.copyFailureDetails(event);
                 },
             });
         }

--- a/src/electron/common/left-nav-item-factory.ts
+++ b/src/electron/common/left-nav-item-factory.ts
@@ -26,7 +26,7 @@ const createLeftNavItem = (
         featureFlag: config.featureFlag,
         onSelect: () => {
             actionCreator.itemSelected(config.key);
-            tabStopsActionCreator.resetTabStopsToDefaultState();
+            void tabStopsActionCreator.resetTabStopsToDefaultState();
         },
     };
 };

--- a/src/electron/views/device-connect-view/components/electron-external-link.tsx
+++ b/src/electron/views/device-connect-view/components/electron-external-link.tsx
@@ -14,8 +14,8 @@ export interface ElectronExternalLinkProps {
 export const ElectronExternalLink = NamedFC<ElectronExternalLinkProps>(
     'ElectronExternalLink',
     (props: ElectronExternalLinkProps) => {
-        const onClick = (event: React.MouseEvent<any>) => {
-            props.shell.openExternal(props.href);
+        const onClick = async (event: React.MouseEvent<any>) => {
+            await props.shell.openExternal(props.href);
             event.preventDefault();
             event.stopPropagation();
         };

--- a/src/electron/views/tab-stops/tab-stops-testing-content.tsx
+++ b/src/electron/views/tab-stops/tab-stops-testing-content.tsx
@@ -25,11 +25,11 @@ export const TabStopsTestingContent = NamedFC<TabStopsTestingContentProps>(
     'TabStopsTestingContent',
     props => {
         const tabStopsActionCreator = props.deps.tabStopsActionCreator;
-        const onToggle = (e: SupportedMouseEvent) => {
+        const onToggle = async (e: SupportedMouseEvent) => {
             if (props.tabStopsEnabled) {
-                tabStopsActionCreator.disableTabStops(e);
+                await tabStopsActionCreator.disableTabStops(e);
             } else {
-                tabStopsActionCreator.enableTabStops(e);
+                await tabStopsActionCreator.enableTabStops(e);
             }
         };
 

--- a/src/tests/electron/tests/needs-review-view.test.ts
+++ b/src/tests/electron/tests/needs-review-view.test.ts
@@ -23,7 +23,7 @@ describe('NeedsReviewView', () => {
         );
 
         app = await createApplication({ suppressFirstTimeDialog: true });
-        app.client.setViewportSize({ width, height });
+        await app.client.setViewportSize({ width, height });
     });
 
     afterEach(async () => {

--- a/src/tests/electron/tests/results-view.test.ts
+++ b/src/tests/electron/tests/results-view.test.ts
@@ -34,7 +34,7 @@ describe('ResultsView', () => {
     });
 
     it('should pass accessibility validation when left nav is showing', async () => {
-        app.client.setViewportSize({
+        await app.client.setViewportSize({
             width: narrowModeThresholds.collapseCommandBarThreshold + 1,
             height,
         });
@@ -50,7 +50,7 @@ describe('ResultsView', () => {
             config => config.featureFlag === undefined,
         )[testIndex].contentPageInfo.title;
 
-        app.client.setViewportSize({
+        await app.client.setViewportSize({
             width: narrowModeThresholds.collapseCommandBarThreshold + 1,
             height,
         });

--- a/src/tests/electron/tests/tab-stops-view.test.ts
+++ b/src/tests/electron/tests/tab-stops-view.test.ts
@@ -34,8 +34,8 @@ describe('TabStopsView', () => {
         await setupMockAdb(commonAdbConfigs['single-device'], mockAdbLogsBase, mockAdbLogsFolder);
 
         app = await createApplication({ suppressFirstTimeDialog: true });
-        app.setFeatureFlag(UnifiedFeatureFlags.tabStops, true);
-        app.client.setViewportSize({ width, height });
+        await app.setFeatureFlag(UnifiedFeatureFlags.tabStops, true);
+        await app.client.setViewportSize({ width, height });
         logController = new LogController(logsContext, mockAdbFolder);
         tabStopsViewController = new TabStopsViewController(app.client);
         virtualKeyboardViewController = new VirtualKeyboardViewController(app.client);

--- a/src/tests/miscellaneous/codecs/codecs-test.js
+++ b/src/tests/miscellaneous/codecs/codecs-test.js
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 const { app, BrowserWindow } = require('electron');
 
-app.whenReady().then(() => {
+void app.whenReady().then(async () => {
     const win = new BrowserWindow({
         webPreferences: {
             webgl: true,
@@ -13,5 +13,5 @@ app.whenReady().then(() => {
             contextIsolation: false,
         },
     });
-    win.loadFile('codecs.html');
+    await win.loadFile('codecs.html');
 });

--- a/src/tests/unit/tests/DevTools/inspect-handler.test.ts
+++ b/src/tests/unit/tests/DevTools/inspect-handler.test.ts
@@ -26,21 +26,21 @@ describe(InspectHandler, () => {
         );
     });
 
-    test('initialize - send about dev tools open message to background ', () => {
+    test('initialize - send about dev tools open message to background ', async () => {
         devtoolsStoreProxyMock.setupAddChangedListener();
         setupDevtoolOpenedMessage();
 
-        testSubject.initialize();
+        await testSubject.initialize();
 
         devtoolsStoreProxyMock.verifyAll();
         browserAdapterMock.verifyAll();
     });
 
-    test('initialize - do not throw when state is null', () => {
+    test('initialize - do not throw when state is null', async () => {
         devtoolsStoreProxyMock.setupAddChangedListener();
         devtoolsStoreProxyMock.setupGetState(null);
         setupDevtoolOpenedMessage();
-        testSubject.initialize();
+        await testSubject.initialize();
 
         devtoolsStoreProxyMock.invokeChangeListener();
 
@@ -48,7 +48,7 @@ describe(InspectHandler, () => {
         browserAdapterMock.verifyAll();
     });
 
-    test('initialize - do not throw when inspectElement is not set', () => {
+    test('initialize - do not throw when inspectElement is not set', async () => {
         const state = {
             inspectElement: null,
         } as DevToolStoreData;
@@ -56,7 +56,7 @@ describe(InspectHandler, () => {
         devtoolsStoreProxyMock.setupAddChangedListener();
         devtoolsStoreProxyMock.setupGetState(state);
         setupDevtoolOpenedMessage();
-        testSubject.initialize();
+        await testSubject.initialize();
 
         devtoolsStoreProxyMock.invokeChangeListener();
 
@@ -64,7 +64,7 @@ describe(InspectHandler, () => {
         browserAdapterMock.verifyAll();
     });
 
-    test('initialize - inspect on state change: target at parent level', () => {
+    test('initialize - inspect on state change: target at parent level', async () => {
         const state = {
             inspectElement: ['#testElement'],
             frameUrl: null,
@@ -77,7 +77,7 @@ describe(InspectHandler, () => {
             .setup(inspector => inspector.inspectElement('#testElement', undefined))
             .verifiable(Times.once());
 
-        testSubject.initialize();
+        await testSubject.initialize();
 
         devtoolsStoreProxyMock.invokeChangeListener();
 
@@ -85,7 +85,7 @@ describe(InspectHandler, () => {
         targetPageInspectorMock.verifyAll();
     });
 
-    test('initialize - inspect on state change: target not at parent level with frame url provided', () => {
+    test('initialize - inspect on state change: target not at parent level with frame url provided', async () => {
         const state = {
             inspectElement: ['#testElement', 'test'],
             frameUrl: 'testUrl',
@@ -98,7 +98,7 @@ describe(InspectHandler, () => {
             .setup(inspector => inspector.inspectElement('test', 'testUrl'))
             .verifiable(Times.once());
 
-        testSubject.initialize();
+        await testSubject.initialize();
 
         devtoolsStoreProxyMock.invokeChangeListener();
 
@@ -106,7 +106,7 @@ describe(InspectHandler, () => {
         targetPageInspectorMock.verifyAll();
     });
 
-    test("initialize - don't inspect if inspect element length > 1 and frame Url not set", () => {
+    test("initialize - don't inspect if inspect element length > 1 and frame Url not set", async () => {
         const state = {
             inspectElement: ['#testElement', 'test'],
             frameUrl: null,
@@ -115,7 +115,7 @@ describe(InspectHandler, () => {
         devtoolsStoreProxyMock.setupGetState(state);
         setupDevtoolOpenedMessage();
 
-        testSubject.initialize();
+        await testSubject.initialize();
         devtoolsStoreProxyMock.invokeChangeListener();
 
         devtoolsStoreProxyMock.verifyAll();

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/electron-external-link.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/electron-external-link.test.tsx
@@ -7,6 +7,7 @@ import {
 } from 'electron/views/device-connect-view/components/electron-external-link';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { Mock, Times } from 'typemoq';
 
 describe('ElectronExternalLink', () => {
@@ -25,7 +26,7 @@ describe('ElectronExternalLink', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    test('click', () => {
+    test('click', async () => {
         const mockShell = Mock.ofType<Shell>();
         const mockPreventDefault = Mock.ofInstance(() => {});
         const mockStopPropagation = Mock.ofInstance(() => {});
@@ -46,6 +47,8 @@ describe('ElectronExternalLink', () => {
 
         const rendered = shallow(<ElectronExternalLink {...props} />);
         rendered.simulate('click', mockEvent);
+
+        await flushSettledPromises();
 
         mockShell.verifyAll();
         mockPreventDefault.verifyAll();

--- a/src/tests/unit/tests/injected/all-frame-runner.test.ts
+++ b/src/tests/unit/tests/injected/all-frame-runner.test.ts
@@ -244,7 +244,7 @@ describe('AllFrameRunnerTests', () => {
                     .verifiable(Times.once());
             });
 
-            expect(commandFunc(fakeCm, fakeWindow)).rejects.toThrow(
+            await expect(commandFunc(fakeCm, fakeWindow)).rejects.toThrow(
                 'unable to get frame element for the given window',
             );
         });

--- a/src/tests/unit/tests/injected/dialog-renderer.test.tsx
+++ b/src/tests/unit/tests/injected/dialog-renderer.test.tsx
@@ -180,8 +180,8 @@ describe('DialogRendererTests', () => {
 
         const testObject = createDialogRenderer();
 
-        GlobalScope.using(getMainWindowContextMock).with(() => {
-            testObject.render(testData);
+        GlobalScope.using(getMainWindowContextMock).with(async () => {
+            await testObject.render(testData);
         });
 
         setupDomMockVerify();
@@ -190,7 +190,7 @@ describe('DialogRendererTests', () => {
         getMainWindowContextMock.verifyAll();
     });
 
-    test('test render in iframe', () => {
+    test('test render in iframe', async () => {
         const testData: HtmlElementAxeResults = {
             ruleResults: null,
             target: [],
@@ -206,8 +206,8 @@ describe('DialogRendererTests', () => {
 
         const testObject = createDialogRenderer();
 
-        GlobalScope.using(getMainWindowContextMock).with(() => {
-            testObject.render(testData);
+        GlobalScope.using(getMainWindowContextMock).with(async () => {
+            await testObject.render(testData);
         });
 
         setupDomMockVerify();
@@ -236,8 +236,8 @@ describe('DialogRendererTests', () => {
 
         createDialogRenderer();
 
-        GlobalScope.using(getMainWindowContextMock).with(() => {
-            addMessageListenerCallback(commandMessage, undefined);
+        GlobalScope.using(getMainWindowContextMock).with(async () => {
+            await addMessageListenerCallback(commandMessage, undefined);
         });
 
         setupDomMockVerify();

--- a/src/tests/unit/tests/injected/drawing-controller.test.ts
+++ b/src/tests/unit/tests/injected/drawing-controller.test.ts
@@ -79,7 +79,7 @@ describe('DrawingControllerTest', () => {
         hTMLElementUtils = Mock.ofType(HTMLElementUtils);
     });
 
-    test('initialize', () => {
+    test('initialize', async () => {
         let addMessageListenerCallback: (
             message: CommandMessage,
         ) => Promise<CommandMessageResponse>;
@@ -130,13 +130,13 @@ describe('DrawingControllerTest', () => {
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
-        addMessageListenerCallback(commandMessage);
+        await addMessageListenerCallback(commandMessage);
 
         frameMessengerMock.verifyAll();
         axeResultsHelperMock.verifyAll();
     });
 
-    test('enable visualization test', () => {
+    test('enable visualization test', async () => {
         const featureFlagStoreData = getDefaultFeatureFlagsWeb();
 
         const configId = 'id';
@@ -229,7 +229,7 @@ describe('DrawingControllerTest', () => {
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
-        addMessageListenerCallback(commandMessage);
+        await addMessageListenerCallback(commandMessage);
 
         frameMessengerMock.verifyAll();
         axeResultsHelperMock.verifyAll();
@@ -237,7 +237,7 @@ describe('DrawingControllerTest', () => {
         drawerMock.verifyAll();
     });
 
-    test('enable visualization test when results is null - tabstops', () => {
+    test('enable visualization test when results is null - tabstops', async () => {
         const configId = 'id';
         let addMessageListenerCallback: (
             message: CommandMessage,
@@ -310,7 +310,7 @@ describe('DrawingControllerTest', () => {
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
-        addMessageListenerCallback(commandMessageStub);
+        await addMessageListenerCallback(commandMessageStub);
 
         frameMessengerMock.verifyAll();
         axeResultsHelperMock.verifyAll();

--- a/src/tests/unit/tests/injected/frameCommunicators/browser-backchannel-window-message-poster.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/browser-backchannel-window-message-poster.test.ts
@@ -121,7 +121,7 @@ describe('BrowserBackchannelWindowMessagePoster', () => {
         mockBackchannelWindowMessageTranslator.verifyAll();
     });
 
-    test('onWindowMessageEvent bails if we cannot parse receive message', () => {
+    test('onWindowMessageEvent bails if we cannot parse receive message', async () => {
         testSubject.initialize();
         const targetWindow = {} as Window;
 
@@ -149,7 +149,7 @@ describe('BrowserBackchannelWindowMessagePoster', () => {
             .verifiable(Times.never());
 
         // trigger message
-        mockWindowUtils.notifyOnMessageEvent(sampleMessageEvent);
+        await mockWindowUtils.notifyOnMessageEvent(sampleMessageEvent);
         mockWindowUtils.verifyAll();
         mockBrowserAdapter.verifyAll();
         mockBackchannelWindowMessageTranslator.verifyAll();

--- a/src/tests/unit/tests/injected/scrolling-controller.test.ts
+++ b/src/tests/unit/tests/injected/scrolling-controller.test.ts
@@ -23,7 +23,7 @@ describe('ScrollingControllerTest', () => {
         HTMLElementUtilsMock = Mock.ofType(HTMLElementUtils);
     });
 
-    test('scroll in current frame', () => {
+    test('scroll in current frame', async () => {
         let addMessageCallback: (message: CommandMessage) => Promise<CommandMessageResponse>;
 
         frameMessengerMock
@@ -63,13 +63,13 @@ describe('ScrollingControllerTest', () => {
         );
 
         testObject.initialize();
-        addMessageCallback(commandMessage);
+        await addMessageCallback(commandMessage);
 
         frameMessengerMock.verifyAll();
         HTMLElementUtilsMock.verifyAll();
     });
 
-    test('scroll to nonexistent element is a noop', () => {
+    test('scroll to nonexistent element is a noop', async () => {
         let addMessageCallback: (message: CommandMessage) => Promise<CommandMessageResponse>;
 
         frameMessengerMock
@@ -105,13 +105,13 @@ describe('ScrollingControllerTest', () => {
         );
 
         testObject.initialize();
-        addMessageCallback(commandMessage);
+        await addMessageCallback(commandMessage);
 
         frameMessengerMock.verifyAll();
         HTMLElementUtilsMock.verifyAll();
     });
 
-    test('scroll in other frames', () => {
+    test('scroll in other frames', async () => {
         let addMessageCallback: (message: CommandMessage) => Promise<CommandMessageResponse>;
 
         frameMessengerMock
@@ -158,7 +158,7 @@ describe('ScrollingControllerTest', () => {
         );
 
         testObject.initialize();
-        addMessageCallback(commandMessageToProcess);
+        await addMessageCallback(commandMessageToProcess);
 
         frameMessengerMock.verifyAll();
         HTMLElementUtilsMock.verifyAll();

--- a/src/tests/unit/tests/injected/visualization/null-drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/null-drawer.test.ts
@@ -3,10 +3,10 @@
 import { NullDrawer } from '../../../../../injected/visualization/null-drawer';
 
 describe('NullDrawer', () => {
-    test('null drawer does nothing', () => {
+    test('null drawer does nothing', async () => {
         const testObject = new NullDrawer();
         testObject.initialize(null);
-        testObject.drawLayout();
+        await testObject.drawLayout();
         testObject.eraseLayout();
     });
 });

--- a/tools/strict-null-checks/progress.js
+++ b/tools/strict-null-checks/progress.js
@@ -23,4 +23,4 @@ async function main() {
     );
 }
 
-main();
+void main();


### PR DESCRIPTION
#### Details

Turns on the [no-floating-promises](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-floating-promises.md) eslint rule for all directories except background/ and injected/, and fixes the errors that were caught.

This PR fixes 26 issues caught by this rule out of 48 in total. The issues fixed in this PR are fairly minor, and the remaining issues in background/ and injected/ are more complex and involve changes that propagate more to other files. Those issues will be addressed in future PRs.

##### Motivation

The no-floating-promises rule was turned off when we migrated from tslint to eslint due to a large number of failures, and was never reenabled. This would be an extremely useful rule to have, especially with the ongoing migration to Manifest V3, to make sure all promises are correctly handled and we aren't unintentionally orphaning promises.

##### Context

As stated above, the remaining 22 warnings for no-floating-promises will be fixed in future PRs. It is likely that, in the course of the MV3 migration, more floating promises will need to be added before they are eventually resolved. Many of the current method signatures don't accurately reflect when async work is happening, and that will need to be changed. I expect this eslint rule to stay off for background/ and injected/ while that work continues.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
