### PR TITLE
fix(mv3-part-4): prevent debug tools window from eating other windows' messages

### DIFF
--- a/src/debug-tools/debug-tools-message-distributor.ts
+++ b/src/debug-tools/debug-tools-message-distributor.ts
@@ -17,9 +17,8 @@ export class DebugToolsMessageDistributor {
         this.browserAdapter.addListenerOnMessage(this.distributeMessage);
     }
 
-    private distributeMessage = (message: any) => {
+    private distributeMessage = (message: any): void | Promise<void> => {
         this.telemetryListener.onTelemetryMessage(message);
-
         return this.storeUpdateMessageHub.handleMessage(message as StoreUpdateMessage<unknown>);
     };
 }

--- a/src/debug-tools/debug-tools-message-distributor.ts
+++ b/src/debug-tools/debug-tools-message-distributor.ts
@@ -19,6 +19,7 @@ export class DebugToolsMessageDistributor {
 
     private distributeMessage = (message: any) => {
         this.telemetryListener.onTelemetryMessage(message);
-        this.storeUpdateMessageHub.handleMessage(message as StoreUpdateMessage<unknown>);
+
+        return this.storeUpdateMessageHub.handleMessage(message as StoreUpdateMessage<unknown>);
     };
 }

--- a/src/debug-tools/debug-tools-message-distributor.ts
+++ b/src/debug-tools/debug-tools-message-distributor.ts
@@ -17,8 +17,8 @@ export class DebugToolsMessageDistributor {
         this.browserAdapter.addListenerOnMessage(this.distributeMessage);
     }
 
-    private distributeMessage = async (message: any) => {
+    private distributeMessage = (message: any) => {
         this.telemetryListener.onTelemetryMessage(message);
-        await this.storeUpdateMessageHub.handleMessage(message as StoreUpdateMessage<unknown>);
+        this.storeUpdateMessageHub.handleMessage(message as StoreUpdateMessage<unknown>);
     };
 }

--- a/src/debug-tools/debug-tools-message-distributor.ts
+++ b/src/debug-tools/debug-tools-message-distributor.ts
@@ -13,7 +13,7 @@ export class DebugToolsMessageDistributor {
         private readonly telemetryListener: TelemetryListener,
     ) {}
 
-    public initialize() {
+    public initialize(): void {
         this.browserAdapter.addListenerOnMessage(this.distributeMessage);
     }
 


### PR DESCRIPTION
#### Details

This PR fixes an issue that @sfoslund and I discovered while validating #5591. @pownkel and @sfoslund did some outstanding debugging to find the root cause.

The symptom we observed that this fixes is that, with #5591, we would sometimes (~30-60% of the time) see messages get lost between different frames of a target page with iframes. The root cause of this wasn't actually loss of the window messages between the frames, it was the loss of some of the messages used by out background backchannel infrastructure in communication between one of the frames and the background page.

We were very confused in debugging this for a while because it was inconsistent; sometimes it would repro half the time, and sometimes not at all. @sfoslund eventually narrowed down that the issue seemed to only repro at the 50% rate if the debug tools page was open (we had been using it to test whether the unhandledError telemetry was flowing, and then to see the unhandledErrors from the target page that indicated this error was occurring). @pownkel had the key insight that maybe the reason we "lost" messages that appeared to be sent successfully from the child frames but never received could be that something unexpected was receiving them and throwing them away.

The root cause is that the listener this PR is changing registers a browser message listener which always returns a promise, even if it doesn't want to indicate that the message is being handled. That means if the debug tools window is open and happens to process a given message before its real destination page does, it accidentally intercepts the message and responds with "undefined", and the original message sender sees the message as "handled, with response undefined" before the real destination gets a chance to handle it and respond back with a real response.

In practice, this only causes problems for messages intended for the background page's postMessageContentHandler - unlike most of our message-based communication, it actually responds to messages with non-undefined responses, so intercepting its messages results in broken behavior rather than just race conditions. This is why the only apparent impact of the issue was breaking communication between frames of a target page.

This was an issue introduced in #5518, but which was being masked by the browser event manager that had been introduced in #5490. #5591 changes the timing of the browser events such that this issue was more likely to be hit.

##### Motivation

Fix issue where communication between target page frames could become lost.

##### Context

This PR is just a minimal fix for the issue. We have some ideas for improvements that would make it harder to accidentally introduce this class of issue in the future; @sfoslund will be making a separate PR with that in parallel with me getting this merged and applied to the last few mv3-part-4 PRs (#5591, #5538)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
