### PR TITLE
chore: Enable and fix `scss/dollar-variable-pattern`

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -23,7 +23,6 @@ module.exports = {
         // TO BE CONFIGURED: Variable, selector, mixin case
         // https://stylelint.io/user-guide/rules/regex
         'selector-class-pattern': null,
-        'scss/dollar-variable-pattern': null,
 
         // Requires investigation
         'property-no-vendor-prefix': null,

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -13,7 +13,7 @@ body {
     margin: 0;
     background: $neutral-0;
     color: $neutral-100;
-    font-family: $fontFamily;
+    font-family: $font-family;
     font-size: 14px;
     height: 100vh;
     max-height: 100vh;

--- a/src/DetailsView/components/adhoc-tab-stops-test-view.scss
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.scss
@@ -9,9 +9,9 @@
 }
 
 .tab-stops-test-view {
-    padding-top: $fastPassRightPanelMarginTop;
-    padding-right: $fastPassRightPanelMarginRight;
-    padding-left: $fastPassRightPanelMarginLeft;
+    padding-top: $fast-pass-right-panel-margin-top;
+    padding-right: $fast-pass-right-panel-margin-right;
+    padding-left: $fast-pass-right-panel-margin-left;
     margin-bottom: auto;
     background-color: $neutral-2;
 

--- a/src/DetailsView/components/change-assessment-dialog.scss
+++ b/src/DetailsView/components/change-assessment-dialog.scss
@@ -14,7 +14,7 @@
     box-shadow: 0 0 10px 0 $neutral-alpha-60;
 
     :global(.ms-Dialog-title) {
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
     }
 
     .change-assessment-dialog-button-container {

--- a/src/DetailsView/components/command-bar-buttons-menu.scss
+++ b/src/DetailsView/components/command-bar-buttons-menu.scss
@@ -16,5 +16,5 @@
 }
 
 .command-bar-buttons-menu {
-    height: $detailsViewCommandBarHeight;
+    height: $details-view-command-bar-height;
 }

--- a/src/DetailsView/components/details-view-command-bar.scss
+++ b/src/DetailsView/components/details-view-command-bar.scss
@@ -10,7 +10,7 @@
 }
 
 .details-view-command-bar {
-    height: $detailsViewCommandBarHeight;
+    height: $details-view-command-bar-height;
     width: 100%;
     display: flex;
     justify-content: space-between;
@@ -19,7 +19,7 @@
     background-color: $neutral-0;
     font-size: 14px;
     font-weight: normal;
-    border-bottom: $detailsViewCommandBarBorderHeight solid $neutral-alpha-8;
+    border-bottom: $details-view-command-bar-border-height solid $neutral-alpha-8;
 
     .details-view-target-page {
         margin-left: 12px;

--- a/src/DetailsView/components/issues-table.scss
+++ b/src/DetailsView/components/issues-table.scss
@@ -6,17 +6,19 @@
 .details-disabled-message {
     margin-top: 5px;
     margin-bottom: 5px;
-    font-size: $fontSizeM;
+    font-size: $font-size-m;
 }
 
 .issues-table {
     background-color: $neutral-2;
-    width: calc(100% - #{$fastPassRightPanelMarginRight} - #{$fastPassRightPanelMarginLeft});
+    width: calc(
+        100% - #{$fast-pass-right-panel-margin-right} - #{$fast-pass-right-panel-margin-left}
+    );
     display: flex;
     flex-direction: column;
-    padding-top: $fastPassRightPanelMarginTop;
-    padding-right: $fastPassRightPanelMarginRight;
-    padding-left: $fastPassRightPanelMarginLeft;
+    padding-top: $fast-pass-right-panel-margin-top;
+    padding-right: $fast-pass-right-panel-margin-right;
+    padding-left: $fast-pass-right-panel-margin-left;
 
     .issues-table-subtitle {
         color: $secondary-text;

--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -9,8 +9,8 @@
     border-right: 1px solid $neutral-8;
     z-index: 100;
     background-color: $neutral-0;
-    max-height: calc(100vh - (#{$detailsViewHeaderBarHeight}));
-    height: calc(100vh - (#{$detailsViewHeaderBarHeight}));
+    max-height: calc(100vh - (#{$details-view-header-bar-height}));
+    height: calc(100vh - (#{$details-view-header-bar-height}));
 
     :global {
         .left-nav-icon {
@@ -81,7 +81,7 @@
 
                 a::after,
                 button::after {
-                    border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle
+                    border-left: $pivot-item-left-border-width $pivot-item-border-style
                         $communication-primary;
                 }
 
@@ -92,7 +92,7 @@
         }
 
         .ms-Pivot-text {
-            font-size: $fontSizeS;
+            font-size: $font-size-s;
         }
 
         .ms-Pivot-icon {

--- a/src/DetailsView/components/left-nav/fluent-side-nav.scss
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.scss
@@ -3,20 +3,20 @@
 @import '../../../common/styles/common.scss';
 
 #side-nav-container {
-    width: $detailsViewLeftNavWidth;
+    width: $details-view-left-nav-width;
 }
 
 .left-nav-panel {
     :global(.ms-Panel-main) {
-        width: $detailsViewLeftNavWidth;
+        width: $details-view-left-nav-width;
     }
 
     :global(.ms-Panel-content) {
         padding: 0;
 
         :global(.main-nav) {
-            max-height: calc(100vh - (#{$detailsViewHeaderBarHeight}));
-            height: calc(100vh - (#{$detailsViewHeaderBarHeight}));
+            max-height: calc(100vh - (#{$details-view-header-bar-height}));
+            height: calc(100vh - (#{$details-view-header-bar-height}));
         }
     }
 }

--- a/src/DetailsView/components/overview-content/help-links.scss
+++ b/src/DetailsView/components/overview-content/help-links.scss
@@ -5,7 +5,7 @@
 
 .help-link {
     padding: 5px 0 5px 0;
-    font-family: $fontFamily;
+    font-family: $font-family;
     line-height: 20px;
     font-size: 15px;
     color: $communication-primary;

--- a/src/DetailsView/components/requirement-instructions.scss
+++ b/src/DetailsView/components/requirement-instructions.scss
@@ -4,15 +4,15 @@
 
 .requirement-instructions-header {
     font-style: normal;
-    font-weight: $fontWeightSemiBold;
-    font-size: $fontSizeML;
+    font-weight: $font-weight-semi-bold;
+    font-size: $font-size-ml;
     line-height: 20px;
     padding-left: 0.5vw;
     display: block;
 }
 
 .requirement-instructions {
-    font-family: $fontFamily;
+    font-family: $font-family;
 
     p,
     ol,

--- a/src/DetailsView/components/requirement-view.scss
+++ b/src/DetailsView/components/requirement-view.scss
@@ -38,7 +38,7 @@
 
     :global(.visual-helper-text) {
         padding-right: 0.9vh;
-        font-family: $fontFamily;
+        font-family: $font-family;
         font-size: 14px;
         line-height: 20px;
     }

--- a/src/DetailsView/components/static-content-common.scss
+++ b/src/DetailsView/components/static-content-common.scss
@@ -4,9 +4,9 @@
 @import '../../common/styles/common.scss';
 
 .static-content-in-details-view {
-    padding-top: $fastPassRightPanelMarginTop;
-    padding-right: $fastPassRightPanelMarginRight;
-    padding-left: $fastPassRightPanelMarginLeft;
+    padding-top: $fast-pass-right-panel-margin-top;
+    padding-right: $fast-pass-right-panel-margin-right;
+    padding-left: $fast-pass-right-panel-margin-left;
     margin-bottom: auto;
 
     ol {

--- a/src/DetailsView/details-view-body.scss
+++ b/src/DetailsView/details-view-body.scss
@@ -11,9 +11,9 @@
     flex-direction: column;
     padding-bottom: 1px;
     box-sizing: border-box;
-    width: calc(100vw - (#{$detailsViewLeftNavWidth}));
+    width: calc(100vw - (#{$details-view-left-nav-width}));
     height: 100%;
-    max-height: calc(100vh - (#{$detailsViewHeaderBarHeight}));
+    max-height: calc(100vh - (#{$details-view-header-bar-height}));
 
     &.narrow-mode {
         width: 100%;
@@ -45,7 +45,7 @@
         width: 100%;
         overflow: auto;
         box-sizing: border-box;
-        max-height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
+        max-height: calc(100vh - (#{$details-view-total-header-height}));
 
         > div {
             width: 100%;
@@ -67,7 +67,7 @@
 
             h1 {
                 margin: 0;
-                font-weight: $fontWeightSemiBold;
+                font-weight: $font-weight-semi-bold;
                 font-size: 21px;
                 color: $neutral-100;
             }

--- a/src/DetailsView/tab-stops-minimal-requirement-header.scss
+++ b/src/DetailsView/tab-stops-minimal-requirement-header.scss
@@ -11,7 +11,7 @@
     text-align: left;
 
     strong {
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
     }
 
     :global(.outcome-chip) {
@@ -27,12 +27,12 @@
 }
 
 .requirement-details-id {
-    font-weight: $fontWeightSemiBold;
+    font-weight: $font-weight-semi-bold;
     color: $primary-text;
     word-break: break-all;
 
     a {
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
         color: $primary-text;
     }
 }

--- a/src/common/components/cards/combined-report-result-section-title.scss
+++ b/src/common/components/cards/combined-report-result-section-title.scss
@@ -19,7 +19,7 @@
     }
 
     .heading {
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;

--- a/src/common/components/cards/instance-details-footer.scss
+++ b/src/common/components/cards/instance-details-footer.scss
@@ -30,7 +30,7 @@
 
         label {
             color: $secondary-text;
-            font-size: $fontSizeM;
+            font-size: $font-size-m;
             overflow-wrap: break-word;
             word-break: break-word;
         }

--- a/src/common/components/cards/result-section-title.scss
+++ b/src/common/components/cards/result-section-title.scss
@@ -31,7 +31,7 @@
     }
 
     .heading {
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;

--- a/src/common/components/cards/rule-resources.scss
+++ b/src/common/components/cards/rule-resources.scss
@@ -18,7 +18,7 @@
     word-break: break-word;
 
     .more-resources-title {
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
     }
 
     .rule-details-id {

--- a/src/common/components/cards/rules-with-instances.scss
+++ b/src/common/components/cards/rules-with-instances.scss
@@ -17,17 +17,17 @@
         }
 
         :global(.rule-details-id) {
-            font-weight: $fontWeightSemiBold;
+            font-weight: $font-weight-semi-bold;
             color: $primary-text;
             word-break: break-all;
 
             a {
-                font-weight: $fontWeightSemiBold;
+                font-weight: $font-weight-semi-bold;
                 color: $primary-text !important;
             }
 
             strong {
-                font-weight: $fontWeightSemiBold;
+                font-weight: $font-weight-semi-bold;
             }
         }
 

--- a/src/common/components/cards/snippet-card-row.scss
+++ b/src/common/components/cards/snippet-card-row.scss
@@ -3,6 +3,6 @@
 @import '../../../common/styles/fonts.scss';
 
 .snippet {
-    font-family: $codeFontFamily;
+    font-family: $code-font-family;
     white-space: normal;
 }

--- a/src/common/components/collapsible-component.scss
+++ b/src/common/components/collapsible-component.scss
@@ -19,7 +19,7 @@ span.collapsible-title {
     align-items: center;
 
     h2 {
-        font-weight: $normalTitleFontWeight;
+        font-weight: $normal-title-font-weight;
         font-size: 17px;
     }
 }

--- a/src/common/components/header.scss
+++ b/src/common/components/header.scss
@@ -11,7 +11,7 @@
     align-items: center;
     align-content: stretch;
     background-color: $ada-brand-color;
-    min-height: $detailsViewHeaderBarHeight;
+    min-height: $details-view-header-bar-height;
     width: 100%;
 
     :global(.header-icon) {
@@ -29,8 +29,8 @@
         margin-right: 32px;
         margin-left: 8px;
         color: $header-bar-title-color;
-        font-size: $fontSizeML;
-        font-family: $fontFamily;
+        font-size: $font-size-ml;
+        font-family: $font-family;
 
         @include ellipsed-text;
     }

--- a/src/common/icons/icon.scss
+++ b/src/common/icons/icon.scss
@@ -11,52 +11,52 @@
     border: $border-size solid $neutral-0;
 }
 
-@mixin check-icon-styles($iconSize, $border-size: 1px, $iconColor: $neutral-0) {
-    // maxTickLength = iconSize - borderthickness - spacingBetweenCircleAndTick
-    $maxTickLength: ($iconSize - $border-size * 2 - 2);
-    $check-height: math.div($maxTickLength, 2);
-    $bottom-value: (math.div($maxTickLength - $check-height, 2) + 1);
+@mixin check-icon-styles($icon-size, $border-size: 1px, $icon-color: $neutral-0) {
+    // max-tick-length = iconSize - borderthickness - spacingBetweenCircleAndTick
+    $max-tick-length: ($icon-size - $border-size * 2 - 2);
+    $check-height: math.div($max-tick-length, 2);
+    $bottom-value: (math.div($max-tick-length - $check-height, 2) + 1);
     $left-value: ($bottom-value);
-    $check-line-thickness: (math.div(2, 14) * $iconSize);
+    $check-line-thickness: (math.div(2, 14) * $icon-size);
 
     .check-container {
-        @include get-check-container-style($iconSize, $border-size);
+        @include get-check-container-style($icon-size, $border-size);
 
         svg circle {
-            fill: $iconColor;
+            fill: $icon-color;
         }
     }
 }
 
-@mixin cross-icon-styles($iconSize, $border-size: 1px, $iconColor: $neutral-0) {
-    $true-icon-size: ($iconSize - $border-size * 2);
+@mixin cross-icon-styles($icon-size, $border-size: 1px, $icon-color: $neutral-0) {
+    $true-icon-size: ($icon-size - $border-size * 2);
     $width-value: (math.div(2, 14) * $true-icon-size);
 
     .check-container {
-        @include get-check-container-style($iconSize, $border-size);
+        @include get-check-container-style($icon-size, $border-size);
 
         $cross-line-height: (math.div(8, 14) * $true-icon-size);
         $bottom-value: math.div($true-icon-size - $cross-line-height, 2);
         $left-value: math.div($true-icon-size - $width-value, 2);
 
         svg circle {
-            fill: $iconColor;
+            fill: $icon-color;
         }
     }
 }
 
-@mixin incomplete-icon-styles($iconSize, $border-size: 1px) {
+@mixin incomplete-icon-styles($icon-size, $border-size: 1px) {
     .check-container {
-        @include get-check-container-style($iconSize, $border-size);
+        @include get-check-container-style($icon-size, $border-size);
     }
 }
 
-@mixin inapplicable-icon-styles($iconSize, $border-size: 1px, $iconColor: $neutral-0) {
-    $true-icon-size: ($iconSize - $border-size * 2);
+@mixin inapplicable-icon-styles($icon-size, $border-size: 1px, $icon-color: $neutral-0) {
+    $true-icon-size: ($icon-size - $border-size * 2);
     $width-value: (math.div(1, 7) * $true-icon-size);
 
     .check-container {
-        @include get-check-container-style($iconSize, $border-size);
+        @include get-check-container-style($icon-size, $border-size);
 
         $inapplicable-line-height: (math.div(4, 7) * $true-icon-size);
         $bottom-value: math.div($true-icon-size - $inapplicable-line-height, 2);

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -17,21 +17,21 @@ $focus-ring-color: $neutral-100;
     }
 }
 
-$normalTitleFontWeight: 300 !default;
-$pivotItemLeftBorderWidth: 3px !default;
-$pivotItemBorderStyle: solid !default;
-$detailsViewHeaderBarHeight: 40px !default;
-$detailsViewNavPivotsHeight: 41px !default;
-$detailsViewCommandBarHeight: 40px !default;
-$detailsViewCommandBarBorderHeight: 1px !default;
-$detailsViewLeftNavWidth: 250px !default;
-$detailsViewLeftNavBorderWidth: 1px;
-$detailsViewTotalHeaderHeight: (
-    #{$detailsViewCommandBarBorderHeight} + #{$detailsViewCommandBarHeight} + #{$detailsViewHeaderBarHeight}
+$normal-title-font-weight: 300 !default;
+$pivot-item-left-border-width: 3px !default;
+$pivot-item-border-style: solid !default;
+$details-view-header-bar-height: 40px !default;
+$details-view-nav-pivots-height: 41px !default;
+$details-view-command-bar-height: 40px !default;
+$details-view-command-bar-border-height: 1px !default;
+$details-view-left-nav-width: 250px !default;
+$details-view-left-nav-border-width: 1px;
+$details-view-total-header-height: (
+    #{$details-view-command-bar-border-height} + #{$details-view-command-bar-height} + #{$details-view-header-bar-height}
 );
-$fastPassRightPanelMarginRight: 24px !default;
-$fastPassRightPanelMarginLeft: 24px !default;
-$fastPassRightPanelMarginTop: 24px !default;
+$fast-pass-right-panel-margin-right: 24px !default;
+$fast-pass-right-panel-margin-left: 24px !default;
+$fast-pass-right-panel-margin-top: 24px !default;
 
 @mixin ellipsed-text {
     white-space: nowrap;
@@ -40,6 +40,6 @@ $fastPassRightPanelMarginTop: 24px !default;
 }
 
 @mixin h3 {
-    font-weight: $fontWeightSemiBold;
+    font-weight: $font-weight-semi-bold;
     font-size: 17px;
 }

--- a/src/common/styles/fonts.scss
+++ b/src/common/styles/fonts.scss
@@ -37,33 +37,33 @@ $fonts: (
     'Segoe UI Symbol'
 );
 $common-font-family: make-font-family($fonts) !default;
-$fontFamily: $common-font-family !default;
-$fontStack: $common-font-family !default;
-$toolbarFontFamily: $common-font-family !default;
-$fontWeightHeavy: bold !default;
-$fontWeightNormal: normal !default;
-$fontWeightLighter: 200 !default;
-$fontWeightSemiBold: 600 !default;
-$gridFontSize: 12px !default;
-$toolbarFontSize: 12px !default;
-$toolbarFontSemiLight: 500 $toolbarFontSize $toolbarFontFamily !default;
-$fontSizeXS: 10px !default;
-$fontSizeS: 11px !default;
-$fontSize: 12px !default;
-$fontSizeM: 14px !default;
-$fontSizeML: 16px !default;
-$fontSizeL: 18px !default;
-$fontSizeLML: 21px !default;
-$fontSizeLL: 24px !default;
-$fontSizeXL: 36px !default;
-$fontSizeXXL: 40px !default;
-$fontSizeXXXL: 56px !default;
-$fontSizeXXXXL: 72px !default;
-$codeFontFamily: menlo, consolas, courier new, monospace !default;
+$font-family: $common-font-family !default;
+$font-stack: $common-font-family !default;
+$toolbar-font-family: $common-font-family !default;
+$font-weight-heavy: bold !default;
+$font-weight-normal: normal !default;
+$font-weight-lighter: 200 !default;
+$font-weight-semi-bold: 600 !default;
+$grid-font-size: 12px !default;
+$toolbar-font-size: 12px !default;
+$toolbar-font-semi-light: 500 $toolbar-font-size $toolbar-font-family !default;
+$font-size-xs: 10px !default;
+$font-size-s: 11px !default;
+$font-size: 12px !default;
+$font-size-m: 14px !default;
+$font-size-ml: 16px !default;
+$font-size-l: 18px !default;
+$font-size-lml: 21px !default;
+$font-size-ll: 24px !default;
+$font-size-xl: 36px !default;
+$font-size-xxl: 40px !default;
+$font-size-xxxl: 56px !default;
+$font-size-xxxxl: 72px !default;
+$code-font-family: menlo, consolas, courier new, monospace !default;
 
 @mixin text-style-title-m {
-    font-weight: $fontWeightSemiBold;
-    font-size: $fontSizeLML;
+    font-weight: $font-weight-semi-bold;
+    font-size: $font-size-lml;
     line-height: 32px;
     letter-spacing: -0.02em;
 }
@@ -76,21 +76,21 @@ $codeFontFamily: menlo, consolas, courier new, monospace !default;
 }
 
 @mixin text-style-title-s {
-    font-weight: $fontWeightSemiBold;
+    font-weight: $font-weight-semi-bold;
     font-size: 17px;
     line-height: 24px;
 }
 
 @mixin text-style-header-s {
-    font-family: $fontFamily;
-    font-weight: $fontWeightNormal;
+    font-family: $font-family;
+    font-weight: $font-weight-normal;
     font-size: 17px;
     line-height: 24px;
 }
 
 @mixin text-style-body-m {
-    font-family: $fontFamily;
-    font-weight: $fontWeightNormal;
-    font-size: $fontSizeM;
+    font-family: $font-family;
+    font-weight: $font-weight-normal;
+    font-size: $font-size-m;
     line-height: 20px;
 }

--- a/src/common/styles/root-level-only/global-styles.scss
+++ b/src/common/styles/root-level-only/global-styles.scss
@@ -53,7 +53,7 @@ button::after {
 }
 
 .insights-code {
-    font-family: $codeFontFamily;
+    font-family: $code-font-family;
 }
 
 .ms-Spinner {

--- a/src/electron/views/common/window-title/window-title.scss
+++ b/src/electron/views/common/window-title/window-title.scss
@@ -53,9 +53,9 @@
 
     .header-text {
         color: $ada-brand-color;
-        font-family: $fontFamily;
+        font-family: $font-family;
         font-size: 14.51px;
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
         line-height: 19.3px;
         margin: 0;
     }

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.scss
@@ -26,8 +26,8 @@
     .header {
         margin-top: 0;
         margin-bottom: 0;
-        font-size: $fontSizeLML;
-        font-weight: $fontWeightNormal;
+        font-size: $font-size-lml;
+        font-weight: $font-weight-normal;
         line-height: 25px;
         letter-spacing: -0.02em;
     }
@@ -41,7 +41,7 @@
         flex-shrink: 1;
         flex-basis: auto;
         width: 100%;
-        font-size: $fontSizeM;
+        font-size: $font-size-m;
         line-height: 16px;
 
         p {

--- a/src/electron/views/left-nav/fluent-left-nav.scss
+++ b/src/electron/views/left-nav/fluent-left-nav.scss
@@ -8,7 +8,7 @@
 
     .left-nav-panel {
         :global(.ms-Panel-main) {
-            width: calc(#{$detailsViewLeftNavWidth} + #{$detailsViewLeftNavBorderWidth});
+            width: calc(#{$details-view-left-nav-width} + #{$details-view-left-nav-border-width});
         }
 
         :global(.ms-Panel-content) {
@@ -18,7 +18,7 @@
 
     .nav-menu-container {
         display: flex;
-        min-height: $detailsViewCommandBarHeight;
+        min-height: $details-view-command-bar-height;
         align-items: center;
 
         .nav-menu {

--- a/src/electron/views/left-nav/left-nav.scss
+++ b/src/electron/views/left-nav/left-nav.scss
@@ -5,9 +5,9 @@
 .left-nav {
     display: flex;
     flex-direction: column;
-    min-width: $detailsViewLeftNavWidth;
-    max-width: $detailsViewLeftNavWidth;
-    border-right: $detailsViewLeftNavBorderWidth solid $neutral-alpha-8;
+    min-width: $details-view-left-nav-width;
+    max-width: $details-view-left-nav-width;
+    border-right: $details-view-left-nav-border-width solid $neutral-alpha-8;
     background-color: $neutral-0;
 
     .header-container {

--- a/src/electron/views/results/components/header-section.scss
+++ b/src/electron/views/results/components/header-section.scss
@@ -17,7 +17,7 @@
     }
 
     .subtitle {
-        font-size: $fontSizeM;
+        font-size: $font-size-m;
         line-height: 16px;
         color: $secondary-text;
         margin-bottom: 0;

--- a/src/electron/views/results/results-view.scss
+++ b/src/electron/views/results/results-view.scss
@@ -35,7 +35,9 @@
         display: flex;
         flex-direction: column;
         overflow: hidden;
-        min-width: calc(100% - (#{$detailsViewLeftNavWidth} + (#{$detailsViewLeftNavBorderWidth})));
+        min-width: calc(
+            100% - (#{$details-view-left-nav-width} + (#{$details-view-left-nav-border-width}))
+        );
     }
 
     .results-panel-layout {

--- a/src/electron/views/root-container/components/root-container.scss
+++ b/src/electron/views/root-container/components/root-container.scss
@@ -7,7 +7,7 @@ body {
     margin: 0;
     height: 100%;
     width: 100%;
-    font-family: $fontFamily;
+    font-family: $font-family;
 }
 
 :global(#root-container) {

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -149,7 +149,7 @@
         margin-bottom: 8px !important;
         font-size: 12px !important;
         color: $negative-outcome !important;
-        font-weight: $fontWeightSemiBold !important;
+        font-weight: $font-weight-semi-bold !important;
     }
 
     .insights-dialog-main-override .file-issue-button-help {
@@ -157,14 +157,14 @@
         margin-bottom: 8px !important;
         font-size: 12px !important;
         color: $negative-outcome;
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
     }
 
     .insights-dialog-main-override .copy-issue-details-button-help {
         margin-top: 4px !important;
         font-size: 12px !important;
         color: $negative-outcome !important;
-        font-weight: $fontWeightSemiBold !important;
+        font-weight: $font-weight-semi-bold !important;
     }
 
     .insights-dialog-main-override {
@@ -173,7 +173,7 @@
             padding-bottom: 0 !important;
             color: $primary-text !important;
             font-size: 21px !important;
-            font-weight: $fontWeightSemiBold !important;
+            font-weight: $font-weight-semi-bold !important;
             letter-spacing: -0.02em !important;
         }
 
@@ -182,7 +182,7 @@
             margin-bottom: 4px !important;
             color: $primary-text !important;
             font-size: 15px !important;
-            font-weight: $fontWeightSemiBold !important;
+            font-weight: $font-weight-semi-bold !important;
         }
 
         .insights-dialog-content {
@@ -207,7 +207,7 @@
                 margin-left: 4px !important;
                 margin-right: 4px !important;
                 line-height: 100% !important;
-                font-weight: $fontWeightSemiBold !important;
+                font-weight: $font-weight-semi-bold !important;
             }
 
             svg {
@@ -220,7 +220,7 @@
             margin-top: 16px !important;
             display: grid !important;
             color: $primary-text !important;
-            font-size: $fontSizeM !important;
+            font-size: $font-size-m !important;
             align-items: center !important;
             grid-template-columns: 100px 1fr 100px !important;
 

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -9,7 +9,7 @@ body {
     overflow-y: auto;
     height: fit-content; // required for the popup's window to resize properly when the details view is zoomed in/out
     background: $neutral-0;
-    font-family: $fontFamily;
+    font-family: $font-family;
 }
 
 .telemetry-permission-dialog-modal {
@@ -46,7 +46,7 @@ div.insights-dialog-main-override.telemetry-permission-dialog {
     }
 
     .ms-Dialog-title {
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
     }
 
     .ms-Checkbox-checkbox {

--- a/src/reports/assessment-report.scss
+++ b/src/reports/assessment-report.scss
@@ -11,7 +11,7 @@
 @import '../common/components/guidance-tags.scss';
 
 * {
-    font-family: $fontFamily;
+    font-family: $font-family;
     -webkit-print-color-adjust: exact;
 
     /* Chrome, Safari */
@@ -38,7 +38,7 @@ header {
     display: flex;
     align-items: center;
     font-size: 21px;
-    font-weight: $fontWeightSemiBold;
+    font-weight: $font-weight-semi-bold;
     line-height: 32px;
 }
 
@@ -52,7 +52,7 @@ header {
     display: flex;
     align-items: center;
     font-size: 17px;
-    font-weight: $fontWeightSemiBold;
+    font-weight: $font-weight-semi-bold;
 }
 
 .step-details {
@@ -70,7 +70,7 @@ header {
 
 .step-header-name {
     font-size: 15px;
-    font-family: $fontFamily;
+    font-family: $font-family;
     display: inline;
     margin-block-start: 0;
     margin-block-end: 0;
@@ -79,7 +79,7 @@ header {
 
 .step-header-description {
     font-size: 15px;
-    font-family: $fontFamily;
+    font-family: $font-family;
     padding-left: 8px;
     padding-right: 8px;
     display: inline;
@@ -87,7 +87,7 @@ header {
 
 .step-header-message {
     font-size: 15px;
-    font-family: $fontFamily;
+    font-family: $font-family;
     padding-left: 8px;
     padding-right: 8px;
     display: inline;
@@ -111,7 +111,7 @@ header {
 
 .instance-value {
     font-size: 12px;
-    font-family: $fontFamily;
+    font-family: $font-family;
     vertical-align: top;
     word-break: break-all;
     white-space: pre-line;
@@ -120,7 +120,7 @@ header {
 .instance-key,
 %instance-key {
     font-size: 12px;
-    font-weight: $fontWeightSemiBold;
+    font-weight: $font-weight-semi-bold;
     vertical-align: top;
     text-align: left;
     width: 140px;
@@ -142,14 +142,14 @@ header {
     display: inline;
     color: $primary-text;
     font-size: 14px;
-    font-family: $fontFamily;
+    font-family: $font-family;
     padding-right: 8px;
     padding-left: 8px;
 }
 
 .report-footer {
     font-size: 14px;
-    font-family: $fontFamily;
+    font-family: $font-family;
     color: $secondary-text;
     padding-top: 24px;
     padding-bottom: 36px;
@@ -159,7 +159,7 @@ header {
 
 .report-footer-link {
     font-size: 14px;
-    font-family: $fontFamily;
+    font-family: $font-family;
     text-decoration: none;
 }
 

--- a/src/reports/components/assessment-report-body-header.scss
+++ b/src/reports/components/assessment-report-body-header.scss
@@ -9,7 +9,7 @@
     h1 {
         font-size: 28px;
         margin: 0 0 24px 0;
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
         line-height: 40px;
         letter-spacing: -1;
     }
@@ -17,7 +17,7 @@
     p {
         font-size: 14px;
         color: $secondary-text;
-        font-family: $fontFamily;
+        font-family: $font-family;
         margin: 0;
         line-height: 20px;
     }

--- a/src/reports/components/assessment-report-summary.scss
+++ b/src/reports/components/assessment-report-summary.scss
@@ -9,7 +9,7 @@
     width: 100%;
 
     > h2 {
-        font-family: $fontFamily;
+        font-family: $font-family;
         font-size: 21px;
         line-height: 32px;
         font-weight: 600;
@@ -23,7 +23,7 @@
 
         line-height: 24px;
         color: $primary-text;
-        font-family: $fontFamily;
+        font-family: $font-family;
         margin: 16px 0 21px 0;
     }
 }

--- a/src/reports/components/assessment-scan-details.scss
+++ b/src/reports/components/assessment-scan-details.scss
@@ -11,12 +11,12 @@
 
     h3 {
         font-size: 17px;
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
     }
 
     td {
         font-size: 12px;
-        font-family: $fontFamily;
+        font-family: $font-family;
         padding-top: 1px;
         padding-bottom: 16px;
 

--- a/src/reports/components/header-bar.scss
+++ b/src/reports/components/header-bar.scss
@@ -10,7 +10,7 @@
     align-items: center;
     flex-wrap: nowrap;
     background-color: $ada-brand-color;
-    height: $detailsViewHeaderBarHeight;
+    height: $details-view-header-bar-height;
     width: 100%;
 
     :global(.header-icon) {

--- a/src/reports/components/instance-details.scss
+++ b/src/reports/components/instance-details.scss
@@ -104,7 +104,7 @@
         flex-grow: 0;
         font-size: 14px;
         line-height: 20px;
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
         color: $primary-text;
         text-align: left;
     }

--- a/src/reports/components/outcome-summary-bar.scss
+++ b/src/reports/components/outcome-summary-bar.scss
@@ -32,7 +32,7 @@ $outcome-not-applicable-color: $neutral-outcome;
 
     .block,
     %block {
-        font-family: $fontFamily;
+        font-family: $font-family;
         line-height: 20px;
         font-size: 16px;
         color: $neutral-0;

--- a/src/reports/components/outcome.scss
+++ b/src/reports/components/outcome.scss
@@ -56,7 +56,7 @@ $outcome-count-border-size: 1.5px;
     }
 
     .count {
-        font-family: $fontFamily;
+        font-family: $font-family;
         line-height: $outcome-chip-icon-size - (2 * $outcome-count-border-size);
         font-size: 11px;
         border-radius: 0 8px 8px 0;

--- a/src/reports/components/report-sections/body-section.scss
+++ b/src/reports/components/report-sections/body-section.scss
@@ -8,5 +8,5 @@ body {
     margin: auto;
     background-color: $neutral-2;
     color: black;
-    font-family: $fontFamily;
+    font-family: $font-family;
 }

--- a/src/reports/components/report-sections/header-section.scss
+++ b/src/reports/components/report-sections/header-section.scss
@@ -19,7 +19,7 @@
         margin: 0 0 0 16px;
         display: flex;
         color: $primary-text;
-        font-family: $fontFamily;
+        font-family: $font-family;
         font-size: 14px;
         line-height: 20px;
         font-weight: normal;

--- a/src/reports/components/report-sections/summary-report-details-section.scss
+++ b/src/reports/components/report-sections/summary-report-details-section.scss
@@ -45,7 +45,7 @@
     }
 
     .label {
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
     }
 
     .label.no-icon {

--- a/src/reports/components/report-sections/summary-results-table.scss
+++ b/src/reports/components/report-sections/summary-results-table.scss
@@ -19,7 +19,7 @@
     }
 
     th {
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
         background-color: $neutral-6;
     }
 

--- a/src/reports/components/report-sections/title-section.scss
+++ b/src/reports/components/report-sections/title-section.scss
@@ -6,7 +6,7 @@
     margin-top: 56px;
 
     h1 {
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
         margin: 0 0 24px 0;
         font-size: 21px;
         line-height: 32px;

--- a/src/reports/components/report-sections/urls-summary-section.scss
+++ b/src/reports/components/report-sections/urls-summary-section.scss
@@ -16,7 +16,7 @@
     }
 
     .total-urls {
-        font-weight: $fontWeightSemiBold;
+        font-weight: $font-weight-semi-bold;
     }
 
     .failure-instances {

--- a/src/views/content/content.scss
+++ b/src/views/content/content.scss
@@ -24,13 +24,13 @@
 .content {
     flex-grow: 10;
     max-width: 1120px;
-    font-family: $fontFamily;
+    font-family: $font-family;
     font-size: 14px;
     margin: 10px;
     word-break: break-word;
 
     table {
-        font-family: $fontFamily;
+        font-family: $font-family;
         font-size: 14px;
     }
 
@@ -92,7 +92,7 @@
 
     .code-example {
         .code-example-code {
-            font-family: $codeFontFamily;
+            font-family: $code-font-family;
             margin-block-start: 1em;
             margin-block-end: 1em;
         }
@@ -130,7 +130,7 @@
     $dont-color: $negative-outcome;
 
     .insights-code {
-        font-family: $codeFontFamily;
+        font-family: $code-font-family;
     }
 
     .pass-fail-grid {

--- a/src/views/page/page.scss
+++ b/src/views/page/page.scss
@@ -9,7 +9,7 @@ body {
     margin: 0;
     background: $neutral-0;
     color: $neutral-100;
-    font-family: $fontFamily;
+    font-family: $font-family;
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
#### Details

Enables stylelint rule [`scss/dollar-variable-pattern`](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dollar-variable-pattern/README.md) and makes required fixes by updating dollar variables to use kebab case.

Aside from reading the changes, we have a few votes of confidence that the name conversions in this pull request are successful:

- `yarn build` does not error. If a variable is in use but not defined, then stylelint would fail.
- No snapshot changes. If there are snapshot changes that means a variable is incorrect..

##### Motivation

Part of https://github.com/microsoft/accessibility-insights-web/issues/5187 as an incremental task to enable stylelint rules.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5187 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
