### PR TITLE
fix: avoid crashing when a browser tab has an invalid URL

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -225,6 +225,8 @@ async function initialize(): Promise<void> {
     );
     await detailsViewController.initialize();
 
+    const urlParser = new UrlParser();
+
     const tabContextFactory = new TabContextFactory(
         visualizationConfigurationFactory,
         telemetryEventHandler,
@@ -240,6 +242,7 @@ async function initialize(): Promise<void> {
         persistedData,
         indexedDBInstance,
         persistData,
+        urlParser,
     );
 
     const targetPageController = new TargetPageController(

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -16,6 +16,7 @@ import { EventResponseFactory } from 'common/browser-adapters/event-response-fac
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { ExceptionTelemetrySanitizer } from 'common/telemetry/exception-telemetry-sanitizer';
+import { UrlParser } from 'common/url-parser';
 import { WindowUtils } from 'common/window-utils';
 import UAParser from 'ua-parser-js';
 import { AxeInfo } from '../common/axe-info';

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -41,6 +41,7 @@ import { NotificationCreator } from 'common/notification-creator';
 import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
 import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { ExceptionTelemetrySanitizer } from 'common/telemetry/exception-telemetry-sanitizer';
+import { UrlParser } from 'common/url-parser';
 import { UrlValidator } from 'common/url-validator';
 import { title, toolName } from 'content/strings/application';
 import { IssueFilingServiceProviderImpl } from 'issue-filing/issue-filing-service-provider-impl';
@@ -210,6 +211,8 @@ async function initialize(): Promise<void> {
     await detailsViewController.initialize();
 
     const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter, logger);
+    const urlParser = new UrlParser();
+
     const tabContextFactory = new TabContextFactory(
         visualizationConfigurationFactory,
         telemetryEventHandler,
@@ -225,6 +228,7 @@ async function initialize(): Promise<void> {
         persistedData,
         indexedDBInstance,
         true,
+        urlParser,
     );
 
     const targetPageController = new TargetPageController(

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -7,6 +7,7 @@ import { NeedsReviewScanResultStore } from 'background/stores/needs-review-scan-
 import { PersistentStore } from 'common/flux/persistent-store';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Logger } from 'common/logging/logger';
+import { UrlParser } from 'common/url-parser';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { StoreType } from '../../common/types/store-type';
 import { generateUID } from '../../common/uid-generator';
@@ -42,6 +43,7 @@ export class TabContextStoreHub implements StoreHub {
         logger: Logger,
         tabId: number,
         persistStoreData: boolean,
+        urlParser: UrlParser,
     ) {
         const persistedTabData = persistedData.tabData ? persistedData.tabData[tabId] : null;
 
@@ -81,6 +83,7 @@ export class TabContextStoreHub implements StoreHub {
             logger,
             tabId,
             persistStoreData,
+            urlParser,
         );
         this.tabStore.initialize();
 

--- a/src/background/stores/tab-store.ts
+++ b/src/background/stores/tab-store.ts
@@ -23,7 +23,7 @@ export class TabStore extends PersistentStore<TabStoreData> {
         logger: Logger,
         tabId: number,
         persistStoreData: boolean,
-        private readonly urlParser: UrlParser = new UrlParser(),
+        private readonly urlParser: UrlParser,
     ) {
         super(
             StoreNames.TabStore,

--- a/src/background/stores/tab-store.ts
+++ b/src/background/stores/tab-store.ts
@@ -7,6 +7,7 @@ import { Tab } from 'common/itab';
 import { Logger } from 'common/logging/logger';
 import { StoreNames } from 'common/stores/store-names';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { UrlParser } from 'common/url-parser';
 import { TabActions } from '../actions/tab-actions';
 import { VisualizationActions } from '../actions/visualization-actions';
 
@@ -22,6 +23,7 @@ export class TabStore extends PersistentStore<TabStoreData> {
         logger: Logger,
         tabId: number,
         persistStoreData: boolean,
+        private readonly urlParser: UrlParser = new UrlParser(),
     ) {
         super(
             StoreNames.TabStore,
@@ -87,7 +89,7 @@ export class TabStore extends PersistentStore<TabStoreData> {
     };
 
     private onExistingTabUpdated = (payload: Tab): void => {
-        if (!this.originsMatch(payload.url, this.state.url)) {
+        if (!this.urlParser.areURLsSameOrigin(this.state.url, payload.url)) {
             this.state.isOriginChanged = true;
         }
         this.state.title = payload.title;
@@ -101,15 +103,5 @@ export class TabStore extends PersistentStore<TabStoreData> {
             this.state.isChanged = false;
             this.emitChanged();
         }
-    };
-
-    private originsMatch = (url1: string, url2: string): boolean => {
-        if (url1 == null && url2 == null) {
-            return true;
-        }
-        if (url1 != null && url2 != null) {
-            return new URL(url1).origin === new URL(url2).origin;
-        }
-        return false;
     };
 }

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -13,6 +13,7 @@ import { Logger } from 'common/logging/logger';
 import { NotificationCreator } from 'common/notification-creator';
 import { PromiseFactory } from 'common/promises/promise-factory';
 import { StateDispatcher } from 'common/state-dispatcher';
+import { UrlParser } from 'common/url-parser';
 import { ActionCreator } from './actions/action-creator';
 import { ActionHub } from './actions/action-hub';
 import { CardSelectionActionCreator } from './actions/card-selection-action-creator';
@@ -53,6 +54,7 @@ export class TabContextFactory {
         private readonly persistedData: PersistedData,
         private readonly indexedDBInstance: IndexedDBAPI,
         private readonly persistStoreData: boolean,
+        private readonly urlParser: UrlParser,
     ) {}
 
     public createTabContext(tabId: number): TabContext {
@@ -66,6 +68,7 @@ export class TabContextFactory {
             this.logger,
             tabId,
             this.persistStoreData,
+            this.urlParser,
         );
         const notificationCreator = new NotificationCreator(
             this.browserAdapter,

--- a/src/common/url-parser.ts
+++ b/src/common/url-parser.ts
@@ -12,14 +12,29 @@ export class UrlParser {
     }
 
     public areURLsEqual(urlA: string, urlB: string): boolean {
-        const urlAObj = new URL(urlA);
-        const urlBObj = new URL(urlB);
+        const urlAObj = this.tryParseUrl(urlA);
+        const urlBObj = this.tryParseUrl(urlB);
+
+        if (urlAObj == null || urlBObj == null) {
+            return urlA === urlB;
+        }
 
         if (this.areBothFileUrls(urlAObj, urlBObj)) {
             return this.areFileUrlsEqual(urlAObj, urlBObj);
         }
 
         return this.areUrlProtocolsEqual(urlAObj, urlBObj) && urlAObj.hostname === urlBObj.hostname;
+    }
+
+    public areURLsSameOrigin(urlA: string, urlB: string): boolean {
+        const urlAOrigin = this.tryParseOrigin(urlA);
+        const urlBOrigin = this.tryParseOrigin(urlB);
+
+        if (urlAOrigin == null || urlBOrigin == null) {
+            return urlA === urlB;
+        } else {
+            return urlAOrigin === urlBOrigin;
+        }
     }
 
     private areFileUrlsEqual(urlAObj: URL, urlBObj: URL): boolean {
@@ -32,5 +47,27 @@ export class UrlParser {
 
     private areUrlProtocolsEqual(urlAObj: URL, urlBObj: URL): boolean {
         return urlAObj.protocol === urlBObj.protocol;
+    }
+
+    private tryParseUrl(url?: string): URL | null {
+        if (url == null) {
+            return null;
+        }
+        try {
+            return new URL(url);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    private tryParseOrigin(url?: string): string | null {
+        const urlObj = this.tryParseUrl(url);
+
+        // Yes, it really can be the string "null" for some browser/Node environments
+        if (urlObj == null || urlObj.origin == null || urlObj.origin === 'null') {
+            return null;
+        }
+
+        return urlObj.origin;
     }
 }

--- a/src/common/url-parser.ts
+++ b/src/common/url-parser.ts
@@ -26,7 +26,10 @@ export class UrlParser {
         return this.areUrlProtocolsEqual(urlAObj, urlBObj) && urlAObj.hostname === urlBObj.hostname;
     }
 
-    public areURLsSameOrigin(urlA: string, urlB: string): boolean {
+    public areURLsSameOrigin(
+        urlA: string | null | undefined,
+        urlB: string | null | undefined,
+    ): boolean {
         const urlAOrigin = this.tryParseOrigin(urlA);
         const urlBOrigin = this.tryParseOrigin(urlB);
 
@@ -49,7 +52,7 @@ export class UrlParser {
         return urlAObj.protocol === urlBObj.protocol;
     }
 
-    private tryParseUrl(url?: string): URL | null {
+    private tryParseUrl(url: string | null | undefined): URL | null {
         if (url == null) {
             return null;
         }
@@ -60,7 +63,7 @@ export class UrlParser {
         }
     }
 
-    private tryParseOrigin(url?: string): string | null {
+    private tryParseOrigin(url: string | null | undefined): string | null {
         const urlObj = this.tryParseUrl(url);
 
         // Yes, it really can be the string "null" for some browser/Node environments

--- a/src/tests/unit/common/tab-store-data-builder.ts
+++ b/src/tests/unit/common/tab-store-data-builder.ts
@@ -7,6 +7,6 @@ import { BaseDataBuilder } from './base-data-builder';
 export class TabStoreDataBuilder extends BaseDataBuilder<TabStoreData> {
     constructor() {
         super();
-        this.data = new TabStore(null, null, null, null, null, null, null).getDefaultState();
+        this.data = new TabStore(null, null, null, null, null, null, null, null).getDefaultState();
     }
 }

--- a/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
@@ -16,6 +16,7 @@ describe('TabContextStoreHubTest', () => {
             null,
             null,
             true,
+            null,
         );
     });
 

--- a/src/tests/unit/tests/background/stores/tab-store.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-store.test.ts
@@ -3,6 +3,8 @@
 import { TabActions } from 'background/actions/tab-actions';
 import { VisualizationActions } from 'background/actions/visualization-actions';
 import { TabStore } from 'background/stores/tab-store';
+import { UrlParser } from 'common/url-parser';
+import { IMock, Mock } from 'typemoq';
 import { Tab } from '../../../../../common/itab';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import { TabStoreData } from '../../../../../common/types/store-data/tab-store-data';
@@ -10,6 +12,11 @@ import { createStoreWithNullParams, StoreTester } from '../../../common/store-te
 import { TabStoreDataBuilder } from '../../../common/tab-store-data-builder';
 
 describe('TabStoreTest', () => {
+    let mockUrlParser: IMock<UrlParser>;
+    beforeEach(() => {
+        mockUrlParser = Mock.ofType<UrlParser>();
+    });
+
     test('constructor, no side effects', () => {
         const testObject = createStoreWithNullParams(TabStore);
         expect(testObject).toBeDefined();
@@ -43,21 +50,24 @@ describe('TabStoreTest', () => {
     });
 
     test.each`
-        payloadUrl                               | differentId | originalIsClosed | originalIsChanged
-        ${'https://original-host/original-path'} | ${true}     | ${false}         | ${false}
-        ${'https://original-host/original-path'} | ${false}    | ${false}         | ${false}
-        ${'https://original-host/new-path'}      | ${false}    | ${false}         | ${false}
-        ${'https://new-host/new-path'}           | ${false}    | ${false}         | ${false}
-        ${'https://original-host/original-path'} | ${false}    | ${false}         | ${true}
-        ${'https://original-host/original-path'} | ${false}    | ${true}          | ${true}
+        differentOrigin | differentId | originalIsClosed | originalIsChanged
+        ${false}        | ${true}     | ${false}         | ${false}
+        ${false}        | ${false}    | ${false}         | ${false}
+        ${true}         | ${false}    | ${false}         | ${false}
+        ${false}        | ${false}    | ${false}         | ${true}
+        ${false}        | ${false}    | ${true}          | ${true}
     `(
-        'onNewTabCreated for differentId=$differentId, payloadUrl=$payloadUrl re-initializes from scratch ' +
+        'onNewTabCreated for differentOrigin=$differentOrigin, differentId=$differentId, re-initializes from scratch ' +
             'regardless of existing initial state isClosed=$originalIsClosed, isChanged=$originalIsChanged',
-        ({ payloadUrl, differentId, originalIsClosed, originalIsChanged }) => {
+        ({ differentOrigin, differentId, originalIsClosed, originalIsChanged }) => {
             const originalId = 1;
+            const originalUrl = 'https://original-host/original-path';
+            const newUrl = differentOrigin
+                ? 'https://new-host/new-path'
+                : 'https://original-host/new-path';
             const initialState = new TabStoreDataBuilder()
                 .with('id', originalId)
-                .with('url', 'https://original-host/original-path')
+                .with('url', originalUrl)
                 .with('title', 'title 1')
                 .with('isClosed', originalIsClosed)
                 .with('isChanged', originalIsChanged)
@@ -66,8 +76,12 @@ describe('TabStoreTest', () => {
             const payload: Tab = {
                 id: differentId ? originalId + 1 : originalId,
                 title: 'test-title',
-                url: payloadUrl,
+                url: newUrl,
             };
+
+            mockUrlParser
+                .setup(m => m.areURLsSameOrigin(originalUrl, newUrl))
+                .returns(() => !differentOrigin);
 
             const expectedState: TabStoreData = new TabStoreDataBuilder()
                 .with('id', payload.id)
@@ -107,26 +121,32 @@ describe('TabStoreTest', () => {
     });
 
     test.each`
-        payloadUrl                               | initialIsOriginChanged | expectedIsOriginChanged
-        ${'https://original-host/original-path'} | ${false}               | ${false}
-        ${'https://original-host/new-path'}      | ${false}               | ${false}
-        ${'https://new-host/new-path'}           | ${false}               | ${true}
-        ${'https://original-host/original-path'} | ${true}                | ${true}
-        ${'https://original-host/new-path'}      | ${true}                | ${true}
-        ${'https://new-host/new-path'}           | ${true}                | ${true}
+        differentOrigin | initialIsOriginChanged | expectedIsOriginChanged
+        ${false}        | ${false}               | ${false}
+        ${true}         | ${false}               | ${true}
+        ${false}        | ${true}                | ${true}
+        ${true}         | ${true}                | ${true}
     `(
-        'onExistingTabUpdated from isOriginChanged=$initialIsOriginChanged with payload url $payloadUrl should result in isOriginChanged=$expectedIsOriginChanged',
-        ({ payloadUrl, initialIsOriginChanged, expectedIsOriginChanged }) => {
+        'onExistingTabUpdated from isOriginChanged=$initialIsOriginChanged with differentOrigin=$differentOrigin should result in isOriginChanged=$expectedIsOriginChanged',
+        ({ differentOrigin, initialIsOriginChanged, expectedIsOriginChanged }) => {
+            const originalUrl = 'https://original-host/original-path';
+            const newUrl = differentOrigin
+                ? 'https://new-host/new-path'
+                : 'https://original-host/new-path';
             const initialState: TabStoreData = new TabStoreDataBuilder()
-                .with('url', 'https://original-host/original-path')
+                .with('url', originalUrl)
                 .with('title', 'title 1')
                 .with('isOriginChanged', initialIsOriginChanged)
                 .build();
 
             const payload: Tab = {
                 title: 'title 2',
-                url: payloadUrl,
+                url: newUrl,
             };
+
+            mockUrlParser
+                .setup(m => m.areURLsSameOrigin(originalUrl, newUrl))
+                .returns(() => !differentOrigin);
 
             const expectedState: TabStoreData = new TabStoreDataBuilder()
                 .with('url', payload.url)
@@ -238,7 +258,16 @@ describe('TabStoreTest', () => {
         actionName: keyof TabActions,
     ): StoreTester<TabStoreData, TabActions> {
         const factory = (actions: TabActions) =>
-            new TabStore(actions, new VisualizationActions(), null, null, null, null, true);
+            new TabStore(
+                actions,
+                new VisualizationActions(),
+                null,
+                null,
+                null,
+                null,
+                true,
+                mockUrlParser.object,
+            );
         return new StoreTester(TabActions, actionName, factory);
     }
 
@@ -246,7 +275,16 @@ describe('TabStoreTest', () => {
         actionName: keyof VisualizationActions,
     ): StoreTester<TabStoreData, VisualizationActions> {
         const factory = (actions: VisualizationActions) =>
-            new TabStore(new TabActions(), actions, null, null, null, null, true);
+            new TabStore(
+                new TabActions(),
+                actions,
+                null,
+                null,
+                null,
+                null,
+                true,
+                mockUrlParser.object,
+            );
         return new StoreTester(VisualizationActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -125,6 +125,7 @@ describe('TabContextFactoryTest', () => {
             persistedDataStub,
             mockDBInstance.object,
             true,
+            null,
         );
 
         const tabContext = testObject.createTabContext(tabId);

--- a/src/tests/unit/tests/common/url-parser.test.ts
+++ b/src/tests/unit/tests/common/url-parser.test.ts
@@ -98,4 +98,38 @@ describe('UrlParserTest', () => {
             expect(testSubject.areURLsEqual(urlA, urlB)).toEqual(false);
         });
     });
+
+    describe('areURLsSameOrigin', () => {
+        it.each`
+            urlA                     | urlB
+            ${'http://foo/bar'}      | ${'http://foo/bar'}
+            ${'http://foo/bar'}      | ${'http://foo/baz'}
+            ${'https://foo/bar'}     | ${'https://foo/baz'}
+            ${'https://foo:123/bar'} | ${'https://foo:123/baz'}
+            ${null}                  | ${null}
+            ${undefined}             | ${undefined}
+            ${'same invalid url!'}   | ${'same invalid url!'}
+        `('returns true for same-origin urls $urlA and $urlB', ({ urlA, urlB }) => {
+            expect(testSubject.areURLsSameOrigin(urlA, urlB)).toBe(true);
+        });
+
+        it.each`
+            urlA                            | urlB
+            ${'http://foo/bar'}             | ${'http://bar/bar'}
+            ${'http://foo/bar'}             | ${'https://foo/bar'}
+            ${'http://foo/bar'}             | ${'https://foo/baz'}
+            ${'https://foo:123/'}           | ${'https://foo:456/'}
+            ${'file:///any/file'}           | ${'file:///any/other-file'}
+            ${'strange-protocol://foo'}     | ${'strange-protocol://bar'}
+            ${'strange-protocol://foo/bar'} | ${'strange-protocol://foo/baz'}
+            ${'https://foo:123/bar'}        | ${'http://foo:123/baz'}
+            ${null}                         | ${undefined}
+            ${null}                         | ${'invalid url!'}
+            ${null}                         | ${'http://foo'}
+            ${'invalid url!'}               | ${'http://foo'}
+            ${'invalid url!'}               | ${'different invalid url!'}
+        `('returns false for different-origin urls $urlA and $urlB', ({ urlA, urlB }) => {
+            expect(testSubject.areURLsSameOrigin(urlA, urlB)).toBe(false);
+        });
+    });
 });


### PR DESCRIPTION
#### Details

* Moves some URL-origin-parsing logic specific to `TabStore` out into `UrlParser` for ease of testing
* Adds support to the logic to handle invalid URL cases

`UrlParser` has no dependencies and there is no other component in the background that uses `UrlParser` today, so I just initialized it in the `TabStore` directly rather than piping it around everywhere.

##### Motivation

Addresses issue #5753

##### Context

I don't have a good way to test the change locally, since we don't have consistent repro steps, but the root cause seems easy enough to understand and it shows up commonly enough in insider/canary telemetry that we should be able to determine if the fix worked by checking there in a few days.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5753
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
