### PR TITLE
feat(mv3-part-4): avoid spurious background console spew when opening background devtools

### DIFF
--- a/src/Devtools/dev-tool-initializer.ts
+++ b/src/Devtools/dev-tool-initializer.ts
@@ -16,6 +16,14 @@ export class DevToolInitializer {
     ) {}
 
     public async initialize(): Promise<void> {
+        const inspectedWindowTabId = this.browserAdapter.getInspectedWindowTabId();
+        if (inspectedWindowTabId === -1) {
+            // This usually means the inspectee is a non-UX context, like a
+            // background page or a service worker, where it doesn't make sense
+            // for us to run.
+            return;
+        }
+
         const storeUpdateMessageHub = new StoreUpdateMessageHub();
 
         const devtoolsStore = new StoreProxy<DevToolStoreData>(

--- a/src/Devtools/dev-tool-initializer.ts
+++ b/src/Devtools/dev-tool-initializer.ts
@@ -16,11 +16,9 @@ export class DevToolInitializer {
     ) {}
 
     public async initialize(): Promise<void> {
-        const inspectedWindowTabId = this.browserAdapter.getInspectedWindowTabId();
-        if (inspectedWindowTabId === -1) {
-            // This usually means the inspectee is a non-UX context, like a
-            // background page or a service worker, where it doesn't make sense
-            // for us to run.
+        if (this.browserAdapter.getInspectedWindowTabId() == null) {
+            // This means the inspectee is a non-UX context, like a background page or a service
+            // worker, where it doesn't make sense for us to run.
             return;
         }
 

--- a/src/Devtools/inspect-handler.ts
+++ b/src/Devtools/inspect-handler.ts
@@ -34,7 +34,7 @@ export class InspectHandler {
     private async sendDevtoolOpened(): Promise<void> {
         const message: InterpreterMessage = {
             messageType: Messages.DevTools.Opened,
-            tabId: this.browserAdapter.getInspectedWindowTabId(),
+            tabId: this.browserAdapter.getInspectedWindowTabId()!,
         };
 
         await this.browserAdapter.sendMessageToFrames(message);

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -61,5 +61,5 @@ export interface BrowserAdapter {
     addListenerOnPermissionsRemoved(callback: (permissions: Permissions.Permissions) => void): void;
     containsPermissions(permissions: Permissions.Permissions): Promise<boolean>;
 
-    getInspectedWindowTabId(): number;
+    getInspectedWindowTabId(): number | null;
 }

--- a/src/common/browser-adapters/webextension-browser-adapter.ts
+++ b/src/common/browser-adapters/webextension-browser-adapter.ts
@@ -258,7 +258,7 @@ export abstract class WebExtensionBrowserAdapter
         return browser.permissions.contains(permissions);
     }
 
-    public getInspectedWindowTabId(): number {
-        return chrome.devtools.inspectedWindow.tabId;
+    public getInspectedWindowTabId(): number | null {
+        return chrome.devtools.inspectedWindow?.tabId;
     }
 }


### PR DESCRIPTION
#### Details

Today, if you open a dev tools console against our background page, you 2 lines of spurious warning spew to the console like this:

```
Unable to interpret message -  {messageType: 'insights/devtools/opened', tabId: -1}
```

This happens because our `dev-tools-init` attempts to run in the context of the background page's dev tools. The background page has no associated window/tab, so this confuses the background page itself because there is no tab context to accept the initialization message.

To avoid the spurious warning, this PR makes the dev tools initializer detect the "no inspected tab" case and bail from initialization since there's nothing for our dev tools code to actually do in that case.

##### Motivation

Avoid spurious console spew

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
