### PR TITLE
fix: Only show undo button in ChoiceGroupPassFail when an option is selected

### DIFF
--- a/src/DetailsView/components/choice-group-pass-fail.tsx
+++ b/src/DetailsView/components/choice-group-pass-fail.tsx
@@ -40,8 +40,10 @@ export class ChoiceGroupPassFail extends React.Component<ChoiceGroupPassFailProp
     };
 
     public render(): JSX.Element {
-        // Hide undo button for TabStopsChoiceGroups until selection
-        const showUndoButton = this.props.selectedKey !== TabStopRequirementStatuses.unknown;
+        // Show undo button when selectedKey is not unknown
+        const showUndoButton =
+            this.props.selectedKey !== TabStopRequirementStatuses.unknown &&
+            this.props.selectedKey !== ManualTestStatus.UNKNOWN;
 
         return (
             <div className={styles.choiceGroupContainer}>

--- a/src/tests/unit/tests/DetailsView/components/choice-group-pass-fail.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/choice-group-pass-fail.test.tsx
@@ -76,6 +76,13 @@ describe('ChoiceGroupPassFail', () => {
         expect(labels.at(1).text()).toEqual('');
     });
 
+    test('verify undo button is present with selection', () => {
+        props.selectedKey = TabStopRequirementStatuses.pass;
+        props.secondaryControls = null;
+        const testSubject = mount(<ChoiceGroupPassFail {...props} />);
+        expect(testSubject.find(IconButton).exists()).toBeTruthy();
+    });
+
     test('verify component is correctly used with undo', () => {
         props.selectedKey = TabStopRequirementStatuses.pass;
         props.secondaryControls = null;

--- a/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
@@ -32,13 +32,13 @@ describe('TestStatusChoiceGroup', () => {
         };
     });
 
-    test('render: unknown (show undo button)', () => {
+    test('render: unknown (do not show undo button)', () => {
         const component = mount(<TestStatusChoiceGroup {...props} />);
         const choiceGroup = component.find(ChoiceGroupPassFail);
         expect(choiceGroup.props()).toMatchObject({
             selectedKey: ManualTestStatus.UNKNOWN,
         });
-        expect(component.find(IconButton).exists()).toBeTruthy();
+        expect(component.find(IconButton).exists()).toBeFalsy();
     });
 
     test('render: status is set to UNKNOWN', () => {


### PR DESCRIPTION
#### Details

Fixes an issue with `ChoiceGroupPassFail` where the undo button appeared when neither Pass/Fail were selected. The expected behavior is for the undo button to appear after the user makes a selection. This bug affects the `TestStatusChoiceGroup` implementation. This pull request will also propose that the labeled variant will also hide the undo button until user makes a selection.


The table below present screenshots for the following environments for `TestStatusChoiceGroup`: On production, the undo button appears after selection when in a row. On Canary, the undo button always appears. With this pull request, the undo button will appear after selection when in a row (to match original state of production). 

 Production  | Canary | This pull request
---|---|---
| ![](https://user-images.githubusercontent.com/2180540/176225555-11e9532a-6695-45c3-a14b-3cfe8fd1bb81.png) | ![image](https://user-images.githubusercontent.com/2180540/176226909-83c364f3-b014-407c-aaf9-a7dc8e3af7bf.png) | ![](https://user-images.githubusercontent.com/2180540/176226106-2e989252-47ed-4388-b71d-5e0f5ab5889b.png)


The table below present screenshots for the following environments for `TestStatusChoiceGroup`:  On production and canary, the undo button always appears. With this pull request, the undo button will appear after selection.

Production  | Canary | This pull request
---|---|---
![](https://user-images.githubusercontent.com/2180540/176228218-4521f663-f5ee-4b38-af26-557dfb0bd85f.png) | ![](https://user-images.githubusercontent.com/2180540/176228246-3127eed6-a9c3-4c48-b523-0d9f56bf9208.png) | ![](https://user-images.githubusercontent.com/2180540/176228276-58830ab6-81fe-405d-8601-830868fc30d7.png)


For posterity, the table below presents screenshots for the `TabStopsChoiceGroup` where the undo button will appear after selection.

Production  | Canary | This pull request
---|---|---
![](https://user-images.githubusercontent.com/2180540/176227695-d6ba204a-669f-4fda-b863-ca882816dc80.png) | ![](https://user-images.githubusercontent.com/2180540/176227769-dfab5b2a-7c56-4377-8aa8-1cda9bf60f6c.png) | ![](https://user-images.githubusercontent.com/2180540/176227844-eafc0312-adf2-40c3-b231-bf00581d537a.png)

The table below shows screenshots for each selected state of the component: When pass is selected the left/green radio button is selected and the undo button appears. When fail is selected the right/red radio button is selected and the undo button appears. When the undo button is clicked, no radio button is selected and the undo button disappears (this is also the component's default state).

Pass | Fail | Undo
---|---|---
![](https://user-images.githubusercontent.com/2180540/176230404-149e9f0e-26be-45f9-aa07-f4a5f99709ec.png) | ![](https://user-images.githubusercontent.com/2180540/176230403-241720e8-0d48-425a-b2c8-54d0ca68dfee.png)  | ![](https://user-images.githubusercontent.com/2180540/176230402-9072bc1a-6239-404b-8783-c76863f70b71.png)


##### Motivation

Addressed #5676

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5676
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
