### PR TITLE
feat(mv3-part-4): fix remaining no-floating-promises issue

### DIFF
--- a/eslintrc.base.js
+++ b/eslintrc.base.js
@@ -92,12 +92,5 @@ module.exports = {
                 'security/detect-eval-with-expression': 'off',
             },
         },
-        {
-            // Temporarily disabling this rule in these directories until the errors are fixed
-            files: ['src/injected/**/*'],
-            rules: {
-                '@typescript-eslint/no-floating-promises': 'off',
-            },
-        },
     ],
 };

--- a/src/injected/frameCommunicators/axe-frame-messenger.ts
+++ b/src/injected/frameCommunicators/axe-frame-messenger.ts
@@ -89,7 +89,10 @@ export class AxeFrameMessenger implements axe.FrameMessenger {
             }
         };
 
-        // float this promise to keep function synchronous and match axe's interface
+        // Float this promise to keep function synchronous and match axe's interface.
+        // This means that we can't catch errors and return false to short-circuit axe's
+        // polling mechanism if this message fails, but axe should still time out and
+        // handle the failure.
         void this.underlyingCommunicator
             .sendCallbackCommandMessage(
                 frameWindow,

--- a/src/injected/frameCommunicators/axe-frame-messenger.ts
+++ b/src/injected/frameCommunicators/axe-frame-messenger.ts
@@ -65,7 +65,7 @@ export class AxeFrameMessenger implements axe.FrameMessenger {
             );
         };
 
-        const responseCallback = (response: CommandMessageResponse): void => {
+        const responseCallback = async (response: CommandMessageResponse): Promise<void> => {
             const payload: PostCommandResponsePayload = response.payload;
             // This behavior of passing an Error object if the respondee throws an error is missing
             // from the axe-core frame-messenger documentation, but it matches the default axe-core
@@ -89,23 +89,24 @@ export class AxeFrameMessenger implements axe.FrameMessenger {
             }
         };
 
-        try {
-            this.underlyingCommunicator.sendCallbackCommandMessage(
+        // float this promise to keep function synchronous and match axe's interface
+        void this.underlyingCommunicator
+            .sendCallbackCommandMessage(
                 frameWindow,
                 message,
                 responseCallback,
                 // Usage for keepAlive is missing from the axe-core frame-messenger documentation,
                 // but this behavior matches the default axe-core frame messenger.
                 topicData.keepalive ? 'multiple' : 'single',
+            )
+            .catch(e =>
+                this.logger.error(
+                    `Error while attempting to send axe-core frameMessenger message: ${e.message}`,
+                    e,
+                ),
             );
-            return true;
-        } catch (e) {
-            this.logger.error(
-                `Error while attempting to send axe-core frameMessenger message: ${e.message}`,
-                e,
-            );
-            return false;
-        }
+
+        return true;
     };
 
     public onMessage: CallbackWindowCommandMessageListener = (

--- a/src/injected/frameCommunicators/browser-backchannel-window-message-poster.ts
+++ b/src/injected/frameCommunicators/browser-backchannel-window-message-poster.ts
@@ -9,7 +9,7 @@ import { BackchannelWindowMessageTranslator } from './backchannel-window-message
 export type WindowMessageListener = (receivedMessage: any, sourceWindow: Window) => void;
 
 export interface WindowMessagePoster {
-    postMessage(win: Window, message: any): void;
+    postMessage(win: Window, message: any): Promise<void>;
     addMessageListener(listener: WindowMessageListener): void;
     dispose(): void;
 }
@@ -37,11 +37,11 @@ export class BrowserBackchannelWindowMessagePoster implements WindowMessagePoste
         this.windowUtils.addEventListener(window, 'message', this.onWindowMessageEvent, false);
     }
 
-    public postMessage(win: Window, message: any): void {
+    public async postMessage(win: Window, message: any): Promise<void> {
         const { windowMessageMetadata: windowMessage, backchannelMessage } =
             this.backchannelWindowMessageTranslator.splitWindowMessage(message);
 
-        this.browserAdapter.sendRuntimeMessage(backchannelMessage);
+        await this.browserAdapter.sendRuntimeMessage(backchannelMessage);
         this.windowUtils.postMessage(win, windowMessage, '*');
     }
 

--- a/src/injected/frameCommunicators/respondable-command-message-communicator.ts
+++ b/src/injected/frameCommunicators/respondable-command-message-communicator.ts
@@ -14,7 +14,7 @@ export type CommandMessageResponse = {
     payload: any;
 };
 
-export type CommandMessageResponseCallback = (response: CommandMessageResponse) => void;
+export type CommandMessageResponseCallback = (response: CommandMessageResponse) => Promise<void>;
 
 // A listener may optionally respond to a message it receives. If it wishes to do so, it should
 // return a Promise which resolves to the response. If it does not wish to respond to a message,
@@ -98,26 +98,26 @@ export class RespondableCommandMessageCommunicator {
     // capability is required per axe-core's frameMessenger documentation, but it should only be
     // used if actually necessary, since there is currently no way for the communicator to know when
     // it's allowed to stop listening for further responses.
-    public sendCallbackCommandMessage(
+    public async sendCallbackCommandMessage(
         target: Window,
         commandMessage: CommandMessage,
-        responseCallback: (response: CommandMessageResponse) => void,
+        responseCallback: (response: CommandMessageResponse) => Promise<void>,
         responsesExpected: 'single' | 'multiple',
-    ): void {
+    ): Promise<void> {
         const commandMessageRequestWrapper =
             this.createCommandMessageRequestWrapper(commandMessage);
         const messageId = commandMessageRequestWrapper.commandMessageId;
 
         let recordedResponseCallback = responseCallback;
         if (responsesExpected === 'single') {
-            recordedResponseCallback = response => {
+            recordedResponseCallback = async response => {
                 delete this.responseCallbacks[messageId];
-                responseCallback(response);
+                await responseCallback(response);
             };
         }
 
         this.responseCallbacks[messageId] = recordedResponseCallback;
-        this.windowMessagePoster.postMessage(target, commandMessageRequestWrapper);
+        await this.windowMessagePoster.postMessage(target, commandMessageRequestWrapper);
     }
 
     // Sends a message to a corresponding listener in the target Window, which must have been
@@ -135,12 +135,12 @@ export class RespondableCommandMessageCommunicator {
         // This creates a "deferred" Promise which we will resolved later in onWindowMessage (by
         // calling the resolver function we're storing in pendingResponseResolvers) when we receive
         // a matching response from the windowMessagePoster.
-        let pendingResponseResolver: CommandMessageResponseCallback;
+        let pendingResponseResolver: (response: CommandMessageResponse) => void;
         const pendingResponsePromise = new Promise<CommandMessageResponse>(resolver => {
             pendingResponseResolver = resolver;
         });
 
-        const responseCallback = (response: CommandMessageResponse) => {
+        const responseCallback = async (response: CommandMessageResponse) => {
             if (timedOut) {
                 this.logger.error(
                     `Received a response for command ${commandMessage.command} after it timed out`,
@@ -149,7 +149,7 @@ export class RespondableCommandMessageCommunicator {
             pendingResponseResolver(response);
         };
 
-        this.sendCallbackCommandMessage(target, commandMessage, responseCallback, 'single');
+        await this.sendCallbackCommandMessage(target, commandMessage, responseCallback, 'single');
 
         try {
             return await this.promiseFactory.timeout(
@@ -218,9 +218,12 @@ export class RespondableCommandMessageCommunicator {
     ): Promise<void> => {
         const responseCallback = this.responseCallbacks[receivedMessage.requestCommandMessageId];
         const unwrappedResponse = { payload: receivedMessage.payload };
-        await this.logErrors(`${receivedMessage.requestCommandMessageId} response callback`, () => {
-            responseCallback?.(unwrappedResponse);
-        });
+        await this.logErrors(
+            `${receivedMessage.requestCommandMessageId} response callback`,
+            async () => {
+                await responseCallback?.(unwrappedResponse);
+            },
+        );
     };
 
     private onRequestMessage = async (
@@ -237,7 +240,7 @@ export class RespondableCommandMessageCommunicator {
         const sendResponse = this.makeSendResponseCallback(commandMessageId, sourceWindow);
 
         if (listener == null) {
-            sendResponse({ payload: null });
+            await sendResponse({ payload: null });
         } else if (listener.type === 'callback') {
             await this.logErrors(`${command} listener callback`, () =>
                 listener.listener(unwrappedRequest, sourceWindow, sendResponse),
@@ -253,13 +256,13 @@ export class RespondableCommandMessageCommunicator {
             if (listenerResponse == null) {
                 listenerResponse = { payload: null };
             }
-            sendResponse(listenerResponse);
+            await sendResponse(listenerResponse);
         }
     };
 
-    private async logErrors(context, operation) {
+    private async logErrors(context: string, operation: (() => void) | (() => Promise<void>)) {
         try {
-            operation();
+            await operation();
         } catch (e) {
             this.logger.error(`Error at ${context}: ${e.message}`, e);
         }
@@ -269,12 +272,12 @@ export class RespondableCommandMessageCommunicator {
         requestCommandMessageId: string,
         sourceWindow: Window,
     ): CommandMessageResponseCallback {
-        return (response: CommandMessageResponse) => {
+        return async (response: CommandMessageResponse) => {
             const responseWrapper = this.createCommandMessageResponseWrapper(
                 requestCommandMessageId,
                 response,
             );
-            this.windowMessagePoster.postMessage(sourceWindow, responseWrapper);
+            await this.windowMessagePoster.postMessage(sourceWindow, responseWrapper);
         };
     }
 

--- a/src/tests/unit/common/linked-respondable-communicator.ts
+++ b/src/tests/unit/common/linked-respondable-communicator.ts
@@ -9,6 +9,7 @@ import {
     CommandMessage,
     CommandMessageResponse,
     RespondableCommandMessageCommunicator,
+    CommandMessageResponseCallback,
 } from 'injected/frameCommunicators/respondable-command-message-communicator';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { Mock } from 'typemoq';
@@ -51,10 +52,10 @@ export class LinkedRespondableCommunicator extends RespondableCommandMessageComm
         return listenerResponse ?? { payload: null };
     }
 
-    public sendCallbackCommandMessage(
+    public async sendCallbackCommandMessage(
         target: Window,
         commandMessage: CommandMessage,
-        responseCallback: (response: CommandMessageResponse) => void,
+        responseCallback: CommandMessageResponseCallback,
         responsesExpected: 'single' | 'multiple',
     ) {
         this.assertIsLinkedWindow(target);
@@ -63,10 +64,10 @@ export class LinkedRespondableCommunicator extends RespondableCommandMessageComm
 
         const originalResponseCallback = responseCallback;
         let responseAlreadyReceived = false;
-        responseCallback = response => {
+        responseCallback = async response => {
             if (!responseAlreadyReceived || responsesExpected === 'multiple') {
                 responseAlreadyReceived = true;
-                originalResponseCallback(response);
+                await originalResponseCallback(response);
             }
         };
 

--- a/src/tests/unit/common/linked-window-message-poster.ts
+++ b/src/tests/unit/common/linked-window-message-poster.ts
@@ -18,7 +18,7 @@ export class LinkedWindowMessagePoster implements WindowMessagePoster {
     private other: LinkedWindowMessagePoster;
     private listeners: WindowMessageListener[] = [];
 
-    postMessage(target: Window, message: any): void {
+    async postMessage(target: Window, message: any): Promise<void> {
         if (target !== this.other.window) {
             throw new Error(
                 'target window unreachable (LinkedWindowMessagePoster not linked to it)',

--- a/src/tests/unit/tests/injected/frameCommunicators/browser-backchannel-window-message-poster.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/browser-backchannel-window-message-poster.test.ts
@@ -115,7 +115,7 @@ describe('BrowserBackchannelWindowMessagePoster', () => {
             .verifiable(Times.once());
 
         // sending message to iframe
-        testSubject.postMessage(targetWindow, sampleMessage);
+        await testSubject.postMessage(targetWindow, sampleMessage);
         mockWindowUtils.verifyAll();
         mockBrowserAdapter.verifyAll();
         mockBackchannelWindowMessageTranslator.verifyAll();

--- a/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
@@ -443,7 +443,7 @@ describe('RespondableCommandMessageCommunicator', () => {
 
     describe('callback message behavior', () => {
         const emptyCommand1Message = { command: 'command1', payload: {} };
-        const noopReplyHandler = () => {};
+        const noopReplyHandler = async () => {};
         const stubGenerateUID = () => 'unique_id';
         let senderWindow: Window;
         let sender: RespondableCommandMessageCommunicator;
@@ -473,12 +473,12 @@ describe('RespondableCommandMessageCommunicator', () => {
                 receiverLogger,
             );
             mockListener = Mock.ofInstance(() => {}, MockBehavior.Strict);
-            mockReplyHandler = Mock.ofInstance(() => {}, MockBehavior.Strict);
+            mockReplyHandler = Mock.ofInstance(async () => {}, MockBehavior.Strict);
             sender.initialize();
             receiver.initialize();
         });
 
-        it('supports callback-based communcation in single-response mode', () => {
+        it('supports callback-based communcation in single-response mode', async () => {
             const sentMessage: CommandMessage = {
                 command: 'command1',
                 payload: { request: 1 },
@@ -495,7 +495,7 @@ describe('RespondableCommandMessageCommunicator', () => {
             mockReplyHandler.setup(h => h(response)).verifiable(Times.once());
 
             receiver.addCallbackCommandMessageListener('command1', mockListener.object);
-            sender.sendCallbackCommandMessage(
+            await sender.sendCallbackCommandMessage(
                 receiverWindow,
                 sentMessage,
                 mockReplyHandler.object,
@@ -508,7 +508,7 @@ describe('RespondableCommandMessageCommunicator', () => {
             receiverLogger.verifyNoErrors();
         });
 
-        it('supports callback-based communcation in multiple-response mode', () => {
+        it('supports callback-based communcation in multiple-response mode', async () => {
             const sentMessage: CommandMessage = {
                 command: 'command1',
                 payload: { request: 1 },
@@ -530,7 +530,7 @@ describe('RespondableCommandMessageCommunicator', () => {
             mockReplyHandler.setup(h => h(response2)).verifiable(Times.once());
 
             receiver.addCallbackCommandMessageListener('command1', mockListener.object);
-            sender.sendCallbackCommandMessage(
+            await sender.sendCallbackCommandMessage(
                 receiverWindow,
                 sentMessage,
                 mockReplyHandler.object,
@@ -543,8 +543,8 @@ describe('RespondableCommandMessageCommunicator', () => {
             receiverLogger.verifyNoErrors();
         });
 
-        it('does not apply a timeout to callback messages', () => {
-            sender.sendCallbackCommandMessage(
+        it('does not apply a timeout to callback messages', async () => {
+            await sender.sendCallbackCommandMessage(
                 receiverWindow,
                 emptyCommand1Message,
                 noopReplyHandler,
@@ -553,7 +553,7 @@ describe('RespondableCommandMessageCommunicator', () => {
             mockPromiseFactory.verify(pf => pf.timeout(It.isAny(), It.isAny()), Times.never());
         });
 
-        it('ignores repeated responses to a single-response message', () => {
+        it('ignores repeated responses to a single-response message', async () => {
             const sentMessage: CommandMessage = {
                 command: 'command1',
                 payload: { request: 1 },
@@ -575,7 +575,7 @@ describe('RespondableCommandMessageCommunicator', () => {
             mockReplyHandler.setup(h => h(response2)).verifiable(Times.never());
 
             receiver.addCallbackCommandMessageListener('command1', mockListener.object);
-            sender.sendCallbackCommandMessage(
+            await sender.sendCallbackCommandMessage(
                 receiverWindow,
                 sentMessage,
                 mockReplyHandler.object,
@@ -588,21 +588,21 @@ describe('RespondableCommandMessageCommunicator', () => {
             receiverLogger.verifyNoErrors();
         });
 
-        it('propagates errors from the underlying postMessage by rejecting with them as-is', () => {
+        it('propagates errors from the underlying postMessage by rejecting with them as-is', async () => {
             const unlinkedWindow = {} as Window;
-            expect(() =>
+            await expect(
                 sender.sendCallbackCommandMessage(
                     unlinkedWindow,
                     emptyCommand1Message,
                     noopReplyHandler,
                     'single',
                 ),
-            ).toThrowErrorMatchingInlineSnapshot(
+            ).rejects.toThrowErrorMatchingInlineSnapshot(
                 `"target window unreachable (LinkedWindowMessagePoster not linked to it)"`,
             );
         });
 
-        it('handles throwing listeners by logging an error at the receiver', () => {
+        it('handles throwing listeners by logging an error at the receiver', async () => {
             const listenerError = new Error('from listener');
             const sentMessage: CommandMessage = {
                 command: 'command1',
@@ -617,7 +617,7 @@ describe('RespondableCommandMessageCommunicator', () => {
             mockReplyHandler.setup(h => h(It.isAny())).verifiable(Times.never());
 
             receiver.addCallbackCommandMessageListener('command1', mockListener.object);
-            sender.sendCallbackCommandMessage(
+            await sender.sendCallbackCommandMessage(
                 receiverWindow,
                 sentMessage,
                 mockReplyHandler.object,
@@ -635,7 +635,7 @@ describe('RespondableCommandMessageCommunicator', () => {
             `);
         });
 
-        it('handles throwing replyHandlers by logging an error at the sender', () => {
+        it('handles throwing replyHandlers by logging an error at the sender', async () => {
             const replyHandlerError = new Error('from replyHandler');
             const sentMessage: CommandMessage = {
                 command: 'command1',
@@ -658,7 +658,7 @@ describe('RespondableCommandMessageCommunicator', () => {
                 .verifiable(Times.once());
 
             receiver.addCallbackCommandMessageListener('command1', mockListener.object);
-            sender.sendCallbackCommandMessage(
+            await sender.sendCallbackCommandMessage(
                 receiverWindow,
                 sentMessage,
                 mockReplyHandler.object,


### PR DESCRIPTION
#### Details

Fixes the last no-floating-promises issue in BackchannelMessagePoster and FrameMessengers, and enable the no-floating-promises rule everywhere.

##### Motivation

Continuing work from #5537, #5517, #5524

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
