### PR TITLE
feat(mv3-part-4): Add exception telemetry listener

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -316,7 +316,7 @@ export class ActionCreator {
         this.visualizationActions.updateSelectedPivotChild.invoke(payload);
         await this.detailsViewController
             .showDetailsView(tabId)
-            .catch(e => this.logger.error(e.message));
+            .catch(e => this.logger.error(e.message, e));
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PIVOT_CHILD_SELECTED, payload);
     };
 

--- a/src/background/actions/inspect-action-creator.ts
+++ b/src/background/actions/inspect-action-creator.ts
@@ -33,7 +33,7 @@ export class InspectActionCreator {
         this.telemetryEventHandler.publishTelemetry(CHANGE_INSPECT_MODE, payload);
         await this.browserAdapter
             .switchToTab(tabId)
-            .catch(error => this.logger.error(`switchToTab failed: ${error}`));
+            .catch(error => this.logger.error(`switchToTab failed: ${error}`, error));
         this.inspectActions.changeInspectMode.invoke(payload);
     };
 

--- a/src/background/actions/inspect-action-creator.ts
+++ b/src/background/actions/inspect-action-creator.ts
@@ -33,7 +33,7 @@ export class InspectActionCreator {
         this.telemetryEventHandler.publishTelemetry(CHANGE_INSPECT_MODE, payload);
         await this.browserAdapter
             .switchToTab(tabId)
-            .catch(error => this.logger.error(`switchToTab failed: ${error}`, error));
+            .catch(error => this.logger.error(`switchToTab failed`, error));
         this.inspectActions.changeInspectMode.invoke(payload);
     };
 

--- a/src/background/actions/tab-action-creator.ts
+++ b/src/background/actions/tab-action-creator.ts
@@ -56,7 +56,7 @@ export class TabActionCreator {
     ): Promise<void> => {
         await this.browserAdapter
             .switchToTab(tabId)
-            .catch(error => this.logger.error(`switchToTab failed: ${error}`));
+            .catch(error => this.logger.error(`switchToTab failed: ${error}`, error));
         this.telemetryEventHandler.publishTelemetry(SWITCH_BACK_TO_TARGET, payload);
     };
 

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -8,6 +8,7 @@ import { TabContextManager } from 'background/tab-context-manager';
 import { TabEventDistributor } from 'background/tab-event-distributor';
 import { ConsoleTelemetryClient } from 'background/telemetry/console-telemetry-client';
 import { DebugToolsTelemetryClient } from 'background/telemetry/debug-tools-telemetry-client';
+import { ExceptionTelemetryListener } from 'background/telemetry/exception-telemetry-listener';
 import { createToolData } from 'common/application-properties-provider';
 import { BrowserAdapterFactory } from 'common/browser-adapters/browser-adapter-factory';
 import { BrowserEventManager } from 'common/browser-adapters/browser-event-manager';
@@ -122,6 +123,9 @@ async function initialize(): Promise<void> {
     const usageLogger = new UsageLogger(browserAdapter, DateProvider.getCurrentDate, logger);
 
     const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
+
+    const exceptionTelemetryListener = new ExceptionTelemetryListener(telemetryEventHandler);
+    exceptionTelemetryListener.initialize(logger);
 
     const browserSpec = new NavigatorUtils(window.navigator, logger).getBrowserSpec();
 

--- a/src/background/browser-message-broadcaster-factory.ts
+++ b/src/background/browser-message-broadcaster-factory.ts
@@ -66,6 +66,6 @@ export class BrowserMessageBroadcasterFactory {
         const msg = `${operationDescription} failed for message ${JSON.stringify(
             message,
         )} with browser error message: ${chromeError.message}`;
-        this.logger.error(msg);
+        this.logger.error(msg, new Error());
     };
 }

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -16,6 +16,7 @@ import { TargetPageController } from 'background/target-page-controller';
 import { TargetTabController } from 'background/target-tab-controller';
 import { ConsoleTelemetryClient } from 'background/telemetry/console-telemetry-client';
 import { DebugToolsTelemetryClient } from 'background/telemetry/debug-tools-telemetry-client';
+import { ExceptionTelemetryListener } from 'background/telemetry/exception-telemetry-listener';
 import {
     getApplicationTelemetryDataFactory,
     getTelemetryClient,
@@ -107,6 +108,9 @@ async function initialize(): Promise<void> {
     const usageLogger = new UsageLogger(browserAdapter, DateProvider.getCurrentDate, logger);
 
     const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
+
+    const exceptionTelemetryListener = new ExceptionTelemetryListener(telemetryEventHandler);
+    exceptionTelemetryListener.initialize(logger);
 
     const browserSpec = new NavigatorUtils(navigator, logger).getBrowserSpec();
 

--- a/src/background/telemetry/exception-telemetry-listener.ts
+++ b/src/background/telemetry/exception-telemetry-listener.ts
@@ -121,7 +121,7 @@ export class ExceptionTelemetryListener {
         source?: string,
     ): void => {
         const telemetry: UnhandledExceptionTelemetryData = {
-            message,
+            message: message.toString(),
             stackTrace,
             source,
             errorType,
@@ -149,7 +149,10 @@ export class ExceptionTelemetryListener {
         if (telemetryData.stackTrace && telemetryData.stackTrace.length > this.MAX_STACK_CHARS) {
             telemetryData.stackTrace = telemetryData.stackTrace.substring(0, this.MAX_STACK_CHARS);
         }
-        if (telemetryData.message?.includes('http') || telemetryData.stackTrace?.includes('http')) {
+        if (
+            (telemetryData.message && telemetryData.message.includes('http')) ||
+            (telemetryData.stackTrace && telemetryData.stackTrace.includes('http'))
+        ) {
             return undefined;
         }
         return telemetryData;

--- a/src/background/telemetry/exception-telemetry-listener.ts
+++ b/src/background/telemetry/exception-telemetry-listener.ts
@@ -16,6 +16,17 @@ enum ErrorType {
 export class ExceptionTelemetryListener {
     private readonly MAX_MESSAGE_CHARS = 300;
     private readonly MAX_STACK_CHARS = 5000;
+    private readonly EXCLUDED_PROPERTIES = [
+        'http',
+        'html',
+        'target',
+        'url',
+        'path',
+        'snippet',
+        'selector',
+        'elementSelector',
+        'cssSelector',
+    ];
 
     constructor(private readonly telemetryEventHandler: TelemetryEventHandler) {}
 
@@ -152,6 +163,18 @@ export class ExceptionTelemetryListener {
         if (
             (telemetryData.message && telemetryData.message.includes('http')) ||
             (telemetryData.stackTrace && telemetryData.stackTrace.includes('http'))
+        ) {
+            return undefined;
+        }
+        if (
+            (telemetryData.message &&
+                this.EXCLUDED_PROPERTIES.some(property =>
+                    telemetryData.message.includes(property),
+                )) ||
+            (telemetryData.stackTrace &&
+                this.EXCLUDED_PROPERTIES.some(property =>
+                    telemetryData.stackTrace.includes(property),
+                ))
         ) {
             return undefined;
         }

--- a/src/background/telemetry/exception-telemetry-listener.ts
+++ b/src/background/telemetry/exception-telemetry-listener.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BaseActionPayload } from 'background/actions/action-payloads';
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { Logger } from 'common/logging/logger';
+import * as TelemetryEvents from '../../common/extension-telemetry-events';
+import { UnhandledExceptionTelemetryData } from '../../common/extension-telemetry-events';
+
+export class ExceptionTelemetryListener {
+    constructor(private readonly telemetryEventHandler: TelemetryEventHandler) {}
+
+    public initialize(logger: Logger): void {
+        const sendExceptionTelemetry = (message: string, stackTrace?: string): void => {
+            const telemetry: UnhandledExceptionTelemetryData = { message, stackTrace };
+            const payload: BaseActionPayload = {
+                telemetry,
+            };
+
+            this.telemetryEventHandler.publishTelemetry(
+                TelemetryEvents.UNHANDLED_EXCEPTION,
+                payload,
+            );
+        };
+
+        // Catch top level synchronous errors
+        window.onerror = function (
+            message: string,
+            source: string,
+            lineno: number,
+            colno: number,
+            error: Error = null,
+        ) {
+            sendExceptionTelemetry(message, error?.stack);
+            return false;
+        };
+
+        // Catch errors thrown in promises
+        window.onunhandledrejection = function (event: PromiseRejectionEvent) {
+            sendExceptionTelemetry(event.reason);
+            return false;
+        };
+
+        // Catch errors written to console.error
+        var consoleError = console.error;
+        console.error = function (message?: any, ...optionalParams: any[]) {
+            const err = optionalParams[0] as Error;
+            if (message || err) {
+                sendExceptionTelemetry(message, err?.stack);
+            }
+
+            consoleError(message, ...optionalParams);
+        };
+
+        // Catch errors written to logger.error
+        var loggerError = logger.error;
+        logger.error = function (message?: any, ...optionalParams: any[]) {
+            const err = optionalParams[0] as Error;
+            if (message || err) {
+                sendExceptionTelemetry(message, err?.stack);
+            }
+
+            loggerError(message, ...optionalParams);
+        };
+    }
+}

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -80,6 +80,7 @@ export const LEFT_NAV_PANEL_EXPANDED: string = 'leftNavPanelExpanded';
 export const NEEDS_REVIEW_TOGGLE: string = 'NeedsReviewToggled';
 export const NAVIGATE_TO_NEW_CARDS_VIEW: string = 'NavigateToNewCardsView';
 export const SET_AUTO_DETECTED_FAILURES_DIALOG_STATE: string = 'setAutoDetectedFailuresDialogState';
+export const UNHANDLED_EXCEPTION: string = 'unhandledException';
 
 export const TriggeredByNotApplicable: TriggeredBy = 'N/A';
 export type TriggeredBy = 'mouseclick' | 'keypress' | 'shortcut' | 'N/A';
@@ -283,6 +284,11 @@ export type AutoDetectedFailuresDialogStateTelemetryData = {
     enabled: boolean;
 };
 
+export type UnhandledExceptionTelemetryData = {
+    message: string;
+    stackTrace?: string;
+};
+
 export type TelemetryData =
     | BaseTelemetryData
     | ToggleTelemetryData
@@ -311,4 +317,5 @@ export type TelemetryData =
     | ScanIncompleteWarningsTelemetryData
     | SetAllUrlsPermissionTelemetryData
     | TabStopsAutomatedResultsTelemetryData
-    | AutoDetectedFailuresDialogStateTelemetryData;
+    | AutoDetectedFailuresDialogStateTelemetryData
+    | UnhandledExceptionTelemetryData;

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -80,7 +80,7 @@ export const LEFT_NAV_PANEL_EXPANDED: string = 'leftNavPanelExpanded';
 export const NEEDS_REVIEW_TOGGLE: string = 'NeedsReviewToggled';
 export const NAVIGATE_TO_NEW_CARDS_VIEW: string = 'NavigateToNewCardsView';
 export const SET_AUTO_DETECTED_FAILURES_DIALOG_STATE: string = 'setAutoDetectedFailuresDialogState';
-export const UNHANDLED_EXCEPTION: string = 'unhandledException';
+export const UNHANDLED_ERROR: string = 'unhandledError';
 
 export const TriggeredByNotApplicable: TriggeredBy = 'N/A';
 export type TriggeredBy = 'mouseclick' | 'keypress' | 'shortcut' | 'N/A';
@@ -284,11 +284,18 @@ export type AutoDetectedFailuresDialogStateTelemetryData = {
     enabled: boolean;
 };
 
-export type UnhandledExceptionTelemetryData = {
+export enum ErrorType {
+    WindowError = 'WindowError',
+    UnhandledRejection = 'UnhandledRejection',
+    ConsoleError = 'ConsoleError',
+    LoggerError = 'LoggerError',
+}
+
+export type UnhandledErrorTelemetryData = {
     message: string;
     stackTrace?: string;
-    source: string;
-    errorType: string;
+    source: TelemetryEventSource;
+    errorType: ErrorType;
 };
 
 export type TelemetryData =
@@ -320,4 +327,4 @@ export type TelemetryData =
     | SetAllUrlsPermissionTelemetryData
     | TabStopsAutomatedResultsTelemetryData
     | AutoDetectedFailuresDialogStateTelemetryData
-    | UnhandledExceptionTelemetryData;
+    | UnhandledErrorTelemetryData;

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -287,6 +287,8 @@ export type AutoDetectedFailuresDialogStateTelemetryData = {
 export type UnhandledExceptionTelemetryData = {
     message: string;
     stackTrace?: string;
+    source: string;
+    errorType: string;
 };
 
 export type TelemetryData =

--- a/src/common/logging/default-logger.ts
+++ b/src/common/logging/default-logger.ts
@@ -5,6 +5,8 @@ import { Logger } from './logger';
 export const createDefaultLogger = (): Logger => {
     return {
         log: console.log,
+        // Note that this can be altered later by ExceptionTelemetryListener, so it's functionally
+        // important for this to remain a direct reference to console.error.
         error: console.error,
     };
 };

--- a/src/common/navigator-utils.ts
+++ b/src/common/navigator-utils.ts
@@ -32,7 +32,7 @@ export class NavigatorUtils {
 
     public copyToClipboard(data: string): Promise<void> {
         return this.navigatorInfo.clipboard.writeText(data).catch(error => {
-            this.logger.error(`Error during copyToClipboard: ${error}`);
+            this.logger.error(`Error during copyToClipboard: ${error}`, error);
             throw error;
         });
     }

--- a/src/injected/frameCommunicators/axe-frame-messenger.ts
+++ b/src/injected/frameCommunicators/axe-frame-messenger.ts
@@ -62,6 +62,7 @@ export class AxeFrameMessenger implements axe.FrameMessenger {
             // use any axe-core plugins that might require this.
             this.logger.error(
                 'AxeFrameMessenger does not support replies-to-replies, but a post replyHandler invoked a responder.',
+                new Error(),
             );
         };
 
@@ -85,6 +86,7 @@ export class AxeFrameMessenger implements axe.FrameMessenger {
                 // frame's console.
                 this.logger.error(
                     'An axe-core error occurred while processing a result from a child frame.',
+                    new Error(),
                 );
             }
         };
@@ -114,7 +116,10 @@ export class AxeFrameMessenger implements axe.FrameMessenger {
         commandMessageResponder: (response: CommandMessageResponse) => void,
     ): void => {
         if (sourceWindow !== this.windowUtils.getParentWindow()) {
-            this.logger.error('Received unexpected axe-core message from a non-parent window');
+            this.logger.error(
+                'Received unexpected axe-core message from a non-parent window',
+                new Error(),
+            );
             return;
         }
 
@@ -130,6 +135,7 @@ export class AxeFrameMessenger implements axe.FrameMessenger {
                 // use any axe-core plugins that might require this.
                 this.logger.error(
                     'AxeFrameMessenger does not support replies-to-replies, but a topicHandler provided a replyHandler in a response callback.',
+                    new Error(),
                 );
             }
             const responsePayload: PostCommandResponsePayload = {

--- a/src/injected/frameCommunicators/respondable-command-message-communicator.ts
+++ b/src/injected/frameCommunicators/respondable-command-message-communicator.ts
@@ -144,6 +144,7 @@ export class RespondableCommandMessageCommunicator {
             if (timedOut) {
                 this.logger.error(
                     `Received a response for command ${commandMessage.command} after it timed out`,
+                    new Error(),
                 );
             }
             pendingResponseResolver(response);

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -1040,7 +1040,7 @@ class ActionCreatorValidator {
     }
 
     public setupLogError(message: string): ActionCreatorValidator {
-        this.loggerMock.setup(logger => logger.error(message)).verifiable(Times.once());
+        this.loggerMock.setup(logger => logger.error(message, It.isAny())).verifiable(Times.once());
 
         return this;
     }

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -109,7 +109,7 @@ describe('InspectActionCreator', () => {
 
             changeInspectModeMock.verifyAll();
             loggerMock.verify(
-                logger => logger.error(`switchToTab failed: ${dummyError}`),
+                logger => logger.error(`switchToTab failed: ${dummyError}`, dummyError),
                 Times.once(),
             );
         });

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -109,7 +109,7 @@ describe('InspectActionCreator', () => {
 
             changeInspectModeMock.verifyAll();
             loggerMock.verify(
-                logger => logger.error(`switchToTab failed: ${dummyError}`, dummyError),
+                logger => logger.error(`switchToTab failed`, dummyError),
                 Times.once(),
             );
         });

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -193,7 +193,7 @@ describe('TestActionCreatorTest', () => {
                 Times.once(),
             );
             loggerMock.verify(
-                logger => logger.error(`switchToTab failed: ${dummyError}`),
+                logger => logger.error(`switchToTab failed: ${dummyError}`, dummyError),
                 Times.once(),
             );
         });

--- a/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
+++ b/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
@@ -65,7 +65,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
                 .setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny()))
                 .returns(() => Promise.resolve());
 
-            loggerMock.setup(m => m.error(expectedMessage)).verifiable(Times.once());
+            loggerMock.setup(m => m.error(expectedMessage, It.isAny())).verifiable(Times.once());
 
             await testSubject.allTabsBroadcaster(testMessage);
 
@@ -88,7 +88,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
                 .setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny()))
                 .returns(() => Promise.reject(testError));
 
-            loggerMock.setup(m => m.error(expectedMessage)).verifiable(Times.once());
+            loggerMock.setup(m => m.error(expectedMessage, It.isAny())).verifiable(Times.once());
 
             await testSubject.allTabsBroadcaster(testMessage);
 
@@ -109,7 +109,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
                 .setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny()))
                 .returns(() => Promise.reject(testError));
 
-            loggerMock.setup(m => m.error(It.isAny())).verifiable(Times.never());
+            loggerMock.setup(m => m.error(It.isAny(), It.isAny())).verifiable(Times.never());
 
             await testSubject.allTabsBroadcaster(testMessage);
 
@@ -150,7 +150,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
                 .setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny()))
                 .returns(() => Promise.resolve());
 
-            loggerMock.setup(m => m.error(expectedMessage)).verifiable(Times.once());
+            loggerMock.setup(m => m.error(expectedMessage, It.isAny())).verifiable(Times.once());
 
             await testSubject.createTabSpecificBroadcaster(1)(testMessage);
 
@@ -170,7 +170,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
                 .setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny()))
                 .returns(() => Promise.reject(testError));
 
-            loggerMock.setup(m => m.error(expectedMessage)).verifiable(Times.once());
+            loggerMock.setup(m => m.error(expectedMessage, It.isAny())).verifiable(Times.once());
 
             await testSubject.createTabSpecificBroadcaster(1)(testMessage);
 

--- a/src/tests/unit/tests/background/telemetry/exception-telemetry-listener.test.ts
+++ b/src/tests/unit/tests/background/telemetry/exception-telemetry-listener.test.ts
@@ -1,8 +1,108 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { BaseActionPayload } from 'background/actions/action-payloads';
 import { ExceptionTelemetryListener } from 'background/telemetry/exception-telemetry-listener';
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { UnhandledExceptionTelemetryData } from 'common/extension-telemetry-events';
+import { Logger } from 'common/logging/logger';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 describe(ExceptionTelemetryListener, () => {
-    // TODO
+    const telemetryType: string = 'unhandledException';
+
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let windowFunctionMock: IMock<(...any) => void>;
+    let loggingFunctionMock: IMock<(message: string, error: Error) => void>;
+    let windowStub: Window;
+    let consoleStub: Console;
+    let loggerStub: Logger;
+
+    let errorMessageStub: string;
+    let errorStub: Error;
+    let rejectedPromiseStub: PromiseRejectionEvent;
+    let expectedTelemetry: UnhandledExceptionTelemetryData;
+    let expectedPayload: BaseActionPayload;
+
+    let testSubject: ExceptionTelemetryListener;
+
+    beforeEach(async () => {
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        windowFunctionMock = Mock.ofType<(...any) => void>();
+        windowFunctionMock.setup(f => f(It.isAny())).verifiable(Times.never());
+        loggingFunctionMock = Mock.ofType<(message: string, error: Error) => void>();
+        windowStub = {
+            onerror: windowFunctionMock.object,
+            onunhandledrejection: windowFunctionMock.object,
+        } as Window;
+        consoleStub = { error: loggingFunctionMock.object } as Console;
+        loggerStub = { error: loggingFunctionMock.object } as Logger;
+
+        errorMessageStub = 'Error message';
+        errorStub = new Error();
+        rejectedPromiseStub = { reason: errorMessageStub } as PromiseRejectionEvent;
+        expectedTelemetry = {
+            message: errorMessageStub,
+            stackTrace: errorStub.stack,
+        };
+        expectedPayload = { telemetry: expectedTelemetry };
+
+        testSubject = new ExceptionTelemetryListener(telemetryEventHandlerMock.object);
+    });
+
+    afterEach(() => {
+        telemetryEventHandlerMock.verifyAll();
+        windowFunctionMock.verifyAll();
+        loggingFunctionMock.verifyAll();
+    });
+
+    test('window on error sends telemetry', () => {
+        telemetryEventHandlerMock
+            .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
+            .verifiable(Times.once());
+
+        testSubject.initialize(loggerStub, windowStub, consoleStub);
+
+        windowStub.onerror(errorMessageStub, '', 0, 0, errorStub);
+    });
+
+    test('window on unhandled rejection sends telemetry', () => {
+        expectedTelemetry = {
+            message: errorMessageStub,
+            stackTrace: undefined,
+        };
+        expectedPayload = { telemetry: expectedTelemetry };
+
+        telemetryEventHandlerMock
+            .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
+            .verifiable(Times.once());
+
+        testSubject.initialize(loggerStub, windowStub, consoleStub);
+
+        windowStub.onunhandledrejection(rejectedPromiseStub);
+    });
+
+    test('console error sends telemetry', () => {
+        telemetryEventHandlerMock
+            .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
+            .verifiable(Times.once());
+
+        loggingFunctionMock.setup(f => f(errorMessageStub, errorStub)).verifiable(Times.once());
+
+        testSubject.initialize(loggerStub, windowStub, consoleStub);
+
+        consoleStub.error(errorMessageStub, errorStub);
+    });
+
+    test('logger error sends telemetry', () => {
+        telemetryEventHandlerMock
+            .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
+            .verifiable(Times.once());
+
+        loggingFunctionMock.setup(f => f(errorMessageStub, errorStub)).verifiable(Times.once());
+
+        testSubject.initialize(loggerStub, windowStub, consoleStub);
+
+        loggerStub.error(errorMessageStub, errorStub);
+    });
 });

--- a/src/tests/unit/tests/background/telemetry/exception-telemetry-listener.test.ts
+++ b/src/tests/unit/tests/background/telemetry/exception-telemetry-listener.test.ts
@@ -190,6 +190,17 @@ describe(ExceptionTelemetryListener, () => {
                     source: sourceStub,
                 };
             });
+
+            test('it does not send data that includes html', () => {
+                errorMessageStub = 'html';
+
+                expectedTelemetry = {
+                    message: errorMessageStub,
+                    stackTrace: errorStub.stack,
+                    errorType: 'WindowError',
+                    source: sourceStub,
+                };
+            });
         });
     });
 });

--- a/src/tests/unit/tests/background/telemetry/exception-telemetry-listener.test.ts
+++ b/src/tests/unit/tests/background/telemetry/exception-telemetry-listener.test.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ExceptionTelemetryListener } from 'background/telemetry/exception-telemetry-listener';
+
+describe(ExceptionTelemetryListener, () => {
+    // TODO
+});

--- a/src/tests/unit/tests/background/telemetry/exception-telemetry-listener.test.ts
+++ b/src/tests/unit/tests/background/telemetry/exception-telemetry-listener.test.ts
@@ -20,6 +20,7 @@ describe(ExceptionTelemetryListener, () => {
 
     let errorMessageStub: string;
     let errorStub: Error;
+    let sourceStub: string;
     let rejectedPromiseStub: PromiseRejectionEvent;
     let expectedTelemetry: UnhandledExceptionTelemetryData;
     let expectedPayload: BaseActionPayload;
@@ -40,12 +41,8 @@ describe(ExceptionTelemetryListener, () => {
 
         errorMessageStub = 'Error message';
         errorStub = new Error();
+        sourceStub = 'Source';
         rejectedPromiseStub = { reason: errorMessageStub } as PromiseRejectionEvent;
-        expectedTelemetry = {
-            message: errorMessageStub,
-            stackTrace: errorStub.stack,
-        };
-        expectedPayload = { telemetry: expectedTelemetry };
 
         testSubject = new ExceptionTelemetryListener(telemetryEventHandlerMock.object);
     });
@@ -56,53 +53,143 @@ describe(ExceptionTelemetryListener, () => {
         loggingFunctionMock.verifyAll();
     });
 
-    test('window on error sends telemetry', () => {
-        telemetryEventHandlerMock
-            .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
-            .verifiable(Times.once());
+    describe('it sends telemetry', () => {
+        test('window on error sends telemetry', () => {
+            expectedTelemetry = {
+                message: errorMessageStub,
+                stackTrace: errorStub.stack,
+                errorType: 'WindowError',
+                source: sourceStub,
+            };
+            expectedPayload = { telemetry: expectedTelemetry };
 
-        testSubject.initialize(loggerStub, windowStub, consoleStub);
+            telemetryEventHandlerMock
+                .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
+                .verifiable(Times.once());
 
-        windowStub.onerror(errorMessageStub, '', 0, 0, errorStub);
+            testSubject.initialize(loggerStub, windowStub, consoleStub);
+
+            windowStub.onerror(errorMessageStub, sourceStub, 0, 0, errorStub);
+        });
+
+        test('window on unhandled rejection sends telemetry', () => {
+            expectedTelemetry = {
+                message: errorMessageStub,
+                stackTrace: undefined,
+                errorType: 'UnhandledRejection',
+                source: undefined,
+            };
+            expectedPayload = { telemetry: expectedTelemetry };
+
+            telemetryEventHandlerMock
+                .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
+                .verifiable(Times.once());
+
+            testSubject.initialize(loggerStub, windowStub, consoleStub);
+
+            windowStub.onunhandledrejection(rejectedPromiseStub);
+        });
+
+        test('console error sends telemetry', () => {
+            expectedTelemetry = {
+                message: errorMessageStub,
+                stackTrace: errorStub.stack,
+                errorType: 'ConsoleError',
+                source: undefined,
+            };
+            expectedPayload = { telemetry: expectedTelemetry };
+
+            telemetryEventHandlerMock
+                .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
+                .verifiable(Times.once());
+
+            loggingFunctionMock.setup(f => f(errorMessageStub, errorStub)).verifiable(Times.once());
+
+            testSubject.initialize(loggerStub, windowStub, consoleStub);
+
+            consoleStub.error(errorMessageStub, errorStub);
+        });
+
+        test('logger error sends telemetry', () => {
+            expectedTelemetry = {
+                message: errorMessageStub,
+                stackTrace: errorStub.stack,
+                errorType: 'LoggerError',
+                source: undefined,
+            };
+            expectedPayload = { telemetry: expectedTelemetry };
+
+            telemetryEventHandlerMock
+                .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
+                .verifiable(Times.once());
+
+            loggingFunctionMock.setup(f => f(errorMessageStub, errorStub)).verifiable(Times.once());
+
+            testSubject.initialize(loggerStub, windowStub, consoleStub);
+
+            loggerStub.error(errorMessageStub, errorStub);
+        });
     });
+    describe('it sanitizes telemetry', () => {
+        describe('it truncates long data', () => {
+            afterEach(() => {
+                expectedPayload = { telemetry: expectedTelemetry };
 
-    test('window on unhandled rejection sends telemetry', () => {
-        expectedTelemetry = {
-            message: errorMessageStub,
-            stackTrace: undefined,
-        };
-        expectedPayload = { telemetry: expectedTelemetry };
+                telemetryEventHandlerMock
+                    .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
+                    .verifiable(Times.once());
 
-        telemetryEventHandlerMock
-            .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
-            .verifiable(Times.once());
+                testSubject.initialize(loggerStub, windowStub, consoleStub);
 
-        testSubject.initialize(loggerStub, windowStub, consoleStub);
+                windowStub.onerror(errorMessageStub, sourceStub, 0, 0, errorStub);
+            });
 
-        windowStub.onunhandledrejection(rejectedPromiseStub);
-    });
+            test('it truncates messages beyond size cap', () => {
+                errorMessageStub = 'very long message'.repeat(30);
 
-    test('console error sends telemetry', () => {
-        telemetryEventHandlerMock
-            .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
-            .verifiable(Times.once());
+                expectedTelemetry = {
+                    message: errorMessageStub.substring(0, 300),
+                    stackTrace: errorStub.stack,
+                    errorType: 'WindowError',
+                    source: sourceStub,
+                };
+            });
 
-        loggingFunctionMock.setup(f => f(errorMessageStub, errorStub)).verifiable(Times.once());
+            test('it truncates stack traces beyond size cap', () => {
+                errorStub.stack = 'very long stack'.repeat(500);
 
-        testSubject.initialize(loggerStub, windowStub, consoleStub);
+                expectedTelemetry = {
+                    message: errorMessageStub,
+                    stackTrace: errorStub.stack.substring(0, 5000),
+                    errorType: 'WindowError',
+                    source: sourceStub,
+                };
+            });
+        });
 
-        consoleStub.error(errorMessageStub, errorStub);
-    });
+        describe('it does not send invalid data', () => {
+            afterEach(() => {
+                expectedPayload = { telemetry: expectedTelemetry };
 
-    test('logger error sends telemetry', () => {
-        telemetryEventHandlerMock
-            .setup(t => t.publishTelemetry(telemetryType, expectedPayload))
-            .verifiable(Times.once());
+                telemetryEventHandlerMock
+                    .setup(t => t.publishTelemetry(It.isAny(), It.isAny()))
+                    .verifiable(Times.never());
 
-        loggingFunctionMock.setup(f => f(errorMessageStub, errorStub)).verifiable(Times.once());
+                testSubject.initialize(loggerStub, windowStub, consoleStub);
 
-        testSubject.initialize(loggerStub, windowStub, consoleStub);
+                windowStub.onerror(errorMessageStub, sourceStub, 0, 0, errorStub);
+            });
 
-        loggerStub.error(errorMessageStub, errorStub);
+            test('it does not send data that includes urls', () => {
+                errorMessageStub = 'https://accessibilityinsights.io/';
+
+                expectedTelemetry = {
+                    message: errorMessageStub,
+                    stackTrace: errorStub.stack,
+                    errorType: 'WindowError',
+                    source: sourceStub,
+                };
+            });
+        });
     });
 });

--- a/src/tests/unit/tests/common/navigator-utils.test.ts
+++ b/src/tests/unit/tests/common/navigator-utils.test.ts
@@ -56,7 +56,7 @@ describe('NavigatorUtils', () => {
                 .verifiable(Times.once());
 
             loggerMock
-                .setup(l => l.error('Error during copyToClipboard: Error: test text'))
+                .setup(l => l.error('Error during copyToClipboard: Error: test text', It.isAny()))
                 .verifiable(Times.once());
 
             await expect(testSubject.copyToClipboard('irrelevant')).rejects.toBe(testError);


### PR DESCRIPTION
#### Details

Adding `ExceptionTelemetryListener`, which listens to for unhandled exceptions and promise rejections and sends telemetry information.

##### Motivation

Feature work.

##### Context

This PR only adds exception listening for the background, follow up PRs will add logic to also send telemetry information from other contexts. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
