### PR TITLE
fix: message bar icon in high contrast, and restyle message bar button/link

### DIFF
--- a/src/DetailsView/details-view-body.scss
+++ b/src/DetailsView/details-view-body.scss
@@ -54,7 +54,12 @@
 
         :global(.ms-MessageBar-icon) i {
             margin-left: 12px;
-            color: $secondary-text;
+            color: $always-black;
+        }
+
+        :global(.ms-MessageBar-text .insights-link) {
+            color: inherit !important;
+            text-decoration: underline;
         }
 
         .view {

--- a/src/DetailsView/details-view-body.scss
+++ b/src/DetailsView/details-view-body.scss
@@ -55,6 +55,9 @@
         :global(.ms-MessageBar-icon) i {
             margin-left: 12px;
             color: $always-black;
+            @include ms-high-contrast-override {
+                color: inherit;
+            }
         }
 
         :global(.ms-MessageBar-text .insights-link) {

--- a/src/tests/end-to-end/tests/details-view/headings.test.ts
+++ b/src/tests/end-to-end/tests/details-view/headings.test.ts
@@ -36,12 +36,9 @@ describe('Details View -> Assessment -> Headings', () => {
             await headingsPage.closeNavTestLink('Headings');
         });
 
-        it.each([
-            [true, 1],
-            [false, 0],
-        ])(
-            'should pass accessibility validation with highContrastMode=%s, %i errors expected',
-            async (highContrastMode, errorsExpected) => {
+        it.each([true, false])(
+            'should pass accessibility validation with highContrastMode=%s',
+            async highContrastMode => {
                 await browser.setHighContrastMode(highContrastMode);
                 await headingsPage.waitForHighContrastMode(highContrastMode);
 
@@ -49,7 +46,7 @@ describe('Details View -> Assessment -> Headings', () => {
                     headingsPage,
                     detailsViewSelectors.mainContent,
                 );
-                expect(results).toHaveLength(errorsExpected);
+                expect(results).toStrictEqual([]);
             },
         );
     });
@@ -63,12 +60,9 @@ describe('Details View -> Assessment -> Headings', () => {
             await headingsPage.closeNavTestLink('Headings');
         });
 
-        it.each([
-            [true, 1],
-            [false, 0],
-        ])(
-            'Getting started page should pass accessibility validation with highContrastMode=%s, %i errors expected',
-            async (highContrastMode, errorsExpected) => {
+        it.each([true, false])(
+            'Getting started page should pass accessibility validation with highContrastMode=%s',
+            async highContrastMode => {
                 await browser.setHighContrastMode(highContrastMode);
                 await headingsPage.waitForHighContrastMode(highContrastMode);
 
@@ -76,7 +70,7 @@ describe('Details View -> Assessment -> Headings', () => {
                     headingsPage,
                     detailsViewSelectors.mainContent,
                 );
-                expect(results).toHaveLength(errorsExpected);
+                expect(results).toStrictEqual([]);
             },
         );
     });


### PR DESCRIPTION
#### Details

* set icon to use `$always-black` rather than `$secondary-text`, so it doesn't end up white on light yellow in high contrast mode
* restyle button/link in message bar to always use underline and to inherit the regular text color of the message bar - avoids yellow button/link on light yellow in high contrast, but also improves visibility of the link in regular contrast mode

##### Motivation

Closes https://github.com/microsoft/accessibility-insights-web/issues/5757

In regular contrast mode, any button/link inside the message bar is not very obvious - and the difference between the blue button/link and the adjacent static text is relatively low.

More importantly/critically, when set to high contrast, the little "i" info icon turns white on light yellow, and the button/link uses yellow text on light yellow making both completely illegible.

This PR attempts to fix these issues with minimal styling changes.

---

###### Screenshots

**Before:**

Regular contrast, icon and button/link (dark gray/nearly black icon and blue button/link on light yellow bar)

![Regular contrast, icon and button/link](https://user-images.githubusercontent.com/895831/179309496-38844691-48d0-4a36-9ad7-095fb2075586.png)

High contrast, icon and button/link (white icon and yellow button/link on light yellow message bar)

![High contrast, icon and button/link](https://user-images.githubusercontent.com/895831/179309602-18e75d41-15bc-4441-aec8-ad09846ea615.png)

**After:**

Regular contrast, icon and button/link (black icon and dark gray/black button/link with underline on light yellow bar)

![Regular contrast, icon and button/link](https://user-images.githubusercontent.com/895831/179309777-c3f18a5f-5b79-44d3-9cfb-de7029db227d.png)

High contrast, icon and button/link (black icon and dark gray/black button/link with underline on light yellow bar)

![High contrast, icon and button/link](https://user-images.githubusercontent.com/895831/179309889-b9f859f6-721e-436f-9649-3c76e5483be4.png)

##### Context

Admittedly the change to using dark text with underline for the button/link may be a bit opinionated, and a slight departure from links anywhere else in the extension. I'd argue though that even in those other cases, it's worth considering making at least the underline visible for the links so as not to just rely mostly on colour to distinguish them from static text.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5757
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
