### PR TITLE
feat(esbuild): use default import for UAParser

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -73,7 +73,7 @@ import {
 import { ReactStaticRenderer } from 'reports/react-static-renderer';
 import { ReportGenerator } from 'reports/report-generator';
 import { WebReportNameGenerator } from 'reports/report-name-generator';
-import * as UAParser from 'ua-parser-js';
+import UAParser from 'ua-parser-js';
 import { AxeInfo } from '../common/axe-info';
 import { provideBlob } from '../common/blob-provider';
 import { allCardInteractionsSupported } from '../common/components/cards/card-interaction-support';

--- a/src/Devtools/dev-tool-init.ts
+++ b/src/Devtools/dev-tool-init.ts
@@ -6,7 +6,7 @@ import { BrowserEventProvider } from 'common/browser-adapters/browser-event-prov
 import { createDefaultLogger } from 'common/logging/default-logger';
 import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
 import { TargetPageInspector } from 'Devtools/target-page-inspector';
-import * as UAParser from 'ua-parser-js';
+import UAParser from 'ua-parser-js';
 import { DevToolInitializer } from './dev-tool-initializer';
 
 const userAgentParser = new UAParser(window.navigator.userAgent);

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -14,7 +14,7 @@ import { BrowserEventManager } from 'common/browser-adapters/browser-event-manag
 import { BrowserEventProvider } from 'common/browser-adapters/browser-event-provider';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { WindowUtils } from 'common/window-utils';
-import * as UAParser from 'ua-parser-js';
+import UAParser from 'ua-parser-js';
 import { AxeInfo } from '../common/axe-info';
 import { DateProvider } from '../common/date-provider';
 import { getIndexedDBStore } from '../common/indexedDB/get-indexeddb-store';

--- a/src/common/browser-adapters/browser-adapter-factory.ts
+++ b/src/common/browser-adapters/browser-adapter-factory.ts
@@ -5,7 +5,7 @@ import { ChromiumAdapter } from 'common/browser-adapters/chromium-adapter';
 import { FirefoxAdapter } from 'common/browser-adapters/firefox-adapter';
 import { WebExtensionBrowserAdapter } from 'common/browser-adapters/webextension-browser-adapter';
 import { DictionaryStringTo } from 'types/common-types';
-import * as UAParser from 'ua-parser-js';
+import UAParser from 'ua-parser-js';
 import { Events } from 'webextension-polyfill';
 
 export class BrowserAdapterFactory {

--- a/src/common/is-supported-browser.ts
+++ b/src/common/is-supported-browser.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as UAParser from 'ua-parser-js';
+import UAParser from 'ua-parser-js';
 
 export type IsSupportedBrowser = () => boolean;
 

--- a/src/debug-tools/initializer/debug-tools-init.tsx
+++ b/src/debug-tools/initializer/debug-tools-init.tsx
@@ -34,7 +34,7 @@ import { DebugToolsMessageDistributor } from 'debug-tools/debug-tools-message-di
 import { DebugToolsNavStore } from 'debug-tools/stores/debug-tools-nav-store';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import * as UAParser from 'ua-parser-js';
+import UAParser from 'ua-parser-js';
 
 export const initializeDebugTools = () => {
     initializeFabricIcons();

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -23,7 +23,7 @@ import { DefaultTabStopsRequirementEvaluator } from 'injected/tab-stops-requirem
 import { TabbableElementGetter } from 'injected/tabbable-element-getter';
 import { getUniqueSelector } from 'scanner/axe-utils';
 import { tabbable } from 'tabbable';
-import * as UAParser from 'ua-parser-js';
+import UAParser from 'ua-parser-js';
 import { AppDataAdapter } from '../common/browser-adapters/app-data-adapter';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';

--- a/src/popup/popup-init.ts
+++ b/src/popup/popup-init.ts
@@ -5,7 +5,7 @@ import { BrowserEventManager } from 'common/browser-adapters/browser-event-manag
 import { BrowserEventProvider } from 'common/browser-adapters/browser-event-provider';
 import { createDefaultLogger } from 'common/logging/default-logger';
 import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
-import * as UAParser from 'ua-parser-js';
+import UAParser from 'ua-parser-js';
 import { initializeFabricIcons } from '../common/fabric-icons';
 import { createSupportedBrowserChecker } from '../common/is-supported-browser';
 import { UrlParser } from '../common/url-parser';

--- a/src/views/insights/initializer.ts
+++ b/src/views/insights/initializer.ts
@@ -9,7 +9,7 @@ import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
 import { SelfFastPass, SelfFastPassContainer } from 'common/self-fast-pass';
 import { ScannerUtils } from 'injected/scanner-utils';
 import { scan } from 'scanner/exposed-apis';
-import * as UAParser from 'ua-parser-js';
+import UAParser from 'ua-parser-js';
 import { rendererDependencies } from './dependencies';
 import { renderer } from './renderer';
 


### PR DESCRIPTION
#### Details

Changes all imports of UAParser to use default style imports.

##### Motivation

Necessary for esbuild to function.

##### Context

Tested dev, prod, and unified to ensure they were still working with these changes.

It seems like this was always an issue that webpack just handled for us; both tsc and esbuild complain about these imports. The esbuild error looks like this:
```Constructing "UAParser" will crash at run-time because it's an import namespace object, not a constructor```
and tsc (with esModuleInterop flag set to true):
```Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.```

Some more info on esbuild and how it imports here: https://esbuild.github.io/content-types/#default-interop.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5412 
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
