### PR TITLE
chore: Enable and fix `declaration-property-value-allowed-list` stylelint rule for `font-weight`

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -11,6 +11,9 @@ module.exports = {
         'scss/comment-no-empty': null, // Disabled to allow for paragraph breaks in longer comments which is not supported yet: https://github.com/stylelint-scss/stylelint-scss/issues/606
         'selector-class-pattern':
             '^(ms-([A-Z][a-z0-9]*)(-[a-z0-9]+)*)|(([a-z][a-z0-9]*)(-[a-z0-9]+)*)$', // Allows: kebab case and ms-Kebab-case
+        'declaration-property-value-allowed-list': {
+            'font-weight': ['unset', '100', '300', 'normal', '600', 'bold'],
+        },
 
         // TO BE ENABLED: Recommended fixes
         'no-descending-specificity': null,
@@ -18,9 +21,6 @@ module.exports = {
         // TO BE CONFIGURED: Limit shorthand for margin, padding
         // Stretch goal: border-width, border-radius, border-color, border-style, grid-gap
         // Example: 'declaration-property-max-values': { padding: 1 },
-
-        // TO BE CONFIGURED: Enforce variable values
-        // Example: 'declaration-property-value-allowed-list': { 'font-weight': ['/^\\$.*$/']},
 
         // Requires investigation
         'property-no-vendor-prefix': null,

--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -458,7 +458,7 @@
         font-size: 11px;
         border-radius: 0 8px 8px 0;
         padding: 0 6px 0 10px;
-        font-weight: 700;
+        font-weight: bold;
         margin-left: -8px;
         height: 13px;
       }
@@ -1038,7 +1038,7 @@
         padding-bottom: 0;
       }
       .issue-filing-dialog--F9jun .ms-Dialog-subText {
-        font-weight: 400;
+        font-weight: normal;
         font-size: 15px;
         color: var(--secondary-text);
       }

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -458,7 +458,7 @@
         font-size: 11px;
         border-radius: 0 8px 8px 0;
         padding: 0 6px 0 10px;
-        font-weight: 700;
+        font-weight: bold;
         margin-left: -8px;
         height: 13px;
       }
@@ -1038,7 +1038,7 @@
         padding-bottom: 0;
       }
       .issue-filing-dialog--F9jun .ms-Dialog-subText {
-        font-weight: 400;
+        font-weight: normal;
         font-size: 15px;
         color: var(--secondary-text);
       }

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -458,7 +458,7 @@
         font-size: 11px;
         border-radius: 0 8px 8px 0;
         padding: 0 6px 0 10px;
-        font-weight: 700;
+        font-weight: bold;
         margin-left: -8px;
         height: 13px;
       }
@@ -1038,7 +1038,7 @@
         padding-bottom: 0;
       }
       .issue-filing-dialog--F9jun .ms-Dialog-subText {
-        font-weight: 400;
+        font-weight: normal;
         font-size: 15px;
         color: var(--secondary-text);
       }

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -458,7 +458,7 @@
         font-size: 11px;
         border-radius: 0 8px 8px 0;
         padding: 0 6px 0 10px;
-        font-weight: 700;
+        font-weight: bold;
         margin-left: -8px;
         height: 13px;
       }
@@ -1038,7 +1038,7 @@
         padding-bottom: 0;
       }
       .issue-filing-dialog--F9jun .ms-Dialog-subText {
-        font-weight: 400;
+        font-weight: normal;
         font-size: 15px;
         color: var(--secondary-text);
       }

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -458,7 +458,7 @@
         font-size: 11px;
         border-radius: 0 8px 8px 0;
         padding: 0 6px 0 10px;
-        font-weight: 700;
+        font-weight: bold;
         margin-left: -8px;
         height: 13px;
       }
@@ -1038,7 +1038,7 @@
         padding-bottom: 0;
       }
       .issue-filing-dialog--F9jun .ms-Dialog-subText {
-        font-weight: 400;
+        font-weight: normal;
         font-size: 15px;
         color: var(--secondary-text);
       }

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -458,7 +458,7 @@
         font-size: 11px;
         border-radius: 0 8px 8px 0;
         padding: 0 6px 0 10px;
-        font-weight: 700;
+        font-weight: bold;
         margin-left: -8px;
         height: 13px;
       }
@@ -1038,7 +1038,7 @@
         padding-bottom: 0;
       }
       .issue-filing-dialog--F9jun .ms-Dialog-subText {
-        font-weight: 400;
+        font-weight: normal;
         font-size: 15px;
         color: var(--secondary-text);
       }

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -458,7 +458,7 @@
         font-size: 11px;
         border-radius: 0 8px 8px 0;
         padding: 0 6px 0 10px;
-        font-weight: 700;
+        font-weight: bold;
         margin-left: -8px;
         height: 13px;
       }
@@ -1038,7 +1038,7 @@
         padding-bottom: 0;
       }
       .issue-filing-dialog--F9jun .ms-Dialog-subText {
-        font-weight: 400;
+        font-weight: normal;
         font-size: 15px;
         color: var(--secondary-text);
       }

--- a/src/DetailsView/components/change-assessment-dialog.scss
+++ b/src/DetailsView/components/change-assessment-dialog.scss
@@ -14,7 +14,7 @@
     box-shadow: 0 0 10px 0 $neutral-alpha-60;
 
     :global(.ms-Dialog-title) {
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
     }
 
     .change-assessment-dialog-button-container {

--- a/src/DetailsView/components/issue-filing-dialog.scss
+++ b/src/DetailsView/components/issue-filing-dialog.scss
@@ -13,7 +13,7 @@
         }
 
         .ms-Dialog-subText {
-            font-weight: 400;
+            font-weight: normal;
             font-size: 15px;
             color: $secondary-text;
         }

--- a/src/DetailsView/components/requirement-instructions.scss
+++ b/src/DetailsView/components/requirement-instructions.scss
@@ -4,7 +4,7 @@
 
 .requirement-instructions-header {
     font-style: normal;
-    font-weight: $font-weight-semi-bold;
+    font-weight: 600;
     font-size: $font-size-ml;
     line-height: 20px;
     padding-left: 0.5vw;

--- a/src/DetailsView/details-view-body.scss
+++ b/src/DetailsView/details-view-body.scss
@@ -67,7 +67,7 @@
 
             h1 {
                 margin: 0;
-                font-weight: $font-weight-semi-bold;
+                font-weight: 600;
                 font-size: 21px;
                 color: $neutral-100;
             }

--- a/src/DetailsView/tab-stops-minimal-requirement-header.scss
+++ b/src/DetailsView/tab-stops-minimal-requirement-header.scss
@@ -11,7 +11,7 @@
     text-align: left;
 
     strong {
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
     }
 
     :global(.outcome-chip) {
@@ -27,12 +27,12 @@
 }
 
 .requirement-details-id {
-    font-weight: $font-weight-semi-bold;
+    font-weight: 600;
     color: $primary-text;
     word-break: break-all;
 
     a {
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
         color: $primary-text;
     }
 }

--- a/src/common/components/cards/combined-report-result-section-title.scss
+++ b/src/common/components/cards/combined-report-result-section-title.scss
@@ -19,7 +19,7 @@
     }
 
     .heading {
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;

--- a/src/common/components/cards/result-section-title.scss
+++ b/src/common/components/cards/result-section-title.scss
@@ -31,7 +31,7 @@
     }
 
     .heading {
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
         font-size: 15px;
         line-height: 20px;
         margin-right: 6px;

--- a/src/common/components/cards/rule-resources.scss
+++ b/src/common/components/cards/rule-resources.scss
@@ -18,7 +18,7 @@
     word-break: break-word;
 
     .more-resources-title {
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
     }
 
     .rule-details-id {

--- a/src/common/components/cards/rules-with-instances.scss
+++ b/src/common/components/cards/rules-with-instances.scss
@@ -17,17 +17,17 @@
         }
 
         :global(.rule-details-id) {
-            font-weight: $font-weight-semi-bold;
+            font-weight: 600;
             color: $primary-text;
             word-break: break-all;
 
             a {
-                font-weight: $font-weight-semi-bold;
+                font-weight: 600;
                 color: $primary-text !important;
             }
 
             strong {
-                font-weight: $font-weight-semi-bold;
+                font-weight: 600;
             }
         }
 

--- a/src/common/components/collapsible-component.scss
+++ b/src/common/components/collapsible-component.scss
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-@import '../../common/styles/common.scss';
-
 span.collapsible-title {
     padding-left: 0.5vw;
 }
@@ -17,11 +15,6 @@ span.collapsible-title {
     display: flex;
     justify-content: flex-start;
     align-items: center;
-
-    h2 {
-        font-weight: $normal-title-font-weight;
-        font-size: 17px;
-    }
 }
 
 .collapsible-content {

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -17,7 +17,6 @@ $focus-ring-color: $neutral-100;
     }
 }
 
-$normal-title-font-weight: 300 !default;
 $pivot-item-left-border-width: 3px !default;
 $pivot-item-border-style: solid !default;
 $details-view-header-bar-height: 40px !default;
@@ -40,6 +39,6 @@ $fast-pass-right-panel-margin-top: 24px !default;
 }
 
 @mixin h3 {
-    font-weight: $font-weight-semi-bold;
+    font-weight: 600;
     font-size: 17px;
 }

--- a/src/common/styles/fonts.scss
+++ b/src/common/styles/fonts.scss
@@ -40,10 +40,6 @@ $common-font-family: make-font-family($fonts) !default;
 $font-family: $common-font-family !default;
 $font-stack: $common-font-family !default;
 $toolbar-font-family: $common-font-family !default;
-$font-weight-heavy: bold !default;
-$font-weight-normal: normal !default;
-$font-weight-lighter: 200 !default;
-$font-weight-semi-bold: 600 !default;
 $grid-font-size: 12px !default;
 $toolbar-font-size: 12px !default;
 $toolbar-font-semi-light: 500 $toolbar-font-size $toolbar-font-family !default;
@@ -62,7 +58,7 @@ $font-size-xxxxl: 72px !default;
 $code-font-family: menlo, consolas, courier new, monospace !default;
 
 @mixin text-style-title-m {
-    font-weight: $font-weight-semi-bold;
+    font-weight: 600;
     font-size: $font-size-lml;
     line-height: 32px;
     letter-spacing: -0.02em;
@@ -70,27 +66,27 @@ $code-font-family: menlo, consolas, courier new, monospace !default;
 
 @mixin text-style-title-l {
     font-size: 28px;
-    font-weight: 700;
+    font-weight: bold;
     letter-spacing: -0.04em;
     line-height: 40px;
 }
 
 @mixin text-style-title-s {
-    font-weight: $font-weight-semi-bold;
+    font-weight: 600;
     font-size: 17px;
     line-height: 24px;
 }
 
 @mixin text-style-header-s {
     font-family: $font-family;
-    font-weight: $font-weight-normal;
+    font-weight: normal;
     font-size: 17px;
     line-height: 24px;
 }
 
 @mixin text-style-body-m {
     font-family: $font-family;
-    font-weight: $font-weight-normal;
+    font-weight: normal;
     font-size: $font-size-m;
     line-height: 20px;
 }

--- a/src/electron/views/common/window-title/window-title.scss
+++ b/src/electron/views/common/window-title/window-title.scss
@@ -55,7 +55,7 @@
         color: $ada-brand-color;
         font-family: $font-family;
         font-size: 14.51px;
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
         line-height: 19.3px;
         margin: 0;
     }

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-step-layout.scss
@@ -27,7 +27,7 @@
         margin-top: 0;
         margin-bottom: 0;
         font-size: $font-size-lml;
-        font-weight: $font-weight-normal;
+        font-weight: normal;
         line-height: 25px;
         letter-spacing: -0.02em;
     }

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -149,7 +149,7 @@
         margin-bottom: 8px !important;
         font-size: 12px !important;
         color: $negative-outcome !important;
-        font-weight: $font-weight-semi-bold !important;
+        font-weight: 600 !important;
     }
 
     .insights-dialog-main-override .file-issue-button-help {
@@ -157,14 +157,14 @@
         margin-bottom: 8px !important;
         font-size: 12px !important;
         color: $negative-outcome;
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
     }
 
     .insights-dialog-main-override .copy-issue-details-button-help {
         margin-top: 4px !important;
         font-size: 12px !important;
         color: $negative-outcome !important;
-        font-weight: $font-weight-semi-bold !important;
+        font-weight: 600 !important;
     }
 
     .insights-dialog-main-override {
@@ -173,7 +173,7 @@
             padding-bottom: 0 !important;
             color: $primary-text !important;
             font-size: 21px !important;
-            font-weight: $font-weight-semi-bold !important;
+            font-weight: 600 !important;
             letter-spacing: -0.02em !important;
         }
 
@@ -182,7 +182,7 @@
             margin-bottom: 4px !important;
             color: $primary-text !important;
             font-size: 15px !important;
-            font-weight: $font-weight-semi-bold !important;
+            font-weight: 600 !important;
         }
 
         .insights-dialog-content {
@@ -207,7 +207,7 @@
                 margin-left: 4px !important;
                 margin-right: 4px !important;
                 line-height: 100% !important;
-                font-weight: $font-weight-semi-bold !important;
+                font-weight: 600 !important;
             }
 
             svg {

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -46,7 +46,7 @@ div.insights-dialog-main-override.telemetry-permission-dialog {
     }
 
     .ms-Dialog-title {
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
     }
 
     .ms-Checkbox-checkbox {

--- a/src/popup/components/diagnostic-view-toggle.scss
+++ b/src/popup/components/diagnostic-view-toggle.scss
@@ -27,7 +27,7 @@
         grid-row: 2;
         grid-column: 2;
         justify-self: end;
-        font-weight: 400;
+        font-weight: normal;
         font-size: 11px;
         color: $secondary-text;
     }

--- a/src/reports/assessment-report.scss
+++ b/src/reports/assessment-report.scss
@@ -38,7 +38,7 @@ header {
     display: flex;
     align-items: center;
     font-size: 21px;
-    font-weight: $font-weight-semi-bold;
+    font-weight: 600;
     line-height: 32px;
 }
 
@@ -52,7 +52,7 @@ header {
     display: flex;
     align-items: center;
     font-size: 17px;
-    font-weight: $font-weight-semi-bold;
+    font-weight: 600;
 }
 
 .step-details {
@@ -120,7 +120,7 @@ header {
 .instance-key,
 %instance-key {
     font-size: 12px;
-    font-weight: $font-weight-semi-bold;
+    font-weight: 600;
     vertical-align: top;
     text-align: left;
     width: 140px;

--- a/src/reports/components/assessment-report-body-header.scss
+++ b/src/reports/components/assessment-report-body-header.scss
@@ -9,7 +9,7 @@
     h1 {
         font-size: 28px;
         margin: 0 0 24px 0;
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
         line-height: 40px;
         letter-spacing: -1;
     }

--- a/src/reports/components/assessment-scan-details.scss
+++ b/src/reports/components/assessment-scan-details.scss
@@ -11,7 +11,7 @@
 
     h3 {
         font-size: 17px;
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
     }
 
     td {

--- a/src/reports/components/instance-details.scss
+++ b/src/reports/components/instance-details.scss
@@ -104,7 +104,7 @@
         flex-grow: 0;
         font-size: 14px;
         line-height: 20px;
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
         color: $primary-text;
         text-align: left;
     }

--- a/src/reports/components/outcome.scss
+++ b/src/reports/components/outcome.scss
@@ -61,7 +61,7 @@ $outcome-count-border-size: 1.5px;
         font-size: 11px;
         border-radius: 0 8px 8px 0;
         padding: 0 6px 0 10px;
-        font-weight: 700;
+        font-weight: bold;
         margin-left: -8px;
         height: $outcome-chip-icon-size - (2 * $outcome-count-border-size);
 

--- a/src/reports/components/report-sections/summary-report-details-section.scss
+++ b/src/reports/components/report-sections/summary-report-details-section.scss
@@ -45,7 +45,7 @@
     }
 
     .label {
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
     }
 
     .label.no-icon {

--- a/src/reports/components/report-sections/summary-results-table.scss
+++ b/src/reports/components/report-sections/summary-results-table.scss
@@ -19,7 +19,7 @@
     }
 
     th {
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
         background-color: $neutral-6;
     }
 

--- a/src/reports/components/report-sections/title-section.scss
+++ b/src/reports/components/report-sections/title-section.scss
@@ -6,7 +6,7 @@
     margin-top: 56px;
 
     h1 {
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
         margin: 0 0 24px 0;
         font-size: 21px;
         line-height: 32px;

--- a/src/reports/components/report-sections/urls-summary-section.scss
+++ b/src/reports/components/report-sections/urls-summary-section.scss
@@ -16,7 +16,7 @@
     }
 
     .total-urls {
-        font-weight: $font-weight-semi-bold;
+        font-weight: 600;
     }
 
     .failure-instances {

--- a/src/views/content/content.scss
+++ b/src/views/content/content.scss
@@ -40,7 +40,7 @@
 
     h2 {
         font-size: 21px;
-        font-weight: 700;
+        font-weight: bold;
         letter-spacing: -0.02em;
         line-height: 32px;
     }
@@ -50,19 +50,19 @@
     }
 
     h4 {
-        font-weight: 400;
+        font-weight: normal;
         font-size: 14px;
         margin-bottom: 4px;
     }
 
     h5 {
-        font-weight: 700;
+        font-weight: bold;
         font-size: 14px;
         margin-bottom: 4px;
     }
 
     a {
-        font-weight: 400;
+        font-weight: normal;
     }
 
     ol {
@@ -279,7 +279,7 @@
         th {
             background: $neutral-100;
             color: $neutral-0;
-            font-weight: 400;
+            font-weight: normal;
         }
 
         td {
@@ -326,7 +326,7 @@
         display: table-cell;
         width: 110px;
         text-align: center;
-        font-weight: 400;
+        font-weight: normal;
         padding: 4px;
         vertical-align: middle;
         border-style: dashed;


### PR DESCRIPTION
#### Details

Enables [`declaration-property-value-allowed-list`](https://stylelint.io/user-guide/rules/list/declaration-property-value-allowed-list/) for `font-weight` where the value of must be one of `'unset', '100', '300', 'normal', '600', 'bold'`. The goal of this rule is to make font-weight values consistent.

To consider for the future: 100 and 300 are both used once (in launchpad title and footer, respectively). While I don't think we'll want to remove 100 as it's part of the extension's brand, we could consider removing the 300 as the visual difference between weight 300 and 400 in the launch pad footer is slight.

This pull request will also remove an unused selector rule -- I confirmed that it's not used in web or unified. I believe the `h2` (How to test) is now a div/span with an aria-level set and is styled by another selector now.


Related:
- https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#syntax

##### Motivation

Part of https://github.com/microsoft/accessibility-insights-web/issues/5187 as an incremental task to enable stylelint rules.


##### Context

Initially, I thought we should use scss variables to define font-weights, but then I did a quick dive into how font-weights are currently set. I found that:

- Most font-weight variables were not used at all or barely used, with the exception of `font-weight-semi-bold`, but that's because I introduced the variables usage in https://github.com/microsoft/accessibility-insights-web/pull/5158 (😅). See table below for a full audit.
- Switching to require a variable value resulted in `116 additions and 106 deletions` whereas this pull request results in `63 additions and 75 deletions`. This is an additional signal that sticking with the current patterns (using css values) could be less disruptive.
- Variables for font-weights can be helpful if they are descriptive to its use rather than value (for example, `title-font-weight`). Since the codebase names font-weight variables for their value, we could use css values and cut out a dependency. (For example, if we switched to variables, we would need to import font.css in a few files that didn't have it before to support the variable.)

One downside to not using variables is if we decide to change weights. With variables, we'd have a single place to update, whereas with the proposed we'd need to find and replace. With how text is styled right now, I don't think we would see the benefits of switching to font-weight variables right now. As we continue to enable more stylelint rules, I think more patterns will emerge and opportunities to reduce redundancy and improve consistency with mixins.

Below is a table of all the values of `font-weight` and how many time the value is used on production:

Weight | Number of times used
---|---:
100 | 1
$font-weight-lighter (= 200) | 0
300 | 1
$normal-title-font-weight (= 300) | 1
400 | 6
normal (= 400) | 7
$font-weight-normal (= 400) | 2
$font-weight-semi-bold (= 600) | 34
600 | 18
700 | 4
bold (= 700) | 5
$font-weight-heavy (= 700) | 0

When setting the rule's values, I ultimately went with what was already used the most. Both `normal` and `bold` were ahead of their counterparts `400` and `700` by 1 additional usage. If we prefer to use all number values, for example use `400` instead of `normal`, I'd be ok with that as well! I definitely welcome suggestions to improve the ergonomics of this rule.



#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5187 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
