### PR TITLE
feat(mv3-part-4): Improve browser event timeout debugability

### DIFF
--- a/src/common/browser-adapters/browser-event-manager.ts
+++ b/src/common/browser-adapters/browser-event-manager.ts
@@ -28,14 +28,14 @@ interface DeferredEventDetails extends EventDetails {
 // As of writing, Chromium maintains its own 5 minute event timeout and will tear down our
 // service worker if this is exceeded, even if other work is outstanding. To avoid this, our
 // own timeout MUST be shorter than Chromium's.
-const EVENT_TIMEOUT_MS = 60 * 1000;
+const EVENT_TIMEOUT_MS = 60 * 1000; // 1 minute
 
 // Ideally, all of our ApplicationListeners would return a Promise whose lifetime encapsulates
 // whether the listener's work is done yet. As of writing, some listeners are "fire and forget",
 // and continue to do some async work after returning undefined. To ensure those listeners have
 // time to do their work, the event manager adds this (arbitrary) delay into its response to the
 // browser event.
-const FIRE_AND_FORGET_EVENT_DELAY_MS = 30 * 1000;
+const FIRE_AND_FORGET_EVENT_DELAY_MS = 30 * 1000; // 30 seconds
 
 // BrowserEventManager is to be used by a BrowserAdapter to ensure the browser does not determine
 // that the service worker can be shut down due to events not responding within 5 minutes.

--- a/src/common/promises/promise-factory.ts
+++ b/src/common/promises/promise-factory.ts
@@ -3,7 +3,7 @@
 export type TimeoutCreator = <T>(
     promise: Promise<T>,
     delayInMilliseconds: number,
-    errorContext?: any,
+    errorContext?: string,
 ) => Promise<T>;
 export type DelayCreator = (result: any, delayInMs: number) => Promise<any>;
 

--- a/src/tests/unit/common/time-simulating-promise-factory.ts
+++ b/src/tests/unit/common/time-simulating-promise-factory.ts
@@ -39,13 +39,15 @@ export class TimeSimulatingPromiseFactory implements PromiseFactory {
         return this.realPromiseFactory.externalResolutionPromise();
     }
 
-    timeout<T>(promise: Promise<T>, delayInMs: number): Promise<T> {
+    timeout<T>(promise: Promise<T>, delayInMs: number, errorContext?: string): Promise<T> {
         const startTime = this.elapsedTime;
-        return this.realPromiseFactory.timeout(promise, this.actualTimeoutMs).catch(async e => {
-            if (e instanceof TimeoutError) {
-                this.elapsedTime = Math.max(startTime + delayInMs, this.elapsedTime);
-            }
-            throw e;
-        });
+        return this.realPromiseFactory
+            .timeout(promise, this.actualTimeoutMs, errorContext)
+            .catch(async e => {
+                if (e instanceof TimeoutError) {
+                    this.elapsedTime = Math.max(startTime + delayInMs, this.elapsedTime);
+                }
+                throw e;
+            });
     }
 }

--- a/src/tests/unit/tests/common/browser-adapters/browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/browser-event-manager.test.ts
@@ -180,7 +180,9 @@ describe(BrowserEventManager, () => {
         );
         const loggedError = recordingLogger.errorRecords[0].optionalParams[0];
         expect(loggedError).toBeInstanceOf(TimeoutError);
-        expect(loggedError.context).toMatchInlineSnapshot();
+        expect(loggedError.context).toMatchInlineSnapshot(
+            `"[deferred browser event: {\\"eventType\\":\\"event-type\\",\\"eventArgs\\":[\\"test-event-arg\\"]}]"`,
+        );
     });
 
     it('times out after 4 minutes if no ApplicationListener registers in time', async () => {
@@ -197,7 +199,9 @@ describe(BrowserEventManager, () => {
         );
         const loggedError = recordingLogger.errorRecords[0].optionalParams[0];
         expect(loggedError).toBeInstanceOf(TimeoutError);
-        expect(loggedError.context).toMatchInlineSnapshot();
+        expect(loggedError.context).toMatchInlineSnapshot(
+            `"[deferred browser event: {\\"eventType\\":\\"event-type\\",\\"eventArgs\\":[]}]"`,
+        );
 
         let appListenerFired = false;
         testSubject.addApplicationListener('event-type', () => {
@@ -224,7 +228,9 @@ describe(BrowserEventManager, () => {
         );
         const loggedError = recordingLogger.errorRecords[0].optionalParams[0];
         expect(loggedError).toBeInstanceOf(TimeoutError);
-        expect(loggedError.context).toMatchInlineSnapshot();
+        expect(loggedError.context).toMatchInlineSnapshot(
+            `"[deferred browser event: {\\"eventType\\":\\"event-type\\",\\"eventArgs\\":[]}]"`,
+        );
 
         stalledAppListenerResponse.resolveHook(null); // test cleanup, avoids Promise leak
     });
@@ -247,7 +253,9 @@ describe(BrowserEventManager, () => {
         );
         const loggedError = recordingLogger.errorRecords[0].optionalParams[0];
         expect(loggedError).toBeInstanceOf(TimeoutError);
-        expect(loggedError.context).toMatchInlineSnapshot();
+        expect(loggedError.context).toMatchInlineSnapshot(
+            `"[browser event listener: {\\"eventType\\":\\"event-type\\",\\"eventArgs\\":[]}]"`,
+        );
 
         stalledAppListenerResponse.resolveHook(null); // test cleanup, avoids Promise leak
     });

--- a/src/tests/unit/tests/common/browser-adapters/browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/browser-event-manager.test.ts
@@ -159,7 +159,8 @@ describe(BrowserEventManager, () => {
 
         testSubject.addBrowserListener(testEvent, 'event-type');
         // event invoked before listener registered
-        const promiseReturnedToEvent = testEvent.invoke();
+        const testEventArg = 'test-event-arg';
+        const promiseReturnedToEvent = testEvent.invoke(testEventArg);
 
         let appListenerFired = false;
         testSubject.addApplicationListener('event-type', () => {
@@ -177,7 +178,9 @@ describe(BrowserEventManager, () => {
         expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
             `"Error while processing browser event-type event: "`,
         );
-        expect(recordingLogger.errorRecords[0].optionalParams[0]).toBeInstanceOf(TimeoutError);
+        const loggedError = recordingLogger.errorRecords[0].optionalParams[0];
+        expect(loggedError).toBeInstanceOf(TimeoutError);
+        expect(loggedError.context).toMatchInlineSnapshot();
     });
 
     it('times out after 4 minutes if no ApplicationListener registers in time', async () => {
@@ -192,7 +195,9 @@ describe(BrowserEventManager, () => {
         expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
             `"Error while processing browser event-type event: "`,
         );
-        expect(recordingLogger.errorRecords[0].optionalParams[0]).toBeInstanceOf(TimeoutError);
+        const loggedError = recordingLogger.errorRecords[0].optionalParams[0];
+        expect(loggedError).toBeInstanceOf(TimeoutError);
+        expect(loggedError.context).toMatchInlineSnapshot();
 
         let appListenerFired = false;
         testSubject.addApplicationListener('event-type', () => {
@@ -217,7 +222,9 @@ describe(BrowserEventManager, () => {
         expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
             `"Error while processing browser event-type event: "`,
         );
-        expect(recordingLogger.errorRecords[0].optionalParams[0]).toBeInstanceOf(TimeoutError);
+        const loggedError = recordingLogger.errorRecords[0].optionalParams[0];
+        expect(loggedError).toBeInstanceOf(TimeoutError);
+        expect(loggedError.context).toMatchInlineSnapshot();
 
         stalledAppListenerResponse.resolveHook(null); // test cleanup, avoids Promise leak
     });
@@ -238,7 +245,9 @@ describe(BrowserEventManager, () => {
         expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
             `"Error while processing browser event-type event: "`,
         );
-        expect(recordingLogger.errorRecords[0].optionalParams[0]).toBeInstanceOf(TimeoutError);
+        const loggedError = recordingLogger.errorRecords[0].optionalParams[0];
+        expect(loggedError).toBeInstanceOf(TimeoutError);
+        expect(loggedError.context).toMatchInlineSnapshot();
 
         stalledAppListenerResponse.resolveHook(null); // test cleanup, avoids Promise leak
     });

--- a/src/tests/unit/tests/common/browser-adapters/browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/browser-event-manager.test.ts
@@ -122,7 +122,7 @@ describe(BrowserEventManager, () => {
 
         await expect(promiseReturnedToEvent).resolves.toBe(undefined);
 
-        expect(timeSimulatingPromiseFactory.elapsedTime).toBe(120000);
+        expect(timeSimulatingPromiseFactory.elapsedTime).toBe(30000);
         expect(recordingLogger.allMessages).toStrictEqual([]);
     });
 
@@ -173,7 +173,7 @@ describe(BrowserEventManager, () => {
 
         await expect(promiseReturnedToEvent).resolves.toBe(undefined);
 
-        expect(timeSimulatingPromiseFactory.elapsedTime).toBe(240000);
+        expect(timeSimulatingPromiseFactory.elapsedTime).toBe(60000);
         expect(recordingLogger.errorRecords).toHaveLength(1);
         expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
             `"Error while processing browser event-type event: "`,
@@ -190,7 +190,7 @@ describe(BrowserEventManager, () => {
         // whole Service Worker with other work still in progress.
         await expect(testEvent.invoke()).resolves.toBe(undefined);
 
-        expect(timeSimulatingPromiseFactory.elapsedTime).toBe(240000);
+        expect(timeSimulatingPromiseFactory.elapsedTime).toBe(60000);
         expect(recordingLogger.errorRecords).toHaveLength(1);
         expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
             `"Error while processing browser event-type event: "`,
@@ -217,7 +217,7 @@ describe(BrowserEventManager, () => {
         testSubject.addApplicationListener('event-type', () => stalledAppListenerResponse.promise);
         await expect(promiseReturnedToEvent).resolves.toBe(undefined);
 
-        expect(timeSimulatingPromiseFactory.elapsedTime).toBe(240000);
+        expect(timeSimulatingPromiseFactory.elapsedTime).toBe(60000);
         expect(recordingLogger.errorRecords).toHaveLength(1);
         expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
             `"Error while processing browser event-type event: "`,
@@ -240,7 +240,7 @@ describe(BrowserEventManager, () => {
         // whole Service Worker with other work still in progress.
         await expect(testEvent.invoke()).resolves.toBe(undefined);
 
-        expect(timeSimulatingPromiseFactory.elapsedTime).toBe(240000);
+        expect(timeSimulatingPromiseFactory.elapsedTime).toBe(60000);
         expect(recordingLogger.errorRecords).toHaveLength(1);
         expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
             `"Error while processing browser event-type event: "`,

--- a/src/tests/unit/tests/common/promises/promise-factory.test.ts
+++ b/src/tests/unit/tests/common/promises/promise-factory.test.ts
@@ -41,12 +41,21 @@ describe(`promiseFactory`, () => {
             await expect(timingOut).rejects.toThrowError(TimeoutError);
         });
 
-        it(' rejects with the pinned error message on timeout', async () => {
+        it('rejects with the pinned error message on timeout', async () => {
             const delay = 1;
             const timingOut = testObject.timeout(neverResolveAsync(), delay);
 
             await expect(timingOut).rejects.toThrowErrorMatchingInlineSnapshot(
                 `"Timed out after 1ms"`,
+            );
+        });
+
+        it('rejects with the pinned error message on timeout with error context', async () => {
+            const delay = 1;
+            const timingOut = testObject.timeout(neverResolveAsync(), delay, 'test-error-context');
+
+            await expect(timingOut).rejects.toThrowErrorMatchingInlineSnapshot(
+                `"Timed out after 1ms at context test-error-context"`,
             );
         });
     });


### PR DESCRIPTION
#### Details

This PR makes 2 improvements to ease debugging of `browser-event-manager` timeouts:

* It reduces the default timeout/fnf delay from 4min/2min to 1min/30s, respectively
    * The original timeouts were chosen mostly based on "being slightly less than the browser's 5min timeout". However, these new timeout values are still plenty high enough that anything hitting them in practice is a bug we should fix, while cutting the time required for a human to sit around waiting to trigger an issue by a factor of 4
* It updates `promiseFactory.timeout` to support an `errorContext` parameter to include in `TimeoutError`s, and updates `BrowserEventManager` to use that to inject details of the event that timed out into the message
    * Previously, a browser event timeout message only showed that "some event's handler timed out", but didn't clarify which event or whether the timeout was due to no handler being registered vs a handler taking too long. The new context info in the error message enables distinguishing these cases.

##### Motivation

This PR addresses 2 pain points I hit while trying to root cause why we're seeing browser-event-manager timeout error spew in context scripts on pages with iframes. Actually fixing that issue is out of scope/for a separate PR, this is just improving debugability.

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
