### PR TITLE
feat(mv3-part-4): Add OptionalMessageResponse

### DIFF
--- a/src/Devtools/dev-tool-message-distributor.ts
+++ b/src/Devtools/dev-tool-message-distributor.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { BrowserAdapter, OptionalMessageResponse } from 'common/browser-adapters/browser-adapter';
 import { Message } from 'common/message';
 import { Messages } from 'common/messages';
 import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
-import { DevToolsStatusRequest, DevToolsStatusResponse } from 'common/types/dev-tools-messages';
+import { DevToolsStatusRequest } from 'common/types/dev-tools-messages';
 import { StoreUpdateMessage } from 'common/types/store-update-message';
 
 export class DevToolsMessageDistributor {
@@ -18,12 +18,10 @@ export class DevToolsMessageDistributor {
         this.browserAdapter.addListenerOnMessage(this.distributeMessage);
     }
 
-    private distributeMessage = (
-        message: Message,
-    ): void | Promise<void> | Promise<DevToolsStatusResponse> => {
+    private distributeMessage = (message: Message): OptionalMessageResponse => {
         if (this.isStatusRequestForTab(message)) {
             // Must return a promise for the response to send correctly
-            return Promise.resolve({ isActive: true });
+            return { messageResponse: Promise.resolve({ isActive: true }) };
         } else {
             return this.storeUpdateHub.handleMessage(message as StoreUpdateMessage<unknown>);
         }

--- a/src/background/background-message-distributor.ts
+++ b/src/background/background-message-distributor.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TabContextManager } from 'background/tab-context-manager';
-import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { BrowserAdapter, OptionalMessageResponse } from 'common/browser-adapters/browser-adapter';
 import { Tab } from '../common/itab';
 import { Logger } from '../common/logging/logger';
 import { InterpreterMessage } from '../common/message';
@@ -25,7 +25,10 @@ export class BackgroundMessageDistributor {
         this.browserAdapter.addListenerOnMessage(this.distributeMessage);
     }
 
-    private distributeMessage = (message: InterpreterMessage, sender?: Sender): any => {
+    private distributeMessage = (
+        message: InterpreterMessage,
+        sender?: Sender,
+    ): OptionalMessageResponse => {
         message.tabId = this.getTabId(message, sender);
 
         const isInterpretedUsingGlobalContext = this.globalContext.interpreter.interpret(message);

--- a/src/background/post-message-content-handler.ts
+++ b/src/background/post-message-content-handler.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { OptionalMessageResponse } from 'common/browser-adapters/browser-adapter';
 import { InterpreterMessage } from '../common/message';
 import {
     BackchannelRequestMessage,
@@ -12,7 +13,7 @@ import { PostMessageContentRepository } from './post-message-content-repository'
 
 export type BackchannelMessageResponse = {
     success: boolean;
-    response?: any;
+    response?: OptionalMessageResponse;
 };
 
 export class PostMessageContentHandler {
@@ -59,11 +60,12 @@ export class PostMessageContentHandler {
 
     public handleMessage(message: InterpreterMessage): BackchannelMessageResponse {
         if (Object.keys(this.messageHandlers).includes(message.messageType)) {
+            const response = this.messageHandlers[message.messageType](
+                message as BackchannelRequestMessage,
+            );
             return {
                 success: true,
-                response: this.messageHandlers[message.messageType](
-                    message as BackchannelRequestMessage,
-                ),
+                response: { messageResponse: response },
             };
         }
 

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -11,6 +11,10 @@ import {
     Windows,
 } from 'webextension-polyfill';
 
+export interface OptionalMessageResponse {
+    messageResponse: void | Promise<any>;
+}
+
 export interface BrowserAdapter {
     allSupportedEvents(): DictionaryStringTo<Events.Event<any>>;
     getAllWindows(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]>;
@@ -49,7 +53,7 @@ export interface BrowserAdapter {
     isAllowedFileSchemeAccess(): Promise<boolean>;
     getManageExtensionUrl(): string;
     addListenerOnMessage(
-        callback: (message: any, sender: Runtime.MessageSender) => void | Promise<any>,
+        callback: (message: any, sender: Runtime.MessageSender) => OptionalMessageResponse,
     ): void;
 
     removeListenersOnMessage(): void;

--- a/src/common/browser-adapters/webextension-browser-adapter.ts
+++ b/src/common/browser-adapters/webextension-browser-adapter.ts
@@ -14,7 +14,7 @@ import browser, {
     Windows,
 } from 'webextension-polyfill';
 
-import { BrowserAdapter } from './browser-adapter';
+import { BrowserAdapter, OptionalMessageResponse } from './browser-adapter';
 import { CommandsAdapter } from './commands-adapter';
 import { StorageAdapter } from './storage-adapter';
 export abstract class WebExtensionBrowserAdapter
@@ -221,9 +221,18 @@ export abstract class WebExtensionBrowserAdapter
     }
 
     public addListenerOnMessage(
-        callback: (message: any, sender: Runtime.MessageSender) => void | Promise<any>,
+        callback: (message: any, sender: Runtime.MessageSender) => OptionalMessageResponse,
     ): void {
-        this.addListener('RuntimeOnMessage', callback);
+        const translatorCallback: (
+            message: any,
+            sender: Runtime.MessageSender,
+        ) => void | Promise<any> = (message: any, sender: Runtime.MessageSender) => {
+            const response: OptionalMessageResponse = callback(message, sender);
+            if (response && response.messageResponse) {
+                return response.messageResponse;
+            }
+        };
+        this.addListener('RuntimeOnMessage', translatorCallback);
     }
 
     public removeListenersOnMessage(): void {

--- a/src/common/store-update-message-hub.ts
+++ b/src/common/store-update-message-hub.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { OptionalMessageResponse } from 'common/browser-adapters/browser-adapter';
 import _ from 'lodash';
 import { StoreType } from './types/store-type';
 import { StoreUpdateMessage, storeUpdateMessageType } from './types/store-update-message';
@@ -22,15 +23,16 @@ export class StoreUpdateMessageHub {
         this.registeredUpdateListeners[storeId] = listener;
     }
 
-    public readonly handleMessage = (message: StoreUpdateMessage<any>): void | Promise<void> => {
+    public readonly handleMessage = (message: StoreUpdateMessage<any>): OptionalMessageResponse => {
         if (!this.isValidMessage(message)) {
-            return;
+            return { messageResponse: undefined };
         }
 
         const listener = this.registeredUpdateListeners[message.storeId];
         if (listener) {
-            return listener(message);
+            return { messageResponse: listener(message) };
         }
+        return { messageResponse: undefined };
     };
 
     private isValidMessage(message: StoreUpdateMessage<any>): boolean {

--- a/src/debug-tools/debug-tools-message-distributor.ts
+++ b/src/debug-tools/debug-tools-message-distributor.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { BrowserAdapter, OptionalMessageResponse } from 'common/browser-adapters/browser-adapter';
 import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { StoreUpdateMessage } from 'common/types/store-update-message';
 import { TelemetryListener } from 'debug-tools/controllers/telemetry-listener';
@@ -17,7 +17,7 @@ export class DebugToolsMessageDistributor {
         this.browserAdapter.addListenerOnMessage(this.distributeMessage);
     }
 
-    private distributeMessage = (message: any): void | Promise<void> => {
+    private distributeMessage = (message: any): OptionalMessageResponse => {
         this.telemetryListener.onTelemetryMessage(message);
         return this.storeUpdateMessageHub.handleMessage(message as StoreUpdateMessage<unknown>);
     };

--- a/src/tests/unit/tests/DevTools/dev-tool-message-distributor.test.ts
+++ b/src/tests/unit/tests/DevTools/dev-tool-message-distributor.test.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { BrowserAdapter, OptionalMessageResponse } from 'common/browser-adapters/browser-adapter';
 import { Message } from 'common/message';
 import { Messages } from 'common/messages';
 import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
-import { DevToolsStatusResponse } from 'common/types/dev-tools-messages';
 import { StoreUpdateMessage } from 'common/types/store-update-message';
 import { DevToolsMessageDistributor } from 'Devtools/dev-tool-message-distributor';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -14,7 +13,7 @@ describe(DevToolsMessageDistributor, () => {
     const inspectedTabId = 10;
     let browserAdapterMock: IMock<BrowserAdapter>;
     let storeUpdateHubMock: IMock<StoreUpdateMessageHub>;
-    let distributeMessage: (message: Message) => void | Promise<DevToolsStatusResponse>;
+    let distributeMessage: (message: Message) => OptionalMessageResponse;
 
     let testSubject: DevToolsMessageDistributor;
 
@@ -56,7 +55,8 @@ describe(DevToolsMessageDistributor, () => {
                 isActive: true,
             };
 
-            const responsePromise = distributeMessage(message);
+            const messageResponse = distributeMessage(message);
+            const responsePromise = messageResponse.messageResponse;
 
             expect(responsePromise).toBeInstanceOf(Promise);
 
@@ -95,10 +95,13 @@ describe(DevToolsMessageDistributor, () => {
             };
             storeUpdateHubMock
                 .setup(s => s.handleMessage(message as StoreUpdateMessage<unknown>))
-                .returns(() => Promise.resolve())
+                .returns(() => {
+                    return { messageResponse: Promise.resolve() };
+                })
                 .verifiable(Times.once());
 
-            const responsePromise = distributeMessage(message);
+            const messageResponse = distributeMessage(message);
+            const responsePromise = messageResponse.messageResponse;
 
             expect(responsePromise).toBeInstanceOf(Promise);
 

--- a/src/tests/unit/tests/background/post-message-content-handler.test.ts
+++ b/src/tests/unit/tests/background/post-message-content-handler.test.ts
@@ -57,10 +57,11 @@ describe('PostMessageContentHandlerTest', () => {
             .verifiable(Times.once());
 
         const { success, response } = testSubject.handleMessage(retrieveRequestMessage);
+        const messageResponse = response.messageResponse;
 
         expect(success).toBeTruthy();
-        expect(response).toBeInstanceOf(Promise);
-        expect(await response).toEqual(retrieveResponseMessage);
+        expect(messageResponse).toBeInstanceOf(Promise);
+        expect(await messageResponse).toEqual(retrieveResponseMessage);
 
         mockPostMessageContentRepository.verifyAll();
     });
@@ -92,10 +93,11 @@ describe('PostMessageContentHandlerTest', () => {
             .verifiable(Times.once());
 
         const { success, response } = testSubject.handleMessage(retrieveRequestMessage);
+        const messageResponse = response.messageResponse;
 
         expect(success).toBeTruthy();
-        expect(response).toBeInstanceOf(Promise);
-        await expect(response).rejects.toThrowError(errorMessage);
+        expect(messageResponse).toBeInstanceOf(Promise);
+        await expect(messageResponse).rejects.toThrowError(errorMessage);
 
         mockPostMessageContentRepository.verifyAll();
     });

--- a/src/tests/unit/tests/background/telemetry/debug-tools-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/debug-tools-telemetry-client.test.ts
@@ -6,7 +6,7 @@ import {
     ApplicationTelemetryDataFactory,
 } from 'background/telemetry/application-telemetry-data-factory';
 import { DebugToolsTelemetryClient } from 'background/telemetry/debug-tools-telemetry-client';
-import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { BrowserAdapter, OptionalMessageResponse } from 'common/browser-adapters/browser-adapter';
 import { FeatureFlags } from 'common/feature-flags';
 import { Messages } from 'common/messages';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -101,7 +101,7 @@ describe('DebugToolsTelemetryClient', () => {
             telemetryDataFactoryMock.setup(factory => factory.getData()).returns(() => stubAppData);
             browserAdapterMock
                 .setup(b => b.sendRuntimeMessage(expectedMessage))
-                .returns(() => Promise.resolve())
+                .returns(() => Promise.resolve({} as OptionalMessageResponse))
                 .verifiable();
 
             testSubject.trackEvent(eventName, eventProperties);

--- a/src/tests/unit/tests/common/store-update-message-hub.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-hub.test.ts
@@ -54,7 +54,8 @@ describe(StoreUpdateMessageHub, () => {
         { ...tabContextMessage, tabId: tabId + 10 },
     ];
     it.each(invalidMessages)('ignores invalid message: %o', message => {
-        const result = testSubject.handleMessage(message);
+        const optionalMessageResponse = testSubject.handleMessage(message);
+        const result = optionalMessageResponse.messageResponse;
 
         expect(registeredListener).toBeCalledTimes(0);
         expect(result).toBeUndefined();
@@ -66,14 +67,16 @@ describe(StoreUpdateMessageHub, () => {
             storeId: 'AnotherStore',
         };
 
-        const result = testSubject.handleMessage(message);
+        const optionalMessageResponse = testSubject.handleMessage(message);
+        const result = optionalMessageResponse.messageResponse;
 
         expect(registeredListener).toBeCalledTimes(0);
         expect(result).toBeUndefined();
     });
 
     it('Calls registered listener for tab context store message', async () => {
-        const resultPromise = testSubject.handleMessage(tabContextMessage);
+        const optionalMessageResponse = testSubject.handleMessage(tabContextMessage);
+        const resultPromise = optionalMessageResponse.messageResponse;
 
         expect(resultPromise).toBe(listenerPromise);
         await resultPromise;
@@ -82,7 +85,8 @@ describe(StoreUpdateMessageHub, () => {
     });
 
     it('Calls registered listener for global store message', async () => {
-        const resultPromise = testSubject.handleMessage(globalStoreMessage);
+        const optionalMessageResponse = testSubject.handleMessage(globalStoreMessage);
+        const resultPromise = optionalMessageResponse.messageResponse;
 
         expect(resultPromise).toBe(listenerPromise);
         await resultPromise;
@@ -94,7 +98,8 @@ describe(StoreUpdateMessageHub, () => {
         testSubject = new StoreUpdateMessageHub();
         testSubject.registerStoreUpdateListener(storeId, registeredListener);
 
-        const resultPromise = testSubject.handleMessage(tabContextMessage);
+        const optionalMessageResponse = testSubject.handleMessage(tabContextMessage);
+        const resultPromise = optionalMessageResponse.messageResponse;
 
         expect(resultPromise).toBe(listenerPromise);
         await resultPromise;
@@ -115,8 +120,11 @@ describe(StoreUpdateMessageHub, () => {
 
         testSubject.registerStoreUpdateListener(anotherStoreId, anotherListener);
 
-        const resultPromise1 = testSubject.handleMessage(messageForStore);
-        const resultPromise2 = testSubject.handleMessage(messageForAnotherStore);
+        const optionalMessageResponse1 = testSubject.handleMessage(messageForStore);
+        const optionalMessageResponse2 = testSubject.handleMessage(messageForAnotherStore);
+
+        const resultPromise1 = optionalMessageResponse1.messageResponse;
+        const resultPromise2 = optionalMessageResponse2.messageResponse;
 
         expect(resultPromise1).toBeInstanceOf(Promise);
         expect(resultPromise2).toBeInstanceOf(Promise);


### PR DESCRIPTION
#### Details

Add an OptionalMessageResponse as the return value for message listeners. This change will prevent listeners from accidentally returning responses to runtime messages, which can prevent intentional message responses from getting through.

##### Motivation

Feature work.

##### Context

This is a follow up to https://github.com/microsoft/accessibility-insights-web/pull/5602, which will make it harder to accidentally re-introduce the issue described there in the future. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
