### PR TITLE
chore: Upgrade codeql to v2 and enable autobuild to support csharp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,9 @@ jobs:
 
     - uses: github/codeql-action/init@v2
       timeout-minutes: 2
+    
+    - uses: github/codeql-action/autobuild@v2
+      timeout-minutes: 2
 
     - uses: github/codeql-action/analyze@v2
       timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,10 @@ jobs:
     - uses: actions/checkout@v2
       timeout-minutes: 2
 
+    - uses: actions/setup-dotnet@v2
+      with: { dotnet-version: "${{ env.DOTNET_SDK_VERSION }}" }
+      timeout-minutes: 2
+
     - uses: github/codeql-action/init@v2
       timeout-minutes: 2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,10 +191,10 @@ jobs:
     - uses: actions/checkout@v2
       timeout-minutes: 2
 
-    - uses: github/codeql-action/init@v1
+    - uses: github/codeql-action/init@v2
       timeout-minutes: 2
 
-    - uses: github/codeql-action/analyze@v1
+    - uses: github/codeql-action/analyze@v2
       timeout-minutes: 10
 
   e2e-web-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,10 +191,6 @@ jobs:
     - uses: actions/checkout@v2
       timeout-minutes: 2
 
-    - uses: actions/setup-dotnet@v2
-      with: { dotnet-version: "${{ env.DOTNET_SDK_VERSION }}" }
-      timeout-minutes: 2
-
     - uses: github/codeql-action/init@v2
       timeout-minutes: 2
 


### PR DESCRIPTION
#### Details

This pull request will update CodeQL to v2 and set up dotnet for CodeQL by adding the [autobuild step](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages#about-autobuild-for-codeql).

CodeQL is failing on several builds when attempting to run csharp with:
> Error: No code found during the build. Please see:
>  https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/troubleshooting-code-scanning#no-code-found-during-the-build

We added csharp to this repo in #5720, the codeql build for that pull request did not detect csharp and so the run passed ([passed](https://github.com/microsoft/accessibility-insights-web/runs/7307739514?check_suite_focus=true)). But upon merge, the CodeQL workflow then detected csharp and failed ([failed run](https://github.com/microsoft/accessibility-insights-web/runs/7309328676?check_suite_focus=true)).

I also noticed that CodeQL v1 has a deprecation warning:
> Warning: CodeQL Action v1 will be deprecated on December 7th, 2022. Please upgrade to v2. For more information, see https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/



##### Motivation

Keep CodeQL up to date.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [ n/a] (UI changes only) Verified usability with NVDA/JAWS
