### PR TITLE
feat(mv3-part-4): Fix content script browser event bug

### DIFF
--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
 import { createToolData } from 'common/application-properties-provider';
+import { BrowserEventProvider } from 'common/browser-adapters/browser-event-provider';
 import { EnumHelper } from 'common/enum-helper';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unavailable';
@@ -32,6 +33,8 @@ import { TargetPageVisualizationUpdater } from 'injected/target-page-visualizati
 import { visualizationNeedsUpdate } from 'injected/visualization-needs-update';
 import { VisualizationStateChangeHandler } from 'injected/visualization-state-change-handler';
 import { GetVisualizationInstancesForTabStops } from 'injected/visualization/get-visualization-instances-for-tab-stops';
+import { DictionaryStringTo } from 'types/common-types';
+import { Events } from 'webextension-polyfill';
 import { AxeInfo } from '../common/axe-info';
 import { InspectConfigurationFactory } from '../common/configs/inspect-configuration-factory';
 import { DateProvider } from '../common/date-provider';
@@ -418,6 +421,11 @@ export class MainWindowInitializer extends WindowInitializer {
         await this.pathSnippetController.listenToStore();
 
         await Promise.all(asyncInitializationSteps);
+    }
+
+    protected override getBrowserEvents(): DictionaryStringTo<Events.Event<any>> {
+        const browserEventProvider = new BrowserEventProvider();
+        return browserEventProvider.getMinimalBrowserEvents();
     }
 
     protected dispose(): void {

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -4,7 +4,6 @@ import { getRTL } from '@fluentui/utilities';
 import * as axe from 'axe-core';
 import { BrowserAdapterFactory } from 'common/browser-adapters/browser-adapter-factory';
 import { BrowserEventManager } from 'common/browser-adapters/browser-event-manager';
-import { BrowserEventProvider } from 'common/browser-adapters/browser-event-provider';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { createDefaultLogger } from 'common/logging/default-logger';
 import { NavigatorUtils } from 'common/navigator-utils';
@@ -23,7 +22,9 @@ import { DefaultTabStopsRequirementEvaluator } from 'injected/tab-stops-requirem
 import { TabbableElementGetter } from 'injected/tabbable-element-getter';
 import { getUniqueSelector } from 'scanner/axe-utils';
 import { tabbable } from 'tabbable';
+import { DictionaryStringTo } from 'types/common-types';
 import UAParser from 'ua-parser-js';
+import { Events } from 'webextension-polyfill';
 import { AppDataAdapter } from '../common/browser-adapters/app-data-adapter';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -77,11 +78,10 @@ export class WindowInitializer {
         const browserAdapterFactory = new BrowserAdapterFactory(userAgentParser);
         const logger = createDefaultLogger();
         const promiseFactory = createDefaultPromiseFactory();
-        const browserEventProvider = new BrowserEventProvider();
         const browserEventManager = new BrowserEventManager(promiseFactory, logger);
         const browserAdapter = browserAdapterFactory.makeFromUserAgent(
             browserEventManager,
-            browserEventProvider.getMinimalBrowserEvents(),
+            this.getBrowserEvents(),
         );
 
         this.browserAdapter = browserAdapter;
@@ -223,6 +223,10 @@ export class WindowInitializer {
         );
         // Intentionally floating this promise
         void extensionDisabledMonitor.monitorUntilDisabled(() => this.dispose());
+    }
+
+    protected getBrowserEvents(): DictionaryStringTo<Events.Event<any>> {
+        return {};
     }
 
     protected dispose(): void {


### PR DESCRIPTION
#### Details

Fix bug in which browser event manager errors when content scripts are run in pages with iframes. These errors were caused by registering browser event listeners but never handling events properly. The fix implemented here is to register no browser event listeners in iframes, as iframes don't need them anyways. 

##### Motivation

Fix bug introduced by feature work.

##### Context

Bug repro steps before this change:

- Run checks on a page with iframes (for example all.html test resource)
- Wait ~1 min
- Observe timeout errors from browser event manager. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
