### PR TITLE
fix(debug-tools): remove telemetry listener on viewer unmount

### DIFF
--- a/src/debug-tools/components/telemetry-viewer/telemetry-viewer.tsx
+++ b/src/debug-tools/components/telemetry-viewer/telemetry-viewer.tsx
@@ -36,6 +36,10 @@ export class TelemetryViewer extends React.Component<TelemetryViewerProps, Telem
         this.props.deps.telemetryListener.addListener(this.onTelemetryMessage);
     }
 
+    public componentWillUnmount(): void {
+        this.props.deps.telemetryListener.removeListener(this.onTelemetryMessage);
+    }
+
     public render(): JSX.Element {
         if (this.state.telemetryMessages.length === 0) {
             return this.renderNoMessages();

--- a/src/debug-tools/controllers/telemetry-listener.ts
+++ b/src/debug-tools/controllers/telemetry-listener.ts
@@ -41,6 +41,10 @@ export class TelemetryListener {
     public addListener(listener: DebugToolsTelemetryMessageListener): void {
         this.listeners.push(listener);
     }
+
+    public removeListener(listener: DebugToolsTelemetryMessageListener): void {
+        this.listeners = this.listeners.filter(l => l !== listener);
+    }
 }
 
 function convertToDebugToolTelemetryMessage(

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-viewer.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-viewer.test.tsx
@@ -28,11 +28,22 @@ describe('TelemetryViewer', () => {
         props = { deps };
     });
 
-    it('add listner for telemetry messages', () => {
+    it('adds listener for telemetry messages on mount', () => {
         shallow(<TelemetryViewer {...props} />);
 
         telemetryListenerMock.verify(
             listener => listener.addListener(It.is(isFunction)),
+            Times.once(),
+        );
+    });
+
+    it('removes listener for telemetry messages on unmount', () => {
+        const testSubject = shallow(<TelemetryViewer {...props} />);
+
+        testSubject.unmount();
+
+        telemetryListenerMock.verify(
+            listener => listener.removeListener(It.is(isFunction)),
             Times.once(),
         );
     });


### PR DESCRIPTION
#### Details

Today, when toggling the debug tools UI from the telemetry viewer back to the store viewer, it emits the following error:

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
    in TelemetryViewer (created by CurrentView)
```

This happens because `TelemetryViewer.componentDidMount` registers a listener that `TelemetryViewer.componentWillUnmount` does not remove.

This PR fixes the warning by ensuring that the listener is removed on unmount of the viewer.

##### Motivation

Avoid unnecessary error spew

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
