### PR TITLE
test: fix unified screenshot on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,6 @@
         "js-yaml": "^4.1.0",
         "lerna": "^5.1.6",
         "license-check-and-add": "^4.0.5",
-        "make-dir": "^3.1.0",
         "mini-css-extract-plugin": "2.6.1",
         "npm-run-all": "^4.1.5",
         "pkg": "^5.7.0",

--- a/src/tests/end-to-end/common/prepare-test-result-file-path.ts
+++ b/src/tests/end-to-end/common/prepare-test-result-file-path.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as fs from 'fs';
 import * as path from 'path';
 import { generateUID } from 'common/uid-generator';
-import * as makeDir from 'make-dir';
 
 function sanitizeFilename(s: string): string {
     return s.replace(/[^a-z0-9.-]+/gi, '_');
@@ -19,7 +19,8 @@ export async function prepareTestResultFilePath(
         '../../../../test-results/e2e',
         resultsSubdirectoryName,
     );
-    await makeDir(subdirectoryPath);
+
+    await fs.promises.mkdir(subdirectoryPath, { recursive: true });
     const fileName = `${sanitizeFilename(generateUID())}.${fileExtension}`;
     const filePath = path.join(subdirectoryPath, fileName);
     return filePath;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8979,7 +8979,7 @@ make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.0, make-dir@^3.1.0:
+make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==


### PR DESCRIPTION
#### Details

`yarn test:unified` has functionality to take screenshots when errors occur, but it looks like it was broken at some point. I suspect the issue is that our use of the `make-dir` library to ensure the screenshot directory exists was broken when we switched the tests to use swc for transpilation and we never noticed.

Using a whole library just for this functionality is unnecessary; `fs.promises.mkdir` works just fine for this, so I ripped out the library and replaced it with the builtin verison.

##### Motivation

Fix unified e2e error reporting to help debug the issue Tania is seeing today

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
