### PR TITLE
feat(esbuild): use esbuild for report package

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -170,9 +170,8 @@ module.exports = function (grunt) {
             'esbuild-dev': `node esbuild.js`,
             'esbuild-dev-mv3': `node esbuild.js --env dev-mv3`,
             'esbuild-prod': `node esbuild.js --env prod`,
-            'webpack-prod': `"${webpackPath}" --config-name prod`,
+            'esbuild-package-report': `node esbuild.js --env report`,
             'webpack-unified': `"${webpackPath}" --config-name unified`,
-            'webpack-package-report': `"${webpackPath}" --config-name package-report`,
             'webpack-package-ui': `"${webpackPath}" --config-name package-ui`,
             'generate-scss-typings': `"${typedScssModulesPath}" src --exportType default`,
             'pkg-mock-adb': `"${pkgPath}" "${mockAdbBinSrcPath}" -d --target host --output "${mockAdbBinOutPath}"`,
@@ -737,7 +736,7 @@ module.exports = function (grunt) {
     grunt.registerTask('package-report', function () {
         const mustExistPath = path.join(packageReportBundlePath, 'report.bundle.js');
 
-        mustExist(mustExistPath, 'Have you run webpack?');
+        mustExist(mustExistPath, 'Have you run esbuild?');
 
         grunt.task.run('embed-styles:package-report');
         grunt.task.run('clean:package-report');
@@ -825,8 +824,8 @@ module.exports = function (grunt) {
     grunt.registerTask('build-package-report', [
         'clean:intermediates',
         'exec:generate-scss-typings',
-        'exec:webpack-prod', // required to get the css assets
-        'exec:webpack-package-report',
+        'exec:esbuild-prod', // required to get the css assets
+        'exec:esbuild-package-report',
         'build-assets',
         'package-report',
     ]);

--- a/esbuild.js
+++ b/esbuild.js
@@ -62,6 +62,8 @@ let format = 'iife';
 let define;
 let target = ['chrome90', 'firefox90'];
 let plugins = [CreateStylePlugin()];
+let minify = false;
+let sourcemap = true;
 
 switch (argsObj.env) {
     // Note: currently causes errors when electron app is run.
@@ -74,7 +76,8 @@ switch (argsObj.env) {
         break;
 
     case 'prod':
-        isProd = true;
+        minify = true;
+        sourcemap = false;
         outdir = prodWebExtensionOutDir;
         break;
 
@@ -124,8 +127,8 @@ const config = {
     external,
     outbase: src,
     bundle: true,
-    minify: isProd,
-    sourcemap: !isProd,
+    minify: minify,
+    sourcemap: sourcemap,
     target,
     outdir: outdir,
     outExtension: {

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
         "extract-zip": "^2.0.1",
         "fake-indexeddb": "^3.1.7",
         "fork-ts-checker-webpack-plugin": "^7.2.11",
+        "generic-names": "^4.0.0",
         "grunt": "^1.5.3",
         "grunt-bom-removal": "1.0.1",
         "grunt-cli": "^1.4.3",

--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -835,29 +835,29 @@
       }</style
     ><style>
       /* css-modules:src/common/components/heading-element-for-level */
-      .heading-element-for-level--wzmxK {
+      .heading-element-for-level--ifVX6 {
         margin-block-start: unset;
         margin-block-end: unset;
       }
 
       /* css-modules:src/common/components/cards/failed-instances-section */
-      .failed-instances-container--pB-u4 .collapsible-content {
+      .failed-instances-container--3UUNb .collapsible-content {
         margin-left: 24px;
       }
 
       /* css-modules:src/reports/components/report-sections/minimal-rule-header */
-      .outcome-chip-container--ja0WM {
+      .outcome-chip-container--G5Dfr {
         min-width: 50px;
       }
 
       /* css-modules:src/reports/components/instance-details */
-      .hidden-highlight-button--to41b {
+      .hidden-highlight-button--vu3B3 {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-      .instance-details-card--lixTP {
+      .instance-details-card--owGQF {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -868,29 +868,29 @@
         width: -webkit-fill-available;
         width: fill-available;
       }
-      .instance-details-card-container--Hjwps.selected--Pf-DQ {
+      .instance-details-card-container--KLHTp.selected--wEA4l {
         outline: 5px solid var(--communication-tint-10);
       }
-      .instance-details-card--lixTP.selected--Pf-DQ {
+      .instance-details-card--owGQF.selected--wEA4l {
         border: 1px solid transparent;
       }
-      .instance-details-card--lixTP.focused--PfWGT,
-      .instance-details-card--lixTP:focus {
+      .instance-details-card--owGQF.focused--pvBWq,
+      .instance-details-card--owGQF:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
-      .instance-details-card--lixTP.selected--Pf-DQ:focus {
+      .instance-details-card--owGQF.selected--wEA4l.focused--pvBWq,
+      .instance-details-card--owGQF.selected--wEA4l:focus {
         outline-offset: 8px;
       }
-      .instance-details-card--lixTP.interactive--su6Sw {
+      .instance-details-card--owGQF.interactive--an0ab {
         cursor: pointer;
       }
-      .instance-details-card--lixTP.interactive--su6Sw:hover {
+      .instance-details-card--owGQF.interactive--an0ab:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-      .report-instance-table--YOlnT {
+      .report-instance-table--3VoZX {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
@@ -902,7 +902,7 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YOlnT .row--9WgHa {
+      .report-instance-table--3VoZX .row---3i35 {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -911,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YOlnT .row--9WgHa > * {
+      .report-instance-table--3VoZX .row---3i35 > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YOlnT .row--9WgHa:last-child {
+      .report-instance-table--3VoZX .row---3i35:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YOlnT .row-label--dri3e {
+      .report-instance-table--3VoZX .row-label--FlVZl {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -931,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YOlnT .row-content--Gt-CK {
+      .report-instance-table--3VoZX .row-content--07KUh {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -943,42 +943,42 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--xUzJx {
+      .multi-line-text-no-bullet--AUXXt {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
-      .multi-line-text-yes-bullet--jH-w4 {
+      .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--jH-w4 li {
+      .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .combination-lists--4wBYq {
+      .combination-lists--boK5y {
         flex-direction: column;
         display: flex;
       }
 
       /* css-modules:src/common/components/cards/urls-card-row */
-      .urls-row-content--rj2oy {
+      .urls-row-content--JDdRx {
         padding-left: 16px;
       }
-      .urls-row-content--rj2oy li {
+      .urls-row-content--JDdRx li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .urls-row-content-new-Failure--7Dq38 {
+      .urls-row-content-new-Failure--oL5lS {
         color: var(--negative-outcome);
         font-weight: bold;
       }
 
       /* css-modules:src/common/components/fix-instruction-panel */
-      .insights-fix-instruction-list--NaN2O
+      .insights-fix-instruction-list--eZigw
         li
-        span.fix-instruction-color-box---mQtG {
+        span.fix-instruction-color-box--sBkHG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -986,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
+      .insights-fix-instruction-list--eZigw .screen-reader-only--irrXo {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,73 +996,73 @@
       }
 
       /* css-modules:src/common/components/cards/how-to-fix-card-row */
-      .how-to-fix-content--Xj-BH {
+      .how-to-fix-content--Zz96u {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--Xj-BH ul {
+      .how-to-fix-content--Zz96u ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--Xj-BH ul li {
+      .how-to-fix-content--Zz96u ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
 
       /* css-modules:src/common/components/cards/snippet-card-row */
-      .snippet--P6i7P {
+      .snippet--hSNfv {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
 
       /* css-modules:src/DetailsView/components/common-dialog-styles */
-      div.insights-dialog-main-override--qzZJk {
+      div.insights-dialog-main-override--ma4DA {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--qzZJk {
+        div.insights-dialog-main-override--ma4DA {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
+      div.insights-dialog-main-override--ma4DA .dialog-body--cmWmz {
         font-size: 16px;
       }
 
       /* css-modules:src/DetailsView/components/issue-filing-dialog */
-      .issue-filing-dialog--l9xMr .ms-Dialog-title {
+      .issue-filing-dialog--F9jun .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
+      .issue-filing-dialog--F9jun .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--l9xMr .textfield-description {
+      .issue-filing-dialog--F9jun .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
 
       /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
-      .action-and-cancel-buttons-component--5-uZX {
+      .action-and-cancel-buttons-component--DF7bf {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--5-uZX
-        .action-cancel-button-col--txH36
-        + .action-cancel-button-col--txH36 {
+      .action-and-cancel-buttons-component--DF7bf
+        .action-cancel-button-col--RMfN-
+        + .action-cancel-button-col--RMfN- {
         margin-left: 8px;
       }
 
       /* css-modules:src/common/components/toast */
-      .toast-container--cNX98 {
+      .toast-container--L-5HM {
         display: inline-block;
       }
-      .toast-content--bk935 {
+      .toast-content--8-Mx1 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1079,84 +1079,84 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
-      div.kebab-menu-callout--A3AHu {
+      div.kebab-menu-callout--XvN24 {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--A3AHu > div {
+      div.kebab-menu-callout--XvN24 > div {
         border-radius: 4px;
       }
-      .kebab-menu--Bm5S1 {
+      .kebab-menu--eKCNX {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--Bm5S1 li {
+      .kebab-menu--eKCNX li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--Bm5S1 button i {
+      .kebab-menu--eKCNX button i {
         color: var(--primary-text);
       }
-      .kebab-menu--Bm5S1 button:hover {
+      .kebab-menu--eKCNX button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--Bm5S1 button:hover {
+        .kebab-menu--eKCNX button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--Bm5S1 button:active {
+      .kebab-menu--eKCNX button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--Bm5S1 button:active i {
+      .kebab-menu--eKCNX button:active i {
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR {
+      button.kebab-menu-button--e-7v- {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--ySFdR svg {
+      button.kebab-menu-button--e-7v- svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR svg {
+        button.kebab-menu-button--e-7v- svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--ySFdR:hover {
+      button.kebab-menu-button--e-7v-:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--ySFdR:active,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+      button.kebab-menu-button--e-7v-:active,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR:active svg > circle,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--e-7v-:active svg > circle,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR:active,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+        button.kebab-menu-button--e-7v-:active,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--ySFdR:active svg > circle,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--e-7v-:active svg > circle,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--ySFdR > span {
+      button.kebab-menu-button--e-7v- > span {
         justify-content: center;
       }
 
       /* css-modules:src/common/components/cards/instance-details-footer */
-      .foot--WBFZ6 {
+      .foot--p1DfC {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1167,22 +1167,22 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj {
+      .foot--p1DfC .highlight-status--xJvvI {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj svg {
+      .foot--p1DfC .highlight-status--xJvvI svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--WBFZ6 .highlight-status--TYXPj svg {
+        .foot--p1DfC .highlight-status--xJvvI svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--WBFZ6 .highlight-status--TYXPj label {
+      .foot--p1DfC .highlight-status--xJvvI label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
@@ -1190,21 +1190,21 @@
       }
 
       /* css-modules:src/common/components/cards/instance-details-group */
-      ul.instance-details-list--bg-Zq {
+      ul.instance-details-list--YfkRy {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--bg-Zq > li {
+      ul.instance-details-list--YfkRy > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--bg-Zq > li:last-child {
+      ul.instance-details-list--YfkRy > li:last-child {
         margin-bottom: unset;
       }
 
       /* css-modules:src/common/components/cards/rule-resources */
-      .rule-more-resources--w4eYl {
+      .rule-more-resources--uw9mc {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1218,53 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
+      .rule-more-resources--uw9mc .more-resources-title--jOuUL {
         font-weight: 600;
       }
-      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
+      .rule-more-resources--uw9mc .rule-details-id--s-TpO {
         padding: 12px 0;
       }
 
       /* css-modules:src/common/components/cards/rules-with-instances */
-      .rule-details-group--ZuRYr .rule-detail {
+      .rule-details-group--Tb-LW .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
+      .rule-details-group--Tb-LW .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
+      .rule-details-group--Tb-LW .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-      .collapsible-rule-details-group--ODFPb {
+      .collapsible-rule-details-group--V-HWh {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--ODFPb .rule-detail {
+      .collapsible-rule-details-group--V-HWh .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
+      .collapsible-rule-details-group--V-HWh:not(.collapsed) {
         box-shadow: unset;
       }
 
       /* css-modules:src/common/components/cards/result-section-title */
-      .result-section-title--vgyHe {
+      .result-section-title--RGFI5 {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1272,49 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--vgyHe .title--6gdF5 {
+      .result-section-title--RGFI5 .title--WBYFE {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .heading--1Ll6- {
+      .result-section-title--RGFI5 .heading--NdP4Q {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
+      .result-section-title--RGFI5 .outcome-chip-container--BT3j5 {
         display: flex;
         height: 16px;
       }
 
       /* css-modules:src/common/components/cards/result-section */
-      .result-section--Av9vc {
+      .result-section--HfO9s {
         padding-bottom: 24px;
       }
-      .result-section--Av9vc
-        .title-container---R9Dm
-        .collapsible-control--5y7Tp::before {
+      .result-section--HfO9s
+        .title-container--JzN4A
+        .collapsible-control--e42Z7::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--Av9vc > h2 {
+      .result-section--HfO9s > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
 
       /* css-modules:src/reports/components/header-bar */
-      .report-header-bar--DNH-8 {
+      .report-header-bar--SDV11 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1323,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--DNH-8 .header-icon {
+      .report-header-bar--SDV11 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--DNH-8 .header-text--v-ac2 {
+      .report-header-bar--SDV11 .header-text--EdTxw {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1345,7 +1345,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/header-section */
-      .report-header-command-bar--8-nLy {
+      .report-header-command-bar--NJWdl {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1355,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX {
+      .report-header-command-bar--NJWdl .target-page--hjh44 {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1368,14 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX a {
+      .report-header-command-bar--NJWdl .target-page--hjh44 a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
       /* css-modules:src/common/components/cards/combined-report-result-section-title */
-      .combined-report-result-section-title--RNekd {
+      .combined-report-result-section-title--TqIZO {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1383,14 +1383,14 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--RNekd .title--CFcXZ {
+      .combined-report-result-section-title--TqIZO .title--6WIyt {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--RNekd .heading--gtY3F {
+      .combined-report-result-section-title--TqIZO .heading--UpAHf {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
@@ -1399,7 +1399,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/urls-summary-section */
-      .urls-summary-section--db4HQ {
+      .urls-summary-section--jNa-v {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1407,26 +1407,26 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--db4HQ h2 {
+      .urls-summary-section--jNa-v h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--db4HQ .total-urls--3pXYz {
+      .urls-summary-section--jNa-v .total-urls--95-ge {
         font-weight: 600;
       }
-      .urls-summary-section--db4HQ .failure-instances--y0Big {
+      .urls-summary-section--jNa-v .failure-instances--2WDtT {
         margin-top: 40px;
       }
-      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
+      .urls-summary-section--jNa-v .failure-outcome-chip--JF-lj {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
 
       /* css-modules:src/reports/components/report-sections/rules-results-container */
-      .rules-results-container--dO76T {
+      .rules-results-container--HaLDw {
         margin-top: 56px;
       }
-      .rules-results-container--dO76T .results-heading--2h1oe {
+      .rules-results-container--HaLDw .results-heading--H9Puz {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
@@ -1435,7 +1435,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/summary-report-details-section */
-      .crawl-details-section--jDqES {
+      .crawl-details-section--a6evz {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1443,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1453,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di li {
         display: inline-block;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
         li
-        .icon--enDUo {
+        .icon--APJEn {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
-        li.targetSite--M6DmE {
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
+        li.targetSite--wBJT- {
         margin-bottom: 6px;
       }
-      .crawl-details-section--jDqES .text--lxa-w,
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .text--rViTo,
+      .crawl-details-section--a6evz .label--DUNYf {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1480,30 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .label--DUNYf {
         font-weight: 600;
       }
-      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
+      .crawl-details-section--a6evz .label--DUNYf.no-icon--VrSr5 {
         padding-left: 29px;
       }
 
       /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
-      .url-result-section--Lsitd {
+      .url-result-section--SkOlZ {
         padding-bottom: 31px;
       }
-      .url-result-section--Lsitd
+      .url-result-section--SkOlZ
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--Lsitd .collapsible-content {
+      .url-result-section--SkOlZ .collapsible-content {
         margin-top: 19px;
       }
 
       /* css-modules:src/reports/components/report-sections/summary-results-table */
-      .summary-results-table--r6fvD {
+      .summary-results-table--Iezr- {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1512,39 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--r6fvD th,
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- th,
+      .summary-results-table--Iezr- td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--r6fvD th {
+      .summary-results-table--Iezr- th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--r6fvD thead tr :first-child {
+      .summary-results-table--Iezr- thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--r6fvD td.text-cell--luh34 {
+      .summary-results-table--Iezr- td.text-cell--EaUrM {
         overflow-wrap: break-word;
       }
-      .summary-results-table--r6fvD td.url-cell--ZGO-o {
+      .summary-results-table--Iezr- td.url-cell--mg-3l {
         overflow-wrap: anywhere;
       }
 
       /* css-modules:src/reports/components/report-sections/results-by-url-container */
-      .url-results-container--xiZ0N {
+      .url-results-container---dq9B {
         margin-top: 56px;
       }
-      .url-results-container--xiZ0N .results-heading--wmQ-W {
+      .url-results-container---dq9B .results-heading--2dWBX {
         margin-top: 32px;
         margin-bottom: 32px;
       }
 
       /* css-modules:src/common/components/cards/fix-instruction-color-box */
-      span.fix-instruction-color-box--lzu-L {
+      span.fix-instruction-color-box--DQpQE {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1552,7 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .screen-reader-only--T-59F {
+      .screen-reader-only--6LUiO {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1564,7 +1564,7 @@
     </style></head
   ><body
     ><header data-automation-id="report-header-section"
-      ><div class="report-header-bar--DNH-8"
+      ><div class="report-header-bar--SDV11"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1721,9 +1721,9 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--v-ac2">Accessibility Insights</div></div
-      ><div class="report-header-command-bar--8-nLy"
-        ><div class="target-page--q7WnX"
+        ><div class="header-text--EdTxw">Accessibility Insights</div></div
+      ><div class="report-header-command-bar--NJWdl"
+        ><div class="target-page--hjh44"
           >Target page: <a
             target="_blank"
             href="https://markreay.github.io/AU/before.html"
@@ -1904,14 +1904,14 @@
           ></div
         ><div class="results-container"
           ><div
-            class="failed-instances-container--pB-u4 result-section--Av9vc"
+            class="failed-instances-container--3UUNb result-section--HfO9s"
             data-automation-id="result-section"
-            ><h2 class="heading-element-for-level--wzmxK"
-              ><span class="result-section-title--vgyHe"
+            ><h2 class="heading-element-for-level--ifVX6"
+              ><span class="result-section-title--RGFI5"
                 ><span class="screen-reader-only">Failed instances 26</span
-                ><span class="title--6gdF5" aria-hidden="true"
+                ><span class="title--WBYFE" aria-hidden="true"
                   >Failed instances</span
-                ><span class="outcome-chip-container--iN0Tt" aria-hidden="true"
+                ><span class="outcome-chip-container--BT3j5" aria-hidden="true"
                   ><span
                     class="outcome-chip outcome-chip-fail"
                     title="26 Failed"
@@ -1940,18 +1940,18 @@
                 ></span
               ></h2
             ><div
-              class="rule-details-group--ZuRYr"
+              class="rule-details-group--Tb-LW"
               data-automation-id="rule-details-group"
               ><div
-                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
-                ><h3 class="heading-element-for-level--wzmxK title-container"
+                class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
+                ><h3 class="heading-element-for-level--ifVX6 title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-bypass"
                     aria-label="bypass 1 Failed Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--ja0WM"
+                      ><span class="outcome-chip-container--G5Dfr"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -2004,10 +2004,10 @@
                   id="content-container-bypass"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--w4eYl"
-                    ><div class="more-resources-title--wqgCn"
+                  ><div class="rule-more-resources--uw9mc"
+                    ><div class="more-resources-title--jOuUL"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--QH6Z9"
+                    ><span class="rule-details-id--s-TpO"
                       ><a
                         target="_blank"
                         href="https://accessibilityinsights.io/info-examples/web/bypass"
@@ -2026,33 +2026,33 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--bg-Zq"
+                    class="instance-details-list--YfkRy"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK">html</td></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh">html</td></tr
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;html
                                     class=&quot;deque-axe-is-ready&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li>No valid skip link found</li
                                           ><li>Page does not have a header</li
                                           ><li
@@ -2073,15 +2073,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
-                ><h3 class="heading-element-for-level--wzmxK title-container"
+                class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
+                ><h3 class="heading-element-for-level--ifVX6 title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-color-contrast"
                     aria-label="color-contrast 4 Failed Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--ja0WM"
+                      ><span class="outcome-chip-container--G5Dfr"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -2134,10 +2134,10 @@
                   id="content-container-color-contrast"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--w4eYl"
-                    ><div class="more-resources-title--wqgCn"
+                  ><div class="rule-more-resources--uw9mc"
+                    ><div class="more-resources-title--jOuUL"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--QH6Z9"
+                    ><span class="rule-details-id--s-TpO"
                       ><a
                         target="_blank"
                         href="https://accessibilityinsights.io/info-examples/web/color-contrast"
@@ -2156,36 +2156,36 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--bg-Zq"
+                    class="instance-details-list--YfkRy"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >li:nth-child(1) &gt;
                                     a[href=&quot;\#&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;a
                                     href=&quot;#&quot;&gt;About&lt;/a&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             ><span aria-hidden="true"
                                               ><span
@@ -2194,7 +2194,7 @@
                                                 color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--lzu-L"
+                                                class="fix-instruction-color-box--DQpQE"
                                                 style="
                                                   background-color: #8a94a8;
                                                 "
@@ -2203,7 +2203,7 @@
                                                 >#8a94a8, background color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--lzu-L"
+                                                class="fix-instruction-color-box--DQpQE"
                                                 style="
                                                   background-color: #e7ecd8;
                                                 "
@@ -2215,7 +2215,7 @@
                                                 4.5:1</span
                                               ></span
                                             ><span
-                                              class="screen-reader-only--T-59F"
+                                              class="screen-reader-only--6LUiO"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
                                               color: #8a94a8, background color:
@@ -2230,7 +2230,7 @@
                                                     Use foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #5e6572;
                                                     "
@@ -2240,7 +2240,7 @@
                                                     background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2250,7 +2250,7 @@
                                                     ratio of 4.86:1.</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--T-59F"
+                                                  class="screen-reader-only--6LUiO"
                                                 >
                                                   Use foreground color: #5e6572
                                                   and the original background
@@ -2274,31 +2274,31 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >li:nth-child(2) &gt;
                                     a[href=&quot;\#&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;a
                                     href=&quot;#&quot;&gt;Academics&lt;/a&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             ><span aria-hidden="true"
                                               ><span
@@ -2307,7 +2307,7 @@
                                                 color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--lzu-L"
+                                                class="fix-instruction-color-box--DQpQE"
                                                 style="
                                                   background-color: #8a94a8;
                                                 "
@@ -2316,7 +2316,7 @@
                                                 >#8a94a8, background color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--lzu-L"
+                                                class="fix-instruction-color-box--DQpQE"
                                                 style="
                                                   background-color: #e7ecd8;
                                                 "
@@ -2328,7 +2328,7 @@
                                                 4.5:1</span
                                               ></span
                                             ><span
-                                              class="screen-reader-only--T-59F"
+                                              class="screen-reader-only--6LUiO"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
                                               color: #8a94a8, background color:
@@ -2343,7 +2343,7 @@
                                                     Use foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #5e6572;
                                                     "
@@ -2353,7 +2353,7 @@
                                                     background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2363,7 +2363,7 @@
                                                     ratio of 4.86:1.</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--T-59F"
+                                                  class="screen-reader-only--6LUiO"
                                                 >
                                                   Use foreground color: #5e6572
                                                   and the original background
@@ -2387,31 +2387,31 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >li:nth-child(3) &gt;
                                     a[href=&quot;\#&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;a
                                     href=&quot;#&quot;&gt;Admissions&lt;/a&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             ><span aria-hidden="true"
                                               ><span
@@ -2420,7 +2420,7 @@
                                                 color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--lzu-L"
+                                                class="fix-instruction-color-box--DQpQE"
                                                 style="
                                                   background-color: #8a94a8;
                                                 "
@@ -2429,7 +2429,7 @@
                                                 >#8a94a8, background color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--lzu-L"
+                                                class="fix-instruction-color-box--DQpQE"
                                                 style="
                                                   background-color: #e7ecd8;
                                                 "
@@ -2441,7 +2441,7 @@
                                                 4.5:1</span
                                               ></span
                                             ><span
-                                              class="screen-reader-only--T-59F"
+                                              class="screen-reader-only--6LUiO"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
                                               color: #8a94a8, background color:
@@ -2456,7 +2456,7 @@
                                                     Use foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #5e6572;
                                                     "
@@ -2466,7 +2466,7 @@
                                                     background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2476,7 +2476,7 @@
                                                     ratio of 4.86:1.</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--T-59F"
+                                                  class="screen-reader-only--6LUiO"
                                                 >
                                                   Use foreground color: #5e6572
                                                   and the original background
@@ -2500,31 +2500,31 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >li:nth-child(4) &gt;
                                     a[href=&quot;\#&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;a
                                     href=&quot;#&quot;&gt;Visitors&lt;/a&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             ><span aria-hidden="true"
                                               ><span
@@ -2533,7 +2533,7 @@
                                                 color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--lzu-L"
+                                                class="fix-instruction-color-box--DQpQE"
                                                 style="
                                                   background-color: #8a94a8;
                                                 "
@@ -2542,7 +2542,7 @@
                                                 >#8a94a8, background color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--lzu-L"
+                                                class="fix-instruction-color-box--DQpQE"
                                                 style="
                                                   background-color: #e7ecd8;
                                                 "
@@ -2554,7 +2554,7 @@
                                                 4.5:1</span
                                               ></span
                                             ><span
-                                              class="screen-reader-only--T-59F"
+                                              class="screen-reader-only--6LUiO"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
                                               color: #8a94a8, background color:
@@ -2569,7 +2569,7 @@
                                                     Use foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #5e6572;
                                                     "
@@ -2579,7 +2579,7 @@
                                                     background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2589,7 +2589,7 @@
                                                     ratio of 4.86:1.</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--T-59F"
+                                                  class="screen-reader-only--6LUiO"
                                                 >
                                                   Use foreground color: #5e6572
                                                   and the original background
@@ -2614,15 +2614,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
-                ><h3 class="heading-element-for-level--wzmxK title-container"
+                class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
+                ><h3 class="heading-element-for-level--ifVX6 title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-html-has-lang"
                     aria-label="html-has-lang 1 Failed Ensures every HTML document has a lang attribute"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--ja0WM"
+                      ><span class="outcome-chip-container--G5Dfr"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -2674,10 +2674,10 @@
                   id="content-container-html-has-lang"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--w4eYl"
-                    ><div class="more-resources-title--wqgCn"
+                  ><div class="rule-more-resources--uw9mc"
+                    ><div class="more-resources-title--jOuUL"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--QH6Z9"
+                    ><span class="rule-details-id--s-TpO"
                       ><a
                         target="_blank"
                         href="https://accessibilityinsights.io/info-examples/web/html-has-lang"
@@ -2696,33 +2696,33 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--bg-Zq"
+                    class="instance-details-list--YfkRy"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK">html</td></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh">html</td></tr
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;html
                                     class=&quot;deque-axe-is-ready&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >The &lt;html&gt; element does not
                                             have a lang attribute</li
@@ -2741,15 +2741,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
-                ><h3 class="heading-element-for-level--wzmxK title-container"
+                class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
+                ><h3 class="heading-element-for-level--ifVX6 title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-image-alt"
                     aria-label="image-alt 4 Failed Ensures &lt;img&gt; elements have alternate text or a role of none or presentation"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--ja0WM"
+                      ><span class="outcome-chip-container--G5Dfr"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -2801,10 +2801,10 @@
                   id="content-container-image-alt"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--w4eYl"
-                    ><div class="more-resources-title--wqgCn"
+                  ><div class="rule-more-resources--uw9mc"
+                    ><div class="more-resources-title--jOuUL"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--QH6Z9"
+                    ><span class="rule-details-id--s-TpO"
                       ><a
                         target="_blank"
                         href="https://accessibilityinsights.io/info-examples/web/image-alt"
@@ -2823,35 +2823,35 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--bg-Zq"
+                    class="instance-details-list--YfkRy"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >img[src$=&quot;slide2\.jpg&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;img
                                     src=&quot;images/slide2.jpg&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >Element does not have an alt
                                             attribute</li
@@ -2888,30 +2888,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >img[src$=&quot;arrow-left\.png&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;img
                                     src=&quot;images/arrow-left.png&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >Element does not have an alt
                                             attribute</li
@@ -2948,30 +2948,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >img[src$=&quot;arrow-right\.png&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;img
                                     src=&quot;images/arrow-right.png&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >Element does not have an alt
                                             attribute</li
@@ -3008,30 +3008,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >img[src$=&quot;captcha\.png&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;img
                                     src=&quot;images/captcha.png&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >Element does not have an alt
                                             attribute</li
@@ -3069,15 +3069,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
-                ><h3 class="heading-element-for-level--wzmxK title-container"
+                class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
+                ><h3 class="heading-element-for-level--ifVX6 title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-label"
                     aria-label="label 13 Failed Ensures every form element has a label"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--ja0WM"
+                      ><span class="outcome-chip-container--G5Dfr"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -3128,10 +3128,10 @@
                   id="content-container-label"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--w4eYl"
-                    ><div class="more-resources-title--wqgCn"
+                  ><div class="rule-more-resources--uw9mc"
+                    ><div class="more-resources-title--jOuUL"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--QH6Z9"
+                    ><span class="rule-details-id--s-TpO"
                       ><a
                         target="_blank"
                         href="https://accessibilityinsights.io/info-examples/web/label"
@@ -3156,35 +3156,35 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--bg-Zq"
+                    class="instance-details-list--YfkRy"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;name&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;name&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3216,30 +3216,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;email&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;email&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3271,30 +3271,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;city&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;city&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3326,30 +3326,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;state&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;state&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3381,30 +3381,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;zip&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;zip&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3436,30 +3436,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;country/region&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;country/region&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3491,30 +3491,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;major_cs&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_cs&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3546,30 +3546,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;major_eng&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_eng&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3601,30 +3601,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;major_econ&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_econ&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3656,30 +3656,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;major_phy&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_phy&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3711,30 +3711,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;major_psy&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_psy&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3766,30 +3766,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;major_sp&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_sp&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3821,30 +3821,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh"
                                     >input[name=&quot;captcha&quot;]</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;captcha&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3877,15 +3877,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
-                ><h3 class="heading-element-for-level--wzmxK title-container"
+                class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
+                ><h3 class="heading-element-for-level--ifVX6 title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-landmark-one-main"
                     aria-label="landmark-one-main 1 Failed Ensures the document has only one main landmark and each iframe in the page has at most one main landmark"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--ja0WM"
+                      ><span class="outcome-chip-container--G5Dfr"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -3938,10 +3938,10 @@
                   id="content-container-landmark-one-main"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--w4eYl"
-                    ><div class="more-resources-title--wqgCn"
+                  ><div class="rule-more-resources--uw9mc"
+                    ><div class="more-resources-title--jOuUL"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--QH6Z9"
+                    ><span class="rule-details-id--s-TpO"
                       ><a
                         target="_blank"
                         href="https://dequeuniversity.com/rules/axe/3.3/landmark-one-main?application=webdriverjs"
@@ -3959,33 +3959,33 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--bg-Zq"
+                    class="instance-details-list--YfkRy"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK">html</td></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh">html</td></tr
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;html
                                     class=&quot;deque-axe-is-ready&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >Document does not have a main
                                             landmark</li
@@ -4004,15 +4004,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
-                ><h3 class="heading-element-for-level--wzmxK title-container"
+                class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
+                ><h3 class="heading-element-for-level--ifVX6 title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-page-has-heading-one"
                     aria-label="page-has-heading-one 1 Failed Ensure that the page, or at least one of its frames contains a level-one heading"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--ja0WM"
+                      ><span class="outcome-chip-container--G5Dfr"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -4064,10 +4064,10 @@
                   id="content-container-page-has-heading-one"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--w4eYl"
-                    ><div class="more-resources-title--wqgCn"
+                  ><div class="rule-more-resources--uw9mc"
+                    ><div class="more-resources-title--jOuUL"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--QH6Z9"
+                    ><span class="rule-details-id--s-TpO"
                       ><a
                         target="_blank"
                         href="https://dequeuniversity.com/rules/axe/3.3/page-has-heading-one?application=webdriverjs"
@@ -4085,33 +4085,33 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--bg-Zq"
+                    class="instance-details-list--YfkRy"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK">html</td></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh">html</td></tr
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;html
                                     class=&quot;deque-axe-is-ready&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >Page must have a level-one
                                             heading</li
@@ -4130,15 +4130,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
-                ><h3 class="heading-element-for-level--wzmxK title-container"
+                class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
+                ><h3 class="heading-element-for-level--ifVX6 title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-region"
                     aria-label="region 1 Failed Ensures all page content is contained by landmarks"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--ja0WM"
+                      ><span class="outcome-chip-container--G5Dfr"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -4190,10 +4190,10 @@
                   id="content-container-region"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--w4eYl"
-                    ><div class="more-resources-title--wqgCn"
+                  ><div class="rule-more-resources--uw9mc"
+                    ><div class="more-resources-title--jOuUL"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--QH6Z9"
+                    ><span class="rule-details-id--s-TpO"
                       ><a
                         target="_blank"
                         href="https://dequeuniversity.com/rules/axe/3.3/region?application=webdriverjs"
@@ -4211,33 +4211,33 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--bg-Zq"
+                    class="instance-details-list--YfkRy"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--Hjwps"
-                        ><div class="instance-details-card--lixTP"
+                        class="instance-details-card-container--KLHTp"
+                        ><div class="instance-details-card--owGQF"
                           ><div
-                            ><table class="report-instance-table--YOlnT"
+                            ><table class="report-instance-table--3VoZX"
                               ><tbody
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Path</th
-                                  ><td class="row-content--Gt-CK">html</td></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">Snippet</th
-                                  ><td class="row-content--Gt-CK snippet--P6i7P"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Path</th
+                                  ><td class="row-content--07KUh">html</td></tr
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">Snippet</th
+                                  ><td class="row-content--07KUh snippet--hSNfv"
                                     >&lt;html
                                     class=&quot;deque-axe-is-ready&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--9WgHa"
-                                  ><th class="row-label--dri3e">How to fix</th
-                                  ><td class="row-content--Gt-CK"
-                                    ><div class="how-to-fix-content--Xj-BH"
+                                ><tr class="row---3i35"
+                                  ><th class="row-label--FlVZl">How to fix</th
+                                  ><td class="row-content--07KUh"
+                                    ><div class="how-to-fix-content--Zz96u"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--NaN2O"
+                                          class="insights-fix-instruction-list--eZigw"
                                           ><li
                                             >Some page content is not contained
                                             by landmarks</li
@@ -4259,17 +4259,17 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="heading-element-for-level--wzmxK title-container"
+              ><h2 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-passed-checks-section"
-                  ><span class="result-section-title--vgyHe"
+                  ><span class="result-section-title--RGFI5"
                     ><span class="screen-reader-only">Passed checks 19</span
-                    ><span class="title--6gdF5" aria-hidden="true"
+                    ><span class="title--WBYFE" aria-hidden="true"
                       >Passed checks</span
                     ><span
-                      class="outcome-chip-container--iN0Tt"
+                      class="outcome-chip-container--BT3j5"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-pass"
@@ -4310,7 +4310,7 @@
                 id="content-container-passed-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--ZuRYr"
+                ><div class="rule-details-group--Tb-LW"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -4808,18 +4808,18 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="heading-element-for-level--wzmxK title-container"
+              ><h2 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-not-applicable-checks-section"
-                  ><span class="result-section-title--vgyHe"
+                  ><span class="result-section-title--RGFI5"
                     ><span class="screen-reader-only"
                       >Not applicable checks 45</span
-                    ><span class="title--6gdF5" aria-hidden="true"
+                    ><span class="title--WBYFE" aria-hidden="true"
                       >Not applicable checks</span
                     ><span
-                      class="outcome-chip-container--iN0Tt"
+                      class="outcome-chip-container--BT3j5"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-inapplicable"
@@ -4865,7 +4865,7 @@
                 id="content-container-not-applicable-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--ZuRYr"
+                ><div class="rule-details-group--Tb-LW"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"

--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -834,24 +834,30 @@
         margin-bottom: unset;
       }</style
     ><style>
-      .heading-element-for-level--OfRDW {
+      /* css-modules:src/common/components/heading-element-for-level */
+      .heading-element-for-level--wzmxK {
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      .failed-instances-container--FqWV6 .collapsible-content {
+
+      /* css-modules:src/common/components/cards/failed-instances-section */
+      .failed-instances-container--pB-u4 .collapsible-content {
         margin-left: 24px;
       }
-      .outcome-chip-container--xYquF {
+
+      /* css-modules:src/reports/components/report-sections/minimal-rule-header */
+      .outcome-chip-container--ja0WM {
         min-width: 50px;
       }
-      .hidden-highlight-button--PePzJ {
+
+      /* css-modules:src/reports/components/instance-details */
+      .hidden-highlight-button--to41b {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-
-      .instance-details-card--R0aAh {
+      .instance-details-card--lixTP {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -859,55 +865,44 @@
           0 3.2px 7.2px var(--box-shadow-132);
         margin-bottom: 16px;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
       }
-
-      .instance-details-card-container--bKrcd.selected--Kp4AC {
+      .instance-details-card-container--Hjwps.selected--Pf-DQ {
         outline: 5px solid var(--communication-tint-10);
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC {
+      .instance-details-card--lixTP.selected--Pf-DQ {
         border: 1px solid transparent;
       }
-
-      .instance-details-card--R0aAh.focused--tV0ic,
-      .instance-details-card--R0aAh:focus {
+      .instance-details-card--lixTP.focused--PfWGT,
+      .instance-details-card--lixTP:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC.focused--tV0ic,
-      .instance-details-card--R0aAh.selected--Kp4AC:focus {
+      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
+      .instance-details-card--lixTP.selected--Pf-DQ:focus {
         outline-offset: 8px;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy {
+      .instance-details-card--lixTP.interactive--su6Sw {
         cursor: pointer;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy:hover {
+      .instance-details-card--lixTP.interactive--su6Sw:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-
-      .report-instance-table--YIu0s {
+      .report-instance-table--YOlnT {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
         border-radius: inherit;
         border-collapse: collapse;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YIu0s .row--m8TLI {
+      .report-instance-table--YOlnT .row--9WgHa {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -916,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YIu0s .row--m8TLI > * {
+      .report-instance-table--YOlnT .row--9WgHa > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YIu0s .row--m8TLI:last-child {
+      .report-instance-table--YOlnT .row--9WgHa:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YIu0s .row-label--MxfuQ {
+      .report-instance-table--YOlnT .row-label--dri3e {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -936,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YIu0s .row-content--ECKwg {
+      .report-instance-table--YOlnT .row-content--Gt-CK {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -946,41 +941,44 @@
         align-items: flex-end;
         display: flex;
       }
-      .multi-line-text-no-bullet--lNJS_ {
+
+      /* css-modules:src/common/components/cards/rich-resolution-content */
+      .multi-line-text-no-bullet--xUzJx {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--lNJS_ li:not(:last-child) {
+      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
         margin-bottom: 4px;
       }
-
-      .multi-line-text-yes-bullet--pp76P {
+      .multi-line-text-yes-bullet--jH-w4 {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--pp76P li {
+      .multi-line-text-yes-bullet--jH-w4 li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .combination-lists--O1dD_ {
+      .combination-lists--4wBYq {
         flex-direction: column;
         display: flex;
       }
-      .urls-row-content--MxcA7 {
+
+      /* css-modules:src/common/components/cards/urls-card-row */
+      .urls-row-content--rj2oy {
         padding-left: 16px;
       }
-      .urls-row-content--MxcA7 li {
+      .urls-row-content--rj2oy li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .urls-row-content-new-Failure--uJPP3 {
+      .urls-row-content-new-Failure--7Dq38 {
         color: var(--negative-outcome);
         font-weight: bold;
       }
-      .insights-fix-instruction-list--G3vyY
+
+      /* css-modules:src/common/components/fix-instruction-panel */
+      .insights-fix-instruction-list--NaN2O
         li
-        span.fix-instruction-color-box--g6NfJ {
+        span.fix-instruction-color-box---mQtG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -988,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--G3vyY .screen-reader-only--yQjgp {
+      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,64 +994,75 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
-      .how-to-fix-content--OHBLC {
+
+      /* css-modules:src/common/components/cards/how-to-fix-card-row */
+      .how-to-fix-content--Xj-BH {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--OHBLC ul {
+      .how-to-fix-content--Xj-BH ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--OHBLC ul li {
+      .how-to-fix-content--Xj-BH ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .snippet--wZrK1 {
+
+      /* css-modules:src/common/components/cards/snippet-card-row */
+      .snippet--P6i7P {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
-      div.insights-dialog-main-override--Mlek6 {
+
+      /* css-modules:src/DetailsView/components/common-dialog-styles */
+      div.insights-dialog-main-override--qzZJk {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--Mlek6 {
+        div.insights-dialog-main-override--qzZJk {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--Mlek6 .dialog-body--QtJ_D {
+      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
         font-size: 16px;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-title {
+
+      /* css-modules:src/DetailsView/components/issue-filing-dialog */
+      .issue-filing-dialog--l9xMr .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-subText {
+      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--ZrD5s .textfield-description {
+      .issue-filing-dialog--l9xMr .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
-      .action-and-cancel-buttons-component--HOvON {
+
+      /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
+      .action-and-cancel-buttons-component--5-uZX {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--HOvON
-        .action-cancel-button-col--VrVAp
-        + .action-cancel-button-col--VrVAp {
+      .action-and-cancel-buttons-component--5-uZX
+        .action-cancel-button-col--txH36
+        + .action-cancel-button-col--txH36 {
         margin-left: 8px;
       }
-      .toast-container--KsxE1 {
+
+      /* css-modules:src/common/components/toast */
+      .toast-container--cNX98 {
         display: inline-block;
       }
-
-      .toast-content--pEpMJ {
+      .toast-content--bk935 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1068,84 +1077,86 @@
         z-index: 1000;
         position: absolute;
       }
-      div.kebab-menu-callout--o23oT {
+
+      /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      div.kebab-menu-callout--A3AHu {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--o23oT > div {
+      div.kebab-menu-callout--A3AHu > div {
         border-radius: 4px;
       }
-
-      .kebab-menu--eviKu {
+      .kebab-menu--Bm5S1 {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--eviKu li {
+      .kebab-menu--Bm5S1 li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--eviKu button i {
+      .kebab-menu--Bm5S1 button i {
         color: var(--primary-text);
       }
-      .kebab-menu--eviKu button:hover {
+      .kebab-menu--Bm5S1 button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--eviKu button:hover {
+        .kebab-menu--Bm5S1 button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--eviKu button:active {
+      .kebab-menu--Bm5S1 button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--eviKu button:active i {
+      .kebab-menu--Bm5S1 button:active i {
         color: var(--light-black);
       }
-
-      button.kebab-menu-button--dy7Ui {
+      button.kebab-menu-button--ySFdR {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--dy7Ui svg {
+      button.kebab-menu-button--ySFdR svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui svg {
+        button.kebab-menu-button--ySFdR svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--dy7Ui:hover {
+      button.kebab-menu-button--ySFdR:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--dy7Ui:active,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+      button.kebab-menu-button--ySFdR:active,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--dy7Ui:active svg > circle,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--ySFdR:active svg > circle,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui:active,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+        button.kebab-menu-button--ySFdR:active,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--dy7Ui:active svg > circle,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--ySFdR:active svg > circle,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--dy7Ui > span {
+      button.kebab-menu-button--ySFdR > span {
         justify-content: center;
       }
-      .foot--d1w5m {
+
+      /* css-modules:src/common/components/cards/instance-details-footer */
+      .foot--WBFZ6 {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1156,40 +1167,44 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--d1w5m .highlight-status--Bmqfx {
+      .foot--WBFZ6 .highlight-status--TYXPj {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--d1w5m .highlight-status--Bmqfx svg {
+      .foot--WBFZ6 .highlight-status--TYXPj svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--d1w5m .highlight-status--Bmqfx svg {
+        .foot--WBFZ6 .highlight-status--TYXPj svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--d1w5m .highlight-status--Bmqfx label {
+      .foot--WBFZ6 .highlight-status--TYXPj label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      ul.instance-details-list--xiPPL {
+
+      /* css-modules:src/common/components/cards/instance-details-group */
+      ul.instance-details-list--bg-Zq {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--xiPPL > li {
+      ul.instance-details-list--bg-Zq > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--xiPPL > li:last-child {
+      ul.instance-details-list--bg-Zq > li:last-child {
         margin-bottom: unset;
       }
-      .rule-more-resources--Bsblo {
+
+      /* css-modules:src/common/components/cards/rule-resources */
+      .rule-more-resources--w4eYl {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1203,50 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--Bsblo .more-resources-title--whTFs {
+      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
         font-weight: 600;
       }
-      .rule-more-resources--Bsblo .rule-details-id--n_S89 {
+      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
         padding: 12px 0;
       }
-      .rule-details-group--U69fz .rule-detail {
+
+      /* css-modules:src/common/components/cards/rules-with-instances */
+      .rule-details-group--ZuRYr .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--U69fz .rule-detail .outcome-chip {
+      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id a {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--U69fz .rule-detail .rule-detail-description {
+      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-
-      .collapsible-rule-details-group--h0lvd {
+      .collapsible-rule-details-group--ODFPb {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--h0lvd .rule-detail {
+      .collapsible-rule-details-group--ODFPb .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--h0lvd:not(.collapsed) {
+      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
         box-shadow: unset;
       }
-      .result-section-title--qv3MK {
+
+      /* css-modules:src/common/components/cards/result-section-title */
+      .result-section-title--vgyHe {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1254,45 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--qv3MK .title--neMma {
+      .result-section-title--vgyHe .title--6gdF5 {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .heading--VbGap {
+      .result-section-title--vgyHe .heading--1Ll6- {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .outcome-chip-container--Wt0k4 {
+      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
         display: flex;
         height: 16px;
       }
-      .result-section--j6fYr {
+
+      /* css-modules:src/common/components/cards/result-section */
+      .result-section--Av9vc {
         padding-bottom: 24px;
       }
-      .result-section--j6fYr
-        .title-container--gMYqW
-        .collapsible-control--V9OlA::before {
+      .result-section--Av9vc
+        .title-container---R9Dm
+        .collapsible-control--5y7Tp::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--j6fYr > h2 {
+      .result-section--Av9vc > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-bar--pkiTM {
+
+      /* css-modules:src/reports/components/header-bar */
+      .report-header-bar--DNH-8 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1301,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--pkiTM .header-icon {
+      .report-header-bar--DNH-8 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--pkiTM .header-text--dfm48 {
+      .report-header-bar--DNH-8 .header-text--v-ac2 {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1321,7 +1343,9 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-command-bar--wDg1t {
+
+      /* css-modules:src/reports/components/report-sections/header-section */
+      .report-header-command-bar--8-nLy {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1331,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--wDg1t .target-page--giudb {
+      .report-header-command-bar--8-nLy .target-page--q7WnX {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1344,12 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
+      .report-header-command-bar--8-nLy .target-page--q7WnX a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      .combined-report-result-section-title--XUDDo {
+
+      /* css-modules:src/common/components/cards/combined-report-result-section-title */
+      .combined-report-result-section-title--RNekd {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1357,21 +1383,23 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--XUDDo .title--lcuIW {
+      .combined-report-result-section-title--RNekd .title--CFcXZ {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--XUDDo .heading--uUq3e {
+      .combined-report-result-section-title--RNekd .heading--gtY3F {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .urls-summary-section--DjUWc {
+
+      /* css-modules:src/reports/components/report-sections/urls-summary-section */
+      .urls-summary-section--db4HQ {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1379,31 +1407,35 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--DjUWc h2 {
+      .urls-summary-section--db4HQ h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--DjUWc .total-urls--Ig_eB {
+      .urls-summary-section--db4HQ .total-urls--3pXYz {
         font-weight: 600;
       }
-      .urls-summary-section--DjUWc .failure-instances--Rq_Tj {
+      .urls-summary-section--db4HQ .failure-instances--y0Big {
         margin-top: 40px;
       }
-      .urls-summary-section--DjUWc .failure-outcome-chip--YtjBX {
+      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
-      .rules-results-container--n7EEu {
+
+      /* css-modules:src/reports/components/report-sections/rules-results-container */
+      .rules-results-container--dO76T {
         margin-top: 56px;
       }
-      .rules-results-container--n7EEu .results-heading--pyS7R {
+      .rules-results-container--dO76T .results-heading--2h1oe {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
       }
-      .crawl-details-section--WhRL4 {
+
+      /* css-modules:src/reports/components/report-sections/summary-report-details-section */
+      .crawl-details-section--jDqES {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1411,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1421,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg li {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
         display: inline-block;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
         li
-        .icon--JdMPq {
+        .icon--enDUo {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
-        li.targetSite--qXxid {
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
+        li.targetSite--M6DmE {
         margin-bottom: 6px;
       }
-      .crawl-details-section--WhRL4 .text--swxfX,
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .text--lxa-w,
+      .crawl-details-section--jDqES .label--TrLq3 {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1448,26 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .label--TrLq3 {
         font-weight: 600;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2.no-icon--J7B9N {
+      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
         padding-left: 29px;
       }
-      .url-result-section--PmEoY {
+
+      /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
+      .url-result-section--Lsitd {
         padding-bottom: 31px;
       }
-      .url-result-section--PmEoY
+      .url-result-section--Lsitd
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--PmEoY .collapsible-content {
+      .url-result-section--Lsitd .collapsible-content {
         margin-top: 19px;
       }
-      .summary-results-table--Pb4_B {
+
+      /* css-modules:src/reports/components/report-sections/summary-results-table */
+      .summary-results-table--r6fvD {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1476,35 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--Pb4_B th,
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD th,
+      .summary-results-table--r6fvD td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--Pb4_B th {
+      .summary-results-table--r6fvD th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--Pb4_B thead tr :first-child {
+      .summary-results-table--r6fvD thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--Pb4_B td.text-cell--p0dxL {
+      .summary-results-table--r6fvD td.text-cell--luh34 {
         overflow-wrap: break-word;
       }
-      .summary-results-table--Pb4_B td.url-cell--yjU1V {
+      .summary-results-table--r6fvD td.url-cell--ZGO-o {
         overflow-wrap: anywhere;
       }
-      .url-results-container--dXQbj {
+
+      /* css-modules:src/reports/components/report-sections/results-by-url-container */
+      .url-results-container--xiZ0N {
         margin-top: 56px;
       }
-      .url-results-container--dXQbj .results-heading--D3Qtr {
+      .url-results-container--xiZ0N .results-heading--wmQ-W {
         margin-top: 32px;
         margin-bottom: 32px;
       }
-      span.fix-instruction-color-box--Xq1E4 {
+
+      /* css-modules:src/common/components/cards/fix-instruction-color-box */
+      span.fix-instruction-color-box--lzu-L {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1512,8 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-
-      .screen-reader-only--n1Ocs {
+      .screen-reader-only--T-59F {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1521,10 +1560,11 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
+      /*# sourceMappingURL=report.css.map */
     </style></head
   ><body
     ><header data-automation-id="report-header-section"
-      ><div class="report-header-bar--pkiTM"
+      ><div class="report-header-bar--DNH-8"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1681,9 +1721,9 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--dfm48">Accessibility Insights</div></div
-      ><div class="report-header-command-bar--wDg1t"
-        ><div class="target-page--giudb"
+        ><div class="header-text--v-ac2">Accessibility Insights</div></div
+      ><div class="report-header-command-bar--8-nLy"
+        ><div class="target-page--q7WnX"
           >Target page: <a
             target="_blank"
             href="https://markreay.github.io/AU/before.html"
@@ -1696,9 +1736,7 @@
               var targetPageLink = doc.getElementById(linkId);
               targetPageLink.addEventListener("click", function (event) {
                 var result = confirmCallback(
-                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                    "Cancel to stay on the current page."
+                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                 );
                 if (result === false) {
                   event.preventDefault();
@@ -1745,9 +1783,7 @@
                     var targetPageLink = doc.getElementById(linkId);
                     targetPageLink.addEventListener("click", function (event) {
                       var result = confirmCallback(
-                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                          "Cancel to stay on the current page."
+                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                       );
                       if (result === false) {
                         event.preventDefault();
@@ -1868,14 +1904,14 @@
           ></div
         ><div class="results-container"
           ><div
-            class="failed-instances-container--FqWV6 result-section--j6fYr"
+            class="failed-instances-container--pB-u4 result-section--Av9vc"
             data-automation-id="result-section"
-            ><h2 class="heading-element-for-level--OfRDW"
-              ><span class="result-section-title--qv3MK"
+            ><h2 class="heading-element-for-level--wzmxK"
+              ><span class="result-section-title--vgyHe"
                 ><span class="screen-reader-only">Failed instances 26</span
-                ><span class="title--neMma" aria-hidden="true"
+                ><span class="title--6gdF5" aria-hidden="true"
                   >Failed instances</span
-                ><span class="outcome-chip-container--Wt0k4" aria-hidden="true"
+                ><span class="outcome-chip-container--iN0Tt" aria-hidden="true"
                   ><span
                     class="outcome-chip outcome-chip-fail"
                     title="26 Failed"
@@ -1904,18 +1940,18 @@
                 ></span
               ></h2
             ><div
-              class="rule-details-group--U69fz"
+              class="rule-details-group--ZuRYr"
               data-automation-id="rule-details-group"
               ><div
-                class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="heading-element-for-level--OfRDW title-container"
+                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                ><h3 class="heading-element-for-level--wzmxK title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-bypass"
                     aria-label="bypass 1 Failed Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--xYquF"
+                      ><span class="outcome-chip-container--ja0WM"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -1968,10 +2004,10 @@
                   id="content-container-bypass"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--Bsblo"
-                    ><div class="more-resources-title--whTFs"
+                  ><div class="rule-more-resources--w4eYl"
+                    ><div class="more-resources-title--wqgCn"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--n_S89"
+                    ><span class="rule-details-id--QH6Z9"
                       ><a
                         target="_blank"
                         href="https://accessibilityinsights.io/info-examples/web/bypass"
@@ -1990,33 +2026,33 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--xiPPL"
+                    class="instance-details-list--bg-Zq"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg">html</td></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK">html</td></tr
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;html
                                     class=&quot;deque-axe-is-ready&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li>No valid skip link found</li
                                           ><li>Page does not have a header</li
                                           ><li
@@ -2037,15 +2073,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="heading-element-for-level--OfRDW title-container"
+                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                ><h3 class="heading-element-for-level--wzmxK title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-color-contrast"
                     aria-label="color-contrast 4 Failed Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--xYquF"
+                      ><span class="outcome-chip-container--ja0WM"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -2098,10 +2134,10 @@
                   id="content-container-color-contrast"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--Bsblo"
-                    ><div class="more-resources-title--whTFs"
+                  ><div class="rule-more-resources--w4eYl"
+                    ><div class="more-resources-title--wqgCn"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--n_S89"
+                    ><span class="rule-details-id--QH6Z9"
                       ><a
                         target="_blank"
                         href="https://accessibilityinsights.io/info-examples/web/color-contrast"
@@ -2120,36 +2156,36 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--xiPPL"
+                    class="instance-details-list--bg-Zq"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >li:nth-child(1) &gt;
                                     a[href=&quot;\#&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;a
                                     href=&quot;#&quot;&gt;About&lt;/a&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             ><span aria-hidden="true"
                                               ><span
@@ -2158,7 +2194,7 @@
                                                 color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--Xq1E4"
+                                                class="fix-instruction-color-box--lzu-L"
                                                 style="
                                                   background-color: #8a94a8;
                                                 "
@@ -2167,7 +2203,7 @@
                                                 >#8a94a8, background color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--Xq1E4"
+                                                class="fix-instruction-color-box--lzu-L"
                                                 style="
                                                   background-color: #e7ecd8;
                                                 "
@@ -2179,7 +2215,7 @@
                                                 4.5:1</span
                                               ></span
                                             ><span
-                                              class="screen-reader-only--n1Ocs"
+                                              class="screen-reader-only--T-59F"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
                                               color: #8a94a8, background color:
@@ -2194,7 +2230,7 @@
                                                     Use foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #5e6572;
                                                     "
@@ -2204,7 +2240,7 @@
                                                     background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2214,7 +2250,7 @@
                                                     ratio of 4.86:1.</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--n1Ocs"
+                                                  class="screen-reader-only--T-59F"
                                                 >
                                                   Use foreground color: #5e6572
                                                   and the original background
@@ -2238,31 +2274,31 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >li:nth-child(2) &gt;
                                     a[href=&quot;\#&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;a
                                     href=&quot;#&quot;&gt;Academics&lt;/a&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             ><span aria-hidden="true"
                                               ><span
@@ -2271,7 +2307,7 @@
                                                 color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--Xq1E4"
+                                                class="fix-instruction-color-box--lzu-L"
                                                 style="
                                                   background-color: #8a94a8;
                                                 "
@@ -2280,7 +2316,7 @@
                                                 >#8a94a8, background color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--Xq1E4"
+                                                class="fix-instruction-color-box--lzu-L"
                                                 style="
                                                   background-color: #e7ecd8;
                                                 "
@@ -2292,7 +2328,7 @@
                                                 4.5:1</span
                                               ></span
                                             ><span
-                                              class="screen-reader-only--n1Ocs"
+                                              class="screen-reader-only--T-59F"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
                                               color: #8a94a8, background color:
@@ -2307,7 +2343,7 @@
                                                     Use foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #5e6572;
                                                     "
@@ -2317,7 +2353,7 @@
                                                     background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2327,7 +2363,7 @@
                                                     ratio of 4.86:1.</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--n1Ocs"
+                                                  class="screen-reader-only--T-59F"
                                                 >
                                                   Use foreground color: #5e6572
                                                   and the original background
@@ -2351,31 +2387,31 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >li:nth-child(3) &gt;
                                     a[href=&quot;\#&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;a
                                     href=&quot;#&quot;&gt;Admissions&lt;/a&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             ><span aria-hidden="true"
                                               ><span
@@ -2384,7 +2420,7 @@
                                                 color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--Xq1E4"
+                                                class="fix-instruction-color-box--lzu-L"
                                                 style="
                                                   background-color: #8a94a8;
                                                 "
@@ -2393,7 +2429,7 @@
                                                 >#8a94a8, background color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--Xq1E4"
+                                                class="fix-instruction-color-box--lzu-L"
                                                 style="
                                                   background-color: #e7ecd8;
                                                 "
@@ -2405,7 +2441,7 @@
                                                 4.5:1</span
                                               ></span
                                             ><span
-                                              class="screen-reader-only--n1Ocs"
+                                              class="screen-reader-only--T-59F"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
                                               color: #8a94a8, background color:
@@ -2420,7 +2456,7 @@
                                                     Use foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #5e6572;
                                                     "
@@ -2430,7 +2466,7 @@
                                                     background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2440,7 +2476,7 @@
                                                     ratio of 4.86:1.</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--n1Ocs"
+                                                  class="screen-reader-only--T-59F"
                                                 >
                                                   Use foreground color: #5e6572
                                                   and the original background
@@ -2464,31 +2500,31 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >li:nth-child(4) &gt;
                                     a[href=&quot;\#&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;a
                                     href=&quot;#&quot;&gt;Visitors&lt;/a&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             ><span aria-hidden="true"
                                               ><span
@@ -2497,7 +2533,7 @@
                                                 color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--Xq1E4"
+                                                class="fix-instruction-color-box--lzu-L"
                                                 style="
                                                   background-color: #8a94a8;
                                                 "
@@ -2506,7 +2542,7 @@
                                                 >#8a94a8, background color: </span
                                               ><span
                                                 aria-hidden="true"
-                                                class="fix-instruction-color-box--Xq1E4"
+                                                class="fix-instruction-color-box--lzu-L"
                                                 style="
                                                   background-color: #e7ecd8;
                                                 "
@@ -2518,7 +2554,7 @@
                                                 4.5:1</span
                                               ></span
                                             ><span
-                                              class="screen-reader-only--n1Ocs"
+                                              class="screen-reader-only--T-59F"
                                               >Element has insufficient color
                                               contrast of 2.52 (foreground
                                               color: #8a94a8, background color:
@@ -2533,7 +2569,7 @@
                                                     Use foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #5e6572;
                                                     "
@@ -2543,7 +2579,7 @@
                                                     background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2553,7 +2589,7 @@
                                                     ratio of 4.86:1.</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--n1Ocs"
+                                                  class="screen-reader-only--T-59F"
                                                 >
                                                   Use foreground color: #5e6572
                                                   and the original background
@@ -2578,15 +2614,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="heading-element-for-level--OfRDW title-container"
+                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                ><h3 class="heading-element-for-level--wzmxK title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-html-has-lang"
                     aria-label="html-has-lang 1 Failed Ensures every HTML document has a lang attribute"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--xYquF"
+                      ><span class="outcome-chip-container--ja0WM"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -2638,10 +2674,10 @@
                   id="content-container-html-has-lang"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--Bsblo"
-                    ><div class="more-resources-title--whTFs"
+                  ><div class="rule-more-resources--w4eYl"
+                    ><div class="more-resources-title--wqgCn"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--n_S89"
+                    ><span class="rule-details-id--QH6Z9"
                       ><a
                         target="_blank"
                         href="https://accessibilityinsights.io/info-examples/web/html-has-lang"
@@ -2660,33 +2696,33 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--xiPPL"
+                    class="instance-details-list--bg-Zq"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg">html</td></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK">html</td></tr
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;html
                                     class=&quot;deque-axe-is-ready&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >The &lt;html&gt; element does not
                                             have a lang attribute</li
@@ -2705,15 +2741,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="heading-element-for-level--OfRDW title-container"
+                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                ><h3 class="heading-element-for-level--wzmxK title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-image-alt"
                     aria-label="image-alt 4 Failed Ensures &lt;img&gt; elements have alternate text or a role of none or presentation"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--xYquF"
+                      ><span class="outcome-chip-container--ja0WM"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -2765,10 +2801,10 @@
                   id="content-container-image-alt"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--Bsblo"
-                    ><div class="more-resources-title--whTFs"
+                  ><div class="rule-more-resources--w4eYl"
+                    ><div class="more-resources-title--wqgCn"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--n_S89"
+                    ><span class="rule-details-id--QH6Z9"
                       ><a
                         target="_blank"
                         href="https://accessibilityinsights.io/info-examples/web/image-alt"
@@ -2787,35 +2823,35 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--xiPPL"
+                    class="instance-details-list--bg-Zq"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >img[src$=&quot;slide2\.jpg&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;img
                                     src=&quot;images/slide2.jpg&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >Element does not have an alt
                                             attribute</li
@@ -2852,30 +2888,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >img[src$=&quot;arrow-left\.png&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;img
                                     src=&quot;images/arrow-left.png&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >Element does not have an alt
                                             attribute</li
@@ -2912,30 +2948,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >img[src$=&quot;arrow-right\.png&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;img
                                     src=&quot;images/arrow-right.png&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >Element does not have an alt
                                             attribute</li
@@ -2972,30 +3008,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >img[src$=&quot;captcha\.png&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;img
                                     src=&quot;images/captcha.png&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >Element does not have an alt
                                             attribute</li
@@ -3033,15 +3069,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="heading-element-for-level--OfRDW title-container"
+                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                ><h3 class="heading-element-for-level--wzmxK title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-label"
                     aria-label="label 13 Failed Ensures every form element has a label"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--xYquF"
+                      ><span class="outcome-chip-container--ja0WM"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -3092,10 +3128,10 @@
                   id="content-container-label"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--Bsblo"
-                    ><div class="more-resources-title--whTFs"
+                  ><div class="rule-more-resources--w4eYl"
+                    ><div class="more-resources-title--wqgCn"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--n_S89"
+                    ><span class="rule-details-id--QH6Z9"
                       ><a
                         target="_blank"
                         href="https://accessibilityinsights.io/info-examples/web/label"
@@ -3120,35 +3156,35 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--xiPPL"
+                    class="instance-details-list--bg-Zq"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;name&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;name&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3180,30 +3216,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;email&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;email&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3235,30 +3271,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;city&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;city&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3290,30 +3326,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;state&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;state&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3345,30 +3381,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;zip&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;zip&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3400,30 +3436,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;country/region&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;country/region&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3455,30 +3491,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;major_cs&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_cs&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3510,30 +3546,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;major_eng&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_eng&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3565,30 +3601,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;major_econ&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_econ&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3620,30 +3656,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;major_phy&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_phy&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3675,30 +3711,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;major_psy&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_psy&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3730,30 +3766,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;major_sp&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;checkbox&quot;
                                     name=&quot;major_sp&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3785,30 +3821,30 @@
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK"
                                     >input[name=&quot;captcha&quot;]</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;input type=&quot;text&quot;
                                     name=&quot;captcha&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix ONE of the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >aria-label attribute does not exist
                                             or is empty</li
@@ -3841,15 +3877,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="heading-element-for-level--OfRDW title-container"
+                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                ><h3 class="heading-element-for-level--wzmxK title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-landmark-one-main"
                     aria-label="landmark-one-main 1 Failed Ensures the document has only one main landmark and each iframe in the page has at most one main landmark"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--xYquF"
+                      ><span class="outcome-chip-container--ja0WM"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -3902,10 +3938,10 @@
                   id="content-container-landmark-one-main"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--Bsblo"
-                    ><div class="more-resources-title--whTFs"
+                  ><div class="rule-more-resources--w4eYl"
+                    ><div class="more-resources-title--wqgCn"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--n_S89"
+                    ><span class="rule-details-id--QH6Z9"
                       ><a
                         target="_blank"
                         href="https://dequeuniversity.com/rules/axe/3.3/landmark-one-main?application=webdriverjs"
@@ -3923,33 +3959,33 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--xiPPL"
+                    class="instance-details-list--bg-Zq"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg">html</td></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK">html</td></tr
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;html
                                     class=&quot;deque-axe-is-ready&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >Document does not have a main
                                             landmark</li
@@ -3968,15 +4004,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="heading-element-for-level--OfRDW title-container"
+                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                ><h3 class="heading-element-for-level--wzmxK title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-page-has-heading-one"
                     aria-label="page-has-heading-one 1 Failed Ensure that the page, or at least one of its frames contains a level-one heading"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--xYquF"
+                      ><span class="outcome-chip-container--ja0WM"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -4028,10 +4064,10 @@
                   id="content-container-page-has-heading-one"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--Bsblo"
-                    ><div class="more-resources-title--whTFs"
+                  ><div class="rule-more-resources--w4eYl"
+                    ><div class="more-resources-title--wqgCn"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--n_S89"
+                    ><span class="rule-details-id--QH6Z9"
                       ><a
                         target="_blank"
                         href="https://dequeuniversity.com/rules/axe/3.3/page-has-heading-one?application=webdriverjs"
@@ -4049,33 +4085,33 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--xiPPL"
+                    class="instance-details-list--bg-Zq"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg">html</td></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK">html</td></tr
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;html
                                     class=&quot;deque-axe-is-ready&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >Page must have a level-one
                                             heading</li
@@ -4094,15 +4130,15 @@
                   ></div
                 ></div
               ><div
-                class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
-                ><h3 class="heading-element-for-level--OfRDW title-container"
+                class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                ><h3 class="heading-element-for-level--wzmxK title-container"
                   ><button
                     class="collapsible-control"
                     aria-expanded="false"
                     aria-controls="content-container-region"
                     aria-label="region 1 Failed Ensures all page content is contained by landmarks"
                     ><span data-automation-id="rule-detail" class="rule-detail"
-                      ><span class="outcome-chip-container--xYquF"
+                      ><span class="outcome-chip-container--ja0WM"
                         ><span aria-hidden="true"
                           ><span
                             class="outcome-chip outcome-chip-fail"
@@ -4154,10 +4190,10 @@
                   id="content-container-region"
                   class="collapsible-content"
                   aria-hidden="true"
-                  ><div class="rule-more-resources--Bsblo"
-                    ><div class="more-resources-title--whTFs"
+                  ><div class="rule-more-resources--w4eYl"
+                    ><div class="more-resources-title--wqgCn"
                       >Resources for this rule</div
-                    ><span class="rule-details-id--n_S89"
+                    ><span class="rule-details-id--QH6Z9"
                       ><a
                         target="_blank"
                         href="https://dequeuniversity.com/rules/axe/3.3/region?application=webdriverjs"
@@ -4175,33 +4211,33 @@
                     ></div
                   ><ul
                     data-automation-id="cards-rule-content"
-                    class="instance-details-list--xiPPL"
+                    class="instance-details-list--bg-Zq"
                     aria-label="instances with additional information like path, snippet and how to fix"
                     ><li
                       ><div
                         data-automation-id="instance-card"
-                        class="instance-details-card-container--bKrcd"
-                        ><div class="instance-details-card--R0aAh"
+                        class="instance-details-card-container--Hjwps"
+                        ><div class="instance-details-card--lixTP"
                           ><div
-                            ><table class="report-instance-table--YIu0s"
+                            ><table class="report-instance-table--YOlnT"
                               ><tbody
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Path</th
-                                  ><td class="row-content--ECKwg">html</td></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">Snippet</th
-                                  ><td class="row-content--ECKwg snippet--wZrK1"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Path</th
+                                  ><td class="row-content--Gt-CK">html</td></tr
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">Snippet</th
+                                  ><td class="row-content--Gt-CK snippet--P6i7P"
                                     >&lt;html
                                     class=&quot;deque-axe-is-ready&quot;&gt;</td
                                   ></tr
-                                ><tr class="row--m8TLI"
-                                  ><th class="row-label--MxfuQ">How to fix</th
-                                  ><td class="row-content--ECKwg"
-                                    ><div class="how-to-fix-content--OHBLC"
+                                ><tr class="row--9WgHa"
+                                  ><th class="row-label--dri3e">How to fix</th
+                                  ><td class="row-content--Gt-CK"
+                                    ><div class="how-to-fix-content--Xj-BH"
                                       ><div
                                         ><div>Fix the following:</div
                                         ><ul
-                                          class="insights-fix-instruction-list--G3vyY"
+                                          class="insights-fix-instruction-list--NaN2O"
                                           ><li
                                             >Some page content is not contained
                                             by landmarks</li
@@ -4223,17 +4259,17 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="heading-element-for-level--OfRDW title-container"
+              ><h2 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-passed-checks-section"
-                  ><span class="result-section-title--qv3MK"
+                  ><span class="result-section-title--vgyHe"
                     ><span class="screen-reader-only">Passed checks 19</span
-                    ><span class="title--neMma" aria-hidden="true"
+                    ><span class="title--6gdF5" aria-hidden="true"
                       >Passed checks</span
                     ><span
-                      class="outcome-chip-container--Wt0k4"
+                      class="outcome-chip-container--iN0Tt"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-pass"
@@ -4274,7 +4310,7 @@
                 id="content-container-passed-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--U69fz"
+                ><div class="rule-details-group--ZuRYr"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -4772,18 +4808,18 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="heading-element-for-level--OfRDW title-container"
+              ><h2 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-not-applicable-checks-section"
-                  ><span class="result-section-title--qv3MK"
+                  ><span class="result-section-title--vgyHe"
                     ><span class="screen-reader-only"
                       >Not applicable checks 45</span
-                    ><span class="title--neMma" aria-hidden="true"
+                    ><span class="title--6gdF5" aria-hidden="true"
                       >Not applicable checks</span
                     ><span
-                      class="outcome-chip-container--Wt0k4"
+                      class="outcome-chip-container--iN0Tt"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-inapplicable"
@@ -4829,7 +4865,7 @@
                 id="content-container-not-applicable-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--U69fz"
+                ><div class="rule-details-group--ZuRYr"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -5997,7 +6033,7 @@
             var _loop = function (index) {
               var container = collapsibles.item(index);
               var button =
-                container === null || container === void 0
+                container == null
                   ? void 0
                   : container.querySelector(".collapsible-control");
               if (button == null) {
@@ -6006,7 +6042,7 @@
               button.addEventListener("click", function () {
                 var _a;
                 var content =
-                  (_a = button.parentElement) === null || _a === void 0
+                  (_a = button.parentElement) == null
                     ? void 0
                     : _a.nextElementSibling;
                 if (content == null) {

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -835,29 +835,29 @@
       }</style
     ><style>
       /* css-modules:src/common/components/heading-element-for-level */
-      .heading-element-for-level--wzmxK {
+      .heading-element-for-level--ifVX6 {
         margin-block-start: unset;
         margin-block-end: unset;
       }
 
       /* css-modules:src/common/components/cards/failed-instances-section */
-      .failed-instances-container--pB-u4 .collapsible-content {
+      .failed-instances-container--3UUNb .collapsible-content {
         margin-left: 24px;
       }
 
       /* css-modules:src/reports/components/report-sections/minimal-rule-header */
-      .outcome-chip-container--ja0WM {
+      .outcome-chip-container--G5Dfr {
         min-width: 50px;
       }
 
       /* css-modules:src/reports/components/instance-details */
-      .hidden-highlight-button--to41b {
+      .hidden-highlight-button--vu3B3 {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-      .instance-details-card--lixTP {
+      .instance-details-card--owGQF {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -868,29 +868,29 @@
         width: -webkit-fill-available;
         width: fill-available;
       }
-      .instance-details-card-container--Hjwps.selected--Pf-DQ {
+      .instance-details-card-container--KLHTp.selected--wEA4l {
         outline: 5px solid var(--communication-tint-10);
       }
-      .instance-details-card--lixTP.selected--Pf-DQ {
+      .instance-details-card--owGQF.selected--wEA4l {
         border: 1px solid transparent;
       }
-      .instance-details-card--lixTP.focused--PfWGT,
-      .instance-details-card--lixTP:focus {
+      .instance-details-card--owGQF.focused--pvBWq,
+      .instance-details-card--owGQF:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
-      .instance-details-card--lixTP.selected--Pf-DQ:focus {
+      .instance-details-card--owGQF.selected--wEA4l.focused--pvBWq,
+      .instance-details-card--owGQF.selected--wEA4l:focus {
         outline-offset: 8px;
       }
-      .instance-details-card--lixTP.interactive--su6Sw {
+      .instance-details-card--owGQF.interactive--an0ab {
         cursor: pointer;
       }
-      .instance-details-card--lixTP.interactive--su6Sw:hover {
+      .instance-details-card--owGQF.interactive--an0ab:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-      .report-instance-table--YOlnT {
+      .report-instance-table--3VoZX {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
@@ -902,7 +902,7 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YOlnT .row--9WgHa {
+      .report-instance-table--3VoZX .row---3i35 {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -911,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YOlnT .row--9WgHa > * {
+      .report-instance-table--3VoZX .row---3i35 > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YOlnT .row--9WgHa:last-child {
+      .report-instance-table--3VoZX .row---3i35:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YOlnT .row-label--dri3e {
+      .report-instance-table--3VoZX .row-label--FlVZl {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -931,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YOlnT .row-content--Gt-CK {
+      .report-instance-table--3VoZX .row-content--07KUh {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -943,42 +943,42 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--xUzJx {
+      .multi-line-text-no-bullet--AUXXt {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
-      .multi-line-text-yes-bullet--jH-w4 {
+      .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--jH-w4 li {
+      .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .combination-lists--4wBYq {
+      .combination-lists--boK5y {
         flex-direction: column;
         display: flex;
       }
 
       /* css-modules:src/common/components/cards/urls-card-row */
-      .urls-row-content--rj2oy {
+      .urls-row-content--JDdRx {
         padding-left: 16px;
       }
-      .urls-row-content--rj2oy li {
+      .urls-row-content--JDdRx li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .urls-row-content-new-Failure--7Dq38 {
+      .urls-row-content-new-Failure--oL5lS {
         color: var(--negative-outcome);
         font-weight: bold;
       }
 
       /* css-modules:src/common/components/fix-instruction-panel */
-      .insights-fix-instruction-list--NaN2O
+      .insights-fix-instruction-list--eZigw
         li
-        span.fix-instruction-color-box---mQtG {
+        span.fix-instruction-color-box--sBkHG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -986,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
+      .insights-fix-instruction-list--eZigw .screen-reader-only--irrXo {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,73 +996,73 @@
       }
 
       /* css-modules:src/common/components/cards/how-to-fix-card-row */
-      .how-to-fix-content--Xj-BH {
+      .how-to-fix-content--Zz96u {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--Xj-BH ul {
+      .how-to-fix-content--Zz96u ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--Xj-BH ul li {
+      .how-to-fix-content--Zz96u ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
 
       /* css-modules:src/common/components/cards/snippet-card-row */
-      .snippet--P6i7P {
+      .snippet--hSNfv {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
 
       /* css-modules:src/DetailsView/components/common-dialog-styles */
-      div.insights-dialog-main-override--qzZJk {
+      div.insights-dialog-main-override--ma4DA {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--qzZJk {
+        div.insights-dialog-main-override--ma4DA {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
+      div.insights-dialog-main-override--ma4DA .dialog-body--cmWmz {
         font-size: 16px;
       }
 
       /* css-modules:src/DetailsView/components/issue-filing-dialog */
-      .issue-filing-dialog--l9xMr .ms-Dialog-title {
+      .issue-filing-dialog--F9jun .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
+      .issue-filing-dialog--F9jun .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--l9xMr .textfield-description {
+      .issue-filing-dialog--F9jun .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
 
       /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
-      .action-and-cancel-buttons-component--5-uZX {
+      .action-and-cancel-buttons-component--DF7bf {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--5-uZX
-        .action-cancel-button-col--txH36
-        + .action-cancel-button-col--txH36 {
+      .action-and-cancel-buttons-component--DF7bf
+        .action-cancel-button-col--RMfN-
+        + .action-cancel-button-col--RMfN- {
         margin-left: 8px;
       }
 
       /* css-modules:src/common/components/toast */
-      .toast-container--cNX98 {
+      .toast-container--L-5HM {
         display: inline-block;
       }
-      .toast-content--bk935 {
+      .toast-content--8-Mx1 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1079,84 +1079,84 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
-      div.kebab-menu-callout--A3AHu {
+      div.kebab-menu-callout--XvN24 {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--A3AHu > div {
+      div.kebab-menu-callout--XvN24 > div {
         border-radius: 4px;
       }
-      .kebab-menu--Bm5S1 {
+      .kebab-menu--eKCNX {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--Bm5S1 li {
+      .kebab-menu--eKCNX li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--Bm5S1 button i {
+      .kebab-menu--eKCNX button i {
         color: var(--primary-text);
       }
-      .kebab-menu--Bm5S1 button:hover {
+      .kebab-menu--eKCNX button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--Bm5S1 button:hover {
+        .kebab-menu--eKCNX button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--Bm5S1 button:active {
+      .kebab-menu--eKCNX button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--Bm5S1 button:active i {
+      .kebab-menu--eKCNX button:active i {
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR {
+      button.kebab-menu-button--e-7v- {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--ySFdR svg {
+      button.kebab-menu-button--e-7v- svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR svg {
+        button.kebab-menu-button--e-7v- svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--ySFdR:hover {
+      button.kebab-menu-button--e-7v-:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--ySFdR:active,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+      button.kebab-menu-button--e-7v-:active,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR:active svg > circle,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--e-7v-:active svg > circle,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR:active,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+        button.kebab-menu-button--e-7v-:active,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--ySFdR:active svg > circle,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--e-7v-:active svg > circle,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--ySFdR > span {
+      button.kebab-menu-button--e-7v- > span {
         justify-content: center;
       }
 
       /* css-modules:src/common/components/cards/instance-details-footer */
-      .foot--WBFZ6 {
+      .foot--p1DfC {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1167,22 +1167,22 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj {
+      .foot--p1DfC .highlight-status--xJvvI {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj svg {
+      .foot--p1DfC .highlight-status--xJvvI svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--WBFZ6 .highlight-status--TYXPj svg {
+        .foot--p1DfC .highlight-status--xJvvI svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--WBFZ6 .highlight-status--TYXPj label {
+      .foot--p1DfC .highlight-status--xJvvI label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
@@ -1190,21 +1190,21 @@
       }
 
       /* css-modules:src/common/components/cards/instance-details-group */
-      ul.instance-details-list--bg-Zq {
+      ul.instance-details-list--YfkRy {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--bg-Zq > li {
+      ul.instance-details-list--YfkRy > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--bg-Zq > li:last-child {
+      ul.instance-details-list--YfkRy > li:last-child {
         margin-bottom: unset;
       }
 
       /* css-modules:src/common/components/cards/rule-resources */
-      .rule-more-resources--w4eYl {
+      .rule-more-resources--uw9mc {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1218,53 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
+      .rule-more-resources--uw9mc .more-resources-title--jOuUL {
         font-weight: 600;
       }
-      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
+      .rule-more-resources--uw9mc .rule-details-id--s-TpO {
         padding: 12px 0;
       }
 
       /* css-modules:src/common/components/cards/rules-with-instances */
-      .rule-details-group--ZuRYr .rule-detail {
+      .rule-details-group--Tb-LW .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
+      .rule-details-group--Tb-LW .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
+      .rule-details-group--Tb-LW .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-      .collapsible-rule-details-group--ODFPb {
+      .collapsible-rule-details-group--V-HWh {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--ODFPb .rule-detail {
+      .collapsible-rule-details-group--V-HWh .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
+      .collapsible-rule-details-group--V-HWh:not(.collapsed) {
         box-shadow: unset;
       }
 
       /* css-modules:src/common/components/cards/result-section-title */
-      .result-section-title--vgyHe {
+      .result-section-title--RGFI5 {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1272,49 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--vgyHe .title--6gdF5 {
+      .result-section-title--RGFI5 .title--WBYFE {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .heading--1Ll6- {
+      .result-section-title--RGFI5 .heading--NdP4Q {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
+      .result-section-title--RGFI5 .outcome-chip-container--BT3j5 {
         display: flex;
         height: 16px;
       }
 
       /* css-modules:src/common/components/cards/result-section */
-      .result-section--Av9vc {
+      .result-section--HfO9s {
         padding-bottom: 24px;
       }
-      .result-section--Av9vc
-        .title-container---R9Dm
-        .collapsible-control--5y7Tp::before {
+      .result-section--HfO9s
+        .title-container--JzN4A
+        .collapsible-control--e42Z7::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--Av9vc > h2 {
+      .result-section--HfO9s > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
 
       /* css-modules:src/reports/components/header-bar */
-      .report-header-bar--DNH-8 {
+      .report-header-bar--SDV11 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1323,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--DNH-8 .header-icon {
+      .report-header-bar--SDV11 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--DNH-8 .header-text--v-ac2 {
+      .report-header-bar--SDV11 .header-text--EdTxw {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1345,7 +1345,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/header-section */
-      .report-header-command-bar--8-nLy {
+      .report-header-command-bar--NJWdl {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1355,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX {
+      .report-header-command-bar--NJWdl .target-page--hjh44 {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1368,14 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX a {
+      .report-header-command-bar--NJWdl .target-page--hjh44 a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
       /* css-modules:src/common/components/cards/combined-report-result-section-title */
-      .combined-report-result-section-title--RNekd {
+      .combined-report-result-section-title--TqIZO {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1383,14 +1383,14 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--RNekd .title--CFcXZ {
+      .combined-report-result-section-title--TqIZO .title--6WIyt {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--RNekd .heading--gtY3F {
+      .combined-report-result-section-title--TqIZO .heading--UpAHf {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
@@ -1399,7 +1399,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/urls-summary-section */
-      .urls-summary-section--db4HQ {
+      .urls-summary-section--jNa-v {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1407,26 +1407,26 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--db4HQ h2 {
+      .urls-summary-section--jNa-v h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--db4HQ .total-urls--3pXYz {
+      .urls-summary-section--jNa-v .total-urls--95-ge {
         font-weight: 600;
       }
-      .urls-summary-section--db4HQ .failure-instances--y0Big {
+      .urls-summary-section--jNa-v .failure-instances--2WDtT {
         margin-top: 40px;
       }
-      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
+      .urls-summary-section--jNa-v .failure-outcome-chip--JF-lj {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
 
       /* css-modules:src/reports/components/report-sections/rules-results-container */
-      .rules-results-container--dO76T {
+      .rules-results-container--HaLDw {
         margin-top: 56px;
       }
-      .rules-results-container--dO76T .results-heading--2h1oe {
+      .rules-results-container--HaLDw .results-heading--H9Puz {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
@@ -1435,7 +1435,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/summary-report-details-section */
-      .crawl-details-section--jDqES {
+      .crawl-details-section--a6evz {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1443,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1453,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di li {
         display: inline-block;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
         li
-        .icon--enDUo {
+        .icon--APJEn {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
-        li.targetSite--M6DmE {
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
+        li.targetSite--wBJT- {
         margin-bottom: 6px;
       }
-      .crawl-details-section--jDqES .text--lxa-w,
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .text--rViTo,
+      .crawl-details-section--a6evz .label--DUNYf {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1480,30 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .label--DUNYf {
         font-weight: 600;
       }
-      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
+      .crawl-details-section--a6evz .label--DUNYf.no-icon--VrSr5 {
         padding-left: 29px;
       }
 
       /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
-      .url-result-section--Lsitd {
+      .url-result-section--SkOlZ {
         padding-bottom: 31px;
       }
-      .url-result-section--Lsitd
+      .url-result-section--SkOlZ
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--Lsitd .collapsible-content {
+      .url-result-section--SkOlZ .collapsible-content {
         margin-top: 19px;
       }
 
       /* css-modules:src/reports/components/report-sections/summary-results-table */
-      .summary-results-table--r6fvD {
+      .summary-results-table--Iezr- {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1512,39 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--r6fvD th,
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- th,
+      .summary-results-table--Iezr- td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--r6fvD th {
+      .summary-results-table--Iezr- th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--r6fvD thead tr :first-child {
+      .summary-results-table--Iezr- thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--r6fvD td.text-cell--luh34 {
+      .summary-results-table--Iezr- td.text-cell--EaUrM {
         overflow-wrap: break-word;
       }
-      .summary-results-table--r6fvD td.url-cell--ZGO-o {
+      .summary-results-table--Iezr- td.url-cell--mg-3l {
         overflow-wrap: anywhere;
       }
 
       /* css-modules:src/reports/components/report-sections/results-by-url-container */
-      .url-results-container--xiZ0N {
+      .url-results-container---dq9B {
         margin-top: 56px;
       }
-      .url-results-container--xiZ0N .results-heading--wmQ-W {
+      .url-results-container---dq9B .results-heading--2dWBX {
         margin-top: 32px;
         margin-bottom: 32px;
       }
 
       /* css-modules:src/common/components/cards/fix-instruction-color-box */
-      span.fix-instruction-color-box--lzu-L {
+      span.fix-instruction-color-box--DQpQE {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1552,7 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .screen-reader-only--T-59F {
+      .screen-reader-only--6LUiO {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1564,7 +1564,7 @@
     </style></head
   ><body
     ><header data-automation-id="report-header-section"
-      ><div class="report-header-bar--DNH-8"
+      ><div class="report-header-bar--SDV11"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1721,9 +1721,9 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--v-ac2">Accessibility Insights</div></div
-      ><div class="report-header-command-bar--8-nLy"
-        ><div class="target-page--q7WnX"
+        ><div class="header-text--EdTxw">Accessibility Insights</div></div
+      ><div class="report-header-command-bar--NJWdl"
+        ><div class="target-page--hjh44"
           >Target page: <a
             target="_blank"
             href="https://markreay.github.io/AU/after.html"
@@ -1904,14 +1904,14 @@
           ></div
         ><div class="results-container"
           ><div
-            class="failed-instances-container--pB-u4 result-section--Av9vc"
+            class="failed-instances-container--3UUNb result-section--HfO9s"
             data-automation-id="result-section"
-            ><h2 class="heading-element-for-level--wzmxK"
-              ><span class="result-section-title--vgyHe"
+            ><h2 class="heading-element-for-level--ifVX6"
+              ><span class="result-section-title--RGFI5"
                 ><span class="screen-reader-only">Failed instances 0</span
-                ><span class="title--6gdF5" aria-hidden="true"
+                ><span class="title--WBYFE" aria-hidden="true"
                   >Failed instances</span
-                ><span class="outcome-chip-container--iN0Tt" aria-hidden="true"
+                ><span class="outcome-chip-container--BT3j5" aria-hidden="true"
                   ><span class="outcome-chip outcome-chip-fail" title="0 Failed"
                     ><span class="icon"
                       ><span class="check-container"
@@ -1940,17 +1940,17 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="heading-element-for-level--wzmxK title-container"
+              ><h2 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-passed-checks-section"
-                  ><span class="result-section-title--vgyHe"
+                  ><span class="result-section-title--RGFI5"
                     ><span class="screen-reader-only">Passed checks 44</span
-                    ><span class="title--6gdF5" aria-hidden="true"
+                    ><span class="title--WBYFE" aria-hidden="true"
                       >Passed checks</span
                     ><span
-                      class="outcome-chip-container--iN0Tt"
+                      class="outcome-chip-container--BT3j5"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-pass"
@@ -1991,7 +1991,7 @@
                 id="content-container-passed-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--ZuRYr"
+                ><div class="rule-details-group--Tb-LW"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -3127,18 +3127,18 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="heading-element-for-level--wzmxK title-container"
+              ><h2 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-not-applicable-checks-section"
-                  ><span class="result-section-title--vgyHe"
+                  ><span class="result-section-title--RGFI5"
                     ><span class="screen-reader-only"
                       >Not applicable checks 26</span
-                    ><span class="title--6gdF5" aria-hidden="true"
+                    ><span class="title--WBYFE" aria-hidden="true"
                       >Not applicable checks</span
                     ><span
-                      class="outcome-chip-container--iN0Tt"
+                      class="outcome-chip-container--BT3j5"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-inapplicable"
@@ -3184,7 +3184,7 @@
                 id="content-container-not-applicable-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--ZuRYr"
+                ><div class="rule-details-group--Tb-LW"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -834,24 +834,30 @@
         margin-bottom: unset;
       }</style
     ><style>
-      .heading-element-for-level--OfRDW {
+      /* css-modules:src/common/components/heading-element-for-level */
+      .heading-element-for-level--wzmxK {
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      .failed-instances-container--FqWV6 .collapsible-content {
+
+      /* css-modules:src/common/components/cards/failed-instances-section */
+      .failed-instances-container--pB-u4 .collapsible-content {
         margin-left: 24px;
       }
-      .outcome-chip-container--xYquF {
+
+      /* css-modules:src/reports/components/report-sections/minimal-rule-header */
+      .outcome-chip-container--ja0WM {
         min-width: 50px;
       }
-      .hidden-highlight-button--PePzJ {
+
+      /* css-modules:src/reports/components/instance-details */
+      .hidden-highlight-button--to41b {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-
-      .instance-details-card--R0aAh {
+      .instance-details-card--lixTP {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -859,55 +865,44 @@
           0 3.2px 7.2px var(--box-shadow-132);
         margin-bottom: 16px;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
       }
-
-      .instance-details-card-container--bKrcd.selected--Kp4AC {
+      .instance-details-card-container--Hjwps.selected--Pf-DQ {
         outline: 5px solid var(--communication-tint-10);
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC {
+      .instance-details-card--lixTP.selected--Pf-DQ {
         border: 1px solid transparent;
       }
-
-      .instance-details-card--R0aAh.focused--tV0ic,
-      .instance-details-card--R0aAh:focus {
+      .instance-details-card--lixTP.focused--PfWGT,
+      .instance-details-card--lixTP:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC.focused--tV0ic,
-      .instance-details-card--R0aAh.selected--Kp4AC:focus {
+      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
+      .instance-details-card--lixTP.selected--Pf-DQ:focus {
         outline-offset: 8px;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy {
+      .instance-details-card--lixTP.interactive--su6Sw {
         cursor: pointer;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy:hover {
+      .instance-details-card--lixTP.interactive--su6Sw:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-
-      .report-instance-table--YIu0s {
+      .report-instance-table--YOlnT {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
         border-radius: inherit;
         border-collapse: collapse;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YIu0s .row--m8TLI {
+      .report-instance-table--YOlnT .row--9WgHa {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -916,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YIu0s .row--m8TLI > * {
+      .report-instance-table--YOlnT .row--9WgHa > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YIu0s .row--m8TLI:last-child {
+      .report-instance-table--YOlnT .row--9WgHa:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YIu0s .row-label--MxfuQ {
+      .report-instance-table--YOlnT .row-label--dri3e {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -936,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YIu0s .row-content--ECKwg {
+      .report-instance-table--YOlnT .row-content--Gt-CK {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -946,41 +941,44 @@
         align-items: flex-end;
         display: flex;
       }
-      .multi-line-text-no-bullet--lNJS_ {
+
+      /* css-modules:src/common/components/cards/rich-resolution-content */
+      .multi-line-text-no-bullet--xUzJx {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--lNJS_ li:not(:last-child) {
+      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
         margin-bottom: 4px;
       }
-
-      .multi-line-text-yes-bullet--pp76P {
+      .multi-line-text-yes-bullet--jH-w4 {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--pp76P li {
+      .multi-line-text-yes-bullet--jH-w4 li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .combination-lists--O1dD_ {
+      .combination-lists--4wBYq {
         flex-direction: column;
         display: flex;
       }
-      .urls-row-content--MxcA7 {
+
+      /* css-modules:src/common/components/cards/urls-card-row */
+      .urls-row-content--rj2oy {
         padding-left: 16px;
       }
-      .urls-row-content--MxcA7 li {
+      .urls-row-content--rj2oy li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .urls-row-content-new-Failure--uJPP3 {
+      .urls-row-content-new-Failure--7Dq38 {
         color: var(--negative-outcome);
         font-weight: bold;
       }
-      .insights-fix-instruction-list--G3vyY
+
+      /* css-modules:src/common/components/fix-instruction-panel */
+      .insights-fix-instruction-list--NaN2O
         li
-        span.fix-instruction-color-box--g6NfJ {
+        span.fix-instruction-color-box---mQtG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -988,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--G3vyY .screen-reader-only--yQjgp {
+      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,64 +994,75 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
-      .how-to-fix-content--OHBLC {
+
+      /* css-modules:src/common/components/cards/how-to-fix-card-row */
+      .how-to-fix-content--Xj-BH {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--OHBLC ul {
+      .how-to-fix-content--Xj-BH ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--OHBLC ul li {
+      .how-to-fix-content--Xj-BH ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .snippet--wZrK1 {
+
+      /* css-modules:src/common/components/cards/snippet-card-row */
+      .snippet--P6i7P {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
-      div.insights-dialog-main-override--Mlek6 {
+
+      /* css-modules:src/DetailsView/components/common-dialog-styles */
+      div.insights-dialog-main-override--qzZJk {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--Mlek6 {
+        div.insights-dialog-main-override--qzZJk {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--Mlek6 .dialog-body--QtJ_D {
+      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
         font-size: 16px;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-title {
+
+      /* css-modules:src/DetailsView/components/issue-filing-dialog */
+      .issue-filing-dialog--l9xMr .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-subText {
+      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--ZrD5s .textfield-description {
+      .issue-filing-dialog--l9xMr .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
-      .action-and-cancel-buttons-component--HOvON {
+
+      /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
+      .action-and-cancel-buttons-component--5-uZX {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--HOvON
-        .action-cancel-button-col--VrVAp
-        + .action-cancel-button-col--VrVAp {
+      .action-and-cancel-buttons-component--5-uZX
+        .action-cancel-button-col--txH36
+        + .action-cancel-button-col--txH36 {
         margin-left: 8px;
       }
-      .toast-container--KsxE1 {
+
+      /* css-modules:src/common/components/toast */
+      .toast-container--cNX98 {
         display: inline-block;
       }
-
-      .toast-content--pEpMJ {
+      .toast-content--bk935 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1068,84 +1077,86 @@
         z-index: 1000;
         position: absolute;
       }
-      div.kebab-menu-callout--o23oT {
+
+      /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      div.kebab-menu-callout--A3AHu {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--o23oT > div {
+      div.kebab-menu-callout--A3AHu > div {
         border-radius: 4px;
       }
-
-      .kebab-menu--eviKu {
+      .kebab-menu--Bm5S1 {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--eviKu li {
+      .kebab-menu--Bm5S1 li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--eviKu button i {
+      .kebab-menu--Bm5S1 button i {
         color: var(--primary-text);
       }
-      .kebab-menu--eviKu button:hover {
+      .kebab-menu--Bm5S1 button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--eviKu button:hover {
+        .kebab-menu--Bm5S1 button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--eviKu button:active {
+      .kebab-menu--Bm5S1 button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--eviKu button:active i {
+      .kebab-menu--Bm5S1 button:active i {
         color: var(--light-black);
       }
-
-      button.kebab-menu-button--dy7Ui {
+      button.kebab-menu-button--ySFdR {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--dy7Ui svg {
+      button.kebab-menu-button--ySFdR svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui svg {
+        button.kebab-menu-button--ySFdR svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--dy7Ui:hover {
+      button.kebab-menu-button--ySFdR:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--dy7Ui:active,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+      button.kebab-menu-button--ySFdR:active,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--dy7Ui:active svg > circle,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--ySFdR:active svg > circle,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui:active,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+        button.kebab-menu-button--ySFdR:active,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--dy7Ui:active svg > circle,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--ySFdR:active svg > circle,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--dy7Ui > span {
+      button.kebab-menu-button--ySFdR > span {
         justify-content: center;
       }
-      .foot--d1w5m {
+
+      /* css-modules:src/common/components/cards/instance-details-footer */
+      .foot--WBFZ6 {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1156,40 +1167,44 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--d1w5m .highlight-status--Bmqfx {
+      .foot--WBFZ6 .highlight-status--TYXPj {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--d1w5m .highlight-status--Bmqfx svg {
+      .foot--WBFZ6 .highlight-status--TYXPj svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--d1w5m .highlight-status--Bmqfx svg {
+        .foot--WBFZ6 .highlight-status--TYXPj svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--d1w5m .highlight-status--Bmqfx label {
+      .foot--WBFZ6 .highlight-status--TYXPj label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      ul.instance-details-list--xiPPL {
+
+      /* css-modules:src/common/components/cards/instance-details-group */
+      ul.instance-details-list--bg-Zq {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--xiPPL > li {
+      ul.instance-details-list--bg-Zq > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--xiPPL > li:last-child {
+      ul.instance-details-list--bg-Zq > li:last-child {
         margin-bottom: unset;
       }
-      .rule-more-resources--Bsblo {
+
+      /* css-modules:src/common/components/cards/rule-resources */
+      .rule-more-resources--w4eYl {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1203,50 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--Bsblo .more-resources-title--whTFs {
+      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
         font-weight: 600;
       }
-      .rule-more-resources--Bsblo .rule-details-id--n_S89 {
+      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
         padding: 12px 0;
       }
-      .rule-details-group--U69fz .rule-detail {
+
+      /* css-modules:src/common/components/cards/rules-with-instances */
+      .rule-details-group--ZuRYr .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--U69fz .rule-detail .outcome-chip {
+      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id a {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--U69fz .rule-detail .rule-detail-description {
+      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-
-      .collapsible-rule-details-group--h0lvd {
+      .collapsible-rule-details-group--ODFPb {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--h0lvd .rule-detail {
+      .collapsible-rule-details-group--ODFPb .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--h0lvd:not(.collapsed) {
+      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
         box-shadow: unset;
       }
-      .result-section-title--qv3MK {
+
+      /* css-modules:src/common/components/cards/result-section-title */
+      .result-section-title--vgyHe {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1254,45 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--qv3MK .title--neMma {
+      .result-section-title--vgyHe .title--6gdF5 {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .heading--VbGap {
+      .result-section-title--vgyHe .heading--1Ll6- {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .outcome-chip-container--Wt0k4 {
+      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
         display: flex;
         height: 16px;
       }
-      .result-section--j6fYr {
+
+      /* css-modules:src/common/components/cards/result-section */
+      .result-section--Av9vc {
         padding-bottom: 24px;
       }
-      .result-section--j6fYr
-        .title-container--gMYqW
-        .collapsible-control--V9OlA::before {
+      .result-section--Av9vc
+        .title-container---R9Dm
+        .collapsible-control--5y7Tp::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--j6fYr > h2 {
+      .result-section--Av9vc > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-bar--pkiTM {
+
+      /* css-modules:src/reports/components/header-bar */
+      .report-header-bar--DNH-8 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1301,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--pkiTM .header-icon {
+      .report-header-bar--DNH-8 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--pkiTM .header-text--dfm48 {
+      .report-header-bar--DNH-8 .header-text--v-ac2 {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1321,7 +1343,9 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-command-bar--wDg1t {
+
+      /* css-modules:src/reports/components/report-sections/header-section */
+      .report-header-command-bar--8-nLy {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1331,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--wDg1t .target-page--giudb {
+      .report-header-command-bar--8-nLy .target-page--q7WnX {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1344,12 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
+      .report-header-command-bar--8-nLy .target-page--q7WnX a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      .combined-report-result-section-title--XUDDo {
+
+      /* css-modules:src/common/components/cards/combined-report-result-section-title */
+      .combined-report-result-section-title--RNekd {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1357,21 +1383,23 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--XUDDo .title--lcuIW {
+      .combined-report-result-section-title--RNekd .title--CFcXZ {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--XUDDo .heading--uUq3e {
+      .combined-report-result-section-title--RNekd .heading--gtY3F {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .urls-summary-section--DjUWc {
+
+      /* css-modules:src/reports/components/report-sections/urls-summary-section */
+      .urls-summary-section--db4HQ {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1379,31 +1407,35 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--DjUWc h2 {
+      .urls-summary-section--db4HQ h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--DjUWc .total-urls--Ig_eB {
+      .urls-summary-section--db4HQ .total-urls--3pXYz {
         font-weight: 600;
       }
-      .urls-summary-section--DjUWc .failure-instances--Rq_Tj {
+      .urls-summary-section--db4HQ .failure-instances--y0Big {
         margin-top: 40px;
       }
-      .urls-summary-section--DjUWc .failure-outcome-chip--YtjBX {
+      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
-      .rules-results-container--n7EEu {
+
+      /* css-modules:src/reports/components/report-sections/rules-results-container */
+      .rules-results-container--dO76T {
         margin-top: 56px;
       }
-      .rules-results-container--n7EEu .results-heading--pyS7R {
+      .rules-results-container--dO76T .results-heading--2h1oe {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
       }
-      .crawl-details-section--WhRL4 {
+
+      /* css-modules:src/reports/components/report-sections/summary-report-details-section */
+      .crawl-details-section--jDqES {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1411,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1421,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg li {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
         display: inline-block;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
         li
-        .icon--JdMPq {
+        .icon--enDUo {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
-        li.targetSite--qXxid {
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
+        li.targetSite--M6DmE {
         margin-bottom: 6px;
       }
-      .crawl-details-section--WhRL4 .text--swxfX,
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .text--lxa-w,
+      .crawl-details-section--jDqES .label--TrLq3 {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1448,26 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .label--TrLq3 {
         font-weight: 600;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2.no-icon--J7B9N {
+      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
         padding-left: 29px;
       }
-      .url-result-section--PmEoY {
+
+      /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
+      .url-result-section--Lsitd {
         padding-bottom: 31px;
       }
-      .url-result-section--PmEoY
+      .url-result-section--Lsitd
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--PmEoY .collapsible-content {
+      .url-result-section--Lsitd .collapsible-content {
         margin-top: 19px;
       }
-      .summary-results-table--Pb4_B {
+
+      /* css-modules:src/reports/components/report-sections/summary-results-table */
+      .summary-results-table--r6fvD {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1476,35 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--Pb4_B th,
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD th,
+      .summary-results-table--r6fvD td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--Pb4_B th {
+      .summary-results-table--r6fvD th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--Pb4_B thead tr :first-child {
+      .summary-results-table--r6fvD thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--Pb4_B td.text-cell--p0dxL {
+      .summary-results-table--r6fvD td.text-cell--luh34 {
         overflow-wrap: break-word;
       }
-      .summary-results-table--Pb4_B td.url-cell--yjU1V {
+      .summary-results-table--r6fvD td.url-cell--ZGO-o {
         overflow-wrap: anywhere;
       }
-      .url-results-container--dXQbj {
+
+      /* css-modules:src/reports/components/report-sections/results-by-url-container */
+      .url-results-container--xiZ0N {
         margin-top: 56px;
       }
-      .url-results-container--dXQbj .results-heading--D3Qtr {
+      .url-results-container--xiZ0N .results-heading--wmQ-W {
         margin-top: 32px;
         margin-bottom: 32px;
       }
-      span.fix-instruction-color-box--Xq1E4 {
+
+      /* css-modules:src/common/components/cards/fix-instruction-color-box */
+      span.fix-instruction-color-box--lzu-L {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1512,8 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-
-      .screen-reader-only--n1Ocs {
+      .screen-reader-only--T-59F {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1521,10 +1560,11 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
+      /*# sourceMappingURL=report.css.map */
     </style></head
   ><body
     ><header data-automation-id="report-header-section"
-      ><div class="report-header-bar--pkiTM"
+      ><div class="report-header-bar--DNH-8"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1681,9 +1721,9 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--dfm48">Accessibility Insights</div></div
-      ><div class="report-header-command-bar--wDg1t"
-        ><div class="target-page--giudb"
+        ><div class="header-text--v-ac2">Accessibility Insights</div></div
+      ><div class="report-header-command-bar--8-nLy"
+        ><div class="target-page--q7WnX"
           >Target page: <a
             target="_blank"
             href="https://markreay.github.io/AU/after.html"
@@ -1696,9 +1736,7 @@
               var targetPageLink = doc.getElementById(linkId);
               targetPageLink.addEventListener("click", function (event) {
                 var result = confirmCallback(
-                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                    "Cancel to stay on the current page."
+                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                 );
                 if (result === false) {
                   event.preventDefault();
@@ -1745,9 +1783,7 @@
                     var targetPageLink = doc.getElementById(linkId);
                     targetPageLink.addEventListener("click", function (event) {
                       var result = confirmCallback(
-                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                          "Cancel to stay on the current page."
+                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                       );
                       if (result === false) {
                         event.preventDefault();
@@ -1868,14 +1904,14 @@
           ></div
         ><div class="results-container"
           ><div
-            class="failed-instances-container--FqWV6 result-section--j6fYr"
+            class="failed-instances-container--pB-u4 result-section--Av9vc"
             data-automation-id="result-section"
-            ><h2 class="heading-element-for-level--OfRDW"
-              ><span class="result-section-title--qv3MK"
+            ><h2 class="heading-element-for-level--wzmxK"
+              ><span class="result-section-title--vgyHe"
                 ><span class="screen-reader-only">Failed instances 0</span
-                ><span class="title--neMma" aria-hidden="true"
+                ><span class="title--6gdF5" aria-hidden="true"
                   >Failed instances</span
-                ><span class="outcome-chip-container--Wt0k4" aria-hidden="true"
+                ><span class="outcome-chip-container--iN0Tt" aria-hidden="true"
                   ><span class="outcome-chip outcome-chip-fail" title="0 Failed"
                     ><span class="icon"
                       ><span class="check-container"
@@ -1904,17 +1940,17 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="heading-element-for-level--OfRDW title-container"
+              ><h2 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-passed-checks-section"
-                  ><span class="result-section-title--qv3MK"
+                  ><span class="result-section-title--vgyHe"
                     ><span class="screen-reader-only">Passed checks 44</span
-                    ><span class="title--neMma" aria-hidden="true"
+                    ><span class="title--6gdF5" aria-hidden="true"
                       >Passed checks</span
                     ><span
-                      class="outcome-chip-container--Wt0k4"
+                      class="outcome-chip-container--iN0Tt"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-pass"
@@ -1955,7 +1991,7 @@
                 id="content-container-passed-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--U69fz"
+                ><div class="rule-details-group--ZuRYr"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -3091,18 +3127,18 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h2 class="heading-element-for-level--OfRDW title-container"
+              ><h2 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-not-applicable-checks-section"
-                  ><span class="result-section-title--qv3MK"
+                  ><span class="result-section-title--vgyHe"
                     ><span class="screen-reader-only"
                       >Not applicable checks 26</span
-                    ><span class="title--neMma" aria-hidden="true"
+                    ><span class="title--6gdF5" aria-hidden="true"
                       >Not applicable checks</span
                     ><span
-                      class="outcome-chip-container--Wt0k4"
+                      class="outcome-chip-container--iN0Tt"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-inapplicable"
@@ -3148,7 +3184,7 @@
                 id="content-container-not-applicable-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--U69fz"
+                ><div class="rule-details-group--ZuRYr"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -3837,7 +3873,7 @@
             var _loop = function (index) {
               var container = collapsibles.item(index);
               var button =
-                container === null || container === void 0
+                container == null
                   ? void 0
                   : container.querySelector(".collapsible-control");
               if (button == null) {
@@ -3846,7 +3882,7 @@
               button.addEventListener("click", function () {
                 var _a;
                 var content =
-                  (_a = button.parentElement) === null || _a === void 0
+                  (_a = button.parentElement) == null
                     ? void 0
                     : _a.nextElementSibling;
                 if (content == null) {

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -834,24 +834,30 @@
         margin-bottom: unset;
       }</style
     ><style>
-      .heading-element-for-level--OfRDW {
+      /* css-modules:src/common/components/heading-element-for-level */
+      .heading-element-for-level--wzmxK {
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      .failed-instances-container--FqWV6 .collapsible-content {
+
+      /* css-modules:src/common/components/cards/failed-instances-section */
+      .failed-instances-container--pB-u4 .collapsible-content {
         margin-left: 24px;
       }
-      .outcome-chip-container--xYquF {
+
+      /* css-modules:src/reports/components/report-sections/minimal-rule-header */
+      .outcome-chip-container--ja0WM {
         min-width: 50px;
       }
-      .hidden-highlight-button--PePzJ {
+
+      /* css-modules:src/reports/components/instance-details */
+      .hidden-highlight-button--to41b {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-
-      .instance-details-card--R0aAh {
+      .instance-details-card--lixTP {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -859,55 +865,44 @@
           0 3.2px 7.2px var(--box-shadow-132);
         margin-bottom: 16px;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
       }
-
-      .instance-details-card-container--bKrcd.selected--Kp4AC {
+      .instance-details-card-container--Hjwps.selected--Pf-DQ {
         outline: 5px solid var(--communication-tint-10);
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC {
+      .instance-details-card--lixTP.selected--Pf-DQ {
         border: 1px solid transparent;
       }
-
-      .instance-details-card--R0aAh.focused--tV0ic,
-      .instance-details-card--R0aAh:focus {
+      .instance-details-card--lixTP.focused--PfWGT,
+      .instance-details-card--lixTP:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC.focused--tV0ic,
-      .instance-details-card--R0aAh.selected--Kp4AC:focus {
+      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
+      .instance-details-card--lixTP.selected--Pf-DQ:focus {
         outline-offset: 8px;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy {
+      .instance-details-card--lixTP.interactive--su6Sw {
         cursor: pointer;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy:hover {
+      .instance-details-card--lixTP.interactive--su6Sw:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-
-      .report-instance-table--YIu0s {
+      .report-instance-table--YOlnT {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
         border-radius: inherit;
         border-collapse: collapse;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YIu0s .row--m8TLI {
+      .report-instance-table--YOlnT .row--9WgHa {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -916,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YIu0s .row--m8TLI > * {
+      .report-instance-table--YOlnT .row--9WgHa > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YIu0s .row--m8TLI:last-child {
+      .report-instance-table--YOlnT .row--9WgHa:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YIu0s .row-label--MxfuQ {
+      .report-instance-table--YOlnT .row-label--dri3e {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -936,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YIu0s .row-content--ECKwg {
+      .report-instance-table--YOlnT .row-content--Gt-CK {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -946,41 +941,44 @@
         align-items: flex-end;
         display: flex;
       }
-      .multi-line-text-no-bullet--lNJS_ {
+
+      /* css-modules:src/common/components/cards/rich-resolution-content */
+      .multi-line-text-no-bullet--xUzJx {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--lNJS_ li:not(:last-child) {
+      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
         margin-bottom: 4px;
       }
-
-      .multi-line-text-yes-bullet--pp76P {
+      .multi-line-text-yes-bullet--jH-w4 {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--pp76P li {
+      .multi-line-text-yes-bullet--jH-w4 li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .combination-lists--O1dD_ {
+      .combination-lists--4wBYq {
         flex-direction: column;
         display: flex;
       }
-      .urls-row-content--MxcA7 {
+
+      /* css-modules:src/common/components/cards/urls-card-row */
+      .urls-row-content--rj2oy {
         padding-left: 16px;
       }
-      .urls-row-content--MxcA7 li {
+      .urls-row-content--rj2oy li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .urls-row-content-new-Failure--uJPP3 {
+      .urls-row-content-new-Failure--7Dq38 {
         color: var(--negative-outcome);
         font-weight: bold;
       }
-      .insights-fix-instruction-list--G3vyY
+
+      /* css-modules:src/common/components/fix-instruction-panel */
+      .insights-fix-instruction-list--NaN2O
         li
-        span.fix-instruction-color-box--g6NfJ {
+        span.fix-instruction-color-box---mQtG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -988,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--G3vyY .screen-reader-only--yQjgp {
+      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,64 +994,75 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
-      .how-to-fix-content--OHBLC {
+
+      /* css-modules:src/common/components/cards/how-to-fix-card-row */
+      .how-to-fix-content--Xj-BH {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--OHBLC ul {
+      .how-to-fix-content--Xj-BH ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--OHBLC ul li {
+      .how-to-fix-content--Xj-BH ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .snippet--wZrK1 {
+
+      /* css-modules:src/common/components/cards/snippet-card-row */
+      .snippet--P6i7P {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
-      div.insights-dialog-main-override--Mlek6 {
+
+      /* css-modules:src/DetailsView/components/common-dialog-styles */
+      div.insights-dialog-main-override--qzZJk {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--Mlek6 {
+        div.insights-dialog-main-override--qzZJk {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--Mlek6 .dialog-body--QtJ_D {
+      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
         font-size: 16px;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-title {
+
+      /* css-modules:src/DetailsView/components/issue-filing-dialog */
+      .issue-filing-dialog--l9xMr .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-subText {
+      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--ZrD5s .textfield-description {
+      .issue-filing-dialog--l9xMr .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
-      .action-and-cancel-buttons-component--HOvON {
+
+      /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
+      .action-and-cancel-buttons-component--5-uZX {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--HOvON
-        .action-cancel-button-col--VrVAp
-        + .action-cancel-button-col--VrVAp {
+      .action-and-cancel-buttons-component--5-uZX
+        .action-cancel-button-col--txH36
+        + .action-cancel-button-col--txH36 {
         margin-left: 8px;
       }
-      .toast-container--KsxE1 {
+
+      /* css-modules:src/common/components/toast */
+      .toast-container--cNX98 {
         display: inline-block;
       }
-
-      .toast-content--pEpMJ {
+      .toast-content--bk935 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1068,84 +1077,86 @@
         z-index: 1000;
         position: absolute;
       }
-      div.kebab-menu-callout--o23oT {
+
+      /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      div.kebab-menu-callout--A3AHu {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--o23oT > div {
+      div.kebab-menu-callout--A3AHu > div {
         border-radius: 4px;
       }
-
-      .kebab-menu--eviKu {
+      .kebab-menu--Bm5S1 {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--eviKu li {
+      .kebab-menu--Bm5S1 li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--eviKu button i {
+      .kebab-menu--Bm5S1 button i {
         color: var(--primary-text);
       }
-      .kebab-menu--eviKu button:hover {
+      .kebab-menu--Bm5S1 button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--eviKu button:hover {
+        .kebab-menu--Bm5S1 button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--eviKu button:active {
+      .kebab-menu--Bm5S1 button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--eviKu button:active i {
+      .kebab-menu--Bm5S1 button:active i {
         color: var(--light-black);
       }
-
-      button.kebab-menu-button--dy7Ui {
+      button.kebab-menu-button--ySFdR {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--dy7Ui svg {
+      button.kebab-menu-button--ySFdR svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui svg {
+        button.kebab-menu-button--ySFdR svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--dy7Ui:hover {
+      button.kebab-menu-button--ySFdR:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--dy7Ui:active,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+      button.kebab-menu-button--ySFdR:active,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--dy7Ui:active svg > circle,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--ySFdR:active svg > circle,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui:active,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+        button.kebab-menu-button--ySFdR:active,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--dy7Ui:active svg > circle,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--ySFdR:active svg > circle,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--dy7Ui > span {
+      button.kebab-menu-button--ySFdR > span {
         justify-content: center;
       }
-      .foot--d1w5m {
+
+      /* css-modules:src/common/components/cards/instance-details-footer */
+      .foot--WBFZ6 {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1156,40 +1167,44 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--d1w5m .highlight-status--Bmqfx {
+      .foot--WBFZ6 .highlight-status--TYXPj {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--d1w5m .highlight-status--Bmqfx svg {
+      .foot--WBFZ6 .highlight-status--TYXPj svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--d1w5m .highlight-status--Bmqfx svg {
+        .foot--WBFZ6 .highlight-status--TYXPj svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--d1w5m .highlight-status--Bmqfx label {
+      .foot--WBFZ6 .highlight-status--TYXPj label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      ul.instance-details-list--xiPPL {
+
+      /* css-modules:src/common/components/cards/instance-details-group */
+      ul.instance-details-list--bg-Zq {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--xiPPL > li {
+      ul.instance-details-list--bg-Zq > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--xiPPL > li:last-child {
+      ul.instance-details-list--bg-Zq > li:last-child {
         margin-bottom: unset;
       }
-      .rule-more-resources--Bsblo {
+
+      /* css-modules:src/common/components/cards/rule-resources */
+      .rule-more-resources--w4eYl {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1203,50 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--Bsblo .more-resources-title--whTFs {
+      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
         font-weight: 600;
       }
-      .rule-more-resources--Bsblo .rule-details-id--n_S89 {
+      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
         padding: 12px 0;
       }
-      .rule-details-group--U69fz .rule-detail {
+
+      /* css-modules:src/common/components/cards/rules-with-instances */
+      .rule-details-group--ZuRYr .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--U69fz .rule-detail .outcome-chip {
+      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id a {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--U69fz .rule-detail .rule-detail-description {
+      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-
-      .collapsible-rule-details-group--h0lvd {
+      .collapsible-rule-details-group--ODFPb {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--h0lvd .rule-detail {
+      .collapsible-rule-details-group--ODFPb .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--h0lvd:not(.collapsed) {
+      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
         box-shadow: unset;
       }
-      .result-section-title--qv3MK {
+
+      /* css-modules:src/common/components/cards/result-section-title */
+      .result-section-title--vgyHe {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1254,45 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--qv3MK .title--neMma {
+      .result-section-title--vgyHe .title--6gdF5 {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .heading--VbGap {
+      .result-section-title--vgyHe .heading--1Ll6- {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .outcome-chip-container--Wt0k4 {
+      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
         display: flex;
         height: 16px;
       }
-      .result-section--j6fYr {
+
+      /* css-modules:src/common/components/cards/result-section */
+      .result-section--Av9vc {
         padding-bottom: 24px;
       }
-      .result-section--j6fYr
-        .title-container--gMYqW
-        .collapsible-control--V9OlA::before {
+      .result-section--Av9vc
+        .title-container---R9Dm
+        .collapsible-control--5y7Tp::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--j6fYr > h2 {
+      .result-section--Av9vc > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-bar--pkiTM {
+
+      /* css-modules:src/reports/components/header-bar */
+      .report-header-bar--DNH-8 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1301,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--pkiTM .header-icon {
+      .report-header-bar--DNH-8 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--pkiTM .header-text--dfm48 {
+      .report-header-bar--DNH-8 .header-text--v-ac2 {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1321,7 +1343,9 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-command-bar--wDg1t {
+
+      /* css-modules:src/reports/components/report-sections/header-section */
+      .report-header-command-bar--8-nLy {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1331,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--wDg1t .target-page--giudb {
+      .report-header-command-bar--8-nLy .target-page--q7WnX {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1344,12 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
+      .report-header-command-bar--8-nLy .target-page--q7WnX a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      .combined-report-result-section-title--XUDDo {
+
+      /* css-modules:src/common/components/cards/combined-report-result-section-title */
+      .combined-report-result-section-title--RNekd {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1357,21 +1383,23 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--XUDDo .title--lcuIW {
+      .combined-report-result-section-title--RNekd .title--CFcXZ {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--XUDDo .heading--uUq3e {
+      .combined-report-result-section-title--RNekd .heading--gtY3F {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .urls-summary-section--DjUWc {
+
+      /* css-modules:src/reports/components/report-sections/urls-summary-section */
+      .urls-summary-section--db4HQ {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1379,31 +1407,35 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--DjUWc h2 {
+      .urls-summary-section--db4HQ h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--DjUWc .total-urls--Ig_eB {
+      .urls-summary-section--db4HQ .total-urls--3pXYz {
         font-weight: 600;
       }
-      .urls-summary-section--DjUWc .failure-instances--Rq_Tj {
+      .urls-summary-section--db4HQ .failure-instances--y0Big {
         margin-top: 40px;
       }
-      .urls-summary-section--DjUWc .failure-outcome-chip--YtjBX {
+      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
-      .rules-results-container--n7EEu {
+
+      /* css-modules:src/reports/components/report-sections/rules-results-container */
+      .rules-results-container--dO76T {
         margin-top: 56px;
       }
-      .rules-results-container--n7EEu .results-heading--pyS7R {
+      .rules-results-container--dO76T .results-heading--2h1oe {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
       }
-      .crawl-details-section--WhRL4 {
+
+      /* css-modules:src/reports/components/report-sections/summary-report-details-section */
+      .crawl-details-section--jDqES {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1411,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1421,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg li {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
         display: inline-block;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
         li
-        .icon--JdMPq {
+        .icon--enDUo {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
-        li.targetSite--qXxid {
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
+        li.targetSite--M6DmE {
         margin-bottom: 6px;
       }
-      .crawl-details-section--WhRL4 .text--swxfX,
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .text--lxa-w,
+      .crawl-details-section--jDqES .label--TrLq3 {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1448,26 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .label--TrLq3 {
         font-weight: 600;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2.no-icon--J7B9N {
+      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
         padding-left: 29px;
       }
-      .url-result-section--PmEoY {
+
+      /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
+      .url-result-section--Lsitd {
         padding-bottom: 31px;
       }
-      .url-result-section--PmEoY
+      .url-result-section--Lsitd
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--PmEoY .collapsible-content {
+      .url-result-section--Lsitd .collapsible-content {
         margin-top: 19px;
       }
-      .summary-results-table--Pb4_B {
+
+      /* css-modules:src/reports/components/report-sections/summary-results-table */
+      .summary-results-table--r6fvD {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1476,35 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--Pb4_B th,
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD th,
+      .summary-results-table--r6fvD td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--Pb4_B th {
+      .summary-results-table--r6fvD th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--Pb4_B thead tr :first-child {
+      .summary-results-table--r6fvD thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--Pb4_B td.text-cell--p0dxL {
+      .summary-results-table--r6fvD td.text-cell--luh34 {
         overflow-wrap: break-word;
       }
-      .summary-results-table--Pb4_B td.url-cell--yjU1V {
+      .summary-results-table--r6fvD td.url-cell--ZGO-o {
         overflow-wrap: anywhere;
       }
-      .url-results-container--dXQbj {
+
+      /* css-modules:src/reports/components/report-sections/results-by-url-container */
+      .url-results-container--xiZ0N {
         margin-top: 56px;
       }
-      .url-results-container--dXQbj .results-heading--D3Qtr {
+      .url-results-container--xiZ0N .results-heading--wmQ-W {
         margin-top: 32px;
         margin-bottom: 32px;
       }
-      span.fix-instruction-color-box--Xq1E4 {
+
+      /* css-modules:src/common/components/cards/fix-instruction-color-box */
+      span.fix-instruction-color-box--lzu-L {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1512,8 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-
-      .screen-reader-only--n1Ocs {
+      .screen-reader-only--T-59F {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1521,10 +1560,11 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
+      /*# sourceMappingURL=report.css.map */
     </style></head
   ><body
     ><header
-      ><div class="report-header-bar--pkiTM"
+      ><div class="report-header-bar--DNH-8"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1681,16 +1721,16 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--dfm48">Accessibility Insights</div></div
+        ><div class="header-text--v-ac2">Accessibility Insights</div></div
       ></header
     ><main class="outer-container"
       ><div class="content-container"
         ><div class="title-section"><h1>Automated checks results</h1></div
-        ><div class="crawl-details-section--WhRL4"
+        ><div class="crawl-details-section--jDqES"
           ><h2>Scan details</h2
-          ><ul class="crawl-details-section-list--Lrjqg"
-            ><li class="targetSite--qXxid"
-              ><span class="icon--JdMPq" aria-hidden="true"
+          ><ul class="crawl-details-section-list--6FyX-"
+            ><li class="targetSite--M6DmE"
+              ><span class="icon--enDUo" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1702,8 +1742,8 @@
                     d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--yUuT2">Target site </span
-              ><span class="text--swxfX"
+              ><span class="label--TrLq3">Target site </span
+              ><span class="text--lxa-w"
                 ><a
                   target="_blank"
                   href="https://example.com/mock-base-url"
@@ -1720,9 +1760,7 @@
                     var targetPageLink = doc.getElementById(linkId);
                     targetPageLink.addEventListener("click", function (event) {
                       var result = confirmCallback(
-                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                          "Cancel to stay on the current page."
+                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                       );
                       if (result === false) {
                         event.preventDefault();
@@ -1736,7 +1774,7 @@
                 </script></span
               ></li
             ><li
-              ><span class="icon--JdMPq" aria-hidden="true"
+              ><span class="icon--enDUo" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1748,18 +1786,18 @@
                     d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--yUuT2">Scans started </span
-              ><span class="text--swxfX">2020-02-02 3:04 AM UTC</span></li
+              ><span class="label--TrLq3">Scans started </span
+              ><span class="text--lxa-w">2020-02-02 3:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--J7B9N label--yUuT2">Scans completed </span
-              ><span class="text--swxfX">2020-02-02 4:04 AM UTC</span></li
+              ><span class="no-icon--jXW2d label--TrLq3">Scans completed </span
+              ><span class="text--lxa-w">2020-02-02 4:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--J7B9N label--yUuT2">Duration </span
-              ><span class="text--swxfX">01:00:00</span></li
+              ><span class="no-icon--jXW2d label--TrLq3">Duration </span
+              ><span class="text--lxa-w">01:00:00</span></li
             ></ul
           ></div
-        ><div class="urls-summary-section--DjUWc"
-          ><h2>URLs</h2><span class="total-urls--Ig_eB">6</span> total URLs
+        ><div class="urls-summary-section--db4HQ"
+          ><h2>URLs</h2><span class="total-urls--3pXYz">6</span> total URLs
           scanned<div
             class="outcome-summary-bar"
             aria-label="3 Failed, 1 Not scanned, 2 Passed"
@@ -1827,9 +1865,9 @@
                 >2<span class="label"> Passed</span></span
               ></div
             ></div
-          ><div class="failure-instances--Rq_Tj"
+          ><div class="failure-instances--y0Big"
             ><h2>Failure Instances</h2
-            ><span class="failure-outcome-chip--YtjBX"
+            ><span class="failure-outcome-chip--vKGs1"
               ><span class="outcome-chip outcome-chip-fail" title="4 Failed"
                 ><span class="icon"
                   ><span class="check-container"
@@ -1855,18 +1893,18 @@
               ><span>Failure instances were detected</span></span
             ></div
           ></div
-        ><div class="rules-results-container--n7EEu"
-          ><div class="results-heading--pyS7R"><h2>Rules</h2></div
+        ><div class="rules-results-container--dO76T"
+          ><div class="results-heading--2h1oe"><h2>Rules</h2></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-combined-report-failed-section"
-                  ><span class="combined-report-result-section-title--XUDDo"
+                  ><span class="combined-report-result-section-title--RNekd"
                     ><span class="screen-reader-only">Failed rules 2</span
-                    ><span class="heading--uUq3e" aria-hidden="true"
+                    ><span class="heading--gtY3F" aria-hidden="true"
                       >Failed rules (2)</span
                     ></span
                   ></button
@@ -1876,12 +1914,12 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><div
-                  class="rule-details-group--U69fz"
+                  class="rule-details-group--ZuRYr"
                   data-automation-id="rule-details-group"
                   ><div
-                    class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
+                    class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
                     ><h4
-                      class="heading-element-for-level--OfRDW title-container"
+                      class="heading-element-for-level--wzmxK title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -1890,7 +1928,7 @@
                         ><span
                           data-automation-id="rule-detail"
                           class="rule-detail"
-                          ><span class="outcome-chip-container--xYquF"
+                          ><span class="outcome-chip-container--ja0WM"
                             ><span aria-hidden="true"
                               ><span
                                 class="outcome-chip outcome-chip-fail"
@@ -1943,10 +1981,10 @@
                       id="content-container-bypass"
                       class="collapsible-content"
                       aria-hidden="true"
-                      ><div class="rule-more-resources--Bsblo"
-                        ><div class="more-resources-title--whTFs"
+                      ><div class="rule-more-resources--w4eYl"
+                        ><div class="more-resources-title--wqgCn"
                           >Resources for this rule</div
-                        ><span class="rule-details-id--n_S89"
+                        ><span class="rule-details-id--QH6Z9"
                           ><a
                             target="_blank"
                             href="https://accessibilityinsights.io/info-examples/web/bypass"
@@ -1964,9 +2002,7 @@
                                 "click",
                                 function (event) {
                                   var result = confirmCallback(
-                                    "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                      "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                      "Cancel to stay on the current page."
+                                    "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                   );
                                   if (result === false) {
                                     event.preventDefault();
@@ -1998,9 +2034,7 @@
                                   "click",
                                   function (event) {
                                     var result = confirmCallback(
-                                      "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                        "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                        "Cancel to stay on the current page."
+                                      "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                     );
                                     if (result === false) {
                                       event.preventDefault();
@@ -2017,20 +2051,20 @@
                         ></div
                       ><ul
                         data-automation-id="cards-rule-content"
-                        class="instance-details-list--xiPPL"
+                        class="instance-details-list--bg-Zq"
                         aria-label="instances with additional information like path, snippet and how to fix"
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--bKrcd"
-                            ><div class="instance-details-card--R0aAh"
+                            class="instance-details-card-container--Hjwps"
+                            ><div class="instance-details-card--lixTP"
                               ><div
-                                ><table class="report-instance-table--YIu0s"
+                                ><table class="report-instance-table--YOlnT"
                                   ><tbody
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">URL</th
-                                      ><td class="row-content--ECKwg"
-                                        ><ul class="urls-row-content--MxcA7"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">URL</th
+                                      ><td class="row-content--Gt-CK"
+                                        ><ul class="urls-row-content--rj2oy"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2051,9 +2085,7 @@
                                                   function (event) {
                                                     var result =
                                                       confirmCallback(
-                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                                          "Cancel to stay on the current page."
+                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                                       );
                                                     if (result === false) {
                                                       event.preventDefault();
@@ -2069,26 +2101,26 @@
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Path</th
-                                      ><td class="row-content--ECKwg"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Path</th
+                                      ><td class="row-content--Gt-CK"
                                         >.rule-1-selector-1</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Snippet</th
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Snippet</th
                                       ><td
-                                        class="row-content--ECKwg snippet--wZrK1"
+                                        class="row-content--Gt-CK snippet--P6i7P"
                                         >&lt;div&gt;snippet 1&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e"
                                         >How to fix</th
-                                      ><td class="row-content--ECKwg"
-                                        ><div class="how-to-fix-content--OHBLC"
+                                      ><td class="row-content--Gt-CK"
+                                        ><div class="how-to-fix-content--Xj-BH"
                                           ><div
                                             ><div>Fix ONE of the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--G3vyY"
+                                              class="insights-fix-instruction-list--NaN2O"
                                               ><li>No valid skip link found</li
                                               ><li
                                                 >Page does not have a header</li
@@ -2109,15 +2141,15 @@
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--bKrcd"
-                            ><div class="instance-details-card--R0aAh"
+                            class="instance-details-card-container--Hjwps"
+                            ><div class="instance-details-card--lixTP"
                               ><div
-                                ><table class="report-instance-table--YIu0s"
+                                ><table class="report-instance-table--YOlnT"
                                   ><tbody
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">URL</th
-                                      ><td class="row-content--ECKwg"
-                                        ><ul class="urls-row-content--MxcA7"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">URL</th
+                                      ><td class="row-content--Gt-CK"
+                                        ><ul class="urls-row-content--rj2oy"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2138,9 +2170,7 @@
                                                   function (event) {
                                                     var result =
                                                       confirmCallback(
-                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                                          "Cancel to stay on the current page."
+                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                                       );
                                                     if (result === false) {
                                                       event.preventDefault();
@@ -2174,9 +2204,7 @@
                                                   function (event) {
                                                     var result =
                                                       confirmCallback(
-                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                                          "Cancel to stay on the current page."
+                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                                       );
                                                     if (result === false) {
                                                       event.preventDefault();
@@ -2190,33 +2218,33 @@
                                               );</script
                                             ><span
                                               aria-hidden="true"
-                                              class="urls-row-content-new-Failure--uJPP3"
+                                              class="urls-row-content-new-Failure--7Dq38"
                                             >
                                               NEW!</span
                                             ></li
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Path</th
-                                      ><td class="row-content--ECKwg"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Path</th
+                                      ><td class="row-content--Gt-CK"
                                         >.rule-1-selector-2</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Snippet</th
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Snippet</th
                                       ><td
-                                        class="row-content--ECKwg snippet--wZrK1"
+                                        class="row-content--Gt-CK snippet--P6i7P"
                                         >&lt;div&gt;snippet 2&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e"
                                         >How to fix</th
-                                      ><td class="row-content--ECKwg"
-                                        ><div class="how-to-fix-content--OHBLC"
+                                      ><td class="row-content--Gt-CK"
+                                        ><div class="how-to-fix-content--Xj-BH"
                                           ><div
                                             ><div>Fix ONE of the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--G3vyY"
+                                              class="insights-fix-instruction-list--NaN2O"
                                               ><li>No valid skip link found</li
                                               ><li
                                                 >Page does not have a header</li
@@ -2238,9 +2266,9 @@
                       ></div
                     ></div
                   ><div
-                    class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
+                    class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
                     ><h4
-                      class="heading-element-for-level--OfRDW title-container"
+                      class="heading-element-for-level--wzmxK title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -2249,7 +2277,7 @@
                         ><span
                           data-automation-id="rule-detail"
                           class="rule-detail"
-                          ><span class="outcome-chip-container--xYquF"
+                          ><span class="outcome-chip-container--ja0WM"
                             ><span aria-hidden="true"
                               ><span
                                 class="outcome-chip outcome-chip-fail"
@@ -2302,10 +2330,10 @@
                       id="content-container-color-contrast"
                       class="collapsible-content"
                       aria-hidden="true"
-                      ><div class="rule-more-resources--Bsblo"
-                        ><div class="more-resources-title--whTFs"
+                      ><div class="rule-more-resources--w4eYl"
+                        ><div class="more-resources-title--wqgCn"
                           >Resources for this rule</div
-                        ><span class="rule-details-id--n_S89"
+                        ><span class="rule-details-id--QH6Z9"
                           ><a
                             target="_blank"
                             href="https://accessibilityinsights.io/info-examples/web/color-contrast"
@@ -2323,9 +2351,7 @@
                                 "click",
                                 function (event) {
                                   var result = confirmCallback(
-                                    "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                      "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                      "Cancel to stay on the current page."
+                                    "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                   );
                                   if (result === false) {
                                     event.preventDefault();
@@ -2357,9 +2383,7 @@
                                   "click",
                                   function (event) {
                                     var result = confirmCallback(
-                                      "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                        "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                        "Cancel to stay on the current page."
+                                      "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                     );
                                     if (result === false) {
                                       event.preventDefault();
@@ -2376,20 +2400,20 @@
                         ></div
                       ><ul
                         data-automation-id="cards-rule-content"
-                        class="instance-details-list--xiPPL"
+                        class="instance-details-list--bg-Zq"
                         aria-label="instances with additional information like path, snippet and how to fix"
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--bKrcd"
-                            ><div class="instance-details-card--R0aAh"
+                            class="instance-details-card-container--Hjwps"
+                            ><div class="instance-details-card--lixTP"
                               ><div
-                                ><table class="report-instance-table--YIu0s"
+                                ><table class="report-instance-table--YOlnT"
                                   ><tbody
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">URL</th
-                                      ><td class="row-content--ECKwg"
-                                        ><ul class="urls-row-content--MxcA7"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">URL</th
+                                      ><td class="row-content--Gt-CK"
+                                        ><ul class="urls-row-content--rj2oy"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2411,9 +2435,7 @@
                                                   function (event) {
                                                     var result =
                                                       confirmCallback(
-                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                                          "Cancel to stay on the current page."
+                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                                       );
                                                     if (result === false) {
                                                       event.preventDefault();
@@ -2427,33 +2449,33 @@
                                               );</script
                                             ><span
                                               aria-hidden="true"
-                                              class="urls-row-content-new-Failure--uJPP3"
+                                              class="urls-row-content-new-Failure--7Dq38"
                                             >
                                               NEW!</span
                                             ></li
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Path</th
-                                      ><td class="row-content--ECKwg"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Path</th
+                                      ><td class="row-content--Gt-CK"
                                         >.rule-2-selector-1</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Snippet</th
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Snippet</th
                                       ><td
-                                        class="row-content--ECKwg snippet--wZrK1"
+                                        class="row-content--Gt-CK snippet--P6i7P"
                                         >&lt;div&gt;snippet&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e"
                                         >How to fix</th
-                                      ><td class="row-content--ECKwg"
-                                        ><div class="how-to-fix-content--OHBLC"
+                                      ><td class="row-content--Gt-CK"
+                                        ><div class="how-to-fix-content--Xj-BH"
                                           ><div
                                             ><div>Fix the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--G3vyY"
+                                              class="insights-fix-instruction-list--NaN2O"
                                               ><li
                                                 ><span aria-hidden="true"
                                                   ><span
@@ -2462,7 +2484,7 @@
                                                     (foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #8a94a8;
                                                     "
@@ -2471,7 +2493,7 @@
                                                     >#8a94a8, background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2483,7 +2505,7 @@
                                                     ratio of 4.5:1</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--n1Ocs"
+                                                  class="screen-reader-only--T-59F"
                                                   >Element has insufficient
                                                   color contrast of 2.52
                                                   (foreground color: #8a94a8,
@@ -2499,7 +2521,7 @@
                                                         Use foreground color: </span
                                                       ><span
                                                         aria-hidden="true"
-                                                        class="fix-instruction-color-box--Xq1E4"
+                                                        class="fix-instruction-color-box--lzu-L"
                                                         style="
                                                           background-color: #5e6572;
                                                         "
@@ -2510,7 +2532,7 @@
                                                         color: </span
                                                       ><span
                                                         aria-hidden="true"
-                                                        class="fix-instruction-color-box--Xq1E4"
+                                                        class="fix-instruction-color-box--lzu-L"
                                                         style="
                                                           background-color: #e7ecd8;
                                                         "
@@ -2521,7 +2543,7 @@
                                                         4.86:1.</span
                                                       ></span
                                                     ><span
-                                                      class="screen-reader-only--n1Ocs"
+                                                      class="screen-reader-only--T-59F"
                                                     >
                                                       Use foreground color:
                                                       #5e6572 and the original
@@ -2551,14 +2573,14 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-pass-checks-section"
-                  ><span class="combined-report-result-section-title--XUDDo"
+                  ><span class="combined-report-result-section-title--RNekd"
                     ><span class="screen-reader-only">Passed rules 2</span
-                    ><span class="heading--uUq3e" aria-hidden="true"
+                    ><span class="heading--gtY3F" aria-hidden="true"
                       >Passed rules (2)</span
                     ></span
                   ></button
@@ -2567,7 +2589,7 @@
                 id="content-container-pass-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--U69fz"
+                ><div class="rule-details-group--ZuRYr"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -2603,9 +2625,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2655,9 +2675,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2687,9 +2705,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2710,15 +2726,15 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-inapplicable-checks-section"
-                  ><span class="combined-report-result-section-title--XUDDo"
+                  ><span class="combined-report-result-section-title--RNekd"
                     ><span class="screen-reader-only"
                       >Not applicable rules 3</span
-                    ><span class="heading--uUq3e" aria-hidden="true"
+                    ><span class="heading--gtY3F" aria-hidden="true"
                       >Not applicable rules (3)</span
                     ></span
                   ></button
@@ -2727,7 +2743,7 @@
                 id="content-container-inapplicable-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--U69fz"
+                ><div class="rule-details-group--ZuRYr"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -2763,9 +2779,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2815,9 +2829,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2867,9 +2879,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2896,7 +2906,7 @@
             var _loop = function (index) {
               var container = collapsibles.item(index);
               var button =
-                container === null || container === void 0
+                container == null
                   ? void 0
                   : container.querySelector(".collapsible-control");
               if (button == null) {
@@ -2905,7 +2915,7 @@
               button.addEventListener("click", function () {
                 var _a;
                 var content =
-                  (_a = button.parentElement) === null || _a === void 0
+                  (_a = button.parentElement) == null
                     ? void 0
                     : _a.nextElementSibling;
                 if (content == null) {

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -835,29 +835,29 @@
       }</style
     ><style>
       /* css-modules:src/common/components/heading-element-for-level */
-      .heading-element-for-level--wzmxK {
+      .heading-element-for-level--ifVX6 {
         margin-block-start: unset;
         margin-block-end: unset;
       }
 
       /* css-modules:src/common/components/cards/failed-instances-section */
-      .failed-instances-container--pB-u4 .collapsible-content {
+      .failed-instances-container--3UUNb .collapsible-content {
         margin-left: 24px;
       }
 
       /* css-modules:src/reports/components/report-sections/minimal-rule-header */
-      .outcome-chip-container--ja0WM {
+      .outcome-chip-container--G5Dfr {
         min-width: 50px;
       }
 
       /* css-modules:src/reports/components/instance-details */
-      .hidden-highlight-button--to41b {
+      .hidden-highlight-button--vu3B3 {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-      .instance-details-card--lixTP {
+      .instance-details-card--owGQF {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -868,29 +868,29 @@
         width: -webkit-fill-available;
         width: fill-available;
       }
-      .instance-details-card-container--Hjwps.selected--Pf-DQ {
+      .instance-details-card-container--KLHTp.selected--wEA4l {
         outline: 5px solid var(--communication-tint-10);
       }
-      .instance-details-card--lixTP.selected--Pf-DQ {
+      .instance-details-card--owGQF.selected--wEA4l {
         border: 1px solid transparent;
       }
-      .instance-details-card--lixTP.focused--PfWGT,
-      .instance-details-card--lixTP:focus {
+      .instance-details-card--owGQF.focused--pvBWq,
+      .instance-details-card--owGQF:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
-      .instance-details-card--lixTP.selected--Pf-DQ:focus {
+      .instance-details-card--owGQF.selected--wEA4l.focused--pvBWq,
+      .instance-details-card--owGQF.selected--wEA4l:focus {
         outline-offset: 8px;
       }
-      .instance-details-card--lixTP.interactive--su6Sw {
+      .instance-details-card--owGQF.interactive--an0ab {
         cursor: pointer;
       }
-      .instance-details-card--lixTP.interactive--su6Sw:hover {
+      .instance-details-card--owGQF.interactive--an0ab:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-      .report-instance-table--YOlnT {
+      .report-instance-table--3VoZX {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
@@ -902,7 +902,7 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YOlnT .row--9WgHa {
+      .report-instance-table--3VoZX .row---3i35 {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -911,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YOlnT .row--9WgHa > * {
+      .report-instance-table--3VoZX .row---3i35 > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YOlnT .row--9WgHa:last-child {
+      .report-instance-table--3VoZX .row---3i35:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YOlnT .row-label--dri3e {
+      .report-instance-table--3VoZX .row-label--FlVZl {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -931,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YOlnT .row-content--Gt-CK {
+      .report-instance-table--3VoZX .row-content--07KUh {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -943,42 +943,42 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--xUzJx {
+      .multi-line-text-no-bullet--AUXXt {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
-      .multi-line-text-yes-bullet--jH-w4 {
+      .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--jH-w4 li {
+      .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .combination-lists--4wBYq {
+      .combination-lists--boK5y {
         flex-direction: column;
         display: flex;
       }
 
       /* css-modules:src/common/components/cards/urls-card-row */
-      .urls-row-content--rj2oy {
+      .urls-row-content--JDdRx {
         padding-left: 16px;
       }
-      .urls-row-content--rj2oy li {
+      .urls-row-content--JDdRx li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .urls-row-content-new-Failure--7Dq38 {
+      .urls-row-content-new-Failure--oL5lS {
         color: var(--negative-outcome);
         font-weight: bold;
       }
 
       /* css-modules:src/common/components/fix-instruction-panel */
-      .insights-fix-instruction-list--NaN2O
+      .insights-fix-instruction-list--eZigw
         li
-        span.fix-instruction-color-box---mQtG {
+        span.fix-instruction-color-box--sBkHG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -986,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
+      .insights-fix-instruction-list--eZigw .screen-reader-only--irrXo {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,73 +996,73 @@
       }
 
       /* css-modules:src/common/components/cards/how-to-fix-card-row */
-      .how-to-fix-content--Xj-BH {
+      .how-to-fix-content--Zz96u {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--Xj-BH ul {
+      .how-to-fix-content--Zz96u ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--Xj-BH ul li {
+      .how-to-fix-content--Zz96u ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
 
       /* css-modules:src/common/components/cards/snippet-card-row */
-      .snippet--P6i7P {
+      .snippet--hSNfv {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
 
       /* css-modules:src/DetailsView/components/common-dialog-styles */
-      div.insights-dialog-main-override--qzZJk {
+      div.insights-dialog-main-override--ma4DA {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--qzZJk {
+        div.insights-dialog-main-override--ma4DA {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
+      div.insights-dialog-main-override--ma4DA .dialog-body--cmWmz {
         font-size: 16px;
       }
 
       /* css-modules:src/DetailsView/components/issue-filing-dialog */
-      .issue-filing-dialog--l9xMr .ms-Dialog-title {
+      .issue-filing-dialog--F9jun .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
+      .issue-filing-dialog--F9jun .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--l9xMr .textfield-description {
+      .issue-filing-dialog--F9jun .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
 
       /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
-      .action-and-cancel-buttons-component--5-uZX {
+      .action-and-cancel-buttons-component--DF7bf {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--5-uZX
-        .action-cancel-button-col--txH36
-        + .action-cancel-button-col--txH36 {
+      .action-and-cancel-buttons-component--DF7bf
+        .action-cancel-button-col--RMfN-
+        + .action-cancel-button-col--RMfN- {
         margin-left: 8px;
       }
 
       /* css-modules:src/common/components/toast */
-      .toast-container--cNX98 {
+      .toast-container--L-5HM {
         display: inline-block;
       }
-      .toast-content--bk935 {
+      .toast-content--8-Mx1 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1079,84 +1079,84 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
-      div.kebab-menu-callout--A3AHu {
+      div.kebab-menu-callout--XvN24 {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--A3AHu > div {
+      div.kebab-menu-callout--XvN24 > div {
         border-radius: 4px;
       }
-      .kebab-menu--Bm5S1 {
+      .kebab-menu--eKCNX {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--Bm5S1 li {
+      .kebab-menu--eKCNX li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--Bm5S1 button i {
+      .kebab-menu--eKCNX button i {
         color: var(--primary-text);
       }
-      .kebab-menu--Bm5S1 button:hover {
+      .kebab-menu--eKCNX button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--Bm5S1 button:hover {
+        .kebab-menu--eKCNX button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--Bm5S1 button:active {
+      .kebab-menu--eKCNX button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--Bm5S1 button:active i {
+      .kebab-menu--eKCNX button:active i {
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR {
+      button.kebab-menu-button--e-7v- {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--ySFdR svg {
+      button.kebab-menu-button--e-7v- svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR svg {
+        button.kebab-menu-button--e-7v- svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--ySFdR:hover {
+      button.kebab-menu-button--e-7v-:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--ySFdR:active,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+      button.kebab-menu-button--e-7v-:active,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR:active svg > circle,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--e-7v-:active svg > circle,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR:active,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+        button.kebab-menu-button--e-7v-:active,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--ySFdR:active svg > circle,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--e-7v-:active svg > circle,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--ySFdR > span {
+      button.kebab-menu-button--e-7v- > span {
         justify-content: center;
       }
 
       /* css-modules:src/common/components/cards/instance-details-footer */
-      .foot--WBFZ6 {
+      .foot--p1DfC {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1167,22 +1167,22 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj {
+      .foot--p1DfC .highlight-status--xJvvI {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj svg {
+      .foot--p1DfC .highlight-status--xJvvI svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--WBFZ6 .highlight-status--TYXPj svg {
+        .foot--p1DfC .highlight-status--xJvvI svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--WBFZ6 .highlight-status--TYXPj label {
+      .foot--p1DfC .highlight-status--xJvvI label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
@@ -1190,21 +1190,21 @@
       }
 
       /* css-modules:src/common/components/cards/instance-details-group */
-      ul.instance-details-list--bg-Zq {
+      ul.instance-details-list--YfkRy {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--bg-Zq > li {
+      ul.instance-details-list--YfkRy > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--bg-Zq > li:last-child {
+      ul.instance-details-list--YfkRy > li:last-child {
         margin-bottom: unset;
       }
 
       /* css-modules:src/common/components/cards/rule-resources */
-      .rule-more-resources--w4eYl {
+      .rule-more-resources--uw9mc {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1218,53 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
+      .rule-more-resources--uw9mc .more-resources-title--jOuUL {
         font-weight: 600;
       }
-      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
+      .rule-more-resources--uw9mc .rule-details-id--s-TpO {
         padding: 12px 0;
       }
 
       /* css-modules:src/common/components/cards/rules-with-instances */
-      .rule-details-group--ZuRYr .rule-detail {
+      .rule-details-group--Tb-LW .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
+      .rule-details-group--Tb-LW .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
+      .rule-details-group--Tb-LW .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-      .collapsible-rule-details-group--ODFPb {
+      .collapsible-rule-details-group--V-HWh {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--ODFPb .rule-detail {
+      .collapsible-rule-details-group--V-HWh .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
+      .collapsible-rule-details-group--V-HWh:not(.collapsed) {
         box-shadow: unset;
       }
 
       /* css-modules:src/common/components/cards/result-section-title */
-      .result-section-title--vgyHe {
+      .result-section-title--RGFI5 {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1272,49 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--vgyHe .title--6gdF5 {
+      .result-section-title--RGFI5 .title--WBYFE {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .heading--1Ll6- {
+      .result-section-title--RGFI5 .heading--NdP4Q {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
+      .result-section-title--RGFI5 .outcome-chip-container--BT3j5 {
         display: flex;
         height: 16px;
       }
 
       /* css-modules:src/common/components/cards/result-section */
-      .result-section--Av9vc {
+      .result-section--HfO9s {
         padding-bottom: 24px;
       }
-      .result-section--Av9vc
-        .title-container---R9Dm
-        .collapsible-control--5y7Tp::before {
+      .result-section--HfO9s
+        .title-container--JzN4A
+        .collapsible-control--e42Z7::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--Av9vc > h2 {
+      .result-section--HfO9s > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
 
       /* css-modules:src/reports/components/header-bar */
-      .report-header-bar--DNH-8 {
+      .report-header-bar--SDV11 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1323,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--DNH-8 .header-icon {
+      .report-header-bar--SDV11 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--DNH-8 .header-text--v-ac2 {
+      .report-header-bar--SDV11 .header-text--EdTxw {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1345,7 +1345,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/header-section */
-      .report-header-command-bar--8-nLy {
+      .report-header-command-bar--NJWdl {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1355,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX {
+      .report-header-command-bar--NJWdl .target-page--hjh44 {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1368,14 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX a {
+      .report-header-command-bar--NJWdl .target-page--hjh44 a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
       /* css-modules:src/common/components/cards/combined-report-result-section-title */
-      .combined-report-result-section-title--RNekd {
+      .combined-report-result-section-title--TqIZO {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1383,14 +1383,14 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--RNekd .title--CFcXZ {
+      .combined-report-result-section-title--TqIZO .title--6WIyt {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--RNekd .heading--gtY3F {
+      .combined-report-result-section-title--TqIZO .heading--UpAHf {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
@@ -1399,7 +1399,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/urls-summary-section */
-      .urls-summary-section--db4HQ {
+      .urls-summary-section--jNa-v {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1407,26 +1407,26 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--db4HQ h2 {
+      .urls-summary-section--jNa-v h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--db4HQ .total-urls--3pXYz {
+      .urls-summary-section--jNa-v .total-urls--95-ge {
         font-weight: 600;
       }
-      .urls-summary-section--db4HQ .failure-instances--y0Big {
+      .urls-summary-section--jNa-v .failure-instances--2WDtT {
         margin-top: 40px;
       }
-      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
+      .urls-summary-section--jNa-v .failure-outcome-chip--JF-lj {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
 
       /* css-modules:src/reports/components/report-sections/rules-results-container */
-      .rules-results-container--dO76T {
+      .rules-results-container--HaLDw {
         margin-top: 56px;
       }
-      .rules-results-container--dO76T .results-heading--2h1oe {
+      .rules-results-container--HaLDw .results-heading--H9Puz {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
@@ -1435,7 +1435,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/summary-report-details-section */
-      .crawl-details-section--jDqES {
+      .crawl-details-section--a6evz {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1443,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1453,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di li {
         display: inline-block;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
         li
-        .icon--enDUo {
+        .icon--APJEn {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
-        li.targetSite--M6DmE {
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
+        li.targetSite--wBJT- {
         margin-bottom: 6px;
       }
-      .crawl-details-section--jDqES .text--lxa-w,
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .text--rViTo,
+      .crawl-details-section--a6evz .label--DUNYf {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1480,30 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .label--DUNYf {
         font-weight: 600;
       }
-      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
+      .crawl-details-section--a6evz .label--DUNYf.no-icon--VrSr5 {
         padding-left: 29px;
       }
 
       /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
-      .url-result-section--Lsitd {
+      .url-result-section--SkOlZ {
         padding-bottom: 31px;
       }
-      .url-result-section--Lsitd
+      .url-result-section--SkOlZ
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--Lsitd .collapsible-content {
+      .url-result-section--SkOlZ .collapsible-content {
         margin-top: 19px;
       }
 
       /* css-modules:src/reports/components/report-sections/summary-results-table */
-      .summary-results-table--r6fvD {
+      .summary-results-table--Iezr- {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1512,39 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--r6fvD th,
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- th,
+      .summary-results-table--Iezr- td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--r6fvD th {
+      .summary-results-table--Iezr- th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--r6fvD thead tr :first-child {
+      .summary-results-table--Iezr- thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--r6fvD td.text-cell--luh34 {
+      .summary-results-table--Iezr- td.text-cell--EaUrM {
         overflow-wrap: break-word;
       }
-      .summary-results-table--r6fvD td.url-cell--ZGO-o {
+      .summary-results-table--Iezr- td.url-cell--mg-3l {
         overflow-wrap: anywhere;
       }
 
       /* css-modules:src/reports/components/report-sections/results-by-url-container */
-      .url-results-container--xiZ0N {
+      .url-results-container---dq9B {
         margin-top: 56px;
       }
-      .url-results-container--xiZ0N .results-heading--wmQ-W {
+      .url-results-container---dq9B .results-heading--2dWBX {
         margin-top: 32px;
         margin-bottom: 32px;
       }
 
       /* css-modules:src/common/components/cards/fix-instruction-color-box */
-      span.fix-instruction-color-box--lzu-L {
+      span.fix-instruction-color-box--DQpQE {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1552,7 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .screen-reader-only--T-59F {
+      .screen-reader-only--6LUiO {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1564,7 +1564,7 @@
     </style></head
   ><body
     ><header
-      ><div class="report-header-bar--DNH-8"
+      ><div class="report-header-bar--SDV11"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1721,16 +1721,16 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--v-ac2">Accessibility Insights</div></div
+        ><div class="header-text--EdTxw">Accessibility Insights</div></div
       ></header
     ><main class="outer-container"
       ><div class="content-container"
         ><div class="title-section"><h1>Automated checks results</h1></div
-        ><div class="crawl-details-section--jDqES"
+        ><div class="crawl-details-section--a6evz"
           ><h2>Scan details</h2
-          ><ul class="crawl-details-section-list--6FyX-"
-            ><li class="targetSite--M6DmE"
-              ><span class="icon--enDUo" aria-hidden="true"
+          ><ul class="crawl-details-section-list--WV1Di"
+            ><li class="targetSite--wBJT-"
+              ><span class="icon--APJEn" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1742,8 +1742,8 @@
                     d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--TrLq3">Target site </span
-              ><span class="text--lxa-w"
+              ><span class="label--DUNYf">Target site </span
+              ><span class="text--rViTo"
                 ><a
                   target="_blank"
                   href="https://example.com/mock-base-url"
@@ -1774,7 +1774,7 @@
                 </script></span
               ></li
             ><li
-              ><span class="icon--enDUo" aria-hidden="true"
+              ><span class="icon--APJEn" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1786,18 +1786,18 @@
                     d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--TrLq3">Scans started </span
-              ><span class="text--lxa-w">2020-02-02 3:04 AM UTC</span></li
+              ><span class="label--DUNYf">Scans started </span
+              ><span class="text--rViTo">2020-02-02 3:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--jXW2d label--TrLq3">Scans completed </span
-              ><span class="text--lxa-w">2020-02-02 4:04 AM UTC</span></li
+              ><span class="no-icon--VrSr5 label--DUNYf">Scans completed </span
+              ><span class="text--rViTo">2020-02-02 4:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--jXW2d label--TrLq3">Duration </span
-              ><span class="text--lxa-w">01:00:00</span></li
+              ><span class="no-icon--VrSr5 label--DUNYf">Duration </span
+              ><span class="text--rViTo">01:00:00</span></li
             ></ul
           ></div
-        ><div class="urls-summary-section--db4HQ"
-          ><h2>URLs</h2><span class="total-urls--3pXYz">6</span> total URLs
+        ><div class="urls-summary-section--jNa-v"
+          ><h2>URLs</h2><span class="total-urls--95-ge">6</span> total URLs
           scanned<div
             class="outcome-summary-bar"
             aria-label="3 Failed, 1 Not scanned, 2 Passed"
@@ -1865,9 +1865,9 @@
                 >2<span class="label"> Passed</span></span
               ></div
             ></div
-          ><div class="failure-instances--y0Big"
+          ><div class="failure-instances--2WDtT"
             ><h2>Failure Instances</h2
-            ><span class="failure-outcome-chip--vKGs1"
+            ><span class="failure-outcome-chip--JF-lj"
               ><span class="outcome-chip outcome-chip-fail" title="4 Failed"
                 ><span class="icon"
                   ><span class="check-container"
@@ -1893,18 +1893,18 @@
               ><span>Failure instances were detected</span></span
             ></div
           ></div
-        ><div class="rules-results-container--dO76T"
-          ><div class="results-heading--2h1oe"><h2>Rules</h2></div
+        ><div class="rules-results-container--HaLDw"
+          ><div class="results-heading--H9Puz"><h2>Rules</h2></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-combined-report-failed-section"
-                  ><span class="combined-report-result-section-title--RNekd"
+                  ><span class="combined-report-result-section-title--TqIZO"
                     ><span class="screen-reader-only">Failed rules 2</span
-                    ><span class="heading--gtY3F" aria-hidden="true"
+                    ><span class="heading--UpAHf" aria-hidden="true"
                       >Failed rules (2)</span
                     ></span
                   ></button
@@ -1914,12 +1914,12 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><div
-                  class="rule-details-group--ZuRYr"
+                  class="rule-details-group--Tb-LW"
                   data-automation-id="rule-details-group"
                   ><div
-                    class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                    class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
                     ><h4
-                      class="heading-element-for-level--wzmxK title-container"
+                      class="heading-element-for-level--ifVX6 title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -1928,7 +1928,7 @@
                         ><span
                           data-automation-id="rule-detail"
                           class="rule-detail"
-                          ><span class="outcome-chip-container--ja0WM"
+                          ><span class="outcome-chip-container--G5Dfr"
                             ><span aria-hidden="true"
                               ><span
                                 class="outcome-chip outcome-chip-fail"
@@ -1981,10 +1981,10 @@
                       id="content-container-bypass"
                       class="collapsible-content"
                       aria-hidden="true"
-                      ><div class="rule-more-resources--w4eYl"
-                        ><div class="more-resources-title--wqgCn"
+                      ><div class="rule-more-resources--uw9mc"
+                        ><div class="more-resources-title--jOuUL"
                           >Resources for this rule</div
-                        ><span class="rule-details-id--QH6Z9"
+                        ><span class="rule-details-id--s-TpO"
                           ><a
                             target="_blank"
                             href="https://accessibilityinsights.io/info-examples/web/bypass"
@@ -2051,20 +2051,20 @@
                         ></div
                       ><ul
                         data-automation-id="cards-rule-content"
-                        class="instance-details-list--bg-Zq"
+                        class="instance-details-list--YfkRy"
                         aria-label="instances with additional information like path, snippet and how to fix"
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--Hjwps"
-                            ><div class="instance-details-card--lixTP"
+                            class="instance-details-card-container--KLHTp"
+                            ><div class="instance-details-card--owGQF"
                               ><div
-                                ><table class="report-instance-table--YOlnT"
+                                ><table class="report-instance-table--3VoZX"
                                   ><tbody
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">URL</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><ul class="urls-row-content--rj2oy"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">URL</th
+                                      ><td class="row-content--07KUh"
+                                        ><ul class="urls-row-content--JDdRx"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2101,26 +2101,26 @@
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Path</th
-                                      ><td class="row-content--Gt-CK"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Path</th
+                                      ><td class="row-content--07KUh"
                                         >.rule-1-selector-1</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Snippet</th
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Snippet</th
                                       ><td
-                                        class="row-content--Gt-CK snippet--P6i7P"
+                                        class="row-content--07KUh snippet--hSNfv"
                                         >&lt;div&gt;snippet 1&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl"
                                         >How to fix</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><div class="how-to-fix-content--Xj-BH"
+                                      ><td class="row-content--07KUh"
+                                        ><div class="how-to-fix-content--Zz96u"
                                           ><div
                                             ><div>Fix ONE of the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--NaN2O"
+                                              class="insights-fix-instruction-list--eZigw"
                                               ><li>No valid skip link found</li
                                               ><li
                                                 >Page does not have a header</li
@@ -2141,15 +2141,15 @@
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--Hjwps"
-                            ><div class="instance-details-card--lixTP"
+                            class="instance-details-card-container--KLHTp"
+                            ><div class="instance-details-card--owGQF"
                               ><div
-                                ><table class="report-instance-table--YOlnT"
+                                ><table class="report-instance-table--3VoZX"
                                   ><tbody
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">URL</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><ul class="urls-row-content--rj2oy"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">URL</th
+                                      ><td class="row-content--07KUh"
+                                        ><ul class="urls-row-content--JDdRx"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2218,33 +2218,33 @@
                                               );</script
                                             ><span
                                               aria-hidden="true"
-                                              class="urls-row-content-new-Failure--7Dq38"
+                                              class="urls-row-content-new-Failure--oL5lS"
                                             >
                                               NEW!</span
                                             ></li
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Path</th
-                                      ><td class="row-content--Gt-CK"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Path</th
+                                      ><td class="row-content--07KUh"
                                         >.rule-1-selector-2</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Snippet</th
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Snippet</th
                                       ><td
-                                        class="row-content--Gt-CK snippet--P6i7P"
+                                        class="row-content--07KUh snippet--hSNfv"
                                         >&lt;div&gt;snippet 2&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl"
                                         >How to fix</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><div class="how-to-fix-content--Xj-BH"
+                                      ><td class="row-content--07KUh"
+                                        ><div class="how-to-fix-content--Zz96u"
                                           ><div
                                             ><div>Fix ONE of the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--NaN2O"
+                                              class="insights-fix-instruction-list--eZigw"
                                               ><li>No valid skip link found</li
                                               ><li
                                                 >Page does not have a header</li
@@ -2266,9 +2266,9 @@
                       ></div
                     ></div
                   ><div
-                    class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                    class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
                     ><h4
-                      class="heading-element-for-level--wzmxK title-container"
+                      class="heading-element-for-level--ifVX6 title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -2277,7 +2277,7 @@
                         ><span
                           data-automation-id="rule-detail"
                           class="rule-detail"
-                          ><span class="outcome-chip-container--ja0WM"
+                          ><span class="outcome-chip-container--G5Dfr"
                             ><span aria-hidden="true"
                               ><span
                                 class="outcome-chip outcome-chip-fail"
@@ -2330,10 +2330,10 @@
                       id="content-container-color-contrast"
                       class="collapsible-content"
                       aria-hidden="true"
-                      ><div class="rule-more-resources--w4eYl"
-                        ><div class="more-resources-title--wqgCn"
+                      ><div class="rule-more-resources--uw9mc"
+                        ><div class="more-resources-title--jOuUL"
                           >Resources for this rule</div
-                        ><span class="rule-details-id--QH6Z9"
+                        ><span class="rule-details-id--s-TpO"
                           ><a
                             target="_blank"
                             href="https://accessibilityinsights.io/info-examples/web/color-contrast"
@@ -2400,20 +2400,20 @@
                         ></div
                       ><ul
                         data-automation-id="cards-rule-content"
-                        class="instance-details-list--bg-Zq"
+                        class="instance-details-list--YfkRy"
                         aria-label="instances with additional information like path, snippet and how to fix"
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--Hjwps"
-                            ><div class="instance-details-card--lixTP"
+                            class="instance-details-card-container--KLHTp"
+                            ><div class="instance-details-card--owGQF"
                               ><div
-                                ><table class="report-instance-table--YOlnT"
+                                ><table class="report-instance-table--3VoZX"
                                   ><tbody
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">URL</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><ul class="urls-row-content--rj2oy"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">URL</th
+                                      ><td class="row-content--07KUh"
+                                        ><ul class="urls-row-content--JDdRx"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2449,33 +2449,33 @@
                                               );</script
                                             ><span
                                               aria-hidden="true"
-                                              class="urls-row-content-new-Failure--7Dq38"
+                                              class="urls-row-content-new-Failure--oL5lS"
                                             >
                                               NEW!</span
                                             ></li
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Path</th
-                                      ><td class="row-content--Gt-CK"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Path</th
+                                      ><td class="row-content--07KUh"
                                         >.rule-2-selector-1</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Snippet</th
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Snippet</th
                                       ><td
-                                        class="row-content--Gt-CK snippet--P6i7P"
+                                        class="row-content--07KUh snippet--hSNfv"
                                         >&lt;div&gt;snippet&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl"
                                         >How to fix</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><div class="how-to-fix-content--Xj-BH"
+                                      ><td class="row-content--07KUh"
+                                        ><div class="how-to-fix-content--Zz96u"
                                           ><div
                                             ><div>Fix the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--NaN2O"
+                                              class="insights-fix-instruction-list--eZigw"
                                               ><li
                                                 ><span aria-hidden="true"
                                                   ><span
@@ -2484,7 +2484,7 @@
                                                     (foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #8a94a8;
                                                     "
@@ -2493,7 +2493,7 @@
                                                     >#8a94a8, background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2505,7 +2505,7 @@
                                                     ratio of 4.5:1</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--T-59F"
+                                                  class="screen-reader-only--6LUiO"
                                                   >Element has insufficient
                                                   color contrast of 2.52
                                                   (foreground color: #8a94a8,
@@ -2521,7 +2521,7 @@
                                                         Use foreground color: </span
                                                       ><span
                                                         aria-hidden="true"
-                                                        class="fix-instruction-color-box--lzu-L"
+                                                        class="fix-instruction-color-box--DQpQE"
                                                         style="
                                                           background-color: #5e6572;
                                                         "
@@ -2532,7 +2532,7 @@
                                                         color: </span
                                                       ><span
                                                         aria-hidden="true"
-                                                        class="fix-instruction-color-box--lzu-L"
+                                                        class="fix-instruction-color-box--DQpQE"
                                                         style="
                                                           background-color: #e7ecd8;
                                                         "
@@ -2543,7 +2543,7 @@
                                                         4.86:1.</span
                                                       ></span
                                                     ><span
-                                                      class="screen-reader-only--T-59F"
+                                                      class="screen-reader-only--6LUiO"
                                                     >
                                                       Use foreground color:
                                                       #5e6572 and the original
@@ -2573,14 +2573,14 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-pass-checks-section"
-                  ><span class="combined-report-result-section-title--RNekd"
+                  ><span class="combined-report-result-section-title--TqIZO"
                     ><span class="screen-reader-only">Passed rules 2</span
-                    ><span class="heading--gtY3F" aria-hidden="true"
+                    ><span class="heading--UpAHf" aria-hidden="true"
                       >Passed rules (2)</span
                     ></span
                   ></button
@@ -2589,7 +2589,7 @@
                 id="content-container-pass-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--ZuRYr"
+                ><div class="rule-details-group--Tb-LW"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -2726,15 +2726,15 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-inapplicable-checks-section"
-                  ><span class="combined-report-result-section-title--RNekd"
+                  ><span class="combined-report-result-section-title--TqIZO"
                     ><span class="screen-reader-only"
                       >Not applicable rules 3</span
-                    ><span class="heading--gtY3F" aria-hidden="true"
+                    ><span class="heading--UpAHf" aria-hidden="true"
                       >Not applicable rules (3)</span
                     ></span
                   ></button
@@ -2743,7 +2743,7 @@
                 id="content-container-inapplicable-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--ZuRYr"
+                ><div class="rule-details-group--Tb-LW"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -834,24 +834,30 @@
         margin-bottom: unset;
       }</style
     ><style>
-      .heading-element-for-level--OfRDW {
+      /* css-modules:src/common/components/heading-element-for-level */
+      .heading-element-for-level--wzmxK {
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      .failed-instances-container--FqWV6 .collapsible-content {
+
+      /* css-modules:src/common/components/cards/failed-instances-section */
+      .failed-instances-container--pB-u4 .collapsible-content {
         margin-left: 24px;
       }
-      .outcome-chip-container--xYquF {
+
+      /* css-modules:src/reports/components/report-sections/minimal-rule-header */
+      .outcome-chip-container--ja0WM {
         min-width: 50px;
       }
-      .hidden-highlight-button--PePzJ {
+
+      /* css-modules:src/reports/components/instance-details */
+      .hidden-highlight-button--to41b {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-
-      .instance-details-card--R0aAh {
+      .instance-details-card--lixTP {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -859,55 +865,44 @@
           0 3.2px 7.2px var(--box-shadow-132);
         margin-bottom: 16px;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
       }
-
-      .instance-details-card-container--bKrcd.selected--Kp4AC {
+      .instance-details-card-container--Hjwps.selected--Pf-DQ {
         outline: 5px solid var(--communication-tint-10);
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC {
+      .instance-details-card--lixTP.selected--Pf-DQ {
         border: 1px solid transparent;
       }
-
-      .instance-details-card--R0aAh.focused--tV0ic,
-      .instance-details-card--R0aAh:focus {
+      .instance-details-card--lixTP.focused--PfWGT,
+      .instance-details-card--lixTP:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC.focused--tV0ic,
-      .instance-details-card--R0aAh.selected--Kp4AC:focus {
+      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
+      .instance-details-card--lixTP.selected--Pf-DQ:focus {
         outline-offset: 8px;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy {
+      .instance-details-card--lixTP.interactive--su6Sw {
         cursor: pointer;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy:hover {
+      .instance-details-card--lixTP.interactive--su6Sw:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-
-      .report-instance-table--YIu0s {
+      .report-instance-table--YOlnT {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
         border-radius: inherit;
         border-collapse: collapse;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YIu0s .row--m8TLI {
+      .report-instance-table--YOlnT .row--9WgHa {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -916,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YIu0s .row--m8TLI > * {
+      .report-instance-table--YOlnT .row--9WgHa > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YIu0s .row--m8TLI:last-child {
+      .report-instance-table--YOlnT .row--9WgHa:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YIu0s .row-label--MxfuQ {
+      .report-instance-table--YOlnT .row-label--dri3e {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -936,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YIu0s .row-content--ECKwg {
+      .report-instance-table--YOlnT .row-content--Gt-CK {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -946,41 +941,44 @@
         align-items: flex-end;
         display: flex;
       }
-      .multi-line-text-no-bullet--lNJS_ {
+
+      /* css-modules:src/common/components/cards/rich-resolution-content */
+      .multi-line-text-no-bullet--xUzJx {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--lNJS_ li:not(:last-child) {
+      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
         margin-bottom: 4px;
       }
-
-      .multi-line-text-yes-bullet--pp76P {
+      .multi-line-text-yes-bullet--jH-w4 {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--pp76P li {
+      .multi-line-text-yes-bullet--jH-w4 li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .combination-lists--O1dD_ {
+      .combination-lists--4wBYq {
         flex-direction: column;
         display: flex;
       }
-      .urls-row-content--MxcA7 {
+
+      /* css-modules:src/common/components/cards/urls-card-row */
+      .urls-row-content--rj2oy {
         padding-left: 16px;
       }
-      .urls-row-content--MxcA7 li {
+      .urls-row-content--rj2oy li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .urls-row-content-new-Failure--uJPP3 {
+      .urls-row-content-new-Failure--7Dq38 {
         color: var(--negative-outcome);
         font-weight: bold;
       }
-      .insights-fix-instruction-list--G3vyY
+
+      /* css-modules:src/common/components/fix-instruction-panel */
+      .insights-fix-instruction-list--NaN2O
         li
-        span.fix-instruction-color-box--g6NfJ {
+        span.fix-instruction-color-box---mQtG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -988,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--G3vyY .screen-reader-only--yQjgp {
+      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,64 +994,75 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
-      .how-to-fix-content--OHBLC {
+
+      /* css-modules:src/common/components/cards/how-to-fix-card-row */
+      .how-to-fix-content--Xj-BH {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--OHBLC ul {
+      .how-to-fix-content--Xj-BH ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--OHBLC ul li {
+      .how-to-fix-content--Xj-BH ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .snippet--wZrK1 {
+
+      /* css-modules:src/common/components/cards/snippet-card-row */
+      .snippet--P6i7P {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
-      div.insights-dialog-main-override--Mlek6 {
+
+      /* css-modules:src/DetailsView/components/common-dialog-styles */
+      div.insights-dialog-main-override--qzZJk {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--Mlek6 {
+        div.insights-dialog-main-override--qzZJk {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--Mlek6 .dialog-body--QtJ_D {
+      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
         font-size: 16px;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-title {
+
+      /* css-modules:src/DetailsView/components/issue-filing-dialog */
+      .issue-filing-dialog--l9xMr .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-subText {
+      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--ZrD5s .textfield-description {
+      .issue-filing-dialog--l9xMr .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
-      .action-and-cancel-buttons-component--HOvON {
+
+      /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
+      .action-and-cancel-buttons-component--5-uZX {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--HOvON
-        .action-cancel-button-col--VrVAp
-        + .action-cancel-button-col--VrVAp {
+      .action-and-cancel-buttons-component--5-uZX
+        .action-cancel-button-col--txH36
+        + .action-cancel-button-col--txH36 {
         margin-left: 8px;
       }
-      .toast-container--KsxE1 {
+
+      /* css-modules:src/common/components/toast */
+      .toast-container--cNX98 {
         display: inline-block;
       }
-
-      .toast-content--pEpMJ {
+      .toast-content--bk935 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1068,84 +1077,86 @@
         z-index: 1000;
         position: absolute;
       }
-      div.kebab-menu-callout--o23oT {
+
+      /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      div.kebab-menu-callout--A3AHu {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--o23oT > div {
+      div.kebab-menu-callout--A3AHu > div {
         border-radius: 4px;
       }
-
-      .kebab-menu--eviKu {
+      .kebab-menu--Bm5S1 {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--eviKu li {
+      .kebab-menu--Bm5S1 li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--eviKu button i {
+      .kebab-menu--Bm5S1 button i {
         color: var(--primary-text);
       }
-      .kebab-menu--eviKu button:hover {
+      .kebab-menu--Bm5S1 button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--eviKu button:hover {
+        .kebab-menu--Bm5S1 button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--eviKu button:active {
+      .kebab-menu--Bm5S1 button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--eviKu button:active i {
+      .kebab-menu--Bm5S1 button:active i {
         color: var(--light-black);
       }
-
-      button.kebab-menu-button--dy7Ui {
+      button.kebab-menu-button--ySFdR {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--dy7Ui svg {
+      button.kebab-menu-button--ySFdR svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui svg {
+        button.kebab-menu-button--ySFdR svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--dy7Ui:hover {
+      button.kebab-menu-button--ySFdR:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--dy7Ui:active,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+      button.kebab-menu-button--ySFdR:active,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--dy7Ui:active svg > circle,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--ySFdR:active svg > circle,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui:active,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+        button.kebab-menu-button--ySFdR:active,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--dy7Ui:active svg > circle,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--ySFdR:active svg > circle,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--dy7Ui > span {
+      button.kebab-menu-button--ySFdR > span {
         justify-content: center;
       }
-      .foot--d1w5m {
+
+      /* css-modules:src/common/components/cards/instance-details-footer */
+      .foot--WBFZ6 {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1156,40 +1167,44 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--d1w5m .highlight-status--Bmqfx {
+      .foot--WBFZ6 .highlight-status--TYXPj {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--d1w5m .highlight-status--Bmqfx svg {
+      .foot--WBFZ6 .highlight-status--TYXPj svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--d1w5m .highlight-status--Bmqfx svg {
+        .foot--WBFZ6 .highlight-status--TYXPj svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--d1w5m .highlight-status--Bmqfx label {
+      .foot--WBFZ6 .highlight-status--TYXPj label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      ul.instance-details-list--xiPPL {
+
+      /* css-modules:src/common/components/cards/instance-details-group */
+      ul.instance-details-list--bg-Zq {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--xiPPL > li {
+      ul.instance-details-list--bg-Zq > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--xiPPL > li:last-child {
+      ul.instance-details-list--bg-Zq > li:last-child {
         margin-bottom: unset;
       }
-      .rule-more-resources--Bsblo {
+
+      /* css-modules:src/common/components/cards/rule-resources */
+      .rule-more-resources--w4eYl {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1203,50 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--Bsblo .more-resources-title--whTFs {
+      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
         font-weight: 600;
       }
-      .rule-more-resources--Bsblo .rule-details-id--n_S89 {
+      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
         padding: 12px 0;
       }
-      .rule-details-group--U69fz .rule-detail {
+
+      /* css-modules:src/common/components/cards/rules-with-instances */
+      .rule-details-group--ZuRYr .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--U69fz .rule-detail .outcome-chip {
+      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id a {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--U69fz .rule-detail .rule-detail-description {
+      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-
-      .collapsible-rule-details-group--h0lvd {
+      .collapsible-rule-details-group--ODFPb {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--h0lvd .rule-detail {
+      .collapsible-rule-details-group--ODFPb .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--h0lvd:not(.collapsed) {
+      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
         box-shadow: unset;
       }
-      .result-section-title--qv3MK {
+
+      /* css-modules:src/common/components/cards/result-section-title */
+      .result-section-title--vgyHe {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1254,45 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--qv3MK .title--neMma {
+      .result-section-title--vgyHe .title--6gdF5 {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .heading--VbGap {
+      .result-section-title--vgyHe .heading--1Ll6- {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .outcome-chip-container--Wt0k4 {
+      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
         display: flex;
         height: 16px;
       }
-      .result-section--j6fYr {
+
+      /* css-modules:src/common/components/cards/result-section */
+      .result-section--Av9vc {
         padding-bottom: 24px;
       }
-      .result-section--j6fYr
-        .title-container--gMYqW
-        .collapsible-control--V9OlA::before {
+      .result-section--Av9vc
+        .title-container---R9Dm
+        .collapsible-control--5y7Tp::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--j6fYr > h2 {
+      .result-section--Av9vc > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-bar--pkiTM {
+
+      /* css-modules:src/reports/components/header-bar */
+      .report-header-bar--DNH-8 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1301,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--pkiTM .header-icon {
+      .report-header-bar--DNH-8 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--pkiTM .header-text--dfm48 {
+      .report-header-bar--DNH-8 .header-text--v-ac2 {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1321,7 +1343,9 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-command-bar--wDg1t {
+
+      /* css-modules:src/reports/components/report-sections/header-section */
+      .report-header-command-bar--8-nLy {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1331,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--wDg1t .target-page--giudb {
+      .report-header-command-bar--8-nLy .target-page--q7WnX {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1344,12 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
+      .report-header-command-bar--8-nLy .target-page--q7WnX a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      .combined-report-result-section-title--XUDDo {
+
+      /* css-modules:src/common/components/cards/combined-report-result-section-title */
+      .combined-report-result-section-title--RNekd {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1357,21 +1383,23 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--XUDDo .title--lcuIW {
+      .combined-report-result-section-title--RNekd .title--CFcXZ {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--XUDDo .heading--uUq3e {
+      .combined-report-result-section-title--RNekd .heading--gtY3F {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .urls-summary-section--DjUWc {
+
+      /* css-modules:src/reports/components/report-sections/urls-summary-section */
+      .urls-summary-section--db4HQ {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1379,31 +1407,35 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--DjUWc h2 {
+      .urls-summary-section--db4HQ h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--DjUWc .total-urls--Ig_eB {
+      .urls-summary-section--db4HQ .total-urls--3pXYz {
         font-weight: 600;
       }
-      .urls-summary-section--DjUWc .failure-instances--Rq_Tj {
+      .urls-summary-section--db4HQ .failure-instances--y0Big {
         margin-top: 40px;
       }
-      .urls-summary-section--DjUWc .failure-outcome-chip--YtjBX {
+      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
-      .rules-results-container--n7EEu {
+
+      /* css-modules:src/reports/components/report-sections/rules-results-container */
+      .rules-results-container--dO76T {
         margin-top: 56px;
       }
-      .rules-results-container--n7EEu .results-heading--pyS7R {
+      .rules-results-container--dO76T .results-heading--2h1oe {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
       }
-      .crawl-details-section--WhRL4 {
+
+      /* css-modules:src/reports/components/report-sections/summary-report-details-section */
+      .crawl-details-section--jDqES {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1411,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1421,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg li {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
         display: inline-block;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
         li
-        .icon--JdMPq {
+        .icon--enDUo {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
-        li.targetSite--qXxid {
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
+        li.targetSite--M6DmE {
         margin-bottom: 6px;
       }
-      .crawl-details-section--WhRL4 .text--swxfX,
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .text--lxa-w,
+      .crawl-details-section--jDqES .label--TrLq3 {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1448,26 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .label--TrLq3 {
         font-weight: 600;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2.no-icon--J7B9N {
+      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
         padding-left: 29px;
       }
-      .url-result-section--PmEoY {
+
+      /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
+      .url-result-section--Lsitd {
         padding-bottom: 31px;
       }
-      .url-result-section--PmEoY
+      .url-result-section--Lsitd
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--PmEoY .collapsible-content {
+      .url-result-section--Lsitd .collapsible-content {
         margin-top: 19px;
       }
-      .summary-results-table--Pb4_B {
+
+      /* css-modules:src/reports/components/report-sections/summary-results-table */
+      .summary-results-table--r6fvD {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1476,35 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--Pb4_B th,
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD th,
+      .summary-results-table--r6fvD td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--Pb4_B th {
+      .summary-results-table--r6fvD th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--Pb4_B thead tr :first-child {
+      .summary-results-table--r6fvD thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--Pb4_B td.text-cell--p0dxL {
+      .summary-results-table--r6fvD td.text-cell--luh34 {
         overflow-wrap: break-word;
       }
-      .summary-results-table--Pb4_B td.url-cell--yjU1V {
+      .summary-results-table--r6fvD td.url-cell--ZGO-o {
         overflow-wrap: anywhere;
       }
-      .url-results-container--dXQbj {
+
+      /* css-modules:src/reports/components/report-sections/results-by-url-container */
+      .url-results-container--xiZ0N {
         margin-top: 56px;
       }
-      .url-results-container--dXQbj .results-heading--D3Qtr {
+      .url-results-container--xiZ0N .results-heading--wmQ-W {
         margin-top: 32px;
         margin-bottom: 32px;
       }
-      span.fix-instruction-color-box--Xq1E4 {
+
+      /* css-modules:src/common/components/cards/fix-instruction-color-box */
+      span.fix-instruction-color-box--lzu-L {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1512,8 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-
-      .screen-reader-only--n1Ocs {
+      .screen-reader-only--T-59F {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1521,10 +1560,11 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
+      /*# sourceMappingURL=report.css.map */
     </style></head
   ><body
     ><header
-      ><div class="report-header-bar--pkiTM"
+      ><div class="report-header-bar--DNH-8"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1681,16 +1721,16 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--dfm48">Accessibility Insights</div></div
+        ><div class="header-text--v-ac2">Accessibility Insights</div></div
       ></header
     ><main class="outer-container"
       ><div class="content-container"
         ><div class="title-section"><h1>Automated checks results</h1></div
-        ><div class="crawl-details-section--WhRL4"
+        ><div class="crawl-details-section--jDqES"
           ><h2>Scan details</h2
-          ><ul class="crawl-details-section-list--Lrjqg"
-            ><li class="targetSite--qXxid"
-              ><span class="icon--JdMPq" aria-hidden="true"
+          ><ul class="crawl-details-section-list--6FyX-"
+            ><li class="targetSite--M6DmE"
+              ><span class="icon--enDUo" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1702,8 +1742,8 @@
                     d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--yUuT2">Target site </span
-              ><span class="text--swxfX"
+              ><span class="label--TrLq3">Target site </span
+              ><span class="text--lxa-w"
                 ><a
                   target="_blank"
                   href="https://example.com/mock-base-url"
@@ -1720,9 +1760,7 @@
                     var targetPageLink = doc.getElementById(linkId);
                     targetPageLink.addEventListener("click", function (event) {
                       var result = confirmCallback(
-                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                          "Cancel to stay on the current page."
+                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                       );
                       if (result === false) {
                         event.preventDefault();
@@ -1736,7 +1774,7 @@
                 </script></span
               ></li
             ><li
-              ><span class="icon--JdMPq" aria-hidden="true"
+              ><span class="icon--enDUo" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1748,18 +1786,18 @@
                     d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--yUuT2">Scans started </span
-              ><span class="text--swxfX">2020-02-02 3:04 AM UTC</span></li
+              ><span class="label--TrLq3">Scans started </span
+              ><span class="text--lxa-w">2020-02-02 3:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--J7B9N label--yUuT2">Scans completed </span
-              ><span class="text--swxfX">2020-02-02 4:04 AM UTC</span></li
+              ><span class="no-icon--jXW2d label--TrLq3">Scans completed </span
+              ><span class="text--lxa-w">2020-02-02 4:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--J7B9N label--yUuT2">Duration </span
-              ><span class="text--swxfX">01:00:00</span></li
+              ><span class="no-icon--jXW2d label--TrLq3">Duration </span
+              ><span class="text--lxa-w">01:00:00</span></li
             ></ul
           ></div
-        ><div class="urls-summary-section--DjUWc"
-          ><h2>URLs</h2><span class="total-urls--Ig_eB">6</span> total URLs
+        ><div class="urls-summary-section--db4HQ"
+          ><h2>URLs</h2><span class="total-urls--3pXYz">6</span> total URLs
           scanned<div
             class="outcome-summary-bar"
             aria-label="3 Failed, 1 Not scanned, 2 Passed"
@@ -1827,9 +1865,9 @@
                 >2<span class="label"> Passed</span></span
               ></div
             ></div
-          ><div class="failure-instances--Rq_Tj"
+          ><div class="failure-instances--y0Big"
             ><h2>Failure Instances</h2
-            ><span class="failure-outcome-chip--YtjBX"
+            ><span class="failure-outcome-chip--vKGs1"
               ><span class="outcome-chip outcome-chip-fail" title="4 Failed"
                 ><span class="icon"
                   ><span class="check-container"
@@ -1855,18 +1893,18 @@
               ><span>Failure instances were detected</span></span
             ></div
           ></div
-        ><div class="rules-results-container--n7EEu"
-          ><div class="results-heading--pyS7R"><h2>Rules</h2></div
+        ><div class="rules-results-container--dO76T"
+          ><div class="results-heading--2h1oe"><h2>Rules</h2></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-combined-report-failed-section"
-                  ><span class="combined-report-result-section-title--XUDDo"
+                  ><span class="combined-report-result-section-title--RNekd"
                     ><span class="screen-reader-only">Failed rules 2</span
-                    ><span class="heading--uUq3e" aria-hidden="true"
+                    ><span class="heading--gtY3F" aria-hidden="true"
                       >Failed rules (2)</span
                     ></span
                   ></button
@@ -1876,12 +1914,12 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><div
-                  class="rule-details-group--U69fz"
+                  class="rule-details-group--ZuRYr"
                   data-automation-id="rule-details-group"
                   ><div
-                    class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
+                    class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
                     ><h4
-                      class="heading-element-for-level--OfRDW title-container"
+                      class="heading-element-for-level--wzmxK title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -1890,7 +1928,7 @@
                         ><span
                           data-automation-id="rule-detail"
                           class="rule-detail"
-                          ><span class="outcome-chip-container--xYquF"
+                          ><span class="outcome-chip-container--ja0WM"
                             ><span aria-hidden="true"
                               ><span
                                 class="outcome-chip outcome-chip-fail"
@@ -1943,10 +1981,10 @@
                       id="content-container-bypass"
                       class="collapsible-content"
                       aria-hidden="true"
-                      ><div class="rule-more-resources--Bsblo"
-                        ><div class="more-resources-title--whTFs"
+                      ><div class="rule-more-resources--w4eYl"
+                        ><div class="more-resources-title--wqgCn"
                           >Resources for this rule</div
-                        ><span class="rule-details-id--n_S89"
+                        ><span class="rule-details-id--QH6Z9"
                           ><a
                             target="_blank"
                             href="https://accessibilityinsights.io/info-examples/web/bypass"
@@ -1964,9 +2002,7 @@
                                 "click",
                                 function (event) {
                                   var result = confirmCallback(
-                                    "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                      "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                      "Cancel to stay on the current page."
+                                    "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                   );
                                   if (result === false) {
                                     event.preventDefault();
@@ -1998,9 +2034,7 @@
                                   "click",
                                   function (event) {
                                     var result = confirmCallback(
-                                      "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                        "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                        "Cancel to stay on the current page."
+                                      "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                     );
                                     if (result === false) {
                                       event.preventDefault();
@@ -2017,20 +2051,20 @@
                         ></div
                       ><ul
                         data-automation-id="cards-rule-content"
-                        class="instance-details-list--xiPPL"
+                        class="instance-details-list--bg-Zq"
                         aria-label="instances with additional information like path, snippet and how to fix"
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--bKrcd"
-                            ><div class="instance-details-card--R0aAh"
+                            class="instance-details-card-container--Hjwps"
+                            ><div class="instance-details-card--lixTP"
                               ><div
-                                ><table class="report-instance-table--YIu0s"
+                                ><table class="report-instance-table--YOlnT"
                                   ><tbody
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">URL</th
-                                      ><td class="row-content--ECKwg"
-                                        ><ul class="urls-row-content--MxcA7"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">URL</th
+                                      ><td class="row-content--Gt-CK"
+                                        ><ul class="urls-row-content--rj2oy"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2051,9 +2085,7 @@
                                                   function (event) {
                                                     var result =
                                                       confirmCallback(
-                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                                          "Cancel to stay on the current page."
+                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                                       );
                                                     if (result === false) {
                                                       event.preventDefault();
@@ -2069,26 +2101,26 @@
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Path</th
-                                      ><td class="row-content--ECKwg"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Path</th
+                                      ><td class="row-content--Gt-CK"
                                         >.rule-1-selector-1</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Snippet</th
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Snippet</th
                                       ><td
-                                        class="row-content--ECKwg snippet--wZrK1"
+                                        class="row-content--Gt-CK snippet--P6i7P"
                                         >&lt;div&gt;snippet 1&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e"
                                         >How to fix</th
-                                      ><td class="row-content--ECKwg"
-                                        ><div class="how-to-fix-content--OHBLC"
+                                      ><td class="row-content--Gt-CK"
+                                        ><div class="how-to-fix-content--Xj-BH"
                                           ><div
                                             ><div>Fix ONE of the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--G3vyY"
+                                              class="insights-fix-instruction-list--NaN2O"
                                               ><li>No valid skip link found</li
                                               ><li
                                                 >Page does not have a header</li
@@ -2109,15 +2141,15 @@
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--bKrcd"
-                            ><div class="instance-details-card--R0aAh"
+                            class="instance-details-card-container--Hjwps"
+                            ><div class="instance-details-card--lixTP"
                               ><div
-                                ><table class="report-instance-table--YIu0s"
+                                ><table class="report-instance-table--YOlnT"
                                   ><tbody
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">URL</th
-                                      ><td class="row-content--ECKwg"
-                                        ><ul class="urls-row-content--MxcA7"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">URL</th
+                                      ><td class="row-content--Gt-CK"
+                                        ><ul class="urls-row-content--rj2oy"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2138,9 +2170,7 @@
                                                   function (event) {
                                                     var result =
                                                       confirmCallback(
-                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                                          "Cancel to stay on the current page."
+                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                                       );
                                                     if (result === false) {
                                                       event.preventDefault();
@@ -2173,9 +2203,7 @@
                                                   function (event) {
                                                     var result =
                                                       confirmCallback(
-                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                                          "Cancel to stay on the current page."
+                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                                       );
                                                     if (result === false) {
                                                       event.preventDefault();
@@ -2191,26 +2219,26 @@
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Path</th
-                                      ><td class="row-content--ECKwg"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Path</th
+                                      ><td class="row-content--Gt-CK"
                                         >.rule-1-selector-2</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Snippet</th
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Snippet</th
                                       ><td
-                                        class="row-content--ECKwg snippet--wZrK1"
+                                        class="row-content--Gt-CK snippet--P6i7P"
                                         >&lt;div&gt;snippet 2&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e"
                                         >How to fix</th
-                                      ><td class="row-content--ECKwg"
-                                        ><div class="how-to-fix-content--OHBLC"
+                                      ><td class="row-content--Gt-CK"
+                                        ><div class="how-to-fix-content--Xj-BH"
                                           ><div
                                             ><div>Fix ONE of the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--G3vyY"
+                                              class="insights-fix-instruction-list--NaN2O"
                                               ><li>No valid skip link found</li
                                               ><li
                                                 >Page does not have a header</li
@@ -2232,9 +2260,9 @@
                       ></div
                     ></div
                   ><div
-                    class="collapsible-container collapsible-rule-details-group--h0lvd collapsed"
+                    class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
                     ><h4
-                      class="heading-element-for-level--OfRDW title-container"
+                      class="heading-element-for-level--wzmxK title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -2243,7 +2271,7 @@
                         ><span
                           data-automation-id="rule-detail"
                           class="rule-detail"
-                          ><span class="outcome-chip-container--xYquF"
+                          ><span class="outcome-chip-container--ja0WM"
                             ><span aria-hidden="true"
                               ><span
                                 class="outcome-chip outcome-chip-fail"
@@ -2296,10 +2324,10 @@
                       id="content-container-color-contrast"
                       class="collapsible-content"
                       aria-hidden="true"
-                      ><div class="rule-more-resources--Bsblo"
-                        ><div class="more-resources-title--whTFs"
+                      ><div class="rule-more-resources--w4eYl"
+                        ><div class="more-resources-title--wqgCn"
                           >Resources for this rule</div
-                        ><span class="rule-details-id--n_S89"
+                        ><span class="rule-details-id--QH6Z9"
                           ><a
                             target="_blank"
                             href="https://accessibilityinsights.io/info-examples/web/color-contrast"
@@ -2317,9 +2345,7 @@
                                 "click",
                                 function (event) {
                                   var result = confirmCallback(
-                                    "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                      "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                      "Cancel to stay on the current page."
+                                    "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                   );
                                   if (result === false) {
                                     event.preventDefault();
@@ -2351,9 +2377,7 @@
                                   "click",
                                   function (event) {
                                     var result = confirmCallback(
-                                      "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                        "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                        "Cancel to stay on the current page."
+                                      "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                     );
                                     if (result === false) {
                                       event.preventDefault();
@@ -2370,20 +2394,20 @@
                         ></div
                       ><ul
                         data-automation-id="cards-rule-content"
-                        class="instance-details-list--xiPPL"
+                        class="instance-details-list--bg-Zq"
                         aria-label="instances with additional information like path, snippet and how to fix"
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--bKrcd"
-                            ><div class="instance-details-card--R0aAh"
+                            class="instance-details-card-container--Hjwps"
+                            ><div class="instance-details-card--lixTP"
                               ><div
-                                ><table class="report-instance-table--YIu0s"
+                                ><table class="report-instance-table--YOlnT"
                                   ><tbody
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">URL</th
-                                      ><td class="row-content--ECKwg"
-                                        ><ul class="urls-row-content--MxcA7"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">URL</th
+                                      ><td class="row-content--Gt-CK"
+                                        ><ul class="urls-row-content--rj2oy"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2404,9 +2428,7 @@
                                                   function (event) {
                                                     var result =
                                                       confirmCallback(
-                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                                          "Cancel to stay on the current page."
+                                                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                                       );
                                                     if (result === false) {
                                                       event.preventDefault();
@@ -2422,26 +2444,26 @@
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Path</th
-                                      ><td class="row-content--ECKwg"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Path</th
+                                      ><td class="row-content--Gt-CK"
                                         >.rule-2-selector-1</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ">Snippet</th
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e">Snippet</th
                                       ><td
-                                        class="row-content--ECKwg snippet--wZrK1"
+                                        class="row-content--Gt-CK snippet--P6i7P"
                                         >&lt;div&gt;snippet&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--m8TLI"
-                                      ><th class="row-label--MxfuQ"
+                                    ><tr class="row--9WgHa"
+                                      ><th class="row-label--dri3e"
                                         >How to fix</th
-                                      ><td class="row-content--ECKwg"
-                                        ><div class="how-to-fix-content--OHBLC"
+                                      ><td class="row-content--Gt-CK"
+                                        ><div class="how-to-fix-content--Xj-BH"
                                           ><div
                                             ><div>Fix the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--G3vyY"
+                                              class="insights-fix-instruction-list--NaN2O"
                                               ><li
                                                 ><span aria-hidden="true"
                                                   ><span
@@ -2450,7 +2472,7 @@
                                                     (foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #8a94a8;
                                                     "
@@ -2459,7 +2481,7 @@
                                                     >#8a94a8, background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--Xq1E4"
+                                                    class="fix-instruction-color-box--lzu-L"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2471,7 +2493,7 @@
                                                     ratio of 4.5:1</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--n1Ocs"
+                                                  class="screen-reader-only--T-59F"
                                                   >Element has insufficient
                                                   color contrast of 2.52
                                                   (foreground color: #8a94a8,
@@ -2487,7 +2509,7 @@
                                                         Use foreground color: </span
                                                       ><span
                                                         aria-hidden="true"
-                                                        class="fix-instruction-color-box--Xq1E4"
+                                                        class="fix-instruction-color-box--lzu-L"
                                                         style="
                                                           background-color: #5e6572;
                                                         "
@@ -2498,7 +2520,7 @@
                                                         color: </span
                                                       ><span
                                                         aria-hidden="true"
-                                                        class="fix-instruction-color-box--Xq1E4"
+                                                        class="fix-instruction-color-box--lzu-L"
                                                         style="
                                                           background-color: #e7ecd8;
                                                         "
@@ -2509,7 +2531,7 @@
                                                         4.86:1.</span
                                                       ></span
                                                     ><span
-                                                      class="screen-reader-only--n1Ocs"
+                                                      class="screen-reader-only--T-59F"
                                                     >
                                                       Use foreground color:
                                                       #5e6572 and the original
@@ -2539,14 +2561,14 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-pass-checks-section"
-                  ><span class="combined-report-result-section-title--XUDDo"
+                  ><span class="combined-report-result-section-title--RNekd"
                     ><span class="screen-reader-only">Passed rules 2</span
-                    ><span class="heading--uUq3e" aria-hidden="true"
+                    ><span class="heading--gtY3F" aria-hidden="true"
                       >Passed rules (2)</span
                     ></span
                   ></button
@@ -2555,7 +2577,7 @@
                 id="content-container-pass-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--U69fz"
+                ><div class="rule-details-group--ZuRYr"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -2591,9 +2613,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2643,9 +2663,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2675,9 +2693,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2698,15 +2714,15 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-inapplicable-checks-section"
-                  ><span class="combined-report-result-section-title--XUDDo"
+                  ><span class="combined-report-result-section-title--RNekd"
                     ><span class="screen-reader-only"
                       >Not applicable rules 3</span
-                    ><span class="heading--uUq3e" aria-hidden="true"
+                    ><span class="heading--gtY3F" aria-hidden="true"
                       >Not applicable rules (3)</span
                     ></span
                   ></button
@@ -2715,7 +2731,7 @@
                 id="content-container-inapplicable-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--U69fz"
+                ><div class="rule-details-group--ZuRYr"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -2751,9 +2767,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2803,9 +2817,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2855,9 +2867,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2884,7 +2894,7 @@
             var _loop = function (index) {
               var container = collapsibles.item(index);
               var button =
-                container === null || container === void 0
+                container == null
                   ? void 0
                   : container.querySelector(".collapsible-control");
               if (button == null) {
@@ -2893,7 +2903,7 @@
               button.addEventListener("click", function () {
                 var _a;
                 var content =
-                  (_a = button.parentElement) === null || _a === void 0
+                  (_a = button.parentElement) == null
                     ? void 0
                     : _a.nextElementSibling;
                 if (content == null) {

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -835,29 +835,29 @@
       }</style
     ><style>
       /* css-modules:src/common/components/heading-element-for-level */
-      .heading-element-for-level--wzmxK {
+      .heading-element-for-level--ifVX6 {
         margin-block-start: unset;
         margin-block-end: unset;
       }
 
       /* css-modules:src/common/components/cards/failed-instances-section */
-      .failed-instances-container--pB-u4 .collapsible-content {
+      .failed-instances-container--3UUNb .collapsible-content {
         margin-left: 24px;
       }
 
       /* css-modules:src/reports/components/report-sections/minimal-rule-header */
-      .outcome-chip-container--ja0WM {
+      .outcome-chip-container--G5Dfr {
         min-width: 50px;
       }
 
       /* css-modules:src/reports/components/instance-details */
-      .hidden-highlight-button--to41b {
+      .hidden-highlight-button--vu3B3 {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-      .instance-details-card--lixTP {
+      .instance-details-card--owGQF {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -868,29 +868,29 @@
         width: -webkit-fill-available;
         width: fill-available;
       }
-      .instance-details-card-container--Hjwps.selected--Pf-DQ {
+      .instance-details-card-container--KLHTp.selected--wEA4l {
         outline: 5px solid var(--communication-tint-10);
       }
-      .instance-details-card--lixTP.selected--Pf-DQ {
+      .instance-details-card--owGQF.selected--wEA4l {
         border: 1px solid transparent;
       }
-      .instance-details-card--lixTP.focused--PfWGT,
-      .instance-details-card--lixTP:focus {
+      .instance-details-card--owGQF.focused--pvBWq,
+      .instance-details-card--owGQF:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
-      .instance-details-card--lixTP.selected--Pf-DQ:focus {
+      .instance-details-card--owGQF.selected--wEA4l.focused--pvBWq,
+      .instance-details-card--owGQF.selected--wEA4l:focus {
         outline-offset: 8px;
       }
-      .instance-details-card--lixTP.interactive--su6Sw {
+      .instance-details-card--owGQF.interactive--an0ab {
         cursor: pointer;
       }
-      .instance-details-card--lixTP.interactive--su6Sw:hover {
+      .instance-details-card--owGQF.interactive--an0ab:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-      .report-instance-table--YOlnT {
+      .report-instance-table--3VoZX {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
@@ -902,7 +902,7 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YOlnT .row--9WgHa {
+      .report-instance-table--3VoZX .row---3i35 {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -911,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YOlnT .row--9WgHa > * {
+      .report-instance-table--3VoZX .row---3i35 > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YOlnT .row--9WgHa:last-child {
+      .report-instance-table--3VoZX .row---3i35:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YOlnT .row-label--dri3e {
+      .report-instance-table--3VoZX .row-label--FlVZl {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -931,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YOlnT .row-content--Gt-CK {
+      .report-instance-table--3VoZX .row-content--07KUh {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -943,42 +943,42 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--xUzJx {
+      .multi-line-text-no-bullet--AUXXt {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
-      .multi-line-text-yes-bullet--jH-w4 {
+      .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--jH-w4 li {
+      .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .combination-lists--4wBYq {
+      .combination-lists--boK5y {
         flex-direction: column;
         display: flex;
       }
 
       /* css-modules:src/common/components/cards/urls-card-row */
-      .urls-row-content--rj2oy {
+      .urls-row-content--JDdRx {
         padding-left: 16px;
       }
-      .urls-row-content--rj2oy li {
+      .urls-row-content--JDdRx li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .urls-row-content-new-Failure--7Dq38 {
+      .urls-row-content-new-Failure--oL5lS {
         color: var(--negative-outcome);
         font-weight: bold;
       }
 
       /* css-modules:src/common/components/fix-instruction-panel */
-      .insights-fix-instruction-list--NaN2O
+      .insights-fix-instruction-list--eZigw
         li
-        span.fix-instruction-color-box---mQtG {
+        span.fix-instruction-color-box--sBkHG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -986,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
+      .insights-fix-instruction-list--eZigw .screen-reader-only--irrXo {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,73 +996,73 @@
       }
 
       /* css-modules:src/common/components/cards/how-to-fix-card-row */
-      .how-to-fix-content--Xj-BH {
+      .how-to-fix-content--Zz96u {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--Xj-BH ul {
+      .how-to-fix-content--Zz96u ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--Xj-BH ul li {
+      .how-to-fix-content--Zz96u ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
 
       /* css-modules:src/common/components/cards/snippet-card-row */
-      .snippet--P6i7P {
+      .snippet--hSNfv {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
 
       /* css-modules:src/DetailsView/components/common-dialog-styles */
-      div.insights-dialog-main-override--qzZJk {
+      div.insights-dialog-main-override--ma4DA {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--qzZJk {
+        div.insights-dialog-main-override--ma4DA {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
+      div.insights-dialog-main-override--ma4DA .dialog-body--cmWmz {
         font-size: 16px;
       }
 
       /* css-modules:src/DetailsView/components/issue-filing-dialog */
-      .issue-filing-dialog--l9xMr .ms-Dialog-title {
+      .issue-filing-dialog--F9jun .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
+      .issue-filing-dialog--F9jun .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--l9xMr .textfield-description {
+      .issue-filing-dialog--F9jun .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
 
       /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
-      .action-and-cancel-buttons-component--5-uZX {
+      .action-and-cancel-buttons-component--DF7bf {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--5-uZX
-        .action-cancel-button-col--txH36
-        + .action-cancel-button-col--txH36 {
+      .action-and-cancel-buttons-component--DF7bf
+        .action-cancel-button-col--RMfN-
+        + .action-cancel-button-col--RMfN- {
         margin-left: 8px;
       }
 
       /* css-modules:src/common/components/toast */
-      .toast-container--cNX98 {
+      .toast-container--L-5HM {
         display: inline-block;
       }
-      .toast-content--bk935 {
+      .toast-content--8-Mx1 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1079,84 +1079,84 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
-      div.kebab-menu-callout--A3AHu {
+      div.kebab-menu-callout--XvN24 {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--A3AHu > div {
+      div.kebab-menu-callout--XvN24 > div {
         border-radius: 4px;
       }
-      .kebab-menu--Bm5S1 {
+      .kebab-menu--eKCNX {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--Bm5S1 li {
+      .kebab-menu--eKCNX li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--Bm5S1 button i {
+      .kebab-menu--eKCNX button i {
         color: var(--primary-text);
       }
-      .kebab-menu--Bm5S1 button:hover {
+      .kebab-menu--eKCNX button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--Bm5S1 button:hover {
+        .kebab-menu--eKCNX button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--Bm5S1 button:active {
+      .kebab-menu--eKCNX button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--Bm5S1 button:active i {
+      .kebab-menu--eKCNX button:active i {
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR {
+      button.kebab-menu-button--e-7v- {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--ySFdR svg {
+      button.kebab-menu-button--e-7v- svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR svg {
+        button.kebab-menu-button--e-7v- svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--ySFdR:hover {
+      button.kebab-menu-button--e-7v-:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--ySFdR:active,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+      button.kebab-menu-button--e-7v-:active,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR:active svg > circle,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--e-7v-:active svg > circle,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR:active,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+        button.kebab-menu-button--e-7v-:active,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--ySFdR:active svg > circle,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--e-7v-:active svg > circle,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--ySFdR > span {
+      button.kebab-menu-button--e-7v- > span {
         justify-content: center;
       }
 
       /* css-modules:src/common/components/cards/instance-details-footer */
-      .foot--WBFZ6 {
+      .foot--p1DfC {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1167,22 +1167,22 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj {
+      .foot--p1DfC .highlight-status--xJvvI {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj svg {
+      .foot--p1DfC .highlight-status--xJvvI svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--WBFZ6 .highlight-status--TYXPj svg {
+        .foot--p1DfC .highlight-status--xJvvI svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--WBFZ6 .highlight-status--TYXPj label {
+      .foot--p1DfC .highlight-status--xJvvI label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
@@ -1190,21 +1190,21 @@
       }
 
       /* css-modules:src/common/components/cards/instance-details-group */
-      ul.instance-details-list--bg-Zq {
+      ul.instance-details-list--YfkRy {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--bg-Zq > li {
+      ul.instance-details-list--YfkRy > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--bg-Zq > li:last-child {
+      ul.instance-details-list--YfkRy > li:last-child {
         margin-bottom: unset;
       }
 
       /* css-modules:src/common/components/cards/rule-resources */
-      .rule-more-resources--w4eYl {
+      .rule-more-resources--uw9mc {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1218,53 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
+      .rule-more-resources--uw9mc .more-resources-title--jOuUL {
         font-weight: 600;
       }
-      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
+      .rule-more-resources--uw9mc .rule-details-id--s-TpO {
         padding: 12px 0;
       }
 
       /* css-modules:src/common/components/cards/rules-with-instances */
-      .rule-details-group--ZuRYr .rule-detail {
+      .rule-details-group--Tb-LW .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
+      .rule-details-group--Tb-LW .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
+      .rule-details-group--Tb-LW .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-      .collapsible-rule-details-group--ODFPb {
+      .collapsible-rule-details-group--V-HWh {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--ODFPb .rule-detail {
+      .collapsible-rule-details-group--V-HWh .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
+      .collapsible-rule-details-group--V-HWh:not(.collapsed) {
         box-shadow: unset;
       }
 
       /* css-modules:src/common/components/cards/result-section-title */
-      .result-section-title--vgyHe {
+      .result-section-title--RGFI5 {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1272,49 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--vgyHe .title--6gdF5 {
+      .result-section-title--RGFI5 .title--WBYFE {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .heading--1Ll6- {
+      .result-section-title--RGFI5 .heading--NdP4Q {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
+      .result-section-title--RGFI5 .outcome-chip-container--BT3j5 {
         display: flex;
         height: 16px;
       }
 
       /* css-modules:src/common/components/cards/result-section */
-      .result-section--Av9vc {
+      .result-section--HfO9s {
         padding-bottom: 24px;
       }
-      .result-section--Av9vc
-        .title-container---R9Dm
-        .collapsible-control--5y7Tp::before {
+      .result-section--HfO9s
+        .title-container--JzN4A
+        .collapsible-control--e42Z7::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--Av9vc > h2 {
+      .result-section--HfO9s > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
 
       /* css-modules:src/reports/components/header-bar */
-      .report-header-bar--DNH-8 {
+      .report-header-bar--SDV11 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1323,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--DNH-8 .header-icon {
+      .report-header-bar--SDV11 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--DNH-8 .header-text--v-ac2 {
+      .report-header-bar--SDV11 .header-text--EdTxw {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1345,7 +1345,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/header-section */
-      .report-header-command-bar--8-nLy {
+      .report-header-command-bar--NJWdl {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1355,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX {
+      .report-header-command-bar--NJWdl .target-page--hjh44 {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1368,14 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX a {
+      .report-header-command-bar--NJWdl .target-page--hjh44 a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
       /* css-modules:src/common/components/cards/combined-report-result-section-title */
-      .combined-report-result-section-title--RNekd {
+      .combined-report-result-section-title--TqIZO {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1383,14 +1383,14 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--RNekd .title--CFcXZ {
+      .combined-report-result-section-title--TqIZO .title--6WIyt {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--RNekd .heading--gtY3F {
+      .combined-report-result-section-title--TqIZO .heading--UpAHf {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
@@ -1399,7 +1399,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/urls-summary-section */
-      .urls-summary-section--db4HQ {
+      .urls-summary-section--jNa-v {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1407,26 +1407,26 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--db4HQ h2 {
+      .urls-summary-section--jNa-v h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--db4HQ .total-urls--3pXYz {
+      .urls-summary-section--jNa-v .total-urls--95-ge {
         font-weight: 600;
       }
-      .urls-summary-section--db4HQ .failure-instances--y0Big {
+      .urls-summary-section--jNa-v .failure-instances--2WDtT {
         margin-top: 40px;
       }
-      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
+      .urls-summary-section--jNa-v .failure-outcome-chip--JF-lj {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
 
       /* css-modules:src/reports/components/report-sections/rules-results-container */
-      .rules-results-container--dO76T {
+      .rules-results-container--HaLDw {
         margin-top: 56px;
       }
-      .rules-results-container--dO76T .results-heading--2h1oe {
+      .rules-results-container--HaLDw .results-heading--H9Puz {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
@@ -1435,7 +1435,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/summary-report-details-section */
-      .crawl-details-section--jDqES {
+      .crawl-details-section--a6evz {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1443,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1453,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di li {
         display: inline-block;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
         li
-        .icon--enDUo {
+        .icon--APJEn {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
-        li.targetSite--M6DmE {
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
+        li.targetSite--wBJT- {
         margin-bottom: 6px;
       }
-      .crawl-details-section--jDqES .text--lxa-w,
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .text--rViTo,
+      .crawl-details-section--a6evz .label--DUNYf {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1480,30 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .label--DUNYf {
         font-weight: 600;
       }
-      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
+      .crawl-details-section--a6evz .label--DUNYf.no-icon--VrSr5 {
         padding-left: 29px;
       }
 
       /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
-      .url-result-section--Lsitd {
+      .url-result-section--SkOlZ {
         padding-bottom: 31px;
       }
-      .url-result-section--Lsitd
+      .url-result-section--SkOlZ
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--Lsitd .collapsible-content {
+      .url-result-section--SkOlZ .collapsible-content {
         margin-top: 19px;
       }
 
       /* css-modules:src/reports/components/report-sections/summary-results-table */
-      .summary-results-table--r6fvD {
+      .summary-results-table--Iezr- {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1512,39 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--r6fvD th,
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- th,
+      .summary-results-table--Iezr- td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--r6fvD th {
+      .summary-results-table--Iezr- th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--r6fvD thead tr :first-child {
+      .summary-results-table--Iezr- thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--r6fvD td.text-cell--luh34 {
+      .summary-results-table--Iezr- td.text-cell--EaUrM {
         overflow-wrap: break-word;
       }
-      .summary-results-table--r6fvD td.url-cell--ZGO-o {
+      .summary-results-table--Iezr- td.url-cell--mg-3l {
         overflow-wrap: anywhere;
       }
 
       /* css-modules:src/reports/components/report-sections/results-by-url-container */
-      .url-results-container--xiZ0N {
+      .url-results-container---dq9B {
         margin-top: 56px;
       }
-      .url-results-container--xiZ0N .results-heading--wmQ-W {
+      .url-results-container---dq9B .results-heading--2dWBX {
         margin-top: 32px;
         margin-bottom: 32px;
       }
 
       /* css-modules:src/common/components/cards/fix-instruction-color-box */
-      span.fix-instruction-color-box--lzu-L {
+      span.fix-instruction-color-box--DQpQE {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1552,7 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .screen-reader-only--T-59F {
+      .screen-reader-only--6LUiO {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1564,7 +1564,7 @@
     </style></head
   ><body
     ><header
-      ><div class="report-header-bar--DNH-8"
+      ><div class="report-header-bar--SDV11"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1721,16 +1721,16 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--v-ac2">Accessibility Insights</div></div
+        ><div class="header-text--EdTxw">Accessibility Insights</div></div
       ></header
     ><main class="outer-container"
       ><div class="content-container"
         ><div class="title-section"><h1>Automated checks results</h1></div
-        ><div class="crawl-details-section--jDqES"
+        ><div class="crawl-details-section--a6evz"
           ><h2>Scan details</h2
-          ><ul class="crawl-details-section-list--6FyX-"
-            ><li class="targetSite--M6DmE"
-              ><span class="icon--enDUo" aria-hidden="true"
+          ><ul class="crawl-details-section-list--WV1Di"
+            ><li class="targetSite--wBJT-"
+              ><span class="icon--APJEn" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1742,8 +1742,8 @@
                     d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--TrLq3">Target site </span
-              ><span class="text--lxa-w"
+              ><span class="label--DUNYf">Target site </span
+              ><span class="text--rViTo"
                 ><a
                   target="_blank"
                   href="https://example.com/mock-base-url"
@@ -1774,7 +1774,7 @@
                 </script></span
               ></li
             ><li
-              ><span class="icon--enDUo" aria-hidden="true"
+              ><span class="icon--APJEn" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1786,18 +1786,18 @@
                     d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--TrLq3">Scans started </span
-              ><span class="text--lxa-w">2020-02-02 3:04 AM UTC</span></li
+              ><span class="label--DUNYf">Scans started </span
+              ><span class="text--rViTo">2020-02-02 3:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--jXW2d label--TrLq3">Scans completed </span
-              ><span class="text--lxa-w">2020-02-02 4:04 AM UTC</span></li
+              ><span class="no-icon--VrSr5 label--DUNYf">Scans completed </span
+              ><span class="text--rViTo">2020-02-02 4:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--jXW2d label--TrLq3">Duration </span
-              ><span class="text--lxa-w">01:00:00</span></li
+              ><span class="no-icon--VrSr5 label--DUNYf">Duration </span
+              ><span class="text--rViTo">01:00:00</span></li
             ></ul
           ></div
-        ><div class="urls-summary-section--db4HQ"
-          ><h2>URLs</h2><span class="total-urls--3pXYz">6</span> total URLs
+        ><div class="urls-summary-section--jNa-v"
+          ><h2>URLs</h2><span class="total-urls--95-ge">6</span> total URLs
           scanned<div
             class="outcome-summary-bar"
             aria-label="3 Failed, 1 Not scanned, 2 Passed"
@@ -1865,9 +1865,9 @@
                 >2<span class="label"> Passed</span></span
               ></div
             ></div
-          ><div class="failure-instances--y0Big"
+          ><div class="failure-instances--2WDtT"
             ><h2>Failure Instances</h2
-            ><span class="failure-outcome-chip--vKGs1"
+            ><span class="failure-outcome-chip--JF-lj"
               ><span class="outcome-chip outcome-chip-fail" title="4 Failed"
                 ><span class="icon"
                   ><span class="check-container"
@@ -1893,18 +1893,18 @@
               ><span>Failure instances were detected</span></span
             ></div
           ></div
-        ><div class="rules-results-container--dO76T"
-          ><div class="results-heading--2h1oe"><h2>Rules</h2></div
+        ><div class="rules-results-container--HaLDw"
+          ><div class="results-heading--H9Puz"><h2>Rules</h2></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-combined-report-failed-section"
-                  ><span class="combined-report-result-section-title--RNekd"
+                  ><span class="combined-report-result-section-title--TqIZO"
                     ><span class="screen-reader-only">Failed rules 2</span
-                    ><span class="heading--gtY3F" aria-hidden="true"
+                    ><span class="heading--UpAHf" aria-hidden="true"
                       >Failed rules (2)</span
                     ></span
                   ></button
@@ -1914,12 +1914,12 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><div
-                  class="rule-details-group--ZuRYr"
+                  class="rule-details-group--Tb-LW"
                   data-automation-id="rule-details-group"
                   ><div
-                    class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                    class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
                     ><h4
-                      class="heading-element-for-level--wzmxK title-container"
+                      class="heading-element-for-level--ifVX6 title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -1928,7 +1928,7 @@
                         ><span
                           data-automation-id="rule-detail"
                           class="rule-detail"
-                          ><span class="outcome-chip-container--ja0WM"
+                          ><span class="outcome-chip-container--G5Dfr"
                             ><span aria-hidden="true"
                               ><span
                                 class="outcome-chip outcome-chip-fail"
@@ -1981,10 +1981,10 @@
                       id="content-container-bypass"
                       class="collapsible-content"
                       aria-hidden="true"
-                      ><div class="rule-more-resources--w4eYl"
-                        ><div class="more-resources-title--wqgCn"
+                      ><div class="rule-more-resources--uw9mc"
+                        ><div class="more-resources-title--jOuUL"
                           >Resources for this rule</div
-                        ><span class="rule-details-id--QH6Z9"
+                        ><span class="rule-details-id--s-TpO"
                           ><a
                             target="_blank"
                             href="https://accessibilityinsights.io/info-examples/web/bypass"
@@ -2051,20 +2051,20 @@
                         ></div
                       ><ul
                         data-automation-id="cards-rule-content"
-                        class="instance-details-list--bg-Zq"
+                        class="instance-details-list--YfkRy"
                         aria-label="instances with additional information like path, snippet and how to fix"
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--Hjwps"
-                            ><div class="instance-details-card--lixTP"
+                            class="instance-details-card-container--KLHTp"
+                            ><div class="instance-details-card--owGQF"
                               ><div
-                                ><table class="report-instance-table--YOlnT"
+                                ><table class="report-instance-table--3VoZX"
                                   ><tbody
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">URL</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><ul class="urls-row-content--rj2oy"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">URL</th
+                                      ><td class="row-content--07KUh"
+                                        ><ul class="urls-row-content--JDdRx"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2101,26 +2101,26 @@
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Path</th
-                                      ><td class="row-content--Gt-CK"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Path</th
+                                      ><td class="row-content--07KUh"
                                         >.rule-1-selector-1</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Snippet</th
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Snippet</th
                                       ><td
-                                        class="row-content--Gt-CK snippet--P6i7P"
+                                        class="row-content--07KUh snippet--hSNfv"
                                         >&lt;div&gt;snippet 1&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl"
                                         >How to fix</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><div class="how-to-fix-content--Xj-BH"
+                                      ><td class="row-content--07KUh"
+                                        ><div class="how-to-fix-content--Zz96u"
                                           ><div
                                             ><div>Fix ONE of the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--NaN2O"
+                                              class="insights-fix-instruction-list--eZigw"
                                               ><li>No valid skip link found</li
                                               ><li
                                                 >Page does not have a header</li
@@ -2141,15 +2141,15 @@
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--Hjwps"
-                            ><div class="instance-details-card--lixTP"
+                            class="instance-details-card-container--KLHTp"
+                            ><div class="instance-details-card--owGQF"
                               ><div
-                                ><table class="report-instance-table--YOlnT"
+                                ><table class="report-instance-table--3VoZX"
                                   ><tbody
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">URL</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><ul class="urls-row-content--rj2oy"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">URL</th
+                                      ><td class="row-content--07KUh"
+                                        ><ul class="urls-row-content--JDdRx"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2219,26 +2219,26 @@
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Path</th
-                                      ><td class="row-content--Gt-CK"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Path</th
+                                      ><td class="row-content--07KUh"
                                         >.rule-1-selector-2</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Snippet</th
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Snippet</th
                                       ><td
-                                        class="row-content--Gt-CK snippet--P6i7P"
+                                        class="row-content--07KUh snippet--hSNfv"
                                         >&lt;div&gt;snippet 2&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl"
                                         >How to fix</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><div class="how-to-fix-content--Xj-BH"
+                                      ><td class="row-content--07KUh"
+                                        ><div class="how-to-fix-content--Zz96u"
                                           ><div
                                             ><div>Fix ONE of the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--NaN2O"
+                                              class="insights-fix-instruction-list--eZigw"
                                               ><li>No valid skip link found</li
                                               ><li
                                                 >Page does not have a header</li
@@ -2260,9 +2260,9 @@
                       ></div
                     ></div
                   ><div
-                    class="collapsible-container collapsible-rule-details-group--ODFPb collapsed"
+                    class="collapsible-container collapsible-rule-details-group--V-HWh collapsed"
                     ><h4
-                      class="heading-element-for-level--wzmxK title-container"
+                      class="heading-element-for-level--ifVX6 title-container"
                       ><button
                         class="collapsible-control"
                         aria-expanded="false"
@@ -2271,7 +2271,7 @@
                         ><span
                           data-automation-id="rule-detail"
                           class="rule-detail"
-                          ><span class="outcome-chip-container--ja0WM"
+                          ><span class="outcome-chip-container--G5Dfr"
                             ><span aria-hidden="true"
                               ><span
                                 class="outcome-chip outcome-chip-fail"
@@ -2324,10 +2324,10 @@
                       id="content-container-color-contrast"
                       class="collapsible-content"
                       aria-hidden="true"
-                      ><div class="rule-more-resources--w4eYl"
-                        ><div class="more-resources-title--wqgCn"
+                      ><div class="rule-more-resources--uw9mc"
+                        ><div class="more-resources-title--jOuUL"
                           >Resources for this rule</div
-                        ><span class="rule-details-id--QH6Z9"
+                        ><span class="rule-details-id--s-TpO"
                           ><a
                             target="_blank"
                             href="https://accessibilityinsights.io/info-examples/web/color-contrast"
@@ -2394,20 +2394,20 @@
                         ></div
                       ><ul
                         data-automation-id="cards-rule-content"
-                        class="instance-details-list--bg-Zq"
+                        class="instance-details-list--YfkRy"
                         aria-label="instances with additional information like path, snippet and how to fix"
                         ><li
                           ><div
                             data-automation-id="instance-card"
-                            class="instance-details-card-container--Hjwps"
-                            ><div class="instance-details-card--lixTP"
+                            class="instance-details-card-container--KLHTp"
+                            ><div class="instance-details-card--owGQF"
                               ><div
-                                ><table class="report-instance-table--YOlnT"
+                                ><table class="report-instance-table--3VoZX"
                                   ><tbody
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">URL</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><ul class="urls-row-content--rj2oy"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">URL</th
+                                      ><td class="row-content--07KUh"
+                                        ><ul class="urls-row-content--JDdRx"
                                           ><li
                                             ><a
                                               target="_blank"
@@ -2444,26 +2444,26 @@
                                           ></ul
                                         ></td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Path</th
-                                      ><td class="row-content--Gt-CK"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Path</th
+                                      ><td class="row-content--07KUh"
                                         >.rule-2-selector-1</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e">Snippet</th
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl">Snippet</th
                                       ><td
-                                        class="row-content--Gt-CK snippet--P6i7P"
+                                        class="row-content--07KUh snippet--hSNfv"
                                         >&lt;div&gt;snippet&lt;/div&gt;</td
                                       ></tr
-                                    ><tr class="row--9WgHa"
-                                      ><th class="row-label--dri3e"
+                                    ><tr class="row---3i35"
+                                      ><th class="row-label--FlVZl"
                                         >How to fix</th
-                                      ><td class="row-content--Gt-CK"
-                                        ><div class="how-to-fix-content--Xj-BH"
+                                      ><td class="row-content--07KUh"
+                                        ><div class="how-to-fix-content--Zz96u"
                                           ><div
                                             ><div>Fix the following:</div
                                             ><ul
-                                              class="insights-fix-instruction-list--NaN2O"
+                                              class="insights-fix-instruction-list--eZigw"
                                               ><li
                                                 ><span aria-hidden="true"
                                                   ><span
@@ -2472,7 +2472,7 @@
                                                     (foreground color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #8a94a8;
                                                     "
@@ -2481,7 +2481,7 @@
                                                     >#8a94a8, background color: </span
                                                   ><span
                                                     aria-hidden="true"
-                                                    class="fix-instruction-color-box--lzu-L"
+                                                    class="fix-instruction-color-box--DQpQE"
                                                     style="
                                                       background-color: #e7ecd8;
                                                     "
@@ -2493,7 +2493,7 @@
                                                     ratio of 4.5:1</span
                                                   ></span
                                                 ><span
-                                                  class="screen-reader-only--T-59F"
+                                                  class="screen-reader-only--6LUiO"
                                                   >Element has insufficient
                                                   color contrast of 2.52
                                                   (foreground color: #8a94a8,
@@ -2509,7 +2509,7 @@
                                                         Use foreground color: </span
                                                       ><span
                                                         aria-hidden="true"
-                                                        class="fix-instruction-color-box--lzu-L"
+                                                        class="fix-instruction-color-box--DQpQE"
                                                         style="
                                                           background-color: #5e6572;
                                                         "
@@ -2520,7 +2520,7 @@
                                                         color: </span
                                                       ><span
                                                         aria-hidden="true"
-                                                        class="fix-instruction-color-box--lzu-L"
+                                                        class="fix-instruction-color-box--DQpQE"
                                                         style="
                                                           background-color: #e7ecd8;
                                                         "
@@ -2531,7 +2531,7 @@
                                                         4.86:1.</span
                                                       ></span
                                                     ><span
-                                                      class="screen-reader-only--T-59F"
+                                                      class="screen-reader-only--6LUiO"
                                                     >
                                                       Use foreground color:
                                                       #5e6572 and the original
@@ -2561,14 +2561,14 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-pass-checks-section"
-                  ><span class="combined-report-result-section-title--RNekd"
+                  ><span class="combined-report-result-section-title--TqIZO"
                     ><span class="screen-reader-only">Passed rules 2</span
-                    ><span class="heading--gtY3F" aria-hidden="true"
+                    ><span class="heading--UpAHf" aria-hidden="true"
                       >Passed rules (2)</span
                     ></span
                   ></button
@@ -2577,7 +2577,7 @@
                 id="content-container-pass-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--ZuRYr"
+                ><div class="rule-details-group--Tb-LW"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -2714,15 +2714,15 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-inapplicable-checks-section"
-                  ><span class="combined-report-result-section-title--RNekd"
+                  ><span class="combined-report-result-section-title--TqIZO"
                     ><span class="screen-reader-only"
                       >Not applicable rules 3</span
-                    ><span class="heading--gtY3F" aria-hidden="true"
+                    ><span class="heading--UpAHf" aria-hidden="true"
                       >Not applicable rules (3)</span
                     ></span
                   ></button
@@ -2731,7 +2731,7 @@
                 id="content-container-inapplicable-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--ZuRYr"
+                ><div class="rule-details-group--Tb-LW"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -834,24 +834,30 @@
         margin-bottom: unset;
       }</style
     ><style>
-      .heading-element-for-level--OfRDW {
+      /* css-modules:src/common/components/heading-element-for-level */
+      .heading-element-for-level--wzmxK {
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      .failed-instances-container--FqWV6 .collapsible-content {
+
+      /* css-modules:src/common/components/cards/failed-instances-section */
+      .failed-instances-container--pB-u4 .collapsible-content {
         margin-left: 24px;
       }
-      .outcome-chip-container--xYquF {
+
+      /* css-modules:src/reports/components/report-sections/minimal-rule-header */
+      .outcome-chip-container--ja0WM {
         min-width: 50px;
       }
-      .hidden-highlight-button--PePzJ {
+
+      /* css-modules:src/reports/components/instance-details */
+      .hidden-highlight-button--to41b {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-
-      .instance-details-card--R0aAh {
+      .instance-details-card--lixTP {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -859,55 +865,44 @@
           0 3.2px 7.2px var(--box-shadow-132);
         margin-bottom: 16px;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
       }
-
-      .instance-details-card-container--bKrcd.selected--Kp4AC {
+      .instance-details-card-container--Hjwps.selected--Pf-DQ {
         outline: 5px solid var(--communication-tint-10);
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC {
+      .instance-details-card--lixTP.selected--Pf-DQ {
         border: 1px solid transparent;
       }
-
-      .instance-details-card--R0aAh.focused--tV0ic,
-      .instance-details-card--R0aAh:focus {
+      .instance-details-card--lixTP.focused--PfWGT,
+      .instance-details-card--lixTP:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC.focused--tV0ic,
-      .instance-details-card--R0aAh.selected--Kp4AC:focus {
+      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
+      .instance-details-card--lixTP.selected--Pf-DQ:focus {
         outline-offset: 8px;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy {
+      .instance-details-card--lixTP.interactive--su6Sw {
         cursor: pointer;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy:hover {
+      .instance-details-card--lixTP.interactive--su6Sw:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-
-      .report-instance-table--YIu0s {
+      .report-instance-table--YOlnT {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
         border-radius: inherit;
         border-collapse: collapse;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YIu0s .row--m8TLI {
+      .report-instance-table--YOlnT .row--9WgHa {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -916,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YIu0s .row--m8TLI > * {
+      .report-instance-table--YOlnT .row--9WgHa > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YIu0s .row--m8TLI:last-child {
+      .report-instance-table--YOlnT .row--9WgHa:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YIu0s .row-label--MxfuQ {
+      .report-instance-table--YOlnT .row-label--dri3e {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -936,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YIu0s .row-content--ECKwg {
+      .report-instance-table--YOlnT .row-content--Gt-CK {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -946,41 +941,44 @@
         align-items: flex-end;
         display: flex;
       }
-      .multi-line-text-no-bullet--lNJS_ {
+
+      /* css-modules:src/common/components/cards/rich-resolution-content */
+      .multi-line-text-no-bullet--xUzJx {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--lNJS_ li:not(:last-child) {
+      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
         margin-bottom: 4px;
       }
-
-      .multi-line-text-yes-bullet--pp76P {
+      .multi-line-text-yes-bullet--jH-w4 {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--pp76P li {
+      .multi-line-text-yes-bullet--jH-w4 li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .combination-lists--O1dD_ {
+      .combination-lists--4wBYq {
         flex-direction: column;
         display: flex;
       }
-      .urls-row-content--MxcA7 {
+
+      /* css-modules:src/common/components/cards/urls-card-row */
+      .urls-row-content--rj2oy {
         padding-left: 16px;
       }
-      .urls-row-content--MxcA7 li {
+      .urls-row-content--rj2oy li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .urls-row-content-new-Failure--uJPP3 {
+      .urls-row-content-new-Failure--7Dq38 {
         color: var(--negative-outcome);
         font-weight: bold;
       }
-      .insights-fix-instruction-list--G3vyY
+
+      /* css-modules:src/common/components/fix-instruction-panel */
+      .insights-fix-instruction-list--NaN2O
         li
-        span.fix-instruction-color-box--g6NfJ {
+        span.fix-instruction-color-box---mQtG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -988,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--G3vyY .screen-reader-only--yQjgp {
+      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,64 +994,75 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
-      .how-to-fix-content--OHBLC {
+
+      /* css-modules:src/common/components/cards/how-to-fix-card-row */
+      .how-to-fix-content--Xj-BH {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--OHBLC ul {
+      .how-to-fix-content--Xj-BH ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--OHBLC ul li {
+      .how-to-fix-content--Xj-BH ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .snippet--wZrK1 {
+
+      /* css-modules:src/common/components/cards/snippet-card-row */
+      .snippet--P6i7P {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
-      div.insights-dialog-main-override--Mlek6 {
+
+      /* css-modules:src/DetailsView/components/common-dialog-styles */
+      div.insights-dialog-main-override--qzZJk {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--Mlek6 {
+        div.insights-dialog-main-override--qzZJk {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--Mlek6 .dialog-body--QtJ_D {
+      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
         font-size: 16px;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-title {
+
+      /* css-modules:src/DetailsView/components/issue-filing-dialog */
+      .issue-filing-dialog--l9xMr .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-subText {
+      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--ZrD5s .textfield-description {
+      .issue-filing-dialog--l9xMr .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
-      .action-and-cancel-buttons-component--HOvON {
+
+      /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
+      .action-and-cancel-buttons-component--5-uZX {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--HOvON
-        .action-cancel-button-col--VrVAp
-        + .action-cancel-button-col--VrVAp {
+      .action-and-cancel-buttons-component--5-uZX
+        .action-cancel-button-col--txH36
+        + .action-cancel-button-col--txH36 {
         margin-left: 8px;
       }
-      .toast-container--KsxE1 {
+
+      /* css-modules:src/common/components/toast */
+      .toast-container--cNX98 {
         display: inline-block;
       }
-
-      .toast-content--pEpMJ {
+      .toast-content--bk935 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1068,84 +1077,86 @@
         z-index: 1000;
         position: absolute;
       }
-      div.kebab-menu-callout--o23oT {
+
+      /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      div.kebab-menu-callout--A3AHu {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--o23oT > div {
+      div.kebab-menu-callout--A3AHu > div {
         border-radius: 4px;
       }
-
-      .kebab-menu--eviKu {
+      .kebab-menu--Bm5S1 {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--eviKu li {
+      .kebab-menu--Bm5S1 li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--eviKu button i {
+      .kebab-menu--Bm5S1 button i {
         color: var(--primary-text);
       }
-      .kebab-menu--eviKu button:hover {
+      .kebab-menu--Bm5S1 button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--eviKu button:hover {
+        .kebab-menu--Bm5S1 button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--eviKu button:active {
+      .kebab-menu--Bm5S1 button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--eviKu button:active i {
+      .kebab-menu--Bm5S1 button:active i {
         color: var(--light-black);
       }
-
-      button.kebab-menu-button--dy7Ui {
+      button.kebab-menu-button--ySFdR {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--dy7Ui svg {
+      button.kebab-menu-button--ySFdR svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui svg {
+        button.kebab-menu-button--ySFdR svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--dy7Ui:hover {
+      button.kebab-menu-button--ySFdR:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--dy7Ui:active,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+      button.kebab-menu-button--ySFdR:active,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--dy7Ui:active svg > circle,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--ySFdR:active svg > circle,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui:active,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+        button.kebab-menu-button--ySFdR:active,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--dy7Ui:active svg > circle,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--ySFdR:active svg > circle,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--dy7Ui > span {
+      button.kebab-menu-button--ySFdR > span {
         justify-content: center;
       }
-      .foot--d1w5m {
+
+      /* css-modules:src/common/components/cards/instance-details-footer */
+      .foot--WBFZ6 {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1156,40 +1167,44 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--d1w5m .highlight-status--Bmqfx {
+      .foot--WBFZ6 .highlight-status--TYXPj {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--d1w5m .highlight-status--Bmqfx svg {
+      .foot--WBFZ6 .highlight-status--TYXPj svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--d1w5m .highlight-status--Bmqfx svg {
+        .foot--WBFZ6 .highlight-status--TYXPj svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--d1w5m .highlight-status--Bmqfx label {
+      .foot--WBFZ6 .highlight-status--TYXPj label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      ul.instance-details-list--xiPPL {
+
+      /* css-modules:src/common/components/cards/instance-details-group */
+      ul.instance-details-list--bg-Zq {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--xiPPL > li {
+      ul.instance-details-list--bg-Zq > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--xiPPL > li:last-child {
+      ul.instance-details-list--bg-Zq > li:last-child {
         margin-bottom: unset;
       }
-      .rule-more-resources--Bsblo {
+
+      /* css-modules:src/common/components/cards/rule-resources */
+      .rule-more-resources--w4eYl {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1203,50 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--Bsblo .more-resources-title--whTFs {
+      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
         font-weight: 600;
       }
-      .rule-more-resources--Bsblo .rule-details-id--n_S89 {
+      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
         padding: 12px 0;
       }
-      .rule-details-group--U69fz .rule-detail {
+
+      /* css-modules:src/common/components/cards/rules-with-instances */
+      .rule-details-group--ZuRYr .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--U69fz .rule-detail .outcome-chip {
+      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id a {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--U69fz .rule-detail .rule-detail-description {
+      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-
-      .collapsible-rule-details-group--h0lvd {
+      .collapsible-rule-details-group--ODFPb {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--h0lvd .rule-detail {
+      .collapsible-rule-details-group--ODFPb .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--h0lvd:not(.collapsed) {
+      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
         box-shadow: unset;
       }
-      .result-section-title--qv3MK {
+
+      /* css-modules:src/common/components/cards/result-section-title */
+      .result-section-title--vgyHe {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1254,45 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--qv3MK .title--neMma {
+      .result-section-title--vgyHe .title--6gdF5 {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .heading--VbGap {
+      .result-section-title--vgyHe .heading--1Ll6- {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .outcome-chip-container--Wt0k4 {
+      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
         display: flex;
         height: 16px;
       }
-      .result-section--j6fYr {
+
+      /* css-modules:src/common/components/cards/result-section */
+      .result-section--Av9vc {
         padding-bottom: 24px;
       }
-      .result-section--j6fYr
-        .title-container--gMYqW
-        .collapsible-control--V9OlA::before {
+      .result-section--Av9vc
+        .title-container---R9Dm
+        .collapsible-control--5y7Tp::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--j6fYr > h2 {
+      .result-section--Av9vc > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-bar--pkiTM {
+
+      /* css-modules:src/reports/components/header-bar */
+      .report-header-bar--DNH-8 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1301,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--pkiTM .header-icon {
+      .report-header-bar--DNH-8 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--pkiTM .header-text--dfm48 {
+      .report-header-bar--DNH-8 .header-text--v-ac2 {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1321,7 +1343,9 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-command-bar--wDg1t {
+
+      /* css-modules:src/reports/components/report-sections/header-section */
+      .report-header-command-bar--8-nLy {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1331,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--wDg1t .target-page--giudb {
+      .report-header-command-bar--8-nLy .target-page--q7WnX {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1344,12 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
+      .report-header-command-bar--8-nLy .target-page--q7WnX a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      .combined-report-result-section-title--XUDDo {
+
+      /* css-modules:src/common/components/cards/combined-report-result-section-title */
+      .combined-report-result-section-title--RNekd {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1357,21 +1383,23 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--XUDDo .title--lcuIW {
+      .combined-report-result-section-title--RNekd .title--CFcXZ {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--XUDDo .heading--uUq3e {
+      .combined-report-result-section-title--RNekd .heading--gtY3F {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .urls-summary-section--DjUWc {
+
+      /* css-modules:src/reports/components/report-sections/urls-summary-section */
+      .urls-summary-section--db4HQ {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1379,31 +1407,35 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--DjUWc h2 {
+      .urls-summary-section--db4HQ h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--DjUWc .total-urls--Ig_eB {
+      .urls-summary-section--db4HQ .total-urls--3pXYz {
         font-weight: 600;
       }
-      .urls-summary-section--DjUWc .failure-instances--Rq_Tj {
+      .urls-summary-section--db4HQ .failure-instances--y0Big {
         margin-top: 40px;
       }
-      .urls-summary-section--DjUWc .failure-outcome-chip--YtjBX {
+      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
-      .rules-results-container--n7EEu {
+
+      /* css-modules:src/reports/components/report-sections/rules-results-container */
+      .rules-results-container--dO76T {
         margin-top: 56px;
       }
-      .rules-results-container--n7EEu .results-heading--pyS7R {
+      .rules-results-container--dO76T .results-heading--2h1oe {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
       }
-      .crawl-details-section--WhRL4 {
+
+      /* css-modules:src/reports/components/report-sections/summary-report-details-section */
+      .crawl-details-section--jDqES {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1411,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1421,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg li {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
         display: inline-block;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
         li
-        .icon--JdMPq {
+        .icon--enDUo {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
-        li.targetSite--qXxid {
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
+        li.targetSite--M6DmE {
         margin-bottom: 6px;
       }
-      .crawl-details-section--WhRL4 .text--swxfX,
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .text--lxa-w,
+      .crawl-details-section--jDqES .label--TrLq3 {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1448,26 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .label--TrLq3 {
         font-weight: 600;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2.no-icon--J7B9N {
+      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
         padding-left: 29px;
       }
-      .url-result-section--PmEoY {
+
+      /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
+      .url-result-section--Lsitd {
         padding-bottom: 31px;
       }
-      .url-result-section--PmEoY
+      .url-result-section--Lsitd
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--PmEoY .collapsible-content {
+      .url-result-section--Lsitd .collapsible-content {
         margin-top: 19px;
       }
-      .summary-results-table--Pb4_B {
+
+      /* css-modules:src/reports/components/report-sections/summary-results-table */
+      .summary-results-table--r6fvD {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1476,35 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--Pb4_B th,
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD th,
+      .summary-results-table--r6fvD td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--Pb4_B th {
+      .summary-results-table--r6fvD th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--Pb4_B thead tr :first-child {
+      .summary-results-table--r6fvD thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--Pb4_B td.text-cell--p0dxL {
+      .summary-results-table--r6fvD td.text-cell--luh34 {
         overflow-wrap: break-word;
       }
-      .summary-results-table--Pb4_B td.url-cell--yjU1V {
+      .summary-results-table--r6fvD td.url-cell--ZGO-o {
         overflow-wrap: anywhere;
       }
-      .url-results-container--dXQbj {
+
+      /* css-modules:src/reports/components/report-sections/results-by-url-container */
+      .url-results-container--xiZ0N {
         margin-top: 56px;
       }
-      .url-results-container--dXQbj .results-heading--D3Qtr {
+      .url-results-container--xiZ0N .results-heading--wmQ-W {
         margin-top: 32px;
         margin-bottom: 32px;
       }
-      span.fix-instruction-color-box--Xq1E4 {
+
+      /* css-modules:src/common/components/cards/fix-instruction-color-box */
+      span.fix-instruction-color-box--lzu-L {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1512,8 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-
-      .screen-reader-only--n1Ocs {
+      .screen-reader-only--T-59F {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1521,10 +1560,11 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
+      /*# sourceMappingURL=report.css.map */
     </style></head
   ><body
     ><header
-      ><div class="report-header-bar--pkiTM"
+      ><div class="report-header-bar--DNH-8"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1681,16 +1721,16 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--dfm48">Accessibility Insights</div></div
+        ><div class="header-text--v-ac2">Accessibility Insights</div></div
       ></header
     ><main class="outer-container"
       ><div class="content-container"
         ><div class="title-section"><h1>Automated checks results</h1></div
-        ><div class="crawl-details-section--WhRL4"
+        ><div class="crawl-details-section--jDqES"
           ><h2>Scan details</h2
-          ><ul class="crawl-details-section-list--Lrjqg"
-            ><li class="targetSite--qXxid"
-              ><span class="icon--JdMPq" aria-hidden="true"
+          ><ul class="crawl-details-section-list--6FyX-"
+            ><li class="targetSite--M6DmE"
+              ><span class="icon--enDUo" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1702,8 +1742,8 @@
                     d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--yUuT2">Target site </span
-              ><span class="text--swxfX"
+              ><span class="label--TrLq3">Target site </span
+              ><span class="text--lxa-w"
                 ><a
                   target="_blank"
                   href="https://example.com/mock-base-url"
@@ -1720,9 +1760,7 @@
                     var targetPageLink = doc.getElementById(linkId);
                     targetPageLink.addEventListener("click", function (event) {
                       var result = confirmCallback(
-                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                          "Cancel to stay on the current page."
+                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                       );
                       if (result === false) {
                         event.preventDefault();
@@ -1736,7 +1774,7 @@
                 </script></span
               ></li
             ><li
-              ><span class="icon--JdMPq" aria-hidden="true"
+              ><span class="icon--enDUo" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1748,18 +1786,18 @@
                     d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--yUuT2">Scans started </span
-              ><span class="text--swxfX">2020-02-02 3:04 AM UTC</span></li
+              ><span class="label--TrLq3">Scans started </span
+              ><span class="text--lxa-w">2020-02-02 3:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--J7B9N label--yUuT2">Scans completed </span
-              ><span class="text--swxfX">2020-02-02 4:04 AM UTC</span></li
+              ><span class="no-icon--jXW2d label--TrLq3">Scans completed </span
+              ><span class="text--lxa-w">2020-02-02 4:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--J7B9N label--yUuT2">Duration </span
-              ><span class="text--swxfX">01:00:00</span></li
+              ><span class="no-icon--jXW2d label--TrLq3">Duration </span
+              ><span class="text--lxa-w">01:00:00</span></li
             ></ul
           ></div
-        ><div class="urls-summary-section--DjUWc"
-          ><h2>URLs</h2><span class="total-urls--Ig_eB">3</span> total URLs
+        ><div class="urls-summary-section--db4HQ"
+          ><h2>URLs</h2><span class="total-urls--3pXYz">3</span> total URLs
           scanned<div
             class="outcome-summary-bar"
             aria-label="0 Failed, 1 Not scanned, 2 Passed"
@@ -1827,9 +1865,9 @@
                 >2<span class="label"> Passed</span></span
               ></div
             ></div
-          ><div class="failure-instances--Rq_Tj"
+          ><div class="failure-instances--y0Big"
             ><h2>Failure Instances</h2
-            ><span class="failure-outcome-chip--YtjBX"
+            ><span class="failure-outcome-chip--vKGs1"
               ><span class="outcome-chip outcome-chip-fail" title="0 Failed"
                 ><span class="icon"
                   ><span class="check-container"
@@ -1855,18 +1893,18 @@
               ><span>Failure instances were detected</span></span
             ></div
           ></div
-        ><div class="rules-results-container--n7EEu"
-          ><div class="results-heading--pyS7R"><h2>Rules</h2></div
+        ><div class="rules-results-container--dO76T"
+          ><div class="results-heading--2h1oe"><h2>Rules</h2></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-combined-report-failed-section"
-                  ><span class="combined-report-result-section-title--XUDDo"
+                  ><span class="combined-report-result-section-title--RNekd"
                     ><span class="screen-reader-only">Failed rules 0</span
-                    ><span class="heading--uUq3e" aria-hidden="true"
+                    ><span class="heading--gtY3F" aria-hidden="true"
                       >Failed rules (0)</span
                     ></span
                   ></button
@@ -1878,14 +1916,14 @@
               ></div></div></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-pass-checks-section"
-                  ><span class="combined-report-result-section-title--XUDDo"
+                  ><span class="combined-report-result-section-title--RNekd"
                     ><span class="screen-reader-only">Passed rules 2</span
-                    ><span class="heading--uUq3e" aria-hidden="true"
+                    ><span class="heading--gtY3F" aria-hidden="true"
                       >Passed rules (2)</span
                     ></span
                   ></button
@@ -1894,7 +1932,7 @@
                 id="content-container-pass-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--U69fz"
+                ><div class="rule-details-group--ZuRYr"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -1930,9 +1968,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -1982,9 +2018,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2014,9 +2048,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2037,15 +2069,15 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-inapplicable-checks-section"
-                  ><span class="combined-report-result-section-title--XUDDo"
+                  ><span class="combined-report-result-section-title--RNekd"
                     ><span class="screen-reader-only"
                       >Not applicable rules 3</span
-                    ><span class="heading--uUq3e" aria-hidden="true"
+                    ><span class="heading--gtY3F" aria-hidden="true"
                       >Not applicable rules (3)</span
                     ></span
                   ></button
@@ -2054,7 +2086,7 @@
                 id="content-container-inapplicable-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--U69fz"
+                ><div class="rule-details-group--ZuRYr"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -2090,9 +2122,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2142,9 +2172,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2194,9 +2222,7 @@
                               "click",
                               function (event) {
                                 var result = confirmCallback(
-                                  "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                                    "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                                    "Cancel to stay on the current page."
+                                  "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                                 );
                                 if (result === false) {
                                   event.preventDefault();
@@ -2223,7 +2249,7 @@
             var _loop = function (index) {
               var container = collapsibles.item(index);
               var button =
-                container === null || container === void 0
+                container == null
                   ? void 0
                   : container.querySelector(".collapsible-control");
               if (button == null) {
@@ -2232,7 +2258,7 @@
               button.addEventListener("click", function () {
                 var _a;
                 var content =
-                  (_a = button.parentElement) === null || _a === void 0
+                  (_a = button.parentElement) == null
                     ? void 0
                     : _a.nextElementSibling;
                 if (content == null) {

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -835,29 +835,29 @@
       }</style
     ><style>
       /* css-modules:src/common/components/heading-element-for-level */
-      .heading-element-for-level--wzmxK {
+      .heading-element-for-level--ifVX6 {
         margin-block-start: unset;
         margin-block-end: unset;
       }
 
       /* css-modules:src/common/components/cards/failed-instances-section */
-      .failed-instances-container--pB-u4 .collapsible-content {
+      .failed-instances-container--3UUNb .collapsible-content {
         margin-left: 24px;
       }
 
       /* css-modules:src/reports/components/report-sections/minimal-rule-header */
-      .outcome-chip-container--ja0WM {
+      .outcome-chip-container--G5Dfr {
         min-width: 50px;
       }
 
       /* css-modules:src/reports/components/instance-details */
-      .hidden-highlight-button--to41b {
+      .hidden-highlight-button--vu3B3 {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-      .instance-details-card--lixTP {
+      .instance-details-card--owGQF {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -868,29 +868,29 @@
         width: -webkit-fill-available;
         width: fill-available;
       }
-      .instance-details-card-container--Hjwps.selected--Pf-DQ {
+      .instance-details-card-container--KLHTp.selected--wEA4l {
         outline: 5px solid var(--communication-tint-10);
       }
-      .instance-details-card--lixTP.selected--Pf-DQ {
+      .instance-details-card--owGQF.selected--wEA4l {
         border: 1px solid transparent;
       }
-      .instance-details-card--lixTP.focused--PfWGT,
-      .instance-details-card--lixTP:focus {
+      .instance-details-card--owGQF.focused--pvBWq,
+      .instance-details-card--owGQF:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
-      .instance-details-card--lixTP.selected--Pf-DQ:focus {
+      .instance-details-card--owGQF.selected--wEA4l.focused--pvBWq,
+      .instance-details-card--owGQF.selected--wEA4l:focus {
         outline-offset: 8px;
       }
-      .instance-details-card--lixTP.interactive--su6Sw {
+      .instance-details-card--owGQF.interactive--an0ab {
         cursor: pointer;
       }
-      .instance-details-card--lixTP.interactive--su6Sw:hover {
+      .instance-details-card--owGQF.interactive--an0ab:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-      .report-instance-table--YOlnT {
+      .report-instance-table--3VoZX {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
@@ -902,7 +902,7 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YOlnT .row--9WgHa {
+      .report-instance-table--3VoZX .row---3i35 {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -911,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YOlnT .row--9WgHa > * {
+      .report-instance-table--3VoZX .row---3i35 > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YOlnT .row--9WgHa:last-child {
+      .report-instance-table--3VoZX .row---3i35:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YOlnT .row-label--dri3e {
+      .report-instance-table--3VoZX .row-label--FlVZl {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -931,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YOlnT .row-content--Gt-CK {
+      .report-instance-table--3VoZX .row-content--07KUh {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -943,42 +943,42 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--xUzJx {
+      .multi-line-text-no-bullet--AUXXt {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
-      .multi-line-text-yes-bullet--jH-w4 {
+      .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--jH-w4 li {
+      .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .combination-lists--4wBYq {
+      .combination-lists--boK5y {
         flex-direction: column;
         display: flex;
       }
 
       /* css-modules:src/common/components/cards/urls-card-row */
-      .urls-row-content--rj2oy {
+      .urls-row-content--JDdRx {
         padding-left: 16px;
       }
-      .urls-row-content--rj2oy li {
+      .urls-row-content--JDdRx li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .urls-row-content-new-Failure--7Dq38 {
+      .urls-row-content-new-Failure--oL5lS {
         color: var(--negative-outcome);
         font-weight: bold;
       }
 
       /* css-modules:src/common/components/fix-instruction-panel */
-      .insights-fix-instruction-list--NaN2O
+      .insights-fix-instruction-list--eZigw
         li
-        span.fix-instruction-color-box---mQtG {
+        span.fix-instruction-color-box--sBkHG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -986,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
+      .insights-fix-instruction-list--eZigw .screen-reader-only--irrXo {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,73 +996,73 @@
       }
 
       /* css-modules:src/common/components/cards/how-to-fix-card-row */
-      .how-to-fix-content--Xj-BH {
+      .how-to-fix-content--Zz96u {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--Xj-BH ul {
+      .how-to-fix-content--Zz96u ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--Xj-BH ul li {
+      .how-to-fix-content--Zz96u ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
 
       /* css-modules:src/common/components/cards/snippet-card-row */
-      .snippet--P6i7P {
+      .snippet--hSNfv {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
 
       /* css-modules:src/DetailsView/components/common-dialog-styles */
-      div.insights-dialog-main-override--qzZJk {
+      div.insights-dialog-main-override--ma4DA {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--qzZJk {
+        div.insights-dialog-main-override--ma4DA {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
+      div.insights-dialog-main-override--ma4DA .dialog-body--cmWmz {
         font-size: 16px;
       }
 
       /* css-modules:src/DetailsView/components/issue-filing-dialog */
-      .issue-filing-dialog--l9xMr .ms-Dialog-title {
+      .issue-filing-dialog--F9jun .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
+      .issue-filing-dialog--F9jun .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--l9xMr .textfield-description {
+      .issue-filing-dialog--F9jun .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
 
       /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
-      .action-and-cancel-buttons-component--5-uZX {
+      .action-and-cancel-buttons-component--DF7bf {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--5-uZX
-        .action-cancel-button-col--txH36
-        + .action-cancel-button-col--txH36 {
+      .action-and-cancel-buttons-component--DF7bf
+        .action-cancel-button-col--RMfN-
+        + .action-cancel-button-col--RMfN- {
         margin-left: 8px;
       }
 
       /* css-modules:src/common/components/toast */
-      .toast-container--cNX98 {
+      .toast-container--L-5HM {
         display: inline-block;
       }
-      .toast-content--bk935 {
+      .toast-content--8-Mx1 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1079,84 +1079,84 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
-      div.kebab-menu-callout--A3AHu {
+      div.kebab-menu-callout--XvN24 {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--A3AHu > div {
+      div.kebab-menu-callout--XvN24 > div {
         border-radius: 4px;
       }
-      .kebab-menu--Bm5S1 {
+      .kebab-menu--eKCNX {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--Bm5S1 li {
+      .kebab-menu--eKCNX li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--Bm5S1 button i {
+      .kebab-menu--eKCNX button i {
         color: var(--primary-text);
       }
-      .kebab-menu--Bm5S1 button:hover {
+      .kebab-menu--eKCNX button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--Bm5S1 button:hover {
+        .kebab-menu--eKCNX button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--Bm5S1 button:active {
+      .kebab-menu--eKCNX button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--Bm5S1 button:active i {
+      .kebab-menu--eKCNX button:active i {
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR {
+      button.kebab-menu-button--e-7v- {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--ySFdR svg {
+      button.kebab-menu-button--e-7v- svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR svg {
+        button.kebab-menu-button--e-7v- svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--ySFdR:hover {
+      button.kebab-menu-button--e-7v-:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--ySFdR:active,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+      button.kebab-menu-button--e-7v-:active,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR:active svg > circle,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--e-7v-:active svg > circle,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR:active,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+        button.kebab-menu-button--e-7v-:active,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--ySFdR:active svg > circle,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--e-7v-:active svg > circle,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--ySFdR > span {
+      button.kebab-menu-button--e-7v- > span {
         justify-content: center;
       }
 
       /* css-modules:src/common/components/cards/instance-details-footer */
-      .foot--WBFZ6 {
+      .foot--p1DfC {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1167,22 +1167,22 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj {
+      .foot--p1DfC .highlight-status--xJvvI {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj svg {
+      .foot--p1DfC .highlight-status--xJvvI svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--WBFZ6 .highlight-status--TYXPj svg {
+        .foot--p1DfC .highlight-status--xJvvI svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--WBFZ6 .highlight-status--TYXPj label {
+      .foot--p1DfC .highlight-status--xJvvI label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
@@ -1190,21 +1190,21 @@
       }
 
       /* css-modules:src/common/components/cards/instance-details-group */
-      ul.instance-details-list--bg-Zq {
+      ul.instance-details-list--YfkRy {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--bg-Zq > li {
+      ul.instance-details-list--YfkRy > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--bg-Zq > li:last-child {
+      ul.instance-details-list--YfkRy > li:last-child {
         margin-bottom: unset;
       }
 
       /* css-modules:src/common/components/cards/rule-resources */
-      .rule-more-resources--w4eYl {
+      .rule-more-resources--uw9mc {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1218,53 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
+      .rule-more-resources--uw9mc .more-resources-title--jOuUL {
         font-weight: 600;
       }
-      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
+      .rule-more-resources--uw9mc .rule-details-id--s-TpO {
         padding: 12px 0;
       }
 
       /* css-modules:src/common/components/cards/rules-with-instances */
-      .rule-details-group--ZuRYr .rule-detail {
+      .rule-details-group--Tb-LW .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
+      .rule-details-group--Tb-LW .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
+      .rule-details-group--Tb-LW .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-      .collapsible-rule-details-group--ODFPb {
+      .collapsible-rule-details-group--V-HWh {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--ODFPb .rule-detail {
+      .collapsible-rule-details-group--V-HWh .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
+      .collapsible-rule-details-group--V-HWh:not(.collapsed) {
         box-shadow: unset;
       }
 
       /* css-modules:src/common/components/cards/result-section-title */
-      .result-section-title--vgyHe {
+      .result-section-title--RGFI5 {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1272,49 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--vgyHe .title--6gdF5 {
+      .result-section-title--RGFI5 .title--WBYFE {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .heading--1Ll6- {
+      .result-section-title--RGFI5 .heading--NdP4Q {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
+      .result-section-title--RGFI5 .outcome-chip-container--BT3j5 {
         display: flex;
         height: 16px;
       }
 
       /* css-modules:src/common/components/cards/result-section */
-      .result-section--Av9vc {
+      .result-section--HfO9s {
         padding-bottom: 24px;
       }
-      .result-section--Av9vc
-        .title-container---R9Dm
-        .collapsible-control--5y7Tp::before {
+      .result-section--HfO9s
+        .title-container--JzN4A
+        .collapsible-control--e42Z7::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--Av9vc > h2 {
+      .result-section--HfO9s > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
 
       /* css-modules:src/reports/components/header-bar */
-      .report-header-bar--DNH-8 {
+      .report-header-bar--SDV11 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1323,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--DNH-8 .header-icon {
+      .report-header-bar--SDV11 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--DNH-8 .header-text--v-ac2 {
+      .report-header-bar--SDV11 .header-text--EdTxw {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1345,7 +1345,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/header-section */
-      .report-header-command-bar--8-nLy {
+      .report-header-command-bar--NJWdl {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1355,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX {
+      .report-header-command-bar--NJWdl .target-page--hjh44 {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1368,14 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX a {
+      .report-header-command-bar--NJWdl .target-page--hjh44 a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
       /* css-modules:src/common/components/cards/combined-report-result-section-title */
-      .combined-report-result-section-title--RNekd {
+      .combined-report-result-section-title--TqIZO {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1383,14 +1383,14 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--RNekd .title--CFcXZ {
+      .combined-report-result-section-title--TqIZO .title--6WIyt {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--RNekd .heading--gtY3F {
+      .combined-report-result-section-title--TqIZO .heading--UpAHf {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
@@ -1399,7 +1399,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/urls-summary-section */
-      .urls-summary-section--db4HQ {
+      .urls-summary-section--jNa-v {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1407,26 +1407,26 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--db4HQ h2 {
+      .urls-summary-section--jNa-v h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--db4HQ .total-urls--3pXYz {
+      .urls-summary-section--jNa-v .total-urls--95-ge {
         font-weight: 600;
       }
-      .urls-summary-section--db4HQ .failure-instances--y0Big {
+      .urls-summary-section--jNa-v .failure-instances--2WDtT {
         margin-top: 40px;
       }
-      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
+      .urls-summary-section--jNa-v .failure-outcome-chip--JF-lj {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
 
       /* css-modules:src/reports/components/report-sections/rules-results-container */
-      .rules-results-container--dO76T {
+      .rules-results-container--HaLDw {
         margin-top: 56px;
       }
-      .rules-results-container--dO76T .results-heading--2h1oe {
+      .rules-results-container--HaLDw .results-heading--H9Puz {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
@@ -1435,7 +1435,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/summary-report-details-section */
-      .crawl-details-section--jDqES {
+      .crawl-details-section--a6evz {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1443,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1453,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di li {
         display: inline-block;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
         li
-        .icon--enDUo {
+        .icon--APJEn {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
-        li.targetSite--M6DmE {
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
+        li.targetSite--wBJT- {
         margin-bottom: 6px;
       }
-      .crawl-details-section--jDqES .text--lxa-w,
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .text--rViTo,
+      .crawl-details-section--a6evz .label--DUNYf {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1480,30 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .label--DUNYf {
         font-weight: 600;
       }
-      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
+      .crawl-details-section--a6evz .label--DUNYf.no-icon--VrSr5 {
         padding-left: 29px;
       }
 
       /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
-      .url-result-section--Lsitd {
+      .url-result-section--SkOlZ {
         padding-bottom: 31px;
       }
-      .url-result-section--Lsitd
+      .url-result-section--SkOlZ
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--Lsitd .collapsible-content {
+      .url-result-section--SkOlZ .collapsible-content {
         margin-top: 19px;
       }
 
       /* css-modules:src/reports/components/report-sections/summary-results-table */
-      .summary-results-table--r6fvD {
+      .summary-results-table--Iezr- {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1512,39 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--r6fvD th,
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- th,
+      .summary-results-table--Iezr- td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--r6fvD th {
+      .summary-results-table--Iezr- th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--r6fvD thead tr :first-child {
+      .summary-results-table--Iezr- thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--r6fvD td.text-cell--luh34 {
+      .summary-results-table--Iezr- td.text-cell--EaUrM {
         overflow-wrap: break-word;
       }
-      .summary-results-table--r6fvD td.url-cell--ZGO-o {
+      .summary-results-table--Iezr- td.url-cell--mg-3l {
         overflow-wrap: anywhere;
       }
 
       /* css-modules:src/reports/components/report-sections/results-by-url-container */
-      .url-results-container--xiZ0N {
+      .url-results-container---dq9B {
         margin-top: 56px;
       }
-      .url-results-container--xiZ0N .results-heading--wmQ-W {
+      .url-results-container---dq9B .results-heading--2dWBX {
         margin-top: 32px;
         margin-bottom: 32px;
       }
 
       /* css-modules:src/common/components/cards/fix-instruction-color-box */
-      span.fix-instruction-color-box--lzu-L {
+      span.fix-instruction-color-box--DQpQE {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1552,7 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .screen-reader-only--T-59F {
+      .screen-reader-only--6LUiO {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1564,7 +1564,7 @@
     </style></head
   ><body
     ><header
-      ><div class="report-header-bar--DNH-8"
+      ><div class="report-header-bar--SDV11"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1721,16 +1721,16 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--v-ac2">Accessibility Insights</div></div
+        ><div class="header-text--EdTxw">Accessibility Insights</div></div
       ></header
     ><main class="outer-container"
       ><div class="content-container"
         ><div class="title-section"><h1>Automated checks results</h1></div
-        ><div class="crawl-details-section--jDqES"
+        ><div class="crawl-details-section--a6evz"
           ><h2>Scan details</h2
-          ><ul class="crawl-details-section-list--6FyX-"
-            ><li class="targetSite--M6DmE"
-              ><span class="icon--enDUo" aria-hidden="true"
+          ><ul class="crawl-details-section-list--WV1Di"
+            ><li class="targetSite--wBJT-"
+              ><span class="icon--APJEn" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1742,8 +1742,8 @@
                     d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--TrLq3">Target site </span
-              ><span class="text--lxa-w"
+              ><span class="label--DUNYf">Target site </span
+              ><span class="text--rViTo"
                 ><a
                   target="_blank"
                   href="https://example.com/mock-base-url"
@@ -1774,7 +1774,7 @@
                 </script></span
               ></li
             ><li
-              ><span class="icon--enDUo" aria-hidden="true"
+              ><span class="icon--APJEn" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1786,18 +1786,18 @@
                     d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--TrLq3">Scans started </span
-              ><span class="text--lxa-w">2020-02-02 3:04 AM UTC</span></li
+              ><span class="label--DUNYf">Scans started </span
+              ><span class="text--rViTo">2020-02-02 3:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--jXW2d label--TrLq3">Scans completed </span
-              ><span class="text--lxa-w">2020-02-02 4:04 AM UTC</span></li
+              ><span class="no-icon--VrSr5 label--DUNYf">Scans completed </span
+              ><span class="text--rViTo">2020-02-02 4:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--jXW2d label--TrLq3">Duration </span
-              ><span class="text--lxa-w">01:00:00</span></li
+              ><span class="no-icon--VrSr5 label--DUNYf">Duration </span
+              ><span class="text--rViTo">01:00:00</span></li
             ></ul
           ></div
-        ><div class="urls-summary-section--db4HQ"
-          ><h2>URLs</h2><span class="total-urls--3pXYz">3</span> total URLs
+        ><div class="urls-summary-section--jNa-v"
+          ><h2>URLs</h2><span class="total-urls--95-ge">3</span> total URLs
           scanned<div
             class="outcome-summary-bar"
             aria-label="0 Failed, 1 Not scanned, 2 Passed"
@@ -1865,9 +1865,9 @@
                 >2<span class="label"> Passed</span></span
               ></div
             ></div
-          ><div class="failure-instances--y0Big"
+          ><div class="failure-instances--2WDtT"
             ><h2>Failure Instances</h2
-            ><span class="failure-outcome-chip--vKGs1"
+            ><span class="failure-outcome-chip--JF-lj"
               ><span class="outcome-chip outcome-chip-fail" title="0 Failed"
                 ><span class="icon"
                   ><span class="check-container"
@@ -1893,18 +1893,18 @@
               ><span>Failure instances were detected</span></span
             ></div
           ></div
-        ><div class="rules-results-container--dO76T"
-          ><div class="results-heading--2h1oe"><h2>Rules</h2></div
+        ><div class="rules-results-container--HaLDw"
+          ><div class="results-heading--H9Puz"><h2>Rules</h2></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-combined-report-failed-section"
-                  ><span class="combined-report-result-section-title--RNekd"
+                  ><span class="combined-report-result-section-title--TqIZO"
                     ><span class="screen-reader-only">Failed rules 0</span
-                    ><span class="heading--gtY3F" aria-hidden="true"
+                    ><span class="heading--UpAHf" aria-hidden="true"
                       >Failed rules (0)</span
                     ></span
                   ></button
@@ -1916,14 +1916,14 @@
               ></div></div></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-pass-checks-section"
-                  ><span class="combined-report-result-section-title--RNekd"
+                  ><span class="combined-report-result-section-title--TqIZO"
                     ><span class="screen-reader-only">Passed rules 2</span
-                    ><span class="heading--gtY3F" aria-hidden="true"
+                    ><span class="heading--UpAHf" aria-hidden="true"
                       >Passed rules (2)</span
                     ></span
                   ></button
@@ -1932,7 +1932,7 @@
                 id="content-container-pass-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--ZuRYr"
+                ><div class="rule-details-group--Tb-LW"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"
@@ -2069,15 +2069,15 @@
             ></div
           ><div class="result-section"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-inapplicable-checks-section"
-                  ><span class="combined-report-result-section-title--RNekd"
+                  ><span class="combined-report-result-section-title--TqIZO"
                     ><span class="screen-reader-only"
                       >Not applicable rules 3</span
-                    ><span class="heading--gtY3F" aria-hidden="true"
+                    ><span class="heading--UpAHf" aria-hidden="true"
                       >Not applicable rules (3)</span
                     ></span
                   ></button
@@ -2086,7 +2086,7 @@
                 id="content-container-inapplicable-checks-section"
                 class="collapsible-content"
                 aria-hidden="true"
-                ><div class="rule-details-group--ZuRYr"
+                ><div class="rule-details-group--Tb-LW"
                   ><div class="rule-detail"
                     ><div>
                       <span class="rule-details-id"

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -835,29 +835,29 @@
       }</style
     ><style>
       /* css-modules:src/common/components/heading-element-for-level */
-      .heading-element-for-level--wzmxK {
+      .heading-element-for-level--ifVX6 {
         margin-block-start: unset;
         margin-block-end: unset;
       }
 
       /* css-modules:src/common/components/cards/failed-instances-section */
-      .failed-instances-container--pB-u4 .collapsible-content {
+      .failed-instances-container--3UUNb .collapsible-content {
         margin-left: 24px;
       }
 
       /* css-modules:src/reports/components/report-sections/minimal-rule-header */
-      .outcome-chip-container--ja0WM {
+      .outcome-chip-container--G5Dfr {
         min-width: 50px;
       }
 
       /* css-modules:src/reports/components/instance-details */
-      .hidden-highlight-button--to41b {
+      .hidden-highlight-button--vu3B3 {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-      .instance-details-card--lixTP {
+      .instance-details-card--owGQF {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -868,29 +868,29 @@
         width: -webkit-fill-available;
         width: fill-available;
       }
-      .instance-details-card-container--Hjwps.selected--Pf-DQ {
+      .instance-details-card-container--KLHTp.selected--wEA4l {
         outline: 5px solid var(--communication-tint-10);
       }
-      .instance-details-card--lixTP.selected--Pf-DQ {
+      .instance-details-card--owGQF.selected--wEA4l {
         border: 1px solid transparent;
       }
-      .instance-details-card--lixTP.focused--PfWGT,
-      .instance-details-card--lixTP:focus {
+      .instance-details-card--owGQF.focused--pvBWq,
+      .instance-details-card--owGQF:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
-      .instance-details-card--lixTP.selected--Pf-DQ:focus {
+      .instance-details-card--owGQF.selected--wEA4l.focused--pvBWq,
+      .instance-details-card--owGQF.selected--wEA4l:focus {
         outline-offset: 8px;
       }
-      .instance-details-card--lixTP.interactive--su6Sw {
+      .instance-details-card--owGQF.interactive--an0ab {
         cursor: pointer;
       }
-      .instance-details-card--lixTP.interactive--su6Sw:hover {
+      .instance-details-card--owGQF.interactive--an0ab:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-      .report-instance-table--YOlnT {
+      .report-instance-table--3VoZX {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
@@ -902,7 +902,7 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YOlnT .row--9WgHa {
+      .report-instance-table--3VoZX .row---3i35 {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -911,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YOlnT .row--9WgHa > * {
+      .report-instance-table--3VoZX .row---3i35 > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YOlnT .row--9WgHa:last-child {
+      .report-instance-table--3VoZX .row---3i35:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YOlnT .row-label--dri3e {
+      .report-instance-table--3VoZX .row-label--FlVZl {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -931,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YOlnT .row-content--Gt-CK {
+      .report-instance-table--3VoZX .row-content--07KUh {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -943,42 +943,42 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--xUzJx {
+      .multi-line-text-no-bullet--AUXXt {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
-      .multi-line-text-yes-bullet--jH-w4 {
+      .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--jH-w4 li {
+      .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .combination-lists--4wBYq {
+      .combination-lists--boK5y {
         flex-direction: column;
         display: flex;
       }
 
       /* css-modules:src/common/components/cards/urls-card-row */
-      .urls-row-content--rj2oy {
+      .urls-row-content--JDdRx {
         padding-left: 16px;
       }
-      .urls-row-content--rj2oy li {
+      .urls-row-content--JDdRx li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .urls-row-content-new-Failure--7Dq38 {
+      .urls-row-content-new-Failure--oL5lS {
         color: var(--negative-outcome);
         font-weight: bold;
       }
 
       /* css-modules:src/common/components/fix-instruction-panel */
-      .insights-fix-instruction-list--NaN2O
+      .insights-fix-instruction-list--eZigw
         li
-        span.fix-instruction-color-box---mQtG {
+        span.fix-instruction-color-box--sBkHG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -986,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
+      .insights-fix-instruction-list--eZigw .screen-reader-only--irrXo {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,73 +996,73 @@
       }
 
       /* css-modules:src/common/components/cards/how-to-fix-card-row */
-      .how-to-fix-content--Xj-BH {
+      .how-to-fix-content--Zz96u {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--Xj-BH ul {
+      .how-to-fix-content--Zz96u ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--Xj-BH ul li {
+      .how-to-fix-content--Zz96u ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
 
       /* css-modules:src/common/components/cards/snippet-card-row */
-      .snippet--P6i7P {
+      .snippet--hSNfv {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
 
       /* css-modules:src/DetailsView/components/common-dialog-styles */
-      div.insights-dialog-main-override--qzZJk {
+      div.insights-dialog-main-override--ma4DA {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--qzZJk {
+        div.insights-dialog-main-override--ma4DA {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
+      div.insights-dialog-main-override--ma4DA .dialog-body--cmWmz {
         font-size: 16px;
       }
 
       /* css-modules:src/DetailsView/components/issue-filing-dialog */
-      .issue-filing-dialog--l9xMr .ms-Dialog-title {
+      .issue-filing-dialog--F9jun .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
+      .issue-filing-dialog--F9jun .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--l9xMr .textfield-description {
+      .issue-filing-dialog--F9jun .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
 
       /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
-      .action-and-cancel-buttons-component--5-uZX {
+      .action-and-cancel-buttons-component--DF7bf {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--5-uZX
-        .action-cancel-button-col--txH36
-        + .action-cancel-button-col--txH36 {
+      .action-and-cancel-buttons-component--DF7bf
+        .action-cancel-button-col--RMfN-
+        + .action-cancel-button-col--RMfN- {
         margin-left: 8px;
       }
 
       /* css-modules:src/common/components/toast */
-      .toast-container--cNX98 {
+      .toast-container--L-5HM {
         display: inline-block;
       }
-      .toast-content--bk935 {
+      .toast-content--8-Mx1 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1079,84 +1079,84 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
-      div.kebab-menu-callout--A3AHu {
+      div.kebab-menu-callout--XvN24 {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--A3AHu > div {
+      div.kebab-menu-callout--XvN24 > div {
         border-radius: 4px;
       }
-      .kebab-menu--Bm5S1 {
+      .kebab-menu--eKCNX {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--Bm5S1 li {
+      .kebab-menu--eKCNX li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--Bm5S1 button i {
+      .kebab-menu--eKCNX button i {
         color: var(--primary-text);
       }
-      .kebab-menu--Bm5S1 button:hover {
+      .kebab-menu--eKCNX button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--Bm5S1 button:hover {
+        .kebab-menu--eKCNX button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--Bm5S1 button:active {
+      .kebab-menu--eKCNX button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--Bm5S1 button:active i {
+      .kebab-menu--eKCNX button:active i {
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR {
+      button.kebab-menu-button--e-7v- {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--ySFdR svg {
+      button.kebab-menu-button--e-7v- svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR svg {
+        button.kebab-menu-button--e-7v- svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--ySFdR:hover {
+      button.kebab-menu-button--e-7v-:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--ySFdR:active,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+      button.kebab-menu-button--e-7v-:active,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR:active svg > circle,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--e-7v-:active svg > circle,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR:active,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+        button.kebab-menu-button--e-7v-:active,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--ySFdR:active svg > circle,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--e-7v-:active svg > circle,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--ySFdR > span {
+      button.kebab-menu-button--e-7v- > span {
         justify-content: center;
       }
 
       /* css-modules:src/common/components/cards/instance-details-footer */
-      .foot--WBFZ6 {
+      .foot--p1DfC {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1167,22 +1167,22 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj {
+      .foot--p1DfC .highlight-status--xJvvI {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj svg {
+      .foot--p1DfC .highlight-status--xJvvI svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--WBFZ6 .highlight-status--TYXPj svg {
+        .foot--p1DfC .highlight-status--xJvvI svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--WBFZ6 .highlight-status--TYXPj label {
+      .foot--p1DfC .highlight-status--xJvvI label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
@@ -1190,21 +1190,21 @@
       }
 
       /* css-modules:src/common/components/cards/instance-details-group */
-      ul.instance-details-list--bg-Zq {
+      ul.instance-details-list--YfkRy {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--bg-Zq > li {
+      ul.instance-details-list--YfkRy > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--bg-Zq > li:last-child {
+      ul.instance-details-list--YfkRy > li:last-child {
         margin-bottom: unset;
       }
 
       /* css-modules:src/common/components/cards/rule-resources */
-      .rule-more-resources--w4eYl {
+      .rule-more-resources--uw9mc {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1218,53 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
+      .rule-more-resources--uw9mc .more-resources-title--jOuUL {
         font-weight: 600;
       }
-      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
+      .rule-more-resources--uw9mc .rule-details-id--s-TpO {
         padding: 12px 0;
       }
 
       /* css-modules:src/common/components/cards/rules-with-instances */
-      .rule-details-group--ZuRYr .rule-detail {
+      .rule-details-group--Tb-LW .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
+      .rule-details-group--Tb-LW .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
+      .rule-details-group--Tb-LW .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-      .collapsible-rule-details-group--ODFPb {
+      .collapsible-rule-details-group--V-HWh {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--ODFPb .rule-detail {
+      .collapsible-rule-details-group--V-HWh .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
+      .collapsible-rule-details-group--V-HWh:not(.collapsed) {
         box-shadow: unset;
       }
 
       /* css-modules:src/common/components/cards/result-section-title */
-      .result-section-title--vgyHe {
+      .result-section-title--RGFI5 {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1272,49 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--vgyHe .title--6gdF5 {
+      .result-section-title--RGFI5 .title--WBYFE {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .heading--1Ll6- {
+      .result-section-title--RGFI5 .heading--NdP4Q {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
+      .result-section-title--RGFI5 .outcome-chip-container--BT3j5 {
         display: flex;
         height: 16px;
       }
 
       /* css-modules:src/common/components/cards/result-section */
-      .result-section--Av9vc {
+      .result-section--HfO9s {
         padding-bottom: 24px;
       }
-      .result-section--Av9vc
-        .title-container---R9Dm
-        .collapsible-control--5y7Tp::before {
+      .result-section--HfO9s
+        .title-container--JzN4A
+        .collapsible-control--e42Z7::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--Av9vc > h2 {
+      .result-section--HfO9s > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
 
       /* css-modules:src/reports/components/header-bar */
-      .report-header-bar--DNH-8 {
+      .report-header-bar--SDV11 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1323,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--DNH-8 .header-icon {
+      .report-header-bar--SDV11 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--DNH-8 .header-text--v-ac2 {
+      .report-header-bar--SDV11 .header-text--EdTxw {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1345,7 +1345,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/header-section */
-      .report-header-command-bar--8-nLy {
+      .report-header-command-bar--NJWdl {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1355,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX {
+      .report-header-command-bar--NJWdl .target-page--hjh44 {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1368,14 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX a {
+      .report-header-command-bar--NJWdl .target-page--hjh44 a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
       /* css-modules:src/common/components/cards/combined-report-result-section-title */
-      .combined-report-result-section-title--RNekd {
+      .combined-report-result-section-title--TqIZO {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1383,14 +1383,14 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--RNekd .title--CFcXZ {
+      .combined-report-result-section-title--TqIZO .title--6WIyt {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--RNekd .heading--gtY3F {
+      .combined-report-result-section-title--TqIZO .heading--UpAHf {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
@@ -1399,7 +1399,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/urls-summary-section */
-      .urls-summary-section--db4HQ {
+      .urls-summary-section--jNa-v {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1407,26 +1407,26 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--db4HQ h2 {
+      .urls-summary-section--jNa-v h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--db4HQ .total-urls--3pXYz {
+      .urls-summary-section--jNa-v .total-urls--95-ge {
         font-weight: 600;
       }
-      .urls-summary-section--db4HQ .failure-instances--y0Big {
+      .urls-summary-section--jNa-v .failure-instances--2WDtT {
         margin-top: 40px;
       }
-      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
+      .urls-summary-section--jNa-v .failure-outcome-chip--JF-lj {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
 
       /* css-modules:src/reports/components/report-sections/rules-results-container */
-      .rules-results-container--dO76T {
+      .rules-results-container--HaLDw {
         margin-top: 56px;
       }
-      .rules-results-container--dO76T .results-heading--2h1oe {
+      .rules-results-container--HaLDw .results-heading--H9Puz {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
@@ -1435,7 +1435,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/summary-report-details-section */
-      .crawl-details-section--jDqES {
+      .crawl-details-section--a6evz {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1443,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1453,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di li {
         display: inline-block;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
         li
-        .icon--enDUo {
+        .icon--APJEn {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
-        li.targetSite--M6DmE {
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
+        li.targetSite--wBJT- {
         margin-bottom: 6px;
       }
-      .crawl-details-section--jDqES .text--lxa-w,
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .text--rViTo,
+      .crawl-details-section--a6evz .label--DUNYf {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1480,30 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .label--DUNYf {
         font-weight: 600;
       }
-      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
+      .crawl-details-section--a6evz .label--DUNYf.no-icon--VrSr5 {
         padding-left: 29px;
       }
 
       /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
-      .url-result-section--Lsitd {
+      .url-result-section--SkOlZ {
         padding-bottom: 31px;
       }
-      .url-result-section--Lsitd
+      .url-result-section--SkOlZ
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--Lsitd .collapsible-content {
+      .url-result-section--SkOlZ .collapsible-content {
         margin-top: 19px;
       }
 
       /* css-modules:src/reports/components/report-sections/summary-results-table */
-      .summary-results-table--r6fvD {
+      .summary-results-table--Iezr- {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1512,39 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--r6fvD th,
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- th,
+      .summary-results-table--Iezr- td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--r6fvD th {
+      .summary-results-table--Iezr- th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--r6fvD thead tr :first-child {
+      .summary-results-table--Iezr- thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--r6fvD td.text-cell--luh34 {
+      .summary-results-table--Iezr- td.text-cell--EaUrM {
         overflow-wrap: break-word;
       }
-      .summary-results-table--r6fvD td.url-cell--ZGO-o {
+      .summary-results-table--Iezr- td.url-cell--mg-3l {
         overflow-wrap: anywhere;
       }
 
       /* css-modules:src/reports/components/report-sections/results-by-url-container */
-      .url-results-container--xiZ0N {
+      .url-results-container---dq9B {
         margin-top: 56px;
       }
-      .url-results-container--xiZ0N .results-heading--wmQ-W {
+      .url-results-container---dq9B .results-heading--2dWBX {
         margin-top: 32px;
         margin-bottom: 32px;
       }
 
       /* css-modules:src/common/components/cards/fix-instruction-color-box */
-      span.fix-instruction-color-box--lzu-L {
+      span.fix-instruction-color-box--DQpQE {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1552,7 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .screen-reader-only--T-59F {
+      .screen-reader-only--6LUiO {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1564,7 +1564,7 @@
     </style></head
   ><body
     ><header
-      ><div class="report-header-bar--DNH-8"
+      ><div class="report-header-bar--SDV11"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1721,16 +1721,16 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--v-ac2">Accessibility Insights</div></div
+        ><div class="header-text--EdTxw">Accessibility Insights</div></div
       ></header
     ><main class="outer-container"
       ><div class="content-container"
         ><div class="title-section"><h1>Automated checks results</h1></div
-        ><div class="crawl-details-section--jDqES"
+        ><div class="crawl-details-section--a6evz"
           ><h2>Scan details</h2
-          ><ul class="crawl-details-section-list--6FyX-"
-            ><li class="targetSite--M6DmE"
-              ><span class="icon--enDUo" aria-hidden="true"
+          ><ul class="crawl-details-section-list--WV1Di"
+            ><li class="targetSite--wBJT-"
+              ><span class="icon--APJEn" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1742,8 +1742,8 @@
                     d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--TrLq3">Target site </span
-              ><span class="text--lxa-w"
+              ><span class="label--DUNYf">Target site </span
+              ><span class="text--rViTo"
                 ><a
                   target="_blank"
                   href="https://example.com/mock-base-url"
@@ -1774,7 +1774,7 @@
                 </script></span
               ></li
             ><li
-              ><span class="icon--enDUo" aria-hidden="true"
+              ><span class="icon--APJEn" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1786,18 +1786,18 @@
                     d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--TrLq3">Scans started </span
-              ><span class="text--lxa-w">2020-02-02 3:04 AM UTC</span></li
+              ><span class="label--DUNYf">Scans started </span
+              ><span class="text--rViTo">2020-02-02 3:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--jXW2d label--TrLq3">Scans completed </span
-              ><span class="text--lxa-w">2020-02-02 4:04 AM UTC</span></li
+              ><span class="no-icon--VrSr5 label--DUNYf">Scans completed </span
+              ><span class="text--rViTo">2020-02-02 4:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--jXW2d label--TrLq3">Duration </span
-              ><span class="text--lxa-w">01:00:00</span></li
+              ><span class="no-icon--VrSr5 label--DUNYf">Duration </span
+              ><span class="text--rViTo">01:00:00</span></li
             ></ul
           ></div
-        ><div class="urls-summary-section--db4HQ"
-          ><h2>URLs</h2><span class="total-urls--3pXYz">4</span> total URLs
+        ><div class="urls-summary-section--jNa-v"
+          ><h2>URLs</h2><span class="total-urls--95-ge">4</span> total URLs
           scanned<div
             class="outcome-summary-bar"
             aria-label="2 Failed, 1 Not scanned, 1 Passed"
@@ -1865,9 +1865,9 @@
                 >1<span class="label"> Passed</span></span
               ></div
             ></div
-          ><div class="failure-instances--y0Big"
+          ><div class="failure-instances--2WDtT"
             ><h2>Failure Instances</h2
-            ><span class="failure-outcome-chip--vKGs1"
+            ><span class="failure-outcome-chip--JF-lj"
               ><span class="outcome-chip outcome-chip-fail" title="6 Failed"
                 ><span class="icon"
                   ><span class="check-container"
@@ -1893,21 +1893,21 @@
               ><span>Failure instances were detected</span></span
             ></div
           ></div
-        ><div class="url-results-container--xiZ0N"
-          ><div class="results-heading--wmQ-W"><h2>Results by URL</h2></div
-          ><div class="url-result-section--Lsitd"
+        ><div class="url-results-container---dq9B"
+          ><div class="results-heading--2dWBX"><h2>Results by URL</h2></div
+          ><div class="url-result-section--SkOlZ"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-failed-urls-section"
-                  ><span class="result-section-title--vgyHe"
+                  ><span class="result-section-title--RGFI5"
                     ><span class="screen-reader-only">Failed URLs 2</span
-                    ><span class="heading--1Ll6-" aria-hidden="true"
+                    ><span class="heading--NdP4Q" aria-hidden="true"
                       >Failed URLs</span
                     ><span
-                      class="outcome-chip-container--iN0Tt"
+                      class="outcome-chip-container--BT3j5"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-fail"
@@ -1947,7 +1947,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--r6fvD"
+                  class="summary-results-table--Iezr-"
                   id="failed-urls-table"
                   ><thead
                     ><tr
@@ -1962,11 +1962,11 @@
                     ><tr
                       ><td
                         headers="failed-urls-table-header0"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         >1</td
                       ><td
                         headers="failed-urls-table-header1"
-                        class="url-cell--ZGO-o"
+                        class="url-cell--mg-3l"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/has-1-failure"
@@ -1975,7 +1975,7 @@
                         ></td
                       ><td
                         headers="failed-urls-table-header2"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         ><a
                           target="_blank"
                           href="./has-1-failure1.html"
@@ -1987,11 +1987,11 @@
                     ><tr
                       ><td
                         headers="failed-urls-table-header0"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         >5</td
                       ><td
                         headers="failed-urls-table-header1"
-                        class="url-cell--ZGO-o"
+                        class="url-cell--mg-3l"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/has-5-failures"
@@ -2000,7 +2000,7 @@
                         ></td
                       ><td
                         headers="failed-urls-table-header2"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         ><a
                           target="_blank"
                           href="./has-5-failures.html"
@@ -2014,19 +2014,19 @@
                 ></div
               ></div
             ></div
-          ><div class="url-result-section--Lsitd"
+          ><div class="url-result-section--SkOlZ"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-not-scanned-urls-section"
-                  ><span class="result-section-title--vgyHe"
+                  ><span class="result-section-title--RGFI5"
                     ><span class="screen-reader-only">Not scanned URLs 1</span
-                    ><span class="heading--1Ll6-" aria-hidden="true"
+                    ><span class="heading--NdP4Q" aria-hidden="true"
                       >Not scanned URLs</span
                     ><span
-                      class="outcome-chip-container--iN0Tt"
+                      class="outcome-chip-container--BT3j5"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-unscannable"
@@ -2073,7 +2073,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--r6fvD"
+                  class="summary-results-table--Iezr-"
                   id="not-scanned-urls-table"
                   ><thead
                     ><tr
@@ -2087,11 +2087,11 @@
                     ><tr
                       ><td
                         headers="not-scanned-urls-table-header0"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         >MockErrorType</td
                       ><td
                         headers="not-scanned-urls-table-header1"
-                        class="url-cell--ZGO-o"
+                        class="url-cell--mg-3l"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/unscannable"
@@ -2100,7 +2100,7 @@
                         ></td
                       ><td
                         headers="not-scanned-urls-table-header2"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         ><a
                           target="_blank"
                           href="./error-log.txt"
@@ -2113,19 +2113,19 @@
                 ></div
               ></div
             ></div
-          ><div class="url-result-section--Lsitd"
+          ><div class="url-result-section--SkOlZ"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-passed-urls-section"
-                  ><span class="result-section-title--vgyHe"
+                  ><span class="result-section-title--RGFI5"
                     ><span class="screen-reader-only">Passed URLs 1</span
-                    ><span class="heading--1Ll6-" aria-hidden="true"
+                    ><span class="heading--NdP4Q" aria-hidden="true"
                       >Passed URLs</span
                     ><span
-                      class="outcome-chip-container--iN0Tt"
+                      class="outcome-chip-container--BT3j5"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-pass"
@@ -2167,7 +2167,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--r6fvD"
+                  class="summary-results-table--Iezr-"
                   id="passed-urls-table"
                   ><thead
                     ><tr
@@ -2182,11 +2182,11 @@
                     ><tr
                       ><td
                         headers="passed-urls-table-header0"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         >0</td
                       ><td
                         headers="passed-urls-table-header1"
-                        class="url-cell--ZGO-o"
+                        class="url-cell--mg-3l"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/passes"
@@ -2195,7 +2195,7 @@
                         ></td
                       ><td
                         headers="passed-urls-table-header2"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         ><a
                           target="_blank"
                           href="./passes.html"

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -834,24 +834,30 @@
         margin-bottom: unset;
       }</style
     ><style>
-      .heading-element-for-level--OfRDW {
+      /* css-modules:src/common/components/heading-element-for-level */
+      .heading-element-for-level--wzmxK {
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      .failed-instances-container--FqWV6 .collapsible-content {
+
+      /* css-modules:src/common/components/cards/failed-instances-section */
+      .failed-instances-container--pB-u4 .collapsible-content {
         margin-left: 24px;
       }
-      .outcome-chip-container--xYquF {
+
+      /* css-modules:src/reports/components/report-sections/minimal-rule-header */
+      .outcome-chip-container--ja0WM {
         min-width: 50px;
       }
-      .hidden-highlight-button--PePzJ {
+
+      /* css-modules:src/reports/components/instance-details */
+      .hidden-highlight-button--to41b {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-
-      .instance-details-card--R0aAh {
+      .instance-details-card--lixTP {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -859,55 +865,44 @@
           0 3.2px 7.2px var(--box-shadow-132);
         margin-bottom: 16px;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
       }
-
-      .instance-details-card-container--bKrcd.selected--Kp4AC {
+      .instance-details-card-container--Hjwps.selected--Pf-DQ {
         outline: 5px solid var(--communication-tint-10);
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC {
+      .instance-details-card--lixTP.selected--Pf-DQ {
         border: 1px solid transparent;
       }
-
-      .instance-details-card--R0aAh.focused--tV0ic,
-      .instance-details-card--R0aAh:focus {
+      .instance-details-card--lixTP.focused--PfWGT,
+      .instance-details-card--lixTP:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC.focused--tV0ic,
-      .instance-details-card--R0aAh.selected--Kp4AC:focus {
+      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
+      .instance-details-card--lixTP.selected--Pf-DQ:focus {
         outline-offset: 8px;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy {
+      .instance-details-card--lixTP.interactive--su6Sw {
         cursor: pointer;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy:hover {
+      .instance-details-card--lixTP.interactive--su6Sw:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-
-      .report-instance-table--YIu0s {
+      .report-instance-table--YOlnT {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
         border-radius: inherit;
         border-collapse: collapse;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YIu0s .row--m8TLI {
+      .report-instance-table--YOlnT .row--9WgHa {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -916,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YIu0s .row--m8TLI > * {
+      .report-instance-table--YOlnT .row--9WgHa > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YIu0s .row--m8TLI:last-child {
+      .report-instance-table--YOlnT .row--9WgHa:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YIu0s .row-label--MxfuQ {
+      .report-instance-table--YOlnT .row-label--dri3e {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -936,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YIu0s .row-content--ECKwg {
+      .report-instance-table--YOlnT .row-content--Gt-CK {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -946,41 +941,44 @@
         align-items: flex-end;
         display: flex;
       }
-      .multi-line-text-no-bullet--lNJS_ {
+
+      /* css-modules:src/common/components/cards/rich-resolution-content */
+      .multi-line-text-no-bullet--xUzJx {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--lNJS_ li:not(:last-child) {
+      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
         margin-bottom: 4px;
       }
-
-      .multi-line-text-yes-bullet--pp76P {
+      .multi-line-text-yes-bullet--jH-w4 {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--pp76P li {
+      .multi-line-text-yes-bullet--jH-w4 li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .combination-lists--O1dD_ {
+      .combination-lists--4wBYq {
         flex-direction: column;
         display: flex;
       }
-      .urls-row-content--MxcA7 {
+
+      /* css-modules:src/common/components/cards/urls-card-row */
+      .urls-row-content--rj2oy {
         padding-left: 16px;
       }
-      .urls-row-content--MxcA7 li {
+      .urls-row-content--rj2oy li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .urls-row-content-new-Failure--uJPP3 {
+      .urls-row-content-new-Failure--7Dq38 {
         color: var(--negative-outcome);
         font-weight: bold;
       }
-      .insights-fix-instruction-list--G3vyY
+
+      /* css-modules:src/common/components/fix-instruction-panel */
+      .insights-fix-instruction-list--NaN2O
         li
-        span.fix-instruction-color-box--g6NfJ {
+        span.fix-instruction-color-box---mQtG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -988,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--G3vyY .screen-reader-only--yQjgp {
+      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,64 +994,75 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
-      .how-to-fix-content--OHBLC {
+
+      /* css-modules:src/common/components/cards/how-to-fix-card-row */
+      .how-to-fix-content--Xj-BH {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--OHBLC ul {
+      .how-to-fix-content--Xj-BH ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--OHBLC ul li {
+      .how-to-fix-content--Xj-BH ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .snippet--wZrK1 {
+
+      /* css-modules:src/common/components/cards/snippet-card-row */
+      .snippet--P6i7P {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
-      div.insights-dialog-main-override--Mlek6 {
+
+      /* css-modules:src/DetailsView/components/common-dialog-styles */
+      div.insights-dialog-main-override--qzZJk {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--Mlek6 {
+        div.insights-dialog-main-override--qzZJk {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--Mlek6 .dialog-body--QtJ_D {
+      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
         font-size: 16px;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-title {
+
+      /* css-modules:src/DetailsView/components/issue-filing-dialog */
+      .issue-filing-dialog--l9xMr .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-subText {
+      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--ZrD5s .textfield-description {
+      .issue-filing-dialog--l9xMr .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
-      .action-and-cancel-buttons-component--HOvON {
+
+      /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
+      .action-and-cancel-buttons-component--5-uZX {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--HOvON
-        .action-cancel-button-col--VrVAp
-        + .action-cancel-button-col--VrVAp {
+      .action-and-cancel-buttons-component--5-uZX
+        .action-cancel-button-col--txH36
+        + .action-cancel-button-col--txH36 {
         margin-left: 8px;
       }
-      .toast-container--KsxE1 {
+
+      /* css-modules:src/common/components/toast */
+      .toast-container--cNX98 {
         display: inline-block;
       }
-
-      .toast-content--pEpMJ {
+      .toast-content--bk935 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1068,84 +1077,86 @@
         z-index: 1000;
         position: absolute;
       }
-      div.kebab-menu-callout--o23oT {
+
+      /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      div.kebab-menu-callout--A3AHu {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--o23oT > div {
+      div.kebab-menu-callout--A3AHu > div {
         border-radius: 4px;
       }
-
-      .kebab-menu--eviKu {
+      .kebab-menu--Bm5S1 {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--eviKu li {
+      .kebab-menu--Bm5S1 li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--eviKu button i {
+      .kebab-menu--Bm5S1 button i {
         color: var(--primary-text);
       }
-      .kebab-menu--eviKu button:hover {
+      .kebab-menu--Bm5S1 button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--eviKu button:hover {
+        .kebab-menu--Bm5S1 button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--eviKu button:active {
+      .kebab-menu--Bm5S1 button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--eviKu button:active i {
+      .kebab-menu--Bm5S1 button:active i {
         color: var(--light-black);
       }
-
-      button.kebab-menu-button--dy7Ui {
+      button.kebab-menu-button--ySFdR {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--dy7Ui svg {
+      button.kebab-menu-button--ySFdR svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui svg {
+        button.kebab-menu-button--ySFdR svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--dy7Ui:hover {
+      button.kebab-menu-button--ySFdR:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--dy7Ui:active,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+      button.kebab-menu-button--ySFdR:active,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--dy7Ui:active svg > circle,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--ySFdR:active svg > circle,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui:active,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+        button.kebab-menu-button--ySFdR:active,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--dy7Ui:active svg > circle,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--ySFdR:active svg > circle,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--dy7Ui > span {
+      button.kebab-menu-button--ySFdR > span {
         justify-content: center;
       }
-      .foot--d1w5m {
+
+      /* css-modules:src/common/components/cards/instance-details-footer */
+      .foot--WBFZ6 {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1156,40 +1167,44 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--d1w5m .highlight-status--Bmqfx {
+      .foot--WBFZ6 .highlight-status--TYXPj {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--d1w5m .highlight-status--Bmqfx svg {
+      .foot--WBFZ6 .highlight-status--TYXPj svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--d1w5m .highlight-status--Bmqfx svg {
+        .foot--WBFZ6 .highlight-status--TYXPj svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--d1w5m .highlight-status--Bmqfx label {
+      .foot--WBFZ6 .highlight-status--TYXPj label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      ul.instance-details-list--xiPPL {
+
+      /* css-modules:src/common/components/cards/instance-details-group */
+      ul.instance-details-list--bg-Zq {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--xiPPL > li {
+      ul.instance-details-list--bg-Zq > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--xiPPL > li:last-child {
+      ul.instance-details-list--bg-Zq > li:last-child {
         margin-bottom: unset;
       }
-      .rule-more-resources--Bsblo {
+
+      /* css-modules:src/common/components/cards/rule-resources */
+      .rule-more-resources--w4eYl {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1203,50 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--Bsblo .more-resources-title--whTFs {
+      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
         font-weight: 600;
       }
-      .rule-more-resources--Bsblo .rule-details-id--n_S89 {
+      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
         padding: 12px 0;
       }
-      .rule-details-group--U69fz .rule-detail {
+
+      /* css-modules:src/common/components/cards/rules-with-instances */
+      .rule-details-group--ZuRYr .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--U69fz .rule-detail .outcome-chip {
+      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id a {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--U69fz .rule-detail .rule-detail-description {
+      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-
-      .collapsible-rule-details-group--h0lvd {
+      .collapsible-rule-details-group--ODFPb {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--h0lvd .rule-detail {
+      .collapsible-rule-details-group--ODFPb .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--h0lvd:not(.collapsed) {
+      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
         box-shadow: unset;
       }
-      .result-section-title--qv3MK {
+
+      /* css-modules:src/common/components/cards/result-section-title */
+      .result-section-title--vgyHe {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1254,45 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--qv3MK .title--neMma {
+      .result-section-title--vgyHe .title--6gdF5 {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .heading--VbGap {
+      .result-section-title--vgyHe .heading--1Ll6- {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .outcome-chip-container--Wt0k4 {
+      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
         display: flex;
         height: 16px;
       }
-      .result-section--j6fYr {
+
+      /* css-modules:src/common/components/cards/result-section */
+      .result-section--Av9vc {
         padding-bottom: 24px;
       }
-      .result-section--j6fYr
-        .title-container--gMYqW
-        .collapsible-control--V9OlA::before {
+      .result-section--Av9vc
+        .title-container---R9Dm
+        .collapsible-control--5y7Tp::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--j6fYr > h2 {
+      .result-section--Av9vc > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-bar--pkiTM {
+
+      /* css-modules:src/reports/components/header-bar */
+      .report-header-bar--DNH-8 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1301,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--pkiTM .header-icon {
+      .report-header-bar--DNH-8 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--pkiTM .header-text--dfm48 {
+      .report-header-bar--DNH-8 .header-text--v-ac2 {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1321,7 +1343,9 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-command-bar--wDg1t {
+
+      /* css-modules:src/reports/components/report-sections/header-section */
+      .report-header-command-bar--8-nLy {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1331,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--wDg1t .target-page--giudb {
+      .report-header-command-bar--8-nLy .target-page--q7WnX {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1344,12 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
+      .report-header-command-bar--8-nLy .target-page--q7WnX a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      .combined-report-result-section-title--XUDDo {
+
+      /* css-modules:src/common/components/cards/combined-report-result-section-title */
+      .combined-report-result-section-title--RNekd {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1357,21 +1383,23 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--XUDDo .title--lcuIW {
+      .combined-report-result-section-title--RNekd .title--CFcXZ {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--XUDDo .heading--uUq3e {
+      .combined-report-result-section-title--RNekd .heading--gtY3F {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .urls-summary-section--DjUWc {
+
+      /* css-modules:src/reports/components/report-sections/urls-summary-section */
+      .urls-summary-section--db4HQ {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1379,31 +1407,35 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--DjUWc h2 {
+      .urls-summary-section--db4HQ h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--DjUWc .total-urls--Ig_eB {
+      .urls-summary-section--db4HQ .total-urls--3pXYz {
         font-weight: 600;
       }
-      .urls-summary-section--DjUWc .failure-instances--Rq_Tj {
+      .urls-summary-section--db4HQ .failure-instances--y0Big {
         margin-top: 40px;
       }
-      .urls-summary-section--DjUWc .failure-outcome-chip--YtjBX {
+      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
-      .rules-results-container--n7EEu {
+
+      /* css-modules:src/reports/components/report-sections/rules-results-container */
+      .rules-results-container--dO76T {
         margin-top: 56px;
       }
-      .rules-results-container--n7EEu .results-heading--pyS7R {
+      .rules-results-container--dO76T .results-heading--2h1oe {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
       }
-      .crawl-details-section--WhRL4 {
+
+      /* css-modules:src/reports/components/report-sections/summary-report-details-section */
+      .crawl-details-section--jDqES {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1411,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1421,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg li {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
         display: inline-block;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
         li
-        .icon--JdMPq {
+        .icon--enDUo {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
-        li.targetSite--qXxid {
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
+        li.targetSite--M6DmE {
         margin-bottom: 6px;
       }
-      .crawl-details-section--WhRL4 .text--swxfX,
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .text--lxa-w,
+      .crawl-details-section--jDqES .label--TrLq3 {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1448,26 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .label--TrLq3 {
         font-weight: 600;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2.no-icon--J7B9N {
+      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
         padding-left: 29px;
       }
-      .url-result-section--PmEoY {
+
+      /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
+      .url-result-section--Lsitd {
         padding-bottom: 31px;
       }
-      .url-result-section--PmEoY
+      .url-result-section--Lsitd
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--PmEoY .collapsible-content {
+      .url-result-section--Lsitd .collapsible-content {
         margin-top: 19px;
       }
-      .summary-results-table--Pb4_B {
+
+      /* css-modules:src/reports/components/report-sections/summary-results-table */
+      .summary-results-table--r6fvD {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1476,35 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--Pb4_B th,
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD th,
+      .summary-results-table--r6fvD td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--Pb4_B th {
+      .summary-results-table--r6fvD th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--Pb4_B thead tr :first-child {
+      .summary-results-table--r6fvD thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--Pb4_B td.text-cell--p0dxL {
+      .summary-results-table--r6fvD td.text-cell--luh34 {
         overflow-wrap: break-word;
       }
-      .summary-results-table--Pb4_B td.url-cell--yjU1V {
+      .summary-results-table--r6fvD td.url-cell--ZGO-o {
         overflow-wrap: anywhere;
       }
-      .url-results-container--dXQbj {
+
+      /* css-modules:src/reports/components/report-sections/results-by-url-container */
+      .url-results-container--xiZ0N {
         margin-top: 56px;
       }
-      .url-results-container--dXQbj .results-heading--D3Qtr {
+      .url-results-container--xiZ0N .results-heading--wmQ-W {
         margin-top: 32px;
         margin-bottom: 32px;
       }
-      span.fix-instruction-color-box--Xq1E4 {
+
+      /* css-modules:src/common/components/cards/fix-instruction-color-box */
+      span.fix-instruction-color-box--lzu-L {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1512,8 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-
-      .screen-reader-only--n1Ocs {
+      .screen-reader-only--T-59F {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1521,10 +1560,11 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
+      /*# sourceMappingURL=report.css.map */
     </style></head
   ><body
     ><header
-      ><div class="report-header-bar--pkiTM"
+      ><div class="report-header-bar--DNH-8"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1681,16 +1721,16 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--dfm48">Accessibility Insights</div></div
+        ><div class="header-text--v-ac2">Accessibility Insights</div></div
       ></header
     ><main class="outer-container"
       ><div class="content-container"
         ><div class="title-section"><h1>Automated checks results</h1></div
-        ><div class="crawl-details-section--WhRL4"
+        ><div class="crawl-details-section--jDqES"
           ><h2>Scan details</h2
-          ><ul class="crawl-details-section-list--Lrjqg"
-            ><li class="targetSite--qXxid"
-              ><span class="icon--JdMPq" aria-hidden="true"
+          ><ul class="crawl-details-section-list--6FyX-"
+            ><li class="targetSite--M6DmE"
+              ><span class="icon--enDUo" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1702,8 +1742,8 @@
                     d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--yUuT2">Target site </span
-              ><span class="text--swxfX"
+              ><span class="label--TrLq3">Target site </span
+              ><span class="text--lxa-w"
                 ><a
                   target="_blank"
                   href="https://example.com/mock-base-url"
@@ -1720,9 +1760,7 @@
                     var targetPageLink = doc.getElementById(linkId);
                     targetPageLink.addEventListener("click", function (event) {
                       var result = confirmCallback(
-                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                          "Cancel to stay on the current page."
+                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                       );
                       if (result === false) {
                         event.preventDefault();
@@ -1736,7 +1774,7 @@
                 </script></span
               ></li
             ><li
-              ><span class="icon--JdMPq" aria-hidden="true"
+              ><span class="icon--enDUo" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1748,18 +1786,18 @@
                     d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--yUuT2">Scans started </span
-              ><span class="text--swxfX">2020-02-02 3:04 AM UTC</span></li
+              ><span class="label--TrLq3">Scans started </span
+              ><span class="text--lxa-w">2020-02-02 3:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--J7B9N label--yUuT2">Scans completed </span
-              ><span class="text--swxfX">2020-02-02 4:04 AM UTC</span></li
+              ><span class="no-icon--jXW2d label--TrLq3">Scans completed </span
+              ><span class="text--lxa-w">2020-02-02 4:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--J7B9N label--yUuT2">Duration </span
-              ><span class="text--swxfX">01:00:00</span></li
+              ><span class="no-icon--jXW2d label--TrLq3">Duration </span
+              ><span class="text--lxa-w">01:00:00</span></li
             ></ul
           ></div
-        ><div class="urls-summary-section--DjUWc"
-          ><h2>URLs</h2><span class="total-urls--Ig_eB">4</span> total URLs
+        ><div class="urls-summary-section--db4HQ"
+          ><h2>URLs</h2><span class="total-urls--3pXYz">4</span> total URLs
           scanned<div
             class="outcome-summary-bar"
             aria-label="2 Failed, 1 Not scanned, 1 Passed"
@@ -1827,9 +1865,9 @@
                 >1<span class="label"> Passed</span></span
               ></div
             ></div
-          ><div class="failure-instances--Rq_Tj"
+          ><div class="failure-instances--y0Big"
             ><h2>Failure Instances</h2
-            ><span class="failure-outcome-chip--YtjBX"
+            ><span class="failure-outcome-chip--vKGs1"
               ><span class="outcome-chip outcome-chip-fail" title="6 Failed"
                 ><span class="icon"
                   ><span class="check-container"
@@ -1855,21 +1893,21 @@
               ><span>Failure instances were detected</span></span
             ></div
           ></div
-        ><div class="url-results-container--dXQbj"
-          ><div class="results-heading--D3Qtr"><h2>Results by URL</h2></div
-          ><div class="url-result-section--PmEoY"
+        ><div class="url-results-container--xiZ0N"
+          ><div class="results-heading--wmQ-W"><h2>Results by URL</h2></div
+          ><div class="url-result-section--Lsitd"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-failed-urls-section"
-                  ><span class="result-section-title--qv3MK"
+                  ><span class="result-section-title--vgyHe"
                     ><span class="screen-reader-only">Failed URLs 2</span
-                    ><span class="heading--VbGap" aria-hidden="true"
+                    ><span class="heading--1Ll6-" aria-hidden="true"
                       >Failed URLs</span
                     ><span
-                      class="outcome-chip-container--Wt0k4"
+                      class="outcome-chip-container--iN0Tt"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-fail"
@@ -1909,7 +1947,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--Pb4_B"
+                  class="summary-results-table--r6fvD"
                   id="failed-urls-table"
                   ><thead
                     ><tr
@@ -1924,11 +1962,11 @@
                     ><tr
                       ><td
                         headers="failed-urls-table-header0"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         >1</td
                       ><td
                         headers="failed-urls-table-header1"
-                        class="url-cell--yjU1V"
+                        class="url-cell--ZGO-o"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/has-1-failure"
@@ -1937,7 +1975,7 @@
                         ></td
                       ><td
                         headers="failed-urls-table-header2"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         ><a
                           target="_blank"
                           href="./has-1-failure1.html"
@@ -1949,11 +1987,11 @@
                     ><tr
                       ><td
                         headers="failed-urls-table-header0"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         >5</td
                       ><td
                         headers="failed-urls-table-header1"
-                        class="url-cell--yjU1V"
+                        class="url-cell--ZGO-o"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/has-5-failures"
@@ -1962,7 +2000,7 @@
                         ></td
                       ><td
                         headers="failed-urls-table-header2"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         ><a
                           target="_blank"
                           href="./has-5-failures.html"
@@ -1976,19 +2014,19 @@
                 ></div
               ></div
             ></div
-          ><div class="url-result-section--PmEoY"
+          ><div class="url-result-section--Lsitd"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-not-scanned-urls-section"
-                  ><span class="result-section-title--qv3MK"
+                  ><span class="result-section-title--vgyHe"
                     ><span class="screen-reader-only">Not scanned URLs 1</span
-                    ><span class="heading--VbGap" aria-hidden="true"
+                    ><span class="heading--1Ll6-" aria-hidden="true"
                       >Not scanned URLs</span
                     ><span
-                      class="outcome-chip-container--Wt0k4"
+                      class="outcome-chip-container--iN0Tt"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-unscannable"
@@ -2035,7 +2073,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--Pb4_B"
+                  class="summary-results-table--r6fvD"
                   id="not-scanned-urls-table"
                   ><thead
                     ><tr
@@ -2049,11 +2087,11 @@
                     ><tr
                       ><td
                         headers="not-scanned-urls-table-header0"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         >MockErrorType</td
                       ><td
                         headers="not-scanned-urls-table-header1"
-                        class="url-cell--yjU1V"
+                        class="url-cell--ZGO-o"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/unscannable"
@@ -2062,7 +2100,7 @@
                         ></td
                       ><td
                         headers="not-scanned-urls-table-header2"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         ><a
                           target="_blank"
                           href="./error-log.txt"
@@ -2075,19 +2113,19 @@
                 ></div
               ></div
             ></div
-          ><div class="url-result-section--PmEoY"
+          ><div class="url-result-section--Lsitd"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-passed-urls-section"
-                  ><span class="result-section-title--qv3MK"
+                  ><span class="result-section-title--vgyHe"
                     ><span class="screen-reader-only">Passed URLs 1</span
-                    ><span class="heading--VbGap" aria-hidden="true"
+                    ><span class="heading--1Ll6-" aria-hidden="true"
                       >Passed URLs</span
                     ><span
-                      class="outcome-chip-container--Wt0k4"
+                      class="outcome-chip-container--iN0Tt"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-pass"
@@ -2129,7 +2167,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--Pb4_B"
+                  class="summary-results-table--r6fvD"
                   id="passed-urls-table"
                   ><thead
                     ><tr
@@ -2144,11 +2182,11 @@
                     ><tr
                       ><td
                         headers="passed-urls-table-header0"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         >0</td
                       ><td
                         headers="passed-urls-table-header1"
-                        class="url-cell--yjU1V"
+                        class="url-cell--ZGO-o"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/passes"
@@ -2157,7 +2195,7 @@
                         ></td
                       ><td
                         headers="passed-urls-table-header2"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         ><a
                           target="_blank"
                           href="./passes.html"
@@ -2177,7 +2215,7 @@
             var _loop = function (index) {
               var container = collapsibles.item(index);
               var button =
-                container === null || container === void 0
+                container == null
                   ? void 0
                   : container.querySelector(".collapsible-control");
               if (button == null) {
@@ -2186,7 +2224,7 @@
               button.addEventListener("click", function () {
                 var _a;
                 var content =
-                  (_a = button.parentElement) === null || _a === void 0
+                  (_a = button.parentElement) == null
                     ? void 0
                     : _a.nextElementSibling;
                 if (content == null) {

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -835,29 +835,29 @@
       }</style
     ><style>
       /* css-modules:src/common/components/heading-element-for-level */
-      .heading-element-for-level--wzmxK {
+      .heading-element-for-level--ifVX6 {
         margin-block-start: unset;
         margin-block-end: unset;
       }
 
       /* css-modules:src/common/components/cards/failed-instances-section */
-      .failed-instances-container--pB-u4 .collapsible-content {
+      .failed-instances-container--3UUNb .collapsible-content {
         margin-left: 24px;
       }
 
       /* css-modules:src/reports/components/report-sections/minimal-rule-header */
-      .outcome-chip-container--ja0WM {
+      .outcome-chip-container--G5Dfr {
         min-width: 50px;
       }
 
       /* css-modules:src/reports/components/instance-details */
-      .hidden-highlight-button--to41b {
+      .hidden-highlight-button--vu3B3 {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-      .instance-details-card--lixTP {
+      .instance-details-card--owGQF {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -868,29 +868,29 @@
         width: -webkit-fill-available;
         width: fill-available;
       }
-      .instance-details-card-container--Hjwps.selected--Pf-DQ {
+      .instance-details-card-container--KLHTp.selected--wEA4l {
         outline: 5px solid var(--communication-tint-10);
       }
-      .instance-details-card--lixTP.selected--Pf-DQ {
+      .instance-details-card--owGQF.selected--wEA4l {
         border: 1px solid transparent;
       }
-      .instance-details-card--lixTP.focused--PfWGT,
-      .instance-details-card--lixTP:focus {
+      .instance-details-card--owGQF.focused--pvBWq,
+      .instance-details-card--owGQF:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
-      .instance-details-card--lixTP.selected--Pf-DQ:focus {
+      .instance-details-card--owGQF.selected--wEA4l.focused--pvBWq,
+      .instance-details-card--owGQF.selected--wEA4l:focus {
         outline-offset: 8px;
       }
-      .instance-details-card--lixTP.interactive--su6Sw {
+      .instance-details-card--owGQF.interactive--an0ab {
         cursor: pointer;
       }
-      .instance-details-card--lixTP.interactive--su6Sw:hover {
+      .instance-details-card--owGQF.interactive--an0ab:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-      .report-instance-table--YOlnT {
+      .report-instance-table--3VoZX {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
@@ -902,7 +902,7 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YOlnT .row--9WgHa {
+      .report-instance-table--3VoZX .row---3i35 {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -911,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YOlnT .row--9WgHa > * {
+      .report-instance-table--3VoZX .row---3i35 > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YOlnT .row--9WgHa:last-child {
+      .report-instance-table--3VoZX .row---3i35:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YOlnT .row-label--dri3e {
+      .report-instance-table--3VoZX .row-label--FlVZl {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -931,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YOlnT .row-content--Gt-CK {
+      .report-instance-table--3VoZX .row-content--07KUh {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -943,42 +943,42 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--xUzJx {
+      .multi-line-text-no-bullet--AUXXt {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
-      .multi-line-text-yes-bullet--jH-w4 {
+      .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--jH-w4 li {
+      .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .combination-lists--4wBYq {
+      .combination-lists--boK5y {
         flex-direction: column;
         display: flex;
       }
 
       /* css-modules:src/common/components/cards/urls-card-row */
-      .urls-row-content--rj2oy {
+      .urls-row-content--JDdRx {
         padding-left: 16px;
       }
-      .urls-row-content--rj2oy li {
+      .urls-row-content--JDdRx li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .urls-row-content-new-Failure--7Dq38 {
+      .urls-row-content-new-Failure--oL5lS {
         color: var(--negative-outcome);
         font-weight: bold;
       }
 
       /* css-modules:src/common/components/fix-instruction-panel */
-      .insights-fix-instruction-list--NaN2O
+      .insights-fix-instruction-list--eZigw
         li
-        span.fix-instruction-color-box---mQtG {
+        span.fix-instruction-color-box--sBkHG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -986,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
+      .insights-fix-instruction-list--eZigw .screen-reader-only--irrXo {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,73 +996,73 @@
       }
 
       /* css-modules:src/common/components/cards/how-to-fix-card-row */
-      .how-to-fix-content--Xj-BH {
+      .how-to-fix-content--Zz96u {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--Xj-BH ul {
+      .how-to-fix-content--Zz96u ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--Xj-BH ul li {
+      .how-to-fix-content--Zz96u ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
 
       /* css-modules:src/common/components/cards/snippet-card-row */
-      .snippet--P6i7P {
+      .snippet--hSNfv {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
 
       /* css-modules:src/DetailsView/components/common-dialog-styles */
-      div.insights-dialog-main-override--qzZJk {
+      div.insights-dialog-main-override--ma4DA {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--qzZJk {
+        div.insights-dialog-main-override--ma4DA {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
+      div.insights-dialog-main-override--ma4DA .dialog-body--cmWmz {
         font-size: 16px;
       }
 
       /* css-modules:src/DetailsView/components/issue-filing-dialog */
-      .issue-filing-dialog--l9xMr .ms-Dialog-title {
+      .issue-filing-dialog--F9jun .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
+      .issue-filing-dialog--F9jun .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--l9xMr .textfield-description {
+      .issue-filing-dialog--F9jun .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
 
       /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
-      .action-and-cancel-buttons-component--5-uZX {
+      .action-and-cancel-buttons-component--DF7bf {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--5-uZX
-        .action-cancel-button-col--txH36
-        + .action-cancel-button-col--txH36 {
+      .action-and-cancel-buttons-component--DF7bf
+        .action-cancel-button-col--RMfN-
+        + .action-cancel-button-col--RMfN- {
         margin-left: 8px;
       }
 
       /* css-modules:src/common/components/toast */
-      .toast-container--cNX98 {
+      .toast-container--L-5HM {
         display: inline-block;
       }
-      .toast-content--bk935 {
+      .toast-content--8-Mx1 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1079,84 +1079,84 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
-      div.kebab-menu-callout--A3AHu {
+      div.kebab-menu-callout--XvN24 {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--A3AHu > div {
+      div.kebab-menu-callout--XvN24 > div {
         border-radius: 4px;
       }
-      .kebab-menu--Bm5S1 {
+      .kebab-menu--eKCNX {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--Bm5S1 li {
+      .kebab-menu--eKCNX li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--Bm5S1 button i {
+      .kebab-menu--eKCNX button i {
         color: var(--primary-text);
       }
-      .kebab-menu--Bm5S1 button:hover {
+      .kebab-menu--eKCNX button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--Bm5S1 button:hover {
+        .kebab-menu--eKCNX button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--Bm5S1 button:active {
+      .kebab-menu--eKCNX button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--Bm5S1 button:active i {
+      .kebab-menu--eKCNX button:active i {
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR {
+      button.kebab-menu-button--e-7v- {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--ySFdR svg {
+      button.kebab-menu-button--e-7v- svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR svg {
+        button.kebab-menu-button--e-7v- svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--ySFdR:hover {
+      button.kebab-menu-button--e-7v-:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--ySFdR:active,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+      button.kebab-menu-button--e-7v-:active,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--ySFdR:active svg > circle,
-      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--e-7v-:active svg > circle,
+      button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--ySFdR:active,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
+        button.kebab-menu-button--e-7v-:active,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--ySFdR:active svg > circle,
-        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--e-7v-:active svg > circle,
+        button.kebab-menu-button--e-7v-[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--ySFdR > span {
+      button.kebab-menu-button--e-7v- > span {
         justify-content: center;
       }
 
       /* css-modules:src/common/components/cards/instance-details-footer */
-      .foot--WBFZ6 {
+      .foot--p1DfC {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1167,22 +1167,22 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj {
+      .foot--p1DfC .highlight-status--xJvvI {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--WBFZ6 .highlight-status--TYXPj svg {
+      .foot--p1DfC .highlight-status--xJvvI svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--WBFZ6 .highlight-status--TYXPj svg {
+        .foot--p1DfC .highlight-status--xJvvI svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--WBFZ6 .highlight-status--TYXPj label {
+      .foot--p1DfC .highlight-status--xJvvI label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
@@ -1190,21 +1190,21 @@
       }
 
       /* css-modules:src/common/components/cards/instance-details-group */
-      ul.instance-details-list--bg-Zq {
+      ul.instance-details-list--YfkRy {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--bg-Zq > li {
+      ul.instance-details-list--YfkRy > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--bg-Zq > li:last-child {
+      ul.instance-details-list--YfkRy > li:last-child {
         margin-bottom: unset;
       }
 
       /* css-modules:src/common/components/cards/rule-resources */
-      .rule-more-resources--w4eYl {
+      .rule-more-resources--uw9mc {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1218,53 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
+      .rule-more-resources--uw9mc .more-resources-title--jOuUL {
         font-weight: 600;
       }
-      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
+      .rule-more-resources--uw9mc .rule-details-id--s-TpO {
         padding: 12px 0;
       }
 
       /* css-modules:src/common/components/cards/rules-with-instances */
-      .rule-details-group--ZuRYr .rule-detail {
+      .rule-details-group--Tb-LW .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
+      .rule-details-group--Tb-LW .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
+      .rule-details-group--Tb-LW .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
+      .rule-details-group--Tb-LW .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-      .collapsible-rule-details-group--ODFPb {
+      .collapsible-rule-details-group--V-HWh {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--ODFPb .rule-detail {
+      .collapsible-rule-details-group--V-HWh .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
+      .collapsible-rule-details-group--V-HWh:not(.collapsed) {
         box-shadow: unset;
       }
 
       /* css-modules:src/common/components/cards/result-section-title */
-      .result-section-title--vgyHe {
+      .result-section-title--RGFI5 {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1272,49 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--RGFI5 .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--vgyHe .title--6gdF5 {
+      .result-section-title--RGFI5 .title--WBYFE {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .heading--1Ll6- {
+      .result-section-title--RGFI5 .heading--NdP4Q {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
+      .result-section-title--RGFI5 .outcome-chip-container--BT3j5 {
         display: flex;
         height: 16px;
       }
 
       /* css-modules:src/common/components/cards/result-section */
-      .result-section--Av9vc {
+      .result-section--HfO9s {
         padding-bottom: 24px;
       }
-      .result-section--Av9vc
-        .title-container---R9Dm
-        .collapsible-control--5y7Tp::before {
+      .result-section--HfO9s
+        .title-container--JzN4A
+        .collapsible-control--e42Z7::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--Av9vc > h2 {
+      .result-section--HfO9s > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
 
       /* css-modules:src/reports/components/header-bar */
-      .report-header-bar--DNH-8 {
+      .report-header-bar--SDV11 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1323,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--DNH-8 .header-icon {
+      .report-header-bar--SDV11 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--DNH-8 .header-text--v-ac2 {
+      .report-header-bar--SDV11 .header-text--EdTxw {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1345,7 +1345,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/header-section */
-      .report-header-command-bar--8-nLy {
+      .report-header-command-bar--NJWdl {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1355,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX {
+      .report-header-command-bar--NJWdl .target-page--hjh44 {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1368,14 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--8-nLy .target-page--q7WnX a {
+      .report-header-command-bar--NJWdl .target-page--hjh44 a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
       /* css-modules:src/common/components/cards/combined-report-result-section-title */
-      .combined-report-result-section-title--RNekd {
+      .combined-report-result-section-title--TqIZO {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1383,14 +1383,14 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--RNekd .title--CFcXZ {
+      .combined-report-result-section-title--TqIZO .title--6WIyt {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--RNekd .heading--gtY3F {
+      .combined-report-result-section-title--TqIZO .heading--UpAHf {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
@@ -1399,7 +1399,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/urls-summary-section */
-      .urls-summary-section--db4HQ {
+      .urls-summary-section--jNa-v {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1407,26 +1407,26 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--db4HQ h2 {
+      .urls-summary-section--jNa-v h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--db4HQ .total-urls--3pXYz {
+      .urls-summary-section--jNa-v .total-urls--95-ge {
         font-weight: 600;
       }
-      .urls-summary-section--db4HQ .failure-instances--y0Big {
+      .urls-summary-section--jNa-v .failure-instances--2WDtT {
         margin-top: 40px;
       }
-      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
+      .urls-summary-section--jNa-v .failure-outcome-chip--JF-lj {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
 
       /* css-modules:src/reports/components/report-sections/rules-results-container */
-      .rules-results-container--dO76T {
+      .rules-results-container--HaLDw {
         margin-top: 56px;
       }
-      .rules-results-container--dO76T .results-heading--2h1oe {
+      .rules-results-container--HaLDw .results-heading--H9Puz {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
@@ -1435,7 +1435,7 @@
       }
 
       /* css-modules:src/reports/components/report-sections/summary-report-details-section */
-      .crawl-details-section--jDqES {
+      .crawl-details-section--a6evz {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1443,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1453,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
+      .crawl-details-section--a6evz .crawl-details-section-list--WV1Di li {
         display: inline-block;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
         li
-        .icon--enDUo {
+        .icon--APJEn {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--jDqES
-        .crawl-details-section-list--6FyX-
-        li.targetSite--M6DmE {
+      .crawl-details-section--a6evz
+        .crawl-details-section-list--WV1Di
+        li.targetSite--wBJT- {
         margin-bottom: 6px;
       }
-      .crawl-details-section--jDqES .text--lxa-w,
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .text--rViTo,
+      .crawl-details-section--a6evz .label--DUNYf {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1480,30 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--jDqES .label--TrLq3 {
+      .crawl-details-section--a6evz .label--DUNYf {
         font-weight: 600;
       }
-      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
+      .crawl-details-section--a6evz .label--DUNYf.no-icon--VrSr5 {
         padding-left: 29px;
       }
 
       /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
-      .url-result-section--Lsitd {
+      .url-result-section--SkOlZ {
         padding-bottom: 31px;
       }
-      .url-result-section--Lsitd
+      .url-result-section--SkOlZ
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--Lsitd .collapsible-content {
+      .url-result-section--SkOlZ .collapsible-content {
         margin-top: 19px;
       }
 
       /* css-modules:src/reports/components/report-sections/summary-results-table */
-      .summary-results-table--r6fvD {
+      .summary-results-table--Iezr- {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1512,39 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--r6fvD th,
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- th,
+      .summary-results-table--Iezr- td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--r6fvD th {
+      .summary-results-table--Iezr- th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--r6fvD thead tr :first-child {
+      .summary-results-table--Iezr- thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--r6fvD td {
+      .summary-results-table--Iezr- td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--r6fvD td.text-cell--luh34 {
+      .summary-results-table--Iezr- td.text-cell--EaUrM {
         overflow-wrap: break-word;
       }
-      .summary-results-table--r6fvD td.url-cell--ZGO-o {
+      .summary-results-table--Iezr- td.url-cell--mg-3l {
         overflow-wrap: anywhere;
       }
 
       /* css-modules:src/reports/components/report-sections/results-by-url-container */
-      .url-results-container--xiZ0N {
+      .url-results-container---dq9B {
         margin-top: 56px;
       }
-      .url-results-container--xiZ0N .results-heading--wmQ-W {
+      .url-results-container---dq9B .results-heading--2dWBX {
         margin-top: 32px;
         margin-bottom: 32px;
       }
 
       /* css-modules:src/common/components/cards/fix-instruction-color-box */
-      span.fix-instruction-color-box--lzu-L {
+      span.fix-instruction-color-box--DQpQE {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1552,7 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .screen-reader-only--T-59F {
+      .screen-reader-only--6LUiO {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1564,7 +1564,7 @@
     </style></head
   ><body
     ><header
-      ><div class="report-header-bar--DNH-8"
+      ><div class="report-header-bar--SDV11"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1721,16 +1721,16 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--v-ac2">Accessibility Insights</div></div
+        ><div class="header-text--EdTxw">Accessibility Insights</div></div
       ></header
     ><main class="outer-container"
       ><div class="content-container"
         ><div class="title-section"><h1>Automated checks results</h1></div
-        ><div class="crawl-details-section--jDqES"
+        ><div class="crawl-details-section--a6evz"
           ><h2>Scan details</h2
-          ><ul class="crawl-details-section-list--6FyX-"
-            ><li class="targetSite--M6DmE"
-              ><span class="icon--enDUo" aria-hidden="true"
+          ><ul class="crawl-details-section-list--WV1Di"
+            ><li class="targetSite--wBJT-"
+              ><span class="icon--APJEn" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1742,8 +1742,8 @@
                     d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--TrLq3">Target site </span
-              ><span class="text--lxa-w"
+              ><span class="label--DUNYf">Target site </span
+              ><span class="text--rViTo"
                 ><a
                   target="_blank"
                   href="https://example.com/mock-base-url"
@@ -1774,7 +1774,7 @@
                 </script></span
               ></li
             ><li
-              ><span class="icon--enDUo" aria-hidden="true"
+              ><span class="icon--APJEn" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1786,18 +1786,18 @@
                     d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--TrLq3">Scans started </span
-              ><span class="text--lxa-w">2020-02-02 3:04 AM UTC</span></li
+              ><span class="label--DUNYf">Scans started </span
+              ><span class="text--rViTo">2020-02-02 3:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--jXW2d label--TrLq3">Scans completed </span
-              ><span class="text--lxa-w">2020-02-02 4:04 AM UTC</span></li
+              ><span class="no-icon--VrSr5 label--DUNYf">Scans completed </span
+              ><span class="text--rViTo">2020-02-02 4:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--jXW2d label--TrLq3">Duration </span
-              ><span class="text--lxa-w">01:00:00</span></li
+              ><span class="no-icon--VrSr5 label--DUNYf">Duration </span
+              ><span class="text--rViTo">01:00:00</span></li
             ></ul
           ></div
-        ><div class="urls-summary-section--db4HQ"
-          ><h2>URLs</h2><span class="total-urls--3pXYz">2</span> total URLs
+        ><div class="urls-summary-section--jNa-v"
+          ><h2>URLs</h2><span class="total-urls--95-ge">2</span> total URLs
           scanned<div
             class="outcome-summary-bar"
             aria-label="0 Failed, 0 Not scanned, 2 Passed"
@@ -1865,9 +1865,9 @@
                 >2<span class="label"> Passed</span></span
               ></div
             ></div
-          ><div class="failure-instances--y0Big"
+          ><div class="failure-instances--2WDtT"
             ><h2>Failure Instances</h2
-            ><span class="failure-outcome-chip--vKGs1"
+            ><span class="failure-outcome-chip--JF-lj"
               ><span class="outcome-chip outcome-chip-fail" title="0 Failed"
                 ><span class="icon"
                   ><span class="check-container"
@@ -1893,21 +1893,21 @@
               ><span>Failure instances were detected</span></span
             ></div
           ></div
-        ><div class="url-results-container--xiZ0N"
-          ><div class="results-heading--wmQ-W"><h2>Results by URL</h2></div
-          ><div class="url-result-section--Lsitd"
+        ><div class="url-results-container---dq9B"
+          ><div class="results-heading--2dWBX"><h2>Results by URL</h2></div
+          ><div class="url-result-section--SkOlZ"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-failed-urls-section"
-                  ><span class="result-section-title--vgyHe"
+                  ><span class="result-section-title--RGFI5"
                     ><span class="screen-reader-only">Failed URLs 0</span
-                    ><span class="heading--1Ll6-" aria-hidden="true"
+                    ><span class="heading--NdP4Q" aria-hidden="true"
                       >Failed URLs</span
                     ><span
-                      class="outcome-chip-container--iN0Tt"
+                      class="outcome-chip-container--BT3j5"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-fail"
@@ -1947,7 +1947,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--r6fvD"
+                  class="summary-results-table--Iezr-"
                   id="failed-urls-table"
                   ><thead
                     ><tr
@@ -1959,19 +1959,19 @@
                       ></tr
                     ></thead
                   ><tbody></tbody></table></div></div></div
-          ><div class="url-result-section--Lsitd"
+          ><div class="url-result-section--SkOlZ"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-not-scanned-urls-section"
-                  ><span class="result-section-title--vgyHe"
+                  ><span class="result-section-title--RGFI5"
                     ><span class="screen-reader-only">Not scanned URLs 0</span
-                    ><span class="heading--1Ll6-" aria-hidden="true"
+                    ><span class="heading--NdP4Q" aria-hidden="true"
                       >Not scanned URLs</span
                     ><span
-                      class="outcome-chip-container--iN0Tt"
+                      class="outcome-chip-container--BT3j5"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-unscannable"
@@ -2018,7 +2018,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--r6fvD"
+                  class="summary-results-table--Iezr-"
                   id="not-scanned-urls-table"
                   ><thead
                     ><tr
@@ -2029,19 +2029,19 @@
                       ></tr
                     ></thead
                   ><tbody></tbody></table></div></div></div
-          ><div class="url-result-section--Lsitd"
+          ><div class="url-result-section--SkOlZ"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--wzmxK title-container"
+              ><h3 class="heading-element-for-level--ifVX6 title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-passed-urls-section"
-                  ><span class="result-section-title--vgyHe"
+                  ><span class="result-section-title--RGFI5"
                     ><span class="screen-reader-only">Passed URLs 2</span
-                    ><span class="heading--1Ll6-" aria-hidden="true"
+                    ><span class="heading--NdP4Q" aria-hidden="true"
                       >Passed URLs</span
                     ><span
-                      class="outcome-chip-container--iN0Tt"
+                      class="outcome-chip-container--BT3j5"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-pass"
@@ -2083,7 +2083,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--r6fvD"
+                  class="summary-results-table--Iezr-"
                   id="passed-urls-table"
                   ><thead
                     ><tr
@@ -2098,11 +2098,11 @@
                     ><tr
                       ><td
                         headers="passed-urls-table-header0"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         >0</td
                       ><td
                         headers="passed-urls-table-header1"
-                        class="url-cell--ZGO-o"
+                        class="url-cell--mg-3l"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/passes-a"
@@ -2111,7 +2111,7 @@
                         ></td
                       ><td
                         headers="passed-urls-table-header2"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         ><a
                           target="_blank"
                           href="./passes-a.html"
@@ -2123,11 +2123,11 @@
                     ><tr
                       ><td
                         headers="passed-urls-table-header0"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         >0</td
                       ><td
                         headers="passed-urls-table-header1"
-                        class="url-cell--ZGO-o"
+                        class="url-cell--mg-3l"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/passes-b"
@@ -2136,7 +2136,7 @@
                         ></td
                       ><td
                         headers="passed-urls-table-header2"
-                        class="text-cell--luh34"
+                        class="text-cell--EaUrM"
                         ><a
                           target="_blank"
                           href="./passes-b.html"

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -834,24 +834,30 @@
         margin-bottom: unset;
       }</style
     ><style>
-      .heading-element-for-level--OfRDW {
+      /* css-modules:src/common/components/heading-element-for-level */
+      .heading-element-for-level--wzmxK {
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      .failed-instances-container--FqWV6 .collapsible-content {
+
+      /* css-modules:src/common/components/cards/failed-instances-section */
+      .failed-instances-container--pB-u4 .collapsible-content {
         margin-left: 24px;
       }
-      .outcome-chip-container--xYquF {
+
+      /* css-modules:src/reports/components/report-sections/minimal-rule-header */
+      .outcome-chip-container--ja0WM {
         min-width: 50px;
       }
-      .hidden-highlight-button--PePzJ {
+
+      /* css-modules:src/reports/components/instance-details */
+      .hidden-highlight-button--to41b {
         opacity: 0;
         margin: 0;
         padding: 0;
         border: none;
       }
-
-      .instance-details-card--R0aAh {
+      .instance-details-card--lixTP {
         border-radius: 4px;
         border: 1px solid var(--card-border);
         outline-style: "border-style";
@@ -859,55 +865,44 @@
           0 3.2px 7.2px var(--box-shadow-132);
         margin-bottom: 16px;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
       }
-
-      .instance-details-card-container--bKrcd.selected--Kp4AC {
+      .instance-details-card-container--Hjwps.selected--Pf-DQ {
         outline: 5px solid var(--communication-tint-10);
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC {
+      .instance-details-card--lixTP.selected--Pf-DQ {
         border: 1px solid transparent;
       }
-
-      .instance-details-card--R0aAh.focused--tV0ic,
-      .instance-details-card--R0aAh:focus {
+      .instance-details-card--lixTP.focused--PfWGT,
+      .instance-details-card--lixTP:focus {
         outline: 2px solid var(--primary-text);
         outline-offset: 2px;
       }
-
-      .instance-details-card--R0aAh.selected--Kp4AC.focused--tV0ic,
-      .instance-details-card--R0aAh.selected--Kp4AC:focus {
+      .instance-details-card--lixTP.selected--Pf-DQ.focused--PfWGT,
+      .instance-details-card--lixTP.selected--Pf-DQ:focus {
         outline-offset: 8px;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy {
+      .instance-details-card--lixTP.interactive--su6Sw {
         cursor: pointer;
       }
-
-      .instance-details-card--R0aAh.interactive--NgYOy:hover {
+      .instance-details-card--lixTP.interactive--su6Sw:hover {
         box-shadow: 0 8px 10px var(--box-shadow-108),
           0 8px 10px var(--box-shadow-132);
       }
-
-      .report-instance-table--YIu0s {
+      .report-instance-table--YOlnT {
         background: var(--neutral-0);
         display: table;
         table-layout: fixed;
         width: -moz-available;
-        /* WebKit-based browsers will ignore this. */
         width: -webkit-fill-available;
-        /* Mozilla-based browsers will ignore this. */
         width: fill-available;
         border-radius: inherit;
         border-collapse: collapse;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .report-instance-table--YIu0s .row--m8TLI {
+      .report-instance-table--YOlnT .row--9WgHa {
         display: flex;
         flex-wrap: wrap;
         padding-top: 2px;
@@ -916,17 +911,17 @@
         padding-right: 20px;
         border-bottom: 0.5px solid var(--neutral-10);
       }
-      .report-instance-table--YIu0s .row--m8TLI > * {
+      .report-instance-table--YOlnT .row--9WgHa > * {
         margin-top: 12px;
         margin-bottom: 0;
         margin-left: 20px;
         margin-right: 0;
         padding: 0;
       }
-      .report-instance-table--YIu0s .row--m8TLI:last-child {
+      .report-instance-table--YOlnT .row--9WgHa:last-child {
         border-bottom: none;
       }
-      .report-instance-table--YIu0s .row-label--MxfuQ {
+      .report-instance-table--YOlnT .row-label--dri3e {
         flex-basis: 90px;
         flex-shrink: 1;
         flex-grow: 0;
@@ -936,7 +931,7 @@
         color: var(--primary-text);
         text-align: left;
       }
-      .report-instance-table--YIu0s .row-content--ECKwg {
+      .report-instance-table--YOlnT .row-content--Gt-CK {
         flex-basis: 200px;
         flex-shrink: 1;
         flex-grow: 1;
@@ -946,41 +941,44 @@
         align-items: flex-end;
         display: flex;
       }
-      .multi-line-text-no-bullet--lNJS_ {
+
+      /* css-modules:src/common/components/cards/rich-resolution-content */
+      .multi-line-text-no-bullet--xUzJx {
         padding-left: 0;
         list-style: none;
       }
-      .multi-line-text-no-bullet--lNJS_ li:not(:last-child) {
+      .multi-line-text-no-bullet--xUzJx li:not(:last-child) {
         margin-bottom: 4px;
       }
-
-      .multi-line-text-yes-bullet--pp76P {
+      .multi-line-text-yes-bullet--jH-w4 {
         padding-left: 16px;
       }
-      .multi-line-text-yes-bullet--pp76P li {
+      .multi-line-text-yes-bullet--jH-w4 li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .combination-lists--O1dD_ {
+      .combination-lists--4wBYq {
         flex-direction: column;
         display: flex;
       }
-      .urls-row-content--MxcA7 {
+
+      /* css-modules:src/common/components/cards/urls-card-row */
+      .urls-row-content--rj2oy {
         padding-left: 16px;
       }
-      .urls-row-content--MxcA7 li {
+      .urls-row-content--rj2oy li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-
-      .urls-row-content-new-Failure--uJPP3 {
+      .urls-row-content-new-Failure--7Dq38 {
         color: var(--negative-outcome);
         font-weight: bold;
       }
-      .insights-fix-instruction-list--G3vyY
+
+      /* css-modules:src/common/components/fix-instruction-panel */
+      .insights-fix-instruction-list--NaN2O
         li
-        span.fix-instruction-color-box--g6NfJ {
+        span.fix-instruction-color-box---mQtG {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -988,7 +986,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-      .insights-fix-instruction-list--G3vyY .screen-reader-only--yQjgp {
+      .insights-fix-instruction-list--NaN2O .screen-reader-only--r8bnE {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -996,64 +994,75 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
-      .how-to-fix-content--OHBLC {
+
+      /* css-modules:src/common/components/cards/how-to-fix-card-row */
+      .how-to-fix-content--Xj-BH {
         margin-bottom: 16px;
       }
-      .how-to-fix-content--OHBLC ul {
+      .how-to-fix-content--Xj-BH ul {
         padding-left: 16px;
       }
-      .how-to-fix-content--OHBLC ul li {
+      .how-to-fix-content--Xj-BH ul li {
         list-style-type: disc;
         margin-bottom: 4px;
       }
-      .snippet--wZrK1 {
+
+      /* css-modules:src/common/components/cards/snippet-card-row */
+      .snippet--P6i7P {
         font-family: menlo, consolas, courier new, monospace;
         white-space: normal;
       }
-      div.insights-dialog-main-override--Mlek6 {
+
+      /* css-modules:src/DetailsView/components/common-dialog-styles */
+      div.insights-dialog-main-override--qzZJk {
         width: 75%;
         max-width: 500px;
         user-select: text;
       }
       @media screen and (max-width: 500px) {
-        div.insights-dialog-main-override--Mlek6 {
+        div.insights-dialog-main-override--qzZJk {
           min-width: 240px;
           width: 75%;
         }
       }
-      div.insights-dialog-main-override--Mlek6 .dialog-body--QtJ_D {
+      div.insights-dialog-main-override--qzZJk .dialog-body--cQ7Jw {
         font-size: 16px;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-title {
+
+      /* css-modules:src/DetailsView/components/issue-filing-dialog */
+      .issue-filing-dialog--l9xMr .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
         font-weight: 600;
         padding-bottom: 0;
       }
-      .issue-filing-dialog--ZrD5s .ms-Dialog-subText {
+      .issue-filing-dialog--l9xMr .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: var(--secondary-text);
       }
-      .issue-filing-dialog--ZrD5s .textfield-description {
+      .issue-filing-dialog--l9xMr .textfield-description {
         color: var(--secondary-text);
         font-style: italic;
       }
-      .action-and-cancel-buttons-component--HOvON {
+
+      /* css-modules:src/DetailsView/components/action-and-cancel-buttons-component */
+      .action-and-cancel-buttons-component--5-uZX {
         display: flex;
         justify-content: flex-end;
       }
-      .action-and-cancel-buttons-component--HOvON
-        .action-cancel-button-col--VrVAp
-        + .action-cancel-button-col--VrVAp {
+      .action-and-cancel-buttons-component--5-uZX
+        .action-cancel-button-col--txH36
+        + .action-cancel-button-col--txH36 {
         margin-left: 8px;
       }
-      .toast-container--KsxE1 {
+
+      /* css-modules:src/common/components/toast */
+      .toast-container--cNX98 {
         display: inline-block;
       }
-
-      .toast-content--pEpMJ {
+      .toast-content--bk935 {
         background: var(--neutral-70);
         border-radius: 4px;
         color: var(--neutral-0);
@@ -1068,84 +1077,86 @@
         z-index: 1000;
         position: absolute;
       }
-      div.kebab-menu-callout--o23oT {
+
+      /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      div.kebab-menu-callout--A3AHu {
         box-shadow: 0 6.4px 14.4px var(--box-shadow-132),
           0 1.2px 3.6px var(--box-shadow-108);
         border-radius: 4px;
         border-width: 0;
       }
-      div.kebab-menu-callout--o23oT > div {
+      div.kebab-menu-callout--A3AHu > div {
         border-radius: 4px;
       }
-
-      .kebab-menu--eviKu {
+      .kebab-menu--Bm5S1 {
         background: var(--neutral-3);
         border: 1px solid var(--menu-border);
       }
-      .kebab-menu--eviKu li {
+      .kebab-menu--Bm5S1 li {
         background-color: var(--neutral-3);
       }
-      .kebab-menu--eviKu button i {
+      .kebab-menu--Bm5S1 button i {
         color: var(--primary-text);
       }
-      .kebab-menu--eviKu button:hover {
+      .kebab-menu--Bm5S1 button:hover {
         background-color: var(--menu-item-background-hover);
       }
       @media screen and (forced-colors: active) {
-        .kebab-menu--eviKu button:hover {
+        .kebab-menu--Bm5S1 button:hover {
           background-color: inherit;
         }
       }
-      .kebab-menu--eviKu button:active {
+      .kebab-menu--Bm5S1 button:active {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      .kebab-menu--eviKu button:active i {
+      .kebab-menu--Bm5S1 button:active i {
         color: var(--light-black);
       }
-
-      button.kebab-menu-button--dy7Ui {
+      button.kebab-menu-button--ySFdR {
         width: 34px;
         height: 32px;
         margin: 8px;
         border-radius: 2px;
         background: transparent;
       }
-      button.kebab-menu-button--dy7Ui svg {
+      button.kebab-menu-button--ySFdR svg {
         stroke: var(--primary-text);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui svg {
+        button.kebab-menu-button--ySFdR svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      button.kebab-menu-button--dy7Ui:hover {
+      button.kebab-menu-button--ySFdR:hover {
         background-color: var(--menu-item-background-hover);
       }
-      button.kebab-menu-button--dy7Ui:active,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+      button.kebab-menu-button--ySFdR:active,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] {
         background-color: var(--menu-item-background-active);
         color: var(--light-black);
       }
-      button.kebab-menu-button--dy7Ui:active svg > circle,
-      button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+      button.kebab-menu-button--ySFdR:active svg > circle,
+      button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
         stroke: var(--light-black);
       }
       @media screen and (forced-colors: active) {
-        button.kebab-menu-button--dy7Ui:active,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] {
+        button.kebab-menu-button--ySFdR:active,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] {
           color: inherit;
         }
-        button.kebab-menu-button--dy7Ui:active svg > circle,
-        button.kebab-menu-button--dy7Ui[aria-expanded="true"] svg > circle {
+        button.kebab-menu-button--ySFdR:active svg > circle,
+        button.kebab-menu-button--ySFdR[aria-expanded="true"] svg > circle {
           stroke: inherit;
         }
       }
-      button.kebab-menu-button--dy7Ui > span {
+      button.kebab-menu-button--ySFdR > span {
         justify-content: center;
       }
-      .foot--d1w5m {
+
+      /* css-modules:src/common/components/cards/instance-details-footer */
+      .foot--WBFZ6 {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -1156,40 +1167,44 @@
         border-bottom-left-radius: inherit;
         border-bottom-right-radius: inherit;
       }
-      .foot--d1w5m .highlight-status--Bmqfx {
+      .foot--WBFZ6 .highlight-status--TYXPj {
         display: flex;
         justify-content: space-between;
         align-items: center;
         background: transparent;
       }
-      .foot--d1w5m .highlight-status--Bmqfx svg {
+      .foot--WBFZ6 .highlight-status--TYXPj svg {
         fill: var(--secondary-text);
       }
       @media screen and (forced-colors: active) {
-        .foot--d1w5m .highlight-status--Bmqfx svg {
+        .foot--WBFZ6 .highlight-status--TYXPj svg {
           fill: ButtonFace !important;
           stroke: ButtonText !important;
         }
       }
-      .foot--d1w5m .highlight-status--Bmqfx label {
+      .foot--WBFZ6 .highlight-status--TYXPj label {
         color: var(--secondary-text);
         font-size: 14px;
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      ul.instance-details-list--xiPPL {
+
+      /* css-modules:src/common/components/cards/instance-details-group */
+      ul.instance-details-list--bg-Zq {
         list-style-type: none;
         padding-inline-start: unset;
         margin-block-start: unset;
         margin-block-end: unset;
       }
-      ul.instance-details-list--xiPPL > li {
+      ul.instance-details-list--bg-Zq > li {
         margin-bottom: 16px;
       }
-      ul.instance-details-list--xiPPL > li:last-child {
+      ul.instance-details-list--bg-Zq > li:last-child {
         margin-bottom: unset;
       }
-      .rule-more-resources--Bsblo {
+
+      /* css-modules:src/common/components/cards/rule-resources */
+      .rule-more-resources--w4eYl {
         display: flex;
         flex-direction: column;
         margin-bottom: 16px;
@@ -1203,50 +1218,53 @@
         overflow-wrap: break-word;
         word-break: break-word;
       }
-      .rule-more-resources--Bsblo .more-resources-title--whTFs {
+      .rule-more-resources--w4eYl .more-resources-title--wqgCn {
         font-weight: 600;
       }
-      .rule-more-resources--Bsblo .rule-details-id--n_S89 {
+      .rule-more-resources--w4eYl .rule-details-id--QH6Z9 {
         padding: 12px 0;
       }
-      .rule-details-group--U69fz .rule-detail {
+
+      /* css-modules:src/common/components/cards/rules-with-instances */
+      .rule-details-group--ZuRYr .rule-detail {
         font-size: 14px;
         padding: 16px 8px;
         display: flex;
         align-items: baseline;
         text-align: left;
       }
-      .rule-details-group--U69fz .rule-detail .outcome-chip {
+      .rule-details-group--ZuRYr .rule-detail .outcome-chip {
         vertical-align: middle;
         margin-bottom: 2px;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id {
         font-weight: 600;
         color: var(--primary-text);
         word-break: break-all;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id a {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id a {
         font-weight: 600;
         color: var(--primary-text) !important;
       }
-      .rule-details-group--U69fz .rule-detail .rule-details-id strong {
+      .rule-details-group--ZuRYr .rule-detail .rule-details-id strong {
         font-weight: 600;
       }
-      .rule-details-group--U69fz .rule-detail .rule-detail-description {
+      .rule-details-group--ZuRYr .rule-detail .rule-detail-description {
         color: var(--secondary-text) !important;
         word-break: break-all;
       }
-
-      .collapsible-rule-details-group--h0lvd {
+      .collapsible-rule-details-group--ODFPb {
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .collapsible-rule-details-group--h0lvd .rule-detail {
+      .collapsible-rule-details-group--ODFPb .rule-detail {
         box-shadow: unset;
       }
-      .collapsible-rule-details-group--h0lvd:not(.collapsed) {
+      .collapsible-rule-details-group--ODFPb:not(.collapsed) {
         box-shadow: unset;
       }
-      .result-section-title--qv3MK {
+
+      /* css-modules:src/common/components/cards/result-section-title */
+      .result-section-title--vgyHe {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1254,45 +1272,49 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail .count {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail .count {
         line-height: 11px;
       }
-      .result-section-title--qv3MK .outcome-chip.outcome-chip-fail svg {
+      .result-section-title--vgyHe .outcome-chip.outcome-chip-fail svg {
         margin-bottom: 3px;
       }
-      .result-section-title--qv3MK .title--neMma {
+      .result-section-title--vgyHe .title--6gdF5 {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .heading--VbGap {
+      .result-section-title--vgyHe .heading--1Ll6- {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .result-section-title--qv3MK .outcome-chip-container--Wt0k4 {
+      .result-section-title--vgyHe .outcome-chip-container--iN0Tt {
         display: flex;
         height: 16px;
       }
-      .result-section--j6fYr {
+
+      /* css-modules:src/common/components/cards/result-section */
+      .result-section--Av9vc {
         padding-bottom: 24px;
       }
-      .result-section--j6fYr
-        .title-container--gMYqW
-        .collapsible-control--V9OlA::before {
+      .result-section--Av9vc
+        .title-container---R9Dm
+        .collapsible-control--5y7Tp::before {
         position: relative;
         bottom: 2px;
       }
-      .result-section--j6fYr > h2 {
+      .result-section--Av9vc > h2 {
         margin: 0;
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-bar--pkiTM {
+
+      /* css-modules:src/reports/components/header-bar */
+      .report-header-bar--DNH-8 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -1301,13 +1323,13 @@
         height: 40px;
         width: 100%;
       }
-      .report-header-bar--pkiTM .header-icon {
+      .report-header-bar--DNH-8 .header-icon {
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
         width: 22px;
       }
-      .report-header-bar--pkiTM .header-text--dfm48 {
+      .report-header-bar--DNH-8 .header-text--v-ac2 {
         margin-left: 8px;
         color: var(--header-bar-title-color);
         flex-shrink: 1;
@@ -1321,7 +1343,9 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .report-header-command-bar--wDg1t {
+
+      /* css-modules:src/reports/components/report-sections/header-section */
+      .report-header-command-bar--8-nLy {
         height: 40px;
         width: 100%;
         display: flex;
@@ -1331,7 +1355,7 @@
         background-color: var(--neutral-0);
         box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
       }
-      .report-header-command-bar--wDg1t .target-page--giudb {
+      .report-header-command-bar--8-nLy .target-page--q7WnX {
         white-space: nowrap;
         margin: 0 0 0 16px;
         display: flex;
@@ -1344,12 +1368,14 @@
         font-weight: normal;
         min-width: 0;
       }
-      .report-header-command-bar--wDg1t .target-page--giudb a {
+      .report-header-command-bar--8-nLy .target-page--q7WnX a {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      .combined-report-result-section-title--XUDDo {
+
+      /* css-modules:src/common/components/cards/combined-report-result-section-title */
+      .combined-report-result-section-title--RNekd {
         display: flex;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -1357,21 +1383,23 @@
         margin-top: 8px;
         margin-bottom: 8px;
       }
-      .combined-report-result-section-title--XUDDo .title--lcuIW {
+      .combined-report-result-section-title--RNekd .title--CFcXZ {
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .combined-report-result-section-title--XUDDo .heading--uUq3e {
+      .combined-report-result-section-title--RNekd .heading--gtY3F {
         font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;
         color: var(--primary-text);
       }
-      .urls-summary-section--DjUWc {
+
+      /* css-modules:src/reports/components/report-sections/urls-summary-section */
+      .urls-summary-section--db4HQ {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1379,31 +1407,35 @@
         padding: 20px;
         margin-bottom: 24px;
       }
-      .urls-summary-section--DjUWc h2 {
+      .urls-summary-section--db4HQ h2 {
         margin-bottom: 16px !important;
       }
-      .urls-summary-section--DjUWc .total-urls--Ig_eB {
+      .urls-summary-section--db4HQ .total-urls--3pXYz {
         font-weight: 600;
       }
-      .urls-summary-section--DjUWc .failure-instances--Rq_Tj {
+      .urls-summary-section--db4HQ .failure-instances--y0Big {
         margin-top: 40px;
       }
-      .urls-summary-section--DjUWc .failure-outcome-chip--YtjBX {
+      .urls-summary-section--db4HQ .failure-outcome-chip--vKGs1 {
         display: flex;
         justify-content: flex-start;
         align-items: center;
       }
-      .rules-results-container--n7EEu {
+
+      /* css-modules:src/reports/components/report-sections/rules-results-container */
+      .rules-results-container--dO76T {
         margin-top: 56px;
       }
-      .rules-results-container--n7EEu .results-heading--pyS7R {
+      .rules-results-container--dO76T .results-heading--2h1oe {
         margin-top: 32px;
         margin-bottom: 32px;
         font-weight: 600;
         font-size: 17px;
         line-height: 24px;
       }
-      .crawl-details-section--WhRL4 {
+
+      /* css-modules:src/reports/components/report-sections/summary-report-details-section */
+      .crawl-details-section--jDqES {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
         border-radius: 4px;
@@ -1411,7 +1443,7 @@
         padding: 20px;
         margin-bottom: 22px;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- {
         list-style: none;
         font-size: 14px;
         line-height: 16px;
@@ -1421,24 +1453,24 @@
         justify-content: center;
         flex-direction: column;
       }
-      .crawl-details-section--WhRL4 .crawl-details-section-list--Lrjqg li {
+      .crawl-details-section--jDqES .crawl-details-section-list--6FyX- li {
         display: inline-block;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
         li
-        .icon--JdMPq {
+        .icon--enDUo {
         padding-right: 12px;
         position: relative;
         top: 3px;
       }
-      .crawl-details-section--WhRL4
-        .crawl-details-section-list--Lrjqg
-        li.targetSite--qXxid {
+      .crawl-details-section--jDqES
+        .crawl-details-section-list--6FyX-
+        li.targetSite--M6DmE {
         margin-bottom: 6px;
       }
-      .crawl-details-section--WhRL4 .text--swxfX,
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .text--lxa-w,
+      .crawl-details-section--jDqES .label--TrLq3 {
         word-break: break-all;
         color: var(--neutral-55);
         font-family: "Segoe UI Web (West European)", "Segoe UI", "-apple-system",
@@ -1448,26 +1480,30 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2 {
+      .crawl-details-section--jDqES .label--TrLq3 {
         font-weight: 600;
       }
-      .crawl-details-section--WhRL4 .label--yUuT2.no-icon--J7B9N {
+      .crawl-details-section--jDqES .label--TrLq3.no-icon--jXW2d {
         padding-left: 29px;
       }
-      .url-result-section--PmEoY {
+
+      /* css-modules:src/reports/components/report-sections/collapsible-url-result-section */
+      .url-result-section--Lsitd {
         padding-bottom: 31px;
       }
-      .url-result-section--PmEoY
+      .url-result-section--Lsitd
         .title-container[aria-level="3"]
         .collapsible-control::before {
         position: relative;
         bottom: 2px;
         margin-right: 14px;
       }
-      .url-result-section--PmEoY .collapsible-content {
+      .url-result-section--Lsitd .collapsible-content {
         margin-top: 19px;
       }
-      .summary-results-table--Pb4_B {
+
+      /* css-modules:src/reports/components/report-sections/summary-results-table */
+      .summary-results-table--r6fvD {
         width: 100%;
         margin: 0;
         text-align: left;
@@ -1476,35 +1512,39 @@
         font-size: 14px;
         line-height: 20px;
       }
-      .summary-results-table--Pb4_B th,
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD th,
+      .summary-results-table--r6fvD td {
         border: 1px solid var(--neutral-20);
         padding: 16px 8px 16px 8px;
       }
-      .summary-results-table--Pb4_B th {
+      .summary-results-table--r6fvD th {
         font-weight: 600;
         background-color: var(--neutral-6);
       }
-      .summary-results-table--Pb4_B thead tr :first-child {
+      .summary-results-table--r6fvD thead tr :first-child {
         width: 172px;
       }
-      .summary-results-table--Pb4_B td {
+      .summary-results-table--r6fvD td {
         background-color: var(--neutral-0);
       }
-      .summary-results-table--Pb4_B td.text-cell--p0dxL {
+      .summary-results-table--r6fvD td.text-cell--luh34 {
         overflow-wrap: break-word;
       }
-      .summary-results-table--Pb4_B td.url-cell--yjU1V {
+      .summary-results-table--r6fvD td.url-cell--ZGO-o {
         overflow-wrap: anywhere;
       }
-      .url-results-container--dXQbj {
+
+      /* css-modules:src/reports/components/report-sections/results-by-url-container */
+      .url-results-container--xiZ0N {
         margin-top: 56px;
       }
-      .url-results-container--dXQbj .results-heading--D3Qtr {
+      .url-results-container--xiZ0N .results-heading--wmQ-W {
         margin-top: 32px;
         margin-bottom: 32px;
       }
-      span.fix-instruction-color-box--Xq1E4 {
+
+      /* css-modules:src/common/components/cards/fix-instruction-color-box */
+      span.fix-instruction-color-box--lzu-L {
         width: 14px;
         height: 14px;
         display: inline-block;
@@ -1512,8 +1552,7 @@
         margin: 0 2px;
         border: 1px solid var(--light-black);
       }
-
-      .screen-reader-only--n1Ocs {
+      .screen-reader-only--T-59F {
         position: absolute;
         left: -10000px;
         top: auto;
@@ -1521,10 +1560,11 @@
         overflow: hidden;
         clip-path: inset(100% 100% 100% 100%);
       }
+      /*# sourceMappingURL=report.css.map */
     </style></head
   ><body
     ><header
-      ><div class="report-header-bar--pkiTM"
+      ><div class="report-header-bar--DNH-8"
         ><svg
           role="img"
           aria-hidden="true"
@@ -1681,16 +1721,16 @@
               <stop offset="1" stop-color="#D6E9F7" stop-opacity="0"></stop>
             </linearGradient>
           </defs></svg
-        ><div class="header-text--dfm48">Accessibility Insights</div></div
+        ><div class="header-text--v-ac2">Accessibility Insights</div></div
       ></header
     ><main class="outer-container"
       ><div class="content-container"
         ><div class="title-section"><h1>Automated checks results</h1></div
-        ><div class="crawl-details-section--WhRL4"
+        ><div class="crawl-details-section--jDqES"
           ><h2>Scan details</h2
-          ><ul class="crawl-details-section-list--Lrjqg"
-            ><li class="targetSite--qXxid"
-              ><span class="icon--JdMPq" aria-hidden="true"
+          ><ul class="crawl-details-section-list--6FyX-"
+            ><li class="targetSite--M6DmE"
+              ><span class="icon--enDUo" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1702,8 +1742,8 @@
                     d="M8.82353 0C9.5579 0 10.2662 0.0963542 10.9485 0.289062C11.6308 0.476562 12.2688 0.744792 12.8626 1.09375C13.4563 1.4375 13.9954 1.85417 14.4798 2.34375C14.9694 2.82812 15.386 3.36719 15.7298 3.96094C16.0787 4.55469 16.347 5.19271 16.5345 5.875C16.7272 6.55729 16.8235 7.26562 16.8235 8C16.8235 8.73438 16.7272 9.44271 16.5345 10.125C16.347 10.8073 16.0787 11.4453 15.7298 12.0391C15.386 12.6328 14.9694 13.1745 14.4798 13.6641C13.9954 14.1484 13.4563 14.5651 12.8626 14.9141C12.2688 15.2578 11.6308 15.526 10.9485 15.7188C10.2662 15.9062 9.5579 16 8.82353 16C8.08915 16 7.38082 15.9062 6.69853 15.7188C6.01624 15.526 5.37822 15.2578 4.78447 14.9141C4.19072 14.5651 3.64905 14.1484 3.15947 13.6641C2.67509 13.1745 2.25843 12.6328 1.90947 12.0391C1.56572 11.4453 1.29749 10.8099 1.10478 10.1328C0.917279 9.45052 0.823529 8.73958 0.823529 8C0.823529 7.26562 0.917279 6.55729 1.10478 5.875C1.29749 5.19271 1.56572 4.55469 1.90947 3.96094C2.25843 3.36719 2.67509 2.82812 3.15947 2.34375C3.64905 1.85417 4.19072 1.4375 4.78447 1.09375C5.37822 0.744792 6.01363 0.476562 6.69072 0.289062C7.37301 0.0963542 8.08395 0 8.82353 0ZM15.1438 5C14.9459 4.57812 14.7063 4.18229 14.4251 3.8125C14.1438 3.4375 13.8313 3.09635 13.4876 2.78906C13.1438 2.48177 12.7714 2.20833 12.3704 1.96875C11.9694 1.72917 11.5501 1.53385 11.1126 1.38281C11.3001 1.64323 11.4694 1.91927 11.6204 2.21094C11.7714 2.5026 11.9043 2.80469 12.0188 3.11719C12.1386 3.42448 12.2402 3.73698 12.3235 4.05469C12.4069 4.3724 12.4798 4.6875 12.5423 5H15.1438ZM15.8235 8C15.8235 7.30729 15.7272 6.64062 15.5345 6H12.6985C12.7402 6.33333 12.7714 6.66667 12.7923 7C12.8131 7.32812 12.8235 7.66146 12.8235 8C12.8235 8.33854 12.8131 8.67448 12.7923 9.00781C12.7714 9.33594 12.7402 9.66667 12.6985 10H15.5345C15.7272 9.35938 15.8235 8.69271 15.8235 8ZM8.82353 15C9.07874 15 9.31572 14.9297 9.53447 14.7891C9.75843 14.6484 9.96415 14.4635 10.1517 14.2344C10.3392 14.0052 10.5058 13.7474 10.6517 13.4609C10.8027 13.1693 10.9355 12.875 11.0501 12.5781C11.1647 12.2812 11.261 11.9948 11.3392 11.7188C11.4173 11.4427 11.4772 11.2031 11.5188 11H6.12822C6.16988 11.2031 6.22978 11.4427 6.3079 11.7188C6.38603 11.9948 6.48238 12.2812 6.59697 12.5781C6.71155 12.875 6.84176 13.1693 6.98759 13.4609C7.13863 13.7474 7.3079 14.0052 7.4954 14.2344C7.6829 14.4635 7.88603 14.6484 8.10478 14.7891C8.32874 14.9297 8.56832 15 8.82353 15ZM11.6907 10C11.7324 9.66667 11.7636 9.33594 11.7845 9.00781C11.8105 8.67448 11.8235 8.33854 11.8235 8C11.8235 7.66146 11.8105 7.32812 11.7845 7C11.7636 6.66667 11.7324 6.33333 11.6907 6H5.95634C5.91468 6.33333 5.88082 6.66667 5.85478 7C5.83395 7.32812 5.82353 7.66146 5.82353 8C5.82353 8.33854 5.83395 8.67448 5.85478 9.00781C5.88082 9.33594 5.91468 9.66667 5.95634 10H11.6907ZM1.82353 8C1.82353 8.69271 1.91988 9.35938 2.11259 10H4.94853C4.90686 9.66667 4.87561 9.33594 4.85478 9.00781C4.83395 8.67448 4.82353 8.33854 4.82353 8C4.82353 7.66146 4.83395 7.32812 4.85478 7C4.87561 6.66667 4.90686 6.33333 4.94853 6H2.11259C1.91988 6.64062 1.82353 7.30729 1.82353 8ZM8.82353 1C8.56832 1 8.32874 1.07031 8.10478 1.21094C7.88603 1.35156 7.6829 1.53646 7.4954 1.76562C7.3079 1.99479 7.13863 2.25521 6.98759 2.54688C6.84176 2.83333 6.71155 3.125 6.59697 3.42188C6.48238 3.71875 6.38603 4.00521 6.3079 4.28125C6.22978 4.55729 6.16988 4.79688 6.12822 5H11.5188C11.4772 4.79688 11.4173 4.55729 11.3392 4.28125C11.261 4.00521 11.1647 3.71875 11.0501 3.42188C10.9355 3.125 10.8027 2.83333 10.6517 2.54688C10.5058 2.25521 10.3392 1.99479 10.1517 1.76562C9.96415 1.53646 9.75843 1.35156 9.53447 1.21094C9.31572 1.07031 9.07874 1 8.82353 1ZM6.53447 1.38281C6.09697 1.53385 5.6777 1.72917 5.27665 1.96875C4.87561 2.20833 4.50322 2.48177 4.15947 2.78906C3.81572 3.09635 3.50322 3.4375 3.22197 3.8125C2.94072 4.18229 2.70113 4.57812 2.50322 5H5.10478C5.16728 4.6875 5.2402 4.3724 5.32353 4.05469C5.40686 3.73698 5.50582 3.42448 5.6204 3.11719C5.7402 2.80469 5.87561 2.5026 6.02665 2.21094C6.1777 1.91927 6.34697 1.64323 6.53447 1.38281ZM2.50322 11C2.70113 11.4219 2.94072 11.8203 3.22197 12.1953C3.50322 12.5651 3.81572 12.9036 4.15947 13.2109C4.50322 13.5182 4.87561 13.7917 5.27665 14.0312C5.6777 14.2708 6.09697 14.4661 6.53447 14.6172C6.34697 14.3568 6.1777 14.0807 6.02665 13.7891C5.87561 13.4974 5.7402 13.1979 5.6204 12.8906C5.50582 12.5781 5.40686 12.263 5.32353 11.9453C5.2402 11.6276 5.16728 11.3125 5.10478 11H2.50322ZM11.1126 14.6172C11.5501 14.4661 11.9694 14.2708 12.3704 14.0312C12.7714 13.7917 13.1438 13.5182 13.4876 13.2109C13.8313 12.9036 14.1438 12.5651 14.4251 12.1953C14.7063 11.8203 14.9459 11.4219 15.1438 11H12.5423C12.4798 11.3125 12.4069 11.6276 12.3235 11.9453C12.2402 12.263 12.1386 12.5781 12.0188 12.8906C11.9043 13.1979 11.7714 13.4974 11.6204 13.7891C11.4694 14.0807 11.3001 14.3568 11.1126 14.6172Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--yUuT2">Target site </span
-              ><span class="text--swxfX"
+              ><span class="label--TrLq3">Target site </span
+              ><span class="text--lxa-w"
                 ><a
                   target="_blank"
                   href="https://example.com/mock-base-url"
@@ -1720,9 +1760,7 @@
                     var targetPageLink = doc.getElementById(linkId);
                     targetPageLink.addEventListener("click", function (event) {
                       var result = confirmCallback(
-                        "Are you sure you want to navigate away from the Accessibility Insights report?\n" +
-                          "This link will open the target page in a new tab.\n\nPress OK to continue or " +
-                          "Cancel to stay on the current page."
+                        "Are you sure you want to navigate away from the Accessibility Insights report?\nThis link will open the target page in a new tab.\n\nPress OK to continue or Cancel to stay on the current page."
                       );
                       if (result === false) {
                         event.preventDefault();
@@ -1736,7 +1774,7 @@
                 </script></span
               ></li
             ><li
-              ><span class="icon--JdMPq" aria-hidden="true"
+              ><span class="icon--enDUo" aria-hidden="true"
                 ><svg
                   width="17"
                   height="16"
@@ -1748,18 +1786,18 @@
                     d="M8.82353 16C8.09697 16 7.39677 15.9062 6.72294 15.7188C6.05497 15.5312 5.42802 15.2676 4.84208 14.9277C4.26201 14.582 3.73173 14.1719 3.25126 13.6973C2.77665 13.2168 2.3665 12.6865 2.02079 12.1064C1.68095 11.5205 1.41728 10.8936 1.22978 10.2256C1.04228 9.55176 0.948529 8.85156 0.948529 8.125C0.948529 7.39844 1.04228 6.70117 1.22978 6.0332C1.41728 5.35937 1.68095 4.73242 2.02079 4.15234C2.3665 3.56641 2.77665 3.03613 3.25126 2.56152C3.73173 2.08105 4.26201 1.6709 4.84208 1.33105C5.42802 0.985352 6.05497 0.71875 6.72294 0.53125C7.39677 0.34375 8.09697 0.25 8.82353 0.25C9.55009 0.25 10.2474 0.34375 10.9153 0.53125C11.5892 0.71875 12.2161 0.985352 12.7962 1.33105C13.3821 1.6709 13.9124 2.08105 14.387 2.56152C14.8675 3.03613 15.2776 3.56641 15.6175 4.15234C15.9632 4.73242 16.2298 5.35937 16.4173 6.0332C16.6048 6.70117 16.6985 7.39844 16.6985 8.125C16.6985 8.85156 16.6048 9.55176 16.4173 10.2256C16.2298 10.8936 15.9632 11.5205 15.6175 12.1064C15.2776 12.6865 14.8675 13.2168 14.387 13.6973C13.9124 14.1719 13.3821 14.582 12.7962 14.9277C12.2161 15.2676 11.5892 15.5312 10.9153 15.7188C10.2474 15.9062 9.55009 16 8.82353 16ZM8.82353 1.375C7.89189 1.375 7.01591 1.55371 6.1956 1.91113C5.38115 2.2627 4.6663 2.74609 4.05107 3.36133C3.44169 3.9707 2.95829 4.68555 2.60087 5.50586C2.24931 6.32031 2.07353 7.19336 2.07353 8.125C2.07353 9.05664 2.24931 9.93262 2.60087 10.7529C2.95829 11.5674 3.44169 12.2822 4.05107 12.8975C4.6663 13.5068 5.38115 13.9902 6.1956 14.3477C7.01591 14.6992 7.89189 14.875 8.82353 14.875C9.75517 14.875 10.6282 14.6992 11.4427 14.3477C12.263 13.9902 12.9778 13.5068 13.5872 12.8975C14.2024 12.2822 14.6858 11.5674 15.0374 10.7529C15.3948 9.93262 15.5735 9.05664 15.5735 8.125C15.5735 7.19336 15.3948 6.32031 15.0374 5.50586C14.6858 4.68555 14.2024 3.9707 13.5872 3.36133C12.9778 2.74609 12.263 2.2627 11.4427 1.91113C10.6282 1.55371 9.75517 1.375 8.82353 1.375ZM8.82353 8.125V3.625H7.69853V9.25H12.1985V8.125H8.82353Z"
                     fill="#737373"
                   ></path></svg></span
-              ><span class="label--yUuT2">Scans started </span
-              ><span class="text--swxfX">2020-02-02 3:04 AM UTC</span></li
+              ><span class="label--TrLq3">Scans started </span
+              ><span class="text--lxa-w">2020-02-02 3:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--J7B9N label--yUuT2">Scans completed </span
-              ><span class="text--swxfX">2020-02-02 4:04 AM UTC</span></li
+              ><span class="no-icon--jXW2d label--TrLq3">Scans completed </span
+              ><span class="text--lxa-w">2020-02-02 4:04 AM UTC</span></li
             ><li
-              ><span class="no-icon--J7B9N label--yUuT2">Duration </span
-              ><span class="text--swxfX">01:00:00</span></li
+              ><span class="no-icon--jXW2d label--TrLq3">Duration </span
+              ><span class="text--lxa-w">01:00:00</span></li
             ></ul
           ></div
-        ><div class="urls-summary-section--DjUWc"
-          ><h2>URLs</h2><span class="total-urls--Ig_eB">2</span> total URLs
+        ><div class="urls-summary-section--db4HQ"
+          ><h2>URLs</h2><span class="total-urls--3pXYz">2</span> total URLs
           scanned<div
             class="outcome-summary-bar"
             aria-label="0 Failed, 0 Not scanned, 2 Passed"
@@ -1827,9 +1865,9 @@
                 >2<span class="label"> Passed</span></span
               ></div
             ></div
-          ><div class="failure-instances--Rq_Tj"
+          ><div class="failure-instances--y0Big"
             ><h2>Failure Instances</h2
-            ><span class="failure-outcome-chip--YtjBX"
+            ><span class="failure-outcome-chip--vKGs1"
               ><span class="outcome-chip outcome-chip-fail" title="0 Failed"
                 ><span class="icon"
                   ><span class="check-container"
@@ -1855,21 +1893,21 @@
               ><span>Failure instances were detected</span></span
             ></div
           ></div
-        ><div class="url-results-container--dXQbj"
-          ><div class="results-heading--D3Qtr"><h2>Results by URL</h2></div
-          ><div class="url-result-section--PmEoY"
+        ><div class="url-results-container--xiZ0N"
+          ><div class="results-heading--wmQ-W"><h2>Results by URL</h2></div
+          ><div class="url-result-section--Lsitd"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-failed-urls-section"
-                  ><span class="result-section-title--qv3MK"
+                  ><span class="result-section-title--vgyHe"
                     ><span class="screen-reader-only">Failed URLs 0</span
-                    ><span class="heading--VbGap" aria-hidden="true"
+                    ><span class="heading--1Ll6-" aria-hidden="true"
                       >Failed URLs</span
                     ><span
-                      class="outcome-chip-container--Wt0k4"
+                      class="outcome-chip-container--iN0Tt"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-fail"
@@ -1909,7 +1947,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--Pb4_B"
+                  class="summary-results-table--r6fvD"
                   id="failed-urls-table"
                   ><thead
                     ><tr
@@ -1921,19 +1959,19 @@
                       ></tr
                     ></thead
                   ><tbody></tbody></table></div></div></div
-          ><div class="url-result-section--PmEoY"
+          ><div class="url-result-section--Lsitd"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-not-scanned-urls-section"
-                  ><span class="result-section-title--qv3MK"
+                  ><span class="result-section-title--vgyHe"
                     ><span class="screen-reader-only">Not scanned URLs 0</span
-                    ><span class="heading--VbGap" aria-hidden="true"
+                    ><span class="heading--1Ll6-" aria-hidden="true"
                       >Not scanned URLs</span
                     ><span
-                      class="outcome-chip-container--Wt0k4"
+                      class="outcome-chip-container--iN0Tt"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-unscannable"
@@ -1980,7 +2018,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--Pb4_B"
+                  class="summary-results-table--r6fvD"
                   id="not-scanned-urls-table"
                   ><thead
                     ><tr
@@ -1991,19 +2029,19 @@
                       ></tr
                     ></thead
                   ><tbody></tbody></table></div></div></div
-          ><div class="url-result-section--PmEoY"
+          ><div class="url-result-section--Lsitd"
             ><div class="collapsible-container collapsed"
-              ><h3 class="heading-element-for-level--OfRDW title-container"
+              ><h3 class="heading-element-for-level--wzmxK title-container"
                 ><button
                   class="collapsible-control"
                   aria-expanded="false"
                   aria-controls="content-container-passed-urls-section"
-                  ><span class="result-section-title--qv3MK"
+                  ><span class="result-section-title--vgyHe"
                     ><span class="screen-reader-only">Passed URLs 2</span
-                    ><span class="heading--VbGap" aria-hidden="true"
+                    ><span class="heading--1Ll6-" aria-hidden="true"
                       >Passed URLs</span
                     ><span
-                      class="outcome-chip-container--Wt0k4"
+                      class="outcome-chip-container--iN0Tt"
                       aria-hidden="true"
                       ><span
                         class="outcome-chip outcome-chip-pass"
@@ -2045,7 +2083,7 @@
                 class="collapsible-content"
                 aria-hidden="true"
                 ><table
-                  class="summary-results-table--Pb4_B"
+                  class="summary-results-table--r6fvD"
                   id="passed-urls-table"
                   ><thead
                     ><tr
@@ -2060,11 +2098,11 @@
                     ><tr
                       ><td
                         headers="passed-urls-table-header0"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         >0</td
                       ><td
                         headers="passed-urls-table-header1"
-                        class="url-cell--yjU1V"
+                        class="url-cell--ZGO-o"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/passes-a"
@@ -2073,7 +2111,7 @@
                         ></td
                       ><td
                         headers="passed-urls-table-header2"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         ><a
                           target="_blank"
                           href="./passes-a.html"
@@ -2085,11 +2123,11 @@
                     ><tr
                       ><td
                         headers="passed-urls-table-header0"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         >0</td
                       ><td
                         headers="passed-urls-table-header1"
-                        class="url-cell--yjU1V"
+                        class="url-cell--ZGO-o"
                         ><a
                           target="_blank"
                           href="https://example.com/mock-base-url/passes-b"
@@ -2098,7 +2136,7 @@
                         ></td
                       ><td
                         headers="passed-urls-table-header2"
-                        class="text-cell--p0dxL"
+                        class="text-cell--luh34"
                         ><a
                           target="_blank"
                           href="./passes-b.html"
@@ -2118,7 +2156,7 @@
             var _loop = function (index) {
               var container = collapsibles.item(index);
               var button =
-                container === null || container === void 0
+                container == null
                   ? void 0
                   : container.querySelector(".collapsible-control");
               if (button == null) {
@@ -2127,7 +2165,7 @@
               button.addEventListener("click", function () {
                 var _a;
                 var content =
-                  (_a = button.parentElement) === null || _a === void 0
+                  (_a = button.parentElement) == null
                     ? void 0
                     : _a.nextElementSibling;
                 if (content == null) {

--- a/pipeline/build-package.template.yaml
+++ b/pipeline/build-package.template.yaml
@@ -25,6 +25,10 @@ jobs:
           - script: yarn scss:build
             displayName: generate typings for scss files
 
+          - script: yarn type:check
+            displayName: type check code
+            timeoutInMinutes: 3
+
           - script: yarn test --ci
             displayName: run unit tests
 

--- a/style-plugin.js
+++ b/style-plugin.js
@@ -5,8 +5,12 @@ const path = require('path');
 const postcss = require('postcss');
 const postCssModules = require('postcss-modules');
 const sass = require('sass');
+const genericNames = require('generic-names');
 
-const CreateStylePlugin = isProd => {
+var generateScopedNameWithHash = genericNames('[local]--[hash:base64:5]');
+var generateScopedNameWithoutHash = genericNames('[local]');
+
+const CreateStylePlugin = (useHash = true) => {
     return {
         name: 'style-plugin',
 
@@ -61,8 +65,14 @@ const CreateStylePlugin = isProd => {
                     let singleModuleCssJSON;
                     const { css } = await postcss([
                         postCssModules({
-                            generateScopedName: '[local]' + (!isProd ? '--[hash:base64:5]' : ''),
+                            generateScopedName: name => {
+                                const scopedName = useHash
+                                    ? generateScopedNameWithHash(name, args.path)
+                                    : generateScopedNameWithoutHash(name, args.path);
+                                return `${scopedName}`;
+                            },
                             localsConvention: 'camelCaseOnly',
+                            hashPrefix: '',
                             getJSON(_, json) {
                                 singleModuleCssJSON = JSON.stringify(json);
                             },

--- a/style-plugin.js
+++ b/style-plugin.js
@@ -61,7 +61,7 @@ const CreateStylePlugin = (useHash = true) => {
                 async args => {
                     // per sass documentation, compile is twice as fast as compileAsync, hence it's
                     // usage here. https://sass-lang.com/documentation/js-api/modules#compileAsync
-                    const normalizedPath = args.path.replace(path.sep, path.posix.sep);
+                    const normalizedPath = args.path.replaceAll(path.sep, path.posix.sep);
                     const source = sass.compile(normalizedPath).css.toString();
                     let singleModuleCssJSON;
                     const { css } = await postcss([

--- a/style-plugin.js
+++ b/style-plugin.js
@@ -72,7 +72,6 @@ const CreateStylePlugin = (useHash = true) => {
                                 return `${scopedName}`;
                             },
                             localsConvention: 'camelCaseOnly',
-                            hashPrefix: '',
                             getJSON(_, json) {
                                 singleModuleCssJSON = JSON.stringify(json);
                             },

--- a/style-plugin.js
+++ b/style-plugin.js
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 
 const path = require('path');
+const genericNames = require('generic-names');
 const postcss = require('postcss');
 const postCssModules = require('postcss-modules');
 const sass = require('sass');
-const genericNames = require('generic-names');
 
-var generateScopedNameWithHash = genericNames('[local]--[hash:base64:5]');
-var generateScopedNameWithoutHash = genericNames('[local]');
+const generateScopedNameWithHash = genericNames('[local]--[hash:base64:5]');
+const generateScopedNameWithoutHash = genericNames('[local]');
 
 const CreateStylePlugin = (useHash = true) => {
     return {


### PR DESCRIPTION
#### Details

Uses esbuild for report package. Updates the snapshots as well.

##### Motivation

esbuild is faster than webpack.

##### Context

I smoke tested each snapshot to validate that the UI was unchanged compared to main.

Removing the webpack config code is planned for a separate/future PR (would like to make that change altogether, after the ui package is done, _hopefully_)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5412 
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
