### PR TITLE
fix: use maxWorkers=2 for GitHub Action CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
     - run: yarn install --frozen-lockfile --prefer-offline
       timeout-minutes: 10
 
+    # We set maxWorkers to 2 since GH Action VMs have 2 cores and by default Jest only uses 1.
+    # If this were to change in the future, the number here should change accordingly.
     - run: yarn test --maxWorkers=2 --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
       timeout-minutes: 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
 
     - name: yarn test:e2e
       run: |
-        xvfb-run --server-args="-screen 0 1024x768x24" yarn test:e2e --maxWorkers=2 --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
+        xvfb-run --server-args="-screen 0 1024x768x24" yarn test:e2e --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
       env:
         # If you need to debug Playwright/Chromium, using pw:* instead may help
         DEBUG: pw:api
@@ -298,7 +298,7 @@ jobs:
 
     - name: yarn test:unified
       run: |
-        yarn test:unified --maxWorkers=2 --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
+        yarn test:unified --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
       timeout-minutes: 15
 
     - name: upload artifact e2e-unified-tests-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     - run: yarn install --frozen-lockfile --prefer-offline
       timeout-minutes: 10
 
-    - run: yarn test --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
+    - run: yarn test --maxWorkers=2 --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
       timeout-minutes: 10
 
     - name: upload artifact unit-tests-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
 
     - name: yarn test:e2e
       run: |
-        xvfb-run --server-args="-screen 0 1024x768x24" yarn test:e2e --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
+        xvfb-run --server-args="-screen 0 1024x768x24" yarn test:e2e --maxWorkers=2 --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
       env:
         # If you need to debug Playwright/Chromium, using pw:* instead may help
         DEBUG: pw:api
@@ -298,7 +298,7 @@ jobs:
 
     - name: yarn test:unified
       run: |
-        yarn test:unified --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
+        yarn test:unified --maxWorkers=2 --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
       timeout-minutes: 15
 
     - name: upload artifact e2e-unified-tests-results

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "start:unified": "electron drop/electron/unified-dev/product/bundle/main.bundle.js",
         "start:unified:dev": "cross-env DEV_MODE=true yarnpkg start:unified",
         "start:unified:mock-adb": "cross-env ANDROID_HOME=drop/mock-adb yarnpkg start:unified",
-        "test": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest --projects src/tests/unit --no-cache --maxWorkers=50%",
+        "test": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest --projects src/tests/unit --maxWorkers=50%",
         "publish-code-coverage": "npx codecov",
         "test:e2e": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest --projects src/tests/end-to-end --runInBand --forceExit --detectOpenHandles",
         "test:e2e:docker:build": "docker build -t accessibility-insights-e2e  --target web .",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "start:unified": "electron drop/electron/unified-dev/product/bundle/main.bundle.js",
         "start:unified:dev": "cross-env DEV_MODE=true yarnpkg start:unified",
         "start:unified:mock-adb": "cross-env ANDROID_HOME=drop/mock-adb yarnpkg start:unified",
-        "test": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest --projects src/tests/unit --maxWorkers=50%",
+        "test": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest --projects src/tests/unit",
         "publish-code-coverage": "npx codecov",
         "test:e2e": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest --projects src/tests/end-to-end --runInBand --forceExit --detectOpenHandles",
         "test:e2e:docker:build": "docker build -t accessibility-insights-e2e  --target web .",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "start:unified": "electron drop/electron/unified-dev/product/bundle/main.bundle.js",
         "start:unified:dev": "cross-env DEV_MODE=true yarnpkg start:unified",
         "start:unified:mock-adb": "cross-env ANDROID_HOME=drop/mock-adb yarnpkg start:unified",
-        "test": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest --projects src/tests/unit",
+        "test": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest --projects src/tests/unit --no-cache --maxWorkers=50%",
         "publish-code-coverage": "npx codecov",
         "test:e2e": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest --projects src/tests/end-to-end --runInBand --forceExit --detectOpenHandles",
         "test:e2e:docker:build": "docker build -t accessibility-insights-e2e  --target web .",


### PR DESCRIPTION
#### Details

Specifies maxWorkers to 2 for our CI build in GH action.

##### Motivation

Speeds up CI builds.

##### Context

I came upon this post: https://bharathvaj.me/blog/speedup-jest-github-actions.

TLDR: Linux VMs on GH Action have two cores (link to GH docs [here](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)) but jest defaults to only using one. This specifies using both. Our unit-tests were previously the slowest portion of our CI builds in GH action and this makes them see about a 40%-50% decrease in runtime. More importantly, this makes the e2e/unified tests our longest-running tasks (saving roughly 2-3 minutes per PR build, about a 25% decrease, based off looking at the last 10-15 successful builds without this change).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
