### PR TITLE
fix: Store last focused element for focus trap detector

### DIFF
--- a/src/injected/analyzers/focus-traps-keydown-handler.ts
+++ b/src/injected/analyzers/focus-traps-keydown-handler.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { PromiseFactory } from 'common/promises/promise-factory';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
+import { TabStopsRequirementEvaluator } from 'injected/tab-stops-requirement-evaluator';
+
+export class FocusTrapsKeydownHandler {
+    // TabStopsOrchestrator already stores latestVisitedTabStop,
+    // but that may be modified by other event listeners before
+    // this one runs, so we need to keep this state separate
+    protected lastFocusedElement: Element | null = null;
+
+    constructor(
+        private readonly tabStopsRequirementEvaluator: TabStopsRequirementEvaluator,
+        private readonly promiseFactory: PromiseFactory,
+        private readonly keyboardTrapTimeout: number = 500,
+    ) {}
+
+    public reset(): void {
+        this.lastFocusedElement = null;
+    }
+
+    public getResultOnKeydown = async (
+        e: KeyboardEvent,
+        dom: Document,
+    ): Promise<AutomatedTabStopRequirementResult | null> => {
+        if (e.key !== 'Tab' || dom.activeElement === dom.body || this.lastFocusedElement == null) {
+            return null;
+        }
+
+        await this.promiseFactory.delay(null, this.keyboardTrapTimeout);
+
+        const currentFocusedElement = dom.activeElement;
+        if (currentFocusedElement == null) {
+            return null;
+        }
+        const result = this.tabStopsRequirementEvaluator.getKeyboardTrapResults(
+            this.lastFocusedElement,
+            currentFocusedElement,
+        );
+        this.lastFocusedElement = currentFocusedElement;
+
+        return result;
+    };
+}

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -35,6 +35,7 @@ import { VisualizationType } from '../common/types/visualization-type';
 import { generateUID } from '../common/uid-generator';
 import { WindowUtils } from '../common/window-utils';
 import { Assessments } from './../assessments/assessments';
+import { FocusTrapsKeydownHandler } from './analyzers/focus-traps-keydown-handler';
 import { ClientUtils } from './client-utils';
 import { rootContainerId } from './constants';
 import { DetailsDialogHandler } from './details-dialog-handler';
@@ -158,10 +159,14 @@ export class WindowInitializer {
             htmlElementUtils,
             getUniqueSelector,
         );
+        const focusTrapsKeydownHandler = new FocusTrapsKeydownHandler(
+            tabStopRequirementEvaluator,
+            promiseFactory,
+        );
         const tabStopsOrchestrator = new TabStopRequirementOrchestrator(
             document,
             tabbableElementGetter,
-            this.windowUtils,
+            focusTrapsKeydownHandler,
             tabStopRequirementEvaluator,
             getUniqueSelector,
         );

--- a/src/tests/unit/tests/injected/analyzers/focus-traps-keydown-handler.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/focus-traps-keydown-handler.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DelayCreator, PromiseFactory } from 'common/promises/promise-factory';
+import { FocusTrapsKeydownHandler } from 'injected/analyzers/focus-traps-keydown-handler';
+import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
+import {
+    DefaultTabStopsRequirementEvaluator,
+    TabStopsRequirementEvaluator,
+} from 'injected/tab-stops-requirement-evaluator';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+class TestableFocusTrapsKeydownHandler extends FocusTrapsKeydownHandler {
+    public lastFocusedElement: HTMLElement;
+}
+
+describe(FocusTrapsKeydownHandler, () => {
+    let evaluatorMock: IMock<TabStopsRequirementEvaluator>;
+    let delayMock: IMock<DelayCreator>;
+    let promiseFactoryStub: PromiseFactory;
+    let domMock: IMock<Document>;
+    const focusTrapTimeout = 20;
+
+    let testSubject: TestableFocusTrapsKeydownHandler;
+
+    beforeEach(() => {
+        evaluatorMock = Mock.ofType<DefaultTabStopsRequirementEvaluator>();
+        delayMock = Mock.ofType<DelayCreator>();
+        promiseFactoryStub = { delay: delayMock.object } as PromiseFactory;
+        domMock = Mock.ofType<Document>();
+
+        testSubject = new TestableFocusTrapsKeydownHandler(
+            evaluatorMock.object,
+            promiseFactoryStub,
+            focusTrapTimeout,
+        );
+    });
+
+    afterEach(() => {
+        evaluatorMock.verifyAll();
+        delayMock.verifyAll();
+    });
+
+    it('constructor sets lastFocusedElement to null', () => {
+        expect(testSubject.lastFocusedElement).toBeNull();
+    });
+
+    it('reset() sets lastFocusedElement to null', () => {
+        testSubject.lastFocusedElement = {} as HTMLElement;
+
+        testSubject.reset();
+
+        expect(testSubject.lastFocusedElement).toBeNull();
+    });
+
+    describe('getResultOnKeydown', () => {
+        const bodyElementStub = {
+            innerText: 'body element',
+        } as HTMLElement;
+        const focusedElementStub = {
+            innerText: 'currently focused element',
+        } as HTMLElement;
+        const lastFocusedElementStub = { innerText: 'last focused element' } as HTMLElement;
+        const tabEvent: KeyboardEvent = { key: 'Tab' } as KeyboardEvent;
+
+        beforeEach(() => {
+            setupDOM();
+            testSubject.lastFocusedElement = lastFocusedElementStub;
+        });
+
+        it('Does nothing if key was not tab', async () => {
+            const keyboardEvent = { key: 'Enter' } as KeyboardEvent;
+
+            setupIgnoreKeydown();
+
+            const result = await testSubject.getResultOnKeydown(keyboardEvent, domMock.object);
+
+            expect(result).toBeNull();
+            expect(testSubject.lastFocusedElement).toBe(lastFocusedElementStub);
+        });
+
+        it('Does nothing if focused element is body', async () => {
+            setupDOM(bodyElementStub);
+
+            setupIgnoreKeydown();
+
+            const result = await testSubject.getResultOnKeydown(tabEvent, domMock.object);
+
+            expect(result).toBeNull();
+            expect(testSubject.lastFocusedElement).toBe(lastFocusedElementStub);
+        });
+
+        it('Does nothing if there was no last focused element', async () => {
+            testSubject.lastFocusedElement = null;
+
+            setupIgnoreKeydown();
+
+            const result = await testSubject.getResultOnKeydown(tabEvent, domMock.object);
+
+            expect(result).toBeNull();
+            expect(testSubject.lastFocusedElement).toBeNull();
+        });
+
+        it('Returns null if no element is focused after delay', async () => {
+            setupDOM(null);
+
+            evaluatorMock
+                .setup(e => e.getFocusOrderResult(It.isAny(), It.isAny()))
+                .verifiable(Times.never());
+            delayMock.setup(d => d(It.isAny(), focusTrapTimeout)).verifiable(Times.once());
+
+            const result = await testSubject.getResultOnKeydown(tabEvent, domMock.object);
+
+            expect(result).toBeNull();
+            expect(testSubject.lastFocusedElement).toBe(lastFocusedElementStub);
+        });
+
+        it('Returns result of getKeyboardTrapResults if an element is focused after delay', async () => {
+            const expectedResult = {
+                selector: ['selector'],
+                html: 'html',
+            } as AutomatedTabStopRequirementResult;
+
+            evaluatorMock
+                .setup(e => e.getKeyboardTrapResults(lastFocusedElementStub, focusedElementStub))
+                .returns(() => expectedResult)
+                .verifiable(Times.once());
+            delayMock.setup(d => d(It.isAny(), focusTrapTimeout)).verifiable(Times.once());
+
+            const result = await testSubject.getResultOnKeydown(tabEvent, domMock.object);
+
+            expect(result).toBe(expectedResult);
+            expect(testSubject.lastFocusedElement).toBe(focusedElementStub);
+        });
+
+        function setupDOM(focusedElement: HTMLElement = focusedElementStub): void {
+            domMock.reset();
+            domMock.setup(d => d.body).returns(() => bodyElementStub);
+            domMock.setup(d => d.activeElement).returns(() => focusedElement);
+        }
+
+        function setupIgnoreKeydown(): void {
+            evaluatorMock
+                .setup(e => e.getFocusOrderResult(It.isAny(), It.isAny()))
+                .verifiable(Times.never());
+            delayMock.setup(d => d(It.isAny(), It.isAny())).verifiable(Times.never());
+        }
+    });
+});


### PR DESCRIPTION
#### Details

- Extracts TabStopsOrchestrator's keydown listener into its own class, FocusTrapsKeydownHandler
- Store the last focused element in FocusTrapsKeydownHandler and use that instead of dom.activeElement to determine whether we've reached a focus trap

##### Motivation

Fixes a race condition in TabStopsOrchestrator that causes a focus trap false positive. The root cause is that, in the keydown listener, we assume that the focus has not yet changed and use dom.activeElement as the "last focused element." However, sometimes the keyboard listener runs after focus has already changed, in which case the extension wrongly detects that the previous and currently focused elements are the same, and reports a focus trap.

This PR fixes the race condition by storing the last focused element in an instance variable that is updated after every tab press.

##### Context

I first tried using TabStopsOrchestrator's existing latestVisitedTabStop variable, but that created a similar race condition: latestVisitedTabStop is changed by the onfocus listener, which may run either before or after the keydown listener. Since each listener needs to track its previous tab stop separately, I thought it would be clearer to refactor the keydown listener into a new class with its own state instead of adding another variable with a confusingly similar name to TabStopsOrchestrator.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5317
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
