### PR TITLE
refactor(mv3-part-5): let StoreTester await async action listeners

### DIFF
--- a/src/common/flux/action.ts
+++ b/src/common/flux/action.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+export type ActionListener<TPayload, TReturn> = (payload: TPayload) => TReturn;
+
 export interface Action<TPayload, TReturn> {
     invoke(payload: TPayload, scope?: string): TReturn;
-    addListener(listener: (payload: TPayload) => TReturn): void;
+    addListener(listener: ActionListener<TPayload, TReturn>): void;
 }

--- a/src/common/flux/async-action.ts
+++ b/src/common/flux/async-action.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { Action, ActionListener } from 'common/flux/action';
 import { ScopeMutex } from 'common/flux/scope-mutex';
 import { mergePromiseResponses } from 'common/merge-promise-responses';
 
 export class AsyncAction<TPayload> implements Action<TPayload, Promise<void>> {
-    private listeners: ((payload: TPayload) => Promise<void>)[] = [];
+    private listeners: ActionListener<TPayload, Promise<void>>[] = [];
 
     constructor(
         private readonly scopeMutex: ScopeMutex = new ScopeMutex(),
@@ -26,7 +26,7 @@ export class AsyncAction<TPayload> implements Action<TPayload, Promise<void>> {
         }
     }
 
-    public addListener(listener: (payload: TPayload) => Promise<void>): void {
+    public addListener(listener: ActionListener<TPayload, Promise<void>>): void {
         this.listeners.push(listener);
     }
 }

--- a/src/common/flux/sync-action.ts
+++ b/src/common/flux/sync-action.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
+import { Action, ActionListener } from 'common/flux/action';
 import { ScopeMutex } from 'common/flux/scope-mutex';
 
 export class SyncAction<TPayload> implements Action<TPayload, void> {
-    private listeners: ((payload: TPayload) => void)[] = [];
+    private listeners: ActionListener<TPayload, void>[] = [];
 
     constructor(private readonly scopeMutex: ScopeMutex = new ScopeMutex()) {}
 
@@ -12,7 +12,7 @@ export class SyncAction<TPayload> implements Action<TPayload, void> {
         this.scopeMutex.tryLockScope(scope);
 
         try {
-            this.listeners.forEach((listener: (payload: TPayload) => void) => {
+            this.listeners.forEach(listener => {
                 listener(payload);
             });
         } finally {
@@ -20,7 +20,7 @@ export class SyncAction<TPayload> implements Action<TPayload, void> {
         }
     }
 
-    public addListener(listener: (payload: TPayload) => void): void {
+    public addListener(listener: ActionListener<TPayload, void>): void {
         this.listeners.push(listener);
     }
 }

--- a/src/tests/unit/common/assessment-store-tester.ts
+++ b/src/tests/unit/common/assessment-store-tester.ts
@@ -20,10 +20,13 @@ export class AssessmentStoreTester<TStoreData, TActions> extends StoreTester<TSt
         this.indexDbMock = indexDbMock;
     }
 
-    public testListenerToBeCalledOnce(initial: TStoreData, expected: TStoreData): void {
+    public async testListenerToBeCalledOnce(
+        initial: TStoreData,
+        expected: TStoreData,
+    ): Promise<void> {
         this.indexDbMock
             .setup(idm => idm.setItem(IndexedDBDataKeys.assessmentStore, It.isValue(expected)))
             .verifiable(Times.once());
-        super.testListenerToBeCalledOnce(initial, expected);
+        await super.testListenerToBeCalledOnce(initial, expected);
     }
 }

--- a/src/tests/unit/common/store-tester.ts
+++ b/src/tests/unit/common/store-tester.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BaseStoreImpl } from 'background/stores/base-store-impl';
-import { Action } from 'common/flux/action';
+import { Action, ActionListener } from 'common/flux/action';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { BaseStore } from '../../../common/base-store';
@@ -10,7 +10,7 @@ import { DefaultConstructor } from '../../../common/types/idefault-constructor';
 export class StoreTester<TStoreData, TActions> {
     private actionName: string;
     private actionParam: any;
-    private listener: Function;
+    private listener: ActionListener<unknown, void | Promise<void>>;
     private actions: DefaultConstructor<TActions>;
     private storeFactory: (actions) => BaseStoreImpl<TStoreData>;
     private postListenerMock: IMock<any>;
@@ -35,15 +35,25 @@ export class StoreTester<TStoreData, TActions> {
         return this;
     }
 
-    public testListenerToNeverBeCalled(initial: TStoreData, expected: TStoreData): void {
-        this.testListenerToBeCalled(initial, expected, Times.never());
+    public async testListenerToNeverBeCalled(
+        initial: TStoreData,
+        expected: TStoreData,
+    ): Promise<void> {
+        await this.testListenerToBeCalled(initial, expected, Times.never());
     }
 
-    public testListenerToBeCalledOnce(initial: TStoreData, expected: TStoreData): void {
-        this.testListenerToBeCalled(initial, expected, Times.once());
+    public async testListenerToBeCalledOnce(
+        initial: TStoreData,
+        expected: TStoreData,
+    ): Promise<void> {
+        await this.testListenerToBeCalled(initial, expected, Times.once());
     }
 
-    public testListenerToBeCalled(initial: TStoreData, expected: TStoreData, times: Times): void {
+    public async testListenerToBeCalled(
+        initial: TStoreData,
+        expected: TStoreData,
+        times: Times,
+    ): Promise<void> {
         const actionsMock = this.createActionsMock();
 
         const testObject = this.storeFactory(actionsMock.object);
@@ -54,7 +64,7 @@ export class StoreTester<TStoreData, TActions> {
 
         testObject.addChangedListener(listenerMock.object);
 
-        this.listener(this.actionParam);
+        await this.listener(this.actionParam);
 
         expect(testObject.getState()).toEqual(expected);
 

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-view-store.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-view-store.test.ts
@@ -36,37 +36,39 @@ describe(TabStopsViewStore, () => {
         expect(testObject.getDefaultState()).toEqual(expected);
     });
 
-    test('onDismissPanel', () => {
+    test('onDismissPanel', async () => {
         const initialState = getDefaultState();
         initialState.failureInstanceState.isPanelOpen = true;
         const finalState = getDefaultState();
-        createStoreForTabStopsViewActions('dismissPanel')
-            .withActionParam(null)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreForTabStopsViewActions('dismissPanel').withActionParam(null);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onUpdateDescription', () => {
+    test('onUpdateDescription', async () => {
         const expectedDescription = 'some description';
         const initialState = getDefaultState();
         const finalState = getDefaultState();
         finalState.failureInstanceState.description = expectedDescription;
-        createStoreForTabStopsViewActions('updateDescription')
-            .withActionParam(expectedDescription)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreForTabStopsViewActions('updateDescription').withActionParam(
+                expectedDescription,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onCreateNewFailureInstancePanel', () => {
+    test('onCreateNewFailureInstancePanel', async () => {
         const requirementId = 'focus-indicator';
         const initialState = getDefaultState();
         const finalState = getDefaultState();
         finalState.failureInstanceState.selectedRequirementId = requirementId;
         finalState.failureInstanceState.isPanelOpen = true;
-        createStoreForTabStopsViewActions('createNewFailureInstancePanel')
-            .withActionParam(requirementId)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreForTabStopsViewActions(
+            'createNewFailureInstancePanel',
+        ).withActionParam(requirementId);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onEditExistingFailureInstance', () => {
+    test('onEditExistingFailureInstance', async () => {
         const requirementId = 'focus-indicator';
         const expectedDescription = 'some description';
         const someInstanceId = 'some instance id';
@@ -84,9 +86,10 @@ describe(TabStopsViewStore, () => {
             requirementId,
             description: expectedDescription,
         };
-        createStoreForTabStopsViewActions('editExistingFailureInstance')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreForTabStopsViewActions(
+            'editExistingFailureInstance',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
     function getDefaultState(): TabStopsViewStoreData {

--- a/src/tests/unit/tests/background/inspect-store.test.ts
+++ b/src/tests/unit/tests/background/inspect-store.test.ts
@@ -24,17 +24,15 @@ describe('InspectStoreTest', () => {
         expect(defaultState.inspectMode).toEqual(InspectMode.off);
     });
 
-    test('on getCurrentState', () => {
+    test('on getCurrentState', async () => {
         const initialState = getDefaultState();
         const finalState = getDefaultState();
 
-        createStoreForInspectActions('getCurrentState').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreForInspectActions('getCurrentState');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on changeMode', () => {
+    test('on changeMode', async () => {
         const initialState = getDefaultState();
         const payload: InspectPayload = {
             inspectMode: InspectMode.scopingAddInclude,
@@ -42,29 +40,28 @@ describe('InspectStoreTest', () => {
 
         const finalState = getDefaultState();
         finalState.inspectMode = payload.inspectMode;
-        createStoreForInspectActions('changeInspectMode')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreForInspectActions('changeInspectMode').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on setHoveredOverSelector', () => {
+    test('on setHoveredOverSelector', async () => {
         const initialState = getDefaultState();
         const payload: string[] = ['some selector'];
         const finalState = getDefaultState();
         finalState.hoveredOverSelector = payload;
-        createStoreForInspectActions('setHoveredOverSelector')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreForInspectActions('setHoveredOverSelector').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on existingTabUpdated', () => {
+    test('on existingTabUpdated', async () => {
         const initialState = getDefaultState();
         initialState.hoveredOverSelector = ['some selector'];
         initialState.inspectMode = InspectMode.scopingAddInclude;
         const finalState = getDefaultState();
-        createStoreForTabActions('existingTabUpdated')
-            .withActionParam(null)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreForTabActions('existingTabUpdated').withActionParam(null);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
     function getDefaultState(): InspectStoreData {

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -234,17 +234,15 @@ describe('AssessmentStore', () => {
         expect(actualState).toEqual(expectedState);
     });
 
-    test('on getCurrentState', () => {
+    test('on getCurrentState', async () => {
         const initialState = getDefaultState();
         const finalState = getDefaultState();
 
-        createStoreTesterForAssessmentActions('getCurrentState').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreTesterForAssessmentActions('getCurrentState');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on resetData: only reset data for one test', () => {
+    test('on resetData: only reset data for one test', async () => {
         const expectedInstanceMap = {};
         const expectedManualTestStepResultMap = {};
 
@@ -291,12 +289,12 @@ describe('AssessmentStore', () => {
             test: assessmentType,
         };
 
-        createStoreTesterForAssessmentActions('resetData')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('resetData').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('on resetData: only reset data for one test with persisted data', () => {
+    test('on resetData: only reset data for one test with persisted data', async () => {
         const expectedInstanceMap = {};
         const expectedManualTestStepResultMap = {};
 
@@ -347,12 +345,14 @@ describe('AssessmentStore', () => {
             test: assessmentType,
         };
 
-        createStoreTesterForAssessmentActions('resetData', initialState)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForAssessmentActions(
+            'resetData',
+            initialState,
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('test that tests indexedDB and also reset', () => {
+    test('test that tests indexedDB and also reset', async () => {
         const expectedInstanceMap = {};
         const expectedManualTestStepResultMap = {};
 
@@ -398,13 +398,13 @@ describe('AssessmentStore', () => {
             test: assessmentType,
         };
 
-        createStoreTesterForAssessmentActions('resetData')
+        const storeTester = createStoreTesterForAssessmentActions('resetData')
             .withActionParam(payload)
-            .withPostListenerMock(indexDBInstanceMock)
-            .testListenerToBeCalledOnce(initialState, finalState);
+            .withPostListenerMock(indexDBInstanceMock);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('test for null indexedDB instance and also reset', () => {
+    test('test for null indexedDB instance and also reset', async () => {
         const expectedInstanceMap = {};
         const expectedManualTestStepResultMap = {};
 
@@ -450,13 +450,13 @@ describe('AssessmentStore', () => {
             test: assessmentType,
         };
 
-        createStoreTesterForAssessmentActions('resetData')
+        const storeTester = createStoreTesterForAssessmentActions('resetData')
             .withActionParam(payload)
-            .withPostListenerMock(indexDBInstanceMock)
-            .testListenerToBeCalledOnce(initialState, finalState);
+            .withPostListenerMock(indexDBInstanceMock);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onResetAllAssessmentsData', () => {
+    test('onResetAllAssessmentsData', async () => {
         const oldTabId = 1;
         const tabId = 1000;
         const url = 'url';
@@ -492,14 +492,14 @@ describe('AssessmentStore', () => {
 
         setupDataGeneratorMock(null, getDefaultState(), Times.exactly(2));
 
-        createStoreTesterForAssessmentActions('resetAllAssessmentsData')
-            .withActionParam(tabId)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('resetAllAssessmentsData').withActionParam(tabId);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
 
         expect(() => rejectCb()).toThrowErrorMatchingSnapshot();
     });
 
-    test('onResetAllAssessmentsData with persisted data', () => {
+    test('onResetAllAssessmentsData with persisted data', async () => {
         const persisted: AssessmentStoreData = {
             persistedTabInfo: null,
             assessments: {
@@ -567,14 +567,16 @@ describe('AssessmentStore', () => {
         // Called without persisted data from resetAllAssessmentsData
         setupDataGeneratorMock(null, getDefaultState(), Times.once());
 
-        createStoreTesterForAssessmentActions('resetAllAssessmentsData', persisted)
-            .withActionParam(tabId)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreTesterForAssessmentActions(
+            'resetAllAssessmentsData',
+            persisted,
+        ).withActionParam(tabId);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
 
         expect(() => rejectCb()).toThrowErrorMatchingSnapshot();
     });
 
-    test('onContinuePreviousAssessment', () => {
+    test('onContinuePreviousAssessment', async () => {
         const oldTabId = 1;
         const tabId = 1000;
         const url = 'url';
@@ -603,12 +605,13 @@ describe('AssessmentStore', () => {
             .withTargetTab(tabId, url, title, 'testId')
             .build();
 
-        createStoreTesterForAssessmentActions('continuePreviousAssessment')
-            .withActionParam(tabId)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreTesterForAssessmentActions(
+            'continuePreviousAssessment',
+        ).withActionParam(tabId);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onLoadAssessment', () => {
+    test('onLoadAssessment', async () => {
         const oldTabId = 1;
         const tabId = 1000;
         const url = 'url';
@@ -651,12 +654,12 @@ describe('AssessmentStore', () => {
             .setup(adapter => adapter.getTab(tabId, It.is(isFunction), It.is(isFunction)))
             .callback((id, resolve) => resolve(tab));
 
-        createStoreTesterForAssessmentActions('LoadAssessment')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('LoadAssessment').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onScanCompleted with an assisted requirement', () => {
+    test('onScanCompleted with an assisted requirement', async () => {
         const initialAssessmentData = new AssessmentDataBuilder()
             .with('testStepStatus', {
                 ['assessment-1-step-1']: getDefaultTestStepData(),
@@ -730,12 +733,12 @@ describe('AssessmentStore', () => {
             )
             .returns(() => expectedInstanceMap);
 
-        createStoreTesterForAssessmentActions('scanCompleted')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('scanCompleted').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onScanCompleted with a manual requirement uses getInitialManualTestStatus to set status', () => {
+    test('onScanCompleted with a manual requirement uses getInitialManualTestStatus to set status', async () => {
         const initialManualTestStepResult = {
             status: ManualTestStatus.UNKNOWN,
             id: requirementKey,
@@ -854,14 +857,14 @@ describe('AssessmentStore', () => {
             )
             .returns(() => fullInstanceMap);
 
-        createStoreTesterForAssessmentActions('scanCompleted')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('scanCompleted').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
 
         mockGetInitialManualTestStatus.verifyAll();
     });
 
-    test('onScanCompleted with a manual requirement skips getInitialManualTestStatus for requirements that already have a status', () => {
+    test('onScanCompleted with a manual requirement skips getInitialManualTestStatus for requirements that already have a status', async () => {
         const initialManualTestStepResult = {
             status: ManualTestStatus.PASS,
             id: requirementKey,
@@ -956,12 +959,12 @@ describe('AssessmentStore', () => {
             )
             .returns(() => expectedInstanceMap);
 
-        createStoreTesterForAssessmentActions('scanCompleted')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('scanCompleted').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onScanUpdate', () => {
+    test('onScanUpdate', async () => {
         const initialAssessmentData = new AssessmentDataBuilder()
             .with('testStepStatus', {
                 ['assessment-1-step-1']: getDefaultTestStepData(),
@@ -1023,12 +1026,12 @@ describe('AssessmentStore', () => {
             )
             .returns(() => expectedInstanceMap);
 
-        createStoreTesterForAssessmentActions('scanUpdate')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('scanUpdate').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onTrackingCompleted', () => {
+    test('onTrackingCompleted', async () => {
         const instanceKey = 'instance-1';
         const initialInstanceMap: DictionaryStringTo<GeneratedAssessmentInstance> = {
             [instanceKey]: {
@@ -1065,12 +1068,12 @@ describe('AssessmentStore', () => {
                 delete initialInstanceMap[instanceKey];
             });
 
-        createStoreTesterForAssessmentActions('trackingCompleted')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('trackingCompleted').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on selectTestStep', () => {
+    test('on selectTestStep', async () => {
         const visualizationType = 1 as VisualizationType;
         const requirement = 'test-step';
         const initialState = new AssessmentsStoreDataBuilder(
@@ -1092,12 +1095,12 @@ describe('AssessmentStore', () => {
 
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
 
-        createStoreTesterForAssessmentActions('selectTestSubview')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('selectTestSubview').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on expandTestNav', () => {
+    test('on expandTestNav', async () => {
         const visualizationType = 1 as VisualizationType;
         const initialState = new AssessmentsStoreDataBuilder(
             assessmentsProvider,
@@ -1116,12 +1119,12 @@ describe('AssessmentStore', () => {
 
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
 
-        createStoreTesterForAssessmentActions('expandTestNav')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('expandTestNav').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on collapseTestNav', () => {
+    test('on collapseTestNav', async () => {
         const initialState = new AssessmentsStoreDataBuilder(
             assessmentsProvider,
             assessmentDataConverterMock.object,
@@ -1135,13 +1138,11 @@ describe('AssessmentStore', () => {
 
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
 
-        createStoreTesterForAssessmentActions('collapseTestNav').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreTesterForAssessmentActions('collapseTestNav');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onUpdateTargetTabId', () => {
+    test('onUpdateTargetTabId', async () => {
         const tabId = 1000;
         const url = 'url';
         const title = 'title';
@@ -1169,13 +1170,13 @@ describe('AssessmentStore', () => {
             .withTargetTab(tabId, url, title)
             .build();
 
-        createStoreTesterForAssessmentActions('updateTargetTabId')
-            .withActionParam(tabId)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('updateTargetTabId').withActionParam(tabId);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
         expect(() => onReject()).toThrowErrorMatchingSnapshot();
     });
 
-    test('onUpdateTargetTabId: tab is null', () => {
+    test('onUpdateTargetTabId: tab is null', async () => {
         const tabId = 1000;
         const tab: Tab = null;
         browserMock
@@ -1191,12 +1192,12 @@ describe('AssessmentStore', () => {
             assessmentDataConverterMock.object,
         ).build();
 
-        createStoreTesterForAssessmentActions('updateTargetTabId')
-            .withActionParam(tabId)
-            .testListenerToNeverBeCalled(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('updateTargetTabId').withActionParam(tabId);
+        await storeTester.testListenerToNeverBeCalled(initialState, finalState);
     });
 
-    test('on changeInstanceStatus, test step status updated', () => {
+    test('on changeInstanceStatus, test step status updated', async () => {
         const generatedAssessmentInstancesMap: DictionaryStringTo<GeneratedAssessmentInstance> = {
             selector: {
                 testStepResults: {
@@ -1250,12 +1251,12 @@ describe('AssessmentStore', () => {
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
-        createStoreTesterForAssessmentActions('changeInstanceStatus')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('changeInstanceStatus').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on changeStepStatus: user marked as pass', () => {
+    test('on changeStepStatus: user marked as pass', async () => {
         const assessmentData = new AssessmentDataBuilder()
             .with('manualTestStepResultMap', {
                 [requirementKey]: {
@@ -1303,12 +1304,14 @@ describe('AssessmentStore', () => {
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
-        createStoreTesterForAssessmentActions('changeRequirementStatus')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('changeRequirementStatus').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on changeStepStatus: user marked as fail', () => {
+    test('on changeStepStatus: user marked as fail', async () => {
         const assessmentData = new AssessmentDataBuilder()
             .with('manualTestStepResultMap', {
                 [requirementKey]: {
@@ -1350,9 +1353,11 @@ describe('AssessmentStore', () => {
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
-        createStoreTesterForAssessmentActions('changeRequirementStatus')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('changeRequirementStatus').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
     test.each`
@@ -1365,7 +1370,7 @@ describe('AssessmentStore', () => {
     `(
         'on changeAssessmentVisualizationState: supportsVisualization:$supportsVisualization, ' +
             'startsEnabled:$startsEnabled, payloadEnabled:$payloadEnabled -> finalEnabled:$expectedFinalEnabled',
-        ({ supportsVisualization, startsEnabled, payloadEnabled, expectedFinalEnabled }) => {
+        async ({ supportsVisualization, startsEnabled, payloadEnabled, expectedFinalEnabled }) => {
             const generatedAssessmentInstancesMap: DictionaryStringTo<GeneratedAssessmentInstance> =
                 {
                     selector: {
@@ -1409,13 +1414,14 @@ describe('AssessmentStore', () => {
 
             const finalState = getStateWithAssessment(expectedAssessment);
 
-            createStoreTesterForAssessmentActions('changeAssessmentVisualizationState')
-                .withActionParam(payload)
-                .testListenerToBeCalledOnce(initialState, finalState);
+            const storeTester = createStoreTesterForAssessmentActions(
+                'changeAssessmentVisualizationState',
+            ).withActionParam(payload);
+            await storeTester.testListenerToBeCalledOnce(initialState, finalState);
         },
     );
 
-    test('changeAssessmentVisualizationStateForAll enables all visualizations that support it', () => {
+    test('changeAssessmentVisualizationStateForAll enables all visualizations that support it', async () => {
         const generatedAssessmentInstancesMap: DictionaryStringTo<GeneratedAssessmentInstance> = {
             selector1: {
                 testStepResults: {
@@ -1480,12 +1486,13 @@ describe('AssessmentStore', () => {
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
-        createStoreTesterForAssessmentActions('changeAssessmentVisualizationStateForAll')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreTesterForAssessmentActions(
+            'changeAssessmentVisualizationStateForAll',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on undoInstanceStatusChange', () => {
+    test('on undoInstanceStatusChange', async () => {
         const generatedAssessmentInstancesMap: DictionaryStringTo<GeneratedAssessmentInstance> = {
             selector: {
                 testStepResults: {
@@ -1536,12 +1543,13 @@ describe('AssessmentStore', () => {
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
-        createStoreTesterForAssessmentActions('undoInstanceStatusChange')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreTesterForAssessmentActions(
+            'undoInstanceStatusChange',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on undoStepStatusChange', () => {
+    test('on undoStepStatusChange', async () => {
         const assessmentData = new AssessmentDataBuilder()
             .with('manualTestStepResultMap', {
                 [requirementKey]: {
@@ -1584,12 +1592,13 @@ describe('AssessmentStore', () => {
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
-        createStoreTesterForAssessmentActions('undoRequirementStatusChange')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreTesterForAssessmentActions(
+            'undoRequirementStatusChange',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on changeInstanceStatus: update test step status, do not go through all instances', () => {
+    test('on changeInstanceStatus: update test step status, do not go through all instances', async () => {
         const selector = 'test-selector';
         const generatedAssessmentInstancesMap = {
             [selector]: {
@@ -1640,12 +1649,12 @@ describe('AssessmentStore', () => {
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
-        createStoreTesterForAssessmentActions('changeInstanceStatus')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('changeInstanceStatus').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on addFailureInstance', () => {
+    test('on addFailureInstance', async () => {
         const assessmentData = new AssessmentDataBuilder()
             .with('manualTestStepResultMap', {
                 [requirementKey]: {
@@ -1707,12 +1716,12 @@ describe('AssessmentStore', () => {
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
-        createStoreTesterForAssessmentActions('addFailureInstance')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('addFailureInstance').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on removeFailureInstance', () => {
+    test('on removeFailureInstance', async () => {
         const failureInstance = {
             id: '1',
             description: 'description',
@@ -1756,12 +1765,12 @@ describe('AssessmentStore', () => {
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
-        createStoreTesterForAssessmentActions('removeFailureInstance')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('removeFailureInstance').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on editFailureInstance', () => {
+    test('on editFailureInstance', async () => {
         const oldDescription = 'old';
         const newDescription = 'new';
         const oldPath = 'old path';
@@ -1823,12 +1832,12 @@ describe('AssessmentStore', () => {
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
-        createStoreTesterForAssessmentActions('editFailureInstance')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('editFailureInstance').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on passUnmarkedInstance', () => {
+    test('on passUnmarkedInstance', async () => {
         const generatedAssessmentInstancesMap: DictionaryStringTo<GeneratedAssessmentInstance> = {
             selector1: {
                 testStepResults: {
@@ -1945,12 +1954,12 @@ describe('AssessmentStore', () => {
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
-        createStoreTesterForAssessmentActions('passUnmarkedInstance')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('passUnmarkedInstance').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on updateSelectedPivotChild, full payload', () => {
+    test('on updateSelectedPivotChild, full payload', async () => {
         const testType = assessmentType;
         const payload: UpdateSelectedDetailsViewPayload = {
             detailsViewType: testType,
@@ -1977,12 +1986,13 @@ describe('AssessmentStore', () => {
             .withSelectedTestType(testType)
             .build();
 
-        createStoreTesterForAssessmentActions('updateSelectedPivotChild')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreTesterForAssessmentActions(
+            'updateSelectedPivotChild',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on updateSelectedPivotChild: details view type is null', () => {
+    test('on updateSelectedPivotChild: details view type is null', async () => {
         const selectedTest = VisualizationType.Color;
         const testType = null;
         const payload: UpdateSelectedDetailsViewPayload = {
@@ -2008,13 +2018,14 @@ describe('AssessmentStore', () => {
             .withSelectedTestType(selectedTest)
             .build();
 
-        createStoreTesterForAssessmentActions('updateSelectedPivotChild')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, finalState);
+        const storeTester = createStoreTesterForAssessmentActions(
+            'updateSelectedPivotChild',
+        ).withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, finalState);
         assessmentsProviderMock.verifyAll();
     });
 
-    test('on updateSelectedPivotChild: when selected pivot is not assessment', () => {
+    test('on updateSelectedPivotChild: when selected pivot is not assessment', async () => {
         const payload: UpdateSelectedDetailsViewPayload = {
             detailsViewType: assessmentType,
             pivotType: DetailsViewPivotType.fastPass,
@@ -2038,9 +2049,10 @@ describe('AssessmentStore', () => {
             .withSelectedTestType(VisualizationType.Color)
             .build();
 
-        createStoreTesterForAssessmentActions('updateSelectedPivotChild')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, finalState);
+        const storeTester = createStoreTesterForAssessmentActions(
+            'updateSelectedPivotChild',
+        ).withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, finalState);
         assessmentsProviderMock.verifyAll();
     });
 
@@ -2049,7 +2061,7 @@ describe('AssessmentStore', () => {
         expect(ManualTestStatus.UNKNOWN < ManualTestStatus.FAIL).toBeTruthy();
     });
 
-    test('onAddResultDescription', () => {
+    test('onAddResultDescription', async () => {
         const payload: AddResultDescriptionPayload = {
             description: 'new-test-description',
         };
@@ -2066,12 +2078,12 @@ describe('AssessmentStore', () => {
             .with('resultDescription', payload.description)
             .build();
 
-        createStoreTesterForAssessmentActions('addResultDescription')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('addResultDescription').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    it.each([true, false])('onUpdateDetailsViewId', includeStartData => {
+    it.each([true, false])('onUpdateDetailsViewId', async includeStartData => {
         const payload: OnDetailsViewInitializedPayload = {
             detailsViewId: 'testId',
         } as OnDetailsViewInitializedPayload;
@@ -2101,9 +2113,9 @@ describe('AssessmentStore', () => {
         }
         const finalState = finalDataBuilder.build();
 
-        createStoreTesterForAssessmentActions('updateDetailsViewId')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForAssessmentActions('updateDetailsViewId').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
     function setupDataGeneratorMock(

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -42,7 +42,7 @@ describe('CardSelectionStore Test', () => {
         result
         ${'fail'}
         ${'unknown'}
-    `('onScanCompleted', ({ result }) => {
+    `('onScanCompleted', async ({ result }) => {
         const initialState = getDefaultState();
 
         const payload: UnifiedScanCompletedPayload = {
@@ -75,9 +75,9 @@ describe('CardSelectionStore Test', () => {
             visualHelperEnabled: true,
         };
 
-        createStoreForUnifiedScanResultActions('scanCompleted')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreForUnifiedScanResultActions('scanCompleted').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function getDefaultState(): CardSelectionStoreData {
@@ -133,29 +133,30 @@ describe('CardSelectionStore Test', () => {
         expectedState = cloneDeep(defaultState);
     });
 
-    test('ToggleRuleExpandCollapse expanded', () => {
+    test('ToggleRuleExpandCollapse expanded', async () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'sampleRuleId1',
         };
 
         expectedState.rules['sampleRuleId1'].isExpanded = true;
 
-        createStoreForCardSelectionActions('toggleRuleExpandCollapse')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreForCardSelectionActions(
+            'toggleRuleExpandCollapse',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onResetFocusedIdentifier', () => {
+    test('onResetFocusedIdentifier', async () => {
         const payload: BaseActionPayload = {};
 
         initialState.focusedResultUid = 'some uid';
 
-        createStoreForCardSelectionActions('resetFocusedIdentifier')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreForCardSelectionActions('resetFocusedIdentifier').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('ToggleRuleExpandCollapse collapsed', () => {
+    test('ToggleRuleExpandCollapse collapsed', async () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'sampleRuleId1',
         };
@@ -163,38 +164,42 @@ describe('CardSelectionStore Test', () => {
         initialState.rules['sampleRuleId1'].isExpanded = true;
         initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
 
-        createStoreForCardSelectionActions('toggleRuleExpandCollapse')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreForCardSelectionActions(
+            'toggleRuleExpandCollapse',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('ToggleRuleExpandCollapse invalid rule', () => {
+    test('ToggleRuleExpandCollapse invalid rule', async () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'invalid-rule-id',
         };
 
-        createStoreForCardSelectionActions('toggleRuleExpandCollapse')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester = createStoreForCardSelectionActions(
+            'toggleRuleExpandCollapse',
+        ).withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('ToggleRuleExpandCollapse no payload', () => {
-        createStoreForCardSelectionActions('toggleRuleExpandCollapse')
-            .withActionParam(null)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+    test('ToggleRuleExpandCollapse no payload', async () => {
+        const storeTester = createStoreForCardSelectionActions(
+            'toggleRuleExpandCollapse',
+        ).withActionParam(null);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('ToggleRuleExpandCollapse invalid payload', () => {
+    test('ToggleRuleExpandCollapse invalid payload', async () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: null,
         };
 
-        createStoreForCardSelectionActions('toggleRuleExpandCollapse')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester = createStoreForCardSelectionActions(
+            'toggleRuleExpandCollapse',
+        ).withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('toggleCardSelection selected', () => {
+    test('toggleCardSelection selected', async () => {
         const payload: CardSelectionPayload = {
             ruleId: 'sampleRuleId1',
             resultInstanceUid: 'sampleUid1',
@@ -204,12 +209,12 @@ describe('CardSelectionStore Test', () => {
         expectedState.focusedResultUid = 'sampleUid1';
         expectedState.visualHelperEnabled = true;
 
-        createStoreForCardSelectionActions('toggleCardSelection')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreForCardSelectionActions('toggleCardSelection').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('toggleCardSelection unselected', () => {
+    test('toggleCardSelection unselected', async () => {
         const payload: CardSelectionPayload = {
             ruleId: 'sampleRuleId1',
             resultInstanceUid: 'sampleUid1',
@@ -217,81 +222,75 @@ describe('CardSelectionStore Test', () => {
 
         initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
 
-        createStoreForCardSelectionActions('toggleCardSelection')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreForCardSelectionActions('toggleCardSelection').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('toggleCardSelection invalid rule', () => {
+    test('toggleCardSelection invalid rule', async () => {
         const payload: CardSelectionPayload = {
             ruleId: 'invalid-rule-id',
             resultInstanceUid: 'sampleUid1',
         };
 
-        createStoreForCardSelectionActions('toggleCardSelection')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreForCardSelectionActions('toggleCardSelection').withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('toggleCardSelection invalid card', () => {
+    test('toggleCardSelection invalid card', async () => {
         const payload: CardSelectionPayload = {
             ruleId: 'sampleRuleId1',
             resultInstanceUid: 'invalid-uid',
         };
 
-        createStoreForCardSelectionActions('toggleCardSelection')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreForCardSelectionActions('toggleCardSelection').withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('toggleCardSelection  no payload', () => {
-        createStoreForCardSelectionActions('toggleCardSelection')
-            .withActionParam(null)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+    test('toggleCardSelection  no payload', async () => {
+        const storeTester =
+            createStoreForCardSelectionActions('toggleCardSelection').withActionParam(null);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('ToggleRuleExpandCollapse invalid payload', () => {
+    test('ToggleRuleExpandCollapse invalid payload', async () => {
         const payload: CardSelectionPayload = {} as CardSelectionPayload;
 
-        createStoreForCardSelectionActions('toggleCardSelection')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreForCardSelectionActions('toggleCardSelection').withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
     describe('collapseAllRules', () => {
-        it('does nothing if rules is null', () => {
+        it('does nothing if rules is null', async () => {
             initialState.rules = null;
             expectedState = cloneDeep(initialState);
 
-            createStoreForCardSelectionActions('collapseAllRules').testListenerToNeverBeCalled(
-                initialState,
-                expectedState,
-            );
+            const storeTester = createStoreForCardSelectionActions('collapseAllRules');
+            await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
         });
 
-        it('collapses all expanded rules', () => {
+        it('collapses all expanded rules', async () => {
             expandRuleSelectCards(initialState.rules['sampleRuleId1']);
             expandRuleSelectCards(initialState.rules['sampleRuleId2']);
 
-            createStoreForCardSelectionActions('collapseAllRules').testListenerToBeCalledOnce(
-                initialState,
-                expectedState,
-            );
+            const storeTester = createStoreForCardSelectionActions('collapseAllRules');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
     });
 
     describe('expandAllRules', () => {
-        it('does nothing if rules is null', () => {
+        it('does nothing if rules is null', async () => {
             initialState.rules = null;
             expectedState = cloneDeep(initialState);
 
-            createStoreForCardSelectionActions('expandAllRules').testListenerToNeverBeCalled(
-                initialState,
-                expectedState,
-            );
+            const storeTester = createStoreForCardSelectionActions('expandAllRules');
+            await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
         });
 
-        test('expands all collapsed rules', () => {
+        test('expands all collapsed rules', async () => {
             initialState.rules['sampleRuleId1'].isExpanded = true;
             initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
 
@@ -299,37 +298,31 @@ describe('CardSelectionStore Test', () => {
             expectedState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
             expectedState.rules['sampleRuleId2'].isExpanded = true;
 
-            createStoreForCardSelectionActions('expandAllRules').testListenerToBeCalledOnce(
-                initialState,
-                expectedState,
-            );
+            const storeTester = createStoreForCardSelectionActions('expandAllRules');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
     });
 
-    test('toggleVisualHelper on - no card selection or rule expansion changes', () => {
+    test('toggleVisualHelper on - no card selection or rule expansion changes', async () => {
         initialState.rules['sampleRuleId1'].isExpanded = true;
         initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
 
         expectedState = cloneDeep(initialState);
         expectedState.visualHelperEnabled = true;
 
-        createStoreForCardSelectionActions('toggleVisualHelper').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreForCardSelectionActions('toggleVisualHelper');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('toggleVisualHelper off - cards deselected, no rule expansion changes', () => {
+    test('toggleVisualHelper off - cards deselected, no rule expansion changes', async () => {
         initialState.rules['sampleRuleId1'].isExpanded = true;
         initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
         initialState.visualHelperEnabled = true;
 
         expectedState.rules['sampleRuleId1'].isExpanded = true;
 
-        createStoreForCardSelectionActions('toggleVisualHelper').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreForCardSelectionActions('toggleVisualHelper');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     describe('navigateToNewCardsView', () => {
@@ -339,7 +332,7 @@ describe('CardSelectionStore Test', () => {
 
         it.each([null, {}])(
             'should reset the focused element and turn of visual helper when rules = %s',
-            rules => {
+            async rules => {
                 initialState.focusedResultUid = 'sampleUid1';
                 initialState.rules = rules;
                 initialState.visualHelperEnabled = true;
@@ -347,13 +340,12 @@ describe('CardSelectionStore Test', () => {
                 expectedState.rules = rules;
                 expectedState.visualHelperEnabled = false;
 
-                createStoreForCardSelectionActions(
-                    'navigateToNewCardsView',
-                ).testListenerToBeCalledOnce(initialState, expectedState);
+                const storeTester = createStoreForCardSelectionActions('navigateToNewCardsView');
+                await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
             },
         );
 
-        it('should keep all rules/cards/results but set them to collapsed/unselected', () => {
+        it('should keep all rules/cards/results but set them to collapsed/unselected', async () => {
             initialState.rules = {
                 sampleRuleId1: {
                     isExpanded: true,
@@ -387,44 +379,36 @@ describe('CardSelectionStore Test', () => {
                 },
             };
 
-            createStoreForCardSelectionActions('navigateToNewCardsView').testListenerToBeCalledOnce(
-                initialState,
-                expectedState,
-            );
+            const storeTester = createStoreForCardSelectionActions('navigateToNewCardsView');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
 
-        it('should set the visualHelperToggle to enabled if there are any rules', () => {
+        it('should set the visualHelperToggle to enabled if there are any rules', async () => {
             initialState.visualHelperEnabled = false;
             expectedState.visualHelperEnabled = true;
 
-            createStoreForCardSelectionActions('navigateToNewCardsView').testListenerToBeCalledOnce(
-                initialState,
-                expectedState,
-            );
+            const storeTester = createStoreForCardSelectionActions('navigateToNewCardsView');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
 
-        it('should set the visualHelperToggle to disabled if there are no rules', () => {
+        it('should set the visualHelperToggle to disabled if there are no rules', async () => {
             initialState.rules = {};
             initialState.visualHelperEnabled = true;
             expectedState.rules = {};
             expectedState.visualHelperEnabled = false;
 
-            createStoreForCardSelectionActions('navigateToNewCardsView').testListenerToBeCalledOnce(
-                initialState,
-                expectedState,
-            );
+            const storeTester = createStoreForCardSelectionActions('navigateToNewCardsView');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
     });
 
-    test('reset data on tab URL change', () => {
+    test('reset data on tab URL change', async () => {
         initialState.rules = {};
         initialState.visualHelperEnabled = true;
         expectedState.rules = null;
         expectedState.visualHelperEnabled = false;
-        createStoreForTabActions('existingTabUpdated').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreForTabActions('existingTabUpdated');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function expandRuleSelectCards(rule: RuleExpandCollapseData): void {

--- a/src/tests/unit/tests/background/stores/details-view-store.test.ts
+++ b/src/tests/unit/tests/background/stores/details-view-store.test.ts
@@ -15,7 +15,7 @@ describe('DetailsViewStoreTest', () => {
         expect(testObject.getId()).toBe(StoreNames[StoreNames.DetailsViewStore]);
     });
 
-    test('onSetSelectedDetailsViewRightContentPanel', () => {
+    test('onSetSelectedDetailsViewRightContentPanel', async () => {
         const initialState = new DetailsViewStoreDataBuilder()
             .withDetailsViewRightContentPanel('Overview')
             .build();
@@ -24,12 +24,13 @@ describe('DetailsViewStoreTest', () => {
             .withDetailsViewRightContentPanel('TestView')
             .build();
 
-        createStoreTesterForDetailsViewActions('setSelectedDetailsViewRightContentPanel')
-            .withActionParam('TestView')
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForDetailsViewActions(
+            'setSelectedDetailsViewRightContentPanel',
+        ).withActionParam('TestView');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onOpenPreviewFeatures', () => {
+    test('onOpenPreviewFeatures', async () => {
         const initialState = new DetailsViewStoreDataBuilder()
             .withPreviewFeaturesOpen(false)
             .build();
@@ -38,12 +39,14 @@ describe('DetailsViewStoreTest', () => {
             .withPreviewFeaturesOpen(true)
             .build();
 
-        createStoreTesterForSidePanelActions('openSidePanel')
-            .withActionParam('PreviewFeatures')
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForSidePanelActions('openSidePanel').withActionParam(
+                'PreviewFeatures',
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onClosePreviewFeatures', () => {
+    test('onClosePreviewFeatures', async () => {
         const initialState = new DetailsViewStoreDataBuilder()
             .withPreviewFeaturesOpen(true)
             .build();
@@ -52,76 +55,78 @@ describe('DetailsViewStoreTest', () => {
             .withPreviewFeaturesOpen(false)
             .build();
 
-        createStoreTesterForSidePanelActions('closeSidePanel')
-            .withActionParam('PreviewFeatures')
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForSidePanelActions('closeSidePanel').withActionParam(
+                'PreviewFeatures',
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onOpenScoping', () => {
+    test('onOpenScoping', async () => {
         const initialState = new DetailsViewStoreDataBuilder().withScopingOpen(false).build();
 
         const expectedState = new DetailsViewStoreDataBuilder().withScopingOpen(true).build();
 
-        createStoreTesterForSidePanelActions('openSidePanel')
-            .withActionParam('Scoping')
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForSidePanelActions('openSidePanel').withActionParam('Scoping');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onCloseScoping', () => {
+    test('onCloseScoping', async () => {
         const initialState = new DetailsViewStoreDataBuilder().withScopingOpen(true).build();
 
         const expectedState = new DetailsViewStoreDataBuilder().withScopingOpen(false).build();
 
-        createStoreTesterForSidePanelActions('closeSidePanel')
-            .withActionParam('Scoping')
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForSidePanelActions('closeSidePanel').withActionParam('Scoping');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onCloseSettings', () => {
+    test('onCloseSettings', async () => {
         const initialState = new DetailsViewStoreDataBuilder().withSettingPanelState(true).build();
 
         const expectedState = new DetailsViewStoreDataBuilder()
             .withSettingPanelState(false)
             .build();
 
-        createStoreTesterForSidePanelActions('closeSidePanel')
-            .withActionParam('Settings')
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForSidePanelActions('closeSidePanel').withActionParam('Settings');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onOpenContent', () => {
+    test('onOpenContent', async () => {
         const initialState = new DetailsViewStoreDataBuilder().withContentOpen(false).build();
 
         const expectedState = new DetailsViewStoreDataBuilder()
             .withContentOpen(true, 'content/path', 'content title')
             .build();
 
-        createStoreTesterForContentActions('openContentPanel')
-            .withActionParam({ contentPath: 'content/path', contentTitle: 'content title' })
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForContentActions('openContentPanel').withActionParam({
+            contentPath: 'content/path',
+            contentTitle: 'content title',
+        });
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onCloseContent', () => {
+    test('onCloseContent', async () => {
         const initialState = new DetailsViewStoreDataBuilder()
             .withContentOpen(true, 'content/path', 'content title')
             .build();
 
         const expectedState = new DetailsViewStoreDataBuilder().withContentOpen(false).build();
 
-        createStoreTesterForContentActions('closeContentPanel').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForContentActions('closeContentPanel');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onOpenSidePanel', () => {
+    test('onOpenSidePanel', async () => {
         const initialState = new DetailsViewStoreDataBuilder().withSettingPanelState(false).build();
 
         const expectedState = new DetailsViewStoreDataBuilder().withSettingPanelState(true).build();
 
-        createStoreTesterForSidePanelActions('openSidePanel')
-            .withActionParam('Settings')
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForSidePanelActions('openSidePanel').withActionParam('Settings');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function createStoreTesterForContentActions(

--- a/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
+++ b/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
@@ -17,17 +17,15 @@ describe('DevToolsStoreTest', () => {
         expect(testObject.getId()).toBe(StoreNames[StoreNames.DevToolsStore]);
     });
 
-    test('on getCurrentState', () => {
+    test('on getCurrentState', async () => {
         const initialState = getDefaultState();
         const expectedState = getDefaultState();
 
-        createStoreTesterForDevToolsActions('getCurrentState').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForDevToolsActions('getCurrentState');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('on setDevToolState, isOpen value change', () => {
+    test('on setDevToolState, isOpen value change', async () => {
         const initialState = getDefaultState();
 
         const payload = true;
@@ -36,23 +34,23 @@ describe('DevToolsStoreTest', () => {
         expectedState.frameUrl = null;
         expectedState.inspectElement = null;
 
-        createStoreTesterForDevToolsActions('setDevToolState')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForDevToolsActions('setDevToolState').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('on setDevToolState, isOpen value is the same', () => {
+    test('on setDevToolState, isOpen value is the same', async () => {
         const initialState = getDefaultState();
         const expectedState = getDefaultState();
 
         const payload = false;
 
-        createStoreTesterForDevToolsActions('setDevToolState')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForDevToolsActions('setDevToolState').withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('on setInspectElement', () => {
+    test('on setInspectElement', async () => {
         const initialState = getDefaultState();
 
         const payload = ['#frame1', '#elem1'];
@@ -62,12 +60,12 @@ describe('DevToolsStoreTest', () => {
         expectedState.frameUrl = null;
         expectedState.inspectElementRequestId = 1;
 
-        createStoreTesterForDevToolsActions('setInspectElement')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForDevToolsActions('setInspectElement').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('on setFrameUrl', () => {
+    test('on setFrameUrl', async () => {
         const initialState = getDefaultState();
 
         const payload = 'https://test-url';
@@ -75,9 +73,9 @@ describe('DevToolsStoreTest', () => {
         const expectedState = getDefaultState();
         expectedState.frameUrl = payload;
 
-        createStoreTesterForDevToolsActions('setFrameUrl')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForDevToolsActions('setFrameUrl').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function getDefaultState(): DevToolStoreData {

--- a/src/tests/unit/tests/background/stores/global/command-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/command-store.test.ts
@@ -30,7 +30,7 @@ describe('CommandStoreTest', () => {
         expect(testObject.getId()).toEqual(StoreNames[StoreNames.CommandStore]);
     });
 
-    test('on getCommands: no command modification', () => {
+    test('on getCommands: no command modification', async () => {
         const prototype = new CommandStore(null, null, null, null, null, null);
         const initialState: CommandStoreData = prototype.getDefaultState();
         const expectedState: CommandStoreData = prototype.getDefaultState();
@@ -40,12 +40,12 @@ describe('CommandStoreTest', () => {
             tabId: 1,
         };
 
-        createStoreTesterForCommandActions('getCommands')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForCommandActions('getCommands').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onGetCommands: modifying commands', () => {
+    test('onGetCommands: modifying commands', async () => {
         const initialCommand: chrome.commands.Command = {
             description: 'Toggle Headings',
             name: 'toggle-headings',
@@ -82,14 +82,14 @@ describe('CommandStoreTest', () => {
             .setup(tp => tp.publishTelemetry(SHORTCUT_MODIFIED, It.isValue(telemetryPayload)))
             .verifiable(Times.once());
 
-        createStoreTesterForCommandActions('getCommands')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForCommandActions('getCommands').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
 
         telemetryEventHandlerMock.verifyAll();
     });
 
-    test("handling weird case: amount of commands change on runtime (this should not happen but we're handling it anyway)", () => {
+    test("handling weird case: amount of commands change on runtime (this should not happen but we're handling it anyway)", async () => {
         const initialState: CommandStoreData = new CommandStore(
             null,
             null,
@@ -121,9 +121,9 @@ describe('CommandStoreTest', () => {
             tabId: tabId,
         };
 
-        createStoreTesterForCommandActions('getCommands')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForCommandActions('getCommands').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function createStoreTesterForCommandActions(

--- a/src/tests/unit/tests/background/stores/global/feature-flag-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/feature-flag-store.test.ts
@@ -89,17 +89,15 @@ describe('FeatureFlagStoreTest', () => {
         expect(testObject.getState()).toEqual(expectedState);
     });
 
-    test('on getCurrentState', () => {
+    test('on getCurrentState', async () => {
         const initialState = createFakeDefaultFeatureFlagValues();
         const finalState = createFakeDefaultFeatureFlagValues();
 
-        createStoreTesterForFeatureFlagActions('getCurrentState').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreTesterForFeatureFlagActions('getCurrentState');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on setFeatureFlag', () => {
+    test('on setFeatureFlag', async () => {
         const initialState = createFakeDefaultFeatureFlagValues();
         const userDataStub: LocalStorageData = {
             featureFlags: createFakeDefaultFeatureFlagValues(),
@@ -120,22 +118,22 @@ describe('FeatureFlagStoreTest', () => {
             )
             .returns(() => Promise.resolve());
 
-        createStoreTesterForFeatureFlagActions('setFeatureFlag', userDataStub)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreTesterForFeatureFlagActions(
+            'setFeatureFlag',
+            userDataStub,
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onResetFeatureFlags', () => {
+    test('onResetFeatureFlags', async () => {
         const initialState = createFakeDefaultFeatureFlagValues();
         const featureFlagName = 'feature-flag-name';
         initialState[featureFlagName] = true;
 
         const finalState = createFakeDefaultFeatureFlagValues();
 
-        createStoreTesterForFeatureFlagActions('resetFeatureFlags').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreTesterForFeatureFlagActions('resetFeatureFlags');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
     function createDefaultTestObject(userDataStub: LocalStorageData): FeatureFlagStore {

--- a/src/tests/unit/tests/background/stores/global/launch-panel-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/launch-panel-state-store.test.ts
@@ -32,15 +32,13 @@ describe('LaunchPanelStateStoreTest', () => {
         expect(testObject.getId()).toEqual(StoreNames[StoreNames.LaunchPanelStateStore]);
     });
 
-    test('on getCurrentState', () => {
+    test('on getCurrentState', async () => {
         const initialState = getDefaultState();
 
         const expectedState = getDefaultState();
 
-        createStoreForLaunchPanelStateActions('getCurrentState').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreForLaunchPanelStateActions('getCurrentState');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     test('initialize, user data is not null', () => {
@@ -53,7 +51,7 @@ describe('LaunchPanelStateStoreTest', () => {
         expect(testObject.getState()).toEqual(expectedState);
     });
 
-    test('onSetLaunchPanelState: preserving state', () => {
+    test('onSetLaunchPanelState: preserving state', async () => {
         const initialState = getDefaultState();
 
         const payload = LaunchPanelType.AdhocToolsPanel;
@@ -69,9 +67,9 @@ describe('LaunchPanelStateStoreTest', () => {
             .setup(adapter => adapter.setUserData(It.isValue(expectedSetUserData)))
             .returns(() => Promise.resolve());
 
-        createStoreForLaunchPanelStateActions('setLaunchPanelType')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreForLaunchPanelStateActions('setLaunchPanelType').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
 
         storageAdapterMock.verifyAll();
     });

--- a/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
@@ -33,18 +33,16 @@ describe('PermissionsStateStoreTest', () => {
         expect(testSubject.getDefaultState()).toMatchSnapshot();
     });
 
-    test('on getCurrentState', () => {
+    test('on getCurrentState', async () => {
         const initialState = createPermissionsState();
         const finalState = createPermissionsState();
 
-        createStoreTesterForPermissionsStateActions('getCurrentState').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreTesterForPermissionsStateActions('getCurrentState');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
     describe('on setPermissionsState', () => {
-        test('updates state when it has changed', () => {
+        test('updates state when it has changed', async () => {
             const initialPermissionsValue = false;
             const finalPermissionsValue = true;
             const initialState = { hasAllUrlAndFilePermissions: initialPermissionsValue };
@@ -53,23 +51,27 @@ describe('PermissionsStateStoreTest', () => {
                 hasAllUrlAndFilePermissions: finalPermissionsValue,
             };
 
-            createStoreTesterForPermissionsStateActions('setPermissionsState')
-                .withActionParam(payload)
-                .testListenerToBeCalledOnce(initialState, finalState);
+            const storeTester =
+                createStoreTesterForPermissionsStateActions('setPermissionsState').withActionParam(
+                    payload,
+                );
+            await storeTester.testListenerToBeCalledOnce(initialState, finalState);
         });
 
         test.each([true, false])(
             'does not update state when there is no change',
-            hasPermissionsValue => {
+            async hasPermissionsValue => {
                 const initialState = { hasAllUrlAndFilePermissions: hasPermissionsValue };
                 const finalState = { hasAllUrlAndFilePermissions: hasPermissionsValue };
                 const payload: SetAllUrlsPermissionStatePayload = {
                     hasAllUrlAndFilePermissions: hasPermissionsValue,
                 };
 
-                createStoreTesterForPermissionsStateActions('setPermissionsState')
-                    .withActionParam(payload)
-                    .testListenerToNeverBeCalled(initialState, finalState);
+                const storeTester =
+                    createStoreTesterForPermissionsStateActions(
+                        'setPermissionsState',
+                    ).withActionParam(payload);
+                await storeTester.testListenerToNeverBeCalled(initialState, finalState);
             },
         );
     });

--- a/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
@@ -35,7 +35,6 @@ describe('ScopingStoreTest', () => {
         const finalState = getDefaultState();
 
         const storeTester = createStoreForScopingActions('getCurrentState');
-        await storeTester;
         await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 

--- a/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
@@ -30,17 +30,16 @@ describe('ScopingStoreTest', () => {
         });
     });
 
-    test('on getCurrentState', () => {
+    test('on getCurrentState', async () => {
         const initialState = getDefaultState();
         const finalState = getDefaultState();
 
-        createStoreForScopingActions('getCurrentState').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreForScopingActions('getCurrentState');
+        await storeTester;
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on addSelector', () => {
+    test('on addSelector', async () => {
         const initialState = getDefaultState();
         const payload: ScopingPayload = {
             inputType: 'include',
@@ -49,12 +48,11 @@ describe('ScopingStoreTest', () => {
         const finalState = getDefaultState();
         finalState.selectors[ScopingInputTypes.include] = [payload.selector];
 
-        createStoreForScopingActions('addSelector')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreForScopingActions('addSelector').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on addSelector prevent duplicate selector', () => {
+    test('on addSelector prevent duplicate selector', async () => {
         const payload: ScopingPayload = {
             inputType: 'include',
             selector: ['iframe', 'selector'],
@@ -64,12 +62,11 @@ describe('ScopingStoreTest', () => {
         const finalState = getDefaultState();
         finalState.selectors[ScopingInputTypes.include] = [payload.selector];
 
-        createStoreForScopingActions('addSelector')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, finalState);
+        const storeTester = createStoreForScopingActions('addSelector').withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, finalState);
     });
 
-    test('on deleteSelector with an actual selector', () => {
+    test('on deleteSelector with an actual selector', async () => {
         const initialState = getDefaultState();
         const payload: ScopingPayload = {
             inputType: ScopingInputTypes.include,
@@ -78,12 +75,11 @@ describe('ScopingStoreTest', () => {
         initialState.selectors[ScopingInputTypes.include] = [payload.selector];
         const finalState = getDefaultState();
 
-        createStoreForScopingActions('deleteSelector')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreForScopingActions('deleteSelector').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on deleteSelector prevent deletion of non-existent selector', () => {
+    test('on deleteSelector prevent deletion of non-existent selector', async () => {
         const initialState = getDefaultState();
         const actualSelector = ['iframe', 'selector'];
         const payload: ScopingPayload = {
@@ -94,9 +90,8 @@ describe('ScopingStoreTest', () => {
         const finalState = getDefaultState();
         finalState.selectors[ScopingInputTypes.include] = [actualSelector];
 
-        createStoreForScopingActions('deleteSelector')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, finalState);
+        const storeTester = createStoreForScopingActions('deleteSelector').withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, finalState);
     });
 
     function getDefaultState(): ScopingStoreData {

--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -183,10 +183,10 @@ describe('UserConfigurationStoreTest', () => {
         expect(testSubject.getId()).toBe(StoreNames[StoreNames.UserConfigurationStore]);
     });
 
-    test('getCurrentState action', () => {
+    test('getCurrentState action', async () => {
         const storeTester = createStoreToTestAction('getCurrentState');
 
-        storeTester.testListenerToBeCalledOnce(initialStoreData, cloneDeep(initialStoreData));
+        await storeTester.testListenerToBeCalledOnce(initialStoreData, cloneDeep(initialStoreData));
     });
 
     describe('setTelemetryConfig action', () => {
@@ -198,7 +198,7 @@ describe('UserConfigurationStoreTest', () => {
             ${false}    | ${false}
         `(
             'sets enableTelemetry per payload and isFirstTime to false for initial state isFirstTime=$isFirstTime enableTelemetry=$enableTelemetry',
-            ({ isFirstTime, enableTelemetry }) => {
+            async ({ isFirstTime, enableTelemetry }) => {
                 const storeTester = createStoreToTestAction('setTelemetryState');
                 initialStoreData = {
                     enableTelemetry: enableTelemetry,
@@ -233,7 +233,7 @@ describe('UserConfigurationStoreTest', () => {
                     .returns(() => Promise.resolve(true))
                     .verifiable(Times.once());
 
-                storeTester
+                await storeTester
                     .withActionParam(enableTelemetry)
                     .withPostListenerMock(indexDbStrictMock)
                     .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
@@ -252,7 +252,7 @@ describe('UserConfigurationStoreTest', () => {
             ${false} | ${false}       | ${false}
         `(
             'sets both enableHighContrast and lastSelectedHighContrast per payload $payload from initialState $initialState',
-            ({ payload, initialEnabled, initialLastSelected }) => {
+            async ({ payload, initialEnabled, initialLastSelected }) => {
                 const storeTester = createStoreToTestAction('setHighContrastMode');
                 initialStoreData = {
                     enableTelemetry: false,
@@ -291,7 +291,7 @@ describe('UserConfigurationStoreTest', () => {
                     .returns(() => Promise.resolve(true))
                     .verifiable(Times.once());
 
-                storeTester
+                await storeTester
                     .withActionParam(setHighContrastData)
                     .withPostListenerMock(indexDbStrictMock)
                     .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
@@ -310,7 +310,7 @@ describe('UserConfigurationStoreTest', () => {
             ${false} | ${false}       | ${false}            | ${false}
         `(
             'sets enableHighContrast by merging initialLastSelected=$initialLastSelected, initialEanbled=$initialEnabled, payload=$payload into $expectedEnabled',
-            ({ payload, initialEnabled, initialLastSelected, expectedEnabled }) => {
+            async ({ payload, initialEnabled, initialLastSelected, expectedEnabled }) => {
                 const storeTester = createStoreToTestAction('setNativeHighContrastMode');
                 initialStoreData = {
                     enableTelemetry: false,
@@ -349,7 +349,7 @@ describe('UserConfigurationStoreTest', () => {
                     .returns(() => Promise.resolve(true))
                     .verifiable(Times.once());
 
-                storeTester
+                await storeTester
                     .withActionParam(setNativeHighContrastData)
                     .withPostListenerMock(indexDbStrictMock)
                     .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
@@ -359,7 +359,7 @@ describe('UserConfigurationStoreTest', () => {
 
     test.each(['none', 'userConfigurationStoreTestIssueFilingService'])(
         'setIssueFilingService action: %s',
-        (testIssueFilingService: string) => {
+        async (testIssueFilingService: string) => {
             const storeTester = createStoreToTestAction('setIssueFilingService');
             initialStoreData = {
                 isFirstTime: false,
@@ -390,7 +390,7 @@ describe('UserConfigurationStoreTest', () => {
                 .returns(() => Promise.resolve(true))
                 .verifiable(Times.once());
 
-            storeTester
+            await storeTester
                 .withActionParam(setIssueFilingServiceData)
                 .withPostListenerMock(indexDbStrictMock)
                 .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
@@ -405,7 +405,7 @@ describe('UserConfigurationStoreTest', () => {
         { 'test-service': { 'test-name': 'test-value' } },
     ])(
         'setIssueFilingServiceProperty with initial map state %p',
-        (initialMapState: IssueFilingServicePropertiesMap) => {
+        async (initialMapState: IssueFilingServicePropertiesMap) => {
             const storeTester = createStoreToTestAction('setIssueFilingServiceProperty');
             initialStoreData = {
                 isFirstTime: false,
@@ -438,14 +438,14 @@ describe('UserConfigurationStoreTest', () => {
                 .returns(() => Promise.resolve(true))
                 .verifiable(Times.once());
 
-            storeTester
+            await storeTester
                 .withActionParam(setIssueFilingServicePropertyData)
                 .withPostListenerMock(indexDbStrictMock)
                 .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
         },
     );
 
-    test('saveIssueFilingSettings', () => {
+    test('saveIssueFilingSettings', async () => {
         const storeTester = createStoreToTestAction('saveIssueFilingSettings');
         const serviceName = 'test service';
         const bugServiceProperties: IssueFilingServiceProperties = {
@@ -468,13 +468,13 @@ describe('UserConfigurationStoreTest', () => {
             .returns(() => Promise.resolve(true))
             .verifiable(Times.once());
 
-        storeTester
+        await storeTester
             .withActionParam(payload)
             .withPostListenerMock(indexDbStrictMock)
             .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
     });
 
-    test('setAdbLocation', () => {
+    test('setAdbLocation', async () => {
         const storeTester = createStoreToTestAction('setAdbLocation');
         const adbLocation = 'adb-here';
         const expectedState: UserConfigurationStoreData = {
@@ -489,13 +489,13 @@ describe('UserConfigurationStoreTest', () => {
             .returns(() => Promise.resolve(true))
             .verifiable(Times.once());
 
-        storeTester
+        await storeTester
             .withActionParam(adbLocation)
             .withPostListenerMock(indexDbStrictMock)
             .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
     });
 
-    test('setAutoDetectedFailuresDialogState', () => {
+    test('setAutoDetectedFailuresDialogState', async () => {
         const storeTester = createStoreToTestAction('setAutoDetectedFailuresDialogState');
         const showAutoDetectedFailuresDialog = false;
         const payload: AutoDetectedFailuresDialogStatePayload = {
@@ -513,7 +513,7 @@ describe('UserConfigurationStoreTest', () => {
             .returns(() => Promise.resolve(true))
             .verifiable(Times.once());
 
-        storeTester
+        await storeTester
             .withActionParam(payload)
             .withPostListenerMock(indexDbStrictMock)
             .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
@@ -521,7 +521,7 @@ describe('UserConfigurationStoreTest', () => {
 
     test.each(['normal', 'maximized', 'full-screen'])(
         'saveLastWindowBounds windowState:$windowState',
-        windowState => {
+        async windowState => {
             const expectBoundsSet: boolean = windowState === 'normal';
             const payload: SaveWindowBoundsPayload = {
                 windowState: windowState as WindowState,
@@ -555,7 +555,7 @@ describe('UserConfigurationStoreTest', () => {
                 .returns(() => Promise.resolve(true))
                 .verifiable(Times.once());
 
-            storeTester
+            await storeTester
                 .withActionParam(payload)
                 .withPostListenerMock(indexDbStrictMock)
                 .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);

--- a/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
@@ -40,7 +40,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
         result
         ${'fail'}
         ${'unknown'}
-    `('onScanCompleted', ({ result }) => {
+    `('onScanCompleted', async ({ result }) => {
         const initialState = getDefaultState();
 
         const payload: UnifiedScanCompletedPayload = {
@@ -73,9 +73,9 @@ describe('NeedsReviewCardSelectionStore Test', () => {
             visualHelperEnabled: true,
         };
 
-        createStoreForNeedsReviewScanResultActions('scanCompleted')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreForNeedsReviewScanResultActions('scanCompleted').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function getDefaultState(): NeedsReviewCardSelectionStoreData {
@@ -131,29 +131,32 @@ describe('NeedsReviewCardSelectionStore Test', () => {
         expectedState = cloneDeep(defaultState);
     });
 
-    test('ToggleRuleExpandCollapse expanded', () => {
+    test('ToggleRuleExpandCollapse expanded', async () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'sampleRuleId1',
         };
 
         expectedState.rules['sampleRuleId1'].isExpanded = true;
 
-        createStoreForNeedsReviewCardSelectionActions('toggleRuleExpandCollapse')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreForNeedsReviewCardSelectionActions(
+            'toggleRuleExpandCollapse',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onResetFocusedIdentifier', () => {
+    test('onResetFocusedIdentifier', async () => {
         const payload: BaseActionPayload = {};
 
         initialState.focusedResultUid = 'some uid';
 
-        createStoreForNeedsReviewCardSelectionActions('resetFocusedIdentifier')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreForNeedsReviewCardSelectionActions('resetFocusedIdentifier').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('ToggleRuleExpandCollapse collapsed', () => {
+    test('ToggleRuleExpandCollapse collapsed', async () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'sampleRuleId1',
         };
@@ -161,38 +164,42 @@ describe('NeedsReviewCardSelectionStore Test', () => {
         initialState.rules['sampleRuleId1'].isExpanded = true;
         initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
 
-        createStoreForNeedsReviewCardSelectionActions('toggleRuleExpandCollapse')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreForNeedsReviewCardSelectionActions(
+            'toggleRuleExpandCollapse',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('ToggleRuleExpandCollapse invalid rule', () => {
+    test('ToggleRuleExpandCollapse invalid rule', async () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'invalid-rule-id',
         };
 
-        createStoreForNeedsReviewCardSelectionActions('toggleRuleExpandCollapse')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester = createStoreForNeedsReviewCardSelectionActions(
+            'toggleRuleExpandCollapse',
+        ).withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('ToggleRuleExpandCollapse no payload', () => {
-        createStoreForNeedsReviewCardSelectionActions('toggleRuleExpandCollapse')
-            .withActionParam(null)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+    test('ToggleRuleExpandCollapse no payload', async () => {
+        const storeTester = createStoreForNeedsReviewCardSelectionActions(
+            'toggleRuleExpandCollapse',
+        ).withActionParam(null);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('ToggleRuleExpandCollapse invalid payload', () => {
+    test('ToggleRuleExpandCollapse invalid payload', async () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: null,
         };
 
-        createStoreForNeedsReviewCardSelectionActions('toggleRuleExpandCollapse')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester = createStoreForNeedsReviewCardSelectionActions(
+            'toggleRuleExpandCollapse',
+        ).withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('toggleCardSelection selected', () => {
+    test('toggleCardSelection selected', async () => {
         const payload: CardSelectionPayload = {
             ruleId: 'sampleRuleId1',
             resultInstanceUid: 'sampleUid1',
@@ -202,12 +209,14 @@ describe('NeedsReviewCardSelectionStore Test', () => {
         expectedState.focusedResultUid = 'sampleUid1';
         expectedState.visualHelperEnabled = true;
 
-        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreForNeedsReviewCardSelectionActions('toggleCardSelection').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('toggleCardSelection unselected', () => {
+    test('toggleCardSelection unselected', async () => {
         const payload: CardSelectionPayload = {
             ruleId: 'sampleRuleId1',
             resultInstanceUid: 'sampleUid1',
@@ -215,78 +224,85 @@ describe('NeedsReviewCardSelectionStore Test', () => {
 
         initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
 
-        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreForNeedsReviewCardSelectionActions('toggleCardSelection').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('toggleCardSelection invalid rule', () => {
+    test('toggleCardSelection invalid rule', async () => {
         const payload: CardSelectionPayload = {
             ruleId: 'invalid-rule-id',
             resultInstanceUid: 'sampleUid1',
         };
 
-        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreForNeedsReviewCardSelectionActions('toggleCardSelection').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('toggleCardSelection invalid card', () => {
+    test('toggleCardSelection invalid card', async () => {
         const payload: CardSelectionPayload = {
             ruleId: 'sampleRuleId1',
             resultInstanceUid: 'invalid-uid',
         };
 
-        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreForNeedsReviewCardSelectionActions('toggleCardSelection').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('toggleCardSelection  no payload', () => {
-        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
-            .withActionParam(null)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+    test('toggleCardSelection  no payload', async () => {
+        const storeTester =
+            createStoreForNeedsReviewCardSelectionActions('toggleCardSelection').withActionParam(
+                null,
+            );
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('ToggleRuleExpandCollapse invalid payload', () => {
+    test('ToggleRuleExpandCollapse invalid payload', async () => {
         const payload: CardSelectionPayload = {} as CardSelectionPayload;
 
-        createStoreForNeedsReviewCardSelectionActions('toggleCardSelection')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreForNeedsReviewCardSelectionActions('toggleCardSelection').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
     describe('collapseAllRules', () => {
-        test('Does nothing if rules is null', () => {
+        test('Does nothing if rules is null', async () => {
             initialState.rules = null;
             expectedState = cloneDeep(initialState);
 
-            createStoreForNeedsReviewCardSelectionActions(
-                'collapseAllRules',
-            ).testListenerToNeverBeCalled(initialState, expectedState);
+            const storeTester = createStoreForNeedsReviewCardSelectionActions('collapseAllRules');
+            await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
         });
 
-        test('collapses all expanded rules', () => {
+        test('collapses all expanded rules', async () => {
             expandRuleSelectCards(initialState.rules['sampleRuleId1']);
             expandRuleSelectCards(initialState.rules['sampleRuleId2']);
 
-            createStoreForNeedsReviewCardSelectionActions(
-                'collapseAllRules',
-            ).testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester = createStoreForNeedsReviewCardSelectionActions('collapseAllRules');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
     });
 
     describe('expandAllRules', () => {
-        test('Does nothing if rules is null', () => {
+        test('Does nothing if rules is null', async () => {
             initialState.rules = null;
             expectedState = cloneDeep(initialState);
 
-            createStoreForNeedsReviewCardSelectionActions(
-                'expandAllRules',
-            ).testListenerToNeverBeCalled(initialState, expectedState);
+            const storeTester = createStoreForNeedsReviewCardSelectionActions('expandAllRules');
+            await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
         });
 
-        test('expands all collapsed rules', () => {
+        test('expands all collapsed rules', async () => {
             initialState.rules['sampleRuleId1'].isExpanded = true;
             initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
 
@@ -294,47 +310,43 @@ describe('NeedsReviewCardSelectionStore Test', () => {
             expectedState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
             expectedState.rules['sampleRuleId2'].isExpanded = true;
 
-            createStoreForNeedsReviewCardSelectionActions(
-                'expandAllRules',
-            ).testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester = createStoreForNeedsReviewCardSelectionActions('expandAllRules');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
     });
 
     describe('toggleVisualHelper', () => {
-        test('toggle on - no card selection or rule expansion changes', () => {
+        test('toggle on - no card selection or rule expansion changes', async () => {
             initialState.rules['sampleRuleId1'].isExpanded = true;
             initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
 
             expectedState = cloneDeep(initialState);
             expectedState.visualHelperEnabled = true;
 
-            createStoreForNeedsReviewCardSelectionActions(
-                'toggleVisualHelper',
-            ).testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester = createStoreForNeedsReviewCardSelectionActions('toggleVisualHelper');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
 
-        test('toggle off - cards deselected, no rule expansion changes', () => {
+        test('toggle off - cards deselected, no rule expansion changes', async () => {
             initialState.rules['sampleRuleId1'].isExpanded = true;
             initialState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
             initialState.visualHelperEnabled = true;
 
             expectedState.rules['sampleRuleId1'].isExpanded = true;
 
-            createStoreForNeedsReviewCardSelectionActions(
-                'toggleVisualHelper',
-            ).testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester = createStoreForNeedsReviewCardSelectionActions('toggleVisualHelper');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
 
-        test('toggle off when rules is null', () => {
+        test('toggle off when rules is null', async () => {
             initialState.rules = null;
             initialState.visualHelperEnabled = true;
 
             expectedState = cloneDeep(initialState);
             expectedState.visualHelperEnabled = false;
 
-            createStoreForNeedsReviewCardSelectionActions(
-                'toggleVisualHelper',
-            ).testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester = createStoreForNeedsReviewCardSelectionActions('toggleVisualHelper');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
     });
 
@@ -345,7 +357,7 @@ describe('NeedsReviewCardSelectionStore Test', () => {
 
         it.each([null, {}])(
             'should reset the focused element and turn off visual helper when rules = %s',
-            rules => {
+            async rules => {
                 initialState.focusedResultUid = 'sampleUid1';
                 initialState.rules = rules;
                 initialState.visualHelperEnabled = true;
@@ -353,13 +365,13 @@ describe('NeedsReviewCardSelectionStore Test', () => {
                 expectedState.rules = rules;
                 expectedState.visualHelperEnabled = false;
 
-                createStoreForNeedsReviewCardSelectionActions(
-                    'navigateToNewCardsView',
-                ).testListenerToBeCalledOnce(initialState, expectedState);
+                const storeTester =
+                    createStoreForNeedsReviewCardSelectionActions('navigateToNewCardsView');
+                await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
             },
         );
 
-        it('should keep all rules/cards/results but set them to collapsed/unselected', () => {
+        it('should keep all rules/cards/results but set them to collapsed/unselected', async () => {
             initialState.rules = {
                 sampleRuleId1: {
                     isExpanded: true,
@@ -393,41 +405,39 @@ describe('NeedsReviewCardSelectionStore Test', () => {
                 },
             };
 
-            createStoreForNeedsReviewCardSelectionActions(
-                'navigateToNewCardsView',
-            ).testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester =
+                createStoreForNeedsReviewCardSelectionActions('navigateToNewCardsView');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
 
-        it('should set the visualHelperToggle to enabled if there are any rules', () => {
+        it('should set the visualHelperToggle to enabled if there are any rules', async () => {
             initialState.visualHelperEnabled = false;
             expectedState.visualHelperEnabled = true;
 
-            createStoreForNeedsReviewCardSelectionActions(
-                'navigateToNewCardsView',
-            ).testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester =
+                createStoreForNeedsReviewCardSelectionActions('navigateToNewCardsView');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
 
-        it('should set the visualHelperToggle to disabled if there are no rules', () => {
+        it('should set the visualHelperToggle to disabled if there are no rules', async () => {
             initialState.rules = {};
             initialState.visualHelperEnabled = true;
             expectedState.rules = {};
             expectedState.visualHelperEnabled = false;
 
-            createStoreForNeedsReviewCardSelectionActions(
-                'navigateToNewCardsView',
-            ).testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester =
+                createStoreForNeedsReviewCardSelectionActions('navigateToNewCardsView');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
     });
 
-    test('reset data on tab URL change', () => {
+    test('reset data on tab URL change', async () => {
         initialState.rules = {};
         initialState.visualHelperEnabled = true;
         expectedState.rules = null;
         expectedState.visualHelperEnabled = false;
-        createStoreForTabActions('existingTabUpdated').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreForTabActions('existingTabUpdated');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function expandRuleSelectCards(rule: RuleExpandCollapseData): void {

--- a/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
@@ -33,17 +33,15 @@ describe('NeedsReviewScanResultStore Test', () => {
         expect(defaultState.platformInfo).toBeNull();
     });
 
-    test('onGetCurrentState', () => {
+    test('onGetCurrentState', async () => {
         const initialState = getDefaultState();
         const finalState = getDefaultState();
 
-        createStoreForNeedsReviewScanResultActions('getCurrentState').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreForNeedsReviewScanResultActions('getCurrentState');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onScanCompleted', () => {
+    test('onScanCompleted', async () => {
         const initialState = getDefaultState();
         const targetAppInfo: TargetAppData = { name: 'app name' };
         const payload: UnifiedScanCompletedPayload = {
@@ -84,12 +82,12 @@ describe('NeedsReviewScanResultStore Test', () => {
             platformInfo: payload.platformInfo,
         };
 
-        createStoreForNeedsReviewScanResultActions('scanCompleted')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreForNeedsReviewScanResultActions('scanCompleted').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onExistingTabUpdated', () => {
+    test('onExistingTabUpdated', async () => {
         const initialState = {
             results: [
                 {
@@ -119,10 +117,8 @@ describe('NeedsReviewScanResultStore Test', () => {
 
         const expectedState = getDefaultState();
 
-        createStoreTesterForTabActions('existingTabUpdated').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForTabActions('existingTabUpdated');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function getDefaultState(): NeedsReviewScanResultStoreData {

--- a/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
+++ b/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
@@ -24,48 +24,44 @@ describe('PathSnippetStoreTest', () => {
         expect(defaultState.snippet).toEqual(null);
     });
 
-    test('on getCurrentState', () => {
+    test('on getCurrentState', async () => {
         const initialState = getDefaultState();
         const finalState = getDefaultState();
 
-        createStoreForPathSnippetActions('getCurrentState').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreForPathSnippetActions('getCurrentState');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on addPath', () => {
+    test('on addPath', async () => {
         const initialState = getDefaultState();
         const payload = 'new path';
         const finalState = getDefaultState();
         finalState.path = payload;
 
-        createStoreForPathSnippetActions('onAddPath')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreForPathSnippetActions('onAddPath').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on addSnippet', () => {
+    test('on addSnippet', async () => {
         const initialState = getDefaultState();
         const payload = 'new snippet';
         const finalState = getDefaultState();
         finalState.snippet = payload;
 
-        createStoreForPathSnippetActions('onAddSnippet')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreForPathSnippetActions('onAddSnippet').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on clearState', () => {
+    test('on clearState', async () => {
         const initialState = {
             path: 'test path',
             snippet: 'test snippet',
         };
         const finalState = getDefaultState();
 
-        createStoreForPathSnippetActions('onClearData')
-            .withActionParam(null)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreForPathSnippetActions('onClearData').withActionParam(null);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
     function getDefaultState(): PathSnippetStoreData {

--- a/src/tests/unit/tests/background/stores/tab-store.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-store.test.ts
@@ -27,7 +27,7 @@ describe('TabStoreTest', () => {
         expect(testObject.getId()).toBe(StoreNames[StoreNames.TabStore]);
     });
 
-    test('onNewTabCreated with empty initial state', () => {
+    test('onNewTabCreated with empty initial state', async () => {
         const initialState = new TabStoreDataBuilder().build();
 
         const payload: Tab = {
@@ -44,9 +44,9 @@ describe('TabStoreTest', () => {
             .with('isChanged', false)
             .build();
 
-        createStoreTesterForTabActions('newTabCreated')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForTabActions('newTabCreated').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     test.each`
@@ -59,7 +59,7 @@ describe('TabStoreTest', () => {
     `(
         'onNewTabCreated for differentOrigin=$differentOrigin, differentId=$differentId, re-initializes from scratch ' +
             'regardless of existing initial state isClosed=$originalIsClosed, isChanged=$originalIsChanged',
-        ({ differentOrigin, differentId, originalIsClosed, originalIsChanged }) => {
+        async ({ differentOrigin, differentId, originalIsClosed, originalIsChanged }) => {
             const originalId = 1;
             const originalUrl = 'https://original-host/original-path';
             const newUrl = differentOrigin
@@ -91,33 +91,29 @@ describe('TabStoreTest', () => {
                 .with('isChanged', false)
                 .build();
 
-            createStoreTesterForTabActions('newTabCreated')
-                .withActionParam(payload)
-                .testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester =
+                createStoreTesterForTabActions('newTabCreated').withActionParam(payload);
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         },
     );
 
-    test('onGetCurrentState', () => {
+    test('onGetCurrentState', async () => {
         const initialState = new TabStoreDataBuilder().build();
         const expectedState = new TabStoreDataBuilder().build();
 
-        createStoreTesterForTabActions('getCurrentState').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForTabActions('getCurrentState');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onTabRemove', () => {
+    test('onTabRemove', async () => {
         const initialState: TabStoreData = new TabStoreDataBuilder().build();
 
         const expectedState: TabStoreData = new TabStoreDataBuilder()
             .with('isClosed', true)
             .build();
 
-        createStoreTesterForTabActions('tabRemove').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForTabActions('tabRemove');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     test.each`
@@ -128,7 +124,7 @@ describe('TabStoreTest', () => {
         ${true}         | ${true}                | ${true}
     `(
         'onExistingTabUpdated from isOriginChanged=$initialIsOriginChanged with differentOrigin=$differentOrigin should result in isOriginChanged=$expectedIsOriginChanged',
-        ({ differentOrigin, initialIsOriginChanged, expectedIsOriginChanged }) => {
+        async ({ differentOrigin, initialIsOriginChanged, expectedIsOriginChanged }) => {
             const originalUrl = 'https://original-host/original-path';
             const newUrl = differentOrigin
                 ? 'https://new-host/new-path'
@@ -155,13 +151,13 @@ describe('TabStoreTest', () => {
                 .with('isOriginChanged', expectedIsOriginChanged)
                 .build();
 
-            createStoreTesterForTabActions('existingTabUpdated')
-                .withActionParam(payload)
-                .testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester =
+                createStoreTesterForTabActions('existingTabUpdated').withActionParam(payload);
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         },
     );
 
-    test('onVisibilityChange, hidden is true', () => {
+    test('onVisibilityChange, hidden is true', async () => {
         const initialState: TabStoreData = new TabStoreDataBuilder().build();
 
         const payload = true;
@@ -169,89 +165,79 @@ describe('TabStoreTest', () => {
             .with('isPageHidden', payload)
             .build();
 
-        createStoreTesterForTabActions('tabVisibilityChange')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester =
+            createStoreTesterForTabActions('tabVisibilityChange').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onVisibilityChange, hidden is false', () => {
+    test('onVisibilityChange, hidden is false', async () => {
         const initialState: TabStoreData = new TabStoreDataBuilder().build();
 
         const finalState: TabStoreData = new TabStoreDataBuilder().build();
 
         const payload = false;
 
-        createStoreTesterForTabActions('tabVisibilityChange')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, finalState);
+        const storeTester =
+            createStoreTesterForTabActions('tabVisibilityChange').withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, finalState);
     });
 
-    test('onEnableVisualization, state.isChanged is true', () => {
+    test('onEnableVisualization, state.isChanged is true', async () => {
         const initialState: TabStoreData = new TabStoreDataBuilder()
             .with('isChanged', true)
             .build();
 
         const finalState: TabStoreData = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions('enableVisualization').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreTesterForVisualizationActions('enableVisualization');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on enableVisualization, state.isChanged is false', () => {
+    test('on enableVisualization, state.isChanged is false', async () => {
         const initialState = new TabStoreDataBuilder().build();
 
         const finalState = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions('enableVisualization').testListenerToNeverBeCalled(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreTesterForVisualizationActions('enableVisualization');
+        await storeTester.testListenerToNeverBeCalled(initialState, finalState);
     });
 
-    test('on updateSelectedPivotChild, state.isChanged is true', () => {
+    test('on updateSelectedPivotChild, state.isChanged is true', async () => {
         const initialState = new TabStoreDataBuilder().with('isChanged', true).build();
 
         const finalState = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions(
-            'updateSelectedPivotChild',
-        ).testListenerToBeCalledOnce(initialState, finalState);
+        const storeTester = createStoreTesterForVisualizationActions('updateSelectedPivotChild');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on updateSelectedPivotChild, state.isChanged is false', () => {
+    test('on updateSelectedPivotChild, state.isChanged is false', async () => {
         const initialState = new TabStoreDataBuilder().build();
 
         const finalState = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions(
-            'updateSelectedPivotChild',
-        ).testListenerToNeverBeCalled(initialState, finalState);
+        const storeTester = createStoreTesterForVisualizationActions('updateSelectedPivotChild');
+        await storeTester.testListenerToNeverBeCalled(initialState, finalState);
     });
 
-    test('on updateSelectedPivot, state.isChanged is true', () => {
+    test('on updateSelectedPivot, state.isChanged is true', async () => {
         const initialState: TabStoreData = new TabStoreDataBuilder()
             .with('isChanged', true)
             .build();
 
         const finalState: TabStoreData = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions('updateSelectedPivot').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreTesterForVisualizationActions('updateSelectedPivot');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on updateSelectedPivot, state.isChange is false', () => {
+    test('on updateSelectedPivot, state.isChange is false', async () => {
         const initialState: TabStoreData = new TabStoreDataBuilder().build();
 
         const finalState: TabStoreData = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions('updateSelectedPivot').testListenerToNeverBeCalled(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreTesterForVisualizationActions('updateSelectedPivot');
+        await storeTester.testListenerToNeverBeCalled(initialState, finalState);
     });
 
     function createStoreTesterForTabActions(

--- a/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
@@ -33,17 +33,15 @@ describe('UnifiedScanResultStore Test', () => {
         expect(defaultState.platformInfo).toBeNull();
     });
 
-    test('onGetCurrentState', () => {
+    test('onGetCurrentState', async () => {
         const initialState = getDefaultState();
         const finalState = getDefaultState();
 
-        createStoreTesterForUnifiedScanResultActions('getCurrentState').testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreTesterForUnifiedScanResultActions('getCurrentState');
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('onScanCompleted', () => {
+    test('onScanCompleted', async () => {
         const initialState = getDefaultState();
         const targetAppInfo: TargetAppData = { name: 'app name' };
         const payload: UnifiedScanCompletedPayload = {
@@ -84,12 +82,12 @@ describe('UnifiedScanResultStore Test', () => {
             platformInfo: payload.platformInfo,
         };
 
-        createStoreTesterForUnifiedScanResultActions('scanCompleted')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForUnifiedScanResultActions('scanCompleted').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onExistingTabUpdated', () => {
+    test('onExistingTabUpdated', async () => {
         const initialState = {
             results: [
                 {
@@ -119,10 +117,8 @@ describe('UnifiedScanResultStore Test', () => {
 
         const expectedState = getDefaultState();
 
-        createStoreTesterForTabActions('existingTabUpdated').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForTabActions('existingTabUpdated');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function getDefaultState(): UnifiedScanResultStoreData {

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -52,16 +52,14 @@ describe('VisualizationScanResultStoreTest', () => {
         expect(testObject.getId()).toBe(StoreNames[StoreNames.VisualizationScanResultStore]);
     });
 
-    test('onGetCurrentState', () => {
+    test('onGetCurrentState', async () => {
         const actionName = 'getCurrentState';
 
         const initialState = new VisualizationScanResultStoreDataBuilder().build();
         const finalState = new VisualizationScanResultStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationScanResultActions(actionName).testListenerToBeCalledOnce(
-            initialState,
-            finalState,
-        );
+        const storeTester = createStoreTesterForVisualizationScanResultActions(actionName);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
     function getTabbedElementDataStub() {
@@ -76,7 +74,7 @@ describe('VisualizationScanResultStoreTest', () => {
         ];
     }
 
-    test('onTabStopDisabled', () => {
+    test('onTabStopDisabled', async () => {
         const tabEvents: TabbedElementData[] = getTabbedElementDataStub();
 
         const initialState = new VisualizationScanResultStoreDataBuilder()
@@ -87,12 +85,11 @@ describe('VisualizationScanResultStoreTest', () => {
             .withTabStopsTabbedElements(null)
             .build();
 
-        createStoreTesterForVisualizationScanResultActions(
-            'disableTabStop',
-        ).testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForVisualizationScanResultActions('disableTabStop');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onRescanVisualization: for test that has state', () => {
+    test('onRescanVisualization: for test that has state', async () => {
         const tabEvents: TabbedElementData[] = getTabbedElementDataStub();
         const testKey = AdHocTestkeys.TabStops;
         const visualizationTypeStub = -2;
@@ -110,12 +107,13 @@ describe('VisualizationScanResultStoreTest', () => {
             .setup(m => m.getConfiguration(visualizationTypeStub))
             .returns(() => configStub);
 
-        createStoreTesterForVisualizationActions('resetDataForVisualization')
-            .withActionParam(visualizationTypeStub)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForVisualizationActions(
+            'resetDataForVisualization',
+        ).withActionParam(visualizationTypeStub);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onRescanVisualizationv: for test that does not have state', () => {
+    test('onRescanVisualizationv: for test that does not have state', async () => {
         const tabEvents: TabbedElementData[] = getTabbedElementDataStub();
         const testKey = 'some test key';
         const visualizationTypeStub = -2;
@@ -131,12 +129,13 @@ describe('VisualizationScanResultStoreTest', () => {
             .setup(m => m.getConfiguration(visualizationTypeStub))
             .returns(() => configStub);
 
-        createStoreTesterForVisualizationActions('resetDataForVisualization')
-            .withActionParam(visualizationTypeStub)
-            .testListenerToNeverBeCalled(initialState, initialState);
+        const storeTester = createStoreTesterForVisualizationActions(
+            'resetDataForVisualization',
+        ).withActionParam(visualizationTypeStub);
+        await storeTester.testListenerToNeverBeCalled(initialState, initialState);
     });
 
-    test('onScanCompleted', () => {
+    test('onScanCompleted', async () => {
         const visualizationType = VisualizationType.Issues;
         const initialState = new VisualizationScanResultStoreDataBuilder().build();
 
@@ -252,12 +251,14 @@ describe('VisualizationScanResultStoreTest', () => {
             key: 'issues',
         };
 
-        createStoreTesterForVisualizationScanResultActions('scanCompleted')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationScanResultActions('scanCompleted').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onAddTabbedElement: first element', () => {
+    test('onAddTabbedElement: first element', async () => {
         const initialState = new VisualizationScanResultStoreDataBuilder().build();
 
         const payload: AddTabbedElementPayload = {
@@ -284,12 +285,14 @@ describe('VisualizationScanResultStoreTest', () => {
             .withTabStopsTabbedElements(tabbedElements)
             .build();
 
-        createStoreTesterForVisualizationScanResultActions('addTabbedElement')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationScanResultActions('addTabbedElement').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onAddTabbedElement: ensure correct tab order', () => {
+    test('onAddTabbedElement: ensure correct tab order', async () => {
         const initialTabbedElements: TabbedElementData[] = [
             {
                 timestamp: 10,
@@ -340,12 +343,14 @@ describe('VisualizationScanResultStoreTest', () => {
             .withTabStopsTabbedElements(expectedTabbedElements)
             .build();
 
-        createStoreTesterForVisualizationScanResultActions('addTabbedElement')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationScanResultActions('addTabbedElement').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onExistingTabUpdated', () => {
+    test('onExistingTabUpdated', async () => {
         const initialState = new VisualizationScanResultStoreDataBuilder()
             .withScanResult(VisualizationType.Headings, [])
             .withTabStopsTabbedElements([])
@@ -353,13 +358,11 @@ describe('VisualizationScanResultStoreTest', () => {
 
         const expectedState = new VisualizationScanResultStoreDataBuilder().build();
 
-        createStoreTesterForTabActions('existingTabUpdated').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForTabActions('existingTabUpdated');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onUpdateTabStopRequirementStatus updates status and removes instances', () => {
+    test('onUpdateTabStopRequirementStatus updates status and removes instances', async () => {
         const initialState = new VisualizationScanResultStoreDataBuilder().build();
         initialState.tabStops.requirements['keyboard-navigation'].status = 'fail';
         initialState.tabStops.requirements['keyboard-navigation'].instances = [
@@ -383,12 +386,13 @@ describe('VisualizationScanResultStoreTest', () => {
             .withTabStopRequirement(requirement)
             .build();
 
-        createStoreTesterForTabStopRequirementActions('updateTabStopsRequirementStatus')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForTabStopRequirementActions(
+            'updateTabStopsRequirementStatus',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onResetTabStopRequirementStatus resets status and removes instances', () => {
+    test('onResetTabStopRequirementStatus resets status and removes instances', async () => {
         const initialState = new VisualizationScanResultStoreDataBuilder().build();
         initialState.tabStops.requirements['keyboard-navigation'].status = 'fail';
         initialState.tabStops.requirements['keyboard-navigation'].instances = [
@@ -411,9 +415,10 @@ describe('VisualizationScanResultStoreTest', () => {
             .withTabStopRequirement(requirement)
             .build();
 
-        createStoreTesterForTabStopRequirementActions('resetTabStopRequirementStatus')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForTabStopRequirementActions(
+            'resetTabStopRequirementStatus',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     describe('onAddTabStopInstance', () => {
@@ -446,14 +451,16 @@ describe('VisualizationScanResultStoreTest', () => {
             .build();
         expectedState.tabStops.requirements[payload.requirementId].status = 'fail';
 
-        test('adds tab stop failure instance', () => {
-            createStoreTesterForTabStopRequirementActions('addTabStopInstance')
-                .withActionParam(payload)
-                .testListenerToBeCalledOnce(initialState, expectedState);
+        test('adds tab stop failure instance', async () => {
+            const storeTester =
+                createStoreTesterForTabStopRequirementActions('addTabStopInstance').withActionParam(
+                    payload,
+                );
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
     });
 
-    test('onUpdateTabStopInstance', () => {
+    test('onUpdateTabStopInstance', async () => {
         const payload: UpdateTabStopInstancePayload = {
             requirementId: 'keyboard-navigation',
             id: 'xyz',
@@ -483,12 +490,14 @@ describe('VisualizationScanResultStoreTest', () => {
             .withTabStopRequirement(requirement)
             .build();
 
-        createStoreTesterForTabStopRequirementActions('addTabStopInstance')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForTabStopRequirementActions('addTabStopInstance').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onRemoveTabStopInstance', () => {
+    test('onRemoveTabStopInstance', async () => {
         const payload: RemoveTabStopInstancePayload = {
             requirementId: 'keyboard-navigation',
             id: 'abc',
@@ -516,12 +525,14 @@ describe('VisualizationScanResultStoreTest', () => {
             .withTabStopRequirement(requirement)
             .build();
 
-        createStoreTesterForTabStopRequirementActions('addTabStopInstance')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForTabStopRequirementActions('addTabStopInstance').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onUpdateTabbingCompleted', () => {
+    test('onUpdateTabbingCompleted', async () => {
         const initialState = new VisualizationScanResultStoreDataBuilder().build();
 
         const expectedState = new VisualizationScanResultStoreDataBuilder()
@@ -532,12 +543,14 @@ describe('VisualizationScanResultStoreTest', () => {
             tabbingCompleted: true,
         };
 
-        createStoreTesterForTabStopRequirementActions('updateTabbingCompleted')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForTabStopRequirementActions('updateTabbingCompleted').withActionParam(
+                payload,
+            );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onUpdateNeedToCollectTabbingResults', () => {
+    test('onUpdateNeedToCollectTabbingResults', async () => {
         const initialState = new VisualizationScanResultStoreDataBuilder().build();
 
         const expectedState = new VisualizationScanResultStoreDataBuilder()
@@ -548,9 +561,10 @@ describe('VisualizationScanResultStoreTest', () => {
             needToCollectTabbingResults: true,
         };
 
-        createStoreTesterForTabStopRequirementActions('updateNeedToCollectTabbingResults')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForTabStopRequirementActions(
+            'updateNeedToCollectTabbingResults',
+        ).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function createStoreTesterForVisualizationScanResultActions(

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -36,7 +36,7 @@ describe('VisualizationStoreTest ', () => {
     describe('onUpdateSelectedPivotChild', () => {
         const actionName = 'updateSelectedPivotChild';
 
-        test('when pivot is different', () => {
+        test('when pivot is different', async () => {
             const viewType = VisualizationType.TabStops;
             const initialPivot = DetailsViewPivotType.assessment;
             const finalPivot = DetailsViewPivotType.fastPass;
@@ -57,12 +57,12 @@ describe('VisualizationStoreTest ', () => {
                 pivotType: finalPivot,
             };
 
-            createStoreTesterForVisualizationActions(actionName)
-                .withActionParam(payload)
-                .testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester =
+                createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
 
-        test('when old pivot does not have current visualization', () => {
+        test('when old pivot does not have current visualization', async () => {
             const viewType = VisualizationType.Landmarks;
             const finalPivot = DetailsViewPivotType.assessment;
 
@@ -81,14 +81,14 @@ describe('VisualizationStoreTest ', () => {
                 pivotType: finalPivot,
             };
 
-            createStoreTesterForVisualizationActions(actionName)
-                .withActionParam(payload)
-                .testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester =
+                createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
 
         it.each([DetailsViewPivotType.assessment, DetailsViewPivotType.fastPass])(
             'when view & pivot are the same',
-            pivotType => {
+            async pivotType => {
                 const viewType = VisualizationType.Issues;
 
                 const expectedState = new VisualizationStoreDataBuilder()
@@ -109,13 +109,13 @@ describe('VisualizationStoreTest ', () => {
                     pivotType: pivotType,
                 };
 
-                createStoreTesterForVisualizationActions(actionName)
-                    .withActionParam(payload)
-                    .testListenerToNeverBeCalled(initialState, expectedState);
+                const storeTester =
+                    createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+                await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
             },
         );
 
-        test('when view changes to null', () => {
+        test('when view changes to null', async () => {
             const expectedState = new VisualizationStoreDataBuilder()
                 .with('selectedAdhocDetailsView', VisualizationType.Landmarks)
                 .build();
@@ -128,12 +128,12 @@ describe('VisualizationStoreTest ', () => {
                 pivotType: null,
             };
 
-            createStoreTesterForVisualizationActions(actionName)
-                .withActionParam(payload)
-                .testListenerToNeverBeCalled(initialState, expectedState);
+            const storeTester =
+                createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+            await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
         });
 
-        test('same pivot different view', () => {
+        test('same pivot different view', async () => {
             const selectedPivot = DetailsViewPivotType.fastPass;
 
             const oldView = VisualizationType.Issues;
@@ -157,12 +157,12 @@ describe('VisualizationStoreTest ', () => {
                 pivotType: selectedPivot,
             };
 
-            createStoreTesterForVisualizationActions(actionName)
-                .withActionParam(payload)
-                .testListenerToBeCalledOnce(initialState, expectedState);
+            const storeTester =
+                createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
 
-        test('when view is different', () => {
+        test('when view is different', async () => {
             const initialState = new VisualizationStoreDataBuilder().build();
 
             const expectedState = new VisualizationStoreDataBuilder()
@@ -174,12 +174,12 @@ describe('VisualizationStoreTest ', () => {
                 pivotType: null,
             };
 
-            createStoreTesterForVisualizationActions(actionName)
-                .withActionParam(payload)
-                .testListenerToNeverBeCalled(initialState, expectedState);
+            const storeTester =
+                createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+            await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
         });
 
-        test('when view is null', () => {
+        test('when view is null', async () => {
             const initialState = new VisualizationStoreDataBuilder()
                 .with('selectedAdhocDetailsView', VisualizationType.Issues)
                 .build();
@@ -190,13 +190,13 @@ describe('VisualizationStoreTest ', () => {
                 pivotType: null,
             };
 
-            createStoreTesterForVisualizationActions(actionName)
-                .withActionParam(payload)
-                .testListenerToNeverBeCalled(initialState, expectedState);
+            const storeTester =
+                createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+            await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
         });
     });
 
-    test('onUpdateSelectedPivot when pivot value is same as before', () => {
+    test('onUpdateSelectedPivot when pivot value is same as before', async () => {
         const actionName = 'updateSelectedPivot';
         const oldPivotValue = DetailsViewPivotType.fastPass;
         const initialState = new VisualizationStoreDataBuilder()
@@ -211,12 +211,12 @@ describe('VisualizationStoreTest ', () => {
             pivotKey: oldPivotValue,
         };
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('onUpdateSelectedPivot when pivot value is different', () => {
+    test('onUpdateSelectedPivot when pivot value is different', async () => {
         const actionName = 'updateSelectedPivot';
         const oldPivotValue = DetailsViewPivotType.fastPass;
         const finalPivotValue = DetailsViewPivotType.assessment;
@@ -239,9 +239,9 @@ describe('VisualizationStoreTest ', () => {
             pivotKey: finalPivotValue,
         };
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     describe('onEnableHeadings with headings already enabled or disabled', () => {
@@ -251,7 +251,7 @@ describe('VisualizationStoreTest ', () => {
             ${new VisualizationStoreDataBuilder()}
         `(
             'case enabled = $initialDataBuilder.data.tests.adhoc.headings.enabled',
-            ({ initialDataBuilder }) => {
+            async ({ initialDataBuilder }) => {
                 const actionName = 'enableVisualization';
                 const payload: ToggleActionPayload = {
                     test: VisualizationType.Headings,
@@ -266,14 +266,14 @@ describe('VisualizationStoreTest ', () => {
                     .with('injectingRequested', true)
                     .build();
 
-                createStoreTesterForVisualizationActions(actionName)
-                    .withActionParam(payload)
-                    .testListenerToBeCalledOnce(initialState, expectedState);
+                const storeTester =
+                    createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+                await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
             },
         );
     });
 
-    test('onEnableHeadingsAssessment without scan', () => {
+    test('onEnableHeadingsAssessment without scan', async () => {
         const actionName = 'enableVisualizationWithoutScan';
         const dataBuilder = new VisualizationStoreDataBuilder();
         const payload: AssessmentToggleActionPayload = {
@@ -288,12 +288,12 @@ describe('VisualizationStoreTest ', () => {
             .with('injectingRequested', true)
             .build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onEnableHeadings when headingsAssessment is enabled', () => {
+    test('onEnableHeadings when headingsAssessment is enabled', async () => {
         const actionName = 'enableVisualization';
         const payload: ToggleActionPayload = {
             test: VisualizationType.Headings,
@@ -310,12 +310,12 @@ describe('VisualizationStoreTest ', () => {
             .with('scanning', 'headings')
             .build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onEnableHeadingsAssessment when some other visualization is already enable', () => {
+    test('onEnableHeadingsAssessment when some other visualization is already enable', async () => {
         const actionName = 'enableVisualization';
         const payload: AssessmentToggleActionPayload = {
             test: VisualizationType.HeadingsAssessment,
@@ -331,12 +331,12 @@ describe('VisualizationStoreTest ', () => {
             .with('scanning', HeadingsTestStep.missingHeadings)
             .build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onEnableHeadingsAssessment from onEnableLandmarksAssessment', () => {
+    test('onEnableHeadingsAssessment from onEnableLandmarksAssessment', async () => {
         const actionName = 'enableVisualization';
         const payload: AssessmentToggleActionPayload = {
             test: VisualizationType.HeadingsAssessment,
@@ -354,12 +354,12 @@ describe('VisualizationStoreTest ', () => {
             .with('scanning', HeadingsTestStep.missingHeadings)
             .build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onEnableHeadingsAssessment switch test steps', () => {
+    test('onEnableHeadingsAssessment switch test steps', async () => {
         const actionName = 'enableVisualization';
         const payload: AssessmentToggleActionPayload = {
             test: VisualizationType.HeadingsAssessment,
@@ -377,12 +377,12 @@ describe('VisualizationStoreTest ', () => {
             .with('scanning', HeadingsTestStep.missingHeadings)
             .build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('OnDisableHeadings when headings is enable', () => {
+    test('OnDisableHeadings when headings is enable', async () => {
         const actionName = 'disableVisualization';
         const dataBuilder = new VisualizationStoreDataBuilder();
         const payload: ToggleActionPayload = {
@@ -391,21 +391,22 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = dataBuilder.build();
         const initialState = dataBuilder.withHeadingsEnable().build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload.test)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForVisualizationActions(actionName).withActionParam(
+            payload.test,
+        );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('disableAssessmentVisualizations', () => {
+    test('disableAssessmentVisualizations', async () => {
         const actionName = 'disableAssessmentVisualizations';
         const dataBuilder = new VisualizationStoreDataBuilder();
 
         const expectedState = dataBuilder.withHeadingsAssessment(false, 'teststep').build();
         const initialState = dataBuilder.withHeadingsAssessment(true, 'teststep').build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(null)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(null);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     describe('onEnableTabStops with TabStops already enabled or disabled', () => {
@@ -415,7 +416,7 @@ describe('VisualizationStoreTest ', () => {
             ${new VisualizationStoreDataBuilder()}
         `(
             'case enabled = $initialDataBuilder.data.tests.adhoc.tabStops.enabled',
-            ({ initialDataBuilder }) => {
+            async ({ initialDataBuilder }) => {
                 const actionName = 'enableVisualization';
                 const payload: ToggleActionPayload = {
                     test: VisualizationType.TabStops,
@@ -429,14 +430,14 @@ describe('VisualizationStoreTest ', () => {
                     .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
                     .build();
 
-                createStoreTesterForVisualizationActions(actionName)
-                    .withActionParam(payload)
-                    .testListenerToBeCalledOnce(initialState, expectedState);
+                const storeTester =
+                    createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+                await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
             },
         );
     });
 
-    test('OnDisableTabStops when TabStops is enable', () => {
+    test('OnDisableTabStops when TabStops is enable', async () => {
         const actionName = 'disableVisualization';
         const dataBuilder = new VisualizationStoreDataBuilder();
         const payload: ToggleActionPayload = {
@@ -445,12 +446,13 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = dataBuilder.build();
         const initialState = dataBuilder.withTabStopsEnable().build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload.test)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForVisualizationActions(actionName).withActionParam(
+            payload.test,
+        );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('disableVisualization when already scanning', () => {
+    test('disableVisualization when already scanning', async () => {
         const actionName = 'disableVisualization';
         const payload: ToggleActionPayload = {
             test: VisualizationType.Issues,
@@ -466,12 +468,12 @@ describe('VisualizationStoreTest ', () => {
             .withIssuesEnable()
             .build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('OnDisableHeadings when headings is already disable', () => {
+    test('OnDisableHeadings when headings is already disable', async () => {
         const actionName = 'disableVisualization';
         const dataBuilder = new VisualizationStoreDataBuilder();
         const payload: ToggleActionPayload = {
@@ -480,9 +482,10 @@ describe('VisualizationStoreTest ', () => {
         const initialState = dataBuilder.build();
         const expectedState = dataBuilder.build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload.test)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester = createStoreTesterForVisualizationActions(actionName).withActionParam(
+            payload.test,
+        );
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
     describe('onEnableLandmarks with landmarks already enabled or disabled', () => {
@@ -492,7 +495,7 @@ describe('VisualizationStoreTest ', () => {
             ${new VisualizationStoreDataBuilder()}
         `(
             'case enabled = $initialDataBuilder.data.tests.adhoc.landmarks.enabled',
-            ({ initialDataBuilder }) => {
+            async ({ initialDataBuilder }) => {
                 const actionName = 'enableVisualization';
                 const payload: ToggleActionPayload = {
                     test: VisualizationType.Landmarks,
@@ -506,14 +509,14 @@ describe('VisualizationStoreTest ', () => {
                     .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
                     .build();
 
-                createStoreTesterForVisualizationActions(actionName)
-                    .withActionParam(payload)
-                    .testListenerToBeCalledOnce(initialState, expectedState);
+                const storeTester =
+                    createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+                await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
             },
         );
     });
 
-    test('onDisableLandmarks when landmarks is enable', () => {
+    test('onDisableLandmarks when landmarks is enable', async () => {
         const actionName = 'disableVisualization';
         const dataBuilder = new VisualizationStoreDataBuilder();
         const payload: ToggleActionPayload = {
@@ -522,12 +525,13 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = dataBuilder.build();
         const initialState = dataBuilder.withLandmarksEnable().build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload.test)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForVisualizationActions(actionName).withActionParam(
+            payload.test,
+        );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onDisableLandmarks when landmarks is already disable', () => {
+    test('onDisableLandmarks when landmarks is already disable', async () => {
         const actionName = 'disableVisualization';
         const dataBuilder = new VisualizationStoreDataBuilder();
         const payload: ToggleActionPayload = {
@@ -536,9 +540,10 @@ describe('VisualizationStoreTest ', () => {
         const initialState = dataBuilder.build();
         const expectedState = dataBuilder.build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload.test)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester = createStoreTesterForVisualizationActions(actionName).withActionParam(
+            payload.test,
+        );
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
     describe('onEnableIssues with issues already enabled or disabled', () => {
@@ -548,7 +553,7 @@ describe('VisualizationStoreTest ', () => {
             ${new VisualizationStoreDataBuilder()}
         `(
             'case enabled = $initialDataBuilder.data.tests.adhoc.issues.enabled',
-            ({ initialDataBuilder }) => {
+            async ({ initialDataBuilder }) => {
                 const actionName = 'enableVisualization';
                 const payload: ToggleActionPayload = {
                     test: VisualizationType.Issues,
@@ -563,14 +568,14 @@ describe('VisualizationStoreTest ', () => {
                     .with('selectedDetailsViewPivot', DetailsViewPivotType.fastPass)
                     .build();
 
-                createStoreTesterForVisualizationActions(actionName)
-                    .withActionParam(payload)
-                    .testListenerToBeCalledOnce(initialState, expectedState);
+                const storeTester =
+                    createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+                await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
             },
         );
     });
 
-    test('onDisableIssues when issues is enable', () => {
+    test('onDisableIssues when issues is enable', async () => {
         const actionName = 'disableVisualization';
         const dataBuilder = new VisualizationStoreDataBuilder();
         const payload: ToggleActionPayload = {
@@ -579,12 +584,13 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = dataBuilder.build();
         const initialState = dataBuilder.withIssuesEnable().build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload.test)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForVisualizationActions(actionName).withActionParam(
+            payload.test,
+        );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onDisableIssues when issues is already disable', () => {
+    test('onDisableIssues when issues is already disable', async () => {
         const actionName = 'disableVisualization';
         const dataBuilder = new VisualizationStoreDataBuilder();
         const payload: ToggleActionPayload = {
@@ -593,12 +599,13 @@ describe('VisualizationStoreTest ', () => {
         const initialState = dataBuilder.build();
         const expectedState = dataBuilder.build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload.test)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester = createStoreTesterForVisualizationActions(actionName).withActionParam(
+            payload.test,
+        );
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('onEnableColor when color is disable', () => {
+    test('onEnableColor when color is disable', async () => {
         const actionName = 'enableVisualization';
 
         const initialState = new VisualizationStoreDataBuilder().build();
@@ -614,12 +621,12 @@ describe('VisualizationStoreTest ', () => {
             .with('injectingRequested', true)
             .build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onDisableColor when color is enable', () => {
+    test('onDisableColor when color is enable', async () => {
         const actionName = 'disableVisualization';
         const dataBuilder = new VisualizationStoreDataBuilder();
         const payload: ToggleActionPayload = {
@@ -628,23 +635,22 @@ describe('VisualizationStoreTest ', () => {
         const expectedState = dataBuilder.build();
         const initialState = dataBuilder.withColorEnable().build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload.test)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForVisualizationActions(actionName).withActionParam(
+            payload.test,
+        );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onGetCurrentState', () => {
+    test('onGetCurrentState', async () => {
         const actionName = 'getCurrentState';
         const initialState = new VisualizationStoreDataBuilder().build();
         const expectedState = new VisualizationStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions(actionName).testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForVisualizationActions(actionName);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('enableVisualization when already scanning', () => {
+    test('enableVisualization when already scanning', async () => {
         const actionName = 'enableVisualization';
         const payload: ToggleActionPayload = {
             test: VisualizationType.Issues,
@@ -657,12 +663,12 @@ describe('VisualizationStoreTest ', () => {
             .with('scanning', 'headings')
             .build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('onInjectionCompleted', () => {
+    test('onInjectionCompleted', async () => {
         const actionName = 'injectionCompleted';
 
         const initialState = new VisualizationStoreDataBuilder().build();
@@ -672,13 +678,11 @@ describe('VisualizationStoreTest ', () => {
             .with('injectingStarted', false)
             .build();
 
-        createStoreTesterForInjectionActions(actionName).testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForInjectionActions(actionName);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onInjectionStarted when injectingStarted is false', () => {
+    test('onInjectionStarted when injectingStarted is false', async () => {
         const actionName = 'injectionStarted';
 
         const initialState = new VisualizationStoreDataBuilder()
@@ -690,13 +694,11 @@ describe('VisualizationStoreTest ', () => {
             .with('injectingStarted', true)
             .build();
 
-        createStoreTesterForInjectionActions(actionName).testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForInjectionActions(actionName);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onInjectionStarted when injectingStarted is true', () => {
+    test('onInjectionStarted when injectingStarted is true', async () => {
         const actionName = 'injectionStarted';
 
         const initialState = new VisualizationStoreDataBuilder()
@@ -708,13 +710,11 @@ describe('VisualizationStoreTest ', () => {
             .with('injectingStarted', true)
             .build();
 
-        createStoreTesterForInjectionActions(actionName).testListenerToNeverBeCalled(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForInjectionActions(actionName);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('onScrollRequested', () => {
+    test('onScrollRequested', async () => {
         const actionName = 'scrollRequested';
 
         const initialState = new VisualizationStoreDataBuilder()
@@ -727,12 +727,12 @@ describe('VisualizationStoreTest ', () => {
 
         const payload = {};
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onScanColorCompleted', () => {
+    test('onScanColorCompleted', async () => {
         const actionName = 'scanCompleted';
 
         const initialState = new VisualizationStoreDataBuilder().with('scanning', 'color').build();
@@ -741,12 +741,12 @@ describe('VisualizationStoreTest ', () => {
 
         const payload = {};
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onScanIssuesCompleted', () => {
+    test('onScanIssuesCompleted', async () => {
         const actionName = 'scanCompleted';
         const initialState = new VisualizationStoreDataBuilder().with('scanning', 'issues').build();
 
@@ -754,12 +754,12 @@ describe('VisualizationStoreTest ', () => {
 
         const payload = {};
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onScanHeadingsCompleted', () => {
+    test('onScanHeadingsCompleted', async () => {
         const actionName = 'scanCompleted';
         const initialState = new VisualizationStoreDataBuilder()
             .with('scanning', 'headings')
@@ -769,12 +769,12 @@ describe('VisualizationStoreTest ', () => {
 
         const payload = {};
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onScanLandmarksCompleted', () => {
+    test('onScanLandmarksCompleted', async () => {
         const actionName = 'scanCompleted';
         const initialState = new VisualizationStoreDataBuilder()
             .with('scanning', 'landmarks')
@@ -784,12 +784,12 @@ describe('VisualizationStoreTest ', () => {
 
         const payload = {};
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onUpdateFocusedInstance', () => {
+    test('onUpdateFocusedInstance', async () => {
         const actionName = 'updateFocusedInstance';
 
         const initialState = new VisualizationStoreDataBuilder().build();
@@ -800,12 +800,12 @@ describe('VisualizationStoreTest ', () => {
             .withFocusedTarget(payload)
             .build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onExistingTabUpdated', () => {
+    test('onExistingTabUpdated', async () => {
         const actionName = 'existingTabUpdated';
         const visualizationType = VisualizationType.Headings;
         const pivot = DetailsViewPivotType.fastPass;
@@ -820,10 +820,8 @@ describe('VisualizationStoreTest ', () => {
             .withLandmarksEnable()
             .build();
 
-        createStoreTesterForTabActions(actionName).testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForTabActions(actionName);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function createStoreTesterForTabActions(

--- a/src/tests/unit/tests/common/flux/async-action.test.ts
+++ b/src/tests/unit/tests/common/flux/async-action.test.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ActionListener } from 'common/flux/action';
 import { AsyncAction } from 'common/flux/async-action';
 import { ScopeMutex } from 'common/flux/scope-mutex';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe(AsyncAction, () => {
-    let listenerMock: IMock<(payload: TestPayload) => Promise<void>>;
+    let listenerMock: IMock<ActionListener<TestPayload, Promise<void>>>;
     const testPayload: TestPayload = { key: 'value' };
     let testObject: AsyncAction<TestPayload>;
     let scopeMutexMock: IMock<ScopeMutex>;

--- a/src/tests/unit/tests/common/flux/sync-action.test.ts
+++ b/src/tests/unit/tests/common/flux/sync-action.test.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ActionListener } from 'common/flux/action';
 import { ScopeMutex } from 'common/flux/scope-mutex';
 import { SyncAction } from 'common/flux/sync-action';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe(SyncAction, () => {
-    let listenerMock: IMock<(payload: TestPayload) => void>;
+    let listenerMock: IMock<ActionListener<TestPayload, void>>;
     const testPayload: TestPayload = { key: 'value' };
     let testObject: SyncAction<TestPayload>;
     let scopeMutexMock: IMock<ScopeMutex>;

--- a/src/tests/unit/tests/debug-tools/stores/debug-tools-nav-store.test.ts
+++ b/src/tests/unit/tests/debug-tools/stores/debug-tools-nav-store.test.ts
@@ -25,7 +25,7 @@ describe('DebugToolsNavStore', () => {
             await storeTester.testListenerToNeverBeCalled(initialState, finalState);
         });
 
-        it('handles tool selected change', async() => {
+        it('handles tool selected change', async () => {
             const initialState = new DebugToolsNavStoreDataBuilder()
                 .with('selectedTool', 'telemetryViewer')
                 .build();

--- a/src/tests/unit/tests/debug-tools/stores/debug-tools-nav-store.test.ts
+++ b/src/tests/unit/tests/debug-tools/stores/debug-tools-nav-store.test.ts
@@ -11,19 +11,21 @@ import { StoreTester } from 'tests/unit/common/store-tester';
 
 describe('DebugToolsNavStore', () => {
     describe('onSetSelectedTool', () => {
-        it('handles tool already selected', () => {
+        it('handles tool already selected', async () => {
             const initialState = new DebugToolsNavStoreDataBuilder().build();
 
             const alreadySelectedKey = initialState.selectedTool;
 
             const finalState = new DebugToolsNavStoreDataBuilder().build();
 
-            createStoreTesterForDebugToolsNavActions('setSelectedTool')
-                .withActionParam(alreadySelectedKey)
-                .testListenerToNeverBeCalled(initialState, finalState);
+            const storeTester =
+                createStoreTesterForDebugToolsNavActions('setSelectedTool').withActionParam(
+                    alreadySelectedKey,
+                );
+            await storeTester.testListenerToNeverBeCalled(initialState, finalState);
         });
 
-        it('handles tool selected change', () => {
+        it('handles tool selected change', async() => {
             const initialState = new DebugToolsNavStoreDataBuilder()
                 .with('selectedTool', 'telemetryViewer')
                 .build();
@@ -34,9 +36,11 @@ describe('DebugToolsNavStore', () => {
                 .with('selectedTool', selectedKey)
                 .build();
 
-            createStoreTesterForDebugToolsNavActions('setSelectedTool')
-                .withActionParam(selectedKey)
-                .testListenerToBeCalledOnce(initialState, finalState);
+            const storeTester =
+                createStoreTesterForDebugToolsNavActions('setSelectedTool').withActionParam(
+                    selectedKey,
+                );
+            await storeTester.testListenerToBeCalledOnce(initialState, finalState);
         });
     });
 

--- a/src/tests/unit/tests/electron/flux/store/android-setup-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/android-setup-store.test.ts
@@ -86,7 +86,7 @@ describe('AndroidSetupStore', () => {
         stateMachineMock.verifyAll();
     });
 
-    it('ensure step transition function results in store update', () => {
+    it('ensure step transition function results in store update', async () => {
         const initialData: AndroidSetupStoreData = { currentStepId: 'detect-adb' };
         const expectedData: AndroidSetupStoreData = { currentStepId: 'prompt-choose-device' };
 
@@ -106,7 +106,7 @@ describe('AndroidSetupStore', () => {
             .verifiable(Times.once());
 
         const storeTester = createAndroidSetupStoreTester('cancel', stateMachineFactoryMock.object);
-        storeTester.testListenerToBeCalledOnce(initialData, expectedData);
+        await storeTester.testListenerToBeCalledOnce(initialData, expectedData);
 
         stateMachineFactoryMock.verifyAll();
         stateMachineMock.verifyAll();

--- a/src/tests/unit/tests/electron/flux/store/device-connection-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/device-connection-store.test.ts
@@ -42,7 +42,7 @@ describe('DeviceConnectionStore', () => {
             const targetAction = 'statusUnknown';
             const expectedStatus = DeviceConnectionStatus.Unknown;
 
-            it.each(initialStatuses)('with initial status <%s>', initialStatus => {
+            it.each(initialStatuses)('with initial status <%s>', async initialStatus => {
                 initialState.status = DeviceConnectionStatus[initialStatus];
 
                 const expectedState: DeviceConnectionStoreData = {
@@ -51,15 +51,11 @@ describe('DeviceConnectionStore', () => {
                 };
 
                 if (initialState.status === expectedStatus) {
-                    createStoreTesterForScanActions(targetAction).testListenerToNeverBeCalled(
-                        initialState,
-                        expectedState,
-                    );
+                    const storeTester = createStoreTesterForScanActions(targetAction);
+                    await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
                 } else {
-                    createStoreTesterForScanActions(targetAction).testListenerToBeCalledOnce(
-                        initialState,
-                        expectedState,
-                    );
+                    const storeTester = createStoreTesterForScanActions(targetAction);
+                    await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
                 }
             });
         });
@@ -70,7 +66,7 @@ describe('DeviceConnectionStore', () => {
             const targetAction = 'statusConnected';
             const expectedStatus = DeviceConnectionStatus.Connected;
 
-            it.each(initialStatuses)('with initial status <%s>', initialStatus => {
+            it.each(initialStatuses)('with initial status <%s>', async initialStatus => {
                 initialState.status = DeviceConnectionStatus[initialStatus];
 
                 const expectedState: DeviceConnectionStoreData = {
@@ -79,15 +75,11 @@ describe('DeviceConnectionStore', () => {
                 };
 
                 if (initialState.status === expectedStatus) {
-                    createStoreTesterForScanActions(targetAction).testListenerToNeverBeCalled(
-                        initialState,
-                        expectedState,
-                    );
+                    const storeTester = createStoreTesterForScanActions(targetAction);
+                    await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
                 } else {
-                    createStoreTesterForScanActions(targetAction).testListenerToBeCalledOnce(
-                        initialState,
-                        expectedState,
-                    );
+                    const storeTester = createStoreTesterForScanActions(targetAction);
+                    await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
                 }
             });
         });
@@ -98,7 +90,7 @@ describe('DeviceConnectionStore', () => {
             const targetAction = 'statusDisconnected';
             const expectedStatus = DeviceConnectionStatus.Disconnected;
 
-            it.each(initialStatuses)('with initial status <%s>', initialStatus => {
+            it.each(initialStatuses)('with initial status <%s>', async initialStatus => {
                 initialState.status = DeviceConnectionStatus[initialStatus];
 
                 const expectedState: DeviceConnectionStoreData = {
@@ -107,15 +99,11 @@ describe('DeviceConnectionStore', () => {
                 };
 
                 if (initialState.status === expectedStatus) {
-                    createStoreTesterForScanActions(targetAction).testListenerToNeverBeCalled(
-                        initialState,
-                        expectedState,
-                    );
+                    const storeTester = createStoreTesterForScanActions(targetAction);
+                    await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
                 } else {
-                    createStoreTesterForScanActions(targetAction).testListenerToBeCalledOnce(
-                        initialState,
-                        expectedState,
-                    );
+                    const storeTester = createStoreTesterForScanActions(targetAction);
+                    await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
                 }
             });
         });

--- a/src/tests/unit/tests/electron/flux/store/left-nav-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/left-nav-store.test.ts
@@ -22,7 +22,7 @@ describe('LeftNavStore', () => {
         expect(store.getState()).toMatchSnapshot();
     });
 
-    it('item selection causes state change', () => {
+    it('item selection causes state change', async () => {
         const initialState: LeftNavStoreData = {
             selectedKey: 'needs-review',
             leftNavVisible: true,
@@ -32,9 +32,10 @@ describe('LeftNavStore', () => {
             leftNavVisible: false,
         };
 
-        CreateStoreTesterForLeftNavActions('itemSelected')
-            .withActionParam(expectedState.selectedKey)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester = createStoreTesterForLeftNavActions('itemSelected').withActionParam(
+            expectedState.selectedKey,
+        );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     it.each([
@@ -42,7 +43,7 @@ describe('LeftNavStore', () => {
         [false, true],
         [false, false],
         [true, true],
-    ])('setLeftNavVisible causes state change', (initialValue, expectedValue) => {
+    ])('setLeftNavVisible causes state change', async (initialValue, expectedValue) => {
         const initialState: LeftNavStoreData = {
             selectedKey: 'needs-review',
             leftNavVisible: initialValue,
@@ -52,12 +53,12 @@ describe('LeftNavStore', () => {
             leftNavVisible: expectedValue,
         };
 
-        CreateStoreTesterForLeftNavActions('setLeftNavVisible')
-            .withActionParam(expectedValue)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForLeftNavActions('setLeftNavVisible').withActionParam(expectedValue);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    function CreateStoreTesterForLeftNavActions(
+    function createStoreTesterForLeftNavActions(
         actionName: keyof LeftNavActions,
     ): StoreTester<LeftNavStoreData, LeftNavActions> {
         const factory = (actions: LeftNavActions) => new LeftNavStore(actions);

--- a/src/tests/unit/tests/electron/flux/store/scan-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/scan-store.test.ts
@@ -34,44 +34,38 @@ describe('ScanStore', () => {
                 ScanStatus[ScanStatus.Failed],
             ];
 
-            it.each(initialStatuses)('from initial state <%s>', initialStatus => {
+            it.each(initialStatuses)('from initial state <%s>', async initialStatus => {
                 initialState.status = ScanStatus[initialStatus];
 
                 const expectedState: ScanStoreData = {
                     status: ScanStatus.Scanning,
                 };
 
-                createStoreTesterForScanActions('scanStarted').testListenerToBeCalledOnce(
-                    initialState,
-                    expectedState,
-                );
+                const storeTester = createStoreTesterForScanActions('scanStarted');
+                await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
             });
         });
 
-        it('does not update if already scanning', () => {
+        it('does not update if already scanning', async () => {
             initialState.status = ScanStatus.Scanning;
 
             const expectedState: ScanStoreData = { ...initialState };
 
-            createStoreTesterForScanActions('scanStarted').testListenerToNeverBeCalled(
-                initialState,
-                expectedState,
-            );
+            const storeTester = createStoreTesterForScanActions('scanStarted');
+            await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
         });
     });
 
     describe('on scan completed', () => {
-        it('updates to completed', () => {
+        it('updates to completed', async () => {
             initialState.status = ScanStatus.Scanning;
 
             const expectedState: ScanStoreData = {
                 status: ScanStatus.Completed,
             };
 
-            createStoreTesterForScanActions('scanCompleted').testListenerToBeCalledOnce(
-                initialState,
-                expectedState,
-            );
+            const storeTester = createStoreTesterForScanActions('scanCompleted');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
 
         describe('does not update if previous state is not scanning', () => {
@@ -81,31 +75,27 @@ describe('ScanStore', () => {
                 ScanStatus[ScanStatus.Completed],
             ];
 
-            it.each(initialStatuses)('with initial status <%s>', initialStatus => {
+            it.each(initialStatuses)('with initial status <%s>', async initialStatus => {
                 initialState.status = ScanStatus[initialStatus];
 
                 const expectedState: ScanStoreData = { ...initialState };
 
-                createStoreTesterForScanActions('scanCompleted').testListenerToNeverBeCalled(
-                    initialState,
-                    expectedState,
-                );
+                const storeTester = createStoreTesterForScanActions('scanCompleted');
+                await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
             });
         });
     });
 
     describe('on scan failed', () => {
-        it('updates to failed', () => {
+        it('updates to failed', async () => {
             initialState.status = ScanStatus.Scanning;
 
             const expectedState: ScanStoreData = {
                 status: ScanStatus.Failed,
             };
 
-            createStoreTesterForScanActions('scanFailed').testListenerToBeCalledOnce(
-                initialState,
-                expectedState,
-            );
+            const storeTester = createStoreTesterForScanActions('scanFailed');
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
 
         describe('does not update if previous state is not scanning', () => {
@@ -115,15 +105,13 @@ describe('ScanStore', () => {
                 ScanStatus[ScanStatus.Completed],
             ];
 
-            it.each(initialStatuses)('with initial status <%s>', initialStatus => {
+            it.each(initialStatuses)('with initial status <%s>', async initialStatus => {
                 initialState.status = ScanStatus[initialStatus];
 
                 const expectedState: ScanStoreData = { ...initialState };
 
-                createStoreTesterForScanActions('scanFailed').testListenerToNeverBeCalled(
-                    initialState,
-                    expectedState,
-                );
+                const storeTester = createStoreTesterForScanActions('scanFailed');
+                await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
             });
         });
     });

--- a/src/tests/unit/tests/electron/flux/store/tab-stops-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/tab-stops-store.test.ts
@@ -22,7 +22,7 @@ describe('TabStopsStore', () => {
         expect(store.getState()).toMatchSnapshot();
     });
 
-    it('onEnableFocusTracking', () => {
+    it('onEnableFocusTracking', async () => {
         const initialState: TabStopsStoreData = {
             focusTracking: false,
         };
@@ -30,13 +30,11 @@ describe('TabStopsStore', () => {
             focusTracking: true,
         };
 
-        CreateStoreTesterForTabStopsActions('enableFocusTracking').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForTabStopsActions('enableFocusTracking');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    it('onDisableFocusTracking', () => {
+    it('onDisableFocusTracking', async () => {
         const initialState: TabStopsStoreData = {
             focusTracking: true,
         };
@@ -44,13 +42,11 @@ describe('TabStopsStore', () => {
             focusTracking: false,
         };
 
-        CreateStoreTesterForTabStopsActions('disableFocusTracking').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForTabStopsActions('disableFocusTracking');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    it('onStartOver', () => {
+    it('onStartOver', async () => {
         const initialState: TabStopsStoreData = {
             focusTracking: true,
         };
@@ -58,13 +54,11 @@ describe('TabStopsStore', () => {
             focusTracking: false,
         };
 
-        CreateStoreTesterForTabStopsActions('startOver').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        const storeTester = createStoreTesterForTabStopsActions('startOver');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    function CreateStoreTesterForTabStopsActions(
+    function createStoreTesterForTabStopsActions(
         actionName: keyof TabStopsActions,
     ): StoreTester<TabStopsStoreData, TabStopsActions> {
         const factory = (actions: TabStopsActions) => new TabStopsStore(actions);

--- a/src/tests/unit/tests/electron/flux/store/window-state-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/window-state-store.test.ts
@@ -22,7 +22,7 @@ describe('WindowStateStore', () => {
         expect(testSubject.getState()).toMatchSnapshot();
     });
 
-    it('changes route id from default to resultsView', () => {
+    it('changes route id from default to resultsView', async () => {
         const payload: RoutePayload = {
             routeId: 'resultsView',
         };
@@ -33,12 +33,12 @@ describe('WindowStateStore', () => {
 
         const initialState = createStoreWithNullParams(WindowStateStore).getDefaultState();
 
-        createStoreTesterForWindowStateActions('setRoute')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForWindowStateActions('setRoute').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    it('does not emit a change when the route is not changing', () => {
+    it('does not emit a change when the route is not changing', async () => {
         const payload: RoutePayload = {
             routeId: 'deviceConnectView',
         };
@@ -49,12 +49,12 @@ describe('WindowStateStore', () => {
 
         const initialState = createStoreWithNullParams(WindowStateStore).getDefaultState();
 
-        createStoreTesterForWindowStateActions('setRoute')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForWindowStateActions('setRoute').withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    it('does not emit a change when the window state is not changing', () => {
+    it('does not emit a change when the window state is not changing', async () => {
         const payload: WindowStatePayload = {
             currentWindowState: 'customSize',
         };
@@ -65,12 +65,12 @@ describe('WindowStateStore', () => {
 
         const initialState = createStoreWithNullParams(WindowStateStore).getDefaultState();
 
-        createStoreTesterForWindowStateActions('setWindowState')
-            .withActionParam(payload)
-            .testListenerToNeverBeCalled(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForWindowStateActions('setWindowState').withActionParam(payload);
+        await storeTester.testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    it('changes currentWindowState from default to maximized', () => {
+    it('changes currentWindowState from default to maximized', async () => {
         const payload: WindowStatePayload = {
             currentWindowState: 'maximized',
         };
@@ -81,9 +81,9 @@ describe('WindowStateStore', () => {
 
         const initialState = createStoreWithNullParams(WindowStateStore).getDefaultState();
 
-        createStoreTesterForWindowStateActions('setWindowState')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+        const storeTester =
+            createStoreTesterForWindowStateActions('setWindowState').withActionParam(payload);
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function createStoreTesterForWindowStateActions(


### PR DESCRIPTION
#### Details

Refactor StoreTester to await async action listeners and update unit tests that use StoreTester

##### Motivation

Feature work (Addresses comment on #5763)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
