### PR TITLE
feat(mv3-part-4): Avoid using stale data in CardSelectionStore

### DIFF
--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -57,6 +57,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
 
     public getDefaultState(): CardSelectionStoreData {
         const defaultValue: CardSelectionStoreData = {
+            rules: null,
             visualHelperEnabled: false,
             focusedResultUid: null,
         };
@@ -81,11 +82,11 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
     };
 
     private toggleRuleExpandCollapse = (payload: RuleExpandCollapsePayload): void => {
-        if (!payload || !this.state.rules || !this.state.rules[payload.ruleId]) {
+        if (!payload || !this.state.rules?.[payload.ruleId]) {
             return;
         }
 
-        const rule = this.state.rules![payload.ruleId];
+        const rule = this.state.rules[payload.ruleId];
 
         rule.isExpanded = !rule.isExpanded;
 
@@ -99,14 +100,13 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
     private toggleCardSelection = (payload: CardSelectionPayload): void => {
         if (
             !payload ||
-            !this.state.rules ||
-            !this.state.rules![payload.ruleId] ||
+            !this.state.rules?.[payload.ruleId] ||
             this.state.rules![payload.ruleId].cards[payload.resultInstanceUid] === undefined
         ) {
             return;
         }
 
-        const rule = this.state.rules![payload.ruleId];
+        const rule = this.state.rules[payload.ruleId];
         const isSelected = !rule.cards[payload.resultInstanceUid];
         rule.cards[payload.resultInstanceUid] = isSelected;
 
@@ -124,7 +124,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
             return;
         }
 
-        forOwn(this.state.rules!, rule => {
+        forOwn(this.state.rules, rule => {
             rule.isExpanded = false;
             this.deselectAllCardsInRule(rule);
         });
@@ -137,7 +137,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
             return;
         }
 
-        forOwn(this.state.rules!, rule => {
+        forOwn(this.state.rules, rule => {
             rule.isExpanded = true;
         });
 
@@ -191,10 +191,10 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.state.focusedResultUid = null;
 
         if (this.state.rules) {
-            for (const ruleId in this.state.rules!) {
-                this.state.rules![ruleId].isExpanded = false;
-                for (const resultId in this.state.rules![ruleId].cards) {
-                    this.state.rules![ruleId].cards[resultId] = false;
+            for (const ruleId in this.state.rules) {
+                this.state.rules[ruleId].isExpanded = false;
+                for (const resultId in this.state.rules[ruleId].cards) {
+                    this.state.rules[ruleId].cards[resultId] = false;
                 }
             }
         }

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TabActions } from 'background/actions/tab-actions';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { PersistentStore } from 'common/flux/persistent-store';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
@@ -22,6 +23,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
     constructor(
         private readonly cardSelectionActions: CardSelectionActions,
         private readonly unifiedScanResultActions: UnifiedScanResultActions,
+        private readonly tabActions: TabActions,
         persistedState: CardSelectionStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
@@ -50,11 +52,11 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.unifiedScanResultActions.scanCompleted.addListener(this.onScanCompleted);
         this.cardSelectionActions.resetFocusedIdentifier.addListener(this.onResetFocusedIdentifier);
         this.cardSelectionActions.navigateToNewCardsView.addListener(this.onNavigateToNewCardsView);
+        this.tabActions.existingTabUpdated.addListener(this.onResetStoreData);
     }
 
     public getDefaultState(): CardSelectionStoreData {
         const defaultValue: CardSelectionStoreData = {
-            rules: {},
             visualHelperEnabled: false,
             focusedResultUid: null,
         };
@@ -79,11 +81,11 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
     };
 
     private toggleRuleExpandCollapse = (payload: RuleExpandCollapsePayload): void => {
-        if (!payload || !this.state.rules[payload.ruleId]) {
+        if (!payload || !this.state.rules || !this.state.rules[payload.ruleId]) {
             return;
         }
 
-        const rule = this.state.rules[payload.ruleId];
+        const rule = this.state.rules![payload.ruleId];
 
         rule.isExpanded = !rule.isExpanded;
 
@@ -97,13 +99,14 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
     private toggleCardSelection = (payload: CardSelectionPayload): void => {
         if (
             !payload ||
-            !this.state.rules[payload.ruleId] ||
-            this.state.rules[payload.ruleId].cards[payload.resultInstanceUid] === undefined
+            !this.state.rules ||
+            !this.state.rules![payload.ruleId] ||
+            this.state.rules![payload.ruleId].cards[payload.resultInstanceUid] === undefined
         ) {
             return;
         }
 
-        const rule = this.state.rules[payload.ruleId];
+        const rule = this.state.rules![payload.ruleId];
         const isSelected = !rule.cards[payload.resultInstanceUid];
         rule.cards[payload.resultInstanceUid] = isSelected;
 
@@ -117,7 +120,11 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
     };
 
     private collapseAllRules = (): void => {
-        forOwn(this.state.rules, rule => {
+        if (!this.state.rules) {
+            return;
+        }
+
+        forOwn(this.state.rules!, rule => {
             rule.isExpanded = false;
             this.deselectAllCardsInRule(rule);
         });
@@ -126,7 +133,11 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
     };
 
     private expandAllRules = (): void => {
-        forOwn(this.state.rules, rule => {
+        if (!this.state.rules) {
+            return;
+        }
+
+        forOwn(this.state.rules!, rule => {
             rule.isExpanded = true;
         });
 
@@ -145,6 +156,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
 
     private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
         this.state = this.getDefaultState();
+        this.state.rules = {};
 
         if (!payload) {
             return;
@@ -155,14 +167,14 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
                 return;
             }
 
-            if (this.state.rules[result.ruleId] === undefined) {
-                this.state.rules[result.ruleId] = {
+            if (this.state.rules![result.ruleId] === undefined) {
+                this.state.rules![result.ruleId] = {
                     isExpanded: false,
                     cards: {},
                 };
             }
 
-            this.state.rules[result.ruleId].cards[result.uid] = false;
+            this.state.rules![result.ruleId].cards[result.uid] = false;
         });
 
         this.state.visualHelperEnabled = true;
@@ -177,13 +189,21 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
 
     private onNavigateToNewCardsView = (): void => {
         this.state.focusedResultUid = null;
-        for (const ruleId in this.state.rules) {
-            this.state.rules[ruleId].isExpanded = false;
-            for (const resultId in this.state.rules[ruleId].cards) {
-                this.state.rules[ruleId].cards[resultId] = false;
+
+        if (this.state.rules) {
+            for (const ruleId in this.state.rules!) {
+                this.state.rules![ruleId].isExpanded = false;
+                for (const resultId in this.state.rules![ruleId].cards) {
+                    this.state.rules![ruleId].cards[resultId] = false;
+                }
             }
         }
         this.state.visualHelperEnabled = !isEmpty(this.state.rules);
+        this.emitChanged();
+    };
+
+    private onResetStoreData = (): void => {
+        this.state = this.getDefaultState();
         this.emitChanged();
     };
 }

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -63,6 +63,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
 
     public getDefaultState(): NeedsReviewCardSelectionStoreData {
         const defaultValue: NeedsReviewCardSelectionStoreData = {
+            rules: null,
             visualHelperEnabled: false,
             focusedResultUid: null,
         };
@@ -85,17 +86,17 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
             return;
         }
 
-        forOwn(this.state.rules!, rule => {
+        forOwn(this.state.rules, rule => {
             this.deselectAllCardsInRule(rule);
         });
     };
 
     private toggleRuleExpandCollapse = (payload: RuleExpandCollapsePayload): void => {
-        if (!payload || !this.state.rules || !this.state.rules![payload.ruleId]) {
+        if (!payload || !this.state.rules?.[payload.ruleId]) {
             return;
         }
 
-        const rule = this.state.rules![payload.ruleId];
+        const rule = this.state.rules[payload.ruleId];
 
         rule.isExpanded = !rule.isExpanded;
 
@@ -109,14 +110,13 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
     private toggleCardSelection = (payload: CardSelectionPayload): void => {
         if (
             !payload ||
-            !this.state.rules ||
-            !this.state.rules![payload.ruleId] ||
-            this.state.rules![payload.ruleId].cards[payload.resultInstanceUid] === undefined
+            !this.state.rules?.[payload.ruleId] ||
+            this.state.rules[payload.ruleId].cards[payload.resultInstanceUid] === undefined
         ) {
             return;
         }
 
-        const rule = this.state.rules![payload.ruleId];
+        const rule = this.state.rules[payload.ruleId];
         const isSelected = !rule.cards[payload.resultInstanceUid];
         rule.cards[payload.resultInstanceUid] = isSelected;
 
@@ -134,7 +134,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
             return;
         }
 
-        forOwn(this.state.rules!, rule => {
+        forOwn(this.state.rules, rule => {
             rule.isExpanded = false;
             this.deselectAllCardsInRule(rule);
         });
@@ -147,7 +147,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
             return;
         }
 
-        forOwn(this.state.rules!, rule => {
+        forOwn(this.state.rules, rule => {
             rule.isExpanded = true;
         });
 
@@ -200,10 +200,10 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
     private onNavigateToNewCardsView = (): void => {
         this.state.focusedResultUid = null;
         if (this.state.rules) {
-            for (const ruleId in this.state.rules!) {
-                this.state.rules![ruleId].isExpanded = false;
-                for (const resultId in this.state.rules![ruleId].cards) {
-                    this.state.rules![ruleId].cards[resultId] = false;
+            for (const ruleId in this.state.rules) {
+                this.state.rules[ruleId].isExpanded = false;
+                for (const resultId in this.state.rules[ruleId].cards) {
+                    this.state.rules[ruleId].cards[resultId] = false;
                 }
             }
         }

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -141,6 +141,7 @@ export class TabContextStoreHub implements StoreHub {
         this.cardSelectionStore = new CardSelectionStore(
             actionHub.cardSelectionActions,
             actionHub.unifiedScanResultActions,
+            actionHub.tabActions,
             persistedTabData?.cardSelectionStoreData,
             indexedDBInstance,
             logger,
@@ -163,6 +164,7 @@ export class TabContextStoreHub implements StoreHub {
         this.needsReviewCardSelectionStore = new NeedsReviewCardSelectionStore(
             actionHub.needsReviewCardSelectionActions,
             actionHub.needsReviewScanResultActions,
+            actionHub.tabActions,
             persistedTabData?.needsReviewCardSelectionStoreData,
             indexedDBInstance,
             logger,

--- a/src/common/get-card-selection-view-data.ts
+++ b/src/common/get-card-selection-view-data.ts
@@ -40,16 +40,16 @@ export const getCardSelectionViewData: GetCardSelectionViewData = (
 ): CardSelectionViewData => {
     const viewData = getEmptyViewData();
 
-    if (isEmpty(cardSelectionStoreData) || unifiedScanResultStoreData?.results == null) {
+    if (isEmpty(cardSelectionStoreData?.rules) || unifiedScanResultStoreData?.results == null) {
         return viewData;
     }
 
     viewData.visualHelperEnabled = cardSelectionStoreData.visualHelperEnabled || false;
-    viewData.expandedRuleIds = getRuleIdsOfExpandedRules(cardSelectionStoreData.rules);
+    viewData.expandedRuleIds = getRuleIdsOfExpandedRules(cardSelectionStoreData.rules!);
 
     const candidateResults = unifiedScanResultStoreData.results.filter(resultsFilter);
     const candidateResultUids = candidateResults.map(res => res.uid);
-    const allFilteredUids = getAllFilteredUids(candidateResultUids, cardSelectionStoreData.rules);
+    const allFilteredUids = getAllFilteredUids(candidateResultUids, cardSelectionStoreData.rules!);
 
     const unavailableResultUids = getResultsWithUnavailableHighlightStatus(
         candidateResults,
@@ -57,7 +57,7 @@ export const getCardSelectionViewData: GetCardSelectionViewData = (
         isResultHighlightUnavailable,
     );
     let selectedResultUids = getOnlyResultUidsFromSelectedCards(
-        cardSelectionStoreData.rules,
+        cardSelectionStoreData.rules!,
         viewData.expandedRuleIds,
         candidateResultUids,
     );
@@ -72,7 +72,7 @@ export const getCardSelectionViewData: GetCardSelectionViewData = (
         visibleResultUids = selectedResultUids;
     } else {
         visibleResultUids = getFilteredResultUidsFromRuleIdArray(
-            cardSelectionStoreData.rules,
+            cardSelectionStoreData.rules!,
             viewData.expandedRuleIds,
             candidateResultUids,
         );

--- a/src/common/get-card-selection-view-data.ts
+++ b/src/common/get-card-selection-view-data.ts
@@ -40,16 +40,16 @@ export const getCardSelectionViewData: GetCardSelectionViewData = (
 ): CardSelectionViewData => {
     const viewData = getEmptyViewData();
 
-    if (isEmpty(cardSelectionStoreData?.rules) || unifiedScanResultStoreData?.results == null) {
+    if (cardSelectionStoreData?.rules == null || unifiedScanResultStoreData?.results == null) {
         return viewData;
     }
 
     viewData.visualHelperEnabled = cardSelectionStoreData.visualHelperEnabled || false;
-    viewData.expandedRuleIds = getRuleIdsOfExpandedRules(cardSelectionStoreData.rules!);
+    viewData.expandedRuleIds = getRuleIdsOfExpandedRules(cardSelectionStoreData.rules);
 
     const candidateResults = unifiedScanResultStoreData.results.filter(resultsFilter);
     const candidateResultUids = candidateResults.map(res => res.uid);
-    const allFilteredUids = getAllFilteredUids(candidateResultUids, cardSelectionStoreData.rules!);
+    const allFilteredUids = getAllFilteredUids(candidateResultUids, cardSelectionStoreData.rules);
 
     const unavailableResultUids = getResultsWithUnavailableHighlightStatus(
         candidateResults,
@@ -57,7 +57,7 @@ export const getCardSelectionViewData: GetCardSelectionViewData = (
         isResultHighlightUnavailable,
     );
     let selectedResultUids = getOnlyResultUidsFromSelectedCards(
-        cardSelectionStoreData.rules!,
+        cardSelectionStoreData.rules,
         viewData.expandedRuleIds,
         candidateResultUids,
     );
@@ -72,7 +72,7 @@ export const getCardSelectionViewData: GetCardSelectionViewData = (
         visibleResultUids = selectedResultUids;
     } else {
         visibleResultUids = getFilteredResultUidsFromRuleIdArray(
-            cardSelectionStoreData.rules!,
+            cardSelectionStoreData.rules,
             viewData.expandedRuleIds,
             candidateResultUids,
         );

--- a/src/common/get-card-selection-view-data.ts
+++ b/src/common/get-card-selection-view-data.ts
@@ -8,7 +8,7 @@ import {
     UnifiedResult,
     UnifiedScanResultStoreData,
 } from 'common/types/store-data/unified-data-interface';
-import { flatMap, forOwn, intersection, isEmpty, keys } from 'lodash';
+import { flatMap, forOwn, intersection, keys } from 'lodash';
 
 import {
     CardSelectionStoreData,

--- a/src/common/types/store-data/card-selection-store-data.ts
+++ b/src/common/types/store-data/card-selection-store-data.ts
@@ -13,7 +13,7 @@ export interface RuleExpandCollapseDataDictionary {
 }
 
 export interface CardSelectionStoreData {
-    rules?: RuleExpandCollapseDataDictionary;
+    rules: RuleExpandCollapseDataDictionary | null;
     visualHelperEnabled: boolean;
     focusedResultUid: string | null;
 }

--- a/src/common/types/store-data/card-selection-store-data.ts
+++ b/src/common/types/store-data/card-selection-store-data.ts
@@ -13,7 +13,7 @@ export interface RuleExpandCollapseDataDictionary {
 }
 
 export interface CardSelectionStoreData {
-    rules: RuleExpandCollapseDataDictionary;
+    rules?: RuleExpandCollapseDataDictionary;
     visualHelperEnabled: boolean;
     focusedResultUid: string | null;
 }

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -270,6 +270,7 @@ getGlobalPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
         const cardSelectionStore = new CardSelectionStore(
             cardSelectionActions,
             unifiedScanResultActions,
+            tabActions,
             null,
             indexedDBInstance,
             logger,

--- a/src/injected/element-based-view-model-creator.ts
+++ b/src/injected/element-based-view-model-creator.ts
@@ -35,12 +35,7 @@ export class ElementBasedViewModelCreator {
         cardSelectionData,
     ) => {
         const { rules, results } = unifiedScanResultStoreData;
-        if (
-            rules == null ||
-            results == null ||
-            cardSelectionData == null ||
-            cardSelectionData.rules == null
-        ) {
+        if (rules == null || results == null || cardSelectionData?.rules == null) {
             return null;
         }
 

--- a/src/injected/element-based-view-model-creator.ts
+++ b/src/injected/element-based-view-model-creator.ts
@@ -35,7 +35,12 @@ export class ElementBasedViewModelCreator {
         cardSelectionData,
     ) => {
         const { rules, results } = unifiedScanResultStoreData;
-        if (rules == null || results == null || cardSelectionData == null) {
+        if (
+            rules == null ||
+            results == null ||
+            cardSelectionData == null ||
+            cardSelectionData.rules == null
+        ) {
             return null;
         }
 

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -152,8 +152,10 @@ export class StoreMocks {
         null,
         null,
         null,
+        null,
     ).getDefaultState();
     public needsReviewCardSelectionStoreData = new NeedsReviewCardSelectionStore(
+        null,
         null,
         null,
         null,

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -35,7 +35,7 @@ describe('CardSelectionStore Test', () => {
     test('check defaultState is as expected', () => {
         const defaultState = getDefaultState();
 
-        expect(defaultState.rules).toBeUndefined();
+        expect(defaultState.rules).toBeNull();
     });
 
     it.each`
@@ -260,7 +260,7 @@ describe('CardSelectionStore Test', () => {
 
     describe('collapseAllRules', () => {
         it('does nothing if rules is null', () => {
-            initialState.rules = undefined;
+            initialState.rules = null;
             expectedState = cloneDeep(initialState);
 
             createStoreForCardSelectionActions('collapseAllRules').testListenerToNeverBeCalled(
@@ -282,7 +282,7 @@ describe('CardSelectionStore Test', () => {
 
     describe('expandAllRules', () => {
         it('does nothing if rules is null', () => {
-            initialState.rules = undefined;
+            initialState.rules = null;
             expectedState = cloneDeep(initialState);
 
             createStoreForCardSelectionActions('expandAllRules').testListenerToNeverBeCalled(
@@ -337,7 +337,7 @@ describe('CardSelectionStore Test', () => {
             expectedState.visualHelperEnabled = true;
         });
 
-        it.each([undefined, {}])(
+        it.each([null, {}])(
             'should reset the focused element and turn of visual helper when rules = %s',
             rules => {
                 initialState.focusedResultUid = 'sampleUid1';
@@ -419,7 +419,7 @@ describe('CardSelectionStore Test', () => {
     test('reset data on tab URL change', () => {
         initialState.rules = {};
         initialState.visualHelperEnabled = true;
-        expectedState.rules = undefined;
+        expectedState.rules = null;
         expectedState.visualHelperEnabled = false;
         createStoreForTabActions('existingTabUpdated').testListenerToBeCalledOnce(
             initialState,

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TabActions } from 'background/actions/tab-actions';
 import { cloneDeep, forOwn } from 'lodash';
 
 import {
@@ -34,7 +35,7 @@ describe('CardSelectionStore Test', () => {
     test('check defaultState is as expected', () => {
         const defaultState = getDefaultState();
 
-        expect(defaultState.rules).toBeDefined();
+        expect(defaultState.rules).toBeUndefined();
     });
 
     it.each`
@@ -90,6 +91,7 @@ describe('CardSelectionStore Test', () => {
             new CardSelectionStore(
                 new CardSelectionActions(),
                 actions,
+                new TabActions(),
                 null,
                 null,
                 null,
@@ -384,6 +386,17 @@ describe('CardSelectionStore Test', () => {
         });
     });
 
+    test('reset data on tab URL change', () => {
+        initialState.rules = {};
+        initialState.visualHelperEnabled = true;
+        expectedState.rules = undefined;
+        expectedState.visualHelperEnabled = false;
+        createStoreForTabActions('existingTabUpdated').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
+    });
+
     function expandRuleSelectCards(rule: RuleExpandCollapseData): void {
         rule.isExpanded = true;
 
@@ -399,6 +412,7 @@ describe('CardSelectionStore Test', () => {
             new CardSelectionStore(
                 actions,
                 new UnifiedScanResultActions(),
+                new TabActions(),
                 null,
                 null,
                 null,
@@ -407,5 +421,23 @@ describe('CardSelectionStore Test', () => {
             );
 
         return new StoreTester(CardSelectionActions, actionName, factory);
+    }
+
+    function createStoreForTabActions(
+        actionName: keyof TabActions,
+    ): StoreTester<CardSelectionStoreData, TabActions> {
+        const factory = (actions: TabActions) =>
+            new CardSelectionStore(
+                new CardSelectionActions(),
+                new UnifiedScanResultActions(),
+                actions,
+                null,
+                null,
+                null,
+                null,
+                true,
+            );
+
+        return new StoreTester(TabActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TabActions } from 'background/actions/tab-actions';
-import { createStore } from 'idb-keyval';
-import { cloneDeep, forOwn, initial } from 'lodash';
+import { cloneDeep, forOwn } from 'lodash';
 
 import {
     BaseActionPayload,

--- a/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review-card-selection-actions';
 import { NeedsReviewScanResultActions } from 'background/actions/needs-review-scan-result-actions';
+import { TabActions } from 'background/actions/tab-actions';
 import { NeedsReviewCardSelectionStore } from 'background/stores/needs-review-card-selection-store';
 import { RuleExpandCollapseData } from 'common/types/store-data/card-selection-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
@@ -32,7 +33,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
     test('check defaultState is as expected', () => {
         const defaultState = getDefaultState();
 
-        expect(defaultState.rules).toBeDefined();
+        expect(defaultState.rules).toBeUndefined();
     });
 
     it.each`
@@ -88,6 +89,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
             new NeedsReviewCardSelectionStore(
                 new NeedsReviewCardSelectionActions(),
                 actions,
+                new TabActions(),
                 null,
                 null,
                 null,
@@ -375,6 +377,17 @@ describe('NeedsReviewCardSelectionStore Test', () => {
         });
     });
 
+    test('reset data on tab URL change', () => {
+        initialState.rules = {};
+        initialState.visualHelperEnabled = true;
+        expectedState.rules = undefined;
+        expectedState.visualHelperEnabled = false;
+        createStoreForTabActions('existingTabUpdated').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
+    });
+
     function expandRuleSelectCards(rule: RuleExpandCollapseData): void {
         rule.isExpanded = true;
 
@@ -390,6 +403,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
             new NeedsReviewCardSelectionStore(
                 actions,
                 new NeedsReviewScanResultActions(),
+                new TabActions(),
                 null,
                 null,
                 null,
@@ -398,5 +412,23 @@ describe('NeedsReviewCardSelectionStore Test', () => {
             );
 
         return new StoreTester(NeedsReviewCardSelectionActions, actionName, factory);
+    }
+
+    function createStoreForTabActions(
+        actionName: keyof TabActions,
+    ): StoreTester<NeedsReviewCardSelectionStoreData, TabActions> {
+        const factory = (actions: TabActions) =>
+            new NeedsReviewCardSelectionStore(
+                new NeedsReviewCardSelectionActions(),
+                new NeedsReviewScanResultActions(),
+                actions,
+                null,
+                null,
+                null,
+                null,
+                true,
+            );
+
+        return new StoreTester(TabActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
@@ -256,51 +256,86 @@ describe('NeedsReviewCardSelectionStore Test', () => {
             .testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('CollapseAllRules', () => {
-        expandRuleSelectCards(initialState.rules['sampleRuleId1']);
-        expandRuleSelectCards(initialState.rules['sampleRuleId2']);
+    describe('collapseAllRules', () => {
+        test('Does nothing if rules is null', () => {
+            initialState.rules = undefined;
+            expectedState = cloneDeep(initialState);
 
-        createStoreForNeedsReviewCardSelectionActions(
-            'collapseAllRules',
-        ).testListenerToBeCalledOnce(initialState, expectedState);
+            createStoreForNeedsReviewCardSelectionActions(
+                'collapseAllRules',
+            ).testListenerToNeverBeCalled(initialState, expectedState);
+        });
+
+        test('collapses all expanded rules', () => {
+            expandRuleSelectCards(initialState.rules['sampleRuleId1']);
+            expandRuleSelectCards(initialState.rules['sampleRuleId2']);
+
+            createStoreForNeedsReviewCardSelectionActions(
+                'collapseAllRules',
+            ).testListenerToBeCalledOnce(initialState, expectedState);
+        });
     });
 
-    test('expandAllRules', () => {
-        initialState.rules['sampleRuleId1'].isExpanded = true;
-        initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+    describe('expandAllRules', () => {
+        test('Does nothing if rules is null', () => {
+            initialState.rules = undefined;
+            expectedState = cloneDeep(initialState);
 
-        expectedState.rules['sampleRuleId1'].isExpanded = true;
-        expectedState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
-        expectedState.rules['sampleRuleId2'].isExpanded = true;
+            createStoreForNeedsReviewCardSelectionActions(
+                'expandAllRules',
+            ).testListenerToNeverBeCalled(initialState, expectedState);
+        });
 
-        createStoreForNeedsReviewCardSelectionActions('expandAllRules').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        test('expands all collapsed rules', () => {
+            initialState.rules['sampleRuleId1'].isExpanded = true;
+            initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+
+            expectedState.rules['sampleRuleId1'].isExpanded = true;
+            expectedState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+            expectedState.rules['sampleRuleId2'].isExpanded = true;
+
+            createStoreForNeedsReviewCardSelectionActions(
+                'expandAllRules',
+            ).testListenerToBeCalledOnce(initialState, expectedState);
+        });
     });
 
-    test('toggleVisualHelper on - no card selection or rule expansion changes', () => {
-        initialState.rules['sampleRuleId1'].isExpanded = true;
-        initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+    describe('toggleVisualHelper', () => {
+        test('toggle on - no card selection or rule expansion changes', () => {
+            initialState.rules['sampleRuleId1'].isExpanded = true;
+            initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
 
-        expectedState = cloneDeep(initialState);
-        expectedState.visualHelperEnabled = true;
+            expectedState = cloneDeep(initialState);
+            expectedState.visualHelperEnabled = true;
 
-        createStoreForNeedsReviewCardSelectionActions(
-            'toggleVisualHelper',
-        ).testListenerToBeCalledOnce(initialState, expectedState);
-    });
+            createStoreForNeedsReviewCardSelectionActions(
+                'toggleVisualHelper',
+            ).testListenerToBeCalledOnce(initialState, expectedState);
+        });
 
-    test('toggleVisualHelper off - cards deselected, no rule expansion changes', () => {
-        initialState.rules['sampleRuleId1'].isExpanded = true;
-        initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
-        initialState.visualHelperEnabled = true;
+        test('toggle off - cards deselected, no rule expansion changes', () => {
+            initialState.rules['sampleRuleId1'].isExpanded = true;
+            initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
+            initialState.visualHelperEnabled = true;
 
-        expectedState.rules['sampleRuleId1'].isExpanded = true;
+            expectedState.rules['sampleRuleId1'].isExpanded = true;
 
-        createStoreForNeedsReviewCardSelectionActions(
-            'toggleVisualHelper',
-        ).testListenerToBeCalledOnce(initialState, expectedState);
+            createStoreForNeedsReviewCardSelectionActions(
+                'toggleVisualHelper',
+            ).testListenerToBeCalledOnce(initialState, expectedState);
+        });
+
+        test('toggle off when rules is undefined', () => {
+            initialState.rules = undefined;
+            initialState.visualHelperEnabled = true;
+
+            expectedState = cloneDeep(initialState);
+            expectedState.visualHelperEnabled = false;
+
+            createStoreForNeedsReviewCardSelectionActions(
+                'toggleVisualHelper',
+            ).testListenerToBeCalledOnce(initialState, expectedState);
+        });
     });
 
     describe('navigateToNewCardsView', () => {
@@ -308,14 +343,21 @@ describe('NeedsReviewCardSelectionStore Test', () => {
             expectedState.visualHelperEnabled = true;
         });
 
-        it('should reset the focused element', () => {
-            initialState.focusedResultUid = 'sampleUid1';
-            expectedState.focusedResultUid = null;
+        it.each([undefined, {}])(
+            'should reset the focused element and turn off visual helper when rules = %s',
+            rules => {
+                initialState.focusedResultUid = 'sampleUid1';
+                initialState.rules = rules;
+                initialState.visualHelperEnabled = true;
+                expectedState.focusedResultUid = null;
+                expectedState.rules = rules;
+                expectedState.visualHelperEnabled = false;
 
-            createStoreForNeedsReviewCardSelectionActions(
-                'navigateToNewCardsView',
-            ).testListenerToBeCalledOnce(initialState, expectedState);
-        });
+                createStoreForNeedsReviewCardSelectionActions(
+                    'navigateToNewCardsView',
+                ).testListenerToBeCalledOnce(initialState, expectedState);
+            },
+        );
 
         it('should keep all rules/cards/results but set them to collapsed/unselected', () => {
             initialState.rules = {

--- a/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
@@ -33,7 +33,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
     test('check defaultState is as expected', () => {
         const defaultState = getDefaultState();
 
-        expect(defaultState.rules).toBeUndefined();
+        expect(defaultState.rules).toBeNull();
     });
 
     it.each`
@@ -258,7 +258,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
 
     describe('collapseAllRules', () => {
         test('Does nothing if rules is null', () => {
-            initialState.rules = undefined;
+            initialState.rules = null;
             expectedState = cloneDeep(initialState);
 
             createStoreForNeedsReviewCardSelectionActions(
@@ -278,7 +278,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
 
     describe('expandAllRules', () => {
         test('Does nothing if rules is null', () => {
-            initialState.rules = undefined;
+            initialState.rules = null;
             expectedState = cloneDeep(initialState);
 
             createStoreForNeedsReviewCardSelectionActions(
@@ -325,8 +325,8 @@ describe('NeedsReviewCardSelectionStore Test', () => {
             ).testListenerToBeCalledOnce(initialState, expectedState);
         });
 
-        test('toggle off when rules is undefined', () => {
-            initialState.rules = undefined;
+        test('toggle off when rules is null', () => {
+            initialState.rules = null;
             initialState.visualHelperEnabled = true;
 
             expectedState = cloneDeep(initialState);
@@ -343,7 +343,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
             expectedState.visualHelperEnabled = true;
         });
 
-        it.each([undefined, {}])(
+        it.each([null, {}])(
             'should reset the focused element and turn off visual helper when rules = %s',
             rules => {
                 initialState.focusedResultUid = 'sampleUid1';
@@ -422,7 +422,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
     test('reset data on tab URL change', () => {
         initialState.rules = {};
         initialState.visualHelperEnabled = true;
-        expectedState.rules = undefined;
+        expectedState.rules = null;
         expectedState.visualHelperEnabled = false;
         createStoreForTabActions('existingTabUpdated').testListenerToBeCalledOnce(
             initialState,

--- a/src/tests/unit/tests/common/get-card-selection-view-data.test.ts
+++ b/src/tests/unit/tests/common/get-card-selection-view-data.test.ts
@@ -364,6 +364,19 @@ describe('getCardSelectionStoreviewData', () => {
         validateEmptyViewData(viewData);
     });
 
+    test('empty CardSelectionStoreData.rules, expect no results', () => {
+        const viewData = getCardSelectionViewData(
+            {
+                visualHelperEnabled: false,
+                focusedResultUid: null,
+            } as CardSelectionStoreData,
+            {} as UnifiedScanResultStoreData,
+            null,
+        );
+
+        validateEmptyViewData(viewData);
+    });
+
     test('null UnifiedScanResultStoreData, expect no results', () => {
         const viewData = getCardSelectionViewData(
             {

--- a/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
+++ b/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
@@ -40,7 +40,7 @@ describe('ElementBasedViewModelCreator', () => {
             isResultHighlightUnavailableStub,
         );
 
-        cardSelectionData = {} as CardSelectionStoreData;
+        cardSelectionData = { rules: {} } as CardSelectionStoreData;
     });
 
     test('getElementBasedViewModel: rules are null', () => {
@@ -66,6 +66,15 @@ describe('ElementBasedViewModelCreator', () => {
             testSubject.getElementBasedViewModel(
                 { rules: [], results: [] } as UnifiedScanResultStoreData,
                 null,
+            ),
+        ).toBeNull();
+    });
+
+    test('getElementBasedViewModel: cardSelectionData.rules are null', () => {
+        expect(
+            testSubject.getElementBasedViewModel(
+                { rules: [], results: [] } as UnifiedScanResultStoreData,
+                { visualHelperEnabled: true, focusedResultUid: null },
             ),
         ).toBeNull();
     });

--- a/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
+++ b/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
@@ -74,7 +74,7 @@ describe('ElementBasedViewModelCreator', () => {
         expect(
             testSubject.getElementBasedViewModel(
                 { rules: [], results: [] } as UnifiedScanResultStoreData,
-                { visualHelperEnabled: true, focusedResultUid: null },
+                { rules: null, visualHelperEnabled: true, focusedResultUid: null },
             ),
         ).toBeNull();
     });


### PR DESCRIPTION
#### Details

- Make CardSelectionStoreData.rules nullable and set it to null by default
- Reset CardSelectionStoreData to the default state when the target tab URL changes
- Do not try to get a selectorMap if CardSelectionStoreData.rules is null

##### Motivation

This fixes an issue exposed by #5537. When the Automated checks or Needs review ad hoc visualizers are enabled, the DrawingController receives two requests, one with an empty list, and one with the correct list of elements to highlight. This is caused by two consecutive store updates, one to UnifiedScanResultStore and one to CardSelectionStore, which both trigger a visualization update. Between these two store updates, stale data in CardSelectionStore causes DrawingController to receive an empty list of elements. While working on #5537, we saw these two visualization requests racing in an E2E test, which caused the visualization to be wiped clean if the invalid request with the empty list was processed after the request with the correct element list.

This PR fixes the issue by setting CardSelectionStoreData.rules to null be default, to distinguish between situations where no scan has yet been run vs when a scan has completed and no issues were found. It also removes stale data from the store if the tab is reloaded or the URL changes. The visualization is not updated unless we have valid data from both the CardSelectionStore and the UnifiedScanResultStore.

##### Context

This PR does not address the underlying issue of store updates racing and being processed out of order, but this should be fixed when the rest of the flux architecture is converted from fire-and-forget to promises.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
