### PR TITLE
chore: fix error spew in card-kebab-menu-button unit tests

### DIFF
--- a/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
@@ -26,6 +26,7 @@ import { mount, ReactWrapper, shallow, ShallowWrapper } from 'enzyme';
 import { IssueFilingServiceProvider } from 'issue-filing/issue-filing-service-provider';
 import { IssueFilingService } from 'issue-filing/types/issue-filing-service';
 import * as React from 'react';
+import { act } from 'react-dom/test-utils';
 import { IMock, Mock, Times } from 'typemoq';
 
 describe('CardKebabMenuButtonTest', () => {
@@ -219,11 +220,7 @@ describe('CardKebabMenuButtonTest', () => {
 
         const rendered = mount(<CardKebabMenuButton {...defaultProps} />);
 
-        rendered.find(ActionButton).simulate('click', event);
-
         const copyFailureDetailsMenuItem = getMenuItemWithKey(rendered, 'copyfailuredetails');
-
-        // tslint:disable-next-line: await-promise
         await copyFailureDetailsMenuItem.onClick(event);
 
         const toast = rendered.find(Toast);
@@ -253,10 +250,7 @@ describe('CardKebabMenuButtonTest', () => {
 
         const rendered = mount(<CardKebabMenuButton {...defaultProps} />);
 
-        rendered.find(ActionButton).simulate('click', event);
-
         const copyFailureDetailsMenuItem = getMenuItemWithKey(rendered, 'copyfailuredetails');
-        // tslint:disable-next-line: await-promise
         await copyFailureDetailsMenuItem.onClick(event);
 
         const toast = rendered.find(Toast);

--- a/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
@@ -26,7 +26,6 @@ import { mount, ReactWrapper, shallow, ShallowWrapper } from 'enzyme';
 import { IssueFilingServiceProvider } from 'issue-filing/issue-filing-service-provider';
 import { IssueFilingService } from 'issue-filing/types/issue-filing-service';
 import * as React from 'react';
-import { act } from 'react-dom/test-utils';
 import { IMock, Mock, Times } from 'typemoq';
 
 describe('CardKebabMenuButtonTest', () => {


### PR DESCRIPTION
#### Details

This PR resolves an issue where running `yarn test -- -- card-kebab-menu-button` passes but emits 2 copies of the following error spew:

```
  console.error
    Warning: An update to ForwardRef inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in ForwardRef
        in ForwardRef (created by StyledCalloutContentBase)
        in StyledCalloutContentBase (created by Callout)
        in div (created by FabricBase)
        in FabricBase (created by StyledFabricBase)
        in StyledFabricBase (created by LayerBase)
        in span (created by LayerBase)
        in LayerBase (created by StyledLayerBase)
        in StyledLayerBase (created by Callout)
        in Callout (created by Context.Consumer)
        in ForwardRef
        in ForwardRef (created by ContextualMenu)
        in ContextualMenu (created by BaseButton)
        in span (created by BaseButton)
        in button (created by BaseButton)
        in BaseButton (created by ActionButton)
        in ActionButton (created by Context.Consumer)
        in CustomizedActionButton (created by CardKebabMenuButton)
        in div (created by CardKebabMenuButton)
        in CardKebabMenuButton (created by WrapperComponent)
        in WrapperComponent

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:88:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:60:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-dom/cjs/react-dom.development.js:23284:7)
      at dispatchAction (node_modules/react-dom/cjs/react-dom.development.js:15656:9)
      at node_modules/@fluentui/react/lib-commonjs/components/src/components/Callout/CalloutContent.base.tsx:196:13
      at animationFrameCallback (node_modules/@fluentui/utilities/src/Async.ts:450:20)
      at invokeTheCallbackFunction (node_modules/jsdom/lib/jsdom/living/generated/Function.js:19:26)
```

The reason this happens is that two of its test cases use full enzyme `mount()`s instead of `shallow` ones to render a Fluent UI component that involves animations, and the test doesn't wait for the animations to complete.

I considered updating the tests to wait for the animations, but felt that that was getting too far into unit testing implementation details of the Fluent UI component, so I instead just omitted the interaction with Fluent UI that causes the animation (opening the context menu) - the tests in question don't actually rely on that interaction since they only open the menu to immediately click on one of the items, and they do that by reaching into props for onClick handlers that exist regardless of whether the menu is open.

##### Motivation

Fix error spew in unit tests

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
