### PR TITLE
fix: Set focus back to Export result button when command bar is not collapsed (unified)

### DIFF
--- a/src/electron/views/results/components/reflow-command-bar.tsx
+++ b/src/electron/views/results/components/reflow-command-bar.tsx
@@ -74,7 +74,14 @@ export class ReflowCommandBar extends React.Component<
             this.props.currentContentPageInfo.allowsExportReport &&
             this.props.scanMetadata !== null
         ) {
-            return <ReportExportButton showReportExportDialog={this.showReportExportDialog} />;
+            return (
+                <ReportExportButton
+                    showReportExportDialog={this.showReportExportDialog}
+                    buttonRef={ref => {
+                        this.dropdownMenuButtonRef = ref;
+                    }}
+                />
+            );
         }
 
         return null;

--- a/src/tests/unit/tests/electron/views/results/components/__snapshots__/reflow-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/results/components/__snapshots__/reflow-command-bar.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`ReflowCommandBar reflow behavior isCommandBarCollapsed is true 1`] = `
 
 exports[`ReflowCommandBar reflow behavior isCommandBarCollapsed is true: export report 1`] = `
 <ReportExportButton
+  buttonRef={[Function]}
   showReportExportDialog={[Function]}
 />
 `;
@@ -20,7 +21,7 @@ exports[`ReflowCommandBar reflow behavior isHeaderAndNavCollapsed is true 1`] = 
 "<section className=\\"commandBar\\" aria-label=\\"command bar\\">
   <FastPassLeftNavHamburgerButton isSideNavOpen={true} setSideNavOpen={[Function: setSideNavOpen]} className=\\"navMenu\\" />
   <div className=\\"farItems reflow\\">
-    <ReportExportButton showReportExportDialog={[Function (anonymous)]} />
+    <ReportExportButton showReportExportDialog={[Function (anonymous)]} buttonRef={[Function: buttonRef]} />
     <InsightsCommandButton data-automation-id=\\"command-button-refresh\\" text=\\"Start over\\" iconProps={{...}} onClick={[Function: onClick]} disabled={false} />
     <InsightsCommandButton data-automation-id=\\"command-button-settings\\" ariaLabel=\\"settings\\" iconProps={{...}} onClick={[Function: onClick]} className=\\"settingsGearButton\\" />
     <ReportExportComponent deps={{...}} isOpen={false} reportExportFormat=\\"FastPass\\" pageTitle=\\"scan target name\\" scanDate={{...}} htmlGenerator={[Function: htmlGenerator]} jsonGenerator={[Function: jsonGenerator]} updatePersistedDescription={[Function: updatePersistedDescription]} getExportDescription={[Function: getExportDescription]} featureFlagStoreData={{...}} dismissExportDialog={[Function: dismissExportDialog]} afterDialogDismissed={[Function: afterDialogDismissed]} reportExportServices={{...}} exportResultsClickedTelemetry={[Function: exportResultsClickedTelemetry]} />
@@ -50,7 +51,7 @@ exports[`ReflowCommandBar renders does not create report export when scan metada
 exports[`ReflowCommandBar renders with start over button disabled 1`] = `
 "<section className=\\"commandBar\\" aria-label=\\"command bar\\">
   <div className=\\"farItems reflow\\">
-    <ReportExportButton showReportExportDialog={[Function (anonymous)]} />
+    <ReportExportButton showReportExportDialog={[Function (anonymous)]} buttonRef={[Function: buttonRef]} />
     <InsightsCommandButton data-automation-id=\\"command-button-refresh\\" text=\\"Start over\\" iconProps={{...}} onClick={[Function: onClick]} disabled={true} />
     <InsightsCommandButton data-automation-id=\\"command-button-settings\\" ariaLabel=\\"settings\\" iconProps={{...}} onClick={[Function: onClick]} className=\\"settingsGearButton\\" />
     <ReportExportComponent deps={{...}} isOpen={false} reportExportFormat=\\"FastPass\\" pageTitle=\\"scan target name\\" scanDate={[undefined]} htmlGenerator={[Function: htmlGenerator]} jsonGenerator={[Function: jsonGenerator]} updatePersistedDescription={[Function: updatePersistedDescription]} getExportDescription={[Function: getExportDescription]} featureFlagStoreData={{...}} dismissExportDialog={[Function: dismissExportDialog]} afterDialogDismissed={[Function: afterDialogDismissed]} reportExportServices={{...}} exportResultsClickedTelemetry={[Function: exportResultsClickedTelemetry]} />

--- a/src/tests/unit/tests/electron/views/results/components/reflow-command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/components/reflow-command-bar.test.tsx
@@ -9,6 +9,7 @@ import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-int
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { CommandBarButtonsMenu } from 'DetailsView/components/command-bar-buttons-menu';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
+import { ReportExportButton } from 'DetailsView/components/report-export-button';
 import { ReportExportComponent } from 'DetailsView/components/report-export-component';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { ContentPageInfo } from 'electron/types/content-page-info';
@@ -222,6 +223,26 @@ describe('ReflowCommandBar', () => {
             const buttonMock = Mock.ofType<IButton>();
             const commandBar = rendered.find(CommandBarButtonsMenu);
             const buttonRefCallback = commandBar.prop('buttonRef') as any;
+
+            const exportDialog = rendered.find(ReportExportComponent);
+            const onDialogDismissCallback = exportDialog.props()['afterDialogDismissed'];
+
+            buttonMock.setup(bm => bm.dismissMenu()).verifiable();
+            buttonMock.setup(bm => bm.focus()).verifiable();
+
+            buttonRefCallback(buttonMock.object);
+            onDialogDismissCallback();
+
+            buttonMock.verifyAll();
+        });
+
+        test('dropdown menu is dismissed and button focused when dialog is dismissed (isCommandBarCollapsed is not collapsed)', () => {
+            props.narrowModeStatus.isCommandBarCollapsed = false;
+            const rendered = shallow(<ReflowCommandBar {...props} />);
+            const buttonMock = Mock.ofType<IButton>();
+
+            const exportButton = rendered.find(ReportExportButton);
+            const buttonRefCallback = exportButton.prop('buttonRef') as any;
 
             const exportDialog = rendered.find(ReportExportComponent);
             const onDialogDismissCallback = exportDialog.props()['afterDialogDismissed'];


### PR DESCRIPTION
#### Details

This pull request will set the value of `this.dropdownMenuButtonRef` for ReportExportButton when command bar is not collapsed. This fixes and issue where when the user clicks "Export result" and then clicks the esc key to leave the dialog, the focus does not return to the Export result button. Previously, the reference for the button was only being set when the command bar was collapsed, which worked on smaller viewports but not on larger ones. 

## Videos

The video below show that the focus returns to the Export result button:


https://user-images.githubusercontent.com/2180540/176748987-d3926ab5-cdcc-4688-99c5-9905ff0130e7.mp4


The video below show that the focus returns to the command bar button:

https://user-images.githubusercontent.com/2180540/176749001-bde9156e-c098-40ff-a273-2ded67a5d168.mp4



##### Motivation

Addresses ADO Trusted Tester bug 1956902.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1956902
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
