### PR TITLE
feat(mv3-part-4): revert async-ification of trackEvent

### DIFF
--- a/src/background/telemetry/app-insights-telemetry-client.ts
+++ b/src/background/telemetry/app-insights-telemetry-client.ts
@@ -36,7 +36,7 @@ export class AppInsightsTelemetryClient implements TelemetryClient {
         this.updateTelemetryState();
     }
 
-    public async trackEvent(name: string, properties?: { [name: string]: string }): Promise<void> {
+    public trackEvent(name: string, properties?: { [name: string]: string }): void {
         if (this.enabled) {
             this.applicationInsights.trackEvent({ name }, properties);
         }

--- a/src/background/telemetry/console-telemetry-client.ts
+++ b/src/background/telemetry/console-telemetry-client.ts
@@ -17,7 +17,7 @@ export class ConsoleTelemetryClient implements TelemetryClient {
     public disableTelemetry(): void {
         // no-op
     }
-    public async trackEvent(name: string, properties?: { [name: string]: string }): Promise<void> {
+    public trackEvent(name: string, properties?: { [name: string]: string }): void {
         properties = {
             ...properties,
             ...this.telemetryDataFactory.getData(),

--- a/src/background/telemetry/multiplexing-telemetry-client.ts
+++ b/src/background/telemetry/multiplexing-telemetry-client.ts
@@ -13,7 +13,7 @@ export class MultiplexingTelemetryClient implements TelemetryClient {
         this.wrappedClients.forEach(c => c.disableTelemetry());
     }
 
-    public async trackEvent(name: string, properties?: Object): Promise<void> {
-        await Promise.all(this.wrappedClients.map(c => c.trackEvent(name, properties)));
+    public trackEvent(name: string, properties?: Object): void {
+        this.wrappedClients.forEach(c => c.trackEvent(name, properties));
     }
 }

--- a/src/background/telemetry/telemetry-client.ts
+++ b/src/background/telemetry/telemetry-client.ts
@@ -3,5 +3,5 @@
 export interface TelemetryClient {
     enableTelemetry(): void;
     disableTelemetry(): void;
-    trackEvent(name: string, properties?: Object): Promise<void>;
+    trackEvent(name: string, properties?: Object): void;
 }

--- a/src/background/telemetry/telemetry-event-handler.ts
+++ b/src/background/telemetry/telemetry-event-handler.ts
@@ -28,9 +28,7 @@ export class TelemetryEventHandler {
 
         const flattenTelemetryInfo: DictionaryStringTo<string> =
             this.flattenTelemetryInfo(telemetryInfo);
-        // Disabling this temporarily to avoid errors in non-async ActionMessageCreators.
-        // Ideally, this method would be marked async so we can await this call.
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+
         this.telemetryClient.trackEvent(eventName, flattenTelemetryInfo);
     }
 

--- a/src/tests/unit/tests/background/telemetry/app-insights-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/app-insights-telemetry-client.test.ts
@@ -128,7 +128,7 @@ describe('AppInsights telemetry client tests', () => {
     });
 
     describe('trackEvent', () => {
-        test('calls appInsights trackEvent', async () => {
+        test('calls appInsights trackEvent', () => {
             invokeFirstEnableTelemetryCall();
 
             const eventName: string = 'testEvent';
@@ -140,13 +140,13 @@ describe('AppInsights telemetry client tests', () => {
                 .setup(ai => ai.trackEvent({ name: eventName }, eventObject))
                 .verifiable(Times.once());
 
-            await testSubject.trackEvent(eventName, eventObject);
+            testSubject.trackEvent(eventName, eventObject);
 
             appInsightsStrictMock.verifyAll();
             expect(telemetryTraceStub.name).toEqual('');
         });
 
-        test('do nothing if not initialized', async () => {
+        test('do nothing if not initialized', () => {
             const eventName: string = 'testEvent';
             const eventObject = {
                 test: 'a',
@@ -155,11 +155,11 @@ describe('AppInsights telemetry client tests', () => {
                 .setup(ai => ai.trackEvent({ name: eventName }, eventObject))
                 .verifiable(Times.never());
 
-            await testSubject.trackEvent(eventName, eventObject);
+            testSubject.trackEvent(eventName, eventObject);
             appInsightsStrictMock.verifyAll();
         });
 
-        test('do nothing when not enabled', async () => {
+        test('do nothing when not enabled', () => {
             invokeFirstEnableTelemetryCall();
 
             const eventName: string = 'testEvent';
@@ -171,11 +171,11 @@ describe('AppInsights telemetry client tests', () => {
                 .setup(ai => ai.trackEvent({ name: eventName }, eventObject))
                 .verifiable(Times.exactly(2));
 
-            await testSubject.trackEvent(eventName, eventObject);
+            testSubject.trackEvent(eventName, eventObject);
             testSubject.disableTelemetry();
-            await testSubject.trackEvent(eventName, eventObject);
+            testSubject.trackEvent(eventName, eventObject);
             testSubject.enableTelemetry();
-            await testSubject.trackEvent(eventName, eventObject);
+            testSubject.trackEvent(eventName, eventObject);
 
             expect(telemetryTraceStub.name).toEqual('');
         });

--- a/src/tests/unit/tests/background/telemetry/console-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/console-telemetry-client.test.ts
@@ -32,7 +32,7 @@ describe('ConsoleTelemetryClient', () => {
     });
 
     describe('trackEvent', () => {
-        it('should log telemetry', async () => {
+        it('should log telemetry', () => {
             const name = 'test-event-name';
             const appDataStub = {
                 applicationVersion: 'test version',
@@ -57,7 +57,7 @@ describe('ConsoleTelemetryClient', () => {
 
             const testObject = createDefaultTestObject();
 
-            await testObject.trackEvent(name, properties);
+            testObject.trackEvent(name, properties);
 
             telemetryDataFactoryMock.verifyAll();
             loggerMock.verifyAll();

--- a/src/tests/unit/tests/background/telemetry/multiplexing-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/multiplexing-telemetry-client.test.ts
@@ -39,13 +39,13 @@ describe('MultiplexingTelemetryClient', () => {
         thirdTelemetryClientMock.verify(client => client.disableTelemetry(), Times.once());
     });
 
-    it('calls trackEvent on all the clients', async () => {
+    it('calls trackEvent on all the clients', () => {
         const testName = 'test-name';
         const testProperties = {
             test: 'property',
         };
 
-        await testSubject.trackEvent(testName, testProperties);
+        testSubject.trackEvent(testName, testProperties);
 
         firstTelemetryClientMock.verify(
             client => client.trackEvent(testName, testProperties),

--- a/src/tests/unit/tests/background/telemetry/telemetry-event-handler.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-event-handler.test.ts
@@ -28,22 +28,22 @@ describe('TelemetryEventHandlerTest', () => {
         telemetryClientStrictMock = Mock.ofType<TelemetryClient>(null, MockBehavior.Strict);
     });
 
-    test('test for when telemetry is null', async () => {
+    test('test for when telemetry is null', () => {
         const payload: BaseActionPayload = {
             telemetry: null,
         };
 
         const testObject = createAndEnableTelemetryEventHandler();
-        await testObject.publishTelemetry(testEventName, payload);
+        testObject.publishTelemetry(testEventName, payload);
     });
 
-    test('test for when tab is null', async () => {
+    test('test for when tab is null', () => {
         telemetryClientStrictMock
             .setup(te => te.trackEvent(It.isAny(), It.isAny()))
             .verifiable(Times.once());
 
         const testObject = createAndEnableTelemetryEventHandler();
-        await testObject.publishTelemetry(testEventName, testTelemetryPayload);
+        testObject.publishTelemetry(testEventName, testTelemetryPayload);
         telemetryClientStrictMock.verifyAll();
     });
 
@@ -63,19 +63,19 @@ describe('TelemetryEventHandlerTest', () => {
         telemetryClientStrictMock.verifyAll();
     });
 
-    test('test for publishTelemetry when tab is not null', async () => {
+    test('test for publishTelemetry when tab is not null', () => {
         const expectedTelemetry = createExpectedAppInsightsTelemetry();
 
         setupTrackEvent(testEventName, expectedTelemetry);
 
         const testObject = createAndEnableTelemetryEventHandler();
 
-        await testObject.publishTelemetry(testEventName, testTelemetryPayload);
+        testObject.publishTelemetry(testEventName, testTelemetryPayload);
 
         telemetryClientStrictMock.verifyAll();
     });
 
-    test('test for publishTelemetry with random object as custom property', async () => {
+    test('test for publishTelemetry with random object as custom property', () => {
         const extraFields: DictionaryStringTo<any> = {
             ___featureA: {
                 __featureB__: {
@@ -102,7 +102,7 @@ describe('TelemetryEventHandlerTest', () => {
 
         const testObject = createAndEnableTelemetryEventHandler();
 
-        await testObject.publishTelemetry(testEventName, customTelemetryPayload);
+        testObject.publishTelemetry(testEventName, customTelemetryPayload);
 
         telemetryClientStrictMock.verifyAll();
     });


### PR DESCRIPTION
#### Details

This PR reverts a part of #5524 that involved making our telemetry clients' `trackEvent` async in the interest of propogating the return value of the `browserAdapter.sendRuntimeMessage` call used by `debug-tools-telemetry-client.ts`.

The issue with that strategy is that it doesn't cooperate with the new unhandled promise rejection hook added by #5550 - particularly, the hook ends up entering an infinite loop if that `sendRuntimeMessage` call fails for any reason. You can see this by clean-installing a dev build of the extension, opening the background page devtools from the extension management page, and enabling the console telemetry logging and debug tools feature flags from the background console (never opening any other extension page/popup UI).

Instead, this PR:

* Reverts `trackEvent` back to synchronous (to make it part of the `TelemetryClient` contract that the onerror hook anti-reentrancy logic will work)
* Moves the promise-voiding to be internal to the `debug-tools-telemetry-client` with a comment explaining why
* Adds a no-op catch handler to the voided `sendRuntimeMessage` promise, to ensure that it won't enter an infinite loop with the rejected promise hook that... tries to send error telemetry.

##### Motivation

Avoid an infinite loop found during #5591 testing (thanks @sfoslund for tracking down repro steps!)

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
