### PR TITLE
feat(mv3-part-4): Return a promise from StoreUpdateMessageHub

### DIFF
--- a/src/Devtools/dev-tool-message-distributor.ts
+++ b/src/Devtools/dev-tool-message-distributor.ts
@@ -18,12 +18,14 @@ export class DevToolsMessageDistributor {
         this.browserAdapter.addListenerOnMessage(this.distributeMessage);
     }
 
-    private distributeMessage = (message: Message): void | Promise<DevToolsStatusResponse> => {
+    private distributeMessage = (
+        message: Message,
+    ): void | Promise<void> | Promise<DevToolsStatusResponse> => {
         if (this.isStatusRequestForTab(message)) {
             // Must return a promise for the response to send correctly
             return Promise.resolve({ isActive: true });
         } else {
-            this.storeUpdateHub.handleMessage(message as StoreUpdateMessage<unknown>);
+            return this.storeUpdateHub.handleMessage(message as StoreUpdateMessage<unknown>);
         }
     };
 

--- a/src/common/store-update-message-hub.ts
+++ b/src/common/store-update-message-hub.ts
@@ -29,7 +29,7 @@ export class StoreUpdateMessageHub {
 
         const listener = this.registeredUpdateListeners[message.storeId];
         if (listener) {
-            return listener(message);
+            return Promise.resolve(listener(message));
         }
     };
 

--- a/src/common/store-update-message-hub.ts
+++ b/src/common/store-update-message-hub.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import { StoreType } from './types/store-type';
 import { StoreUpdateMessage, storeUpdateMessageType } from './types/store-update-message';
 
-type StoreUpdateMessageListener = (message: StoreUpdateMessage<any>) => void;
+type StoreUpdateMessageListener = (message: StoreUpdateMessage<any>) => void | Promise<void>;
 
 export class StoreUpdateMessageHub {
     private readonly registeredUpdateListeners: { [key: string]: StoreUpdateMessageListener } = {};
@@ -22,14 +22,14 @@ export class StoreUpdateMessageHub {
         this.registeredUpdateListeners[storeId] = listener;
     }
 
-    public readonly handleMessage = (message: StoreUpdateMessage<any>): void => {
+    public readonly handleMessage = (message: StoreUpdateMessage<any>): void | Promise<void> => {
         if (!this.isValidMessage(message)) {
             return;
         }
 
         const listener = this.registeredUpdateListeners[message.storeId];
         if (listener) {
-            listener(message);
+            return listener(message);
         }
     };
 

--- a/src/common/store-update-message-hub.ts
+++ b/src/common/store-update-message-hub.ts
@@ -29,7 +29,7 @@ export class StoreUpdateMessageHub {
 
         const listener = this.registeredUpdateListeners[message.storeId];
         if (listener) {
-            return Promise.resolve(listener(message));
+            return listener(message);
         }
     };
 

--- a/src/debug-tools/debug-tools-message-distributor.ts
+++ b/src/debug-tools/debug-tools-message-distributor.ts
@@ -17,8 +17,8 @@ export class DebugToolsMessageDistributor {
         this.browserAdapter.addListenerOnMessage(this.distributeMessage);
     }
 
-    private distributeMessage = (message: any) => {
+    private distributeMessage = async (message: any) => {
         this.telemetryListener.onTelemetryMessage(message);
-        this.storeUpdateMessageHub.handleMessage(message as StoreUpdateMessage<unknown>);
+        await this.storeUpdateMessageHub.handleMessage(message as StoreUpdateMessage<unknown>);
     };
 }

--- a/src/tests/unit/tests/DevTools/dev-tool-message-distributor.test.ts
+++ b/src/tests/unit/tests/DevTools/dev-tool-message-distributor.test.ts
@@ -88,5 +88,23 @@ describe(DevToolsMessageDistributor, () => {
 
             expect(response).toBeUndefined();
         });
+
+        it('Returns a promise if storeUpdateMessageHub returns a promise', async () => {
+            const message = {
+                messageType: 'another message type',
+            };
+            storeUpdateHubMock
+                .setup(s => s.handleMessage(message as StoreUpdateMessage<unknown>))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+
+            const responsePromise = distributeMessage(message);
+
+            expect(responsePromise).toBeInstanceOf(Promise);
+
+            const response = await responsePromise;
+
+            expect(response).toBeUndefined();
+        });
     });
 });

--- a/src/tests/unit/tests/common/store-update-message-hub.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-hub.test.ts
@@ -19,7 +19,7 @@ describe(StoreUpdateMessageHub, () => {
     let testSubject: StoreUpdateMessageHub;
 
     beforeEach(() => {
-        registeredListener = jest.fn();
+        registeredListener = jest.fn(() => Promise.resolve());
 
         tabContextMessage = {
             messageType: storeUpdateMessageType,
@@ -51,40 +51,40 @@ describe(StoreUpdateMessageHub, () => {
         { ...tabContextMessage, storeId: undefined },
         { ...tabContextMessage, tabId: tabId + 10 },
     ];
-    it.each(invalidMessages)('ignores invalid message: %o', message => {
-        testSubject.handleMessage(message);
+    it.each(invalidMessages)('ignores invalid message: %o', async message => {
+        await testSubject.handleMessage(message);
 
         expect(registeredListener).toBeCalledTimes(0);
     });
 
-    it('ignores if no listener is registered for this message', () => {
+    it('ignores if no listener is registered for this message', async () => {
         const message = {
             ...tabContextMessage,
             storeId: 'AnotherStore',
         };
 
-        testSubject.handleMessage(message);
+        await testSubject.handleMessage(message);
 
         expect(registeredListener).toBeCalledTimes(0);
     });
 
-    it('Calls registered listener for tab context store message', () => {
-        testSubject.handleMessage(tabContextMessage);
+    it('Calls registered listener for tab context store message', async () => {
+        await testSubject.handleMessage(tabContextMessage);
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
     });
 
-    it('Calls registered listener for global store message', () => {
-        testSubject.handleMessage(globalStoreMessage);
+    it('Calls registered listener for global store message', async () => {
+        await testSubject.handleMessage(globalStoreMessage);
 
         expect(registeredListener).toBeCalledWith(globalStoreMessage);
     });
 
-    it('Calls registered listener if not created with a tab id', () => {
+    it('Calls registered listener if not created with a tab id', async () => {
         testSubject = new StoreUpdateMessageHub();
         testSubject.registerStoreUpdateListener(storeId, registeredListener);
 
-        testSubject.handleMessage(tabContextMessage);
+        await testSubject.handleMessage(tabContextMessage);
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
     });
@@ -93,7 +93,7 @@ describe(StoreUpdateMessageHub, () => {
         expect(() => testSubject.registerStoreUpdateListener(storeId, () => null)).toThrow();
     });
 
-    it('Registers multiple listeners and distributes messages correctly', () => {
+    it('Registers multiple listeners and distributes messages correctly', async () => {
         const anotherStoreId = 'AnotherStore';
         const anotherListener = jest.fn();
 
@@ -102,8 +102,8 @@ describe(StoreUpdateMessageHub, () => {
 
         testSubject.registerStoreUpdateListener(anotherStoreId, anotherListener);
 
-        testSubject.handleMessage(messageForStore);
-        testSubject.handleMessage(messageForAnotherStore);
+        await testSubject.handleMessage(messageForStore);
+        await testSubject.handleMessage(messageForAnotherStore);
 
         expect(registeredListener).toBeCalledWith(messageForStore);
         expect(anotherListener).toBeCalledWith(messageForAnotherStore);

--- a/src/tests/unit/tests/common/store-update-message-hub.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-hub.test.ts
@@ -15,11 +15,13 @@ describe(StoreUpdateMessageHub, () => {
 
     let tabContextMessage: StoreUpdateMessage<string>;
     let globalStoreMessage: StoreUpdateMessage<string>;
+    let listenerPromise: Promise<void>;
 
     let testSubject: StoreUpdateMessageHub;
 
     beforeEach(() => {
-        registeredListener = jest.fn(() => null);
+        listenerPromise = Promise.resolve();
+        registeredListener = jest.fn(() => listenerPromise);
 
         tabContextMessage = {
             messageType: storeUpdateMessageType,
@@ -73,7 +75,7 @@ describe(StoreUpdateMessageHub, () => {
     it('Calls registered listener for tab context store message', async () => {
         const resultPromise = testSubject.handleMessage(tabContextMessage);
 
-        expect(resultPromise).toBeInstanceOf(Promise);
+        expect(resultPromise).toBe(listenerPromise);
         await resultPromise;
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
@@ -82,7 +84,7 @@ describe(StoreUpdateMessageHub, () => {
     it('Calls registered listener for global store message', async () => {
         const resultPromise = testSubject.handleMessage(globalStoreMessage);
 
-        expect(resultPromise).toBeInstanceOf(Promise);
+        expect(resultPromise).toBe(listenerPromise);
         await resultPromise;
 
         expect(registeredListener).toBeCalledWith(globalStoreMessage);
@@ -94,7 +96,7 @@ describe(StoreUpdateMessageHub, () => {
 
         const resultPromise = testSubject.handleMessage(tabContextMessage);
 
-        expect(resultPromise).toBeInstanceOf(Promise);
+        expect(resultPromise).toBe(listenerPromise);
         await resultPromise;
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
@@ -106,7 +108,7 @@ describe(StoreUpdateMessageHub, () => {
 
     it('Registers multiple listeners and distributes messages correctly', async () => {
         const anotherStoreId = 'AnotherStore';
-        const anotherListener = jest.fn();
+        const anotherListener = jest.fn(() => Promise.resolve());
 
         const messageForStore = { ...tabContextMessage };
         const messageForAnotherStore = { ...tabContextMessage, storeId: anotherStoreId };


### PR DESCRIPTION
#### Details

- Allow StoreUpdateMessageHub to register async listeners
- Return a promise from StoreUpdateMessageHub if a listener is registered for that message

##### Motivation

Feature work for MV3 migration

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
