### PR TITLE
fix: demo link label-name-content-mismatch failure

### DIFF
--- a/src/popup/components/launch-pad.tsx
+++ b/src/popup/components/launch-pad.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-
 import { AxeInfo } from '../../common/axe-info';
 import { ExternalLink, ExternalLinkDeps } from '../../common/components/external-link';
 import { PopupActionMessageCreator } from '../actions/popup-action-message-creator';
@@ -28,8 +27,6 @@ export interface LaunchPadRowConfiguration {
 }
 
 export class LaunchPad extends React.Component<LaunchPadProps, undefined> {
-    public static demoLink: string = 'https://go.microsoft.com/fwlink/?linkid=2082374';
-
     constructor(props: LaunchPadProps) {
         super(props);
     }

--- a/src/popup/components/popup-view.tsx
+++ b/src/popup/components/popup-view.tsx
@@ -62,6 +62,8 @@ export interface PopupViewControllerState {
     userConfigurationStoreData: UserConfigurationStoreData;
 }
 
+const demoLink: string = 'https://go.microsoft.com/fwlink/?linkid=2082374';
+
 export class PopupView extends React.Component<PopupViewProps> {
     private handler: PopupViewControllerHandler;
     private openTogglesView: () => void;
@@ -158,12 +160,7 @@ export class PopupView extends React.Component<PopupViewProps> {
                     title={this.props.title}
                     subtitle={
                         <>
-                            <NewTabLink
-                                href={LaunchPad.demoLink}
-                                aria-label="demo video"
-                                title="watch the 3 minute video introduction"
-                                onClick={onClickTutorialLink}
-                            >
+                            <NewTabLink href={demoLink} onClick={onClickTutorialLink}>
                                 Watch 3-minute video introduction
                             </NewTabLink>{' '}
                         </>

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -66,11 +66,9 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
         class="subtitle--{{CSS_MODULE_HASH}}"
       >
         <a
-          aria-label="demo video"
           class="ms-Link insights-link root-000"
           href="https://go.microsoft.com/fwlink/?linkid=2082374"
           target="_blank"
-          title="watch the 3 minute video introduction"
         >
           Watch 3-minute video introduction
         </a>

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`PopupView render actual content render toggles view: launch pad 1`] = `
 
 exports[`PopupView render actual content render toggles view: launch pad: subtitle 1`] = `
 "<Fragment>
-  <NewTabLink href=\\"https://go.microsoft.com/fwlink/?linkid=2082374\\" aria-label=\\"demo video\\" title=\\"watch the 3 minute video introduction\\" onClick={[Function: onClickTutorialLink]}>
+  <NewTabLink href=\\"https://go.microsoft.com/fwlink/?linkid=2082374\\" onClick={[Function: onClickTutorialLink]}>
     Watch 3-minute video introduction
   </NewTabLink>
    


### PR DESCRIPTION
#### Details

Removes unnecessary title and label for demo link.

##### Motivation

fixes a label-name-content-mismatch true positive failure in needs review.

##### Context

Title and label aren't needed because the text is self-explanatory for the link.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
