### PR TITLE
chore: Enable stylelint rule `scss/at-mixin-pattern`

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -23,7 +23,6 @@ module.exports = {
         // TO BE CONFIGURED: Variable, selector, mixin case
         // https://stylelint.io/user-guide/rules/regex
         'selector-class-pattern': null,
-        'scss/at-mixin-pattern': null,
         'scss/dollar-variable-pattern': null,
 
         // Requires investigation

--- a/src/common/components/header.scss
+++ b/src/common/components/header.scss
@@ -32,7 +32,7 @@
         font-size: $fontSizeML;
         font-family: $fontFamily;
 
-        @include ellipsedText;
+        @include ellipsed-text;
     }
 
     .spacer {

--- a/src/common/icons/icon.scss
+++ b/src/common/icons/icon.scss
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 @use 'sass:math';
 
-@mixin getCheckContainerStyle($height, $border-size: 1px) {
+@mixin get-check-container-style($height, $border-size: 1px) {
     position: relative;
     width: ($height - $border-size * 2);
     height: ($height - $border-size * 2);
@@ -20,7 +20,7 @@
     $check-line-thickness: (math.div(2, 14) * $iconSize);
 
     .check-container {
-        @include getCheckContainerStyle($iconSize, $border-size);
+        @include get-check-container-style($iconSize, $border-size);
 
         svg circle {
             fill: $iconColor;
@@ -33,7 +33,7 @@
     $width-value: (math.div(2, 14) * $true-icon-size);
 
     .check-container {
-        @include getCheckContainerStyle($iconSize, $border-size);
+        @include get-check-container-style($iconSize, $border-size);
 
         $cross-line-height: (math.div(8, 14) * $true-icon-size);
         $bottom-value: math.div($true-icon-size - $cross-line-height, 2);
@@ -47,7 +47,7 @@
 
 @mixin incomplete-icon-styles($iconSize, $border-size: 1px) {
     .check-container {
-        @include getCheckContainerStyle($iconSize, $border-size);
+        @include get-check-container-style($iconSize, $border-size);
     }
 }
 
@@ -56,7 +56,7 @@
     $width-value: (math.div(1, 7) * $true-icon-size);
 
     .check-container {
-        @include getCheckContainerStyle($iconSize, $border-size);
+        @include get-check-container-style($iconSize, $border-size);
 
         $inapplicable-line-height: (math.div(4, 7) * $true-icon-size);
         $bottom-value: math.div($true-icon-size - $inapplicable-line-height, 2);

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -33,7 +33,7 @@ $fastPassRightPanelMarginRight: 24px !default;
 $fastPassRightPanelMarginLeft: 24px !default;
 $fastPassRightPanelMarginTop: 24px !default;
 
-@mixin ellipsedText {
+@mixin ellipsed-text {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/reports/automated-checks-report.scss
+++ b/src/reports/automated-checks-report.scss
@@ -33,7 +33,7 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
 }
 
 .summary-section {
-    @include boxShadow;
+    @include box-shadow;
 
     background-color: $neutral-0;
     padding: 20px;

--- a/src/reports/components/header-bar.scss
+++ b/src/reports/components/header-bar.scss
@@ -24,7 +24,7 @@
         margin-left: 8px;
         color: $header-bar-title-color;
         flex-shrink: 1;
-        @include ellipsedText;
+        @include ellipsed-text;
         @include text-style-header-s;
     }
 }

--- a/src/reports/components/report-sections/common-mixins.scss
+++ b/src/reports/components/report-sections/common-mixins.scss
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 @import '../../../common/styles/colors.scss';
 
-@mixin contentSize {
+@mixin content-size {
     max-width: 960px;
     margin: 0 auto;
 }
 
-@mixin boxShadow {
+@mixin box-shadow {
     box-shadow: 0 0.3px 0.9px rgb(0 0 0 / 10.8%), 0 1.6px 3.6px rgb(0 0 0 / 13.2%);
     border-radius: 4px;
 }

--- a/src/reports/components/report-sections/content-container.scss
+++ b/src/reports/components/report-sections/content-container.scss
@@ -6,7 +6,7 @@
     box-shadow: 0 1px 0 rgb(0 0 0 / 8%);
 
     .content-container {
-        @include contentSize;
+        @include content-size;
 
         margin-top: 24px;
 

--- a/src/reports/components/report-sections/details-section.scss
+++ b/src/reports/components/report-sections/details-section.scss
@@ -5,7 +5,7 @@
 @import './common-mixins.scss';
 
 .scan-details-section {
-    @include boxShadow;
+    @include box-shadow;
 
     background-color: $neutral-0;
     padding: 20px;

--- a/src/reports/components/report-sections/footer-section.scss
+++ b/src/reports/components/report-sections/footer-section.scss
@@ -4,7 +4,7 @@
 @import './common-mixins.scss';
 
 .report-footer-container {
-    @include contentSize;
+    @include content-size;
 
     margin-bottom: 68px;
     margin-top: 24px;

--- a/src/reports/components/report-sections/header-section.scss
+++ b/src/reports/components/report-sections/header-section.scss
@@ -26,7 +26,7 @@
         min-width: 0;
 
         a {
-            @include ellipsedText;
+            @include ellipsed-text;
         }
     }
 }

--- a/src/reports/components/report-sections/summary-report-details-section.scss
+++ b/src/reports/components/report-sections/summary-report-details-section.scss
@@ -6,7 +6,7 @@
 @import '../../../common/styles/fonts.scss';
 
 .crawl-details-section {
-    @include boxShadow;
+    @include box-shadow;
 
     background-color: $neutral-0;
     padding: 20px;

--- a/src/reports/components/report-sections/urls-summary-section.scss
+++ b/src/reports/components/report-sections/urls-summary-section.scss
@@ -5,7 +5,7 @@
 @import '../../../common/styles/fonts.scss';
 
 .urls-summary-section {
-    @include boxShadow;
+    @include box-shadow;
 
     background-color: $neutral-0;
     padding: 20px;


### PR DESCRIPTION
#### Details

Enables and makes required fixes for the stylelint rule [`scss/at-mixin-pattern`](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-mixin-pattern/README.md). The default pattern is kebab case and this pull request will update mixins that do not follow the pattern.

##### Motivation

Part of https://github.com/microsoft/accessibility-insights-web/issues/5187 as an incremental task to enable stylelint rules.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5187 
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
