### PR TITLE
fix(electron-orca-a11y-bugs): Announce which item in a dropdown list is selected

### DIFF
--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Dropdown, IDropdownOption } from '@fluentui/react';
+import { IDropdownOption } from '@fluentui/react';
 import { Icon } from '@fluentui/react';
 import { ResponsiveMode } from '@fluentui/react';
+import { InsightsDropdown } from 'common/components/insights-dropdown';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import * as React from 'react';
 
@@ -80,7 +81,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
     public render(): JSX.Element {
         return (
             <div className={styles.leftNavSwitcher} role="region" aria-label="activity">
-                <Dropdown
+                <InsightsDropdown
                     className={styles.leftNavSwitcherDropdown}
                     ariaLabel="select activity"
                     responsiveMode={ResponsiveMode.large}

--- a/src/common/components/insights-dropdown.tsx
+++ b/src/common/components/insights-dropdown.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Dropdown, IDropdownOption, IDropdownProps } from '@fluentui/react';
+import * as React from 'react';
+import { NamedFC } from '../react/named-fc';
+
+export type InsightsDropdownProps = IDropdownProps & {
+    selectedKey: string | number | null;
+};
+
+export const InsightsDropdown = NamedFC<InsightsDropdownProps>('InsightsDropdown', props => {
+    const { options, selectedKey } = props;
+
+    const addSelectedToAriaLabel = (option: IDropdownOption): IDropdownOption => {
+        const isSelected = selectedKey === option.key;
+        const screenreaderText = option.ariaLabel ?? option.text;
+        return { ...option, ariaLabel: isSelected ? `${screenreaderText} selected` : undefined };
+    };
+
+    const modifiedProps = {
+        ...props,
+        options: options.map(addSelectedToAriaLabel),
+    };
+
+    return <Dropdown {...modifiedProps} />;
+});

--- a/src/issue-filing/services/azure-boards/azure-boards-settings-form.tsx
+++ b/src/issue-filing/services/azure-boards/azure-boards-settings-form.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Dropdown, IDropdownOption, TextField } from '@fluentui/react';
+import { IDropdownOption, TextField } from '@fluentui/react';
+import { InsightsDropdown } from 'common/components/insights-dropdown';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import { SettingsFormProps } from '../../types/settings-form-props';
@@ -16,18 +17,16 @@ import {
 export const AzureBoardsSettingsForm = NamedFC<SettingsFormProps<AzureBoardsIssueFilingSettings>>(
     'AzureBoardsSettingsForm',
     props => {
-        const createDropdownOption = (
-            key: AzureBoardsIssueDetailField,
-            text: string,
-        ): AzureBoardsIssueDetailLocationDropdownOption => {
-            const isSelected = props.settings?.issueDetailsField === key;
-
-            return {
-                key,
-                text,
-                ariaLabel: isSelected ? `${text} selected` : undefined,
-            };
-        };
+        const options: AzureBoardsIssueDetailLocationDropdownOption[] = [
+            {
+                key: 'reproSteps',
+                text: 'Repro steps',
+            },
+            {
+                key: 'description',
+                text: 'Description',
+            },
+        ];
 
         const onProjectURLChange = (
             event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -56,11 +55,6 @@ export const AzureBoardsSettingsForm = NamedFC<SettingsFormProps<AzureBoardsIssu
         };
         const descriptionId = 'azure-boards-description';
 
-        const options: AzureBoardsIssueDetailLocationDropdownOption[] = [
-            createDropdownOption('reproSteps', 'Repro steps'),
-            createDropdownOption('description', 'Description'),
-        ];
-
         return (
             <>
                 <TextField
@@ -73,12 +67,12 @@ export const AzureBoardsSettingsForm = NamedFC<SettingsFormProps<AzureBoardsIssu
                 <span id={descriptionId} className="textfield-description">
                     example: https://dev.azure.com/org/project
                 </span>
-                <Dropdown
+                <InsightsDropdown
                     options={options}
                     placeholder="Select an option"
                     label="Select a field for issue details"
                     onChange={onIssueDetailLocationChange}
-                    selectedKey={props.settings ? props.settings.issueDetailsField : null}
+                    selectedKey={props.settings?.issueDetailsField}
                 />
             </>
         );

--- a/src/issue-filing/services/azure-boards/azure-boards-settings-form.tsx
+++ b/src/issue-filing/services/azure-boards/azure-boards-settings-form.tsx
@@ -16,16 +16,18 @@ import {
 export const AzureBoardsSettingsForm = NamedFC<SettingsFormProps<AzureBoardsIssueFilingSettings>>(
     'AzureBoardsSettingsForm',
     props => {
-        const options: AzureBoardsIssueDetailLocationDropdownOption[] = [
-            {
-                key: 'reproSteps',
-                text: 'Repro steps',
-            },
-            {
-                key: 'description',
-                text: 'Description',
-            },
-        ];
+        const createDropdownOption = (
+            key: AzureBoardsIssueDetailField,
+            text: string,
+        ): AzureBoardsIssueDetailLocationDropdownOption => {
+            const isSelected = props.settings?.issueDetailsField === key;
+
+            return {
+                key,
+                text,
+                ariaLabel: isSelected ? `${text} selected` : undefined,
+            };
+        };
 
         const onProjectURLChange = (
             event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -53,6 +55,11 @@ export const AzureBoardsSettingsForm = NamedFC<SettingsFormProps<AzureBoardsIssu
             props.onPropertyUpdateCallback(payload);
         };
         const descriptionId = 'azure-boards-description';
+
+        const options: AzureBoardsIssueDetailLocationDropdownOption[] = [
+            createDropdownOption('reproSteps', 'Repro steps'),
+            createDropdownOption('description', 'Description'),
+        ];
 
         return (
             <>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
@@ -23,7 +23,7 @@ Array [
 
 exports[`Switcher renders Switcher itself matches snapshot 1`] = `
 "<div className=\\"leftNavSwitcher\\" role=\\"region\\" aria-label=\\"activity\\">
-  <Dropdown className=\\"leftNavSwitcherDropdown\\" ariaLabel=\\"select activity\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function (anonymous)]} onRenderTitle={[Function (anonymous)]} onChange={[Function (anonymous)]} options={{...}} />
+  <InsightsDropdown className=\\"leftNavSwitcherDropdown\\" ariaLabel=\\"select activity\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function (anonymous)]} onRenderTitle={[Function (anonymous)]} onChange={[Function (anonymous)]} options={{...}} />
 </div>"
 `;
 

--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Dropdown, IDropdownOption } from '@fluentui/react';
+import { IDropdownOption } from '@fluentui/react';
+import { InsightsDropdown } from 'common/components/insights-dropdown';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { Switcher, SwitcherProps } from 'DetailsView/components/switcher';
@@ -32,7 +33,7 @@ describe('Switcher', () => {
         it('option renderer override matches snapshot ', () => {
             const renderer = shallow(<Switcher {...defaultProps} />);
 
-            const dropdown = renderer.find(Dropdown);
+            const dropdown = renderer.find(InsightsDropdown);
 
             const options = dropdown.prop('options');
 
@@ -46,7 +47,7 @@ describe('Switcher', () => {
         it('dropdown has correct options', () => {
             const renderer = shallow(<Switcher {...defaultProps} />);
 
-            const dropdown = renderer.find(Dropdown);
+            const dropdown = renderer.find(InsightsDropdown);
 
             expect(dropdown.prop('options')).toMatchSnapshot();
         });
@@ -62,7 +63,7 @@ describe('Switcher', () => {
                 )
                 .verifiable(Times.once());
             const wrapper = shallow<Switcher>(<Switcher {...defaultProps} />);
-            const dropdown = wrapper.find(Dropdown);
+            const dropdown = wrapper.find(InsightsDropdown);
 
             expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.fastPass);
 

--- a/src/tests/unit/tests/common/components/__snapshots__/insights-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/insights-dropdown.test.tsx.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InsightsDropdown adds aria-label for selected item with no label 1`] = `
+<Dropdown
+  options={
+    Array [
+      Object {
+        "ariaLabel": "Item 1 selected",
+        "key": "key1",
+        "text": "Item 1",
+      },
+      Object {
+        "ariaLabel": undefined,
+        "key": "key2",
+        "text": "Item 2",
+      },
+    ]
+  }
+  placeHolder="placeholder"
+  selectedKey="key1"
+/>
+`;
+
+exports[`InsightsDropdown modifies aria-label for selected item with a label 1`] = `
+<Dropdown
+  options={
+    Array [
+      Object {
+        "ariaLabel": undefined,
+        "key": "key1",
+        "text": "Item 1",
+      },
+      Object {
+        "ariaLabel": "Existing aria label selected",
+        "key": "key2",
+        "text": "Item 2",
+      },
+    ]
+  }
+  placeHolder="placeholder"
+  selectedKey="key2"
+/>
+`;
+
+exports[`InsightsDropdown renders with no item selected 1`] = `
+<Dropdown
+  options={
+    Array [
+      Object {
+        "ariaLabel": undefined,
+        "key": "key1",
+        "text": "Item 1",
+      },
+      Object {
+        "ariaLabel": undefined,
+        "key": "key2",
+        "text": "Item 2",
+      },
+    ]
+  }
+  placeHolder="placeholder"
+  selectedKey={null}
+/>
+`;

--- a/src/tests/unit/tests/common/components/insights-dropdown.test.tsx
+++ b/src/tests/unit/tests/common/components/insights-dropdown.test.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { IDropdownOption } from '@fluentui/react';
+import { InsightsDropdown, InsightsDropdownProps } from 'common/components/insights-dropdown';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('InsightsDropdown', () => {
+    const options: IDropdownOption[] = [
+        {
+            key: 'key1',
+            text: 'Item 1',
+        },
+        {
+            key: 'key2',
+            text: 'Item 2',
+            ariaLabel: 'Existing aria label',
+        },
+    ];
+
+    it('renders with no item selected', () => {
+        const props: InsightsDropdownProps = {
+            options,
+            selectedKey: null,
+            placeHolder: 'placeholder',
+        };
+        const wrapper = shallow(<InsightsDropdown {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    it('adds aria-label for selected item with no label', () => {
+        const props: InsightsDropdownProps = {
+            options,
+            selectedKey: 'key1',
+            placeHolder: 'placeholder',
+        };
+        const wrapper = shallow(<InsightsDropdown {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    it('modifies aria-label for selected item with a label', () => {
+        const props: InsightsDropdownProps = {
+            options,
+            selectedKey: 'key2',
+            placeHolder: 'placeholder',
+        };
+        const wrapper = shallow(<InsightsDropdown {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/__snapshots__/azure-boards-settings-form.test.tsx.snap
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/__snapshots__/azure-boards-settings-form.test.tsx.snap
@@ -21,10 +21,12 @@ exports[`AzureBoardsSettingsForm renders settings is null 1`] = `
     options={
       Array [
         Object {
+          "ariaLabel": undefined,
           "key": "reproSteps",
           "text": "Repro steps",
         },
         Object {
+          "ariaLabel": undefined,
           "key": "description",
           "text": "Description",
         },
@@ -57,10 +59,12 @@ exports[`AzureBoardsSettingsForm renders with projectUrl and issueDetailsField 1
     options={
       Array [
         Object {
+          "ariaLabel": undefined,
           "key": "reproSteps",
           "text": "Repro steps",
         },
         Object {
+          "ariaLabel": "Description selected",
           "key": "description",
           "text": "Description",
         },

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/__snapshots__/azure-boards-settings-form.test.tsx.snap
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/__snapshots__/azure-boards-settings-form.test.tsx.snap
@@ -15,25 +15,22 @@ exports[`AzureBoardsSettingsForm renders settings is null 1`] = `
   >
     example: https://dev.azure.com/org/project
   </span>
-  <Dropdown
+  <InsightsDropdown
     label="Select a field for issue details"
     onChange={[Function]}
     options={
       Array [
         Object {
-          "ariaLabel": undefined,
           "key": "reproSteps",
           "text": "Repro steps",
         },
         Object {
-          "ariaLabel": undefined,
           "key": "description",
           "text": "Description",
         },
       ]
     }
     placeholder="Select an option"
-    selectedKey={null}
   />
 </React.Fragment>
 `;
@@ -53,18 +50,16 @@ exports[`AzureBoardsSettingsForm renders with projectUrl and issueDetailsField 1
   >
     example: https://dev.azure.com/org/project
   </span>
-  <Dropdown
+  <InsightsDropdown
     label="Select a field for issue details"
     onChange={[Function]}
     options={
       Array [
         Object {
-          "ariaLabel": undefined,
           "key": "reproSteps",
           "text": "Repro steps",
         },
         Object {
-          "ariaLabel": "Description selected",
           "key": "description",
           "text": "Description",
         },

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-settings-form.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-settings-form.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Dropdown, TextField } from '@fluentui/react';
+import { TextField } from '@fluentui/react';
+import { InsightsDropdown } from 'common/components/insights-dropdown';
 import { SettingsDeps } from 'DetailsView/components/details-view-overlay/settings-panel/settings/settings-props';
 import { shallow } from 'enzyme';
 import { OnPropertyUpdateCallback } from 'issue-filing/components/issue-filing-settings-container';
@@ -85,7 +86,9 @@ describe('AzureBoardsSettingsForm', () => {
 
             const testSubject = shallow(<AzureBoardsSettingsForm {...props} />);
 
-            testSubject.find(Dropdown).simulate('change', null, { key: newIssueDetailsFieldKey });
+            testSubject
+                .find(InsightsDropdown)
+                .simulate('change', null, { key: newIssueDetailsFieldKey });
 
             onPropertyUpdateCallbackMock.verifyAll();
         });


### PR DESCRIPTION
#### Details

Adds an aria-label to the selected item in dropdown lists to indicate that that item is selected. This affects the details view switcher in AI Web and the Azure boards issue filing menu in electron (pictured below).

<img width="257" alt="details view switcher" src="https://user-images.githubusercontent.com/55459788/173164018-66ab9848-b042-4cc0-aa15-12795780ac6b.png">

![select a field for issue details dropdown](https://user-images.githubusercontent.com/55459788/173163992-99de7350-6ce4-45b2-903c-5545e3bfbb40.png)

##### Motivation

The fluentUI Dropdown component does correctly set aria-selected on dropdown items. However, Orca and JAWS do not announce which items in any dropdown or combobox are selected, so a JAWS or Orca user navigating through the dropdown menu cannot tell what item is currently selected, since selection does not follow focus.

##### Context

NVDA announces "not selected" after a non-selected list item, but does not announce "selected" for a selected item. This PR only adds "selected" after the selected item, so the state will not be read twice with NVDA. This does not affect screen reader behavior when the dropdown is closed.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1944170
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
