### PR TITLE
feat(mv3-part-4): improve browser message response type safety

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -176,7 +176,7 @@ if (tabId != null) {
                 actionMessageDispatcher,
                 tab.id,
             );
-            browserAdapter.addListenerOnMessage(storeUpdateMessageHub.handleBrowserMessage);
+            browserAdapter.addListenerOnRuntimeMessage(storeUpdateMessageHub.handleBrowserMessage);
 
             const visualizationStore = new StoreProxy<VisualizationStoreData>(
                 StoreNames[StoreNames.VisualizationStore],

--- a/src/Devtools/dev-tools-status-responder.ts
+++ b/src/Devtools/dev-tools-status-responder.ts
@@ -2,21 +2,23 @@
 // Licensed under the MIT License.
 
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { BrowserMessageHandler } from 'common/browser-adapters/browser-message-distributor';
+import { BrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { Message } from 'common/message';
 import { Messages } from 'common/messages';
-import { DevToolsStatusRequest, DevToolsStatusResponse } from 'common/types/dev-tools-messages';
+import { DevToolsStatusRequest } from 'common/types/dev-tools-messages';
 
 export class DevToolsStatusResponder {
     constructor(private readonly browserAdapter: BrowserAdapter) {}
 
-    public handleBrowserMessage: BrowserMessageHandler = (
-        message: Message,
-    ): void | Promise<DevToolsStatusResponse> => {
+    public handleBrowserMessage = (message: Message): BrowserMessageResponse => {
         if (this.isStatusRequestForTab(message)) {
-            // Must return a promise for the response to send correctly
-            return Promise.resolve({ isActive: true });
+            return {
+                messageHandled: true,
+                response: Promise.resolve({ isActive: true }),
+            };
         }
+
+        return { messageHandled: false };
     };
 
     private isStatusRequestForTab(message: Message): boolean {

--- a/src/Devtools/dev-tools-status-responder.ts
+++ b/src/Devtools/dev-tools-status-responder.ts
@@ -14,7 +14,7 @@ export class DevToolsStatusResponder {
         if (this.isStatusRequestForTab(message)) {
             return {
                 messageHandled: true,
-                response: Promise.resolve({ isActive: true }),
+                result: Promise.resolve({ isActive: true }),
             };
         }
 

--- a/src/background/browser-permissions-tracker.ts
+++ b/src/background/browser-permissions-tracker.ts
@@ -44,9 +44,7 @@ export class BrowserPermissionsTracker {
             };
 
             const response = this.interpreter.interpret(message);
-            if (response.messageHandled) {
-                await response.result;
-            }
+            await response.result;
         }
     };
 }

--- a/src/background/browser-permissions-tracker.ts
+++ b/src/background/browser-permissions-tracker.ts
@@ -44,7 +44,9 @@ export class BrowserPermissionsTracker {
             };
 
             const response = this.interpreter.interpret(message);
-            await response.result;
+            if (response.messageHandled) {
+                await response.result;
+            }
         }
     };
 }

--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -124,6 +124,8 @@ export class ExtensionDetailsViewController implements DetailsViewController {
             payload: null,
             tabId: targetTabId,
         });
-        await response.result;
+        if (response.messageHandled) {
+            await response.result;
+        }
     }
 }

--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -124,8 +124,6 @@ export class ExtensionDetailsViewController implements DetailsViewController {
             payload: null,
             tabId: targetTabId,
         });
-        if (response.messageHandled) {
-            await response.result;
-        }
+        await response.result;
     }
 }

--- a/src/background/post-message-content-handler.ts
+++ b/src/background/post-message-content-handler.ts
@@ -1,72 +1,53 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { BrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { InterpreterMessage } from '../common/message';
 import {
     BackchannelRequestMessage,
-    BackchannelRequestMessageType,
     BackchannelStoreRequestMessage,
     BackchannelRetrieveResponseMessage,
 } from '../common/types/backchannel-message-type';
 import { PostMessageContentRepository } from './post-message-content-repository';
 
-export type BackchannelMessageResponse = {
-    messageHandled: boolean;
-    response?: any;
-};
-
 export class PostMessageContentHandler {
     constructor(private readonly postMessageContentRepository: PostMessageContentRepository) {}
 
-    private storeContentOnMessageReceived = (message: BackchannelRequestMessage): void => {
-        const storeRequestMessage = message as BackchannelStoreRequestMessage;
+    private storeContentOnMessageReceived = (message: BackchannelStoreRequestMessage): void => {
         this.postMessageContentRepository.storeContent(
-            storeRequestMessage.messageId,
-            storeRequestMessage.stringifiedMessageData,
+            message.messageId,
+            message.stringifiedMessageData,
         );
     };
 
-    // It's important that this is NOT an async function. See
-    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/Runtime/onMessage
-    private retrieveContentOnMessageReceived = (
+    private retrieveContentOnMessageReceived = async (
         message: BackchannelRequestMessage,
-    ): Promise<BackchannelRetrieveResponseMessage> | void => {
-        let content: string;
-        try {
-            content = this.postMessageContentRepository.popContent(message.messageId);
-        } catch (error) {
-            return Promise.reject(error);
-        }
-
-        const responseMessage: BackchannelRetrieveResponseMessage = {
+    ): Promise<BackchannelRetrieveResponseMessage> => {
+        const content = this.postMessageContentRepository.popContent(message.messageId);
+        return {
             messageType: 'backchannel_window_message.retrieve_response',
             messageId: message.messageId,
             stringifiedMessageData: content,
         };
-
-        return Promise.resolve(responseMessage);
     };
 
-    // Map enforces that every BackchannelRequestMessageType has a handler
-    private readonly messageHandlers: {
-        [key in BackchannelRequestMessageType]: (
-            message: BackchannelRequestMessage,
-        ) => void | Promise<BackchannelRetrieveResponseMessage>;
-    } = {
-        'backchannel_window_message.retrieve_request': this.retrieveContentOnMessageReceived,
-        'backchannel_window_message.store_request': this.storeContentOnMessageReceived,
-    };
-
-    public handleMessage(message: InterpreterMessage): BackchannelMessageResponse {
-        if (Object.keys(this.messageHandlers).includes(message.messageType)) {
-            return {
-                messageHandled: true,
-                response: this.messageHandlers[message.messageType](
-                    message as BackchannelRequestMessage,
-                ),
-            };
+    public handleBrowserMessage(message: InterpreterMessage): BrowserMessageResponse {
+        switch (message.messageType) {
+            case 'backchannel_window_message.retrieve_request':
+                return {
+                    messageHandled: true,
+                    result: this.retrieveContentOnMessageReceived(
+                        message as BackchannelRequestMessage,
+                    ),
+                };
+            case 'backchannel_window_message.store_request':
+                this.storeContentOnMessageReceived(message as BackchannelStoreRequestMessage);
+                return {
+                    messageHandled: true,
+                    result: Promise.resolve(),
+                };
+            default:
+                return { messageHandled: false };
         }
-
-        return { messageHandled: false };
     }
 }

--- a/src/background/user-configuration-controller.ts
+++ b/src/background/user-configuration-controller.ts
@@ -22,7 +22,9 @@ export class UserConfigurationController {
             tabId: null,
         };
         const response = this.interpreter.interpret(message);
-        await response.result;
+        if (response.messageHandled) {
+            await response.result;
+        }
     }
 
     public async setTelemetryState(enableTelemetry: boolean): Promise<void> {
@@ -35,7 +37,9 @@ export class UserConfigurationController {
             tabId: null,
         };
         const response = this.interpreter.interpret(message);
-        await response.result;
+        if (response.messageHandled) {
+            await response.result;
+        }
     }
 
     public async saveWindowBounds(payload: SaveWindowBoundsPayload): Promise<void> {
@@ -44,6 +48,8 @@ export class UserConfigurationController {
             payload: payload,
         };
         const response = this.interpreter.interpret(message);
-        await response.result;
+        if (response.messageHandled) {
+            await response.result;
+        }
     }
 }

--- a/src/background/user-configuration-controller.ts
+++ b/src/background/user-configuration-controller.ts
@@ -22,9 +22,7 @@ export class UserConfigurationController {
             tabId: null,
         };
         const response = this.interpreter.interpret(message);
-        if (response.messageHandled) {
-            await response.result;
-        }
+        await response.result;
     }
 
     public async setTelemetryState(enableTelemetry: boolean): Promise<void> {
@@ -37,9 +35,7 @@ export class UserConfigurationController {
             tabId: null,
         };
         const response = this.interpreter.interpret(message);
-        if (response.messageHandled) {
-            await response.result;
-        }
+        await response.result;
     }
 
     public async saveWindowBounds(payload: SaveWindowBoundsPayload): Promise<void> {
@@ -48,8 +44,6 @@ export class UserConfigurationController {
             payload: payload,
         };
         const response = this.interpreter.interpret(message);
-        if (response.messageHandled) {
-            await response.result;
-        }
+        await response.result;
     }
 }

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BrowserMessageHandler } from 'common/browser-adapters/browser-message-handler';
 import { DictionaryStringTo } from 'types/common-types';
 import {
     Events,
     ExtensionTypes,
     Notifications,
     Permissions,
-    Runtime,
     Tabs,
     Windows,
 } from 'webextension-polyfill';
@@ -48,9 +48,7 @@ export interface BrowserAdapter {
     getRuntimeLastError(): chrome.runtime.LastError | undefined;
     isAllowedFileSchemeAccess(): Promise<boolean>;
     getManageExtensionUrl(): string;
-    addListenerOnMessage(
-        callback: (message: any, sender: Runtime.MessageSender) => void | Promise<any>,
-    ): void;
+    addListenerOnRuntimeMessage(callback: BrowserMessageHandler): void;
 
     removeListenersOnMessage(): void;
     getManifest(): chrome.runtime.Manifest;

--- a/src/common/browser-adapters/browser-message-distributor.ts
+++ b/src/common/browser-adapters/browser-message-distributor.ts
@@ -1,12 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-
-// Returning a Promise indicates that this handler "handled" the message.
-//
-// BrowserMessageHandlers SHOULD NOT be async functions, since an async function would always
-// indicate that the message is "handled".
-export type BrowserMessageHandler = (message: any) => void | Promise<any>;
+import { Runtime } from 'webextension-polyfill';
+import { BrowserMessageHandler, BrowserMessageResponse } from './browser-message-handler';
 
 export class BrowserMessageDistributor {
     constructor(
@@ -15,15 +11,20 @@ export class BrowserMessageDistributor {
     ) {}
 
     public initialize(): void {
-        this.browserAdapter.addListenerOnMessage(this.distributeMessage);
+        this.browserAdapter.addListenerOnRuntimeMessage(this.distributeMessage);
     }
 
-    private distributeMessage = (message: any): void | Promise<any> => {
+    private distributeMessage: BrowserMessageHandler = (
+        message: any,
+        sender: Runtime.MessageSender,
+    ): BrowserMessageResponse => {
         for (const handler of this.messageHandlers) {
-            const response = handler(message);
-            if (response != null) {
+            const response = handler(message, sender);
+            if (response.messageHandled) {
                 return response;
             }
         }
+
+        return { messageHandled: false };
     };
 }

--- a/src/common/browser-adapters/browser-message-handler.ts
+++ b/src/common/browser-adapters/browser-message-handler.ts
@@ -10,18 +10,15 @@ export type BrowserMessageResponse =
 
 export type HandledBrowserMessageResponse = {
     messageHandled: true;
-    response: Promise<any>;
-};
 
+    // void indicates a legacy "fire-and-forget" response which might include some async work not
+    // tracked by a Promise. To indicate that the all work to handle this response completed
+    // synchronously, use Promise.resolve().
+    result: Promise<any> | void;
+};
 export type UnhandledBrowserMessageResponse = {
     messageHandled: false;
 };
-
-export function isResponseHandled(
-    response: BrowserMessageResponse,
-): response is HandledBrowserMessageResponse {
-    return response.messageHandled;
-}
 
 export type BrowserMessageHandler = (
     message: any,
@@ -41,6 +38,6 @@ export function makeRawBrowserMessageHandler(
     // browser treats as "message handled, no response".
     return (message, sender) => {
         const response = handler(message, sender);
-        return response.messageHandled ? response.response : undefined;
+        return response.messageHandled ? response.result : undefined;
     };
 }

--- a/src/common/browser-adapters/browser-message-handler.ts
+++ b/src/common/browser-adapters/browser-message-handler.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import type { Runtime } from 'webextension-polyfill';
+
+// We wrap all of our individual responses/handlers in this type solely so that typescript can help
+// us avoid a gotcha involving the use of async handler functions (see #5602).
+export type BrowserMessageResponse =
+    | HandledBrowserMessageResponse
+    | UnhandledBrowserMessageResponse;
+
+export type HandledBrowserMessageResponse = {
+    messageHandled: true;
+    response: Promise<any>;
+};
+
+export type UnhandledBrowserMessageResponse = {
+    messageHandled: false;
+};
+
+export function isResponseHandled(
+    response: BrowserMessageResponse,
+): response is HandledBrowserMessageResponse {
+    return response.messageHandled;
+}
+
+export type BrowserMessageHandler = (
+    message: any,
+    sender: Runtime.MessageSender,
+) => BrowserMessageResponse;
+
+export type RawBrowserMessageHandler = (
+    message: any,
+    sender: Runtime.MessageSender,
+) => void | Promise<void>;
+
+export function makeRawBrowserMessageHandler(
+    handler: BrowserMessageHandler,
+): RawBrowserMessageHandler {
+    // The raw handler *MUST NOT* be async. This is because we need to distinguish void responses,
+    // which the browser treats as "message not handled", from Promise<void> responses, which the
+    // browser treats as "message handled, no response".
+    return (message, sender) => {
+        const response = handler(message, sender);
+        return response.messageHandled ? response.response : undefined;
+    };
+}

--- a/src/common/browser-adapters/browser-message-handler.ts
+++ b/src/common/browser-adapters/browser-message-handler.ts
@@ -20,6 +20,10 @@ export type HandledBrowserMessageResponse = {
 };
 export type UnhandledBrowserMessageResponse = {
     messageHandled: false;
+
+    // It would be more accurate to omit this, but including it makes it much more ergonomic for
+    // tests/etc await response.result or expect(response.result)
+    result?: undefined;
 };
 
 export type BrowserMessageHandler = (

--- a/src/common/browser-adapters/browser-message-handler.ts
+++ b/src/common/browser-adapters/browser-message-handler.ts
@@ -11,6 +11,8 @@ export type BrowserMessageResponse =
 export type HandledBrowserMessageResponse = {
     messageHandled: true;
 
+    // This is intentionally non-optional; don't use void unless you really mean it!
+    //
     // void indicates a legacy "fire-and-forget" response which might include some async work not
     // tracked by a Promise. To indicate that the all work to handle this response completed
     // synchronously, use Promise.resolve().

--- a/src/common/browser-adapters/event-response-factory.ts
+++ b/src/common/browser-adapters/event-response-factory.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
+import {
+    BrowserMessageResponse,
+    HandledBrowserMessageResponse,
+} from 'common/browser-adapters/browser-message-handler';
 import { isPromise } from 'common/promises/is-promise';
 import { PromiseFactory } from 'common/promises/promise-factory';
 import { partition } from 'lodash';
@@ -49,7 +52,9 @@ export class EventResponseFactory {
     public mergeBrowserMessageResponses(
         responses: BrowserMessageResponse[],
     ): BrowserMessageResponse {
-        const handledResponses = responses.filter(r => r.messageHandled);
+        const handledResponses = responses.filter(
+            (r): r is HandledBrowserMessageResponse => r.messageHandled,
+        );
         if (handledResponses.length === 0) {
             return { messageHandled: false };
         }

--- a/src/common/browser-adapters/event-response-factory.ts
+++ b/src/common/browser-adapters/event-response-factory.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { InterpreterResponse } from 'common/message';
+import { BrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { isPromise } from 'common/promises/is-promise';
 import { PromiseFactory } from 'common/promises/promise-factory';
 import { partition } from 'lodash';
@@ -46,21 +46,23 @@ export class EventResponseFactory {
         }
     }
 
-    public mergeInterpreterResponses(
-        interpreterResponses: InterpreterResponse[],
-    ): InterpreterResponse {
-        const handledResponses = interpreterResponses.filter(r => r.messageHandled);
+    public mergeBrowserMessageResponses(
+        responses: BrowserMessageResponse[],
+    ): BrowserMessageResponse {
+        const handledResponses = responses.filter(r => r.messageHandled);
         if (handledResponses.length === 0) {
             return { messageHandled: false };
         }
 
         return {
             messageHandled: true,
-            result: this.mergeResponses(handledResponses.map(r => r.result)),
+            result: this.mergeRawBrowserMessageResponses(handledResponses.map(r => r.result)),
         };
     }
 
-    public mergeResponses(responses: (void | Promise<void>)[]): void | Promise<void> {
+    public mergeRawBrowserMessageResponses(
+        responses: (void | Promise<void>)[],
+    ): void | Promise<void> {
         const [asyncResponses, fireAndForgetResponses] = partition(responses, isPromise);
 
         if (asyncResponses.length === 0) {

--- a/src/common/browser-adapters/webextension-browser-adapter.ts
+++ b/src/common/browser-adapters/webextension-browser-adapter.ts
@@ -4,6 +4,10 @@ import {
     ApplicationListener,
     BrowserEventManager,
 } from 'common/browser-adapters/browser-event-manager';
+import {
+    BrowserMessageHandler,
+    makeRawBrowserMessageHandler,
+} from 'common/browser-adapters/browser-message-handler';
 import { DictionaryStringTo } from 'types/common-types';
 import browser, {
     Events,
@@ -220,10 +224,8 @@ export abstract class WebExtensionBrowserAdapter
         chrome.commands.getAll(callback);
     }
 
-    public addListenerOnMessage(
-        callback: (message: any, sender: Runtime.MessageSender) => void | Promise<any>,
-    ): void {
-        this.addListener('RuntimeOnMessage', callback);
+    public addListenerOnRuntimeMessage(callback: BrowserMessageHandler): void {
+        this.addListener('RuntimeOnMessage', makeRawBrowserMessageHandler(callback));
     }
 
     public removeListenersOnMessage(): void {

--- a/src/common/browser-adapters/webextension-browser-adapter.ts
+++ b/src/common/browser-adapters/webextension-browser-adapter.ts
@@ -9,14 +9,7 @@ import {
     makeRawBrowserMessageHandler,
 } from 'common/browser-adapters/browser-message-handler';
 import { DictionaryStringTo } from 'types/common-types';
-import browser, {
-    Events,
-    Notifications,
-    Permissions,
-    Runtime,
-    Tabs,
-    Windows,
-} from 'webextension-polyfill';
+import browser, { Events, Notifications, Permissions, Tabs, Windows } from 'webextension-polyfill';
 
 import { BrowserAdapter } from './browser-adapter';
 import { CommandsAdapter } from './commands-adapter';

--- a/src/common/message.ts
+++ b/src/common/message.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-
-import { UnhandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
-
 // Licensed under the MIT License.
+import { UnhandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 export interface Message {
     messageType: string;
     payload?: any;

--- a/src/common/message.ts
+++ b/src/common/message.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-import { BrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 
+import { UnhandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
+
+// Licensed under the MIT License.
 export interface Message {
     messageType: string;
     payload?: any;
@@ -9,7 +10,20 @@ export interface Message {
 
 export type InterpreterMessage = Message & { tabId?: number };
 
-export type InterpreterResponse = BrowserMessageResponse;
+// InterpreterResponse is intentionally the same shape as BrowserMessageResponse; the only
+// difference is that intepreters don't accept response values, so result can only be a
+// Promise<void> and not a Promise<any>
+export type InterpreterResponse = UnhandledBrowserMessageResponse | HandledInterpreterResponse;
+export type HandledInterpreterResponse = {
+    messageHandled: true;
+
+    // This is intentionally non-optional; don't use void unless you really mean it!
+    //
+    // void indicates a legacy "fire-and-forget" response which might include some async work not
+    // tracked by a Promise. To indicate that the all work to handle this response completed
+    // synchronously, use Promise.resolve().
+    result: Promise<void> | void;
+};
 
 export interface PayloadCallback<Payload> {
     (payload: Payload, tabId?: number): void | Promise<void>;

--- a/src/common/message.ts
+++ b/src/common/message.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
+
 export interface Message {
     messageType: string;
     payload?: any;
@@ -7,10 +9,7 @@ export interface Message {
 
 export type InterpreterMessage = Message & { tabId?: number };
 
-export interface InterpreterResponse {
-    messageHandled: boolean;
-    result?: Promise<void> | void;
-}
+export type InterpreterResponse = BrowserMessageResponse;
 
 export interface PayloadCallback<Payload> {
     (payload: Payload, tabId?: number): void | Promise<void>;

--- a/src/common/store-update-message-hub.ts
+++ b/src/common/store-update-message-hub.ts
@@ -55,6 +55,8 @@ export class StoreUpdateMessageHub {
             listener(message);
             return { messageHandled: true, result: Promise.resolve() };
         }
+
+        return { messageHandled: false };
     };
 
     private isValidMessage(message: StoreUpdateMessage<any>): boolean {

--- a/src/common/store-update-message-hub.ts
+++ b/src/common/store-update-message-hub.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { getStoreStateMessage } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
@@ -7,7 +8,7 @@ import _ from 'lodash';
 import { StoreType } from './types/store-type';
 import { StoreUpdateMessage, storeUpdateMessageType } from './types/store-update-message';
 
-type StoreUpdateMessageListener = (message: StoreUpdateMessage<any>) => void | Promise<void>;
+type StoreUpdateMessageListener = (message: StoreUpdateMessage<any>) => void;
 
 export class StoreUpdateMessageHub {
     private browserMessageHandlerUsed: boolean = false;
@@ -37,21 +38,22 @@ export class StoreUpdateMessageHub {
         this.dispatcher.dispatchType(message);
     }
 
-    public get handleBrowserMessage(): (message: StoreUpdateMessage<any>) => void | Promise<void> {
+    public get handleBrowserMessage(): (message: any) => BrowserMessageResponse {
         this.browserMessageHandlerUsed = true;
         return this.handleBrowserMessageImpl;
     }
 
     private readonly handleBrowserMessageImpl = (
         message: StoreUpdateMessage<any>,
-    ): void | Promise<void> => {
+    ): BrowserMessageResponse => {
         if (!this.isValidMessage(message)) {
-            return;
+            return { messageHandled: false };
         }
 
         const listener = this.registeredUpdateListeners[message.storeId];
         if (listener) {
-            return listener(message);
+            listener(message);
+            return { messageHandled: true, response: Promise.resolve() };
         }
     };
 

--- a/src/common/store-update-message-hub.ts
+++ b/src/common/store-update-message-hub.ts
@@ -53,7 +53,7 @@ export class StoreUpdateMessageHub {
         const listener = this.registeredUpdateListeners[message.storeId];
         if (listener) {
             listener(message);
-            return { messageHandled: true, response: Promise.resolve() };
+            return { messageHandled: true, result: Promise.resolve() };
         }
     };
 

--- a/src/debug-tools/controllers/telemetry-listener.ts
+++ b/src/debug-tools/controllers/telemetry-listener.ts
@@ -34,7 +34,7 @@ export class TelemetryListener {
                 listener(convertToDebugToolTelemetryMessage(browserMessage, this.getDate)),
             );
 
-            return { messageHandled: true, response: Promise.resolve() };
+            return { messageHandled: true, result: Promise.resolve() };
         }
     };
 

--- a/src/debug-tools/controllers/telemetry-listener.ts
+++ b/src/debug-tools/controllers/telemetry-listener.ts
@@ -36,6 +36,8 @@ export class TelemetryListener {
 
             return { messageHandled: true, result: Promise.resolve() };
         }
+
+        return { messageHandled: false };
     };
 
     public addListener(listener: DebugToolsTelemetryMessageListener): void {

--- a/src/debug-tools/controllers/telemetry-listener.ts
+++ b/src/debug-tools/controllers/telemetry-listener.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
+import { BrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { Messages } from 'common/messages';
 
 export type DebugToolsTelemetryMessage = {
@@ -28,13 +28,13 @@ export class TelemetryListener {
 
     constructor(private readonly getDate: GetDate) {}
 
-    public readonly handleBrowserMessage = (browserMessage: any): void | Promise<void> => {
+    public readonly handleBrowserMessage = (browserMessage: any): BrowserMessageResponse => {
         if (browserMessage.messageType === Messages.DebugTools.Telemetry) {
             this.listeners.forEach(listener =>
                 listener(convertToDebugToolTelemetryMessage(browserMessage, this.getDate)),
             );
 
-            return Promise.resolve(); // Indicates that we "handled" the message
+            return { messageHandled: true, response: Promise.resolve() };
         }
     };
 

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -105,7 +105,9 @@ export class MainWindowInitializer extends WindowInitializer {
         asyncInitializationSteps.push(super.initialize(logger));
 
         this.storeUpdateMessageHub = new StoreUpdateMessageHub(this.actionMessageDispatcher);
-        this.browserAdapter.addListenerOnMessage(this.storeUpdateMessageHub.handleBrowserMessage);
+        this.browserAdapter.addListenerOnRuntimeMessage(
+            this.storeUpdateMessageHub.handleBrowserMessage,
+        );
 
         this.visualizationStoreProxy = new StoreProxy<VisualizationStoreData>(
             StoreNames[StoreNames.VisualizationStore],

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -132,7 +132,7 @@ export class PopupInitializer {
         );
 
         const storeUpdateMessageHub = new StoreUpdateMessageHub(actionMessageDispatcher, tab.id);
-        this.browserAdapter.addListenerOnMessage(storeUpdateMessageHub.handleBrowserMessage);
+        this.browserAdapter.addListenerOnRuntimeMessage(storeUpdateMessageHub.handleBrowserMessage);
 
         const visualizationStoreName = StoreNames[StoreNames.VisualizationStore];
         const commandStoreName = StoreNames[StoreNames.CommandStore];

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -72,7 +72,7 @@ export function createSimulatedBrowserAdapter(
     mock.setup(m => m.addListenerOnWindowsFocusChanged(It.is(isFunction))).callback(
         c => (mock.notifyWindowsFocusChanged = c),
     );
-    mock.setup(m => m.addListenerOnMessage(It.is(isFunction))).callback(c =>
+    mock.setup(m => m.addListenerOnRuntimeMessage(It.is(isFunction))).callback(c =>
         messageListeners.push(c),
     );
 

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -142,8 +142,8 @@ export function createSimulatedBrowserAdapter(
             if (response.messageHandled) {
                 return response;
             }
-            return { messageHandled: false };
         }
+        return { messageHandled: false };
     };
 
     return mock as SimulatedBrowserAdapter;

--- a/src/tests/unit/tests/DevTools/dev-tools-status-responder.test.ts
+++ b/src/tests/unit/tests/DevTools/dev-tools-status-responder.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { HandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { Messages } from 'common/messages';
 import { DevToolsStatusResponder } from 'Devtools/dev-tools-status-responder';
 import { IMock, Mock } from 'typemoq';
@@ -32,9 +30,7 @@ describe(DevToolsStatusResponder, () => {
         const response = testSubject.handleBrowserMessage(message);
 
         expect(response.messageHandled).toBe(true);
-        await expect((response as HandledBrowserMessageResponse).result).resolves.toEqual(
-            expectedResponse,
-        );
+        await expect(response.result).resolves.toEqual(expectedResponse);
     });
 
     it('Does not handle status requests for a different tab', () => {

--- a/src/tests/unit/tests/DevTools/dev-tools-status-responder.test.ts
+++ b/src/tests/unit/tests/DevTools/dev-tools-status-responder.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { HandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { Messages } from 'common/messages';
 import { DevToolsStatusResponder } from 'Devtools/dev-tools-status-responder';
 import { IMock, Mock } from 'typemoq';
@@ -28,10 +29,15 @@ describe(DevToolsStatusResponder, () => {
             isActive: true,
         };
 
-        await expect(testSubject.handleBrowserMessage(message)).resolves.toEqual(expectedResponse);
+        const response = testSubject.handleBrowserMessage(message);
+
+        expect(response.messageHandled).toBe(true);
+        await expect((response as HandledBrowserMessageResponse).response).resolves.toEqual(
+            expectedResponse,
+        );
     });
 
-    it('Returns void for status requests for a different tab', () => {
+    it('Does not handle status requests for a different tab', () => {
         const message = {
             messageType: Messages.DevTools.StatusRequest,
             tabId: inspectedTabId + 10,
@@ -39,16 +45,16 @@ describe(DevToolsStatusResponder, () => {
 
         const response = testSubject.handleBrowserMessage(message);
 
-        expect(response).toBeUndefined();
+        expect(response.messageHandled).toBe(false);
     });
 
-    it('Returns void for unknown message types', () => {
+    it('Does not handle unknown message types', () => {
         const message = {
             messageType: 'another message type',
         };
 
         const response = testSubject.handleBrowserMessage(message);
 
-        expect(response).toBeUndefined();
+        expect(response.messageHandled).toBe(false);
     });
 });

--- a/src/tests/unit/tests/DevTools/dev-tools-status-responder.test.ts
+++ b/src/tests/unit/tests/DevTools/dev-tools-status-responder.test.ts
@@ -32,7 +32,7 @@ describe(DevToolsStatusResponder, () => {
         const response = testSubject.handleBrowserMessage(message);
 
         expect(response.messageHandled).toBe(true);
-        await expect((response as HandledBrowserMessageResponse).response).resolves.toEqual(
+        await expect((response as HandledBrowserMessageResponse).result).resolves.toEqual(
             expectedResponse,
         );
     });

--- a/src/tests/unit/tests/background/background-message-distributor.test.ts
+++ b/src/tests/unit/tests/background/background-message-distributor.test.ts
@@ -6,6 +6,10 @@ import { Interpreter } from 'background/interpreter';
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { TabContextManager } from 'background/tab-context-manager';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import {
+    BrowserMessageResponse,
+    HandledBrowserMessageResponse,
+} from 'common/browser-adapters/browser-message-handler';
 import { EventResponseFactory } from 'common/browser-adapters/event-response-factory';
 import { InterpreterMessage, InterpreterResponse, Message } from 'common/message';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -22,7 +26,7 @@ describe(BackgroundMessageDistributor, () => {
 
     let testSubject: BackgroundMessageDistributor;
 
-    let distributeMessageCallback: (message: any, sender?: Sender) => any;
+    let distributeMessageCallback: (message: any, sender?: Sender) => BrowserMessageResponse;
 
     beforeEach(() => {
         mockBrowserAdapter = Mock.ofType<BrowserAdapter>();
@@ -101,7 +105,7 @@ describe(BackgroundMessageDistributor, () => {
 
                 eventResponseFactoryMock
                     .setup(m =>
-                        m.mergeInterpreterResponses([
+                        m.mergeBrowserMessageResponses([
                             globalInterpreterResponse,
                             tabInterpreterResponse,
                         ]),
@@ -113,14 +117,14 @@ describe(BackgroundMessageDistributor, () => {
             it('merges interpreter responses when tabId is embedded in message', () => {
                 const response = distributeMessageCallback(tabBoundMessage);
 
-                expect(response).toBe(mergedResponse.result);
+                expect(response).toBe(mergedResponse);
             });
 
             it('merges interpreter responses when tabId is inferred from sender', () => {
                 const sender = { tab: { id: tabId } };
                 const response = distributeMessageCallback(globalOnlyMessage, sender);
 
-                expect(response).toBe(mergedResponse.result);
+                expect(response).toBe(mergedResponse);
             });
         });
 
@@ -145,7 +149,7 @@ describe(BackgroundMessageDistributor, () => {
             };
 
             eventResponseFactoryMock
-                .setup(m => m.mergeInterpreterResponses(It.isAny()))
+                .setup(m => m.mergeBrowserMessageResponses(It.isAny()))
                 .callback(input => {
                     expect(input).toEqual([globalInterpreterResponse, notHandledResponse]);
                 })
@@ -154,7 +158,7 @@ describe(BackgroundMessageDistributor, () => {
 
             const response = distributeMessageCallback(globalOnlyMessage);
 
-            expect(response).toBe(mergedResponse.result);
+            expect(response).toBe(mergedResponse);
         });
     });
 
@@ -166,35 +170,14 @@ describe(BackgroundMessageDistributor, () => {
             testSubject.initialize();
         });
 
-        it('should return undefined if there is no response object', () => {
-            setupInterpretBackchannelMessage(message as InterpreterMessage);
-
-            const actualResponse = distributeMessageCallback(message);
-
-            expect(actualResponse).toBeUndefined();
-        });
-
-        it('should return received non-promise response wrapped in a promise', async () => {
-            const response = 'response obj';
-            setupInterpretBackchannelMessage(message as InterpreterMessage, response);
-
-            const actualResponse = distributeMessageCallback(message);
-
-            expect(actualResponse).toBeInstanceOf(Promise);
-            expect(await actualResponse).toBe(response);
-        });
-
         it('should return received promise response', async () => {
-            const response = 'response obj';
-            setupInterpretBackchannelMessage(
-                message as InterpreterMessage,
-                Promise.resolve(response),
-            );
+            const backchannelResult = Promise.resolve('from backchannel');
+            setupBackchannelToHandleMessage(message as InterpreterMessage, backchannelResult);
 
-            const actualResponse = distributeMessageCallback(message);
+            const response = distributeMessageCallback(message);
 
-            expect(actualResponse).toBeInstanceOf(Promise);
-            expect(await actualResponse).toBe(response);
+            expect(response.messageHandled).toBe(true);
+            expect((response as HandledBrowserMessageResponse).result).toBe(backchannelResult);
         });
     });
 
@@ -209,9 +192,12 @@ describe(BackgroundMessageDistributor, () => {
 
             testSubject.initialize();
 
-            const result = distributeMessageCallback(message);
+            const response = distributeMessageCallback(message);
 
-            await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
+            expect(response.messageHandled).toBe(true);
+            await expect(
+                (response as HandledBrowserMessageResponse).result,
+            ).rejects.toThrowErrorMatchingInlineSnapshot(
                 `"Unable to interpret message - {\\"payload\\":\\"test-payload\\"}"`,
             );
         });
@@ -229,22 +215,25 @@ describe(BackgroundMessageDistributor, () => {
             .verifiable(Times.atMostOnce());
 
         eventResponseFactoryMock
-            .setup(m => m.mergeInterpreterResponses(It.isAny()))
+            .setup(m => m.mergeBrowserMessageResponses(It.isAny()))
             .returns(() => ({ messageHandled: false }))
             .verifiable(Times.atMostOnce());
     }
 
     function setupBackchannelToIgnoreMessages(): void {
         postMessageContentHandlerMock
-            .setup(o => o.handleMessage(It.isAny()))
+            .setup(o => o.handleBrowserMessage(It.isAny()))
             .returns(() => ({ messageHandled: false }))
             .verifiable(Times.atMostOnce());
     }
 
-    function setupInterpretBackchannelMessage(message: InterpreterMessage, response?: any): void {
+    function setupBackchannelToHandleMessage(
+        message: InterpreterMessage,
+        result: void | Promise<any>,
+    ): void {
         postMessageContentHandlerMock
-            .setup(o => o.handleMessage(It.isObjectWith(message)))
-            .returns(() => ({ messageHandled: true, response }))
+            .setup(o => o.handleBrowserMessage(It.isObjectWith(message)))
+            .returns(() => ({ messageHandled: true, result }))
             .verifiable();
     }
 });

--- a/src/tests/unit/tests/background/background-message-distributor.test.ts
+++ b/src/tests/unit/tests/background/background-message-distributor.test.ts
@@ -6,10 +6,7 @@ import { Interpreter } from 'background/interpreter';
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { TabContextManager } from 'background/tab-context-manager';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import {
-    BrowserMessageResponse,
-    HandledBrowserMessageResponse,
-} from 'common/browser-adapters/browser-message-handler';
+import { BrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { EventResponseFactory } from 'common/browser-adapters/event-response-factory';
 import { InterpreterMessage, InterpreterResponse, Message } from 'common/message';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -177,7 +174,7 @@ describe(BackgroundMessageDistributor, () => {
             const response = distributeMessageCallback(message);
 
             expect(response.messageHandled).toBe(true);
-            expect((response as HandledBrowserMessageResponse).result).toBe(backchannelResult);
+            expect(response.result).toBe(backchannelResult);
         });
     });
 
@@ -195,9 +192,7 @@ describe(BackgroundMessageDistributor, () => {
             const response = distributeMessageCallback(message);
 
             expect(response.messageHandled).toBe(true);
-            await expect(
-                (response as HandledBrowserMessageResponse).result,
-            ).rejects.toThrowErrorMatchingInlineSnapshot(
+            await expect(response.result).rejects.toThrowErrorMatchingInlineSnapshot(
                 `"Unable to interpret message - {\\"payload\\":\\"test-payload\\"}"`,
             );
         });

--- a/src/tests/unit/tests/background/background-message-distributor.test.ts
+++ b/src/tests/unit/tests/background/background-message-distributor.test.ts
@@ -47,7 +47,7 @@ describe(BackgroundMessageDistributor, () => {
         );
 
         mockBrowserAdapter
-            .setup(adapter => adapter.addListenerOnMessage(It.isAny()))
+            .setup(adapter => adapter.addListenerOnRuntimeMessage(It.isAny()))
             .callback(callback => {
                 distributeMessageCallback = callback;
             })

--- a/src/tests/unit/tests/background/browser-permissions-tracker.test.ts
+++ b/src/tests/unit/tests/background/browser-permissions-tracker.test.ts
@@ -29,6 +29,7 @@ describe('BrowserPermissionsTracker', () => {
             .setup(i => i.interpret(It.isAny()))
             .returns(() => ({
                 messageHandled: true,
+                result: undefined,
             }));
 
         testSubject = new BrowserPermissionsTracker(

--- a/src/tests/unit/tests/background/dev-tools-monitor.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-monitor.test.ts
@@ -235,7 +235,7 @@ describe(DevToolsMonitor, () => {
                     messageType: Messages.DevTools.Closed,
                 }),
             )
-            .returns(() => ({ messageHandled: true }))
+            .returns(() => ({ messageHandled: true, result: undefined }))
             .verifiable(times ?? Times.once());
     }
 });

--- a/src/tests/unit/tests/background/extension-details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/extension-details-view-controller.test.ts
@@ -20,7 +20,10 @@ describe('ExtensionDetailsViewController', () => {
 
     beforeEach(() => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
-        interpretMessageForTabMock = Mock.ofInstance(() => ({ messageHandled: true }));
+        interpretMessageForTabMock = Mock.ofInstance(() => ({
+            messageHandled: true,
+            result: undefined,
+        }));
 
         tabIdToDetailsViewMap = {};
         idbInstanceMock.reset();
@@ -76,7 +79,7 @@ describe('ExtensionDetailsViewController', () => {
                             tabId: 3,
                         }),
                     )
-                    .returns(() => ({ messageHandled: true }))
+                    .returns(() => ({ messageHandled: true, result: undefined }))
                     .verifiable(Times.once());
 
                 if (persistData) {
@@ -341,7 +344,7 @@ describe('ExtensionDetailsViewController', () => {
                         messageType: Messages.Visualizations.DetailsView.Close,
                     }),
                 )
-                .returns(() => ({ messageHandled: true }))
+                .returns(() => ({ messageHandled: true, result: undefined }))
                 .verifiable();
 
             setupCreateDetailsView(targetTabId, detailsViewTabId);
@@ -376,7 +379,7 @@ describe('ExtensionDetailsViewController', () => {
 
             interpretMessageForTabMock
                 .setup(i => i(It.isAny(), It.isAny()))
-                .returns(() => ({ messageHandled: true }));
+                .returns(() => ({ messageHandled: true, result: undefined }));
 
             setupCreateDetailsView(targetTabId, detailsViewTabId);
 
@@ -569,7 +572,7 @@ describe('ExtensionDetailsViewController', () => {
                         messageType: Messages.Visualizations.DetailsView.Close,
                     }),
                 )
-                .returns(() => ({ messageHandled: true }))
+                .returns(() => ({ messageHandled: true, result: undefined }))
                 .verifiable();
 
             // call show details once
@@ -596,7 +599,7 @@ describe('ExtensionDetailsViewController', () => {
 
             interpretMessageForTabMock
                 .setup(i => i(It.isAny(), It.isAny()))
-                .returns(() => ({ messageHandled: true }));
+                .returns(() => ({ messageHandled: true, result: undefined }));
 
             setupCreateDetailsView(targetTabId, detailsViewTabId);
 

--- a/src/tests/unit/tests/background/feature-flags-controller.test.ts
+++ b/src/tests/unit/tests/background/feature-flags-controller.test.ts
@@ -81,7 +81,7 @@ describe('FeatureFlagsControllerTest', () => {
 
         interpreterMock
             .setup(i => i.interpret(It.isObjectWith(message)))
-            .returns(() => ({ messageHandled: true }))
+            .returns(() => ({ messageHandled: true, result: undefined }))
             .verifiable();
         featureFlagStoreMock
             .setup(f => f.getState())
@@ -106,7 +106,7 @@ describe('FeatureFlagsControllerTest', () => {
         };
         interpreterMock
             .setup(i => i.interpret(It.isObjectWith(message)))
-            .returns(() => ({ messageHandled: true }))
+            .returns(() => ({ messageHandled: true, result: undefined }))
             .verifiable();
 
         testObject = new FeatureFlagsController(

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -223,7 +223,7 @@ class InjectorControllerValidator {
                     }),
                 ),
             )
-            .returns(() => ({ messageHandled: true }))
+            .returns(() => ({ messageHandled: true, result: undefined }))
             .verifiable(Times.exactly(numTimes));
 
         return this;

--- a/src/tests/unit/tests/background/post-message-content-handler.test.ts
+++ b/src/tests/unit/tests/background/post-message-content-handler.test.ts
@@ -3,7 +3,6 @@
 
 import { PostMessageContentHandler } from 'background/post-message-content-handler';
 import { PostMessageContentRepository } from 'background/post-message-content-repository';
-import { HandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { InterpreterMessage } from 'common/message';
 import {
     BackchannelStoreRequestMessage,
@@ -49,8 +48,7 @@ describe('PostMessageContentHandlerTest', () => {
         const response = testSubject.handleBrowserMessage(storeMessage);
 
         expect(response.messageHandled).toBe(true);
-        const { result } = response as HandledBrowserMessageResponse;
-        await expect(result).resolves.toBeUndefined();
+        await expect(response.result).resolves.toBeUndefined();
 
         mockPostMessageContentRepository.verifyAll();
     });
@@ -64,8 +62,7 @@ describe('PostMessageContentHandlerTest', () => {
         const response = testSubject.handleBrowserMessage(retrieveRequestMessage);
 
         expect(response.messageHandled).toBe(true);
-        const { result } = response as HandledBrowserMessageResponse;
-        await expect(result).resolves.toEqual(retrieveResponseMessage);
+        await expect(response.result).resolves.toEqual(retrieveResponseMessage);
 
         mockPostMessageContentRepository.verifyAll();
     });
@@ -98,8 +95,7 @@ describe('PostMessageContentHandlerTest', () => {
         const response = testSubject.handleBrowserMessage(retrieveRequestMessage);
 
         expect(response.messageHandled).toBe(true);
-        const { result } = response as HandledBrowserMessageResponse;
-        await expect(result).rejects.toThrowError(errorMessage);
+        await expect(response.result).rejects.toThrowError(errorMessage);
 
         mockPostMessageContentRepository.verifyAll();
     });

--- a/src/tests/unit/tests/background/tab-context-manager.test.ts
+++ b/src/tests/unit/tests/background/tab-context-manager.test.ts
@@ -99,7 +99,7 @@ describe(TabContextManager, () => {
             isInterpreted => {
                 const message: Message = { messageType: 'test message' };
                 tabToContextMap[tabId] = tabContextMock.object;
-                const expectedReturnValue = { messageHandled: isInterpreted };
+                const expectedReturnValue = { messageHandled: isInterpreted, result: undefined };
 
                 tabContextMock.setup(t => t.interpreter).returns(() => interpreterMock.object);
                 interpreterMock.setup(i => i.interpret(message)).returns(() => expectedReturnValue);

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -60,7 +60,7 @@ describe('TargetPageController', () => {
         mockTabContextManager = Mock.ofType<TabContextManager>();
         mockTabContextManager
             .setup(m => m.interpretMessageForTab(It.isAny(), It.isAny()))
-            .returns(() => ({ messageHandled: true }));
+            .returns(() => ({ messageHandled: true, result: undefined }));
         idbInstanceMock.reset();
         knownTabIds = {};
     });
@@ -229,7 +229,7 @@ describe('TargetPageController', () => {
                 };
                 mockTabContextManager
                     .setup(m => m.interpretMessageForTab(EXISTING_ACTIVE_TAB_ID, expectedMessage))
-                    .returns(() => ({ messageHandled: true }))
+                    .returns(() => ({ messageHandled: true, result: undefined }))
                     .verifiable();
 
                 await testSubject.initialize();
@@ -529,7 +529,7 @@ describe('TargetPageController', () => {
         }
         mockTabContextManager
             .setup(m => m.interpretMessageForTab(tabId, expectedMessage))
-            .returns(() => ({ messageHandled: true }))
+            .returns(() => ({ messageHandled: true, result: undefined }))
             .verifiable();
     }
 

--- a/src/tests/unit/tests/background/user-configuration-controller.test.ts
+++ b/src/tests/unit/tests/background/user-configuration-controller.test.ts
@@ -16,7 +16,7 @@ describe('UserConfigurationController', () => {
         interpreterMock = Mock.ofType<Interpreter>();
         interpreterMock
             .setup(i => i.interpret(It.isAny()))
-            .returns(() => ({ messageHandled: true }));
+            .returns(() => ({ messageHandled: true, result: undefined }));
 
         testSubject = new UserConfigurationController(interpreterMock.object);
     });

--- a/src/tests/unit/tests/common/browser-adapters/browser-message-distributor.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/browser-message-distributor.test.ts
@@ -16,7 +16,7 @@ describe(BrowserMessageDistributor, () => {
     }
 
     function makeRespondingHandler(response: any): BrowserMessageHandler {
-        return () => ({ messageHandled: true, response });
+        return () => ({ messageHandled: true, result: response });
     }
 
     beforeEach(() => {

--- a/src/tests/unit/tests/common/browser-adapters/browser-message-distributor.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/browser-message-distributor.test.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 import { BrowserMessageDistributor } from 'common/browser-adapters/browser-message-distributor';
-import { BrowserMessageHandler } from 'common/browser-adapters/browser-message-handler';
+import {
+    BrowserMessageHandler,
+    HandledBrowserMessageResponse,
+} from 'common/browser-adapters/browser-message-handler';
 import {
     createSimulatedBrowserAdapter,
     SimulatedBrowserAdapter,
@@ -34,9 +37,11 @@ describe(BrowserMessageDistributor, () => {
         ]);
         testSubject.initialize();
 
-        await expect(mockBrowserAdapter.notifyOnMessage('message')).resolves.toBe(
-            'second handler response',
-        );
+        const response = mockBrowserAdapter.notifyOnMessage('message');
+
+        expect(response.messageHandled).toBe(true);
+        const { result } = response as HandledBrowserMessageResponse;
+        await expect(result).resolves.toBe('second handler response');
     });
 
     it("stops invoking further listeners once one indicates that it's handled the message", () => {
@@ -60,6 +65,7 @@ describe(BrowserMessageDistributor, () => {
         ]);
         testSubject.initialize();
 
-        expect(mockBrowserAdapter.notifyOnMessage('message')).toBeUndefined();
+        const response = mockBrowserAdapter.notifyOnMessage('message');
+        expect(response.messageHandled).toBe(false);
     });
 });

--- a/src/tests/unit/tests/common/browser-adapters/browser-message-distributor.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/browser-message-distributor.test.ts
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {
-    BrowserMessageDistributor,
-    BrowserMessageHandler,
-} from 'common/browser-adapters/browser-message-distributor';
+import { BrowserMessageDistributor } from 'common/browser-adapters/browser-message-distributor';
+import { BrowserMessageHandler } from 'common/browser-adapters/browser-message-handler';
 import {
     createSimulatedBrowserAdapter,
     SimulatedBrowserAdapter,
@@ -14,11 +12,11 @@ describe(BrowserMessageDistributor, () => {
     let mockBrowserAdapter: SimulatedBrowserAdapter;
 
     function makeIgnoringHandler(): BrowserMessageHandler {
-        return () => {};
+        return () => ({ messageHandled: false });
     }
 
     function makeRespondingHandler(response: any): BrowserMessageHandler {
-        return () => response;
+        return () => ({ messageHandled: true, response });
     }
 
     beforeEach(() => {

--- a/src/tests/unit/tests/common/browser-adapters/browser-message-distributor.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/browser-message-distributor.test.ts
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 import { BrowserMessageDistributor } from 'common/browser-adapters/browser-message-distributor';
-import {
-    BrowserMessageHandler,
-    HandledBrowserMessageResponse,
-} from 'common/browser-adapters/browser-message-handler';
+import { BrowserMessageHandler } from 'common/browser-adapters/browser-message-handler';
 import {
     createSimulatedBrowserAdapter,
     SimulatedBrowserAdapter,
@@ -40,8 +37,7 @@ describe(BrowserMessageDistributor, () => {
         const response = mockBrowserAdapter.notifyOnMessage('message');
 
         expect(response.messageHandled).toBe(true);
-        const { result } = response as HandledBrowserMessageResponse;
-        await expect(result).resolves.toBe('second handler response');
+        await expect(response.result).resolves.toBe('second handler response');
     });
 
     it("stops invoking further listeners once one indicates that it's handled the message", () => {

--- a/src/tests/unit/tests/common/browser-adapters/browser-message-handler.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/browser-message-handler.test.ts
@@ -23,7 +23,7 @@ describe(makeRawBrowserMessageHandler, () => {
     it('propagates handled responses as their response value', () => {
         const originalResponsePromise = Promise.resolve();
         const underlyingHandler = jest.fn((_message, _sender) => ({
-            messageHandled: true,
+            messageHandled: true as const,
             result: originalResponsePromise,
         }));
         const testSubject = makeRawBrowserMessageHandler(underlyingHandler);

--- a/src/tests/unit/tests/common/browser-adapters/browser-message-handler.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/browser-message-handler.test.ts
@@ -24,7 +24,7 @@ describe(makeRawBrowserMessageHandler, () => {
         const originalResponsePromise = Promise.resolve();
         const underlyingHandler = jest.fn((_message, _sender) => ({
             messageHandled: true,
-            response: originalResponsePromise,
+            result: originalResponsePromise,
         }));
         const testSubject = makeRawBrowserMessageHandler(underlyingHandler);
 

--- a/src/tests/unit/tests/common/browser-adapters/browser-message-handler.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/browser-message-handler.test.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { makeRawBrowserMessageHandler } from 'common/browser-adapters/browser-message-handler';
+import type { Runtime } from 'webextension-polyfill';
+
+describe(makeRawBrowserMessageHandler, () => {
+    const stubMessage = { messageContent: 'stub' };
+    const stubSender: Runtime.MessageSender = {};
+
+    it('propagates unhandled responses as void', () => {
+        const underlyingHandler = jest.fn((_message, _sender) => ({
+            messageHandled: false as const,
+        }));
+        const testSubject = makeRawBrowserMessageHandler(underlyingHandler);
+
+        const response = testSubject(stubMessage, stubSender);
+
+        expect(underlyingHandler).toHaveBeenCalledTimes(1);
+        expect(underlyingHandler).toHaveBeenCalledWith(stubMessage, stubSender);
+        expect(response).toBeUndefined();
+    });
+
+    it('propagates handled responses as their response value', () => {
+        const originalResponsePromise = Promise.resolve();
+        const underlyingHandler = jest.fn((_message, _sender) => ({
+            messageHandled: true,
+            response: originalResponsePromise,
+        }));
+        const testSubject = makeRawBrowserMessageHandler(underlyingHandler);
+
+        const response = testSubject(stubMessage, stubSender);
+
+        expect(underlyingHandler).toHaveBeenCalledTimes(1);
+        expect(underlyingHandler).toHaveBeenCalledWith(stubMessage, stubSender);
+        expect(response).toBe(originalResponsePromise);
+    });
+});

--- a/src/tests/unit/tests/common/browser-adapters/event-response-factory.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/event-response-factory.test.ts
@@ -71,9 +71,9 @@ describe(EventResponseFactory, () => {
 
         it('delegates to mergeRawBrowserMessageResponses behavior if some responses handle the message', () => {
             const mixedResponses = [
-                { messageHandled: true },
-                { messageHandled: false },
-                { messageHandled: true, result: Promise.resolve() },
+                { messageHandled: true as const, result: undefined },
+                { messageHandled: false as const },
+                { messageHandled: true as const, result: Promise.resolve() },
             ];
             const handledResults = [undefined, mixedResponses[2].result];
 

--- a/src/tests/unit/tests/common/browser-adapters/event-response-factory.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/event-response-factory.test.ts
@@ -77,13 +77,15 @@ describe(EventResponseFactory, () => {
             const handledResults = [undefined, mixedResponses[2].result];
 
             const mergeResponsesResult = Promise.resolve();
-            testSubject.mergeResponses = jest.fn(() => mergeResponsesResult);
+            testSubject.mergeRawBrowserMessageResponses = jest.fn(() => mergeResponsesResult);
 
             const mergeInterpreterResponsesOutput =
                 testSubject.mergeInterpreterResponses(mixedResponses);
 
             expect(mergeInterpreterResponsesOutput.messageHandled).toBe(true);
-            expect(testSubject.mergeResponses).toHaveBeenCalledWith(handledResults);
+            expect(testSubject.mergeRawBrowserMessageResponses).toHaveBeenCalledWith(
+                handledResults,
+            );
             expect(mergeInterpreterResponsesOutput.result).toBe(mergeResponsesResult);
         });
     });
@@ -94,12 +96,14 @@ describe(EventResponseFactory, () => {
         });
 
         it('returns void if all inputs are void', async () => {
-            expect(testSubject.mergeResponses([undefined, undefined, undefined])).toBe(undefined);
+            expect(
+                testSubject.mergeRawBrowserMessageResponses([undefined, undefined, undefined]),
+            ).toBe(undefined);
         });
 
         it('returns input without wrapping for a single async response', async () => {
             const input = Promise.resolve();
-            expect(testSubject.mergeResponses([input])).toBe(input);
+            expect(testSubject.mergeRawBrowserMessageResponses([input])).toBe(input);
         });
 
         it('awaits all input promises concurrently if all inputs are async and successful', async () => {
@@ -109,7 +113,7 @@ describe(EventResponseFactory, () => {
                 timeSimulatingPromiseFactory.delay(undefined, 3),
             ];
 
-            await testSubject.mergeResponses(inputs);
+            await testSubject.mergeRawBrowserMessageResponses(inputs);
 
             expect(timeSimulatingPromiseFactory.elapsedTime).toBe(5);
         });
@@ -122,7 +126,9 @@ describe(EventResponseFactory, () => {
                 timeSimulatingPromiseFactory.delay(undefined, 2),
             ];
 
-            await expect(testSubject.mergeResponses(inputs)).rejects.toThrowError(error);
+            await expect(testSubject.mergeRawBrowserMessageResponses(inputs)).rejects.toThrowError(
+                error,
+            );
             expect(timeSimulatingPromiseFactory.elapsedTime).toBe(2);
         });
 
@@ -136,7 +142,7 @@ describe(EventResponseFactory, () => {
             ];
 
             try {
-                await testSubject.mergeResponses(inputs);
+                await testSubject.mergeRawBrowserMessageResponses(inputs);
                 fail('should have thrown');
             } catch (e) {
                 expect(e).toBeInstanceOf(AggregateError);
@@ -153,7 +159,7 @@ describe(EventResponseFactory, () => {
             ];
             const inputs = [undefined, ...asyncInputs, undefined];
 
-            await testSubject.mergeResponses(inputs);
+            await testSubject.mergeRawBrowserMessageResponses(inputs);
 
             expect(timeSimulatingPromiseFactory.elapsedTime).toBe(30000);
         });

--- a/src/tests/unit/tests/common/browser-adapters/event-response-factory.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/event-response-factory.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { HandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { EventResponseFactory } from 'common/browser-adapters/event-response-factory';
 import { TimeoutError } from 'common/promises/promise-factory';
 import { TimeSimulatingPromiseFactory } from 'tests/unit/common/time-simulating-promise-factory';
@@ -53,13 +54,13 @@ describe(EventResponseFactory, () => {
         );
     });
 
-    describe('mergeInterpreterResponses', () => {
+    describe('mergeBrowserMessageResponses', () => {
         beforeEach(() => {
             testSubject = new EventResponseFactory(timeSimulatingPromiseFactory, true);
         });
 
         it('returns messageHandled false if no interpreter handled the message', () => {
-            const output = testSubject.mergeInterpreterResponses([
+            const output = testSubject.mergeBrowserMessageResponses([
                 { messageHandled: false },
                 { messageHandled: false },
                 { messageHandled: false },
@@ -68,7 +69,7 @@ describe(EventResponseFactory, () => {
             expect(output).toStrictEqual({ messageHandled: false });
         });
 
-        it('delegates to mergeResponses behavior if some interpreters handle the message', () => {
+        it('delegates to mergeRawBrowserMessageResponses behavior if some responses handle the message', () => {
             const mixedResponses = [
                 { messageHandled: true },
                 { messageHandled: false },
@@ -79,18 +80,18 @@ describe(EventResponseFactory, () => {
             const mergeResponsesResult = Promise.resolve();
             testSubject.mergeRawBrowserMessageResponses = jest.fn(() => mergeResponsesResult);
 
-            const mergeInterpreterResponsesOutput =
-                testSubject.mergeInterpreterResponses(mixedResponses);
+            const mergedOutput = testSubject.mergeBrowserMessageResponses(mixedResponses);
 
-            expect(mergeInterpreterResponsesOutput.messageHandled).toBe(true);
+            expect(mergedOutput.messageHandled).toBe(true);
             expect(testSubject.mergeRawBrowserMessageResponses).toHaveBeenCalledWith(
                 handledResults,
             );
-            expect(mergeInterpreterResponsesOutput.result).toBe(mergeResponsesResult);
+            const { result } = mergedOutput as HandledBrowserMessageResponse;
+            expect(result).toBe(mergeResponsesResult);
         });
     });
 
-    describe('mergeResponses', () => {
+    describe('mergeRawBrowserMessageResponses', () => {
         beforeEach(() => {
             testSubject = new EventResponseFactory(timeSimulatingPromiseFactory, true);
         });

--- a/src/tests/unit/tests/common/browser-adapters/event-response-factory.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/event-response-factory.test.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
-import { HandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { EventResponseFactory } from 'common/browser-adapters/event-response-factory';
 import { TimeoutError } from 'common/promises/promise-factory';
 import { TimeSimulatingPromiseFactory } from 'tests/unit/common/time-simulating-promise-factory';
@@ -86,8 +84,7 @@ describe(EventResponseFactory, () => {
             expect(testSubject.mergeRawBrowserMessageResponses).toHaveBeenCalledWith(
                 handledResults,
             );
-            const { result } = mergedOutput as HandledBrowserMessageResponse;
-            expect(result).toBe(mergeResponsesResult);
+            expect(mergedOutput.result).toBe(mergeResponsesResult);
         });
     });
 

--- a/src/tests/unit/tests/common/store-update-message-hub.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-hub.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import { HandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { getStoreStateMessage } from 'common/messages';
@@ -66,7 +65,7 @@ describe(StoreUpdateMessageHub, () => {
         const result = testSubject.handleBrowserMessage(message);
 
         expect(registeredListener).toBeCalledTimes(0);
-        expect(result).toBeUndefined();
+        expect(result).toEqual({ messageHandled: false });
     });
 
     it('sends an initial getStoreState message on registration', () => {
@@ -94,8 +93,8 @@ describe(StoreUpdateMessageHub, () => {
         const response = testSubject.handleBrowserMessage(tabContextMessage);
 
         expect(response.messageHandled).toBe(true);
-        expect((response as HandledBrowserMessageResponse).result).toBe(listenerPromise);
-        await listenerPromise;
+        const { result } = response as HandledBrowserMessageResponse;
+        await expect(result).resolves.toBe(undefined);
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
     });
@@ -104,8 +103,8 @@ describe(StoreUpdateMessageHub, () => {
         const response = testSubject.handleBrowserMessage(globalStoreMessage);
 
         expect(response.messageHandled).toBe(true);
-        expect((response as HandledBrowserMessageResponse).result).toBe(listenerPromise);
-        await listenerPromise;
+        const { result } = response as HandledBrowserMessageResponse;
+        await expect(result).resolves.toBe(undefined);
 
         expect(registeredListener).toBeCalledWith(globalStoreMessage);
     });
@@ -130,8 +129,8 @@ describe(StoreUpdateMessageHub, () => {
         const response = testSubject.handleBrowserMessage(tabContextMessage);
 
         expect(response.messageHandled).toBe(true);
-        expect((response as HandledBrowserMessageResponse).result).toBe(listenerPromise);
-        await listenerPromise;
+        const { result } = response as HandledBrowserMessageResponse;
+        await expect(result).resolves.toBe(undefined);
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
     });

--- a/src/tests/unit/tests/common/store-update-message-hub.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-hub.test.ts
@@ -94,7 +94,7 @@ describe(StoreUpdateMessageHub, () => {
         const response = testSubject.handleBrowserMessage(tabContextMessage);
 
         expect(response.messageHandled).toBe(true);
-        expect((response as HandledBrowserMessageResponse).response).toBe(listenerPromise);
+        expect((response as HandledBrowserMessageResponse).result).toBe(listenerPromise);
         await listenerPromise;
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
@@ -104,7 +104,7 @@ describe(StoreUpdateMessageHub, () => {
         const response = testSubject.handleBrowserMessage(globalStoreMessage);
 
         expect(response.messageHandled).toBe(true);
-        expect((response as HandledBrowserMessageResponse).response).toBe(listenerPromise);
+        expect((response as HandledBrowserMessageResponse).result).toBe(listenerPromise);
         await listenerPromise;
 
         expect(registeredListener).toBeCalledWith(globalStoreMessage);
@@ -130,7 +130,7 @@ describe(StoreUpdateMessageHub, () => {
         const response = testSubject.handleBrowserMessage(tabContextMessage);
 
         expect(response.messageHandled).toBe(true);
-        expect((response as HandledBrowserMessageResponse).response).toBe(listenerPromise);
+        expect((response as HandledBrowserMessageResponse).result).toBe(listenerPromise);
         await listenerPromise;
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
@@ -155,11 +155,11 @@ describe(StoreUpdateMessageHub, () => {
         expect(response1.messageHandled).toBe(true);
         expect(response2.messageHandled).toBe(true);
 
-        expect((response1 as HandledBrowserMessageResponse).response).toBeInstanceOf(Promise);
-        expect((response2 as HandledBrowserMessageResponse).response).toBeInstanceOf(Promise);
+        expect((response1 as HandledBrowserMessageResponse).result).toBeInstanceOf(Promise);
+        expect((response2 as HandledBrowserMessageResponse).result).toBeInstanceOf(Promise);
 
-        await (response1 as HandledBrowserMessageResponse).response;
-        await (response2 as HandledBrowserMessageResponse).response;
+        await (response1 as HandledBrowserMessageResponse).result;
+        await (response2 as HandledBrowserMessageResponse).result;
 
         expect(registeredListener).toBeCalledWith(messageForStore);
         expect(anotherListener).toBeCalledWith(messageForAnotherStore);

--- a/src/tests/unit/tests/common/store-update-message-hub.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-hub.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { HandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { getStoreStateMessage } from 'common/messages';
 import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
@@ -93,8 +92,7 @@ describe(StoreUpdateMessageHub, () => {
         const response = testSubject.handleBrowserMessage(tabContextMessage);
 
         expect(response.messageHandled).toBe(true);
-        const { result } = response as HandledBrowserMessageResponse;
-        await expect(result).resolves.toBe(undefined);
+        await expect(response.result).resolves.toBe(undefined);
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
     });
@@ -103,8 +101,7 @@ describe(StoreUpdateMessageHub, () => {
         const response = testSubject.handleBrowserMessage(globalStoreMessage);
 
         expect(response.messageHandled).toBe(true);
-        const { result } = response as HandledBrowserMessageResponse;
-        await expect(result).resolves.toBe(undefined);
+        await expect(response.result).resolves.toBe(undefined);
 
         expect(registeredListener).toBeCalledWith(globalStoreMessage);
     });
@@ -129,8 +126,7 @@ describe(StoreUpdateMessageHub, () => {
         const response = testSubject.handleBrowserMessage(tabContextMessage);
 
         expect(response.messageHandled).toBe(true);
-        const { result } = response as HandledBrowserMessageResponse;
-        await expect(result).resolves.toBe(undefined);
+        await expect(response.result).resolves.toBe(undefined);
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
     });
@@ -154,11 +150,8 @@ describe(StoreUpdateMessageHub, () => {
         expect(response1.messageHandled).toBe(true);
         expect(response2.messageHandled).toBe(true);
 
-        expect((response1 as HandledBrowserMessageResponse).result).toBeInstanceOf(Promise);
-        expect((response2 as HandledBrowserMessageResponse).result).toBeInstanceOf(Promise);
-
-        await (response1 as HandledBrowserMessageResponse).result;
-        await (response2 as HandledBrowserMessageResponse).result;
+        await expect(response1.result).resolves.toBe(undefined);
+        await expect(response2.result).resolves.toBe(undefined);
 
         expect(registeredListener).toBeCalledWith(messageForStore);
         expect(anotherListener).toBeCalledWith(messageForAnotherStore);

--- a/src/tests/unit/tests/common/store-update-message-hub.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-hub.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { HandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { getStoreStateMessage } from 'common/messages';
 import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
@@ -86,23 +87,25 @@ describe(StoreUpdateMessageHub, () => {
         const result = testSubject.handleBrowserMessage(message);
 
         expect(registeredListener).toBeCalledTimes(0);
-        expect(result).toBeUndefined();
+        expect(result).toEqual({ messageHandled: false });
     });
 
     it('Calls registered listener for tab context store message', async () => {
-        const resultPromise = testSubject.handleBrowserMessage(tabContextMessage);
+        const response = testSubject.handleBrowserMessage(tabContextMessage);
 
-        expect(resultPromise).toBe(listenerPromise);
-        await resultPromise;
+        expect(response.messageHandled).toBe(true);
+        expect((response as HandledBrowserMessageResponse).response).toBe(listenerPromise);
+        await listenerPromise;
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
     });
 
     it('Calls registered listener for global store message', async () => {
-        const resultPromise = testSubject.handleBrowserMessage(globalStoreMessage);
+        const response = testSubject.handleBrowserMessage(globalStoreMessage);
 
-        expect(resultPromise).toBe(listenerPromise);
-        await resultPromise;
+        expect(response.messageHandled).toBe(true);
+        expect((response as HandledBrowserMessageResponse).response).toBe(listenerPromise);
+        await listenerPromise;
 
         expect(registeredListener).toBeCalledWith(globalStoreMessage);
     });
@@ -124,10 +127,11 @@ describe(StoreUpdateMessageHub, () => {
         testSubject.handleBrowserMessage;
         testSubject.registerStoreUpdateListener(storeId, registeredListener);
 
-        const resultPromise = testSubject.handleBrowserMessage(tabContextMessage);
+        const response = testSubject.handleBrowserMessage(tabContextMessage);
 
-        expect(resultPromise).toBe(listenerPromise);
-        await resultPromise;
+        expect(response.messageHandled).toBe(true);
+        expect((response as HandledBrowserMessageResponse).response).toBe(listenerPromise);
+        await listenerPromise;
 
         expect(registeredListener).toBeCalledWith(tabContextMessage);
     });
@@ -145,14 +149,17 @@ describe(StoreUpdateMessageHub, () => {
 
         testSubject.registerStoreUpdateListener(anotherStoreId, anotherListener);
 
-        const resultPromise1 = testSubject.handleBrowserMessage(messageForStore);
-        const resultPromise2 = testSubject.handleBrowserMessage(messageForAnotherStore);
+        const response1 = testSubject.handleBrowserMessage(messageForStore);
+        const response2 = testSubject.handleBrowserMessage(messageForAnotherStore);
 
-        expect(resultPromise1).toBeInstanceOf(Promise);
-        expect(resultPromise2).toBeInstanceOf(Promise);
+        expect(response1.messageHandled).toBe(true);
+        expect(response2.messageHandled).toBe(true);
 
-        await resultPromise1;
-        await resultPromise2;
+        expect((response1 as HandledBrowserMessageResponse).response).toBeInstanceOf(Promise);
+        expect((response2 as HandledBrowserMessageResponse).response).toBeInstanceOf(Promise);
+
+        await (response1 as HandledBrowserMessageResponse).response;
+        await (response2 as HandledBrowserMessageResponse).response;
 
         expect(registeredListener).toBeCalledWith(messageForStore);
         expect(anotherListener).toBeCalledWith(messageForAnotherStore);

--- a/src/tests/unit/tests/debug-tools/controllers/telemetry-listener.test.ts
+++ b/src/tests/unit/tests/debug-tools/controllers/telemetry-listener.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { HandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { Messages } from 'common/messages';
 import {
     DebugToolsTelemetryMessage,
@@ -58,7 +57,7 @@ describe('TelemetryListener', () => {
 
         const response = testSubject.handleBrowserMessage(legitimateInputMessage);
         expect(response.messageHandled).toBe(true);
-        await expect((response as HandledBrowserMessageResponse).result).resolves.toBe(undefined);
+        await expect(response.result).resolves.toBe(undefined);
 
         const expectedMessage = {
             name,
@@ -97,7 +96,7 @@ describe('TelemetryListener', () => {
 
         const response = testSubject.handleBrowserMessage(legitimateInputMessage);
         expect(response.messageHandled).toBe(true);
-        await expect((response as HandledBrowserMessageResponse).result).resolves.toBe(undefined);
+        await expect(response.result).resolves.toBe(undefined);
 
         externalListenerMock.verify(listener => listener(It.isAny()), Times.never());
     });

--- a/src/tests/unit/tests/debug-tools/controllers/telemetry-listener.test.ts
+++ b/src/tests/unit/tests/debug-tools/controllers/telemetry-listener.test.ts
@@ -58,7 +58,7 @@ describe('TelemetryListener', () => {
 
         const response = testSubject.handleBrowserMessage(legitimateInputMessage);
         expect(response.messageHandled).toBe(true);
-        await expect((response as HandledBrowserMessageResponse).response).resolves.toBe(undefined);
+        await expect((response as HandledBrowserMessageResponse).result).resolves.toBe(undefined);
 
         const expectedMessage = {
             name,
@@ -97,7 +97,7 @@ describe('TelemetryListener', () => {
 
         const response = testSubject.handleBrowserMessage(legitimateInputMessage);
         expect(response.messageHandled).toBe(true);
-        await expect((response as HandledBrowserMessageResponse).response).resolves.toBe(undefined);
+        await expect((response as HandledBrowserMessageResponse).result).resolves.toBe(undefined);
 
         externalListenerMock.verify(listener => listener(It.isAny()), Times.never());
     });

--- a/src/tests/unit/tests/debug-tools/controllers/telemetry-listener.test.ts
+++ b/src/tests/unit/tests/debug-tools/controllers/telemetry-listener.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { HandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 import { Messages } from 'common/messages';
 import {
     DebugToolsTelemetryMessage,
@@ -55,9 +56,9 @@ describe('TelemetryListener', () => {
         const externalListenerMock = Mock.ofType<DebugToolsTelemetryMessageListener>();
         testSubject.addListener(externalListenerMock.object);
 
-        await expect(testSubject.handleBrowserMessage(legitimateInputMessage)).resolves.toBe(
-            undefined,
-        );
+        const response = testSubject.handleBrowserMessage(legitimateInputMessage);
+        expect(response.messageHandled).toBe(true);
+        await expect((response as HandledBrowserMessageResponse).response).resolves.toBe(undefined);
 
         const expectedMessage = {
             name,
@@ -82,7 +83,8 @@ describe('TelemetryListener', () => {
             timestamp: 0,
         };
 
-        expect(testSubject.handleBrowserMessage(nonTelemetryMessage)).toBeUndefined();
+        const response = testSubject.handleBrowserMessage(nonTelemetryMessage);
+        expect(response.messageHandled).toBe(false);
 
         externalListenerMock.verify(listener => listener(It.isAny()), Times.never());
     });
@@ -93,9 +95,9 @@ describe('TelemetryListener', () => {
         testSubject.addListener(externalListenerMock.object);
         testSubject.removeListener(externalListenerMock.object);
 
-        await expect(testSubject.handleBrowserMessage(legitimateInputMessage)).resolves.toBe(
-            undefined,
-        );
+        const response = testSubject.handleBrowserMessage(legitimateInputMessage);
+        expect(response.messageHandled).toBe(true);
+        await expect((response as HandledBrowserMessageResponse).response).resolves.toBe(undefined);
 
         externalListenerMock.verify(listener => listener(It.isAny()), Times.never());
     });

--- a/src/views/insights/initializer.ts
+++ b/src/views/insights/initializer.ts
@@ -57,7 +57,7 @@ const contentActionMessageCreator = new ContentActionMessageCreator(
 );
 
 const storeUpdateMessageHub = new StoreUpdateMessageHub(actionMessageDispatcher);
-browserAdapter.addListenerOnMessage(storeUpdateMessageHub.handleBrowserMessage);
+browserAdapter.addListenerOnRuntimeMessage(storeUpdateMessageHub.handleBrowserMessage);
 
 const userConfigurationStore = new StoreProxy<UserConfigurationStoreData>(
     StoreNames[StoreNames.UserConfigurationStore],


### PR DESCRIPTION
#### Details

This PR extends/replaces #5612. It introduces new wrapper types for Browser message handlers/responses (see `browser-message-handler.ts`) which enable catching the type of issue we encountered in #5602 as a type check failure, and it updates all of our Browser message listeners and adapters to use it. It also updates the existing similar response types used in `PostMessageContentHandler` and `Interpreter` to be consistent with the browser message handler types.

Reviewers should give extra attention to the `PostMessageContentHandler` changes, I modified how it worked more substantially/functionally than related code.

Manually smoke tested all pages of the web extension with the changes.

##### Motivation

Prevent the underlying class of issue we fixed one instance of in #5602

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
