### PR TITLE
feat(esbuild): change to use default imports for styles

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -173,7 +173,7 @@ module.exports = function (grunt) {
             'webpack-unified': `"${webpackPath}" --config-name unified`,
             'webpack-package-report': `"${webpackPath}" --config-name package-report`,
             'webpack-package-ui': `"${webpackPath}" --config-name package-ui`,
-            'generate-scss-typings': `"${typedScssModulesPath}" src`,
+            'generate-scss-typings': `"${typedScssModulesPath}" src --exportType default`,
             'pkg-mock-adb': `"${pkgPath}" "${mockAdbBinSrcPath}" -d --target host --output "${mockAdbBinOutPath}"`,
         },
         sass: {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "react-devtools": "react-devtools",
         "react-devtools:setup": "yarn add -W --dev react-devtools && echo \"react-devtools installed, rebuild required. Do not commit this package.json/yarn.lock change!\"",
         "run:binskim": "node ./pipeline/scripts/run-binskim.js",
-        "scss:build": "typed-scss-modules \"src/**/*.scss\"",
+        "scss:build": "typed-scss-modules \"src/**/*.scss\" --exportType default",
         "scss:clean": "grunt clean:scss",
         "start:unified": "electron drop/electron/unified-dev/product/bundle/main.bundle.js",
         "start:unified:dev": "cross-env DEV_MODE=true yarnpkg start:unified",

--- a/src/DetailsView/components/action-and-cancel-buttons-component.tsx
+++ b/src/DetailsView/components/action-and-cancel-buttons-component.tsx
@@ -4,7 +4,7 @@ import { DefaultButton } from '@fluentui/react';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 
-import * as styles from './action-and-cancel-buttons-component.scss';
+import styles from './action-and-cancel-buttons-component.scss';
 
 export interface ActionAndCancelButtonsComponentProps {
     isHidden: boolean;

--- a/src/DetailsView/components/adhoc-issues-test-view.tsx
+++ b/src/DetailsView/components/adhoc-issues-test-view.tsx
@@ -11,7 +11,7 @@ import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
-import * as styles from 'DetailsView/components/adhoc-issues-test-view.scss';
+import styles from 'DetailsView/components/adhoc-issues-test-view.scss';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import {
     ScanIncompleteWarning,

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -16,9 +16,9 @@ import { VisualizationScanResultData } from 'common/types/store-data/visualizati
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
-import * as styles from 'DetailsView/components/adhoc-tab-stops-test-view.scss';
+import styles from 'DetailsView/components/adhoc-tab-stops-test-view.scss';
 import { AutoDetectedFailuresDialog } from 'DetailsView/components/auto-detected-failures-dialog';
-import * as requirementInstructionStyles from 'DetailsView/components/requirement-instructions.scss';
+import requirementInstructionStyles from 'DetailsView/components/requirement-instructions.scss';
 import {
     TabStopsFailedInstanceSection,
     TabStopsFailedInstanceSectionDeps,

--- a/src/DetailsView/components/assessment-instance-details-column.tsx
+++ b/src/DetailsView/components/assessment-instance-details-column.tsx
@@ -4,7 +4,7 @@ import { TooltipHost } from '@fluentui/react';
 import { css } from '@fluentui/utilities';
 import * as React from 'react';
 
-import * as styles from './assessment-instance-details-column.scss';
+import styles from './assessment-instance-details-column.scss';
 
 export interface AssessmentInstanceDetailsColumnProps {
     labelText?: string;

--- a/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
+++ b/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
@@ -7,7 +7,7 @@ import { FailureInstanceData } from 'common/types/failure-instance-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import * as React from 'react';
-import * as styles from './assessment-instance-edit-and-remove-control.scss';
+import styles from './assessment-instance-edit-and-remove-control.scss';
 import { FailureInstancePanelControl } from './failure-instance-panel-control';
 
 export interface AssessmentInstanceEditAndRemoveControlProps {

--- a/src/DetailsView/components/assessment-instance-selected-button.tsx
+++ b/src/DetailsView/components/assessment-instance-selected-button.tsx
@@ -4,7 +4,7 @@ import { IconButton } from '@fluentui/react';
 import classNames from 'classnames';
 import { VisualizationType } from 'common/types/visualization-type';
 import * as React from 'react';
-import * as styles from './assessment-instance-selected-button.scss';
+import styles from './assessment-instance-selected-button.scss';
 
 export interface AssessmentInstanceSelectedButtonProps {
     test: VisualizationType;

--- a/src/DetailsView/components/auto-detected-failures-dialog.tsx
+++ b/src/DetailsView/components/auto-detected-failures-dialog.tsx
@@ -5,7 +5,7 @@ import { Checkbox, Dialog, DialogFooter, DialogType, PrimaryButton } from '@flue
 import { UserConfigMessageCreator } from 'common/message-creators/user-config-message-creator';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
-import * as styles from 'DetailsView/components/common-dialog-styles.scss';
+import styles from 'DetailsView/components/common-dialog-styles.scss';
 import * as React from 'react';
 
 export type AutoDetectedFailuresDialogState = {

--- a/src/DetailsView/components/base-left-nav.tsx
+++ b/src/DetailsView/components/base-left-nav.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { INav, INavLink, LinkBase, Nav } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
-import * as styles from 'DetailsView/components/base-left-nav.scss';
+import styles from 'DetailsView/components/base-left-nav.scss';
 import { NavLinkButton } from 'DetailsView/components/nav-link-button';
 import * as React from 'react';
 

--- a/src/DetailsView/components/change-assessment-dialog.tsx
+++ b/src/DetailsView/components/change-assessment-dialog.tsx
@@ -7,8 +7,8 @@ import { BlockingDialog } from 'common/components/blocking-dialog';
 import { NewTabLink } from 'common/components/new-tab-link';
 import { Tab } from 'common/itab';
 import { NamedFC } from 'common/react/named-fc';
-import * as styles from 'DetailsView/components/change-assessment-dialog.scss';
-import * as commonDialogStyles from 'DetailsView/components/common-dialog-styles.scss';
+import styles from 'DetailsView/components/change-assessment-dialog.scss';
+import commonDialogStyles from 'DetailsView/components/common-dialog-styles.scss';
 import * as React from 'react';
 export interface ChangeAssessmentDialogProps {
     prevTab: Tab;

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -4,7 +4,7 @@ import { CommandBarButton, IButton, IContextualMenuItem, IRefObject } from '@flu
 import { NamedFC } from 'common/react/named-fc';
 import { StartOverMenuItem } from 'DetailsView/components/start-over-component-factory';
 import * as React from 'react';
-import * as styles from './command-bar-buttons-menu.scss';
+import styles from './command-bar-buttons-menu.scss';
 
 export type CommandBarButtonsMenuProps = {
     renderExportReportButton: () => JSX.Element;

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -12,7 +12,7 @@ import { VersionedAssessmentData } from 'common/types/versioned-assessment-data'
 import { VisualizationType } from 'common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { CommandBarButtonsMenu } from 'DetailsView/components/command-bar-buttons-menu';
-import { detailsViewCommandButtons } from 'DetailsView/components/details-view-command-bar.scss';
+import styles from 'DetailsView/components/details-view-command-bar.scss';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import { ExportDialogDeps } from 'DetailsView/components/export-dialog';
 import { InvalidLoadAssessmentDialog } from 'DetailsView/components/invalid-load-assessment-dialog';
@@ -47,7 +47,6 @@ import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
-import * as styles from './details-view-command-bar.scss';
 import { DetailsRightPanelConfiguration } from './details-view-right-panel';
 
 export type DetailsViewCommandBarDeps = {
@@ -168,7 +167,7 @@ export class DetailsViewCommandBar extends React.Component<
             startOverElement
         ) {
             return (
-                <div className={detailsViewCommandButtons}>
+                <div className={styles.detailsViewCommandButtons}>
                     {reportExportElement}
                     {saveAssessmentButtonElement}
                     {loadAssessmentButtonElement}

--- a/src/DetailsView/components/details-view-overlay/scoping-panel/scoping-container.tsx
+++ b/src/DetailsView/components/details-view-overlay/scoping-panel/scoping-container.tsx
@@ -9,7 +9,7 @@ import { ScopingActionMessageCreator } from 'common/message-creators/scoping-act
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { ScopingStoreData } from 'common/types/store-data/scoping-store-data';
 import * as React from 'react';
-import * as styles from './scoping-container.scss';
+import styles from './scoping-container.scss';
 
 export interface ScopingContainerProps {
     featureFlagData: FeatureFlagStoreData;

--- a/src/DetailsView/components/details-view-overlay/settings-panel/settings-panel.tsx
+++ b/src/DetailsView/components/details-view-overlay/settings-panel/settings-panel.tsx
@@ -6,7 +6,7 @@ import { UserConfigurationStoreData } from 'common/types/store-data/user-configu
 import * as React from 'react';
 import { DetailsViewActionMessageCreator } from '../../../actions/details-view-action-message-creator';
 import { GenericPanel } from '../../generic-panel';
-import * as styles from './settings-panel.scss';
+import styles from './settings-panel.scss';
 import { SettingsDeps } from './settings/settings-props';
 import { SettingsComponent, SettingsProvider } from './settings/settings-provider';
 

--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -12,7 +12,7 @@ import {
 import { ReportExportFormat } from '../../common/extension-telemetry-events';
 import { FileURLProvider } from '../../common/file-url-provider';
 import { NamedFC } from '../../common/react/named-fc';
-import * as styles from './export-dialog.scss';
+import styles from './export-dialog.scss';
 
 export const singleExportToHtmlButtonDataAutomationId = 'single-export-to-html-button';
 

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -19,7 +19,7 @@ import { clone, isEqual } from 'lodash';
 import * as React from 'react';
 import { ActionAndCancelButtonsComponent } from './action-and-cancel-buttons-component';
 import { FailureInstancePanelDetails } from './failure-instance-panel-details';
-import * as styles from './failure-instance-panel.scss';
+import styles from './failure-instance-panel.scss';
 import { GenericPanel, GenericPanelProps } from './generic-panel';
 
 export interface FailureInstancePanelControlProps {

--- a/src/DetailsView/components/failure-instance-panel-details.tsx
+++ b/src/DetailsView/components/failure-instance-panel-details.tsx
@@ -1,20 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DefaultButton } from '@fluentui/react';
-import { Icon } from '@fluentui/react';
-import { ILabelStyles } from '@fluentui/react';
-import { ITextFieldStyles, TextField } from '@fluentui/react';
+import { DefaultButton, Icon, ILabelStyles, ITextFieldStyles, TextField } from '@fluentui/react';
 import * as React from 'react';
-
 import { NamedFC } from '../../common/react/named-fc';
-import {
-    failureInstanceSelectorNote,
-    failureInstanceSnippetEmptyBody,
-    failureInstanceSnippetError,
-    failureInstanceSnippetErrorIcon,
-    failureInstanceSnippetFilledBody,
-    failureInstanceSnippetTitle,
-} from './failure-instance-panel.scss';
+import styles from './failure-instance-panel.scss';
 
 export type FailureInstancePanelDetailsProps = {
     path: string;
@@ -29,22 +18,24 @@ export const FailureInstancePanelDetails = NamedFC<FailureInstancePanelDetailsPr
         const getSnippetInfo = (): JSX.Element => {
             if (!props.snippet) {
                 return (
-                    <div className={failureInstanceSnippetEmptyBody}>
+                    <div className={styles.failureInstanceSnippetEmptyBody}>
                         Code snippet will auto-populate based on the CSS selector input.
                     </div>
                 );
             } else if (props.snippet.startsWith('No code snippet is map')) {
                 return (
-                    <div className={failureInstanceSnippetError}>
+                    <div className={styles.failureInstanceSnippetError}>
                         <Icon
                             iconName="statusErrorFull"
-                            className={failureInstanceSnippetErrorIcon}
+                            className={styles.failureInstanceSnippetErrorIcon}
                         />
                         <div>{props.snippet}</div>
                     </div>
                 );
             } else {
-                return <div className={failureInstanceSnippetFilledBody}>{props.snippet}</div>;
+                return (
+                    <div className={styles.failureInstanceSnippetFilledBody}>{props.snippet}</div>
+                );
             }
         };
         return (
@@ -59,7 +50,7 @@ export const FailureInstancePanelDetails = NamedFC<FailureInstancePanelDetailsPr
                     resizable={false}
                     placeholder="CSS Selector"
                 />
-                <div className={failureInstanceSelectorNote}>
+                <div className={styles.failureInstanceSelectorNote}>
                     Note: If the CSS selector maps to multiple snippets, the first will be selected
                 </div>
                 <div>
@@ -70,7 +61,7 @@ export const FailureInstancePanelDetails = NamedFC<FailureInstancePanelDetailsPr
                     />
                 </div>
                 <div aria-live="polite" aria-atomic="true">
-                    <div className={failureInstanceSnippetTitle}>Code Snippet</div>
+                    <div className={styles.failureInstanceSnippetTitle}>Code Snippet</div>
                     {getSnippetInfo()}
                 </div>
             </div>

--- a/src/DetailsView/components/generic-dialog.tsx
+++ b/src/DetailsView/components/generic-dialog.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DefaultButton, Dialog, DialogFooter, DialogType, PrimaryButton } from '@fluentui/react';
-import * as styles from 'DetailsView/components/common-dialog-styles.scss';
+import styles from 'DetailsView/components/common-dialog-styles.scss';
 import * as React from 'react';
 import { NamedFC } from '../../common/react/named-fc';
 

--- a/src/DetailsView/components/generic-panel.tsx
+++ b/src/DetailsView/components/generic-panel.tsx
@@ -4,7 +4,7 @@ import { IPanelProps, Panel } from '@fluentui/react';
 import { css } from '@fluentui/utilities';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './generic-panel.scss';
+import styles from './generic-panel.scss';
 
 export type GenericPanelProps = IPanelProps & {
     innerPanelAutomationId?: string;

--- a/src/DetailsView/components/generic-toggle.tsx
+++ b/src/DetailsView/components/generic-toggle.tsx
@@ -3,7 +3,7 @@
 import { Toggle } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './generic-toggle.scss';
+import styles from './generic-toggle.scss';
 
 export interface GenericToggleProps {
     enabled: boolean;

--- a/src/DetailsView/components/getting-started-view.tsx
+++ b/src/DetailsView/components/getting-started-view.tsx
@@ -3,7 +3,7 @@
 import { Assessment } from 'assessments/types/iassessment';
 import { HeadingWithContentLink } from 'common/components/heading-with-content-link';
 import { NamedFC } from 'common/react/named-fc';
-import * as styles from 'DetailsView/components/getting-started-view.scss';
+import styles from 'DetailsView/components/getting-started-view.scss';
 import {
     NextRequirementButton,
     NextRequirementButtonDeps,

--- a/src/DetailsView/components/inline-start-over-button.tsx
+++ b/src/DetailsView/components/inline-start-over-button.tsx
@@ -6,7 +6,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { VisualizationType } from 'common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import * as React from 'react';
-import * as styles from './inline-start-over-button.scss';
+import styles from './inline-start-over-button.scss';
 
 export const inlineStartOverButtonDataAutomationId = 'inline-start-over-button';
 

--- a/src/DetailsView/components/interactive-header.tsx
+++ b/src/DetailsView/components/interactive-header.tsx
@@ -6,7 +6,7 @@ import { Header, HeaderDeps } from 'common/components/header';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import * as styles from 'DetailsView/components/interactive-header.scss';
+import styles from 'DetailsView/components/interactive-header.scss';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import * as React from 'react';
 import { SwitcherDeps } from './switcher';

--- a/src/DetailsView/components/invalid-load-assessment-dialog.tsx
+++ b/src/DetailsView/components/invalid-load-assessment-dialog.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { Dialog, DialogFooter, DialogType, PrimaryButton } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
-import * as styles from 'DetailsView/components/invalid-load-assessment-dialog.scss';
+import styles from 'DetailsView/components/invalid-load-assessment-dialog.scss';
 import * as React from 'react';
 
 export const invalidLoadAssessmentDialogOkButtonAutomationId =

--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 import { Dialog, DialogFooter, DialogType } from '@fluentui/react';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
-import * as styles from 'DetailsView/components/common-dialog-styles.scss';
-import * as issueFilingDialogStyles from 'DetailsView/components/issue-filing-dialog.scss';
+import styles from 'DetailsView/components/common-dialog-styles.scss';
+import issueFilingDialogStyles from 'DetailsView/components/issue-filing-dialog.scss';
 import { cloneDeep, isEqual } from 'lodash';
 import * as React from 'react';
 import { IssueFilingActionMessageCreator } from '../../common/message-creators/issue-filing-action-message-creator';

--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -12,7 +12,7 @@ import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
-import * as styles from 'DetailsView/components/issues-table.scss';
+import styles from 'DetailsView/components/issues-table.scss';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { ExportDialogDeps } from './export-dialog';

--- a/src/DetailsView/components/left-nav/details-view-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.tsx
@@ -13,7 +13,7 @@ import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-f
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { DetailsRightPanelConfiguration } from '../details-view-right-panel';
 import { DetailsViewSwitcherNavConfiguration, LeftNavDeps } from '../details-view-switcher-nav';
-import * as styles from './details-view-left-nav.scss';
+import styles from './details-view-left-nav.scss';
 
 export type DetailsViewLeftNavDeps = {
     assessmentsProvider: AssessmentsProvider;

--- a/src/DetailsView/components/left-nav/fluent-side-nav.tsx
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.tsx
@@ -12,7 +12,7 @@ import {
     DetailsViewLeftNavDeps,
     DetailsViewLeftNavProps,
 } from 'DetailsView/components/left-nav/details-view-left-nav';
-import * as styles from 'DetailsView/components/left-nav/fluent-side-nav.scss';
+import styles from 'DetailsView/components/left-nav/fluent-side-nav.scss';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import * as React from 'react';
 

--- a/src/DetailsView/components/left-nav/getting-started-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/getting-started-nav-link.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import * as styles from 'DetailsView/components/left-nav/common-left-nav-link.scss';
+import styles from 'DetailsView/components/left-nav/common-left-nav-link.scss';
 import * as React from 'react';
 
 export type GettingStartedNavLinkProps = {};

--- a/src/DetailsView/components/left-nav/left-nav-icon.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-icon.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css, INavLink } from '@fluentui/react';
-import * as styles from 'DetailsView/components/left-nav/left-nav-icon.scss';
+import styles from 'DetailsView/components/left-nav/left-nav-icon.scss';
 import * as React from 'react';
 import { NamedFC } from '../../../common/react/named-fc';
 import { StatusIcon } from '../status-icon';

--- a/src/DetailsView/components/left-nav/nav-link-renderer.tsx
+++ b/src/DetailsView/components/left-nav/nav-link-renderer.tsx
@@ -7,10 +7,10 @@ import {
     AssessmentLeftNavLink,
     TestRequirementLeftNavLink,
 } from 'DetailsView/components/left-nav/assessment-left-nav';
-import * as commonLeftNavLinkStyles from 'DetailsView/components/left-nav/common-left-nav-link.scss';
+import commonLeftNavLinkStyles from 'DetailsView/components/left-nav/common-left-nav-link.scss';
 import { GettingStartedNavLink } from 'DetailsView/components/left-nav/getting-started-nav-link';
 import { LeftNavIndexIcon, LeftNavStatusIcon } from 'DetailsView/components/left-nav/left-nav-icon';
-import * as styles from 'DetailsView/components/left-nav/nav-link-renderer.scss';
+import styles from 'DetailsView/components/left-nav/nav-link-renderer.scss';
 import { OverviewLeftNavLink } from 'DetailsView/components/left-nav/overview-left-nav-link';
 import { TestViewLeftNavLink } from 'DetailsView/components/left-nav/test-view-left-nav-link';
 import * as React from 'react';

--- a/src/DetailsView/components/left-nav/overview-left-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/overview-left-nav-link.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { Icon } from '@fluentui/react';
 import { css } from '@fluentui/utilities';
-import * as styles from 'DetailsView/components/left-nav/common-left-nav-link.scss';
+import styles from 'DetailsView/components/left-nav/common-left-nav-link.scss';
 import * as React from 'react';
 import { NamedFC } from '../../../common/react/named-fc';
 import { BaseLeftNavLinkProps } from '../base-left-nav';

--- a/src/DetailsView/components/left-nav/test-view-left-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/test-view-left-nav-link.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as commonStyles from 'DetailsView/components/left-nav/common-left-nav-link.scss';
-import * as styles from 'DetailsView/components/left-nav/test-view-left-nav-link.scss';
+import commonStyles from 'DetailsView/components/left-nav/common-left-nav-link.scss';
+import styles from 'DetailsView/components/left-nav/test-view-left-nav-link.scss';
 import * as React from 'react';
 import { NamedFC } from '../../../common/react/named-fc';
 import { BaseLeftNavLinkProps } from '../base-left-nav';

--- a/src/DetailsView/components/load-assessment-dialog.tsx
+++ b/src/DetailsView/components/load-assessment-dialog.tsx
@@ -9,7 +9,7 @@ import {
     ChangeAssessmentDialog,
     ChangeAssessmentDialogProps,
 } from 'DetailsView/components/change-assessment-dialog';
-import * as styles from 'DetailsView/components/load-assessment-dialog.scss';
+import styles from 'DetailsView/components/load-assessment-dialog.scss';
 import * as React from 'react';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 

--- a/src/DetailsView/components/nav-link-button.tsx
+++ b/src/DetailsView/components/nav-link-button.tsx
@@ -3,7 +3,7 @@
 import { css, INavButtonProps, Link } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import { BaseLeftNavLink } from 'DetailsView/components/base-left-nav';
-import * as styles from 'DetailsView/components/nav-link-button.scss';
+import styles from 'DetailsView/components/nav-link-button.scss';
 import * as React from 'react';
 
 export interface NavLinkButtonProps extends INavButtonProps {

--- a/src/DetailsView/components/no-content-available/no-content-available.tsx
+++ b/src/DetailsView/components/no-content-available/no-content-available.tsx
@@ -5,7 +5,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { productName } from 'content/strings/application';
 import * as React from 'react';
 
-import * as styles from './no-content-available.scss';
+import styles from './no-content-available.scss';
 
 export const NoContentAvailable = NamedFC('NoContentAvailable', () => {
     return (

--- a/src/DetailsView/components/no-displayable-preview-features-message.tsx
+++ b/src/DetailsView/components/no-displayable-preview-features-message.tsx
@@ -4,7 +4,7 @@ import { DisplayableStrings } from 'common/constants/displayable-strings';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import * as styles from './no-displayable-preview-features-message.scss';
+import styles from './no-displayable-preview-features-message.scss';
 
 export const NoDisplayableFeatureFlagMessage = NamedFC('NoDisplayableFeatureFlagMessage', () => (
     <>

--- a/src/DetailsView/components/overview-content/help-links.tsx
+++ b/src/DetailsView/components/overview-content/help-links.tsx
@@ -5,7 +5,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { HyperlinkDefinition } from 'common/types/hyperlink-definition';
 import * as React from 'react';
 
-import * as styles from './help-links.scss';
+import styles from './help-links.scss';
 
 export type HelpLinksDeps = ExternalLinkDeps;
 

--- a/src/DetailsView/components/overview-content/overview-content-container.tsx
+++ b/src/DetailsView/components/overview-content/overview-content-container.tsx
@@ -15,7 +15,7 @@ import { AssessmentReportSummary } from 'reports/components/assessment-report-su
 import { GetAssessmentSummaryModelFromProviderAndStoreData } from 'reports/get-assessment-summary-model';
 
 import { TargetChangeDialog, TargetChangeDialogDeps } from '../target-change-dialog';
-import * as styles from './overview-content-container.scss';
+import styles from './overview-content-container.scss';
 import { OverviewHeading } from './overview-heading';
 import { OverviewHelpSection, OverviewHelpSectionDeps } from './overview-help-section';
 

--- a/src/DetailsView/components/overview-content/overview-heading.tsx
+++ b/src/DetailsView/components/overview-content/overview-heading.tsx
@@ -4,7 +4,7 @@ import { productName } from 'content/strings/application';
 import * as React from 'react';
 
 import { NamedFC } from '../../../common/react/named-fc';
-import * as styles from './overview-heading.scss';
+import styles from './overview-heading.scss';
 
 export const overviewHeadingAutomationId = 'overview-heading';
 

--- a/src/DetailsView/components/overview-content/overview-help-section.tsx
+++ b/src/DetailsView/components/overview-content/overview-help-section.tsx
@@ -5,7 +5,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { HyperlinkDefinition } from 'common/types/hyperlink-definition';
 import * as React from 'react';
 import { HelpLinks, HelpLinksDeps } from './help-links';
-import * as styles from './overview-help-section.scss';
+import styles from './overview-help-section.scss';
 
 export type OverviewHelpSectionDeps = HelpLinksDeps;
 

--- a/src/DetailsView/components/preview-features-toggle-list.tsx
+++ b/src/DetailsView/components/preview-features-toggle-list.tsx
@@ -5,7 +5,7 @@ import { DisplayableFeatureFlag } from 'common/types/store-data/displayable-feat
 import * as React from 'react';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { GenericToggle } from './generic-toggle';
-import * as styles from './preview-features-toggle-list.scss';
+import styles from './preview-features-toggle-list.scss';
 
 export type PreviewFeaturesToggleListDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;

--- a/src/DetailsView/components/requirement-instructions.tsx
+++ b/src/DetailsView/components/requirement-instructions.tsx
@@ -3,7 +3,7 @@
 import { CollapsibleComponent } from 'common/components/collapsible-component';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './requirement-instructions.scss';
+import styles from './requirement-instructions.scss';
 
 export interface RequirementInstructionsProps {
     howToTest: JSX.Element;

--- a/src/DetailsView/components/requirement-view-title.tsx
+++ b/src/DetailsView/components/requirement-view-title.tsx
@@ -6,7 +6,7 @@ import { HyperlinkDefinition } from 'common/types/hyperlink-definition';
 import * as React from 'react';
 import { ContentPageComponent } from 'views/content/content-page';
 import { ContentPanelButton, ContentPanelButtonDeps } from 'views/content/content-panel-button';
-import * as styles from './requirement-view-title.scss';
+import styles from './requirement-view-title.scss';
 
 export type RequirementViewTitleDeps = GuidanceTagsDeps & ContentPanelButtonDeps;
 

--- a/src/DetailsView/components/requirement-view.tsx
+++ b/src/DetailsView/components/requirement-view.tsx
@@ -27,7 +27,7 @@ import {
 } from 'DetailsView/components/requirement-view-title';
 import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
 import * as React from 'react';
-import * as styles from './requirement-view.scss';
+import styles from './requirement-view.scss';
 
 export type RequirementViewDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -14,7 +14,7 @@ import {
     StartOverProps,
 } from 'DetailsView/components/start-over-dropdown';
 import * as React from 'react';
-import * as styles from './start-over-menu-item.scss';
+import styles from './start-over-menu-item.scss';
 
 export type StartOverFactoryDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;

--- a/src/DetailsView/components/static-content-details-view.tsx
+++ b/src/DetailsView/components/static-content-details-view.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { HeadingWithContentLink } from 'common/components/heading-with-content-link';
-import * as styles from 'DetailsView/components/static-content-common.scss';
+import styles from 'DetailsView/components/static-content-common.scss';
 import * as React from 'react';
 import { ContentInclude, ContentIncludeDeps } from 'views/content/content-include';
 import { ContentLinkDeps } from 'views/content/content-link';

--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -7,7 +7,7 @@ import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import * as React from 'react';
 
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
-import * as styles from './switcher.scss';
+import styles from './switcher.scss';
 
 export type SwitcherDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;

--- a/src/DetailsView/components/tab-stops-failed-instance-section.tsx
+++ b/src/DetailsView/components/tab-stops-failed-instance-section.tsx
@@ -5,7 +5,7 @@ import { ResultSectionTitle } from 'common/components/cards/result-section-title
 import { HeadingElementForLevel, HeadingLevel } from 'common/components/heading-element-for-level';
 import { NamedFC } from 'common/react/named-fc';
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
-import * as styles from 'DetailsView/components/tab-stops-failed-instance-section.scss';
+import styles from 'DetailsView/components/tab-stops-failed-instance-section.scss';
 import { requirements } from 'DetailsView/components/tab-stops/requirements';
 import { TabStopsInstanceSectionPropsFactory } from 'DetailsView/components/tab-stops/tab-stops-instance-section-props-factory';
 import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';

--- a/src/DetailsView/components/tab-stops/failed-instance-panel.tsx
+++ b/src/DetailsView/components/tab-stops/failed-instance-panel.tsx
@@ -5,7 +5,7 @@ import { TextField } from '@fluentui/react';
 import { ActionAndCancelButtonsComponent } from 'DetailsView/components/action-and-cancel-buttons-component';
 import { GenericPanel, GenericPanelProps } from 'DetailsView/components/generic-panel';
 import * as React from 'react';
-import * as styles from '../failure-instance-panel.scss';
+import styles from '../failure-instance-panel.scss';
 
 export interface FailedInstancePanelProps {
     isOpen: boolean;

--- a/src/DetailsView/components/tab-stops/tab-stops-choice-group.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-choice-group.tsx
@@ -4,7 +4,7 @@ import { ChoiceGroup, IChoiceGroup, IChoiceGroupOption, Icon, Link } from '@flue
 import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import { InstanceResultStatus } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
-import * as styles from './tab-stops-choice-group.scss';
+import styles from './tab-stops-choice-group.scss';
 
 export type onGroupChoiceChange = (ev: SupportedMouseEvent, status: InstanceResultStatus) => void;
 export type onUndoClicked = (ev: SupportedMouseEvent) => void;

--- a/src/DetailsView/components/tab-stops/tab-stops-instance-section-props-factory.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-instance-section-props-factory.tsx
@@ -6,7 +6,7 @@ import { TabStopsMinimalRequirementHeader } from 'DetailsView/tab-stops-minimal-
 import { TabStopsRequirementInstancesCollapsibleContent } from 'DetailsView/tab-stops-requirement-instances-collapsible-content';
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 import { TabStopsRequirementsWithInstancesProps } from 'DetailsView/tab-stops-requirements-with-instances';
-import * as styles from 'DetailsView/tab-stops-requirements-with-instances.scss';
+import styles from 'DetailsView/tab-stops-requirements-with-instances.scss';
 import * as React from 'react';
 import { InstanceReportModel } from 'reports/assessment-report-model';
 import { TabStopsReportInstanceList } from 'reports/components/report-sections/tab-stops-report-instance-list';

--- a/src/DetailsView/components/tab-stops/tab-stops-requirements-table.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-requirements-table.tsx
@@ -7,7 +7,7 @@ import { TabStopRequirementState } from 'common/types/store-data/visualization-s
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { requirementsList } from 'DetailsView/components/tab-stops/requirements';
 import { TabStopsChoiceGroup } from 'DetailsView/components/tab-stops/tab-stops-choice-group';
-import * as styles from 'DetailsView/components/tab-stops/tab-stops-requirement-table.scss';
+import styles from 'DetailsView/components/tab-stops/tab-stops-requirement-table.scss';
 import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
 import * as React from 'react';
 

--- a/src/DetailsView/components/target-change-dialog.tsx
+++ b/src/DetailsView/components/target-change-dialog.tsx
@@ -11,7 +11,7 @@ import {
     ChangeAssessmentDialog,
     ChangeAssessmentDialogProps,
 } from 'DetailsView/components/change-assessment-dialog';
-import * as styles from 'DetailsView/components/target-change-dialog.scss';
+import styles from 'DetailsView/components/target-change-dialog.scss';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';

--- a/src/DetailsView/components/target-page-changed-view.tsx
+++ b/src/DetailsView/components/target-page-changed-view.tsx
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { InlineStartOverButton } from 'DetailsView/components/inline-start-over-button';
-import * as commonStaticStyles from 'DetailsView/components/static-content-common.scss';
-import * as styles from 'DetailsView/components/target-page-changed-view.scss';
+import commonStaticStyles from 'DetailsView/components/static-content-common.scss';
+import styles from 'DetailsView/components/target-page-changed-view.scss';
 import * as React from 'react';
 
 import { NamedFC } from '../../common/react/named-fc';

--- a/src/DetailsView/components/test-status-choice-group.tsx
+++ b/src/DetailsView/components/test-status-choice-group.tsx
@@ -13,7 +13,7 @@ import * as React from 'react';
 
 import { ManualTestStatus } from '../../common/types/manual-test-status';
 import { VisualizationType } from '../../common/types/visualization-type';
-import * as styles from './test-status-choice-group.scss';
+import styles from './test-status-choice-group.scss';
 
 export interface TestStatusChoiceGroupProps {
     test: VisualizationType;

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -9,7 +9,7 @@ import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-
 import { FluentSideNav, FluentSideNavDeps } from 'DetailsView/components/left-nav/fluent-side-nav';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
-import * as styles from 'DetailsView/details-view-body.scss';
+import styles from 'DetailsView/details-view-body.scss';
 import * as React from 'react';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { DropdownClickHandler } from '../common/dropdown-click-handler';

--- a/src/DetailsView/tab-stops-minimal-requirement-header.tsx
+++ b/src/DetailsView/tab-stops-minimal-requirement-header.tsx
@@ -5,7 +5,7 @@ import { TabStopsFailedCounter } from 'DetailsView/tab-stops-failed-counter';
 import { TabStopsRequirementResult } from 'DetailsView/tab-stops-requirement-result';
 import * as React from 'react';
 import { OutcomeChip } from 'reports/components/outcome-chip';
-import * as styles from '../DetailsView/tab-stops-minimal-requirement-header.scss';
+import styles from '../DetailsView/tab-stops-minimal-requirement-header.scss';
 
 export interface TabStopsMinimalRequirementHeaderDeps {
     tabStopsFailedCounter: TabStopsFailedCounter;

--- a/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
+++ b/src/DetailsView/tab-stops-requirement-instances-collapsible-content.tsx
@@ -15,7 +15,7 @@ import { tabStopsRequirementsTableActionColumnWidthPx } from 'DetailsView/compon
 import { TabStopsRequirementResultInstance } from 'DetailsView/tab-stops-requirement-result';
 import * as React from 'react';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
-import * as styles from './tab-stops-requirement-instances-collapsible-content.scss';
+import styles from './tab-stops-requirement-instances-collapsible-content.scss';
 
 export type TabStopsRequirementInstancesCollapsibleContentProps = {
     requirementId: TabStopRequirementId;

--- a/src/assessments/assessment-default-message-generator.tsx
+++ b/src/assessments/assessment-default-message-generator.tsx
@@ -8,7 +8,7 @@ import {
 } from 'common/types/store-data/assessment-result-data';
 import { isEmpty, size } from 'lodash';
 import * as React from 'react';
-import * as styles from './assessment-default-message-generator.scss';
+import styles from './assessment-default-message-generator.scss';
 
 export type IMessageGenerator = (
     instancesMap: AssessmentInstancesMap,

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -19,7 +19,7 @@ import {
 import { IssueFilingButtonDeps } from '../issue-filing-button';
 import { Toast, ToastDeps } from '../toast';
 import { CardInteractionSupport } from './card-interaction-support';
-import * as styles from './card-kebab-menu-button.scss';
+import styles from './card-kebab-menu-button.scss';
 
 export type CardKebabMenuButtonDeps = {
     issueDetailsTextGenerator: IssueDetailsTextGenerator;

--- a/src/common/components/cards/cards-visualization-modifier-buttons.tsx
+++ b/src/common/components/cards/cards-visualization-modifier-buttons.tsx
@@ -10,7 +10,7 @@ import {
 } from 'common/components/cards/visual-helper-toggle';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './cards-visualization-modifier-buttons.scss';
+import styles from './cards-visualization-modifier-buttons.scss';
 
 export type CardsVisualizationModifierButtonsProps = ExpandCollapseAllButtonProps &
     VisualHelperToggleProps;

--- a/src/common/components/cards/collapsible-component-cards.tsx
+++ b/src/common/components/cards/collapsible-component-cards.tsx
@@ -6,7 +6,7 @@ import { HeadingElementForLevel, HeadingLevel } from 'common/components/heading-
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { SetFocusVisibility } from 'types/set-focus-visibility';
-import * as styles from './collapsible-component-cards.scss';
+import styles from './collapsible-component-cards.scss';
 
 export const collapsibleButtonAutomationId = 'collapsible-component-cards-button';
 

--- a/src/common/components/cards/combined-report-result-section-title.tsx
+++ b/src/common/components/cards/combined-report-result-section-title.tsx
@@ -4,7 +4,7 @@ import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { OutcomeType } from 'reports/components/outcome-type';
 
-import * as styles from './combined-report-result-section-title.scss';
+import styles from './combined-report-result-section-title.scss';
 
 export type CombinedReportResultSectionTitleProps = {
     title: string;

--- a/src/common/components/cards/expand-collapse-all-button.tsx
+++ b/src/common/components/cards/expand-collapse-all-button.tsx
@@ -4,7 +4,7 @@ import { ActionButton } from '@fluentui/react';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './expand-collapse-all-button.scss';
+import styles from './expand-collapse-all-button.scss';
 
 export type ExpandCollapseAllButtonProps = {
     allCardsCollapsed: boolean;

--- a/src/common/components/cards/failed-instances-section.tsx
+++ b/src/common/components/cards/failed-instances-section.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { OutcomeCounter } from 'reports/components/outcome-counter';
 
 import { CommonInstancesSectionProps } from './common-instances-section-props';
-import * as styles from './failed-instances-section.scss';
+import styles from './failed-instances-section.scss';
 import { ResultSection } from './result-section';
 
 export const FailedInstancesSection = NamedFC<CommonInstancesSectionProps>(

--- a/src/common/components/cards/how-to-fix-card-row.tsx
+++ b/src/common/components/cards/how-to-fix-card-row.tsx
@@ -6,7 +6,7 @@ import { CardRowProps } from '../../../common/configs/unified-result-property-co
 import { NamedFC } from '../../../common/react/named-fc';
 import { CheckType } from '../../types/check-type';
 import { FixInstructionPanel } from '../fix-instruction-panel';
-import * as styles from './how-to-fix-card-row.scss';
+import styles from './how-to-fix-card-row.scss';
 import { SimpleCardRow } from './simple-card-row';
 
 export interface HowToFixWebPropertyData {

--- a/src/common/components/cards/instance-details-footer.tsx
+++ b/src/common/components/cards/instance-details-footer.tsx
@@ -16,7 +16,7 @@ import * as React from 'react';
 
 import { CardInteractionSupport } from './card-interaction-support';
 import { CardKebabMenuButton, CardKebabMenuButtonDeps } from './card-kebab-menu-button';
-import * as styles from './instance-details-footer.scss';
+import styles from './instance-details-footer.scss';
 
 export type HighlightState = 'visible' | 'hidden' | 'unavailable';
 

--- a/src/common/components/cards/instance-details-group.tsx
+++ b/src/common/components/cards/instance-details-group.tsx
@@ -13,7 +13,7 @@ import {
 import { CardRuleResult } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { InstanceDetails, InstanceDetailsDeps } from './instance-details';
-import * as styles from './instance-details-group.scss';
+import styles from './instance-details-group.scss';
 
 export const ruleContentAutomationId = 'cards-rule-content';
 

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -6,16 +6,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { CardResult } from 'common/types/store-data/card-view-model';
 import { forOwn, isEmpty } from 'lodash';
 import * as React from 'react';
-import {
-    focused,
-    hiddenHighlightButton,
-    instanceDetailsCard,
-    instanceDetailsCardContainer,
-    interactive,
-    reportInstanceTable,
-    selected,
-} from 'reports/components/instance-details.scss';
-
+import styles from 'reports/components/instance-details.scss';
 import {
     CardRowDeps,
     PropertyConfiguration,
@@ -59,15 +50,15 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
     const isHighlightSupported: boolean = deps.cardInteractionSupport.supportsHighlighting;
 
     const instanceDetailsCardStyling = classNames({
-        [instanceDetailsCard]: true,
-        [selected]: isHighlightSupported && result.isSelected,
-        [focused]: isHighlightSupported && cardFocused,
-        [interactive]: isHighlightSupported,
+        [styles.instanceDetailsCard]: true,
+        [styles.selected]: isHighlightSupported && result.isSelected,
+        [styles.focused]: isHighlightSupported && cardFocused,
+        [styles.interactive]: isHighlightSupported,
     });
 
     const instanceDetailsCardContainerStyling = classNames({
-        [instanceDetailsCardContainer]: true,
-        [selected]: isHighlightSupported && result.isSelected,
+        [styles.instanceDetailsCardContainer]: true,
+        [styles.selected]: isHighlightSupported && result.isSelected,
     });
 
     const toggleSelectHandler = (event: React.SyntheticEvent): void => {
@@ -93,7 +84,7 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
         >
             <div className={instanceDetailsCardStyling} {...cardHighlightingProperties}>
                 <div>
-                    <table className={reportInstanceTable}>
+                    <table className={styles.reportInstanceTable}>
                         <tbody>
                             {renderCardRowsForPropertyBag(result.identifiers, props)}
                             {renderCardRowsForPropertyBag(result.descriptors, props)}
@@ -104,7 +95,7 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
                         <button
                             ref={hiddenButton}
                             onClick={toggleSelectHandler}
-                            className={hiddenHighlightButton}
+                            className={styles.hiddenHighlightButton}
                             aria-label={`highlight ${
                                 result.identifiers && result.identifiers.identifier
                                     ? result.identifiers.identifier

--- a/src/common/components/cards/result-section-title.tsx
+++ b/src/common/components/cards/result-section-title.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import { OutcomeType } from 'reports/components/outcome-type';
 import { OutcomeChip } from '../../../reports/components/outcome-chip';
-import * as styles from './result-section-title.scss';
+import styles from './result-section-title.scss';
 
 export type ResultSectionTitleProps = {
     title: string;

--- a/src/common/components/cards/result-section.tsx
+++ b/src/common/components/cards/result-section.tsx
@@ -11,7 +11,7 @@ import {
     ResultSectionContentProps,
 } from './result-section-content';
 import { ResultSectionTitle, ResultSectionTitleProps } from './result-section-title';
-import * as styles from './result-section.scss';
+import styles from './result-section.scss';
 
 export type ResultSectionDeps = ResultSectionContentDeps;
 

--- a/src/common/components/cards/rich-resolution-content.tsx
+++ b/src/common/components/cards/rich-resolution-content.tsx
@@ -5,7 +5,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { LinkComponentType } from 'common/types/link-component-type';
 import * as React from 'react';
 import { DictionaryStringTo } from 'types/common-types';
-import * as styles from './rich-resolution-content.scss';
+import styles from './rich-resolution-content.scss';
 
 export type RichResolutionContentDeps = {
     LinkComponent: LinkComponentType;

--- a/src/common/components/cards/rule-resources.tsx
+++ b/src/common/components/cards/rule-resources.tsx
@@ -8,7 +8,7 @@ import { UnifiedRule } from 'common/types/store-data/unified-data-interface';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 
-import * as styles from './rule-resources.scss';
+import styles from './rule-resources.scss';
 
 export type RuleResourcesDeps = GuidanceTagsDeps & {
     LinkComponent: LinkComponentType;

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -16,7 +16,7 @@ import {
     CollapsibleComponentCardsProps,
 } from './collapsible-component-cards';
 import { RuleContent, RuleContentDeps } from './rule-content';
-import * as styles from './rules-with-instances.scss';
+import styles from './rules-with-instances.scss';
 
 export const ruleGroupAutomationId = 'cards-rule-group';
 

--- a/src/common/components/cards/simple-card-row.tsx
+++ b/src/common/components/cards/simple-card-row.tsx
@@ -4,7 +4,7 @@ import { css } from '@fluentui/utilities';
 import * as React from 'react';
 
 import { NamedFC } from '../../../common/react/named-fc';
-import * as styles from '../../../reports/components/instance-details.scss';
+import styles from '../../../reports/components/instance-details.scss';
 
 export interface SimpleCardRowProps {
     label: string;

--- a/src/common/components/cards/snippet-card-row.tsx
+++ b/src/common/components/cards/snippet-card-row.tsx
@@ -2,6 +2,6 @@
 // Licensed under the MIT License.
 import { GetLabelledStringPropertyCardRow } from './get-labelled-string-property-card-row';
 
-import * as styles from './snippet-card-row.scss';
+import styles from './snippet-card-row.scss';
 
 export const SnippetCardRow = GetLabelledStringPropertyCardRow('Snippet', styles.snippet);

--- a/src/common/components/cards/urls-card-row.tsx
+++ b/src/common/components/cards/urls-card-row.tsx
@@ -6,7 +6,7 @@ import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { UrlInfo } from 'reports/package/accessibilityInsightsReport';
 import { SimpleCardRow } from './simple-card-row';
-import * as styles from './urls-card-row.scss';
+import styles from './urls-card-row.scss';
 
 export interface UrlsPropertyData {
     urlInfos: UrlInfo[];

--- a/src/common/components/cards/visual-helper-toggle.tsx
+++ b/src/common/components/cards/visual-helper-toggle.tsx
@@ -4,7 +4,7 @@ import { css, Toggle } from '@fluentui/react';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './visual-helper-toggle.scss';
+import styles from './visual-helper-toggle.scss';
 
 export type VisualHelperToggleProps = {
     visualHelperEnabled: boolean;

--- a/src/common/components/collapsible-component.tsx
+++ b/src/common/components/collapsible-component.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { ActionButton } from '@fluentui/react';
 import { css } from '@fluentui/utilities';
-import * as styles from 'common/components/collapsible-component.scss';
+import styles from 'common/components/collapsible-component.scss';
 import * as React from 'react';
 
 export interface CollapsibleComponentProps {

--- a/src/common/components/controls/insights-command-button.tsx
+++ b/src/common/components/controls/insights-command-button.tsx
@@ -3,7 +3,7 @@
 import { ActionButton, css, IButtonProps } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './insights-command-button.scss';
+import styles from './insights-command-button.scss';
 
 export type InsightsCommandButtonProps = IButtonProps;
 

--- a/src/common/components/fix-instruction-panel.tsx
+++ b/src/common/components/fix-instruction-panel.tsx
@@ -5,7 +5,7 @@ import { RecommendColor } from 'common/components/recommend-color';
 import { CheckType } from 'common/types/check-type';
 import * as React from 'react';
 import { NamedFC } from '../react/named-fc';
-import * as styles from './fix-instruction-panel.scss';
+import styles from './fix-instruction-panel.scss';
 
 export interface FixInstructionPanelDeps {
     fixInstructionProcessor: FixInstructionProcessor;

--- a/src/common/components/fix-instruction-processor.tsx
+++ b/src/common/components/fix-instruction-processor.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { RecommendColor } from 'common/components/recommend-color';
 import * as React from 'react';
-import * as styles from './cards/fix-instruction-color-box.scss';
+import styles from './cards/fix-instruction-color-box.scss';
 
 type ColorMatch = {
     splitIndex: number;

--- a/src/common/components/gear-menu-button.tsx
+++ b/src/common/components/gear-menu-button.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { DropdownClickHandler } from '../dropdown-click-handler';
 import { FeatureFlags } from '../feature-flags';
 import { FeatureFlagStoreData } from '../types/store-data/feature-flag-store-data';
-import * as styles from './gear-menu-button.scss';
+import styles from './gear-menu-button.scss';
 
 export type GearMenuButtonDeps = {
     dropdownClickHandler: DropdownClickHandler;

--- a/src/common/components/hamburger-menu-button.tsx
+++ b/src/common/components/hamburger-menu-button.tsx
@@ -9,7 +9,7 @@ import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-cr
 import { LaunchPanelHeader } from 'popup/components/launch-panel-header';
 import { LaunchPanelHeaderClickHandler } from 'popup/handlers/launch-panel-header-click-handler';
 import * as React from 'react';
-import * as styles from './hamburger-menu-button.scss';
+import styles from './hamburger-menu-button.scss';
 
 const telemetryEventSource = TelemetryEventSource.HamburgerMenu;
 

--- a/src/common/components/header.tsx
+++ b/src/common/components/header.tsx
@@ -5,7 +5,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { TextContent } from 'content/strings/text-content';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import * as React from 'react';
-import * as styles from './header.scss';
+import styles from './header.scss';
 
 export type HeaderDeps = { textContent: Pick<TextContent, 'applicationTitle'> } & HeaderIconDeps;
 

--- a/src/common/components/heading-element-for-level.tsx
+++ b/src/common/components/heading-element-for-level.tsx
@@ -3,7 +3,7 @@
 import { css } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './heading-element-for-level.scss';
+import styles from './heading-element-for-level.scss';
 
 export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 export type HeadingElementForLevelProps = React.DetailedHTMLProps<

--- a/src/common/components/heading-with-content-link.tsx
+++ b/src/common/components/heading-with-content-link.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as styles from 'common/components/heading-with-content-common.scss';
+import styles from 'common/components/heading-with-content-common.scss';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { ContentLink, ContentLinkDeps } from 'views/content/content-link';

--- a/src/common/components/left-nav-hamburger-button.tsx
+++ b/src/common/components/left-nav-hamburger-button.tsx
@@ -4,7 +4,7 @@ import { IconButton, css } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import * as styles from './left-nav-hamburger-button.scss';
+import styles from './left-nav-hamburger-button.scss';
 
 export type LeftNavHamburgerButtonProps = {
     ariaLabel: string;

--- a/src/common/components/new-tab-link-with-tooltip.tsx
+++ b/src/common/components/new-tab-link-with-tooltip.tsx
@@ -4,7 +4,7 @@ import { ICalloutProps, ILinkProps, ITooltipHostStyles, TooltipHost } from '@flu
 import { NewTabLink } from 'common/components/new-tab-link';
 import * as React from 'react';
 import { NamedFC } from '../react/named-fc';
-import * as styles from './new-tab-link-with-tooltip.scss';
+import styles from './new-tab-link-with-tooltip.scss';
 
 export type NewTabLinkWithTooltipProps = ILinkProps & { tooltipContent: string | undefined };
 

--- a/src/common/components/scanning-spinner/scanning-spinner.tsx
+++ b/src/common/components/scanning-spinner/scanning-spinner.tsx
@@ -3,7 +3,7 @@
 import { Spinner, SpinnerSize } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './scanning-spinner.scss';
+import styles from './scanning-spinner.scss';
 
 export type ScanningSpinnerProps = {
     isSpinning: boolean;

--- a/src/common/components/selector-input-list.tsx
+++ b/src/common/components/selector-input-list.tsx
@@ -9,7 +9,7 @@ import {
     List,
     TextField,
 } from '@fluentui/react';
-import * as styles from 'common/components/selector-input-list.scss';
+import styles from 'common/components/selector-input-list.scss';
 import * as _ from 'lodash/index';
 import * as React from 'react';
 import { SingleElementSelector } from '../types/store-data/scoping-store-data';

--- a/src/common/components/toast.tsx
+++ b/src/common/components/toast.tsx
@@ -3,7 +3,7 @@
 import { css } from '@fluentui/utilities';
 import * as React from 'react';
 import { WindowUtils } from '../window-utils';
-import * as styles from './toast.scss';
+import styles from './toast.scss';
 
 export type ToastDeps = {
     windowUtils: WindowUtils;

--- a/src/debug-tools/components/current-view/current-view.tsx
+++ b/src/debug-tools/components/current-view/current-view.tsx
@@ -8,7 +8,7 @@ import {
     TelemetryViewerDeps,
 } from 'debug-tools/components/telemetry-viewer/telemetry-viewer';
 import * as React from 'react';
-import * as styles from '../debug-tools-view.scss';
+import styles from '../debug-tools-view.scss';
 
 export type CurrentViewState = StoresTreeState & DebugToolsNavState;
 export type CurrentViewDeps = TelemetryViewerDeps & StoresTreeDeps;

--- a/src/debug-tools/components/debug-tools-view.tsx
+++ b/src/debug-tools/components/debug-tools-view.tsx
@@ -22,7 +22,7 @@ import {
     NarrowModeDetectorDeps,
 } from 'DetailsView/components/narrow-mode-detector';
 import * as React from 'react';
-import * as styles from './debug-tools-view.scss';
+import styles from './debug-tools-view.scss';
 
 export type DebugToolsViewState = DebugToolsNavState & CurrentViewState;
 

--- a/src/debug-tools/components/telemetry-viewer/telemetry-common-fields.tsx
+++ b/src/debug-tools/components/telemetry-viewer/telemetry-common-fields.tsx
@@ -3,7 +3,7 @@
 import { NamedFC } from 'common/react/named-fc';
 import { DebugToolsTelemetryMessage } from 'debug-tools/controllers/telemetry-listener';
 import * as React from 'react';
-import * as styles from './telemetry-common-fields.scss';
+import styles from './telemetry-common-fields.scss';
 
 export type TelemetryCommonFieldsProps = Pick<
     DebugToolsTelemetryMessage,

--- a/src/electron/views/common/window-title/window-title.tsx
+++ b/src/electron/views/common/window-title/window-title.tsx
@@ -8,7 +8,7 @@ import { PlatformInfo } from 'electron/window-management/platform-info';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
-import * as styles from './window-title.scss';
+import styles from './window-title.scss';
 
 export interface WindowTitleDeps {
     platformInfo: PlatformInfo;

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-spinner-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-spinner-step.tsx
@@ -4,7 +4,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { AndroidSetupSpinner } from 'electron/views/device-connect-view/components/android-setup/android-setup-spinner';
 import * as React from 'react';
-import * as styles from './android-setup-spinner-step.scss';
+import styles from './android-setup-spinner-step.scss';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 
 export type AndroidSetupSpinnerStepDeps = {

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-spinner.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-spinner.tsx
@@ -3,7 +3,7 @@
 import { Spinner, SpinnerSize } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './android-setup-spinner.scss';
+import styles from './android-setup-spinner.scss';
 
 export type AndroidSetupSpinnerProps = {
     label: string;

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.scss
@@ -16,7 +16,7 @@
     padding-bottom: 32px;
     padding-top: 17px;
 
-    > {
+    > * {
         // All flex growth is allocated to .prompt-content
         flex-grow: 0;
         flex-shrink: 0;
@@ -56,7 +56,7 @@
         flex-direction: row;
         justify-content: space-between;
 
-        > {
+        > * {
             margin-left: 8px;
         }
     }

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.tsx
@@ -9,7 +9,7 @@ import {
     rightFooterButtonAutomationId,
 } from 'electron/views/device-connect-view/components/automation-ids';
 import * as React from 'react';
-import * as styles from './android-setup-step-layout.scss';
+import styles from './android-setup-step-layout.scss';
 
 export type AndroidSetupFooterButtonProps = IButtonProps;
 export type AndroidSetupStepLayoutProps = {

--- a/src/electron/views/device-connect-view/components/android-setup/device-description.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/device-description.tsx
@@ -5,7 +5,7 @@ import { css, Icon } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 import * as React from 'react';
-import * as styles from './device-description.scss';
+import styles from './device-description.scss';
 
 export interface DeviceDescriptionProps {
     deviceInfo?: DeviceInfo;

--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
@@ -5,7 +5,7 @@ import { Logger } from 'common/logging/logger';
 import { NamedFC } from 'common/react/named-fc';
 import { OpenDialogOptions, OpenDialogReturnValue } from 'electron';
 import * as React from 'react';
-import * as styles from './folder-picker.scss';
+import styles from './folder-picker.scss';
 
 export type FolderPickerDeps = {
     showOpenFileDialog: (opts: OpenDialogOptions) => Promise<OpenDialogReturnValue>;

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -15,7 +15,7 @@ import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
 import { DeviceDescription } from './device-description';
-import * as styles from './prompt-choose-device-step.scss';
+import styles from './prompt-choose-device-step.scss';
 
 export type PromptChooseDeviceListItem = {
     deviceInfo: DeviceInfo;

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
@@ -6,7 +6,7 @@ import { detectDeviceAutomationId } from 'electron/views/device-connect-view/com
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
-import * as styles from './prompt-connect-to-device-step.scss';
+import styles from './prompt-connect-to-device-step.scss';
 
 export const PromptConnectToDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptConnectToDeviceStep',

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.tsx
@@ -6,7 +6,7 @@ import {
     DeviceDescription,
     DeviceDescriptionProps,
 } from 'electron/views/device-connect-view/components/android-setup/device-description';
-import * as styles from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss';
+import styles from 'electron/views/device-connect-view/components/android-setup/prompt-connected-start-testing-step.scss';
 import { rescanAutomationId } from 'electron/views/device-connect-view/components/automation-ids';
 import * as React from 'react';
 

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-establishing-connection-failed-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-establishing-connection-failed-step.tsx
@@ -10,7 +10,7 @@ import { tryAgainAutomationId } from 'electron/views/device-connect-view/compone
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
-import * as styles from './prompt-install-failed-step.scss';
+import styles from './prompt-install-failed-step.scss';
 
 export const PromptEstablishingConnectionFailedStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptEstablishingConnectionFailedStep',

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
@@ -10,7 +10,7 @@ import { tryAgainAutomationId } from 'electron/views/device-connect-view/compone
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
-import * as styles from './prompt-grant-permissions-step.scss';
+import styles from './prompt-grant-permissions-step.scss';
 
 export const PromptGrantPermissionsStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptGrantPermissionsStep',

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.tsx
@@ -10,7 +10,7 @@ import { tryAgainAutomationId } from 'electron/views/device-connect-view/compone
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
-import * as styles from './prompt-install-failed-step.scss';
+import styles from './prompt-install-failed-step.scss';
 
 export const PromptInstallFailedStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptInstallFailedStep',

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-install-service-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-install-service-step.tsx
@@ -9,7 +9,7 @@ import {
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
-import * as styles from './prompt-install-service-step.scss';
+import styles from './prompt-install-service-step.scss';
 
 export const installAutomationId = 'install';
 export const PromptInstallServiceStep = NamedFC<CommonAndroidSetupStepProps>(

--- a/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
@@ -13,7 +13,7 @@ import { AndroidSetupStepContainer } from 'electron/views/device-connect-view/co
 import * as React from 'react';
 import { WindowTitle, WindowTitleDeps } from '../../common/window-title/window-title';
 import { AndroidSetupPageDeps } from './android-setup/android-setup-types';
-import * as styles from './device-connect-view-container.scss';
+import styles from './device-connect-view-container.scss';
 
 export type DeviceConnectViewContainerDeps = TelemetryPermissionDialogDeps &
     WindowTitleDeps &

--- a/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogFooter, DialogType } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import * as styles from './device-disconnected-popup.scss';
+import styles from './device-disconnected-popup.scss';
 import { StatusCautionIcon } from './status-caution-icon';
 
 export type DeviceDisconnectedPopupProps = {

--- a/src/electron/views/left-nav/fluent-left-nav.tsx
+++ b/src/electron/views/left-nav/fluent-left-nav.tsx
@@ -7,7 +7,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { GenericPanel } from 'DetailsView/components/generic-panel';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
-import * as styles from 'electron/views/left-nav/fluent-left-nav.scss';
+import styles from 'electron/views/left-nav/fluent-left-nav.scss';
 import { LeftNav, LeftNavDeps, LeftNavProps } from 'electron/views/left-nav/left-nav';
 import * as React from 'react';
 

--- a/src/electron/views/left-nav/left-nav.tsx
+++ b/src/electron/views/left-nav/left-nav.tsx
@@ -8,7 +8,7 @@ import { BaseLeftNav, BaseLeftNavLink } from 'DetailsView/components/base-left-n
 import { NavLinkRenderer } from 'DetailsView/components/left-nav/nav-link-renderer';
 import { LeftNavItem } from 'electron/types/left-nav-item';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
-import * as styles from 'electron/views/left-nav/left-nav.scss';
+import styles from 'electron/views/left-nav/left-nav.scss';
 import * as React from 'react';
 
 export type LeftNavDeps = {

--- a/src/electron/views/results/components/header-section.tsx
+++ b/src/electron/views/results/components/header-section.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './header-section.scss';
+import styles from './header-section.scss';
 
 export type HeaderSectionProps = {
     title: string;

--- a/src/electron/views/results/components/reflow-command-bar.tsx
+++ b/src/electron/views/results/components/reflow-command-bar.tsx
@@ -22,7 +22,7 @@ import { ContentPageInfo } from 'electron/types/content-page-info';
 import * as React from 'react';
 import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
 import { ReportHtmlGenerator } from 'reports/report-html-generator';
-import * as styles from './reflow-command-bar.scss';
+import styles from './reflow-command-bar.scss';
 
 export type ReflowCommandBarDeps = {
     scanActionCreator: ScanActionCreator;

--- a/src/electron/views/results/components/title-bar.tsx
+++ b/src/electron/views/results/components/title-bar.tsx
@@ -8,7 +8,7 @@ import { WindowStateStoreData } from 'electron/flux/types/window-state-store-dat
 import { WindowTitle, WindowTitleDeps } from 'electron/views/common/window-title/window-title';
 import * as React from 'react';
 import { MaximizeRestoreButton } from './maximize-restore-button';
-import * as styles from './title-bar.scss';
+import styles from './title-bar.scss';
 
 export type TitleBarDeps = {
     windowFrameActionCreator: WindowFrameActionCreator;

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -45,7 +45,7 @@ import { TitleBar, TitleBarDeps } from 'electron/views/results/components/title-
 import { TestView, TestViewDeps } from 'electron/views/results/test-view';
 import { ScreenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
 import * as React from 'react';
-import * as styles from './results-view.scss';
+import styles from './results-view.scss';
 
 export const resultsViewAutomationId = 'results-view';
 

--- a/src/electron/views/screenshot/highlight-box.tsx
+++ b/src/electron/views/screenshot/highlight-box.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { highlightBox, highlightBoxLabel } from 'electron/views/screenshot/highlight-box.scss';
+import styles from 'electron/views/screenshot/highlight-box.scss';
 import { HighlightBoxViewModel } from 'electron/views/screenshot/screenshot-view-model';
 import * as React from 'react';
 import { CSSProperties } from 'react';
@@ -22,11 +22,13 @@ export const HighlightBox = NamedFC<HighlightBoxProps>('HighlightBox', props => 
         left: viewModel.left,
     };
     const renderedLabel =
-        viewModel.label == null ? null : <div className={highlightBoxLabel}>{viewModel.label}</div>;
+        viewModel.label == null ? null : (
+            <div className={styles.highlightBoxLabel}>{viewModel.label}</div>
+        );
 
     return (
         <div
-            className={highlightBox}
+            className={styles.highlightBox}
             style={boxStyles}
             aria-hidden="true"
             data-automation-id={highlightBoxAutomationId}

--- a/src/electron/views/screenshot/screenshot-container.tsx
+++ b/src/electron/views/screenshot/screenshot-container.tsx
@@ -4,7 +4,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { ScreenshotData } from 'common/types/store-data/unified-data-interface';
 import { HighlightBox } from 'electron/views/screenshot/highlight-box';
 import { Screenshot } from 'electron/views/screenshot/screenshot';
-import { screenshotContainer } from 'electron/views/screenshot/screenshot-container.scss';
+import styles from 'electron/views/screenshot/screenshot-container.scss';
 import { HighlightBoxViewModel } from 'electron/views/screenshot/screenshot-view-model';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
@@ -18,7 +18,7 @@ export const ScreenshotContainer = NamedFC<ScreenshotContainerProps>(
     'ScreenshotContainer',
     props => {
         return (
-            <div className={screenshotContainer}>
+            <div className={styles.screenshotContainer}>
                 <Screenshot encodedImage={props.screenshotData.base64PngData} />
                 {renderHighlightBoxes(props.highlightBoxViewModels)}
             </div>

--- a/src/electron/views/screenshot/screenshot-view.tsx
+++ b/src/electron/views/screenshot/screenshot-view.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import * as styles from 'electron/views/screenshot/common-visual-helper-section-styles.scss';
+import styles from 'electron/views/screenshot/common-visual-helper-section-styles.scss';
 import { ScreenshotContainer } from 'electron/views/screenshot/screenshot-container';
 import { isEmpty } from 'lodash';
 import * as React from 'react';

--- a/src/electron/views/screenshot/screenshot.tsx
+++ b/src/electron/views/screenshot/screenshot.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './screenshot.scss';
+import styles from './screenshot.scss';
 
 export const screenshotImageAutomationId = 'screenshot-image';
 

--- a/src/electron/views/tab-stops/tab-stops-testing-content.tsx
+++ b/src/electron/views/tab-stops/tab-stops-testing-content.tsx
@@ -6,7 +6,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
 import * as React from 'react';
-import * as styles from './tab-stops-testing-content.scss';
+import styles from './tab-stops-testing-content.scss';
 
 export type TabStopsTestingContentDeps = {
     tabStopsActionCreator: TabStopsActionCreator;

--- a/src/electron/views/tab-stops/virtual-keyboard-buttons.tsx
+++ b/src/electron/views/tab-stops/virtual-keyboard-buttons.tsx
@@ -5,7 +5,7 @@ import { DefaultButton, css, Icon } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { TabStopsActionCreator } from 'electron/flux/action/tab-stops-action-creator';
-import * as styles from 'electron/views/tab-stops/virtual-keyboard-buttons.scss';
+import styles from 'electron/views/tab-stops/virtual-keyboard-buttons.scss';
 import * as React from 'react';
 
 export type VirtualKeyboardButtonsDeps = {

--- a/src/electron/views/tab-stops/virtual-keyboard-view.tsx
+++ b/src/electron/views/tab-stops/virtual-keyboard-view.tsx
@@ -4,7 +4,7 @@
 import { css } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
-import * as commonStyles from 'electron/views/screenshot/common-visual-helper-section-styles.scss';
+import commonStyles from 'electron/views/screenshot/common-visual-helper-section-styles.scss';
 import {
     VirtualKeyboardButtons,
     VirtualKeyboardButtonsDeps,

--- a/src/popup/components/ad-hoc-tools-panel.tsx
+++ b/src/popup/components/ad-hoc-tools-panel.tsx
@@ -4,7 +4,7 @@ import { css, Icon, Link } from '@fluentui/react';
 import { NamedFC } from 'common/react/named-fc';
 import { flatMap } from 'lodash';
 import * as React from 'react';
-import * as styles from './ad-hoc-tools-panel.scss';
+import styles from './ad-hoc-tools-panel.scss';
 import { DiagnosticViewToggleFactory } from './diagnostic-view-toggle-factory';
 
 export interface AdHocToolsPanelProps {

--- a/src/popup/components/diagnostic-view-toggle.tsx
+++ b/src/popup/components/diagnostic-view-toggle.tsx
@@ -14,7 +14,7 @@ import { DictionaryStringTo } from 'types/common-types';
 import { ContentLink, ContentLinkDeps } from 'views/content/content-link';
 import { PopupActionMessageCreator } from '../actions/popup-action-message-creator';
 import { DiagnosticViewClickHandler } from '../handlers/diagnostic-view-toggle-click-handler';
-import * as styles from './diagnostic-view-toggle.scss';
+import styles from './diagnostic-view-toggle.scss';
 
 export interface DiagnosticViewToggleProps {
     deps: DiagnosticViewToggleDeps;

--- a/src/popup/components/header.tsx
+++ b/src/popup/components/header.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './header.scss';
+import styles from './header.scss';
 
 export interface HeaderProps {
     title: string;

--- a/src/reports/components/assessment-report-summary.tsx
+++ b/src/reports/components/assessment-report-summary.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import * as styles from 'reports/components/assessment-report-summary.scss';
+import styles from 'reports/components/assessment-report-summary.scss';
 import { OverviewSummaryReportModel } from '../assessment-report-model';
 import { AssessmentSummaryDetails } from './assessment-summary-details';
 import { OutcomeSummaryBar } from './outcome-summary-bar';

--- a/src/reports/components/assessment-summary-details.tsx
+++ b/src/reports/components/assessment-summary-details.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import * as styles from 'reports/components/assessment-summary-details.scss';
+import styles from 'reports/components/assessment-summary-details.scss';
 import { AssessmentSummaryReportModel } from '../assessment-report-model';
 import { OutcomeChipSet } from './outcome-chip-set';
 import { OutcomeIconSet } from './outcome-icon-set';

--- a/src/reports/components/header-bar.tsx
+++ b/src/reports/components/header-bar.tsx
@@ -3,7 +3,7 @@
 import { NamedFC } from 'common/react/named-fc';
 import { BrandWhite } from 'icons/brand/white/brand-white';
 import * as React from 'react';
-import * as styles from './header-bar.scss';
+import styles from './header-bar.scss';
 
 export type HeaderBarProps = {
     headerText: string;

--- a/src/reports/components/report-sections/collapsible-url-result-section.tsx
+++ b/src/reports/components/report-sections/collapsible-url-result-section.tsx
@@ -7,7 +7,7 @@ import {
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { ReportCollapsibleContainerProps } from 'reports/components/report-sections/report-collapsible-container';
-import * as styles from './collapsible-url-result-section.scss';
+import styles from './collapsible-url-result-section.scss';
 
 export type CollapsibleUrlResultSectionDeps = {
     collapsibleControl: (props: ReportCollapsibleContainerProps) => JSX.Element;

--- a/src/reports/components/report-sections/footer-section.tsx
+++ b/src/reports/components/report-sections/footer-section.tsx
@@ -6,7 +6,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { toolName } from 'content/strings/application';
 import * as React from 'react';
 
-import * as styles from './footer-section.scss';
+import styles from './footer-section.scss';
 
 export const FooterSection = NamedFC('FooterSection', () => {
     return (

--- a/src/reports/components/report-sections/header-section.tsx
+++ b/src/reports/components/report-sections/header-section.tsx
@@ -5,7 +5,7 @@ import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import { HeaderBar } from 'reports/components/header-bar';
 import { NewTabLinkWithConfirmationDialog } from 'reports/components/new-tab-link-confirmation-dialog';
-import * as styles from './header-section.scss';
+import styles from './header-section.scss';
 
 export const reportHeaderSectionDataAutomationId: string = 'report-header-section';
 export interface HeaderSectionProps {

--- a/src/reports/components/report-sections/minimal-rule-header.tsx
+++ b/src/reports/components/report-sections/minimal-rule-header.tsx
@@ -3,8 +3,7 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { OutcomeCounter } from 'reports/components/outcome-counter';
-import { outcomeChipContainer } from 'reports/components/report-sections/minimal-rule-header.scss';
-
+import styles from 'reports/components/report-sections/minimal-rule-header.scss';
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { OutcomeChip } from '../outcome-chip';
 
@@ -50,7 +49,7 @@ export const MinimalRuleHeader = NamedFC<MinimalRuleHeaderProps>('MinimalRuleHea
 
     return (
         <span data-automation-id={ruleDetailAutomationId} className="rule-detail">
-            <span className={outcomeChipContainer}>{renderCountBadge()}</span>
+            <span className={styles.outcomeChipContainer}>{renderCountBadge()}</span>
             <span>
                 {renderRuleName()}: {renderDescription()}
             </span>

--- a/src/reports/components/report-sections/no-failed-instances-congrats.tsx
+++ b/src/reports/components/report-sections/no-failed-instances-congrats.tsx
@@ -4,7 +4,7 @@ import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { InlineImage, InlineImageType } from 'reports/components/inline-image';
 import { InstanceOutcomeType } from 'reports/components/instance-outcome-type';
-import * as styles from './no-failed-instances-congrats.scss';
+import styles from './no-failed-instances-congrats.scss';
 
 export type NoFailedInstancesCongratsDeps = {
     customCongratsContinueInvestigatingMessage?: string;

--- a/src/reports/components/report-sections/results-by-url-container.tsx
+++ b/src/reports/components/report-sections/results-by-url-container.tsx
@@ -3,7 +3,7 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { SummaryReportSectionProps } from 'reports/components/report-sections/summary-report-section-factory';
-import * as styles from './results-by-url-container.scss';
+import styles from './results-by-url-container.scss';
 export type ResultsByUrlContainerProps = Pick<SummaryReportSectionProps, 'getCollapsibleScript'>;
 
 export const ResultsByUrlContainer = NamedFC<ResultsByUrlContainerProps>(

--- a/src/reports/components/report-sections/rules-only.tsx
+++ b/src/reports/components/report-sections/rules-only.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as styles from 'common/components/cards/rules-with-instances.scss';
+import styles from 'common/components/cards/rules-with-instances.scss';
 import { NamedFC } from 'common/react/named-fc';
 import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import * as React from 'react';

--- a/src/reports/components/report-sections/rules-results-container.tsx
+++ b/src/reports/components/report-sections/rules-results-container.tsx
@@ -3,7 +3,7 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { CombinedReportSectionProps } from 'reports/components/report-sections/combined-report-section-factory';
-import * as styles from './rules-results-container.scss';
+import styles from './rules-results-container.scss';
 
 export type RulesResultsContainerProps = Pick<CombinedReportSectionProps, 'getCollapsibleScript'>;
 

--- a/src/reports/components/report-sections/summary-report-details-section.tsx
+++ b/src/reports/components/report-sections/summary-report-details-section.tsx
@@ -7,7 +7,7 @@ import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { NewTabLinkWithConfirmationDialog } from 'reports/components/new-tab-link-confirmation-dialog';
 import { BaseSummaryReportSectionProps } from 'reports/components/report-sections/base-summary-report-section-props';
-import * as styles from './summary-report-details-section.scss';
+import styles from './summary-report-details-section.scss';
 
 export const SummaryReportDetailsSection = NamedFC<BaseSummaryReportSectionProps>(
     'SummaryReportDetailsSection',

--- a/src/reports/components/report-sections/summary-results-table.tsx
+++ b/src/reports/components/report-sections/summary-results-table.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import * as styles from './summary-results-table.scss';
+import styles from './summary-results-table.scss';
 
 const cellClassNames = {
     text: styles.textCell,

--- a/src/reports/components/report-sections/tab-stops-report-instance-list.tsx
+++ b/src/reports/components/report-sections/tab-stops-report-instance-list.tsx
@@ -6,7 +6,7 @@ import {
     ReportInstanceList,
     ReportInstanceListProps,
 } from 'reports/components/report-instance-list';
-import * as styles from './tab-stops-report-instance-list.scss';
+import styles from './tab-stops-report-instance-list.scss';
 
 export type TabStopsReportInstanceListProps = ReportInstanceListProps;
 

--- a/src/reports/components/report-sections/urls-summary-section.tsx
+++ b/src/reports/components/report-sections/urls-summary-section.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { OutcomeChip } from 'reports/components/outcome-chip';
 import { OutcomeSummaryBar } from 'reports/components/outcome-summary-bar';
 import { allUrlOutcomeTypes, UrlOutcomeType } from 'reports/components/url-outcome-type';
-import * as styles from './urls-summary-section.scss';
+import styles from './urls-summary-section.scss';
 
 export type UrlsSummarySectionProps = {
     passedUrlsCount: number;

--- a/src/tests/common/identity-obj-proxy.js
+++ b/src/tests/common/identity-obj-proxy.js
@@ -6,7 +6,7 @@
 //
 // We use this in our unit tests via a Jest moduleMapper rule that applies to all *.scss
 // imports so that unit tests can run without having to build *.scss.js files first, even if
-// a component uses "import * as styles from './self.scss';".
+// a component uses "import styles from './self.scss';".
 //
 // This is an alternative implementation of the identity-obj-proxy package which is
 // compatible with being used as an ESM module. We require this because swc requires

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-details-column.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-details-column.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TooltipHost } from '@fluentui/react';
-import * as styles from 'DetailsView/components/assessment-instance-details-column.scss';
+import styles from 'DetailsView/components/assessment-instance-details-column.scss';
 import * as Enzyme from 'enzyme';
 import * as React from 'react';
 

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
@@ -8,7 +8,7 @@ import {
     AssessmentInstanceEditAndRemoveControl,
     AssessmentInstanceEditAndRemoveControlProps,
 } from 'DetailsView/components/assessment-instance-edit-and-remove-control';
-import * as styles from 'DetailsView/components/assessment-instance-edit-and-remove-control.scss';
+import styles from 'DetailsView/components/assessment-instance-edit-and-remove-control.scss';
 import { FailureInstancePanelControl } from 'DetailsView/components/failure-instance-panel-control';
 import * as React from 'react';
 import { CreateTestAssessmentProvider } from 'tests/unit/common/test-assessment-provider';

--- a/src/tests/unit/tests/DetailsView/components/details-view-overlay/scoping-panel/scoping-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-overlay/scoping-panel/scoping-container.test.tsx
@@ -10,7 +10,7 @@ import {
     ScopingContainer,
     ScopingContainerProps,
 } from 'DetailsView/components/details-view-overlay/scoping-panel/scoping-container';
-import * as styles from 'DetailsView/components/details-view-overlay/scoping-panel/scoping-container.scss';
+import styles from 'DetailsView/components/details-view-overlay/scoping-panel/scoping-container.scss';
 import * as Enzyme from 'enzyme';
 import * as React from 'react';
 import { Mock } from 'typemoq';

--- a/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
@@ -5,13 +5,12 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import * as TestUtils from 'react-dom/test-utils';
 import { Mock, Times } from 'typemoq';
-
 import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
 import {
     TestStatusChoiceGroup,
     TestStatusChoiceGroupProps,
 } from '../../../../../DetailsView/components/test-status-choice-group';
-import { undoButton } from '../../../../../DetailsView/components/test-status-choice-group.scss';
+import styles from '../../../../../DetailsView/components/test-status-choice-group.scss';
 
 describe('TestStatusChoiceGroup', () => {
     const options = [
@@ -151,7 +150,7 @@ describe('TestStatusChoiceGroup', () => {
 
         const component = React.createElement(TestableTestStatusChoiceGroup, props);
         const testObject = TestUtils.renderIntoDocument(component);
-        const link = TestUtils.findRenderedDOMComponentWithClass(testObject, undoButton);
+        const link = TestUtils.findRenderedDOMComponentWithClass(testObject, styles.undoButton);
 
         expect(link).toBeDefined();
 

--- a/src/tests/unit/tests/assessments/assessment-default-message-generator.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-default-message-generator.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
-import * as styles from 'assessments/assessment-default-message-generator.scss';
+import styles from 'assessments/assessment-default-message-generator.scss';
 import { ManualTestStatus } from 'common/types/manual-test-status';
 import { GeneratedAssessmentInstance } from 'common/types/store-data/assessment-result-data';
 import * as React from 'react';

--- a/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
@@ -20,13 +20,8 @@ import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
 import { UnifiedResolution, UnifiedResult } from 'common/types/store-data/unified-data-interface';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import {
-    focused,
-    hiddenHighlightButton,
-    instanceDetailsCard,
-} from 'reports/components/instance-details.scss';
+import styles from 'reports/automated-checks-report.scss';
 import { IMock, It, Mock, Times } from 'typemoq';
-
 import { exampleUnifiedResult } from './sample-view-model-data';
 
 jest.mock('react', () => {
@@ -82,7 +77,7 @@ describe('InstanceDetails', () => {
         setupGetPropertyConfigByIdMock();
 
         const wrapper = shallow(<InstanceDetails {...props} />);
-        const element = wrapper.find(`.${instanceDetailsCard}`);
+        const element = wrapper.find(`.${styles.instanceDetailsCard}`);
         expect(element.length).toBe(1);
 
         element.simulate('click');
@@ -104,7 +99,7 @@ describe('InstanceDetails', () => {
             .verifiable(Times.once());
 
         const wrapper = shallow(<InstanceDetails {...props} />);
-        const element = wrapper.find(`.${hiddenHighlightButton}`);
+        const element = wrapper.find(`.${styles.hiddenHighlightButton}`);
         expect(element.length).toBe(1);
 
         element.simulate('click', eventStub);
@@ -116,14 +111,14 @@ describe('InstanceDetails', () => {
         (React.useRef as jest.Mock).mockReturnValue(hiddenButtonRefStub);
         setupGetPropertyConfigByIdMock();
         const wrapper = shallow(<InstanceDetails {...props} />);
-        const button = wrapper.find(`.${hiddenHighlightButton}`);
+        const button = wrapper.find(`.${styles.hiddenHighlightButton}`);
         expect(button.length).toBe(1);
 
         button.prop('onFocus')({} as any);
-        expect(wrapper.find(`.${focused}`).length).toBe(1);
+        expect(wrapper.find(`.${styles.focused}`).length).toBe(1);
 
         button.prop('onBlur')({} as any);
-        expect(wrapper.find(`.${focused}`).length).toBe(0);
+        expect(wrapper.find(`.${styles.focused}`).length).toBe(0);
     });
 
     it('does not dispatch the card selection message when card is clicked if highlighting is not supported', () => {
@@ -144,7 +139,7 @@ describe('InstanceDetails', () => {
             .verifiable(Times.never());
 
         const wrapper = shallow(<InstanceDetails {...props} />);
-        const divElem = wrapper.find(`.${instanceDetailsCard}`);
+        const divElem = wrapper.find(`.${styles.instanceDetailsCard}`);
         expect(divElem.length).toBe(1);
 
         divElem.simulate('click');

--- a/src/tests/unit/tests/common/components/selector-input-list.test.tsx
+++ b/src/tests/unit/tests/common/components/selector-input-list.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DefaultButton, FocusZone, IconButton, ITextField, List, TextField } from '@fluentui/react';
-import * as styles from 'common/components/selector-input-list.scss';
+import styles from 'common/components/selector-input-list.scss';
 import * as Enzyme from 'enzyme';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,7 +79,6 @@ const scssRule = (useHash = true) => ({
             options: {
                 esModule: true,
                 modules: {
-                    namedExport: true,
                     localIdentName: '[local]' + (useHash ? '--[hash:base64:5]' : ''),
                     exportLocalsConvention: 'camelCaseOnly',
                 },


### PR DESCRIPTION
#### Details

Changes all our style imports to use default exports/imports. Most of the changes are simply just import changes and then the others are to build default export typings and to load css through default import/exports.

##### Motivation

Necessary for migration to esbuild.

##### Context

This is the biggest necessary change for esbuild migration. As a result, I'm doing this separately such that it's a bit easier to review. Doing this separately means we can always switch back to webpack with ease (the point here being that these changes work with both webpack and esbuild).

I tested dev, prod, unified, and the report package locally to verify that everything looked good (and e2e tests).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5412 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
