### PR TITLE
fix: remove extra fields in InspectTelemetryData

### DIFF
--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -174,11 +174,6 @@ export type ModifiedCommandsTelemetryData = {
     modifiedCommands: string;
 };
 
-export type InspectTelemetryData = {
-    frameUrl?: string;
-    target?: string[];
-} & BaseTelemetryData;
-
 export type ScopingTelemetryData = {
     inputType: string;
 } & BaseTelemetryData;
@@ -282,7 +277,6 @@ export type TelemetryData =
     | DetailsViewPivotSelectedTelemetryData
     | RequirementSelectTelemetryData
     | ModifiedCommandsTelemetryData
-    | InspectTelemetryData
     | AssessmentTelemetryData
     | ScopingTelemetryData
     | RequirementActionTelemetryData

--- a/src/common/message-creators/dev-tool-action-message-creator.ts
+++ b/src/common/message-creators/dev-tool-action-message-creator.ts
@@ -31,7 +31,7 @@ export class DevToolActionMessageCreator {
     public setInspectElement(event: React.SyntheticEvent<MouseEvent>, target: string[]): void {
         const payload: InspectElementPayload = {
             target: target,
-            telemetry: this.telemetryFactory.forInspectElement(event, target),
+            telemetry: this.telemetryFactory.forInspectElement(event),
         };
         const message: Message = {
             messageType: Messages.DevTools.InspectElement,

--- a/src/common/telemetry-data-factory.ts
+++ b/src/common/telemetry-data-factory.ts
@@ -17,7 +17,6 @@ import {
     ExportResultsTelemetryData,
     FeatureFlagToggleTelemetryData,
     FileIssueClickTelemetryData,
-    InspectTelemetryData,
     IssuesAnalyzerScanTelemetryData,
     NeedsReviewAnalyzerScanTelemetryData,
     ReportExportFormat,
@@ -242,10 +241,9 @@ export class TelemetryDataFactory {
         };
     }
 
-    public forInspectElement(event: SupportedMouseEvent, target: string[]): InspectTelemetryData {
+    public forInspectElement(event: SupportedMouseEvent): BaseTelemetryData {
         return {
             ...this.withTriggeredByAndSource(event, TelemetryEventSource.IssueDetailsDialog),
-            target: target,
         };
     }
 

--- a/src/tests/unit/tests/common/message-creators/dev-tool-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/dev-tool-action-message-creator.test.ts
@@ -48,7 +48,7 @@ describe('DevToolActionMessageCreatorTest', () => {
         const event = eventStubFactory.createKeypressEvent() as any;
         const target = ['$iframe1', 'div1'];
         const telemetryFactory = new TelemetryDataFactory();
-        const telemetry = telemetryFactory.forInspectElement(event, target);
+        const telemetry = telemetryFactory.forInspectElement(event);
         const expectedMessage = {
             messageType: Messages.DevTools.InspectElement,
             payload: {

--- a/src/tests/unit/tests/common/telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/common/telemetry-data-factory.test.ts
@@ -10,7 +10,6 @@ import {
     ExportResultsTelemetryData,
     FeatureFlagToggleTelemetryData,
     FileIssueClickTelemetryData,
-    InspectTelemetryData,
     RequirementActionTelemetryData,
     RequirementSelectTelemetryData,
     RuleAnalyzerScanTelemetryData,
@@ -281,13 +280,11 @@ describe('TelemetryDataFactoryTest', () => {
 
     test('forInspectElement', () => {
         const event = keypressEvent;
-        const target = ['#frame', 'div'];
-        const result: InspectTelemetryData = testObject.forInspectElement(event, target);
+        const result: BaseTelemetryData = testObject.forInspectElement(event);
 
-        const expected: InspectTelemetryData = {
+        const expected: BaseTelemetryData = {
             triggeredBy: 'keypress',
             source: TelemetryEventSource.IssueDetailsDialog,
-            target: target,
         };
 
         expect(result).toEqual(expected);


### PR DESCRIPTION
#### Details

When the 'inspect' button is clicked, we don't want some of the current fields in telemetry. This PR removes the extra properties so that the sent data is limited.

##### Motivation

Limit the amount of data in telemetry

##### Context

Once #5728 is merged, I might explore whether we can restrict `BaseTelemetryData` to exclude properties with the type `Target`. This might help avoid regressing the behavior in the future.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
