### PR TITLE
fix: Use globalThis in ExceptionTelemetryListener instead of window

### DIFF
--- a/src/common/telemetry/exception-telemetry-listener.ts
+++ b/src/common/telemetry/exception-telemetry-listener.ts
@@ -17,7 +17,7 @@ export class ExceptionTelemetryListener {
 
     public initialize(
         logger: Logger,
-        extWindow: Window = window,
+        extGlobalScope: typeof globalThis = globalThis,
         extConsole: Console = console,
     ): void {
         const sendExceptionTelemetry = this.sendExceptionTelemetry;
@@ -27,7 +27,7 @@ export class ExceptionTelemetryListener {
         let loggingHookIsActive = false;
 
         // Catch top level synchronous errors
-        extWindow.onerror = function (
+        extGlobalScope.onerror = function (
             message: string,
             source: string,
             lineno: number,
@@ -51,7 +51,7 @@ export class ExceptionTelemetryListener {
         };
 
         // Catch errors thrown in promises
-        extWindow.onunhandledrejection = function (event: PromiseRejectionEvent) {
+        extGlobalScope.onunhandledrejection = function (event: PromiseRejectionEvent) {
             if (windowRejectionHookIsActive) {
                 return;
             }


### PR DESCRIPTION
#### Details

Replace `window` in ExceptionTelemetryListener with `globalThis`.

##### Motivation

Fixes a bug in the MV3 version of the extension. ExceptionTelemetryListener is referenced by SendingExceptionTelemetryListener, which is used in the service worker. Since `window` doesn't exist in the service worker, attempting to initialize SendingExceptionTelemetryListener crashes the service worker initialization script. Using [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) instead will keep the same functionality in non-background contexts while fixing the error in the service worker.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
