### PR TITLE
refactor(mv3-part-5): SyncAction and AsyncAction

### DIFF
--- a/src/DetailsView/components/tab-stops/tab-stops-view-actions.ts
+++ b/src/DetailsView/components/tab-stops/tab-stops-view-actions.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 
 export interface EditExistingFailureInstancePayload {
@@ -11,8 +11,9 @@ export interface EditExistingFailureInstancePayload {
 }
 
 export class TabStopsViewActions {
-    public readonly createNewFailureInstancePanel = new Action<string>();
-    public readonly editExistingFailureInstance = new Action<EditExistingFailureInstancePayload>();
-    public readonly dismissPanel = new Action<void>();
-    public readonly updateDescription = new Action<string>();
+    public readonly createNewFailureInstancePanel = new SyncAction<string>();
+    public readonly editExistingFailureInstance =
+        new SyncAction<EditExistingFailureInstancePayload>();
+    public readonly dismissPanel = new SyncAction<void>();
+    public readonly updateDescription = new SyncAction<string>();
 }

--- a/src/background/actions/assessment-actions.ts
+++ b/src/background/actions/assessment-actions.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import {
     ScanBasePayload,
     ScanCompletedPayload,
@@ -24,31 +24,31 @@ import {
 } from './action-payloads';
 
 export class AssessmentActions {
-    public readonly selectTestSubview = new Action<SelectTestSubviewPayload>();
-    public readonly expandTestNav = new Action<ExpandTestNavPayload>();
-    public readonly collapseTestNav = new Action<null>();
-    public readonly changeInstanceStatus = new Action<ChangeInstanceStatusPayload>();
-    public readonly changeRequirementStatus = new Action<ChangeRequirementStatusPayload>();
-    public readonly addFailureInstance = new Action<AddFailureInstancePayload>();
-    public readonly addResultDescription = new Action<AddResultDescriptionPayload>();
-    public readonly removeFailureInstance = new Action<RemoveFailureInstancePayload>();
-    public readonly editFailureInstance = new Action<EditFailureInstancePayload>();
-    public readonly passUnmarkedInstance = new Action<ToggleActionPayload>();
+    public readonly selectTestSubview = new SyncAction<SelectTestSubviewPayload>();
+    public readonly expandTestNav = new SyncAction<ExpandTestNavPayload>();
+    public readonly collapseTestNav = new SyncAction<null>();
+    public readonly changeInstanceStatus = new SyncAction<ChangeInstanceStatusPayload>();
+    public readonly changeRequirementStatus = new SyncAction<ChangeRequirementStatusPayload>();
+    public readonly addFailureInstance = new SyncAction<AddFailureInstancePayload>();
+    public readonly addResultDescription = new SyncAction<AddResultDescriptionPayload>();
+    public readonly removeFailureInstance = new SyncAction<RemoveFailureInstancePayload>();
+    public readonly editFailureInstance = new SyncAction<EditFailureInstancePayload>();
+    public readonly passUnmarkedInstance = new SyncAction<ToggleActionPayload>();
     public readonly changeAssessmentVisualizationState =
-        new Action<ChangeInstanceSelectionPayload>();
+        new SyncAction<ChangeInstanceSelectionPayload>();
     public readonly changeAssessmentVisualizationStateForAll =
-        new Action<ChangeInstanceSelectionPayload>();
-    public readonly undoInstanceStatusChange = new Action<AssessmentActionInstancePayload>();
-    public readonly undoRequirementStatusChange = new Action<ChangeRequirementStatusPayload>();
-    public readonly getCurrentState = new Action<void>();
-    public readonly scanCompleted = new Action<ScanCompletedPayload<null>>();
-    public readonly resetData = new Action<ToggleActionPayload>();
-    public readonly resetAllAssessmentsData = new Action<number>();
-    public readonly scanUpdate = new Action<ScanUpdatePayload>();
-    public readonly trackingCompleted = new Action<ScanBasePayload>();
-    public readonly updateSelectedPivotChild = new Action<UpdateSelectedDetailsViewPayload>();
-    public readonly updateTargetTabId = new Action<number>();
-    public readonly continuePreviousAssessment = new Action<number>();
-    public readonly LoadAssessment = new Action<LoadAssessmentPayload>();
-    public readonly updateDetailsViewId = new Action<OnDetailsViewInitializedPayload>();
+        new SyncAction<ChangeInstanceSelectionPayload>();
+    public readonly undoInstanceStatusChange = new SyncAction<AssessmentActionInstancePayload>();
+    public readonly undoRequirementStatusChange = new SyncAction<ChangeRequirementStatusPayload>();
+    public readonly getCurrentState = new SyncAction<void>();
+    public readonly scanCompleted = new SyncAction<ScanCompletedPayload<null>>();
+    public readonly resetData = new SyncAction<ToggleActionPayload>();
+    public readonly resetAllAssessmentsData = new SyncAction<number>();
+    public readonly scanUpdate = new SyncAction<ScanUpdatePayload>();
+    public readonly trackingCompleted = new SyncAction<ScanBasePayload>();
+    public readonly updateSelectedPivotChild = new SyncAction<UpdateSelectedDetailsViewPayload>();
+    public readonly updateTargetTabId = new SyncAction<number>();
+    public readonly continuePreviousAssessment = new SyncAction<number>();
+    public readonly LoadAssessment = new SyncAction<LoadAssessmentPayload>();
+    public readonly updateDetailsViewId = new SyncAction<OnDetailsViewInitializedPayload>();
 }

--- a/src/background/actions/card-selection-actions.ts
+++ b/src/background/actions/card-selection-actions.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { CardSelectionPayload, RuleExpandCollapsePayload } from './action-payloads';
 
 export class CardSelectionActions {
-    public readonly getCurrentState = new Action();
-    public readonly navigateToNewCardsView = new Action();
-    public readonly toggleRuleExpandCollapse = new Action<RuleExpandCollapsePayload>();
-    public readonly toggleCardSelection = new Action<CardSelectionPayload>();
-    public readonly collapseAllRules = new Action();
-    public readonly expandAllRules = new Action();
-    public readonly toggleVisualHelper = new Action();
-    public readonly resetFocusedIdentifier = new Action();
+    public readonly getCurrentState = new SyncAction();
+    public readonly navigateToNewCardsView = new SyncAction();
+    public readonly toggleRuleExpandCollapse = new SyncAction<RuleExpandCollapsePayload>();
+    public readonly toggleCardSelection = new SyncAction<CardSelectionPayload>();
+    public readonly collapseAllRules = new SyncAction();
+    public readonly expandAllRules = new SyncAction();
+    public readonly toggleVisualHelper = new SyncAction();
+    public readonly resetFocusedIdentifier = new SyncAction();
 }

--- a/src/background/actions/command-actions.ts
+++ b/src/background/actions/command-actions.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+
+import { SyncAction } from 'common/flux/sync-action';
 
 export interface GetCommandsPayload {
     commands: chrome.commands.Command[];
@@ -8,5 +9,5 @@ export interface GetCommandsPayload {
 }
 
 export class CommandActions {
-    public readonly getCommands = new Action<GetCommandsPayload>();
+    public readonly getCommands = new SyncAction<GetCommandsPayload>();
 }

--- a/src/background/actions/content-actions.ts
+++ b/src/background/actions/content-actions.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { BaseActionPayload } from './action-payloads';
 
 export interface ContentPayload extends BaseActionPayload {
@@ -9,6 +9,6 @@ export interface ContentPayload extends BaseActionPayload {
 }
 
 export class ContentActions {
-    public readonly openContentPanel = new Action<ContentPayload>();
-    public readonly closeContentPanel = new Action<void>();
+    public readonly openContentPanel = new SyncAction<ContentPayload>();
+    public readonly closeContentPanel = new SyncAction<void>();
 }

--- a/src/background/actions/details-view-actions.ts
+++ b/src/background/actions/details-view-actions.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { DetailsViewRightContentPanelType } from '../../DetailsView/components/left-nav/details-view-right-content-panel-type';
 
 export class DetailsViewActions {
     public readonly setSelectedDetailsViewRightContentPanel =
-        new Action<DetailsViewRightContentPanelType>();
-    public readonly getCurrentState = new Action();
+        new SyncAction<DetailsViewRightContentPanelType>();
+    public readonly getCurrentState = new SyncAction();
 }

--- a/src/background/actions/dev-tools-actions.ts
+++ b/src/background/actions/dev-tools-actions.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 
 export class DevToolActions {
-    public readonly setDevToolState = new Action<boolean>();
-    public readonly setInspectElement = new Action<string[]>();
-    public readonly setFrameUrl = new Action<string>();
-    public readonly getCurrentState = new Action();
+    public readonly setDevToolState = new SyncAction<boolean>();
+    public readonly setInspectElement = new SyncAction<string[]>();
+    public readonly setFrameUrl = new SyncAction<string>();
+    public readonly getCurrentState = new SyncAction();
 }

--- a/src/background/actions/feature-flag-actions.ts
+++ b/src/background/actions/feature-flag-actions.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
 
+import { SyncAction } from 'common/flux/sync-action';
 import { BaseActionPayload } from './action-payloads';
 
 export interface FeatureFlagPayload extends BaseActionPayload {
@@ -10,7 +10,7 @@ export interface FeatureFlagPayload extends BaseActionPayload {
 }
 
 export class FeatureFlagActions {
-    public readonly getCurrentState = new Action<void>();
-    public readonly setFeatureFlag = new Action<FeatureFlagPayload>();
-    public readonly resetFeatureFlags = new Action<void>();
+    public readonly getCurrentState = new SyncAction<void>();
+    public readonly setFeatureFlag = new SyncAction<FeatureFlagPayload>();
+    public readonly resetFeatureFlags = new SyncAction<void>();
 }

--- a/src/background/actions/injection-actions.ts
+++ b/src/background/actions/injection-actions.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 
 export class InjectionActions {
-    public readonly injectionCompleted = new Action();
-    public readonly injectionStarted = new Action();
+    public readonly injectionCompleted = new SyncAction();
+    public readonly injectionStarted = new SyncAction();
 }

--- a/src/background/actions/inspect-actions.ts
+++ b/src/background/actions/inspect-actions.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { InspectMode } from '../inspect-modes';
 import { BaseActionPayload } from './action-payloads';
 
@@ -9,7 +9,7 @@ export interface InspectPayload extends BaseActionPayload {
 }
 
 export class InspectActions {
-    public readonly changeInspectMode = new Action<InspectPayload>();
-    public readonly getCurrentState = new Action<void>();
-    public readonly setHoveredOverSelector = new Action<string[]>();
+    public readonly changeInspectMode = new SyncAction<InspectPayload>();
+    public readonly getCurrentState = new SyncAction<void>();
+    public readonly setHoveredOverSelector = new SyncAction<string[]>();
 }

--- a/src/background/actions/launch-panel-state-action.ts
+++ b/src/background/actions/launch-panel-state-action.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
 
 export class LaunchPanelStateActions {
-    public readonly setLaunchPanelType = new Action<LaunchPanelType>();
-    public readonly getCurrentState = new Action();
+    public readonly setLaunchPanelType = new SyncAction<LaunchPanelType>();
+    public readonly getCurrentState = new SyncAction();
 }

--- a/src/background/actions/needs-review-card-selection-actions.ts
+++ b/src/background/actions/needs-review-card-selection-actions.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { CardSelectionPayload, RuleExpandCollapsePayload } from './action-payloads';
 
 export class NeedsReviewCardSelectionActions {
-    public readonly getCurrentState = new Action();
-    public readonly navigateToNewCardsView = new Action();
-    public readonly toggleRuleExpandCollapse = new Action<RuleExpandCollapsePayload>();
-    public readonly toggleCardSelection = new Action<CardSelectionPayload>();
-    public readonly collapseAllRules = new Action();
-    public readonly expandAllRules = new Action();
-    public readonly toggleVisualHelper = new Action();
-    public readonly resetFocusedIdentifier = new Action();
+    public readonly getCurrentState = new SyncAction();
+    public readonly navigateToNewCardsView = new SyncAction();
+    public readonly toggleRuleExpandCollapse = new SyncAction<RuleExpandCollapsePayload>();
+    public readonly toggleCardSelection = new SyncAction<CardSelectionPayload>();
+    public readonly collapseAllRules = new SyncAction();
+    public readonly expandAllRules = new SyncAction();
+    public readonly toggleVisualHelper = new SyncAction();
+    public readonly resetFocusedIdentifier = new SyncAction();
 }

--- a/src/background/actions/needs-review-scan-result-actions.ts
+++ b/src/background/actions/needs-review-scan-result-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { UnifiedScanCompletedPayload } from './action-payloads';
 
 export class NeedsReviewScanResultActions {
-    public readonly scanCompleted = new Action<UnifiedScanCompletedPayload>();
-    public readonly getCurrentState = new Action();
+    public readonly scanCompleted = new SyncAction<UnifiedScanCompletedPayload>();
+    public readonly getCurrentState = new SyncAction();
 }

--- a/src/background/actions/path-snippet-actions.ts
+++ b/src/background/actions/path-snippet-actions.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+
+import { SyncAction } from 'common/flux/sync-action';
 
 export class PathSnippetActions {
-    public readonly getCurrentState = new Action<void>();
-    public readonly onAddPath = new Action<string>();
-    public readonly onAddSnippet = new Action<string>();
-    public readonly onClearData = new Action<void>();
+    public readonly getCurrentState = new SyncAction<void>();
+    public readonly onAddPath = new SyncAction<string>();
+    public readonly onAddSnippet = new SyncAction<string>();
+    public readonly onClearData = new SyncAction<void>();
 }

--- a/src/background/actions/permissions-state-actions.ts
+++ b/src/background/actions/permissions-state-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 
 export class PermissionsStateActions {
-    public readonly getCurrentState = new Action<void>();
-    public readonly setPermissionsState = new Action<SetAllUrlsPermissionStatePayload>();
+    public readonly getCurrentState = new SyncAction<void>();
+    public readonly setPermissionsState = new SyncAction<SetAllUrlsPermissionStatePayload>();
 }

--- a/src/background/actions/scoping-actions.ts
+++ b/src/background/actions/scoping-actions.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { BaseActionPayload } from './action-payloads';
 
 export interface ScopingPayload extends BaseActionPayload {
@@ -9,7 +9,7 @@ export interface ScopingPayload extends BaseActionPayload {
 }
 
 export class ScopingActions {
-    public readonly addSelector = new Action<ScopingPayload>();
-    public readonly deleteSelector = new Action<ScopingPayload>();
-    public readonly getCurrentState = new Action<void>();
+    public readonly addSelector = new SyncAction<ScopingPayload>();
+    public readonly deleteSelector = new SyncAction<ScopingPayload>();
+    public readonly getCurrentState = new SyncAction<void>();
 }

--- a/src/background/actions/side-panel-actions.ts
+++ b/src/background/actions/side-panel-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { SidePanel } from 'background/stores/side-panel';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 
 export class SidePanelActions {
-    public readonly openSidePanel = new Action<SidePanel>();
-    public readonly closeSidePanel = new Action<SidePanel>();
+    public readonly openSidePanel = new SyncAction<SidePanel>();
+    public readonly closeSidePanel = new SyncAction<SidePanel>();
 }

--- a/src/background/actions/tab-actions.ts
+++ b/src/background/actions/tab-actions.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { Tab } from 'common/itab';
 
 export class TabActions {
-    public readonly newTabCreated = new Action<Tab>();
-    public readonly getCurrentState = new Action();
-    public readonly injectedScripts = new Action();
-    public readonly tabRemove = new Action();
-    public readonly existingTabUpdated = new Action<Tab>();
-    public readonly tabVisibilityChange = new Action<boolean>();
+    public readonly newTabCreated = new SyncAction<Tab>();
+    public readonly getCurrentState = new SyncAction();
+    public readonly injectedScripts = new SyncAction();
+    public readonly tabRemove = new SyncAction();
+    public readonly existingTabUpdated = new SyncAction<Tab>();
+    public readonly tabVisibilityChange = new SyncAction<boolean>();
 }

--- a/src/background/actions/tab-stop-requirement-actions.ts
+++ b/src/background/actions/tab-stop-requirement-actions.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import {
     AddTabStopInstancePayload,
     BaseActionPayload,
@@ -16,18 +16,18 @@ import {
 } from './action-payloads';
 
 export class TabStopRequirementActions {
-    public readonly getCurrentState = new Action();
+    public readonly getCurrentState = new SyncAction();
     public readonly updateTabStopsRequirementStatus =
-        new Action<UpdateTabStopRequirementStatusPayload>();
-    public readonly addTabStopInstance = new Action<AddTabStopInstancePayload>();
-    public readonly updateTabStopInstance = new Action<UpdateTabStopInstancePayload>();
-    public readonly removeTabStopInstance = new Action<RemoveTabStopInstancePayload>();
+        new SyncAction<UpdateTabStopRequirementStatusPayload>();
+    public readonly addTabStopInstance = new SyncAction<AddTabStopInstancePayload>();
+    public readonly updateTabStopInstance = new SyncAction<UpdateTabStopInstancePayload>();
+    public readonly removeTabStopInstance = new SyncAction<RemoveTabStopInstancePayload>();
     public readonly resetTabStopRequirementStatus =
-        new Action<ResetTabStopRequirementStatusPayload>();
+        new SyncAction<ResetTabStopRequirementStatusPayload>();
     public readonly toggleTabStopRequirementExpand =
-        new Action<ToggleTabStopRequirementExpandPayload>();
-    public readonly updateTabbingCompleted = new Action<UpdateTabbingCompletedPayload>();
+        new SyncAction<ToggleTabStopRequirementExpandPayload>();
+    public readonly updateTabbingCompleted = new SyncAction<UpdateTabbingCompletedPayload>();
     public readonly updateNeedToCollectTabbingResults =
-        new Action<UpdateNeedToCollectTabbingResultsPayload>();
-    public readonly automatedTabbingResultsCompleted = new Action<BaseActionPayload>();
+        new SyncAction<UpdateNeedToCollectTabbingResultsPayload>();
+    public readonly automatedTabbingResultsCompleted = new SyncAction<BaseActionPayload>();
 }

--- a/src/background/actions/unified-scan-result-actions.ts
+++ b/src/background/actions/unified-scan-result-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { UnifiedScanCompletedPayload } from './action-payloads';
 
 export class UnifiedScanResultActions {
-    public readonly scanCompleted = new Action<UnifiedScanCompletedPayload>();
-    public readonly getCurrentState = new Action();
+    public readonly scanCompleted = new SyncAction<UnifiedScanCompletedPayload>();
+    public readonly getCurrentState = new SyncAction();
 }

--- a/src/background/actions/user-configuration-actions.ts
+++ b/src/background/actions/user-configuration-actions.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import {
     AutoDetectedFailuresDialogStatePayload,
     SaveIssueFilingSettingsPayload,
@@ -11,16 +11,16 @@ import {
 } from './action-payloads';
 
 export class UserConfigurationActions {
-    public readonly setAdbLocation = new Action<string>();
-    public readonly setTelemetryState = new Action<boolean>();
-    public readonly getCurrentState = new Action<void>();
-    public readonly setHighContrastMode = new Action<SetHighContrastModePayload>();
-    public readonly setNativeHighContrastMode = new Action<SetHighContrastModePayload>();
-    public readonly setIssueFilingService = new Action<SetIssueFilingServicePayload>();
+    public readonly setAdbLocation = new SyncAction<string>();
+    public readonly setTelemetryState = new SyncAction<boolean>();
+    public readonly getCurrentState = new SyncAction<void>();
+    public readonly setHighContrastMode = new SyncAction<SetHighContrastModePayload>();
+    public readonly setNativeHighContrastMode = new SyncAction<SetHighContrastModePayload>();
+    public readonly setIssueFilingService = new SyncAction<SetIssueFilingServicePayload>();
     public readonly setIssueFilingServiceProperty =
-        new Action<SetIssueFilingServicePropertyPayload>();
-    public readonly saveIssueFilingSettings = new Action<SaveIssueFilingSettingsPayload>();
-    public readonly saveWindowBounds = new Action<SaveWindowBoundsPayload>();
+        new SyncAction<SetIssueFilingServicePropertyPayload>();
+    public readonly saveIssueFilingSettings = new SyncAction<SaveIssueFilingSettingsPayload>();
+    public readonly saveWindowBounds = new SyncAction<SaveWindowBoundsPayload>();
     public readonly setAutoDetectedFailuresDialogState =
-        new Action<AutoDetectedFailuresDialogStatePayload>();
+        new SyncAction<AutoDetectedFailuresDialogStatePayload>();
 }

--- a/src/background/actions/visualization-actions.ts
+++ b/src/background/actions/visualization-actions.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { VisualizationType } from 'common/types/visualization-type';
 import {
     ToggleActionPayload,
@@ -9,21 +9,21 @@ import {
 } from './action-payloads';
 
 export class VisualizationActions {
-    public readonly enableVisualization = new Action<ToggleActionPayload>();
-    public readonly enableVisualizationWithoutScan = new Action<ToggleActionPayload>();
-    public readonly disableVisualization = new Action<VisualizationType>();
-    public readonly disableAssessmentVisualizations = new Action<void>();
-    public readonly resetDataForVisualization = new Action<VisualizationType>();
+    public readonly enableVisualization = new SyncAction<ToggleActionPayload>();
+    public readonly enableVisualizationWithoutScan = new SyncAction<ToggleActionPayload>();
+    public readonly disableVisualization = new SyncAction<VisualizationType>();
+    public readonly disableAssessmentVisualizations = new SyncAction<void>();
+    public readonly resetDataForVisualization = new SyncAction<VisualizationType>();
 
-    public readonly updateFocusedInstance = new Action<string[]>();
+    public readonly updateFocusedInstance = new SyncAction<string[]>();
 
-    public readonly scanCompleted = new Action<void>();
-    public readonly scrollRequested = new Action();
-    public readonly getCurrentState = new Action();
+    public readonly scanCompleted = new SyncAction<void>();
+    public readonly scrollRequested = new SyncAction();
+    public readonly getCurrentState = new SyncAction();
 
-    public readonly updateSelectedPivotChild = new Action<UpdateSelectedDetailsViewPayload>();
-    public readonly updateSelectedPivot = new Action<UpdateSelectedPivot>();
+    public readonly updateSelectedPivotChild = new SyncAction<UpdateSelectedDetailsViewPayload>();
+    public readonly updateSelectedPivot = new SyncAction<UpdateSelectedPivot>();
 
-    public readonly injectionCompleted = new Action();
-    public readonly injectionStarted = new Action();
+    public readonly injectionCompleted = new SyncAction();
+    public readonly injectionStarted = new SyncAction();
 }

--- a/src/background/actions/visualization-scan-result-actions.ts
+++ b/src/background/actions/visualization-scan-result-actions.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { ScanCompletedPayload } from '../../injected/analyzers/analyzer';
 import { AddTabbedElementPayload } from './action-payloads';
 
 export class VisualizationScanResultActions {
-    public readonly scanCompleted = new Action<ScanCompletedPayload<any>>();
-    public readonly getCurrentState = new Action();
-    public readonly addTabbedElement = new Action<AddTabbedElementPayload>();
-    public readonly disableTabStop = new Action();
+    public readonly scanCompleted = new SyncAction<ScanCompletedPayload<any>>();
+    public readonly getCurrentState = new SyncAction();
+    public readonly addTabbedElement = new SyncAction<AddTabbedElementPayload>();
+    public readonly disableTabStop = new SyncAction();
 }

--- a/src/common/flux/action.ts
+++ b/src/common/flux/action.ts
@@ -1,37 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DictionaryStringTo } from '../../types/common-types';
 
-export class Action<TPayload> {
-    /**
-     * A mutex to ensure that only one action in a given scope is executing at any time.
-     * This prevents cascading actions.
-     */
-    private static executingScopes: DictionaryStringTo<boolean> = {};
-
-    private listeners: ((payload: TPayload) => void)[] = [];
-    private scope: string = 'DEFAULT_SCOPE';
-
-    public invoke(payload: TPayload, scope?: string): void {
-        const activeScope = scope ?? this.scope;
-        if (Action.executingScopes[activeScope]) {
-            throw new Error(
-                `Cannot invoke an action with scope ${activeScope} from inside another action with the same scope`,
-            );
-        }
-
-        Action.executingScopes[activeScope] = true;
-
-        try {
-            this.listeners.forEach((listener: (payload: TPayload) => void) => {
-                listener(payload);
-            });
-        } finally {
-            delete Action.executingScopes[activeScope];
-        }
-    }
-
-    public addListener(listener: (payload: TPayload) => void): void {
-        this.listeners.push(listener);
-    }
+export interface Action<TPayload, TReturn> {
+    invoke(payload: TPayload, scope?: string): TReturn;
+    addListener(listener: (payload: TPayload) => TReturn): void;
 }

--- a/src/common/flux/async-action.ts
+++ b/src/common/flux/async-action.ts
@@ -14,9 +14,10 @@ export class AsyncAction<TPayload> implements Action<TPayload, Promise<void>> {
         this.scopeMutex.tryLockScope(scope);
 
         try {
-            await Promise.all(
+            const results = await Promise.allSettled(
                 this.listeners.map((listener: (payload: TPayload) => void) => listener(payload)),
             );
+            this.throwCombinedRejections(results);
         } finally {
             this.scopeMutex.unlockScope(scope);
         }
@@ -24,5 +25,20 @@ export class AsyncAction<TPayload> implements Action<TPayload, Promise<void>> {
 
     public addListener(listener: (payload: TPayload) => Promise<void>): void {
         this.listeners.push(listener);
+    }
+
+    private throwCombinedRejections(promiseResults: PromiseSettledResult<void>[]): void {
+        const rejectedResults = promiseResults.filter(
+            (r): r is PromiseRejectedResult => r.status === 'rejected',
+        );
+
+        if (rejectedResults.length === 1) {
+            throw rejectedResults[0].reason;
+        }
+
+        if (rejectedResults.length > 0) {
+            const rejectedReasons = rejectedResults.map(r => r.reason);
+            throw new AggregateError(rejectedReasons);
+        }
     }
 }

--- a/src/common/flux/async-action.ts
+++ b/src/common/flux/async-action.ts
@@ -4,20 +4,23 @@
 // Licensed under the MIT License.
 import { Action } from 'common/flux/action';
 import { ScopeMutex } from 'common/flux/scope-mutex';
+import { mergePromiseResponses } from 'common/merge-promise-responses';
 
 export class AsyncAction<TPayload> implements Action<TPayload, Promise<void>> {
     private listeners: ((payload: TPayload) => Promise<void>)[] = [];
 
-    constructor(private readonly scopeMutex: ScopeMutex = new ScopeMutex()) {}
+    constructor(
+        private readonly scopeMutex: ScopeMutex = new ScopeMutex(),
+        private mergePromises: (
+            promises: Promise<unknown>[],
+        ) => Promise<void> = mergePromiseResponses,
+    ) {}
 
     public async invoke(payload: TPayload, scope?: string): Promise<void> {
         this.scopeMutex.tryLockScope(scope);
 
         try {
-            const results = await Promise.allSettled(
-                this.listeners.map((listener: (payload: TPayload) => void) => listener(payload)),
-            );
-            this.throwCombinedRejections(results);
+            await this.mergePromises(this.listeners.map(listener => listener(payload)));
         } finally {
             this.scopeMutex.unlockScope(scope);
         }
@@ -25,20 +28,5 @@ export class AsyncAction<TPayload> implements Action<TPayload, Promise<void>> {
 
     public addListener(listener: (payload: TPayload) => Promise<void>): void {
         this.listeners.push(listener);
-    }
-
-    private throwCombinedRejections(promiseResults: PromiseSettledResult<void>[]): void {
-        const rejectedResults = promiseResults.filter(
-            (r): r is PromiseRejectedResult => r.status === 'rejected',
-        );
-
-        if (rejectedResults.length === 1) {
-            throw rejectedResults[0].reason;
-        }
-
-        if (rejectedResults.length > 0) {
-            const rejectedReasons = rejectedResults.map(r => r.reason);
-            throw new AggregateError(rejectedReasons);
-        }
     }
 }

--- a/src/common/flux/async-action.ts
+++ b/src/common/flux/async-action.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Action } from 'common/flux/action';
+import { ScopeMutex } from 'common/flux/scope-mutex';
+
+export class AsyncAction<TPayload> implements Action<TPayload, Promise<void>> {
+    private listeners: ((payload: TPayload) => Promise<void>)[] = [];
+
+    constructor(private readonly scopeMutex: ScopeMutex = new ScopeMutex()) {}
+
+    public async invoke(payload: TPayload, scope?: string): Promise<void> {
+        this.scopeMutex.tryLockScope(scope);
+
+        try {
+            await Promise.all(
+                this.listeners.map((listener: (payload: TPayload) => void) => listener(payload)),
+            );
+        } finally {
+            this.scopeMutex.unlockScope(scope);
+        }
+    }
+
+    public addListener(listener: (payload: TPayload) => Promise<void>): void {
+        this.listeners.push(listener);
+    }
+}

--- a/src/common/flux/scope-mutex.ts
+++ b/src/common/flux/scope-mutex.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DictionaryStringTo } from 'types/common-types';
+
+export class ScopeMutex {
+    /**
+     * A mutex to ensure that only one action in a given scope is executing at any time.
+     * This prevents cascading actions.
+     */
+    private static executingScopes: DictionaryStringTo<boolean> = {};
+    private static defaultScope: string = 'DEFAULT_SCOPE';
+
+    public tryLockScope(scope?: string): void {
+        const activeScope = scope ?? ScopeMutex.defaultScope;
+        if (ScopeMutex.executingScopes[activeScope]) {
+            throw new Error(
+                `Cannot invoke an action with scope ${activeScope} from inside another action with the same scope`,
+            );
+        }
+
+        ScopeMutex.executingScopes[activeScope] = true;
+    }
+
+    public unlockScope(scope?: string): void {
+        const activeScope = scope ?? ScopeMutex.defaultScope;
+        delete ScopeMutex.executingScopes[activeScope];
+    }
+}

--- a/src/common/flux/sync-action.ts
+++ b/src/common/flux/sync-action.ts
@@ -1,34 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Action } from 'common/flux/action';
-import { DictionaryStringTo } from '../../types/common-types';
+import { ScopeMutex } from 'common/flux/scope-mutex';
 
 export class SyncAction<TPayload> implements Action<TPayload, void> {
-    /**
-     * A mutex to ensure that only one action in a given scope is executing at any time.
-     * This prevents cascading actions.
-     */
-    private static executingScopes: DictionaryStringTo<boolean> = {};
-
     private listeners: ((payload: TPayload) => void)[] = [];
-    private scope: string = 'DEFAULT_SCOPE';
+
+    constructor(private readonly scopeMutex: ScopeMutex = new ScopeMutex()) {}
 
     public invoke(payload: TPayload, scope?: string): void {
-        const activeScope = scope ?? this.scope;
-        if (SyncAction.executingScopes[activeScope]) {
-            throw new Error(
-                `Cannot invoke an action with scope ${activeScope} from inside another action with the same scope`,
-            );
-        }
-
-        SyncAction.executingScopes[activeScope] = true;
+        this.scopeMutex.tryLockScope(scope);
 
         try {
             this.listeners.forEach((listener: (payload: TPayload) => void) => {
                 listener(payload);
             });
         } finally {
-            delete SyncAction.executingScopes[activeScope];
+            this.scopeMutex.unlockScope(scope);
         }
     }
 

--- a/src/common/flux/sync-action.ts
+++ b/src/common/flux/sync-action.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Action } from 'common/flux/action';
+import { DictionaryStringTo } from '../../types/common-types';
+
+export class SyncAction<TPayload> implements Action<TPayload, void> {
+    /**
+     * A mutex to ensure that only one action in a given scope is executing at any time.
+     * This prevents cascading actions.
+     */
+    private static executingScopes: DictionaryStringTo<boolean> = {};
+
+    private listeners: ((payload: TPayload) => void)[] = [];
+    private scope: string = 'DEFAULT_SCOPE';
+
+    public invoke(payload: TPayload, scope?: string): void {
+        const activeScope = scope ?? this.scope;
+        if (SyncAction.executingScopes[activeScope]) {
+            throw new Error(
+                `Cannot invoke an action with scope ${activeScope} from inside another action with the same scope`,
+            );
+        }
+
+        SyncAction.executingScopes[activeScope] = true;
+
+        try {
+            this.listeners.forEach((listener: (payload: TPayload) => void) => {
+                listener(payload);
+            });
+        } finally {
+            delete SyncAction.executingScopes[activeScope];
+        }
+    }
+
+    public addListener(listener: (payload: TPayload) => void): void {
+        this.listeners.push(listener);
+    }
+}

--- a/src/common/merge-promise-responses.ts
+++ b/src/common/merge-promise-responses.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// We want behavior in between Promise.all and Promise.allSettled; we want to wait for every
+// promise even if one errors immediately, like allSettled, but we also want to reject the
+// wrapping promise if any of the inner ones fail (for error reporting purposes).
+export async function mergePromiseResponses(asyncResponses: Promise<unknown>[]): Promise<void> {
+    const results = await Promise.allSettled(asyncResponses);
+
+    const rejectedResults = results.filter(
+        (r): r is PromiseRejectedResult => r.status === 'rejected',
+    );
+
+    if (rejectedResults.length === 1) {
+        throw rejectedResults[0].reason;
+    }
+
+    if (rejectedResults.length > 0) {
+        const rejectedReasons = rejectedResults.map(r => r.reason);
+        throw new AggregateError(rejectedReasons);
+    }
+}

--- a/src/debug-tools/actions/debug-tools-nav-actions.ts
+++ b/src/debug-tools/actions/debug-tools-nav-actions.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { ToolsNavKey } from 'debug-tools/stores/debug-tools-nav-store';
 
 export class DebugToolsNavActions {
-    public readonly setSelectedTool = new Action<ToolsNavKey>();
+    public readonly setSelectedTool = new SyncAction<ToolsNavKey>();
 }

--- a/src/electron/flux/action/android-setup-actions.ts
+++ b/src/electron/flux/action/android-setup-actions.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
 
 // This class needs only to represent possible simultaneously invokable actions
 // So, for example, the 'next' action may represent 'continue', 'try again', or 'start scanning'
 export class AndroidSetupActions {
-    public readonly cancel = new Action<void>();
-    public readonly next = new Action<void>();
-    public readonly readyToStart = new Action<void>();
-    public readonly rescan = new Action<void>();
-    public readonly saveAdbPath = new Action<string>();
-    public readonly setSelectedDevice = new Action<DeviceInfo>();
+    public readonly cancel = new SyncAction<void>();
+    public readonly next = new SyncAction<void>();
+    public readonly readyToStart = new SyncAction<void>();
+    public readonly rescan = new SyncAction<void>();
+    public readonly saveAdbPath = new SyncAction<string>();
+    public readonly setSelectedDevice = new SyncAction<DeviceInfo>();
 }

--- a/src/electron/flux/action/device-connection-actions.ts
+++ b/src/electron/flux/action/device-connection-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 
 export class DeviceConnectionActions {
-    public readonly statusUnknown = new Action<void>();
-    public readonly statusConnected = new Action<void>();
-    public readonly statusDisconnected = new Action<void>();
+    public readonly statusUnknown = new SyncAction<void>();
+    public readonly statusConnected = new SyncAction<void>();
+    public readonly statusDisconnected = new SyncAction<void>();
 }

--- a/src/electron/flux/action/left-nav-actions.ts
+++ b/src/electron/flux/action/left-nav-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 
 export class LeftNavActions {
-    public readonly itemSelected = new Action<LeftNavItemKey>();
-    public readonly setLeftNavVisible = new Action<boolean>();
+    public readonly itemSelected = new SyncAction<LeftNavItemKey>();
+    public readonly setLeftNavVisible = new SyncAction<boolean>();
 }

--- a/src/electron/flux/action/scan-actions.ts
+++ b/src/electron/flux/action/scan-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 
 export class ScanActions {
-    public readonly scanStarted = new Action<void>();
-    public readonly scanCompleted = new Action<void>();
-    public readonly scanFailed = new Action<void>();
+    public readonly scanStarted = new SyncAction<void>();
+    public readonly scanCompleted = new SyncAction<void>();
+    public readonly scanFailed = new SyncAction<void>();
 }

--- a/src/electron/flux/action/tab-stops-actions.ts
+++ b/src/electron/flux/action/tab-stops-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 
 export class TabStopsActions {
-    public readonly enableFocusTracking = new Action<void>();
-    public readonly disableFocusTracking = new Action<void>();
-    public readonly startOver = new Action<void>();
+    public readonly enableFocusTracking = new SyncAction<void>();
+    public readonly disableFocusTracking = new SyncAction<void>();
+    public readonly startOver = new SyncAction<void>();
 }

--- a/src/electron/flux/action/window-frame-actions.ts
+++ b/src/electron/flux/action/window-frame-actions.ts
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { Rectangle } from 'electron';
 import { SetSizePayload } from 'electron/flux/action/window-frame-actions-payloads';
 
 export class WindowFrameActions {
-    public readonly enterFullScreen = new Action<void>();
-    public readonly maximize = new Action<void>();
-    public readonly minimize = new Action<void>();
-    public readonly restore = new Action<void>();
-    public readonly close = new Action<void>();
-    public readonly setWindowSize = new Action<SetSizePayload>();
-    public readonly setWindowBounds = new Action<Rectangle>();
+    public readonly enterFullScreen = new SyncAction<void>();
+    public readonly maximize = new SyncAction<void>();
+    public readonly minimize = new SyncAction<void>();
+    public readonly restore = new SyncAction<void>();
+    public readonly close = new SyncAction<void>();
+    public readonly setWindowSize = new SyncAction<SetSizePayload>();
+    public readonly setWindowBounds = new SyncAction<Rectangle>();
 }

--- a/src/electron/flux/action/window-state-actions.ts
+++ b/src/electron/flux/action/window-state-actions.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { WindowStatePayload } from 'electron/flux/action/window-state-payload';
 import { RoutePayload } from './route-payloads';
 
 export class WindowStateActions {
-    public readonly setRoute = new Action<RoutePayload>();
-    public readonly setWindowState = new Action<WindowStatePayload>();
+    public readonly setRoute = new SyncAction<RoutePayload>();
+    public readonly setWindowState = new SyncAction<WindowStatePayload>();
 }

--- a/src/electron/ipc/ipc-renderer-shim.ts
+++ b/src/electron/ipc/ipc-renderer-shim.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { IpcRenderer, OpenDialogOptions, OpenDialogReturnValue, Rectangle } from 'electron';
 import {
     SetSizePayload,
@@ -67,10 +67,11 @@ export class IpcRendererShim {
 
     // Listen to these events to receive data sent TO renderer process
     public readonly fromBrowserWindowClose = new AsyncAction();
-    public readonly fromBrowserWindowMaximize = new Action<void>();
-    public readonly fromBrowserWindowUnmaximize = new Action<void>();
-    public readonly fromBrowserWindowEnterFullScreen = new Action<void>();
-    public readonly fromBrowserWindowWindowBoundsChanged = new Action<WindowBoundsChangedPayload>();
+    public readonly fromBrowserWindowMaximize = new SyncAction<void>();
+    public readonly fromBrowserWindowUnmaximize = new SyncAction<void>();
+    public readonly fromBrowserWindowEnterFullScreen = new SyncAction<void>();
+    public readonly fromBrowserWindowWindowBoundsChanged =
+        new SyncAction<WindowBoundsChangedPayload>();
 
     public getAppPath = async (): Promise<string> => {
         return await this.ipcRenderer.invoke(IPC_FROMRENDERER_GET_APP_PATH_CHANNEL_NAME);

--- a/src/electron/platform/android/setup/state-machine/state-machine-action-callback.ts
+++ b/src/electron/platform/android/setup/state-machine/state-machine-action-callback.ts
@@ -9,7 +9,7 @@ import { Action } from 'common/flux/action';
 // how the indexer type on the class can't be infered.
 // https://github.com/microsoft/TypeScript/issues/15300
 export type ActionBag<ActionT> = {
-    [key in keyof ActionT]: Action<unknown>;
+    [key in keyof ActionT]: Action<unknown, void | Promise<void>>;
 };
 
 // This type represents a callback of form `(payload: PayloadT) => void`, where PayloadT matches

--- a/src/tests/unit/common/store-tester.ts
+++ b/src/tests/unit/common/store-tester.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { BaseStoreImpl } from 'background/stores/base-store-impl';
 import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { BaseStore } from '../../../common/base-store';
@@ -78,8 +79,8 @@ export class StoreTester<TStoreData, TActions> {
         return actionsMock;
     }
 
-    private createActionMock(): IMock<Action<unknown>> {
-        const actionMock = Mock.ofType(Action);
+    private createActionMock(): IMock<Action<unknown, unknown>> {
+        const actionMock = Mock.ofType<Action<unknown, unknown>>();
 
         actionMock
             .setup(a => a.addListener(It.is(param => param instanceof Function)))

--- a/src/tests/unit/common/store-tester.ts
+++ b/src/tests/unit/common/store-tester.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { BaseStoreImpl } from 'background/stores/base-store-impl';
 import { Action } from 'common/flux/action';
-import { SyncAction } from 'common/flux/sync-action';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { BaseStore } from '../../../common/base-store';

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-test-view-controller.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-test-view-controller.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
 import {
     EditExistingFailureInstancePayload,
@@ -64,8 +64,8 @@ describe('TabStopsTestViewController', () => {
         return actionsMock;
     }
 
-    function createActionMock(): IMock<Action<unknown>> {
-        const actionMock = Mock.ofType(Action);
+    function createActionMock(): IMock<SyncAction<unknown>> {
+        const actionMock = Mock.ofType(SyncAction);
 
         actionMock
             .setup(a => a.addListener(It.is(param => param instanceof Function)))

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -40,6 +40,7 @@ import {
     TriggeredBy,
 } from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { NotificationCreator } from 'common/notification-creator';
@@ -908,16 +909,16 @@ describe('ActionCreatorTest', () => {
 
 class ActionCreatorValidator {
     private visualizationActionsContainerMock = Mock.ofType(VisualizationActions);
-    private visualizationActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
-    private devToolsActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
-    private cardSelectionActionsMocks: DictionaryStringTo<IMock<Action<any>>> = {};
-    private needsReviewCardSelectionActionsMocks: DictionaryStringTo<IMock<Action<any>>> = {};
-    private unifiedScanResultActionsMocks: DictionaryStringTo<IMock<Action<any>>> = {};
-    private tabStopRequirementActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
+    private visualizationActionMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
+    private devToolsActionMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
+    private cardSelectionActionsMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
+    private needsReviewCardSelectionActionsMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
+    private unifiedScanResultActionsMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
+    private tabStopRequirementActionMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
     private visualizationScanResultActionsContainerMock = Mock.ofType(
         VisualizationScanResultActions,
     );
-    private visualizationScanResultActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
+    private visualizationScanResultActionMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
 
     private tabStopRequirementActionsContainerMock = Mock.ofType(TabStopRequirementActions);
     private detailsViewActionsContainerMock = Mock.ofType(DetailsViewActions);
@@ -930,11 +931,11 @@ class ActionCreatorValidator {
         NeedsReviewCardSelectionActions,
     );
     private unifiedScanResultsActionsContainerMock = Mock.ofType(UnifiedScanResultActions);
-    private sidePanelActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
-    private scopingActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
-    private detailsViewActionsMocks: DictionaryStringTo<IMock<Action<any>>> = {};
+    private sidePanelActionMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
+    private scopingActionMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
+    private detailsViewActionsMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
 
-    private inspectActionsMock: DictionaryStringTo<IMock<Action<any>>> = {};
+    private inspectActionsMock: DictionaryStringTo<IMock<Action<any, any>>> = {};
 
     private devToolActionsContainerMock = Mock.ofType(DevToolActions);
 
@@ -989,12 +990,12 @@ class ActionCreatorValidator {
     private setupActionWithInvokeParameter(
         actionName: string,
         expectedInvokeParam: any,
-        actionsMap: DictionaryStringTo<IMock<Action<any>>>,
+        actionsMap: DictionaryStringTo<IMock<Action<any, any>>>,
     ): ActionCreatorValidator {
         let action = actionsMap[actionName];
 
         if (action == null) {
-            action = Mock.ofType(Action);
+            action = Mock.ofType(SyncAction);
             actionsMap[actionName] = action;
         }
 
@@ -1157,13 +1158,13 @@ class ActionCreatorValidator {
 
     private setupAction(
         actionName: string,
-        actionsMap: DictionaryStringTo<IMock<Action<any>>>,
+        actionsMap: DictionaryStringTo<IMock<Action<any, any>>>,
         actionsContainerMock: IMock<any>,
     ): ActionCreatorValidator {
         let action = actionsMap[actionName];
 
         if (action == null) {
-            action = Mock.ofType(Action);
+            action = Mock.ofType(SyncAction);
             actionsMap[actionName] = action;
         }
 
@@ -1322,7 +1323,7 @@ class ActionCreatorValidator {
         this.verifyAllActions(this.needsReviewCardSelectionActionsMocks);
     }
 
-    private verifyAllActions(actionsMap: DictionaryStringTo<IMock<Action<any>>>): void {
+    private verifyAllActions(actionsMap: DictionaryStringTo<IMock<Action<any, any>>>): void {
         forOwn(actionsMap, action => {
             action.verifyAll();
         });

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -21,7 +21,7 @@ import { AssessmentActions } from 'background/actions/assessment-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import * as TelemetryEvents from 'common/extension-telemetry-events';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
@@ -34,7 +34,7 @@ import {
 } from 'injected/analyzers/analyzer';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -57,8 +57,8 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles PassUnmarkedInstances message', () => {
-        const updateTabIdActionMock = createActionMock(testTabId);
-        const passUnmarkedInstanceActionMock = createActionMock(telemetryOnlyPayload);
+        const updateTabIdActionMock = createSyncActionMock(testTabId);
+        const passUnmarkedInstanceActionMock = createSyncActionMock(telemetryOnlyPayload);
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('passUnmarkedInstance', passUnmarkedInstanceActionMock);
@@ -90,7 +90,7 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles ContinuePreviousAssessment message', () => {
-        const continuePreviousAssessmentMock = createActionMock(testTabId);
+        const continuePreviousAssessmentMock = createSyncActionMock(testTabId);
         const actionsMock = createActionsMock(
             'continuePreviousAssessment',
             continuePreviousAssessmentMock.object,
@@ -126,7 +126,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as EditFailureInstancePayload;
 
-        const editFailureInstanceMock = createActionMock(payload);
+        const editFailureInstanceMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'editFailureInstance',
             editFailureInstanceMock.object,
@@ -158,7 +158,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as RemoveFailureInstancePayload;
 
-        const removeFailureInstanceMock = createActionMock(payload);
+        const removeFailureInstanceMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'removeFailureInstance',
             removeFailureInstanceMock.object,
@@ -189,7 +189,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as AddFailureInstancePayload;
 
-        const addFailureInstanceMock = createActionMock(payload);
+        const addFailureInstanceMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('addFailureInstance', addFailureInstanceMock.object);
         const interpreterMock = createInterpreterMock(
             AssessmentMessages.AddFailureInstance,
@@ -216,7 +216,7 @@ describe('AssessmentActionCreatorTest', () => {
             description: 'test-description',
         };
 
-        const addResultDescriptionMock = createActionMock(payload);
+        const addResultDescriptionMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'addResultDescription',
             addResultDescriptionMock.object,
@@ -243,8 +243,8 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeRequirementStatusPayload;
 
-        const updateTabIdActionMock = createActionMock(testTabId);
-        const changeRequirementStatusMock = createActionMock(payload);
+        const updateTabIdActionMock = createSyncActionMock(testTabId);
+        const changeRequirementStatusMock = createSyncActionMock(payload);
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('changeRequirementStatus', changeRequirementStatusMock);
@@ -277,7 +277,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeRequirementStatusPayload;
 
-        const undoRequirementStatusChange = createActionMock(payload);
+        const undoRequirementStatusChange = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'undoRequirementStatusChange',
             undoRequirementStatusChange.object,
@@ -310,7 +310,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as AssessmentActionInstancePayload;
 
-        const undoInstanceStatusChangeMock = createActionMock(payload);
+        const undoInstanceStatusChangeMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'undoInstanceStatusChange',
             undoInstanceStatusChangeMock.object,
@@ -338,8 +338,8 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeInstanceSelectionPayload;
 
-        const updateTabIdActionMock = createActionMock(testTabId);
-        const changeInstanceStatusMock = createActionMock(payload);
+        const updateTabIdActionMock = createSyncActionMock(testTabId);
+        const changeInstanceStatusMock = createSyncActionMock(payload);
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('changeInstanceStatus', changeInstanceStatusMock);
@@ -372,7 +372,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeInstanceSelectionPayload;
 
-        const changeAssessmentVisualizationStateMock = createActionMock(payload);
+        const changeAssessmentVisualizationStateMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'changeAssessmentVisualizationState',
             changeAssessmentVisualizationStateMock.object,
@@ -407,7 +407,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeInstanceSelectionPayload;
 
-        const changeAssessmentVisualizationStateForAllMock = createActionMock(payload);
+        const changeAssessmentVisualizationStateForAllMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'changeAssessmentVisualizationStateForAll',
             changeAssessmentVisualizationStateForAllMock.object,
@@ -442,7 +442,7 @@ describe('AssessmentActionCreatorTest', () => {
             test: -1 as VisualizationType,
         };
 
-        const resetDataMock = createActionMock(payload);
+        const resetDataMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('resetData', resetDataMock.object);
         const interpreterMock = createInterpreterMock(AssessmentMessages.StartOverTest, payload);
 
@@ -460,7 +460,7 @@ describe('AssessmentActionCreatorTest', () => {
     it('handles StartOverAllAssessments message', () => {
         const payload = {};
 
-        const resetAllAssessmentsData = createActionMock(testTabId);
+        const resetAllAssessmentsData = createSyncActionMock(testTabId);
         const actionsMock = createActionsMock(
             'resetAllAssessmentsData',
             resetAllAssessmentsData.object,
@@ -487,8 +487,8 @@ describe('AssessmentActionCreatorTest', () => {
             key: 'test-key',
         } as ScanCompletedPayload<any>;
 
-        const updateTabIdActionMock = createActionMock(testTabId);
-        const scanCompleteMock = createActionMock(payload);
+        const updateTabIdActionMock = createSyncActionMock(testTabId);
+        const scanCompleteMock = createSyncActionMock(payload);
 
         setupAssessmentActionsMock('scanCompleted', scanCompleteMock);
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
@@ -511,7 +511,7 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles GetCurrentState message', () => {
-        const getCurrentStateMock = createActionMock<void>(null);
+        const getCurrentStateMock = createSyncActionMock<void>(null);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
         const interpreterMock = createInterpreterMock(
             getStoreStateMessage(StoreNames.AssessmentStore),
@@ -535,7 +535,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as SelectTestSubviewPayload;
 
-        const selectRequirementMock = createActionMock(payload);
+        const selectRequirementMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('selectTestSubview', selectRequirementMock.object);
         const interpreterMock = createInterpreterMock(
             AssessmentMessages.SelectTestRequirement,
@@ -563,7 +563,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as SelectTestSubviewPayload;
 
-        const selectNextRequirement = createActionMock(payload);
+        const selectNextRequirement = createSyncActionMock(payload);
         const actionsMock = createActionsMock('selectTestSubview', selectNextRequirement.object);
         const interpreterMock = createInterpreterMock(
             AssessmentMessages.SelectNextRequirement,
@@ -594,7 +594,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as SelectTestSubviewPayload;
 
-        const selectRequirementMock = createActionMock(actionPayload);
+        const selectRequirementMock = createSyncActionMock(actionPayload);
         const actionsMock = createActionsMock('selectTestSubview', selectRequirementMock.object);
         const interpreterMock = createInterpreterMock(
             AssessmentMessages.SelectGettingStarted,
@@ -621,7 +621,7 @@ describe('AssessmentActionCreatorTest', () => {
             selectedTest: 1,
         } as ExpandTestNavPayload;
 
-        const expandTestNavMock = createActionMock(payload);
+        const expandTestNavMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('expandTestNav', expandTestNavMock.object);
         const interpreterMock = createInterpreterMock(AssessmentMessages.ExpandTestNav, payload);
 
@@ -637,7 +637,7 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles CollapseTestNav message', () => {
-        const collapseTestNavMock = createActionMock(null);
+        const collapseTestNavMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('collapseTestNav', collapseTestNavMock.object);
         const interpreterMock = createInterpreterMock(AssessmentMessages.CollapseTestNav, null);
 
@@ -658,7 +658,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ScanUpdatePayload;
 
-        const scanUpdateMock = createActionMock(payload);
+        const scanUpdateMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('scanUpdate', scanUpdateMock.object);
         const interpreterMock = createInterpreterMock(AssessmentMessages.ScanUpdate, payload);
 
@@ -682,7 +682,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ScanBasePayload;
 
-        const trackingCompletedMock = createActionMock(payload);
+        const trackingCompletedMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('trackingCompleted', trackingCompletedMock.object);
         const interpreterMock = createInterpreterMock(
             AssessmentMessages.TrackingCompleted,
@@ -709,7 +709,7 @@ describe('AssessmentActionCreatorTest', () => {
             pivotType: -1 as DetailsViewPivotType,
         } as OnDetailsViewOpenPayload;
 
-        const updateSelectedPivotChildMock = createActionMock(payload);
+        const updateSelectedPivotChildMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'updateSelectedPivotChild',
             updateSelectedPivotChildMock.object,
@@ -757,7 +757,7 @@ describe('AssessmentActionCreatorTest', () => {
             detailsViewId: 'testId',
         } as OnDetailsViewInitializedPayload;
 
-        const detailsViewInitMock = createActionMock(payload);
+        const detailsViewInitMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('updateDetailsViewId', detailsViewInitMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.Visualizations.DetailsView.Initialize,
@@ -777,7 +777,7 @@ describe('AssessmentActionCreatorTest', () => {
 
     function setupAssessmentActionsMock(
         actionName: keyof AssessmentActions,
-        actionMock: IMock<Action<any>>,
+        actionMock: IMock<SyncAction<any>>,
     ): void {
         assessmentActionsMock
             .setup(actions => actions[actionName])

--- a/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
@@ -13,7 +13,7 @@ import { Messages } from 'common/messages';
 import { IMock, Mock, Times } from 'typemoq';
 
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -30,7 +30,7 @@ describe('CardSelectionActionCreator', () => {
             resultInstanceUid: 'test-instance-uuid',
             ruleId: 'test-rule-id',
         };
-        const toggleCardSelectionMock = createActionMock(payload);
+        const toggleCardSelectionMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'toggleCardSelection',
             toggleCardSelectionMock.object,
@@ -60,7 +60,7 @@ describe('CardSelectionActionCreator', () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'test-rule-id',
         };
-        const ruleExpansionToggleMock = createActionMock(payload);
+        const ruleExpansionToggleMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'toggleRuleExpandCollapse',
             ruleExpansionToggleMock.object,
@@ -88,7 +88,7 @@ describe('CardSelectionActionCreator', () => {
 
     test('onToggleVisualHelper', () => {
         const payloadStub: BaseActionPayload = {};
-        const toggleVisualHelperMock = createActionMock(null);
+        const toggleVisualHelperMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('toggleVisualHelper', toggleVisualHelperMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.CardSelection.ToggleVisualHelper,
@@ -113,7 +113,7 @@ describe('CardSelectionActionCreator', () => {
 
     test('onCollapseAllRules', () => {
         const payloadStub: BaseActionPayload = {};
-        const collapseAllRulesActionMock = createActionMock(null);
+        const collapseAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock(
             'collapseAllRules',
             collapseAllRulesActionMock.object,
@@ -141,7 +141,7 @@ describe('CardSelectionActionCreator', () => {
 
     test('onExpandAllRules', () => {
         const payloadStub: BaseActionPayload = {};
-        const expandAllRulesActionMock = createActionMock(null);
+        const expandAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('expandAllRules', expandAllRulesActionMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.CardSelection.ExpandAllRules,

--- a/src/tests/unit/tests/background/actions/content-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/content-action-creator.test.ts
@@ -11,13 +11,13 @@ import {
     CONTENT_PANEL_OPENED,
     TelemetryEventSource,
 } from 'common/extension-telemetry-events';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { Logger } from 'common/logging/logger';
 import { Messages } from 'common/messages';
 import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { IMock, Mock, Times } from 'typemoq';
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -43,12 +43,12 @@ describe('ContentActionMessageCreator', () => {
 
         const tabId = -2;
 
-        let openContentPanelMock: IMock<Action<ContentPayload>>;
+        let openContentPanelMock: IMock<SyncAction<ContentPayload>>;
         let detailsViewControllerMock: IMock<ExtensionDetailsViewController>;
         let loggerMock: IMock<Logger>;
 
         beforeEach(() => {
-            openContentPanelMock = createActionMock(payload);
+            openContentPanelMock = createSyncActionMock(payload);
             actionsMock = createActionsMock('openContentPanel', openContentPanelMock.object);
             interpreterMock = createInterpreterMock(
                 Messages.ContentPanel.OpenPanel,
@@ -113,7 +113,7 @@ describe('ContentActionMessageCreator', () => {
             },
         };
 
-        const closeContentPanelMock = createActionMock<void>(undefined);
+        const closeContentPanelMock = createSyncActionMock<void>(undefined);
         actionsMock = createActionsMock('closeContentPanel', closeContentPanelMock.object);
         interpreterMock = createInterpreterMock(Messages.ContentPanel.ClosePanel, payload);
 

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -18,7 +18,7 @@ import {
     TelemetryEventSource,
     TriggeredBy,
 } from 'common/extension-telemetry-events';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
@@ -26,7 +26,7 @@ import { DetailsViewRightContentPanelType } from 'DetailsView/components/left-na
 import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -54,7 +54,7 @@ describe('DetailsViewActionCreatorTest', () => {
             MockBehavior.Strict,
         );
 
-        let openSidePanelMock: IMock<Action<SidePanel>>;
+        let openSidePanelMock: IMock<SyncAction<SidePanel>>;
         let sidePanelActionsMock: IMock<SidePanelActions>;
 
         let interpreterMock: IMock<Interpreter>;
@@ -66,7 +66,7 @@ describe('DetailsViewActionCreatorTest', () => {
             ${'Messages.Scoping.OpenPanel'}         | ${Messages.Scoping.OpenPanel}         | ${'Scoping'}         | ${SCOPING_OPEN}
         `('$messageFriendlyName', ({ actualMessage, sidePanel, telemetryEventName }) => {
             beforeEach(() => {
-                openSidePanelMock = createActionMock<SidePanel>(sidePanel);
+                openSidePanelMock = createSyncActionMock<SidePanel>(sidePanel);
                 sidePanelActionsMock = createSidePanelActionsMock(
                     'openSidePanel',
                     openSidePanelMock.object,
@@ -141,7 +141,7 @@ describe('DetailsViewActionCreatorTest', () => {
             ${'Messages.PreviewFeatures.ClosePanel'} | ${Messages.PreviewFeatures.ClosePanel} | ${'PreviewFeatures'} | ${PREVIEW_FEATURES_CLOSE}
             ${'Messages.Scoping.ClosePanel'}         | ${Messages.Scoping.ClosePanel}         | ${'Scoping'}         | ${SCOPING_CLOSE}
         `('$messageFriendlyName', ({ actualMessage, sidePanel, telemetryEventName }) => {
-            const closeSidePanelMock = createActionMock<SidePanel>(sidePanel);
+            const closeSidePanelMock = createSyncActionMock<SidePanel>(sidePanel);
 
             const sidePanelActionsMock = createSidePanelActionsMock(
                 'closeSidePanel',
@@ -171,7 +171,7 @@ describe('DetailsViewActionCreatorTest', () => {
     it('handles Visualization.DetailsView.SetDetailsViewRightContentPanel message', () => {
         const payload: DetailsViewRightContentPanelType = 'Overview';
 
-        const setSelectedDetailsViewRightContentPanelMock = createActionMock(payload);
+        const setSelectedDetailsViewRightContentPanelMock = createSyncActionMock(payload);
         const detailsViewActionsMock = createDetailsViewActionsMock(
             'setSelectedDetailsViewRightContentPanel',
             setSelectedDetailsViewRightContentPanelMock.object,
@@ -195,7 +195,7 @@ describe('DetailsViewActionCreatorTest', () => {
     });
 
     it('handles Visualization.DetailsView.GetState message', () => {
-        const getCurrentStateMock = createActionMock<void>(null);
+        const getCurrentStateMock = createSyncActionMock<void>(null);
         const detailsViewActionsMock = createDetailsViewActionsMock(
             'getCurrentState',
             getCurrentStateMock.object,

--- a/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
@@ -10,7 +10,7 @@ import { StoreNames } from 'common/stores/store-names';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -23,7 +23,7 @@ describe('DevToolsActionCreatorTest', () => {
     });
 
     it('handles DevToolOpened message', () => {
-        const setDevToolsStateMock = createActionMock(true);
+        const setDevToolsStateMock = createSyncActionMock(true);
         const actionsMock = createActionsMock('setDevToolState', setDevToolsStateMock.object);
         const interpreterMock = createInterpreterMock(Messages.DevTools.Opened, null, tabId);
 
@@ -39,7 +39,7 @@ describe('DevToolsActionCreatorTest', () => {
     });
 
     it('handles DevToolClosed message', () => {
-        const setDevToolsStateMock = createActionMock(false);
+        const setDevToolsStateMock = createSyncActionMock(false);
         const actionsMock = createActionsMock('setDevToolState', setDevToolsStateMock.object);
         const interpreterMock = createInterpreterMock(Messages.DevTools.Closed, undefined, tabId);
 
@@ -55,7 +55,7 @@ describe('DevToolsActionCreatorTest', () => {
     });
 
     it('handles GetState message', () => {
-        const getCurrentStateMock = createActionMock(null);
+        const getCurrentStateMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
         const interpreterMock = createInterpreterMock(
             getStoreStateMessage(StoreNames.DevToolsStore),
@@ -79,7 +79,7 @@ describe('DevToolsActionCreatorTest', () => {
             frameUrl: 'frame-url',
         };
 
-        const setFrameUrlMock = createActionMock(payload.frameUrl);
+        const setFrameUrlMock = createSyncActionMock(payload.frameUrl);
         const actionsMock = createActionsMock('setFrameUrl', setFrameUrlMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.DevTools.InspectFrameUrl,
@@ -107,7 +107,7 @@ describe('DevToolsActionCreatorTest', () => {
             .setup(publisher => publisher.publishTelemetry(TelemetryEvents.INSPECT_OPEN, payload))
             .verifiable(Times.once());
 
-        const setInspectElementMock = createActionMock(payload.target);
+        const setInspectElementMock = createSyncActionMock(payload.target);
         const actionsMock = createActionsMock('setInspectElement', setInspectElementMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.DevTools.InspectElement,

--- a/src/tests/unit/tests/background/actions/injection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/injection-action-creator.test.ts
@@ -4,14 +4,14 @@ import { InjectionActionCreator } from 'background/actions/injection-action-crea
 import { InjectionActions } from 'background/actions/injection-actions';
 import { Messages } from 'common/messages';
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from 'tests/unit/tests/background/global-action-creators/action-creator-test-helpers';
 import { IMock, Mock } from 'typemoq';
 
 describe('InjectionActionCreator', () => {
     it('handles InjectionStarted message', () => {
-        const injectionStartedMock = createActionMock(null);
+        const injectionStartedMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('injectionStarted', injectionStartedMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.Visualizations.State.InjectionStarted,
@@ -26,7 +26,7 @@ describe('InjectionActionCreator', () => {
     });
 
     it('handles InjectionCompleted message', () => {
-        const injectionCompletedMock = createActionMock<void>(null);
+        const injectionCompletedMock = createSyncActionMock<void>(null);
         const actionsMock = createActionsMock('injectionCompleted', injectionCompletedMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.Visualizations.State.InjectionCompleted,

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -7,14 +7,14 @@ import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { CHANGE_INSPECT_MODE } from 'common/extension-telemetry-events';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -30,7 +30,7 @@ describe('InspectActionCreator', () => {
     });
 
     it('handles GetState message', () => {
-        const getCurrentStateMock = createActionMock(undefined);
+        const getCurrentStateMock = createSyncActionMock(undefined);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
         const interpreterMock = createInterpreterMock(
             getStoreStateMessage(StoreNames.InspectStore),
@@ -57,7 +57,7 @@ describe('InspectActionCreator', () => {
 
         const tabId: number = -1;
 
-        let changeInspectModeMock: IMock<Action<InspectPayload>>;
+        let changeInspectModeMock: IMock<SyncAction<InspectPayload>>;
         let actionsMock: IMock<InspectActions>;
         let interpreterMock: IMock<Interpreter>;
 
@@ -68,7 +68,7 @@ describe('InspectActionCreator', () => {
                 .setup(publisher => publisher.publishTelemetry(CHANGE_INSPECT_MODE, payload))
                 .verifiable(Times.once());
 
-            changeInspectModeMock = createActionMock(payload);
+            changeInspectModeMock = createSyncActionMock(payload);
             actionsMock = createActionsMock('changeInspectMode', changeInspectModeMock.object);
             interpreterMock = createInterpreterMock(
                 Messages.Inspect.ChangeInspectMode,

--- a/src/tests/unit/tests/background/actions/needs-review-card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/needs-review-card-selection-action-creator.test.ts
@@ -13,7 +13,7 @@ import { Messages } from 'common/messages';
 import { IMock, Mock, Times } from 'typemoq';
 
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -30,7 +30,7 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
             resultInstanceUid: 'test-instance-uuid',
             ruleId: 'test-rule-id',
         };
-        const toggleNeedsReviewCardSelectionMock = createActionMock(payload);
+        const toggleNeedsReviewCardSelectionMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'toggleCardSelection',
             toggleNeedsReviewCardSelectionMock.object,
@@ -60,7 +60,7 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'test-rule-id',
         };
-        const ruleExpansionToggleMock = createActionMock(payload);
+        const ruleExpansionToggleMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'toggleRuleExpandCollapse',
             ruleExpansionToggleMock.object,
@@ -88,7 +88,7 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
 
     test('onToggleVisualHelper', () => {
         const payloadStub: BaseActionPayload = {};
-        const toggleVisualHelperMock = createActionMock(null);
+        const toggleVisualHelperMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('toggleVisualHelper', toggleVisualHelperMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.NeedsReviewCardSelection.ToggleVisualHelper,
@@ -113,7 +113,7 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
 
     test('onCollapseAllRules', () => {
         const payloadStub: BaseActionPayload = {};
-        const collapseAllRulesActionMock = createActionMock(null);
+        const collapseAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock(
             'collapseAllRules',
             collapseAllRulesActionMock.object,
@@ -141,7 +141,7 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
 
     test('onExpandAllRules', () => {
         const payloadStub: BaseActionPayload = {};
-        const expandAllRulesActionMock = createActionMock(null);
+        const expandAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('expandAllRules', expandAllRulesActionMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.NeedsReviewCardSelection.ExpandAllRules,

--- a/src/tests/unit/tests/background/actions/needs-review-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/needs-review-scan-result-action-creator.test.ts
@@ -15,7 +15,7 @@ import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { IMock, Mock, Times } from 'typemoq';
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -43,7 +43,7 @@ describe('NeedsReviewScanResultActionCreator', () => {
             telemetry,
         };
 
-        const scanCompletedMock = createActionMock(payload);
+        const scanCompletedMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('scanCompleted', scanCompletedMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.NeedsReviewScan.ScanCompleted,
@@ -73,7 +73,7 @@ describe('NeedsReviewScanResultActionCreator', () => {
     it('should handle GetState message', () => {
         const payload = null;
 
-        const getCurrentStateMock = createActionMock<null>(payload);
+        const getCurrentStateMock = createSyncActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
         const interpreterMock = createInterpreterMock(
             getStoreStateMessage(StoreNames.NeedsReviewScanResultStore),

--- a/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
@@ -7,7 +7,7 @@ import { IMock, Mock } from 'typemoq';
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -15,7 +15,7 @@ describe('PathSnippetActionCreatorTest', () => {
     it('handles AddPathForValidation message', () => {
         const payload = 'test path';
 
-        const onAddPathMock = createActionMock(payload);
+        const onAddPathMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('onAddPath', onAddPathMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.PathSnippet.AddPathForValidation,
@@ -35,7 +35,7 @@ describe('PathSnippetActionCreatorTest', () => {
     it('handles AddCorrespondingSnippet message', () => {
         const payload = 'test snippet';
 
-        const onAddSnippetMock = createActionMock(payload);
+        const onAddSnippetMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('onAddSnippet', onAddSnippetMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.PathSnippet.AddCorrespondingSnippet,
@@ -53,7 +53,7 @@ describe('PathSnippetActionCreatorTest', () => {
     });
 
     it('handles GetPathSnippetCurrentState message', () => {
-        const getCurrentStateMock = createActionMock(undefined);
+        const getCurrentStateMock = createSyncActionMock(undefined);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
         const interpreterMock = createInterpreterMock(
             getStoreStateMessage(StoreNames.PathSnippetStore),
@@ -71,7 +71,7 @@ describe('PathSnippetActionCreatorTest', () => {
     });
 
     it('handles ClearPathSnippetData message', () => {
-        const onClearDataMock = createActionMock(undefined);
+        const onClearDataMock = createSyncActionMock(undefined);
         const actionsMock = createActionsMock('onClearData', onClearDataMock.object);
         const interpreterMock = createInterpreterMock(
             Messages.PathSnippet.ClearPathSnippetData,

--- a/src/tests/unit/tests/background/actions/popup-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/popup-action-creator.test.ts
@@ -14,7 +14,7 @@ import { Messages } from 'common/messages';
 import { IMock, Mock, Times } from 'typemoq';
 
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -32,7 +32,7 @@ describe('PopupActionCreator', () => {
             },
         };
 
-        const actionMock = createActionMock(payload.tab);
+        const actionMock = createSyncActionMock(payload.tab);
         const actionsMock = createTabActionsMock('newTabCreated', actionMock.object);
         const interpreterMock = createInterpreterMock(Messages.Popup.Initialized, payload);
         const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -23,7 +23,7 @@ import { StoreNames } from 'common/stores/store-names';
 import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { IMock, Mock, Times } from 'typemoq';
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -46,7 +46,7 @@ describe('TestActionCreatorTest', () => {
             telemetry: null,
         };
 
-        const actionMock = createActionMock(payload);
+        const actionMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('newTabCreated', actionMock.object);
         const interpreterMock = createInterpreterMock(Messages.Tab.NewTabCreated, payload);
 
@@ -68,7 +68,7 @@ describe('TestActionCreatorTest', () => {
     });
 
     it('handles Tab.GetCurrent message', () => {
-        const getCurrentStateMock = createActionMock<void>(null);
+        const getCurrentStateMock = createSyncActionMock<void>(null);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
         const interpreterMock = createInterpreterMock(
             getStoreStateMessage(StoreNames.TabStore),
@@ -89,7 +89,7 @@ describe('TestActionCreatorTest', () => {
     });
 
     it('handles Tab.Remove message', () => {
-        const tabRemoveMock = createActionMock<void>(null);
+        const tabRemoveMock = createSyncActionMock<void>(null);
         const actionsMock = createActionsMock('tabRemove', tabRemoveMock.object);
         const interpreterMock = createInterpreterMock(Messages.Tab.Remove, null);
 
@@ -117,7 +117,7 @@ describe('TestActionCreatorTest', () => {
             },
         };
 
-        const actionMock = createActionMock(payload);
+        const actionMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('existingTabUpdated', actionMock.object);
         const interpreterMock = createInterpreterMock(Messages.Tab.ExistingTabUpdated, payload);
 
@@ -204,7 +204,7 @@ describe('TestActionCreatorTest', () => {
             hidden: true,
         };
 
-        const tabVisibilityChangeMock = createActionMock(payload.hidden);
+        const tabVisibilityChangeMock = createSyncActionMock(payload.hidden);
         const actionsMock = createActionsMock(
             'tabVisibilityChange',
             tabVisibilityChangeMock.object,

--- a/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
@@ -19,7 +19,7 @@ import { Messages } from 'common/messages';
 import { IMock, Mock, Times } from 'typemoq';
 
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -38,7 +38,7 @@ describe('TabStopRequirementActionCreator', () => {
             status: 'pass',
         };
 
-        const updateTabStopRequirementStatusMock = createActionMock(payload);
+        const updateTabStopRequirementStatusMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(
             actionName,
@@ -74,7 +74,7 @@ describe('TabStopRequirementActionCreator', () => {
             requirementId: requirementId,
         };
 
-        const resetTabStopRequirementStatusMock = createActionMock(payload);
+        const resetTabStopRequirementStatusMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, resetTabStopRequirementStatusMock.object);
         const interpreterMock = createInterpreterMock(
@@ -109,7 +109,7 @@ describe('TabStopRequirementActionCreator', () => {
             description: 'testing',
         };
 
-        const addTabStopRequirementInstanceMock = createActionMock(payload);
+        const addTabStopRequirementInstanceMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, addTabStopRequirementInstanceMock.object);
         const interpreterMock = createInterpreterMock(
@@ -145,7 +145,7 @@ describe('TabStopRequirementActionCreator', () => {
             id: 'abc',
         };
 
-        const updateTabStopRequirementInstanceMock = createActionMock(payload);
+        const updateTabStopRequirementInstanceMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(
             actionName,
@@ -181,7 +181,7 @@ describe('TabStopRequirementActionCreator', () => {
             requirementId: requirementId,
         };
 
-        const onRequirementExpansionToggledMock = createActionMock(payload);
+        const onRequirementExpansionToggledMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, onRequirementExpansionToggledMock.object);
         const interpreterMock = createInterpreterMock(
@@ -208,7 +208,7 @@ describe('TabStopRequirementActionCreator', () => {
             id: 'abc',
         };
 
-        const removeTabStopRequirementInstanceMock = createActionMock(payload);
+        const removeTabStopRequirementInstanceMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(
             actionName,
@@ -244,7 +244,7 @@ describe('TabStopRequirementActionCreator', () => {
             tabbingCompleted: true,
         };
 
-        const onTabbingCompletedMock = createActionMock(payload);
+        const onTabbingCompletedMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, onTabbingCompletedMock.object);
         const interpreterMock = createInterpreterMock(
@@ -269,7 +269,7 @@ describe('TabStopRequirementActionCreator', () => {
             needToCollectTabbingResults: true,
         };
 
-        const onNeedToCollectTabbingResultsMock = createActionMock(payload);
+        const onNeedToCollectTabbingResultsMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, onNeedToCollectTabbingResultsMock.object);
         const interpreterMock = createInterpreterMock(
@@ -295,7 +295,7 @@ describe('TabStopRequirementActionCreator', () => {
             telemetry: {} as TelemetryEvents.TelemetryData,
         };
 
-        const instanceMock = createActionMock(payload);
+        const instanceMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, instanceMock.object);
         const interpreterMock = createInterpreterMock(

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -15,7 +15,7 @@ import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { IMock, Mock, Times } from 'typemoq';
 import {
-    createActionMock,
+    createSyncActionMock,
     createInterpreterMock,
 } from '../global-action-creators/action-creator-test-helpers';
 
@@ -43,7 +43,7 @@ describe('UnifiedScanResultActionCreator', () => {
             telemetry,
         };
 
-        const scanCompletedMock = createActionMock(payload);
+        const scanCompletedMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('scanCompleted', scanCompletedMock.object);
         const interpreterMock = createInterpreterMock(Messages.UnifiedScan.ScanCompleted, payload);
 
@@ -70,7 +70,7 @@ describe('UnifiedScanResultActionCreator', () => {
     it('should handle GetState message', () => {
         const payload = null;
 
-        const getCurrentStateMock = createActionMock<null>(payload);
+        const getCurrentStateMock = createSyncActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
         const interpreterMock = createInterpreterMock(
             getStoreStateMessage(StoreNames.UnifiedScanResultStore),

--- a/src/tests/unit/tests/background/dev-tools-monitor.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-monitor.test.ts
@@ -6,7 +6,7 @@ import { DevToolActions } from 'background/actions/dev-tools-actions';
 import { DevToolsMonitor } from 'background/dev-tools-monitor';
 import { Interpreter } from 'background/interpreter';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { Messages } from 'common/messages';
 import {
     DelayCreator,
@@ -38,7 +38,7 @@ describe(DevToolsMonitor, () => {
     let promiseFactory: PromiseFactory;
     let interpreterMock: IMock<Interpreter>;
 
-    let setDevToolStateActionMock: IMock<Action<boolean>>;
+    let setDevToolStateActionMock: IMock<SyncAction<boolean>>;
     let onStateChanged: (status: boolean) => void;
 
     let testSubject: TestDevToolsMonitor;
@@ -53,7 +53,7 @@ describe(DevToolsMonitor, () => {
         } as PromiseFactory;
         interpreterMock = Mock.ofType<Interpreter>();
 
-        setDevToolStateActionMock = Mock.ofType<Action<boolean>>();
+        setDevToolStateActionMock = Mock.ofType<SyncAction<boolean>>();
         setDevToolStateActionMock
             .setup(s => s.addListener(It.isAny()))
             .returns(listener => (onStateChanged = listener))

--- a/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
+++ b/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Interpreter } from 'background/interpreter';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { isFunction } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
 
-export const createActionMock = <Payload>(
+export const createSyncActionMock = <Payload>(
     payload: Payload,
     scope?: string,
-): IMock<Action<Payload>> => {
-    const actionMock = Mock.ofType<Action<Payload>>(Action);
+): IMock<SyncAction<Payload>> => {
+    const actionMock = Mock.ofType<SyncAction<Payload>>();
     if (scope) {
         actionMock.setup(action => action.invoke(payload, scope)).verifiable(Times.once());
     } else {

--- a/src/tests/unit/tests/background/global-action-creators/feature-flags-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/feature-flags-action-creator.test.ts
@@ -9,7 +9,7 @@ import { IMock, It, Mock } from 'typemoq';
 
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import { createActionMock } from './action-creator-test-helpers';
+import { createSyncActionMock } from './action-creator-test-helpers';
 
 describe('FeatureFlagsActionCreator', () => {
     let interpreterMock: IMock<Interpreter>;
@@ -35,7 +35,7 @@ describe('FeatureFlagsActionCreator', () => {
 
         setupInterpreterMock(expectedMessage);
 
-        const getCurrentStateMock = createActionMock(undefined);
+        const getCurrentStateMock = createSyncActionMock(undefined);
 
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
 
@@ -54,7 +54,7 @@ describe('FeatureFlagsActionCreator', () => {
 
         setupInterpreterMock(expectedMessage, payload);
 
-        const setFeatureFlagMock = createActionMock(payload);
+        const setFeatureFlagMock = createSyncActionMock(payload);
 
         setupActionsMock('setFeatureFlag', setFeatureFlagMock.object);
 
@@ -68,7 +68,7 @@ describe('FeatureFlagsActionCreator', () => {
 
         setupInterpreterMock(expectedMessage);
 
-        const resetFeatureFlagMock = createActionMock(undefined);
+        const resetFeatureFlagMock = createSyncActionMock(undefined);
 
         setupActionsMock('resetFeatureFlags', resetFeatureFlagMock.object);
 

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -12,6 +12,7 @@ import { GlobalActionCreator } from 'background/global-action-creators/global-ac
 import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { CommandsAdapter } from '../../../../../common/browser-adapters/commands-adapter';
@@ -98,9 +99,9 @@ describe('GlobalActionCreatorTest', () => {
 
 class GlobalActionCreatorValidator {
     public testSubject: GlobalActionCreator;
-    private commandActionMocksMap: DictionaryStringTo<IMock<Action<any>>> = {};
-    private featureFlagActionsMockMap: DictionaryStringTo<IMock<Action<any>>> = {};
-    private launchPanelActionsMockMap: DictionaryStringTo<IMock<Action<any>>> = {};
+    private commandActionMocksMap: DictionaryStringTo<IMock<Action<any, any>>> = {};
+    private featureFlagActionsMockMap: DictionaryStringTo<IMock<Action<any, any>>> = {};
+    private launchPanelActionsMockMap: DictionaryStringTo<IMock<Action<any, any>>> = {};
 
     private commandActionsContainerMock = Mock.ofType(CommandActions);
     private featureFlagActionsContainerMock = Mock.ofType(FeatureFlagActions);
@@ -193,7 +194,7 @@ class GlobalActionCreatorValidator {
     private setupActionWithInvokeParameter(
         actionName: string,
         expectedInvokeParam: any,
-        actionsMockMap: DictionaryStringTo<IMock<Action<any>>>,
+        actionsMockMap: DictionaryStringTo<IMock<Action<any, any>>>,
     ): GlobalActionCreatorValidator {
         const action = this.getOrCreateAction(actionName, actionsMockMap);
 
@@ -204,12 +205,12 @@ class GlobalActionCreatorValidator {
 
     private getOrCreateAction(
         actionName: string,
-        actionsMockMap: DictionaryStringTo<IMock<Action<any>>>,
-    ): IMock<Action<any>> {
+        actionsMockMap: DictionaryStringTo<IMock<Action<any, any>>>,
+    ): IMock<Action<any, any>> {
         let action = actionsMockMap[actionName];
 
         if (action == null) {
-            action = Mock.ofType(Action);
+            action = Mock.ofType(SyncAction);
             actionsMockMap[actionName] = action;
         }
         return action;
@@ -218,7 +219,7 @@ class GlobalActionCreatorValidator {
     private setupAction(
         actionName: string,
         actionsContainerMock: IMock<any>,
-        actionsMapMock: DictionaryStringTo<IMock<Action<any>>>,
+        actionsMapMock: DictionaryStringTo<IMock<Action<any, any>>>,
     ): GlobalActionCreatorValidator {
         const action = this.getOrCreateAction(actionName, actionsMapMock);
 
@@ -282,7 +283,7 @@ class GlobalActionCreatorValidator {
         this.verifyAllActions(this.launchPanelActionsMockMap);
     }
 
-    private verifyAllActions(actionsMap: DictionaryStringTo<IMock<Action<any>>>): void {
+    private verifyAllActions(actionsMap: DictionaryStringTo<IMock<Action<any, any>>>): void {
         for (const actionName in actionsMap) {
             if (actionsMap.hasOwnProperty(actionName)) {
                 actionsMap[actionName].verifyAll();

--- a/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
@@ -9,7 +9,7 @@ import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { IMock, Mock } from 'typemoq';
 
-import { createActionMock, createInterpreterMock } from './action-creator-test-helpers';
+import { createSyncActionMock, createInterpreterMock } from './action-creator-test-helpers';
 
 describe('PermissionsStateActionCreator', () => {
     let permissionsStateActionsMock: IMock<PermissionsStateActions>;
@@ -21,7 +21,7 @@ describe('PermissionsStateActionCreator', () => {
     it('handles getStoreState message', () => {
         const expectedMessage = getStoreStateMessage(StoreNames.PermissionsStateStore);
         const interpreterMock = createInterpreterMock(expectedMessage, null);
-        const getCurrentStateMock = createActionMock(undefined);
+        const getCurrentStateMock = createSyncActionMock(undefined);
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
         const testSubject = new PermissionsStateActionCreator(
             interpreterMock.object,
@@ -43,7 +43,7 @@ describe('PermissionsStateActionCreator', () => {
                 telemetry: {} as TelemetryData,
             };
             const interpreterMock = createInterpreterMock(expectedMessage, payload);
-            const setPermissionsStateMock = createActionMock(payload);
+            const setPermissionsStateMock = createSyncActionMock(payload);
             const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
             setupActionsMock('setPermissionsState', setPermissionsStateMock.object);
             const testSubject = new PermissionsStateActionCreator(

--- a/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
@@ -8,7 +8,7 @@ import { IMock, It, Mock } from 'typemoq';
 
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import { createActionMock } from './action-creator-test-helpers';
+import { createSyncActionMock } from './action-creator-test-helpers';
 
 describe('ScopingActionCreator', () => {
     let interpreterMock: IMock<Interpreter>;
@@ -28,7 +28,7 @@ describe('ScopingActionCreator', () => {
 
         setupInterpreterMock(expectedMessage);
 
-        const getCurrentStateMock = createActionMock(undefined);
+        const getCurrentStateMock = createSyncActionMock(undefined);
 
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
 
@@ -47,7 +47,7 @@ describe('ScopingActionCreator', () => {
 
         setupInterpreterMock(expectedMessage, payload);
 
-        const addSelectorMock = createActionMock(payload);
+        const addSelectorMock = createSyncActionMock(payload);
 
         setupActionsMock('addSelector', addSelectorMock.object);
 
@@ -66,7 +66,7 @@ describe('ScopingActionCreator', () => {
 
         setupInterpreterMock(expectedMessage, payload);
 
-        const deleteSelectorMock = createActionMock(payload);
+        const deleteSelectorMock = createSyncActionMock(payload);
 
         setupActionsMock('deleteSelector', deleteSelectorMock.object);
 

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -15,7 +15,7 @@ import { UserConfigurationActionCreator } from 'background/global-action-creator
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { IMock, Mock, Times } from 'typemoq';
 import * as TelemetryEvents from '../../../../../common/extension-telemetry-events';
-import { createActionMock } from './action-creator-test-helpers';
+import { createSyncActionMock } from './action-creator-test-helpers';
 
 describe('UserConfigurationActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -25,7 +25,7 @@ describe('UserConfigurationActionCreator', () => {
     });
 
     it('handles GetCurrentState message', () => {
-        const getCurrentStateMock = createActionMock<void>(undefined);
+        const getCurrentStateMock = createSyncActionMock<void>(undefined);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
         const testSubject = new UserConfigurationActionCreator(
             actionsMock.object,
@@ -40,7 +40,7 @@ describe('UserConfigurationActionCreator', () => {
     it('should SetTelemetryConfig message', () => {
         const setTelemetryState = true;
 
-        const setTelemetryStateMock = createActionMock(setTelemetryState);
+        const setTelemetryStateMock = createSyncActionMock(setTelemetryState);
         const actionsMock = createActionsMock('setTelemetryState', setTelemetryStateMock.object);
         const testSubject = new UserConfigurationActionCreator(
             actionsMock.object,
@@ -56,7 +56,7 @@ describe('UserConfigurationActionCreator', () => {
         const payload: SetHighContrastModePayload = {
             enableHighContrast: true,
         };
-        const setHighContrastConfigMock = createActionMock(payload);
+        const setHighContrastConfigMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'setHighContrastMode',
             setHighContrastConfigMock.object,
@@ -75,7 +75,7 @@ describe('UserConfigurationActionCreator', () => {
         const payload: SetNativeHighContrastModePayload = {
             enableHighContrast: true,
         };
-        const setNativeHighContrastConfigMock = createActionMock(payload);
+        const setNativeHighContrastConfigMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'setNativeHighContrastMode',
             setNativeHighContrastConfigMock.object,
@@ -94,7 +94,7 @@ describe('UserConfigurationActionCreator', () => {
         const payload: SetIssueFilingServicePayload = {
             issueFilingServiceName: 'none',
         };
-        const setBugServiceMock = createActionMock(payload);
+        const setBugServiceMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('setIssueFilingService', setBugServiceMock.object);
         const testSubject = new UserConfigurationActionCreator(
             actionsMock.object,
@@ -112,7 +112,7 @@ describe('UserConfigurationActionCreator', () => {
             propertyName: 'property-name',
             propertyValue: 'property-value',
         };
-        const setIssueFilingServicePropertyMock = createActionMock(payload);
+        const setIssueFilingServicePropertyMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'setIssueFilingServiceProperty',
             setIssueFilingServicePropertyMock.object,
@@ -132,7 +132,7 @@ describe('UserConfigurationActionCreator', () => {
             issueFilingServiceName: 'test bug service',
             issueFilingSettings: { name: 'issueFilingSettings' },
         };
-        const setIssueFilingSettings = createActionMock(payload);
+        const setIssueFilingSettings = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'saveIssueFilingSettings',
             setIssueFilingSettings.object,
@@ -150,7 +150,7 @@ describe('UserConfigurationActionCreator', () => {
     it('should SetAdbLocation Message', () => {
         const expectedAdbLocation = 'Somewhere over the rainbow';
 
-        const setAdbLocationConfigMock = createActionMock(
+        const setAdbLocationConfigMock = createSyncActionMock(
             expectedAdbLocation,
             'UserConfigurationActionCreator',
         );
@@ -171,7 +171,7 @@ describe('UserConfigurationActionCreator', () => {
             windowBounds: { x: 10, y: 20, height: 100, width: 150 },
         };
 
-        const saveWindowBoundsActionMock = createActionMock(payload);
+        const saveWindowBoundsActionMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'saveWindowBounds',
             saveWindowBoundsActionMock.object,
@@ -190,7 +190,7 @@ describe('UserConfigurationActionCreator', () => {
         const expectedDialogState = { enabled: false };
         const expectedPayload = expectedDialogState as BaseActionPayload;
 
-        const dialogStateConfigMock = createActionMock(expectedDialogState);
+        const dialogStateConfigMock = createSyncActionMock(expectedDialogState);
         const actionsMock = createActionsMock(
             'setAutoDetectedFailuresDialogState',
             dialogStateConfigMock.object,

--- a/src/tests/unit/tests/common/flux/async-action.test.ts
+++ b/src/tests/unit/tests/common/flux/async-action.test.ts
@@ -2,121 +2,115 @@
 // Licensed under the MIT License.
 import { AsyncAction } from 'common/flux/async-action';
 import { ScopeMutex } from 'common/flux/scope-mutex';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe(AsyncAction, () => {
     let listenerMock: IMock<(payload: TestPayload) => Promise<void>>;
     const testPayload: TestPayload = { key: 'value' };
     let testObject: AsyncAction<TestPayload>;
     let scopeMutexMock: IMock<ScopeMutex>;
+    let mergePromisesMock: IMock<(promises: Promise<unknown>[]) => Promise<void>>;
+    let mergedPromiseInternalMock: IMock<() => void>;
 
     beforeEach(() => {
         listenerMock = Mock.ofInstance(_ => Promise.resolve(), MockBehavior.Strict);
         scopeMutexMock = Mock.ofType<ScopeMutex>();
+        mergePromisesMock = Mock.ofInstance(async _ => null);
+        mergedPromiseInternalMock = Mock.ofInstance(() => null);
 
-        testObject = new AsyncAction<TestPayload>(scopeMutexMock.object);
+        testObject = new AsyncAction<TestPayload>(scopeMutexMock.object, mergePromisesMock.object);
     });
 
     afterEach(() => {
         listenerMock.verifyAll();
         scopeMutexMock.verifyAll();
+        mergePromisesMock.verifyAll();
+        mergedPromiseInternalMock.verifyAll();
     });
 
     test('addListener and invoke', async () => {
-        listenerMock.setup(l => l(testPayload)).verifiable(Times.once());
+        const listenerPromise = Promise.resolve();
+        listenerMock
+            .setup(l => l(testPayload))
+            .returns(() => listenerPromise)
+            .verifiable(Times.once());
 
         testObject.addListener(listenerMock.object);
 
-        scopeMutexMock.setup(m => m.tryLockScope(undefined)).verifiable(Times.once());
-        scopeMutexMock.setup(m => m.unlockScope(undefined)).verifiable(Times.once());
+        setupScopeMutex();
+        setupMergePromises([listenerPromise]);
 
         await testObject.invoke(testPayload);
     });
 
     test('addListener and invoke with scope', async () => {
         const scope = 'test_scope';
-        listenerMock.setup(l => l(testPayload)).verifiable(Times.once());
+        const listenerPromise = Promise.resolve();
+        listenerMock
+            .setup(l => l(testPayload))
+            .returns(() => listenerPromise)
+            .verifiable(Times.once());
 
         testObject.addListener(listenerMock.object);
 
-        scopeMutexMock.setup(m => m.tryLockScope(scope)).verifiable(Times.once());
-        scopeMutexMock.setup(m => m.unlockScope(scope)).verifiable(Times.once());
+        setupScopeMutex(scope);
+        setupMergePromises([listenerPromise]);
 
         await testObject.invoke(testPayload, scope);
     });
 
-    test('invoke calls all registered listeners', async () => {
-        const listenerMocks: IMock<(payload: TestPayload) => Promise<void>>[] = [
-            Mock.ofInstance(_ => Promise.resolve(), MockBehavior.Strict),
-            Mock.ofInstance(_ => Promise.resolve(), MockBehavior.Strict),
-            Mock.ofInstance(_ => Promise.resolve(), MockBehavior.Strict),
+    test('invoke merges all registered listeners', async () => {
+        const listenerPromises: Promise<void>[] = [
+            Promise.resolve(),
+            Promise.resolve(),
+            Promise.resolve(),
         ];
+        const listenerMocks: IMock<(payload: TestPayload) => Promise<void>>[] =
+            listenerPromises.map(listenerPromise => {
+                const listenerMock = Mock.ofInstance(_ => Promise.resolve(), MockBehavior.Strict);
+                listenerMock
+                    .setup(l => l(testPayload))
+                    .returns(() => listenerPromise)
+                    .verifiable(Times.once());
+                testObject.addListener(listenerMock.object);
 
-        listenerMocks.forEach(mock => {
-            mock.setup(l => l(testPayload)).verifiable(Times.once());
-            testObject.addListener(mock.object);
-        });
+                return listenerMock;
+            });
 
-        scopeMutexMock.setup(m => m.tryLockScope(undefined)).verifiable(Times.once());
-        scopeMutexMock.setup(m => m.unlockScope(undefined)).verifiable(Times.once());
+        setupScopeMutex();
+        setupMergePromises(listenerPromises);
 
         await testObject.invoke(testPayload);
 
         listenerMocks.forEach(mock => mock.verifyAll());
     });
 
-    test('invoke throws if a listener throws error', async () => {
+    test('invoke throws if merged promise throws', async () => {
         const testError = new Error('test error');
-        listenerMock
-            .setup(l => l(testPayload))
-            .returns(async () => {
-                throw testError;
-            })
+
+        testObject.addListener(() => null);
+
+        setupScopeMutex();
+        mergePromisesMock
+            .setup(m => m(It.isAny()))
+            .returns(() => Promise.reject(testError))
             .verifiable(Times.once());
-
-        testObject.addListener(listenerMock.object);
-
-        scopeMutexMock.setup(m => m.tryLockScope(undefined)).verifiable(Times.once());
-        scopeMutexMock.setup(m => m.unlockScope(undefined)).verifiable(Times.once());
 
         await expect(() => testObject.invoke(testPayload)).rejects.toThrow(testError);
     });
 
-    test('invoke aggregates errors if multiple listeners throw', async () => {
-        const testErrors: Error[] = [];
-        const listenerMocks: IMock<(payload: TestPayload) => Promise<void>>[] = [
-            Mock.ofInstance(_ => Promise.resolve(), MockBehavior.Strict),
-            Mock.ofInstance(_ => Promise.resolve(), MockBehavior.Strict),
-        ];
-        listenerMocks.forEach(mock => {
-            const testError = new Error('test error');
-            testErrors.push(testError);
-            mock.setup(l => l(testPayload))
-                .returns(async () => {
-                    throw testError;
-                })
-                .verifiable(Times.once());
-            testObject.addListener(mock.object);
-        });
+    function setupScopeMutex(scope?: string) {
+        scopeMutexMock.setup(m => m.tryLockScope(scope)).verifiable(Times.once());
+        scopeMutexMock.setup(m => m.unlockScope(scope)).verifiable(Times.once());
+    }
 
-        scopeMutexMock.setup(m => m.tryLockScope(undefined)).verifiable(Times.once());
-        scopeMutexMock.setup(m => m.unlockScope(undefined)).verifiable(Times.once());
-
-        try {
-            await testObject.invoke(testPayload);
-            fail('Expected invoke to throw error');
-        } catch (e) {
-            expect(e).toBeInstanceOf(AggregateError);
-
-            listenerMocks.forEach(mock => mock.verifyAll());
-
-            const aggregateError = e as AggregateError;
-            expect(aggregateError.errors.length).toBe(testErrors.length);
-            testErrors.forEach(error => {
-                expect(aggregateError.errors).toContain(error);
-            });
-        }
-    });
+    function setupMergePromises(promises: Promise<void>[]) {
+        mergedPromiseInternalMock.setup(m => m()).verifiable(Times.once());
+        mergePromisesMock
+            .setup(m => m(promises))
+            .returns(async () => mergedPromiseInternalMock.object())
+            .verifiable(Times.once());
+    }
 });
 
 interface TestPayload {

--- a/src/tests/unit/tests/common/flux/scope-mutex.test.ts
+++ b/src/tests/unit/tests/common/flux/scope-mutex.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ScopeMutex } from 'common/flux/scope-mutex';
+
+describe(ScopeMutex, () => {
+    const testScope = 'test_scope';
+
+    let testSubject: ScopeMutex;
+
+    beforeEach(() => {
+        testSubject = new ScopeMutex();
+    });
+
+    it('Should not allow locking the default scope twice', () => {
+        testSubject.tryLockScope();
+
+        expect(() => testSubject.tryLockScope()).toThrowError(/.*DEFAULT_SCOPE.*/);
+
+        testSubject.unlockScope();
+    });
+
+    it('Should not allow locking the same non-default scope twice', () => {
+        testSubject.tryLockScope(testScope);
+
+        expect(() => testSubject.tryLockScope(testScope)).toThrowError(/.*test_scope.*/);
+
+        testSubject.unlockScope(testScope);
+    });
+
+    it.each([undefined, testScope])('Should allow locking %s scope after an unlock', scope => {
+        testSubject.tryLockScope(scope);
+        testSubject.unlockScope(scope);
+
+        expect(() => testSubject.tryLockScope(scope)).not.toThrow();
+
+        testSubject.unlockScope(scope);
+    });
+
+    it('Should allow locking different scopes consecutively', () => {
+        const anotherScope = 'another_test_scope';
+
+        testSubject.tryLockScope();
+        expect(() => testSubject.tryLockScope(testScope)).not.toThrow();
+        expect(() => testSubject.tryLockScope(anotherScope)).not.toThrow();
+
+        testSubject.unlockScope();
+        testSubject.unlockScope(testScope);
+        testSubject.unlockScope(anotherScope);
+    });
+});

--- a/src/tests/unit/tests/common/flux/sync-action.test.ts
+++ b/src/tests/unit/tests/common/flux/sync-action.test.ts
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
-describe('ActionTest', () => {
+describe(SyncAction, () => {
     let listenerMock: IMock<(payload: TestPayload) => void>;
     const testPayload: TestPayload = { key: 'value' };
-    let testObject: Action<TestPayload>;
-    let nestedObject: Action<TestPayload>;
+    let testObject: SyncAction<TestPayload>;
+    let nestedObject: SyncAction<TestPayload>;
 
     beforeEach(() => {
         listenerMock = Mock.ofInstance(payload => {}, MockBehavior.Strict);
-        testObject = new Action<TestPayload>();
-        nestedObject = new Action<TestPayload>();
+        testObject = new SyncAction<TestPayload>();
+        nestedObject = new SyncAction<TestPayload>();
     });
 
     afterEach(() => {

--- a/src/tests/unit/tests/common/merge-promise-responses.test.ts
+++ b/src/tests/unit/tests/common/merge-promise-responses.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { mergePromiseResponses } from 'common/merge-promise-responses';
+import { compact } from 'lodash';
+
+type VerifiablePromise = {
+    promise: Promise<void>;
+    verify: () => void;
+    error?: Error;
+};
+
+describe(mergePromiseResponses, () => {
+    it('awaits all input promises concurrently if all inputs are async and successful', async () => {
+        const verifiablePromises = [
+            createVerifiableResolvingPromise(),
+            createVerifiableResolvingPromise(),
+            createVerifiableResolvingPromise(),
+        ];
+        const promises = verifiablePromises.map(item => item.promise);
+
+        await mergePromiseResponses(promises);
+
+        verifiablePromises.forEach(item => item.verify());
+    });
+
+    it('awaits all input promises and rejects without wrapping if a single input rejects', async () => {
+        const verifiableRejectingPromise = createVerifiableRejectingPromise();
+        const verifiablePromises = [
+            createVerifiableResolvingPromise(),
+            verifiableRejectingPromise,
+            createVerifiableResolvingPromise(),
+        ];
+        const promises = verifiablePromises.map(item => item.promise);
+
+        await expect(mergePromiseResponses(promises)).rejects.toThrowError(
+            verifiableRejectingPromise.error,
+        );
+        verifiablePromises.forEach(item => item.verify());
+    });
+
+    it('awaits all input promises and aggregates errors if all inputs are async', async () => {
+        const verifiablePromises = [
+            createVerifiableResolvingPromise(),
+            createVerifiableRejectingPromise(),
+            createVerifiableRejectingPromise(),
+        ];
+        const promises = verifiablePromises.map(item => item.promise);
+        const errors = compact(verifiablePromises.map(item => item.error));
+
+        await expect(mergePromiseResponses(promises)).rejects.toMatchObject({ errors: errors });
+
+        verifiablePromises.forEach(item => item.verify());
+    });
+
+    function createVerifiableResolvingPromise(): VerifiablePromise {
+        const runPromiseMock = jest.fn();
+
+        const createPromise = async () => runPromiseMock();
+
+        return {
+            promise: createPromise(),
+            verify: () => expect(runPromiseMock).toHaveBeenCalledTimes(1),
+        };
+    }
+
+    function createVerifiableRejectingPromise(): VerifiablePromise {
+        const error = new Error('test error');
+        const runPromiseMock = jest.fn();
+
+        const createPromise = async () => {
+            runPromiseMock();
+            throw error;
+        };
+
+        return {
+            promise: createPromise(),
+            verify: () => expect(runPromiseMock).toHaveBeenCalledTimes(1),
+            error: error,
+        };
+    }
+});

--- a/src/tests/unit/tests/debug-tools/action-creators/debug-tools-nav-action-creator.test.ts
+++ b/src/tests/unit/tests/debug-tools/action-creators/debug-tools-nav-action-creator.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { DebugToolsNavActionCreator } from 'debug-tools/action-creators/debug-tools-nav-action-creator';
 import { DebugToolsNavActions } from 'debug-tools/actions/debug-tools-nav-actions';
 import { ToolsNavKey } from 'debug-tools/stores/debug-tools-nav-store';
@@ -9,7 +9,7 @@ import { Mock, Times } from 'typemoq';
 
 describe('DebugToolsNavActionCreator', () => {
     it('onSelectTool', () => {
-        const setSelectedToolMock = Mock.ofType<Action<ToolsNavKey>>();
+        const setSelectedToolMock = Mock.ofType<SyncAction<ToolsNavKey>>();
 
         const debugToolsNavActionsMock = Mock.ofType(DebugToolsNavActions);
 

--- a/src/tests/unit/tests/electron/flux/action-creator/android-setup-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/android-setup-action-creator.test.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions';
 import { DeviceInfo } from 'electron/platform/android/adb-wrapper';
-import { createActionMock } from 'tests/unit/tests/background/global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from 'tests/unit/tests/background/global-action-creators/action-creator-test-helpers';
 import { IMock, Mock, Times } from 'typemoq';
 
 describe(AndroidSetupActionCreator, () => {
@@ -17,7 +17,7 @@ describe(AndroidSetupActionCreator, () => {
     });
 
     it('invokes cancel action on cancel', () => {
-        const actionMock = Mock.ofType<Action<void>>();
+        const actionMock = Mock.ofType<SyncAction<void>>();
         androidSetupActionsMock.setup(actions => actions.cancel).returns(() => actionMock.object);
         actionMock.setup(s => s.invoke()).verifiable(Times.once());
 
@@ -26,7 +26,7 @@ describe(AndroidSetupActionCreator, () => {
     });
 
     it('invokes next action on rescan', () => {
-        const actionMock = Mock.ofType<Action<void>>();
+        const actionMock = Mock.ofType<SyncAction<void>>();
         androidSetupActionsMock.setup(actions => actions.next).returns(() => actionMock.object);
         actionMock.setup(s => s.invoke()).verifiable(Times.once());
 
@@ -35,7 +35,7 @@ describe(AndroidSetupActionCreator, () => {
     });
 
     it('invokes rescan action on rescan', () => {
-        const actionMock = Mock.ofType<Action<void>>();
+        const actionMock = Mock.ofType<SyncAction<void>>();
         androidSetupActionsMock.setup(actions => actions.rescan).returns(() => actionMock.object);
         actionMock.setup(s => s.invoke()).verifiable(Times.once());
 
@@ -50,7 +50,7 @@ describe(AndroidSetupActionCreator, () => {
             isEmulator: true,
         };
 
-        const actionMock = Mock.ofType<Action<DeviceInfo>>();
+        const actionMock = Mock.ofType<SyncAction<DeviceInfo>>();
         androidSetupActionsMock
             .setup(actions => actions.setSelectedDevice)
             .returns(() => actionMock.object);
@@ -61,7 +61,7 @@ describe(AndroidSetupActionCreator, () => {
     });
 
     it('invokes saveAdbPath action on saveAdbPath', () => {
-        const actionMock = Mock.ofType<Action<string>>();
+        const actionMock = Mock.ofType<SyncAction<string>>();
         androidSetupActionsMock
             .setup(actions => actions.saveAdbPath)
             .returns(() => actionMock.object);
@@ -72,7 +72,7 @@ describe(AndroidSetupActionCreator, () => {
     });
 
     it('invokes readyToStart action on readyToStart', () => {
-        const readyToStartMock = createActionMock<void>(undefined, 'AndroidSetupActionCreator');
+        const readyToStartMock = createSyncActionMock<void>(undefined, 'AndroidSetupActionCreator');
         androidSetupActionsMock
             .setup(actions => actions.readyToStart)
             .returns(() => readyToStartMock.object);

--- a/src/tests/unit/tests/electron/flux/action-creator/left-nav-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/left-nav-action-creator.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { LeftNavActions } from 'electron/flux/action/left-nav-actions';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
@@ -26,13 +26,13 @@ describe('LeftNavActionCreator', () => {
     });
 
     it('itemSelected', () => {
-        const itemSelectedMock = Mock.ofType<Action<LeftNavItemKey>>();
+        const itemSelectedMock = Mock.ofType<SyncAction<LeftNavItemKey>>();
         leftNavActionsMock
             .setup(actions => actions.itemSelected)
             .returns(() => itemSelectedMock.object)
             .verifiable();
 
-        const navigateToNewCardsViewMock = Mock.ofType<Action<void>>();
+        const navigateToNewCardsViewMock = Mock.ofType<SyncAction<void>>();
         cardSelectionActionsMock
             .setup(actions => actions.navigateToNewCardsView)
             .returns(() => navigateToNewCardsViewMock.object)
@@ -52,7 +52,7 @@ describe('LeftNavActionCreator', () => {
     });
 
     it.each([[true], [false]])('setLeftNavVisible', testValue => {
-        const setLeftNavVisibleMock = Mock.ofType<Action<boolean>>();
+        const setLeftNavVisibleMock = Mock.ofType<SyncAction<boolean>>();
         leftNavActionsMock
             .setup(actions => actions.setLeftNavVisible)
             .returns(() => setLeftNavVisibleMock.object)

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { DeviceConnectionActions } from 'electron/flux/action/device-connection-actions';
 import { ScanActions } from 'electron/flux/action/scan-actions';
@@ -8,20 +8,20 @@ import { IMock, Mock, Times } from 'typemoq';
 
 describe('ScanActionCreator', () => {
     let scanActionsMock: IMock<ScanActions>;
-    let scanStartedMock: IMock<Action<void>>;
+    let scanStartedMock: IMock<SyncAction<void>>;
     let deviceConnectionActionsMock: IMock<DeviceConnectionActions>;
-    let statusUnknown: IMock<Action<void>>;
+    let statusUnknown: IMock<SyncAction<void>>;
 
     let testSubject: ScanActionCreator;
 
     beforeEach(() => {
         scanActionsMock = Mock.ofType<ScanActions>();
-        scanStartedMock = Mock.ofType<Action<void>>();
+        scanStartedMock = Mock.ofType<SyncAction<void>>();
 
         scanActionsMock.setup(actions => actions.scanStarted).returns(() => scanStartedMock.object);
 
         deviceConnectionActionsMock = Mock.ofType<DeviceConnectionActions>();
-        statusUnknown = Mock.ofType<Action<void>>();
+        statusUnknown = Mock.ofType<SyncAction<void>>();
 
         deviceConnectionActionsMock
             .setup(actions => actions.statusUnknown)

--- a/src/tests/unit/tests/electron/flux/action-creator/tab-stops-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/tab-stops-action-creator.test.ts
@@ -7,7 +7,7 @@ import {
     TelemetryEventSource,
     TriggeredByNotApplicable,
 } from 'common/extension-telemetry-events';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { Logger } from 'common/logging/logger';
 import { SupportedMouseEvent, TelemetryDataFactory } from 'common/telemetry-data-factory';
 import {
@@ -27,20 +27,20 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 describe('TabStopsActionCreator', () => {
     let tabStopsActionsMock: IMock<TabStopsActions>;
     let testSubject: TabStopsActionCreator;
-    let actionMock: IMock<Action<void>>;
+    let actionMock: IMock<SyncAction<void>>;
     let deviceFocusControllerMock: IMock<DeviceFocusController>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let deviceConnectionActionsMock: IMock<DeviceConnectionActions>;
     let loggerMock: IMock<Logger>;
-    let statusDisconnectedMock: IMock<Action<void>>;
-    let statusConnectedMock: IMock<Action<void>>;
+    let statusDisconnectedMock: IMock<SyncAction<void>>;
+    let statusConnectedMock: IMock<SyncAction<void>>;
     let telemetryDataFactoryMock: IMock<TelemetryDataFactory>;
     let eventStub: React.SyntheticEvent;
     let telemetryStub: BaseTelemetryData;
 
     beforeEach(() => {
         tabStopsActionsMock = Mock.ofType<TabStopsActions>();
-        actionMock = Mock.ofType<Action<void>>();
+        actionMock = Mock.ofType<SyncAction<void>>();
         deviceFocusControllerMock = Mock.ofType<DeviceFocusController>(
             undefined,
             MockBehavior.Strict,
@@ -54,8 +54,8 @@ describe('TabStopsActionCreator', () => {
             MockBehavior.Strict,
         );
         loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
-        statusDisconnectedMock = Mock.ofType<Action<void>>();
-        statusConnectedMock = Mock.ofType<Action<void>>();
+        statusDisconnectedMock = Mock.ofType<SyncAction<void>>();
+        statusConnectedMock = Mock.ofType<SyncAction<void>>();
         telemetryDataFactoryMock = Mock.ofType<TelemetryDataFactory>();
         eventStub = {} as React.SyntheticEvent;
         telemetryStub = {

--- a/src/tests/unit/tests/electron/flux/action-creator/window-frame-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/window-frame-action-creator.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { Rectangle } from 'electron';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
@@ -18,7 +18,7 @@ describe(WindowFrameActionCreator, () => {
     });
 
     it('calling setWindowSize invokes setWindowSize action with given payload', () => {
-        const setRouteActionMock = Mock.ofType<Action<SetSizePayload>>();
+        const setRouteActionMock = Mock.ofType<SyncAction<SetSizePayload>>();
         const testPayload: SetSizePayload = {
             height: 1,
             width: 2,
@@ -34,7 +34,7 @@ describe(WindowFrameActionCreator, () => {
     });
 
     it('calling maximize invokes maximize action', () => {
-        const maximizeActionMock = Mock.ofType<Action<void>>();
+        const maximizeActionMock = Mock.ofType<SyncAction<void>>();
 
         windowFrameActionsMock
             .setup(actions => actions.maximize)
@@ -47,7 +47,7 @@ describe(WindowFrameActionCreator, () => {
     });
 
     it('calling minimize invokes minimize action', () => {
-        const minimizeActionMock = Mock.ofType<Action<void>>();
+        const minimizeActionMock = Mock.ofType<SyncAction<void>>();
 
         windowFrameActionsMock
             .setup(actions => actions.minimize)
@@ -60,7 +60,7 @@ describe(WindowFrameActionCreator, () => {
     });
 
     it('calling maximize invokes restore action', () => {
-        const restoreActionMock = Mock.ofType<Action<void>>();
+        const restoreActionMock = Mock.ofType<SyncAction<void>>();
 
         windowFrameActionsMock
             .setup(actions => actions.restore)
@@ -73,7 +73,7 @@ describe(WindowFrameActionCreator, () => {
     });
 
     it('calling close invokes close action', () => {
-        const closeActionMock = Mock.ofType<Action<void>>();
+        const closeActionMock = Mock.ofType<SyncAction<void>>();
 
         windowFrameActionsMock
             .setup(actions => actions.close)
@@ -92,7 +92,7 @@ describe(WindowFrameActionCreator, () => {
             height: 78,
             width: 89,
         };
-        const setWindowBoundsActionMock = Mock.ofType<Action<Rectangle>>();
+        const setWindowBoundsActionMock = Mock.ofType<SyncAction<Rectangle>>();
 
         windowFrameActionsMock
             .setup(actions => actions.setWindowBounds)

--- a/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { Rectangle } from 'electron';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
@@ -35,7 +35,7 @@ describe(WindowStateActionCreator, () => {
     });
 
     it('calling setRoute invokes setRoute action with given payload', () => {
-        const setRouteActionMock = Mock.ofType<Action<RoutePayload>>();
+        const setRouteActionMock = Mock.ofType<SyncAction<RoutePayload>>();
         const testPayload: RoutePayload = {
             routeId: 'resultsView',
         };
@@ -57,7 +57,7 @@ describe(WindowStateActionCreator, () => {
     });
 
     it('calling setRoute with deviceConnectView, invokes setWindowSize', () => {
-        const setRouteActionMock = Mock.ofType<Action<RoutePayload>>();
+        const setRouteActionMock = Mock.ofType<SyncAction<RoutePayload>>();
         const testPayload: RoutePayload = {
             routeId: 'deviceConnectView',
         };
@@ -78,7 +78,7 @@ describe(WindowStateActionCreator, () => {
     });
 
     it('calling setWindowState invokes setWindowState action', () => {
-        const setWindowStatePayload = Mock.ofType<Action<WindowStatePayload>>();
+        const setWindowStatePayload = Mock.ofType<SyncAction<WindowStatePayload>>();
         const testPayload: WindowStatePayload = {
             currentWindowState: 'maximized',
         };
@@ -102,7 +102,7 @@ describe(WindowStateActionCreator, () => {
         let setRouteActionMock;
 
         beforeEach(() => {
-            setRouteActionMock = Mock.ofType<Action<RoutePayload>>();
+            setRouteActionMock = Mock.ofType<SyncAction<RoutePayload>>();
             setRouteActionMock.setup(s => s.invoke(testPayload)).verifiable(Times.once());
             windowStateActionsMock
                 .setup(actions => actions.setRoute)

--- a/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
@@ -4,7 +4,7 @@ import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads'
 import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { Logger } from 'common/logging/logger';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import {
@@ -36,13 +36,13 @@ describe('ScanController', () => {
     let loggerMock: IMock<Logger>;
 
     let scanActionsMock: IMock<ScanActions>;
-    let scanStartedMock: IMock<Action<void>>;
-    let scanCompletedMock: IMock<Action<void>>;
-    let scanFailedMock: IMock<Action<void>>;
+    let scanStartedMock: IMock<SyncAction<void>>;
+    let scanCompletedMock: IMock<SyncAction<void>>;
+    let scanFailedMock: IMock<SyncAction<void>>;
 
     let deviceConnectionActionsMock: IMock<DeviceConnectionActions>;
-    let deviceConnectedMock: IMock<Action<void>>;
-    let deviceDisconnectedMock: IMock<Action<void>>;
+    let deviceConnectedMock: IMock<SyncAction<void>>;
+    let deviceDisconnectedMock: IMock<SyncAction<void>>;
 
     let unifiedScanResultActionsMock: IMock<UnifiedScanResultActions>;
     let unifiedResultsBuilderMock: IMock<UnifiedScanCompletedPayloadBuilder>;
@@ -54,15 +54,15 @@ describe('ScanController', () => {
         deviceCommunicatorMock = Mock.ofType<DeviceCommunicator>();
         scanActionsMock = Mock.ofType<ScanActions>();
 
-        scanStartedMock = Mock.ofType<Action<void>>();
+        scanStartedMock = Mock.ofType<SyncAction<void>>();
         scanStartedMock
             .setup(scanStarted => scanStarted.addListener(It.is(isFunction)))
             .callback(listener => listener());
-        scanCompletedMock = Mock.ofType<Action<void>>();
-        scanFailedMock = Mock.ofType<Action<void>>();
+        scanCompletedMock = Mock.ofType<SyncAction<void>>();
+        scanFailedMock = Mock.ofType<SyncAction<void>>();
 
-        deviceConnectedMock = Mock.ofType<Action<void>>();
-        deviceDisconnectedMock = Mock.ofType<Action<void>>();
+        deviceConnectedMock = Mock.ofType<SyncAction<void>>();
+        deviceDisconnectedMock = Mock.ofType<SyncAction<void>>();
         deviceConnectionActionsMock = Mock.ofType<DeviceConnectionActions>();
         deviceConnectionActionsMock
             .setup(actions => actions.statusConnected)
@@ -177,7 +177,7 @@ describe('ScanController', () => {
             .setup(builder => builder(scanResults))
             .returns(() => unifiedPayload);
 
-        const unifiedScanCompletedMock = Mock.ofType<Action<UnifiedScanCompletedPayload>>();
+        const unifiedScanCompletedMock = Mock.ofType<SyncAction<UnifiedScanCompletedPayload>>();
         unifiedScanCompletedMock
             .setup(action => action.invoke(unifiedPayload))
             .verifiable(Times.once());

--- a/src/tests/unit/tests/electron/platform/android/setup/state-machine/state-machine-step-configs.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/state-machine/state-machine-step-configs.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { StateMachineStep } from 'electron/platform/android/setup/state-machine/state-machine-step';
 import {
     createStateMachineSteps,
@@ -12,8 +12,8 @@ import { StateMachineSteps } from 'electron/platform/android/setup/state-machine
 type MartiniStepId = 'gin' | 'vermouth' | 'olives';
 
 class MartiniActions {
-    public shake = new Action<void>();
-    public stir = new Action<void>();
+    public shake = new SyncAction<void>();
+    public stir = new SyncAction<void>();
 }
 
 type MartiniDeps = {

--- a/src/tests/unit/tests/electron/platform/android/setup/state-machine/state-machine.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/state-machine/state-machine.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { StateMachine } from 'electron/platform/android/setup/state-machine/state-machine';
 import { StateMachineSteps } from 'electron/platform/android/setup/state-machine/state-machine-steps';
 import { ExpectedCallType, It, Mock, MockBehavior, Times } from 'typemoq';
@@ -9,9 +9,9 @@ import { ExpectedCallType, It, Mock, MockBehavior, Times } from 'typemoq';
 type MartiniStepId = 'gin' | 'vermouth' | 'olives';
 
 class MartiniActions {
-    public shake = new Action<void>();
-    public stir = new Action<void>();
-    public garnish = new Action<string>();
+    public shake = new SyncAction<void>();
+    public stir = new SyncAction<void>();
+    public garnish = new SyncAction<string>();
 }
 
 type MartiniSteps = StateMachineSteps<MartiniStepId, MartiniActions>;

--- a/src/tests/unit/tests/electron/window-management/window-frame-listener.test.ts
+++ b/src/tests/unit/tests/electron/window-management/window-frame-listener.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { SaveWindowBoundsPayload } from 'background/actions/action-payloads';
-import { Action } from 'common/flux/action';
+import { SyncAction } from 'common/flux/sync-action';
 import { UserConfigMessageCreator } from 'common/message-creators/user-config-message-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { WindowBoundsChangedPayload } from 'electron/flux/action/window-frame-actions-payloads';
@@ -32,10 +32,10 @@ describe(WindowFrameListener, () => {
         userConfigMessageCreatorMock = Mock.ofType(UserConfigMessageCreator);
         windowStateStoreMock = Mock.ofType(WindowStateStore);
 
-        maximizeEvent = new Action<void>();
-        unmaximizeEvent = new Action<void>();
-        enterFullScreenEvent = new Action<void>();
-        windowBoundsChangedEvent = new Action<SaveWindowBoundsPayload>();
+        maximizeEvent = new SyncAction<void>();
+        unmaximizeEvent = new SyncAction<void>();
+        enterFullScreenEvent = new SyncAction<void>();
+        windowBoundsChangedEvent = new SyncAction<SaveWindowBoundsPayload>();
 
         testSubject = new WindowFrameListener(
             windowStateActionsCreatorMock.object,


### PR DESCRIPTION
#### Details

- Rename Action to SyncAction
- Create a generic Action interface
- Create an AsyncAction, which accepts async listeners and returns a Promise from invoke()
- Refactor scoping/mutex logic out of SyncAction and share it with AsyncAction

##### Motivation

Feature work (Converting Flux logic to use promises as part of the migration to Manifest V3)

##### Context

Future work will include converting existing Actions/SyncActions into AsyncActions

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
