### PR TITLE
chore: Change workspace recommendation for debugger extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
     "recommendations": [
         "esbenp.prettier-vscode",
         "dbaeumer.vscode-eslint",
-        "msjsdiag.debugger-for-chrome",
+        "ms-vscode.js-debug",
         "psioniq.psi-header",
         "stylelint.vscode-stylelint"
     ]


### PR DESCRIPTION
#### Details

The original "Debugger for Chrome" https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome is deprecated. Swapping for the recommended replacement https://marketplace.visualstudio.com/items?itemName=ms-vscode.js-debug

##### Motivation

Recommended extension is deprecated.

##### Context


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
