### PR TITLE
refactor(mv3-part-5): MockInterpreter

### DIFF
--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -32,15 +32,14 @@ import {
     ScanCompletedPayload,
     ScanUpdatePayload,
 } from 'injected/analyzers/analyzer';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import {
-    createSyncActionMock,
-    createInterpreterMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('AssessmentActionCreatorTest', () => {
     let assessmentActionsMock: IMock<AssessmentActions>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let interpreterMock: MockInterpreter;
 
     const AssessmentMessages = Messages.Assessment;
     const testTabId = -1;
@@ -54,20 +53,15 @@ describe('AssessmentActionCreatorTest', () => {
     beforeEach(() => {
         assessmentActionsMock = Mock.ofType(AssessmentActions, MockBehavior.Strict);
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        interpreterMock = new MockInterpreter();
     });
 
-    it('handles PassUnmarkedInstances message', () => {
+    it('handles PassUnmarkedInstances message', async () => {
         const updateTabIdActionMock = createSyncActionMock(testTabId);
         const passUnmarkedInstanceActionMock = createSyncActionMock(telemetryOnlyPayload);
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('passUnmarkedInstance', passUnmarkedInstanceActionMock);
-
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.PassUnmarkedInstances,
-            telemetryOnlyPayload,
-            testTabId,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -76,6 +70,12 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            AssessmentMessages.PassUnmarkedInstances,
+            telemetryOnlyPayload,
+            testTabId,
+        );
 
         updateTabIdActionMock.verifyAll();
         passUnmarkedInstanceActionMock.verifyAll();
@@ -89,16 +89,11 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles ContinuePreviousAssessment message', () => {
+    it('handles ContinuePreviousAssessment message', async () => {
         const continuePreviousAssessmentMock = createSyncActionMock(testTabId);
         const actionsMock = createActionsMock(
             'continuePreviousAssessment',
             continuePreviousAssessmentMock.object,
-        );
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.ContinuePreviousAssessment,
-            telemetryOnlyPayload,
-            testTabId,
         );
 
         const testSubject = new AssessmentActionCreator(
@@ -108,6 +103,12 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            AssessmentMessages.ContinuePreviousAssessment,
+            telemetryOnlyPayload,
+            testTabId,
+        );
 
         continuePreviousAssessmentMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -120,7 +121,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles EditFailureInstance message', () => {
+    it('handles EditFailureInstance message', async () => {
         const payload: EditFailureInstancePayload = {
             id: 'test-id',
             ...telemetryOnlyPayload,
@@ -131,11 +132,6 @@ describe('AssessmentActionCreatorTest', () => {
             'editFailureInstance',
             editFailureInstanceMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.EditFailureInstance,
-            payload,
-            testTabId,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -145,6 +141,12 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(
+            AssessmentMessages.EditFailureInstance,
+            payload,
+            testTabId,
+        );
+
         editFailureInstanceMock.verifyAll();
         telemetryEventHandlerMock.verify(
             tp => tp.publishTelemetry(TelemetryEvents.EDIT_FAILURE_INSTANCE, payload),
@@ -152,7 +154,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles RemoveFailureInstance message', () => {
+    it('handles RemoveFailureInstance message', async () => {
         const payload: RemoveFailureInstancePayload = {
             id: 'test-id',
             ...telemetryOnlyPayload,
@@ -163,10 +165,6 @@ describe('AssessmentActionCreatorTest', () => {
             'removeFailureInstance',
             removeFailureInstanceMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.RemoveFailureInstance,
-            payload,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -175,6 +173,8 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(AssessmentMessages.RemoveFailureInstance, payload);
 
         removeFailureInstanceMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -183,7 +183,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles AddFailureInstance message', () => {
+    it('handles AddFailureInstance message', async () => {
         const payload: AddFailureInstancePayload = {
             test: -1 as VisualizationType,
             ...telemetryOnlyPayload,
@@ -191,10 +191,6 @@ describe('AssessmentActionCreatorTest', () => {
 
         const addFailureInstanceMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('addFailureInstance', addFailureInstanceMock.object);
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.AddFailureInstance,
-            payload,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -204,6 +200,8 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(AssessmentMessages.AddFailureInstance, payload);
+
         addFailureInstanceMock.verifyAll();
         telemetryEventHandlerMock.verify(
             handler => handler.publishTelemetry(TelemetryEvents.ADD_FAILURE_INSTANCE, payload),
@@ -211,7 +209,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles AddResultDescription message', () => {
+    it('handles AddResultDescription message', async () => {
         const payload: AddResultDescriptionPayload = {
             description: 'test-description',
         };
@@ -221,10 +219,6 @@ describe('AssessmentActionCreatorTest', () => {
             'addResultDescription',
             addResultDescriptionMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.AddResultDescription,
-            payload,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -234,10 +228,12 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(AssessmentMessages.AddResultDescription, payload);
+
         addResultDescriptionMock.verifyAll();
     });
 
-    it('handles ChangeManualRequirementStatus message', () => {
+    it('handles ChangeManualRequirementStatus message', async () => {
         const payload: ChangeRequirementStatusPayload = {
             test: -1 as VisualizationType,
             ...telemetryOnlyPayload,
@@ -249,12 +245,6 @@ describe('AssessmentActionCreatorTest', () => {
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('changeRequirementStatus', changeRequirementStatusMock);
 
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.ChangeRequirementStatus,
-            payload,
-            testTabId,
-        );
-
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
             assessmentActionsMock.object,
@@ -262,6 +252,12 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            AssessmentMessages.ChangeRequirementStatus,
+            payload,
+            testTabId,
+        );
 
         changeRequirementStatusMock.verifyAll();
         updateTabIdActionMock.verifyAll();
@@ -271,7 +267,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles UndoChangeManualRequirementStatus message', () => {
+    it('handles UndoChangeManualRequirementStatus message', async () => {
         const payload: ChangeRequirementStatusPayload = {
             test: -1 as VisualizationType,
             ...telemetryOnlyPayload,
@@ -282,11 +278,6 @@ describe('AssessmentActionCreatorTest', () => {
             'undoRequirementStatusChange',
             undoRequirementStatusChange.object,
         );
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.UndoChangeRequirementStatus,
-            payload,
-            testTabId,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -296,6 +287,12 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(
+            AssessmentMessages.UndoChangeRequirementStatus,
+            payload,
+            testTabId,
+        );
+
         undoRequirementStatusChange.verifyAll();
         telemetryEventHandlerMock.verify(
             handler =>
@@ -304,7 +301,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles UndoAssessmentInstanceStatusChange message', () => {
+    it('handles UndoAssessmentInstanceStatusChange message', async () => {
         const payload: AssessmentActionInstancePayload = {
             test: -1 as VisualizationType,
             ...telemetryOnlyPayload,
@@ -315,7 +312,6 @@ describe('AssessmentActionCreatorTest', () => {
             'undoInstanceStatusChange',
             undoInstanceStatusChangeMock.object,
         );
-        const interpreterMock = createInterpreterMock(AssessmentMessages.Undo, payload);
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -325,6 +321,8 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(AssessmentMessages.Undo, payload);
+
         undoInstanceStatusChangeMock.verifyAll();
         telemetryEventHandlerMock.verify(
             handler => handler.publishTelemetry(TelemetryEvents.UNDO_TEST_STATUS_CHANGE, payload),
@@ -332,7 +330,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles ChangeAssessmentInstanceStatus message', () => {
+    it('handles ChangeAssessmentInstanceStatus message', async () => {
         const payload: ChangeInstanceSelectionPayload = {
             selector: 'test-selector',
             ...telemetryOnlyPayload,
@@ -344,12 +342,6 @@ describe('AssessmentActionCreatorTest', () => {
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('changeInstanceStatus', changeInstanceStatusMock);
 
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.ChangeStatus,
-            payload,
-            testTabId,
-        );
-
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
             assessmentActionsMock.object,
@@ -357,6 +349,8 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(AssessmentMessages.ChangeStatus, payload, testTabId);
 
         changeInstanceStatusMock.verifyAll();
         updateTabIdActionMock.verifyAll();
@@ -366,7 +360,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles ChangeAssessmentVisualizationState message', () => {
+    it('handles ChangeAssessmentVisualizationState message', async () => {
         const payload: ChangeInstanceSelectionPayload = {
             isVisualizationEnabled: true,
             ...telemetryOnlyPayload,
@@ -377,10 +371,6 @@ describe('AssessmentActionCreatorTest', () => {
             'changeAssessmentVisualizationState',
             changeAssessmentVisualizationStateMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.ChangeVisualizationState,
-            payload,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -389,6 +379,8 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(AssessmentMessages.ChangeVisualizationState, payload);
 
         changeAssessmentVisualizationStateMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -401,7 +393,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles ChangeVisualizationStateForAll message', () => {
+    it('handles ChangeVisualizationStateForAll message', async () => {
         const payload: ChangeInstanceSelectionPayload = {
             isVisualizationEnabled: true,
             ...telemetryOnlyPayload,
@@ -412,11 +404,6 @@ describe('AssessmentActionCreatorTest', () => {
             'changeAssessmentVisualizationStateForAll',
             changeAssessmentVisualizationStateForAllMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.ChangeVisualizationStateForAll,
-            payload,
-            testTabId,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -425,6 +412,12 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            AssessmentMessages.ChangeVisualizationStateForAll,
+            payload,
+            testTabId,
+        );
 
         changeAssessmentVisualizationStateForAllMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -437,14 +430,13 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles StartOverAssessment message', () => {
+    it('handles StartOverAssessment message', async () => {
         const payload: ToggleActionPayload = {
             test: -1 as VisualizationType,
         };
 
         const resetDataMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('resetData', resetDataMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.StartOverTest, payload);
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -454,10 +446,12 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(AssessmentMessages.StartOverTest, payload);
+
         resetDataMock.verifyAll();
     });
 
-    it('handles StartOverAllAssessments message', () => {
+    it('handles StartOverAllAssessments message', async () => {
         const payload = {};
 
         const resetAllAssessmentsData = createSyncActionMock(testTabId);
@@ -465,11 +459,6 @@ describe('AssessmentActionCreatorTest', () => {
             'resetAllAssessmentsData',
             resetAllAssessmentsData.object,
         );
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.StartOverAllAssessments,
-            payload,
-            testTabId,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -479,10 +468,16 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(
+            AssessmentMessages.StartOverAllAssessments,
+            payload,
+            testTabId,
+        );
+
         resetAllAssessmentsData.verifyAll();
     });
 
-    it('handles AssessmentScanCompleted message', () => {
+    it('handles AssessmentScanCompleted message', async () => {
         const payload: ScanCompletedPayload<any> = {
             key: 'test-key',
         } as ScanCompletedPayload<any>;
@@ -493,12 +488,6 @@ describe('AssessmentActionCreatorTest', () => {
         setupAssessmentActionsMock('scanCompleted', scanCompleteMock);
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
 
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.AssessmentScanCompleted,
-            payload,
-            testTabId,
-        );
-
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
             assessmentActionsMock.object,
@@ -507,16 +496,18 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(
+            AssessmentMessages.AssessmentScanCompleted,
+            payload,
+            testTabId,
+        );
+
         scanCompleteMock.verifyAll();
     });
 
-    it('handles GetCurrentState message', () => {
+    it('handles GetCurrentState message', async () => {
         const getCurrentStateMock = createSyncActionMock<void>(null);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(
-            getStoreStateMessage(StoreNames.AssessmentStore),
-            null,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -526,10 +517,15 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(
+            getStoreStateMessage(StoreNames.AssessmentStore),
+            null,
+        );
+
         getCurrentStateMock.verifyAll();
     });
 
-    it('handles SelectTestRequirement message', () => {
+    it('handles SelectTestRequirement message', async () => {
         const payload: SelectTestSubviewPayload = {
             selectedTestSubview: 'test-requirement',
             ...telemetryOnlyPayload,
@@ -537,10 +533,6 @@ describe('AssessmentActionCreatorTest', () => {
 
         const selectRequirementMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('selectTestSubview', selectRequirementMock.object);
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.SelectTestRequirement,
-            payload,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -549,6 +541,8 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(AssessmentMessages.SelectTestRequirement, payload);
 
         selectRequirementMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -557,7 +551,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles SelectNextRequirement message', () => {
+    it('handles SelectNextRequirement message', async () => {
         const payload: SelectTestSubviewPayload = {
             selectedTestSubview: 'test-requirement',
             ...telemetryOnlyPayload,
@@ -565,10 +559,6 @@ describe('AssessmentActionCreatorTest', () => {
 
         const selectNextRequirement = createSyncActionMock(payload);
         const actionsMock = createActionsMock('selectTestSubview', selectNextRequirement.object);
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.SelectNextRequirement,
-            payload,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -578,6 +568,8 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(AssessmentMessages.SelectNextRequirement, payload);
+
         selectNextRequirement.verifyAll();
         telemetryEventHandlerMock.verify(
             tp => tp.publishTelemetry(TelemetryEvents.SELECT_NEXT_REQUIREMENT, payload),
@@ -585,7 +577,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles SelectGettingStarted message', () => {
+    it('handles SelectGettingStarted message', async () => {
         const payload: SelectGettingStartedPayload = {
             ...telemetryOnlyPayload,
         } as SelectGettingStartedPayload;
@@ -596,10 +588,6 @@ describe('AssessmentActionCreatorTest', () => {
 
         const selectRequirementMock = createSyncActionMock(actionPayload);
         const actionsMock = createActionsMock('selectTestSubview', selectRequirementMock.object);
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.SelectGettingStarted,
-            payload,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -608,6 +596,8 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(AssessmentMessages.SelectGettingStarted, payload);
 
         selectRequirementMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -616,14 +606,13 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles ExpandTestNav message', () => {
+    it('handles ExpandTestNav message', async () => {
         const payload: ExpandTestNavPayload = {
             selectedTest: 1,
         } as ExpandTestNavPayload;
 
         const expandTestNavMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('expandTestNav', expandTestNavMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.ExpandTestNav, payload);
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -632,14 +621,15 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(AssessmentMessages.ExpandTestNav, payload);
 
         expandTestNavMock.verifyAll();
     });
 
-    it('handles CollapseTestNav message', () => {
+    it('handles CollapseTestNav message', async () => {
         const collapseTestNavMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('collapseTestNav', collapseTestNavMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.CollapseTestNav, null);
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -649,10 +639,12 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(AssessmentMessages.CollapseTestNav, null);
+
         collapseTestNavMock.verifyAll();
     });
 
-    it('handles ScanUpdate message', () => {
+    it('handles ScanUpdate message', async () => {
         const payload: ScanUpdatePayload = {
             key: 'hello',
             ...telemetryOnlyPayload,
@@ -660,7 +652,6 @@ describe('AssessmentActionCreatorTest', () => {
 
         const scanUpdateMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('scanUpdate', scanUpdateMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.ScanUpdate, payload);
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -669,6 +660,8 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(AssessmentMessages.ScanUpdate, payload);
 
         scanUpdateMock.verifyAll();
         telemetryEventHandlerMock
@@ -676,7 +669,7 @@ describe('AssessmentActionCreatorTest', () => {
             .verifiable(Times.once());
     });
 
-    it('handles TrackingCompleted message', () => {
+    it('handles TrackingCompleted message', async () => {
         const payload: ScanBasePayload = {
             key: 'hello',
             ...telemetryOnlyPayload,
@@ -684,10 +677,6 @@ describe('AssessmentActionCreatorTest', () => {
 
         const trackingCompletedMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('trackingCompleted', trackingCompletedMock.object);
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.TrackingCompleted,
-            payload,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -696,6 +685,8 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(AssessmentMessages.TrackingCompleted, payload);
 
         trackingCompletedMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -704,7 +695,7 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles PivotChildSelected message', () => {
+    it('handles PivotChildSelected message', async () => {
         const payload: OnDetailsViewOpenPayload = {
             pivotType: -1 as DetailsViewPivotType,
         } as OnDetailsViewOpenPayload;
@@ -714,10 +705,6 @@ describe('AssessmentActionCreatorTest', () => {
             'updateSelectedPivotChild',
             updateSelectedPivotChildMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.DetailsView.Select,
-            payload,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -727,16 +714,12 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(Messages.Visualizations.DetailsView.Select, payload);
+
         updateSelectedPivotChildMock.verifyAll();
     });
 
-    it('handles SaveAssessment message', () => {
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.SaveAssessment,
-            telemetryOnlyPayload,
-            testTabId,
-        );
-
+    it('handles SaveAssessment message', async () => {
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
             assessmentActionsMock.object,
@@ -745,6 +728,12 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(
+            AssessmentMessages.SaveAssessment,
+            telemetryOnlyPayload,
+            testTabId,
+        );
+
         telemetryEventHandlerMock.verify(
             handler =>
                 handler.publishTelemetry(TelemetryEvents.SAVE_ASSESSMENT, telemetryOnlyPayload),
@@ -752,17 +741,13 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles DetailsViewInitialize message', () => {
+    it('handles DetailsViewInitialize message', async () => {
         const payload: OnDetailsViewInitializedPayload = {
             detailsViewId: 'testId',
         } as OnDetailsViewInitializedPayload;
 
         const detailsViewInitMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('updateDetailsViewId', detailsViewInitMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.DetailsView.Initialize,
-            payload,
-        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -771,6 +756,11 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.Visualizations.DetailsView.Initialize,
+            payload,
+        );
 
         detailsViewInitMock.verifyAll();
     });

--- a/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
@@ -10,22 +10,22 @@ import { CardSelectionActions } from 'background/actions/card-selection-actions'
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import * as TelemetryEvents from 'common/extension-telemetry-events';
 import { Messages } from 'common/messages';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
 
-import {
-    createSyncActionMock,
-    createInterpreterMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('CardSelectionActionCreator', () => {
     const tabId = -2;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let interpreterMock: MockInterpreter;
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        interpreterMock = new MockInterpreter();
     });
 
-    it('handles card selection toggle', () => {
+    it('handles card selection toggle', async () => {
         const payload: CardSelectionPayload = {
             resultInstanceUid: 'test-instance-uuid',
             ruleId: 'test-rule-id',
@@ -35,11 +35,6 @@ describe('CardSelectionActionCreator', () => {
             'toggleCardSelection',
             toggleCardSelectionMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            Messages.CardSelection.CardSelectionToggled,
-            payload,
-            tabId,
-        );
 
         const testSubject = new CardSelectionActionCreator(
             interpreterMock.object,
@@ -48,6 +43,12 @@ describe('CardSelectionActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.CardSelection.CardSelectionToggled,
+            payload,
+            tabId,
+        );
 
         toggleCardSelectionMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -56,7 +57,7 @@ describe('CardSelectionActionCreator', () => {
         );
     });
 
-    test('onRuleExpansionToggle', () => {
+    test('onRuleExpansionToggle', async () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'test-rule-id',
         };
@@ -65,11 +66,6 @@ describe('CardSelectionActionCreator', () => {
             'toggleRuleExpandCollapse',
             ruleExpansionToggleMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            Messages.CardSelection.RuleExpansionToggled,
-            payload,
-            tabId,
-        );
 
         const testSubject = new CardSelectionActionCreator(
             interpreterMock.object,
@@ -78,6 +74,12 @@ describe('CardSelectionActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.CardSelection.RuleExpansionToggled,
+            payload,
+            tabId,
+        );
 
         ruleExpansionToggleMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -86,15 +88,10 @@ describe('CardSelectionActionCreator', () => {
         );
     });
 
-    test('onToggleVisualHelper', () => {
+    test('onToggleVisualHelper', async () => {
         const payloadStub: BaseActionPayload = {};
         const toggleVisualHelperMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('toggleVisualHelper', toggleVisualHelperMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.CardSelection.ToggleVisualHelper,
-            payloadStub,
-            tabId,
-        );
 
         const testSubject = new CardSelectionActionCreator(
             interpreterMock.object,
@@ -103,6 +100,12 @@ describe('CardSelectionActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.CardSelection.ToggleVisualHelper,
+            payloadStub,
+            tabId,
+        );
 
         toggleVisualHelperMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -111,17 +114,12 @@ describe('CardSelectionActionCreator', () => {
         );
     });
 
-    test('onCollapseAllRules', () => {
+    test('onCollapseAllRules', async () => {
         const payloadStub: BaseActionPayload = {};
         const collapseAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock(
             'collapseAllRules',
             collapseAllRulesActionMock.object,
-        );
-        const interpreterMock = createInterpreterMock(
-            Messages.CardSelection.CollapseAllRules,
-            payloadStub,
-            tabId,
         );
 
         const testSubject = new CardSelectionActionCreator(
@@ -131,6 +129,12 @@ describe('CardSelectionActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.CardSelection.CollapseAllRules,
+            payloadStub,
+            tabId,
+        );
 
         collapseAllRulesActionMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -139,15 +143,10 @@ describe('CardSelectionActionCreator', () => {
         );
     });
 
-    test('onExpandAllRules', () => {
+    test('onExpandAllRules', async () => {
         const payloadStub: BaseActionPayload = {};
         const expandAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('expandAllRules', expandAllRulesActionMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.CardSelection.ExpandAllRules,
-            payloadStub,
-            tabId,
-        );
 
         const testSubject = new CardSelectionActionCreator(
             interpreterMock.object,
@@ -156,6 +155,12 @@ describe('CardSelectionActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.CardSelection.ExpandAllRules,
+            payloadStub,
+            tabId,
+        );
 
         expandAllRulesActionMock.verifyAll();
         telemetryEventHandlerMock.verify(

--- a/src/tests/unit/tests/background/actions/content-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/content-action-creator.test.ts
@@ -4,7 +4,6 @@ import { BaseActionPayload } from 'background/actions/action-payloads';
 import { ContentActionCreator } from 'background/actions/content-action-creator';
 import { ContentActions, ContentPayload } from 'background/actions/content-actions';
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
-import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import {
     CONTENT_PANEL_CLOSED,
@@ -14,17 +13,14 @@ import {
 import { SyncAction } from 'common/flux/sync-action';
 import { Logger } from 'common/logging/logger';
 import { Messages } from 'common/messages';
-import { flushSettledPromises } from 'tests/common/flush-settled-promises';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
-import {
-    createSyncActionMock,
-    createInterpreterMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('ContentActionMessageCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let actionsMock: IMock<ContentActions>;
-    let interpreterMock: IMock<Interpreter>;
+    let interpreterMock: MockInterpreter;
     let testSubject: ContentActionCreator;
 
     beforeEach(() => {
@@ -50,11 +46,8 @@ describe('ContentActionMessageCreator', () => {
         beforeEach(() => {
             openContentPanelMock = createSyncActionMock(payload);
             actionsMock = createActionsMock('openContentPanel', openContentPanelMock.object);
-            interpreterMock = createInterpreterMock(
-                Messages.ContentPanel.OpenPanel,
-                payload,
-                tabId,
-            );
+            interpreterMock = new MockInterpreter();
+
             detailsViewControllerMock = Mock.ofType<ExtensionDetailsViewController>();
             loggerMock = Mock.ofType<Logger>();
             testSubject = new ContentActionCreator(
@@ -74,8 +67,7 @@ describe('ContentActionMessageCreator', () => {
                 .verifiable(Times.once());
 
             testSubject.registerCallbacks();
-
-            await flushSettledPromises();
+            await interpreterMock.simulateMessage(Messages.ContentPanel.OpenPanel, payload, tabId);
 
             openContentPanelMock.verifyAll();
             detailsViewControllerMock.verifyAll();
@@ -93,8 +85,7 @@ describe('ContentActionMessageCreator', () => {
                 .verifiable(Times.once());
 
             testSubject.registerCallbacks();
-
-            await flushSettledPromises();
+            await interpreterMock.simulateMessage(Messages.ContentPanel.OpenPanel, payload, tabId);
 
             openContentPanelMock.verifyAll();
             detailsViewControllerMock.verifyAll();
@@ -105,7 +96,7 @@ describe('ContentActionMessageCreator', () => {
         });
     });
 
-    it('handles ClosePanel message', () => {
+    it('handles ClosePanel message', async () => {
         const payload: BaseActionPayload = {
             telemetry: {
                 triggeredBy: 'N/A',
@@ -115,7 +106,6 @@ describe('ContentActionMessageCreator', () => {
 
         const closeContentPanelMock = createSyncActionMock<void>(undefined);
         actionsMock = createActionsMock('closeContentPanel', closeContentPanelMock.object);
-        interpreterMock = createInterpreterMock(Messages.ContentPanel.ClosePanel, payload);
 
         testSubject = new ContentActionCreator(
             interpreterMock.object,
@@ -125,6 +115,8 @@ describe('ContentActionMessageCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(Messages.ContentPanel.ClosePanel, payload);
 
         closeContentPanelMock.verifyAll();
         telemetryEventHandlerMock.verify(

--- a/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
@@ -7,25 +7,24 @@ import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-hand
 import * as TelemetryEvents from 'common/extension-telemetry-events';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
-import {
-    createSyncActionMock,
-    createInterpreterMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('DevToolsActionCreatorTest', () => {
     const tabId: number = -1;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let interpreterMock: MockInterpreter;
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
+        interpreterMock = new MockInterpreter();
     });
 
-    it('handles DevToolOpened message', () => {
+    it('handles DevToolOpened message', async () => {
         const setDevToolsStateMock = createSyncActionMock(true);
         const actionsMock = createActionsMock('setDevToolState', setDevToolsStateMock.object);
-        const interpreterMock = createInterpreterMock(Messages.DevTools.Opened, null, tabId);
 
         const newTestObject = new DevToolsActionCreator(
             interpreterMock.object,
@@ -35,13 +34,14 @@ describe('DevToolsActionCreatorTest', () => {
 
         newTestObject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(Messages.DevTools.Opened, null, tabId);
+
         setDevToolsStateMock.verifyAll();
     });
 
-    it('handles DevToolClosed message', () => {
+    it('handles DevToolClosed message', async () => {
         const setDevToolsStateMock = createSyncActionMock(false);
         const actionsMock = createActionsMock('setDevToolState', setDevToolsStateMock.object);
-        const interpreterMock = createInterpreterMock(Messages.DevTools.Closed, undefined, tabId);
 
         const newTestObject = new DevToolsActionCreator(
             interpreterMock.object,
@@ -51,41 +51,38 @@ describe('DevToolsActionCreatorTest', () => {
 
         newTestObject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(Messages.DevTools.Closed, undefined, tabId);
+
         setDevToolsStateMock.verifyAll();
     });
 
-    it('handles GetState message', () => {
+    it('handles GetState message', async () => {
         const getCurrentStateMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(
+
+        const newTestObject = new DevToolsActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        newTestObject.registerCallbacks();
+        await interpreterMock.simulateMessage(
             getStoreStateMessage(StoreNames.DevToolsStore),
             null,
             tabId,
         );
 
-        const newTestObject = new DevToolsActionCreator(
-            interpreterMock.object,
-            actionsMock.object,
-            telemetryEventHandlerMock.object,
-        );
-
-        newTestObject.registerCallbacks();
-
         getCurrentStateMock.verifyAll();
     });
 
-    it('handles InspectFrameUrl message', () => {
+    it('handles InspectFrameUrl message', async () => {
         const payload: InspectFrameUrlPayload = {
             frameUrl: 'frame-url',
         };
 
         const setFrameUrlMock = createSyncActionMock(payload.frameUrl);
         const actionsMock = createActionsMock('setFrameUrl', setFrameUrlMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.DevTools.InspectFrameUrl,
-            payload,
-            tabId,
-        );
 
         const newTestObject = new DevToolsActionCreator(
             interpreterMock.object,
@@ -95,10 +92,12 @@ describe('DevToolsActionCreatorTest', () => {
 
         newTestObject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(Messages.DevTools.InspectFrameUrl, payload, tabId);
+
         setFrameUrlMock.verifyAll();
     });
 
-    it('handles InspectElement message', () => {
+    it('handles InspectElement message', async () => {
         const payload: InspectElementPayload = {
             target: ['target'],
         };
@@ -109,11 +108,6 @@ describe('DevToolsActionCreatorTest', () => {
 
         const setInspectElementMock = createSyncActionMock(payload.target);
         const actionsMock = createActionsMock('setInspectElement', setInspectElementMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.DevTools.InspectElement,
-            payload,
-            tabId,
-        );
 
         const newTestObject = new DevToolsActionCreator(
             interpreterMock.object,
@@ -122,6 +116,8 @@ describe('DevToolsActionCreatorTest', () => {
         );
 
         newTestObject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(Messages.DevTools.InspectElement, payload, tabId);
 
         setInspectElementMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();

--- a/src/tests/unit/tests/background/actions/injection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/injection-action-creator.test.ts
@@ -3,39 +3,42 @@
 import { InjectionActionCreator } from 'background/actions/injection-action-creator';
 import { InjectionActions } from 'background/actions/injection-actions';
 import { Messages } from 'common/messages';
-import {
-    createSyncActionMock,
-    createInterpreterMock,
-} from 'tests/unit/tests/background/global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from 'tests/unit/tests/background/global-action-creators/action-creator-test-helpers';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock } from 'typemoq';
 
 describe('InjectionActionCreator', () => {
-    it('handles InjectionStarted message', () => {
+    let interpreterMock: MockInterpreter;
+
+    beforeEach(() => {
+        interpreterMock = new MockInterpreter();
+    });
+
+    it('handles InjectionStarted message', async () => {
         const injectionStartedMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('injectionStarted', injectionStartedMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.State.InjectionStarted,
-            null,
-        );
 
         const testSubject = new InjectionActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(Messages.Visualizations.State.InjectionStarted, null);
 
         injectionStartedMock.verifyAll();
     });
 
-    it('handles InjectionCompleted message', () => {
+    it('handles InjectionCompleted message', async () => {
         const injectionCompletedMock = createSyncActionMock<void>(null);
         const actionsMock = createActionsMock('injectionCompleted', injectionCompletedMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.State.InjectionCompleted,
-            null,
-        );
 
         const testSubject = new InjectionActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.Visualizations.State.InjectionCompleted,
+            null,
+        );
 
         injectionCompletedMock.verifyAll();
     });

--- a/src/tests/unit/tests/background/actions/needs-review-card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/needs-review-card-selection-action-creator.test.ts
@@ -10,22 +10,22 @@ import { NeedsReviewCardSelectionActions } from 'background/actions/needs-review
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import * as TelemetryEvents from 'common/extension-telemetry-events';
 import { Messages } from 'common/messages';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
 
-import {
-    createSyncActionMock,
-    createInterpreterMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('NeedsReviewCardSelectionActionCreator', () => {
     const tabId = -2;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let interpreterMock: MockInterpreter;
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        interpreterMock = new MockInterpreter();
     });
 
-    it('handles card selection toggle', () => {
+    it('handles card selection toggle', async () => {
         const payload: CardSelectionPayload = {
             resultInstanceUid: 'test-instance-uuid',
             ruleId: 'test-rule-id',
@@ -35,11 +35,6 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
             'toggleCardSelection',
             toggleNeedsReviewCardSelectionMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            Messages.NeedsReviewCardSelection.CardSelectionToggled,
-            payload,
-            tabId,
-        );
 
         const testSubject = new NeedsReviewCardSelectionActionCreator(
             interpreterMock.object,
@@ -48,6 +43,12 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.NeedsReviewCardSelection.CardSelectionToggled,
+            payload,
+            tabId,
+        );
 
         toggleNeedsReviewCardSelectionMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -56,7 +57,7 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
         );
     });
 
-    test('onRuleExpansionToggle', () => {
+    test('onRuleExpansionToggle', async () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'test-rule-id',
         };
@@ -65,11 +66,6 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
             'toggleRuleExpandCollapse',
             ruleExpansionToggleMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            Messages.NeedsReviewCardSelection.RuleExpansionToggled,
-            payload,
-            tabId,
-        );
 
         const testSubject = new NeedsReviewCardSelectionActionCreator(
             interpreterMock.object,
@@ -78,6 +74,12 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.NeedsReviewCardSelection.RuleExpansionToggled,
+            payload,
+            tabId,
+        );
 
         ruleExpansionToggleMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -86,15 +88,10 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
         );
     });
 
-    test('onToggleVisualHelper', () => {
+    test('onToggleVisualHelper', async () => {
         const payloadStub: BaseActionPayload = {};
         const toggleVisualHelperMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('toggleVisualHelper', toggleVisualHelperMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.NeedsReviewCardSelection.ToggleVisualHelper,
-            payloadStub,
-            tabId,
-        );
 
         const testSubject = new NeedsReviewCardSelectionActionCreator(
             interpreterMock.object,
@@ -103,6 +100,12 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.NeedsReviewCardSelection.ToggleVisualHelper,
+            payloadStub,
+            tabId,
+        );
 
         toggleVisualHelperMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -111,17 +114,12 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
         );
     });
 
-    test('onCollapseAllRules', () => {
+    test('onCollapseAllRules', async () => {
         const payloadStub: BaseActionPayload = {};
         const collapseAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock(
             'collapseAllRules',
             collapseAllRulesActionMock.object,
-        );
-        const interpreterMock = createInterpreterMock(
-            Messages.NeedsReviewCardSelection.CollapseAllRules,
-            payloadStub,
-            tabId,
         );
 
         const testSubject = new NeedsReviewCardSelectionActionCreator(
@@ -131,6 +129,12 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.NeedsReviewCardSelection.CollapseAllRules,
+            payloadStub,
+            tabId,
+        );
 
         collapseAllRulesActionMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -139,15 +143,10 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
         );
     });
 
-    test('onExpandAllRules', () => {
+    test('onExpandAllRules', async () => {
         const payloadStub: BaseActionPayload = {};
         const expandAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('expandAllRules', expandAllRulesActionMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.NeedsReviewCardSelection.ExpandAllRules,
-            payloadStub,
-            tabId,
-        );
 
         const testSubject = new NeedsReviewCardSelectionActionCreator(
             interpreterMock.object,
@@ -156,6 +155,12 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.NeedsReviewCardSelection.ExpandAllRules,
+            payloadStub,
+            tabId,
+        );
 
         expandAllRulesActionMock.verifyAll();
         telemetryEventHandlerMock.verify(

--- a/src/tests/unit/tests/background/actions/needs-review-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/needs-review-scan-result-action-creator.test.ts
@@ -13,22 +13,22 @@ import { NotificationCreator } from 'common/notification-creator';
 import { StoreNames } from 'common/stores/store-names';
 import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete-warnings';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
-import {
-    createSyncActionMock,
-    createInterpreterMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('NeedsReviewScanResultActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let notificationCreatorMock: IMock<NotificationCreator>;
+    let interpreterMock: MockInterpreter;
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
         notificationCreatorMock = Mock.ofType<NotificationCreator>();
+        interpreterMock = new MockInterpreter();
     });
 
-    it('should handle ScanCompleted message', () => {
+    it('should handle ScanCompleted message', async () => {
         const scanIncompleteWarnings = ['test-warning-id' as ScanIncompleteWarningId];
         const telemetry = {
             scanIncompleteWarnings,
@@ -45,10 +45,6 @@ describe('NeedsReviewScanResultActionCreator', () => {
 
         const scanCompletedMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('scanCompleted', scanCompletedMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.NeedsReviewScan.ScanCompleted,
-            payload,
-        );
 
         const testSubject = new NeedsReviewScanResultActionCreator(
             interpreterMock.object,
@@ -58,6 +54,8 @@ describe('NeedsReviewScanResultActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(Messages.NeedsReviewScan.ScanCompleted, payload);
 
         scanCompletedMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -70,15 +68,11 @@ describe('NeedsReviewScanResultActionCreator', () => {
         );
     });
 
-    it('should handle GetState message', () => {
+    it('should handle GetState message', async () => {
         const payload = null;
 
         const getCurrentStateMock = createSyncActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(
-            getStoreStateMessage(StoreNames.NeedsReviewScanResultStore),
-            payload,
-        );
 
         const testSubject = new NeedsReviewScanResultActionCreator(
             interpreterMock.object,
@@ -88,6 +82,11 @@ describe('NeedsReviewScanResultActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            getStoreStateMessage(StoreNames.NeedsReviewScanResultStore),
+            payload,
+        );
 
         getCurrentStateMock.verifyAll();
     });

--- a/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
@@ -2,25 +2,25 @@
 // Licensed under the MIT License.
 import { PathSnippetActionCreator } from 'background/actions/path-snippet-action-creator';
 import { PathSnippetActions } from 'background/actions/path-snippet-actions';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock } from 'typemoq';
 
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import {
-    createSyncActionMock,
-    createInterpreterMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('PathSnippetActionCreatorTest', () => {
-    it('handles AddPathForValidation message', () => {
+    let interpreterMock: MockInterpreter;
+
+    beforeEach(() => {
+        interpreterMock = new MockInterpreter();
+    });
+
+    it('handles AddPathForValidation message', async () => {
         const payload = 'test path';
 
         const onAddPathMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('onAddPath', onAddPathMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.PathSnippet.AddPathForValidation,
-            payload,
-        );
 
         const newTestObject = new PathSnippetActionCreator(
             interpreterMock.object,
@@ -28,20 +28,37 @@ describe('PathSnippetActionCreatorTest', () => {
         );
 
         newTestObject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(Messages.PathSnippet.AddPathForValidation, payload);
 
         onAddPathMock.verifyAll();
     });
 
-    it('handles AddCorrespondingSnippet message', () => {
+    it('handles AddCorrespondingSnippet message', async () => {
         const payload = 'test snippet';
 
         const onAddSnippetMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('onAddSnippet', onAddSnippetMock.object);
-        const interpreterMock = createInterpreterMock(
+
+        const newTestObject = new PathSnippetActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+        );
+
+        newTestObject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
             Messages.PathSnippet.AddCorrespondingSnippet,
             payload,
         );
 
+        onAddSnippetMock.verifyAll();
+    });
+
+    it('handles GetPathSnippetCurrentState message', async () => {
+        const getCurrentStateMock = createSyncActionMock(undefined);
+        const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
+
         const newTestObject = new PathSnippetActionCreator(
             interpreterMock.object,
             actionsMock.object,
@@ -49,34 +66,17 @@ describe('PathSnippetActionCreatorTest', () => {
 
         newTestObject.registerCallbacks();
 
-        onAddSnippetMock.verifyAll();
-    });
-
-    it('handles GetPathSnippetCurrentState message', () => {
-        const getCurrentStateMock = createSyncActionMock(undefined);
-        const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(
+        await interpreterMock.simulateMessage(
             getStoreStateMessage(StoreNames.PathSnippetStore),
             null,
         );
 
-        const newTestObject = new PathSnippetActionCreator(
-            interpreterMock.object,
-            actionsMock.object,
-        );
-
-        newTestObject.registerCallbacks();
-
         getCurrentStateMock.verifyAll();
     });
 
-    it('handles ClearPathSnippetData message', () => {
+    it('handles ClearPathSnippetData message', async () => {
         const onClearDataMock = createSyncActionMock(undefined);
         const actionsMock = createActionsMock('onClearData', onClearDataMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.PathSnippet.ClearPathSnippetData,
-            null,
-        );
 
         const newTestObject = new PathSnippetActionCreator(
             interpreterMock.object,
@@ -84,6 +84,8 @@ describe('PathSnippetActionCreatorTest', () => {
         );
 
         newTestObject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(Messages.PathSnippet.ClearPathSnippetData, null);
 
         onClearDataMock.verifyAll();
     });

--- a/src/tests/unit/tests/background/actions/popup-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/popup-action-creator.test.ts
@@ -11,15 +11,13 @@ import {
     TriggeredBy,
 } from 'common/extension-telemetry-events';
 import { Messages } from 'common/messages';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
 
-import {
-    createSyncActionMock,
-    createInterpreterMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('PopupActionCreator', () => {
-    it('handles Messages.Popup.Initialized', () => {
+    it('handles Messages.Popup.Initialized', async () => {
         const payload: PopupInitializedPayload = {
             telemetry: {
                 triggeredBy: 'test' as TriggeredBy,
@@ -34,7 +32,8 @@ describe('PopupActionCreator', () => {
 
         const actionMock = createSyncActionMock(payload.tab);
         const actionsMock = createTabActionsMock('newTabCreated', actionMock.object);
-        const interpreterMock = createInterpreterMock(Messages.Popup.Initialized, payload);
+        const interpreterMock = new MockInterpreter();
+
         const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
         const usageLoggerMock = Mock.ofType<UsageLogger>();
 
@@ -46,6 +45,8 @@ describe('PopupActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(Messages.Popup.Initialized, payload);
 
         actionMock.verifyAll();
         telemetryEventHandlerMock.verify(

--- a/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
@@ -16,22 +16,22 @@ import { TabStopRequirementActions } from 'background/actions/tab-stop-requireme
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import * as TelemetryEvents from 'common/extension-telemetry-events';
 import { Messages } from 'common/messages';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
 
-import {
-    createSyncActionMock,
-    createInterpreterMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('TabStopRequirementActionCreator', () => {
     const requirementId = 'focus-indicator';
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let interpreterMock: MockInterpreter;
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        interpreterMock = new MockInterpreter();
     });
 
-    test('registerCallback for update tab stops requirement status', () => {
+    test('registerCallback for update tab stops requirement status', async () => {
         const actionName = 'updateTabStopsRequirementStatus';
         const payload: UpdateTabStopRequirementStatusPayload = {
             requirementId: requirementId,
@@ -44,10 +44,6 @@ describe('TabStopRequirementActionCreator', () => {
             actionName,
             updateTabStopRequirementStatusMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.TabStops.UpdateTabStopsRequirementStatus,
-            payload,
-        );
 
         const testSubject = new TabStopRequirementActionCreator(
             interpreterMock.object,
@@ -56,6 +52,11 @@ describe('TabStopRequirementActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.Visualizations.TabStops.UpdateTabStopsRequirementStatus,
+            payload,
+        );
 
         updateTabStopRequirementStatusMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -68,7 +69,7 @@ describe('TabStopRequirementActionCreator', () => {
         );
     });
 
-    test('registerCallback for reset tab stops requirement status', () => {
+    test('registerCallback for reset tab stops requirement status', async () => {
         const actionName = 'resetTabStopRequirementStatus';
         const payload: ResetTabStopRequirementStatusPayload = {
             requirementId: requirementId,
@@ -77,10 +78,6 @@ describe('TabStopRequirementActionCreator', () => {
         const resetTabStopRequirementStatusMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, resetTabStopRequirementStatusMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.TabStops.ResetTabStopsRequirementStatus,
-            payload,
-        );
 
         const testSubject = new TabStopRequirementActionCreator(
             interpreterMock.object,
@@ -89,6 +86,11 @@ describe('TabStopRequirementActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.Visualizations.TabStops.ResetTabStopsRequirementStatus,
+            payload,
+        );
 
         resetTabStopRequirementStatusMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -101,7 +103,7 @@ describe('TabStopRequirementActionCreator', () => {
         );
     });
 
-    test('registerCallback for add tab stops requirement instance', () => {
+    test('registerCallback for add tab stops requirement instance', async () => {
         const actionName = 'addTabStopInstance';
 
         const payload: AddTabStopInstancePayload = {
@@ -112,10 +114,6 @@ describe('TabStopRequirementActionCreator', () => {
         const addTabStopRequirementInstanceMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, addTabStopRequirementInstanceMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.TabStops.AddTabStopInstance,
-            payload,
-        );
 
         const testSubject = new TabStopRequirementActionCreator(
             interpreterMock.object,
@@ -124,6 +122,11 @@ describe('TabStopRequirementActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.Visualizations.TabStops.AddTabStopInstance,
+            payload,
+        );
 
         addTabStopRequirementInstanceMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -136,7 +139,7 @@ describe('TabStopRequirementActionCreator', () => {
         );
     });
 
-    test('registerCallback for update tab stops requirement instance', () => {
+    test('registerCallback for update tab stops requirement instance', async () => {
         const actionName = 'updateTabStopInstance';
 
         const payload: UpdateTabStopInstancePayload = {
@@ -151,10 +154,6 @@ describe('TabStopRequirementActionCreator', () => {
             actionName,
             updateTabStopRequirementInstanceMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.TabStops.UpdateTabStopInstance,
-            payload,
-        );
 
         const testSubject = new TabStopRequirementActionCreator(
             interpreterMock.object,
@@ -163,6 +162,11 @@ describe('TabStopRequirementActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.Visualizations.TabStops.UpdateTabStopInstance,
+            payload,
+        );
 
         updateTabStopRequirementInstanceMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -175,7 +179,7 @@ describe('TabStopRequirementActionCreator', () => {
         );
     });
 
-    test('registerCallback for on requirement expansion toggled', () => {
+    test('registerCallback for on requirement expansion toggled', async () => {
         const actionName = 'toggleTabStopRequirementExpand';
         const payload: ToggleTabStopRequirementExpandPayload = {
             requirementId: requirementId,
@@ -184,10 +188,6 @@ describe('TabStopRequirementActionCreator', () => {
         const onRequirementExpansionToggledMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, onRequirementExpansionToggledMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.TabStops.RequirementExpansionToggled,
-            payload,
-        );
 
         const testSubject = new TabStopRequirementActionCreator(
             interpreterMock.object,
@@ -197,10 +197,15 @@ describe('TabStopRequirementActionCreator', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(
+            Messages.Visualizations.TabStops.RequirementExpansionToggled,
+            payload,
+        );
+
         onRequirementExpansionToggledMock.verifyAll();
     });
 
-    test('registerCallback for remove tab stops requirement instance', () => {
+    test('registerCallback for remove tab stops requirement instance', async () => {
         const actionName = 'removeTabStopInstance';
 
         const payload: RemoveTabStopInstancePayload = {
@@ -214,10 +219,6 @@ describe('TabStopRequirementActionCreator', () => {
             actionName,
             removeTabStopRequirementInstanceMock.object,
         );
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.TabStops.RemoveTabStopInstance,
-            payload,
-        );
 
         const testSubject = new TabStopRequirementActionCreator(
             interpreterMock.object,
@@ -226,6 +227,11 @@ describe('TabStopRequirementActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.Visualizations.TabStops.RemoveTabStopInstance,
+            payload,
+        );
 
         removeTabStopRequirementInstanceMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -238,7 +244,7 @@ describe('TabStopRequirementActionCreator', () => {
         );
     });
 
-    test('registerCallback for on tabbing completed', () => {
+    test('registerCallback for on tabbing completed', async () => {
         const actionName = 'updateTabbingCompleted';
         const payload: UpdateTabbingCompletedPayload = {
             tabbingCompleted: true,
@@ -247,10 +253,6 @@ describe('TabStopRequirementActionCreator', () => {
         const onTabbingCompletedMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, onTabbingCompletedMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.TabStops.TabbingCompleted,
-            payload,
-        );
 
         const testSubject = new TabStopRequirementActionCreator(
             interpreterMock.object,
@@ -260,10 +262,15 @@ describe('TabStopRequirementActionCreator', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(
+            Messages.Visualizations.TabStops.TabbingCompleted,
+            payload,
+        );
+
         onTabbingCompletedMock.verifyAll();
     });
 
-    test('registerCallback for on need to collect tabbing results', () => {
+    test('registerCallback for on need to collect tabbing results', async () => {
         const actionName = 'updateNeedToCollectTabbingResults';
         const payload: UpdateNeedToCollectTabbingResultsPayload = {
             needToCollectTabbingResults: true,
@@ -272,10 +279,6 @@ describe('TabStopRequirementActionCreator', () => {
         const onNeedToCollectTabbingResultsMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, onNeedToCollectTabbingResultsMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.TabStops.NeedToCollectTabbingResults,
-            payload,
-        );
 
         const testSubject = new TabStopRequirementActionCreator(
             interpreterMock.object,
@@ -285,10 +288,15 @@ describe('TabStopRequirementActionCreator', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(
+            Messages.Visualizations.TabStops.NeedToCollectTabbingResults,
+            payload,
+        );
+
         onNeedToCollectTabbingResultsMock.verifyAll();
     });
 
-    test('registerCallback for automated tabbing results completed', () => {
+    test('registerCallback for automated tabbing results completed', async () => {
         const actionName = 'automatedTabbingResultsCompleted';
 
         const payload: BaseActionPayload = {
@@ -298,10 +306,6 @@ describe('TabStopRequirementActionCreator', () => {
         const instanceMock = createSyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, instanceMock.object);
-        const interpreterMock = createInterpreterMock(
-            Messages.Visualizations.TabStops.AutomatedTabbingResultsCompleted,
-            payload,
-        );
 
         const testSubject = new TabStopRequirementActionCreator(
             interpreterMock.object,
@@ -310,6 +314,11 @@ describe('TabStopRequirementActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.Visualizations.TabStops.AutomatedTabbingResultsCompleted,
+            payload,
+        );
 
         instanceMock.verifyAll();
         telemetryEventHandlerMock.verify(

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -13,22 +13,22 @@ import { NotificationCreator } from 'common/notification-creator';
 import { StoreNames } from 'common/stores/store-names';
 import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete-warnings';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
-import {
-    createSyncActionMock,
-    createInterpreterMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('UnifiedScanResultActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let notificationCreatorMock: IMock<NotificationCreator>;
+    let interpreterMock: MockInterpreter;
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
         notificationCreatorMock = Mock.ofType<NotificationCreator>();
+        interpreterMock = new MockInterpreter();
     });
 
-    it('should handle ScanCompleted message', () => {
+    it('should handle ScanCompleted message', async () => {
         const scanIncompleteWarnings = ['test-warning-id' as ScanIncompleteWarningId];
         const telemetry = {
             scanIncompleteWarnings,
@@ -45,7 +45,6 @@ describe('UnifiedScanResultActionCreator', () => {
 
         const scanCompletedMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('scanCompleted', scanCompletedMock.object);
-        const interpreterMock = createInterpreterMock(Messages.UnifiedScan.ScanCompleted, payload);
 
         const testSubject = new UnifiedScanResultActionCreator(
             interpreterMock.object,
@@ -55,6 +54,8 @@ describe('UnifiedScanResultActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(Messages.UnifiedScan.ScanCompleted, payload);
 
         scanCompletedMock.verifyAll();
         telemetryEventHandlerMock.verify(
@@ -67,15 +68,11 @@ describe('UnifiedScanResultActionCreator', () => {
         );
     });
 
-    it('should handle GetState message', () => {
+    it('should handle GetState message', async () => {
         const payload = null;
 
         const getCurrentStateMock = createSyncActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(
-            getStoreStateMessage(StoreNames.UnifiedScanResultStore),
-            payload,
-        );
 
         const testSubject = new UnifiedScanResultActionCreator(
             interpreterMock.object,
@@ -85,6 +82,11 @@ describe('UnifiedScanResultActionCreator', () => {
         );
 
         testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            getStoreStateMessage(StoreNames.UnifiedScanResultStore),
+            payload,
+        );
 
         getCurrentStateMock.verifyAll();
     });

--- a/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
+++ b/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Interpreter } from 'background/interpreter';
 import { SyncAction } from 'common/flux/sync-action';
-import { isFunction } from 'lodash';
-import { IMock, It, Mock, Times } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 
 export const createSyncActionMock = <Payload>(
     payload: Payload,
@@ -16,22 +14,4 @@ export const createSyncActionMock = <Payload>(
         actionMock.setup(action => action.invoke(payload)).verifiable(Times.once());
     }
     return actionMock;
-};
-
-export const createInterpreterMock = <Payload>(
-    message: string,
-    payload: Payload,
-    tabId?: number,
-): IMock<Interpreter> => {
-    const interpreterMock = Mock.ofType<Interpreter>();
-    interpreterMock
-        .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
-        .callback((_, handler) => {
-            if (tabId) {
-                handler(payload, tabId);
-            } else {
-                handler(payload);
-            }
-        });
-    return interpreterMock;
 };

--- a/src/tests/unit/tests/background/global-action-creators/mock-interpreter.ts
+++ b/src/tests/unit/tests/background/global-action-creators/mock-interpreter.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Interpreter } from 'background/interpreter';
+import { PayloadCallback } from 'common/message';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { DictionaryStringTo } from 'types/common-types';
+
+export class MockInterpreter {
+    private internalMock: IMock<Interpreter>;
+    private messageCallbacksMap: DictionaryStringTo<PayloadCallback<unknown>>;
+
+    constructor() {
+        this.messageCallbacksMap = {};
+        this.internalMock = Mock.ofType<Interpreter>();
+
+        this.internalMock
+            .setup(interpreter => interpreter.registerTypeToPayloadCallback(It.isAny(), It.isAny()))
+            .callback((message, handler) => {
+                this.messageCallbacksMap[message] = handler;
+            });
+    }
+
+    public get object(): Interpreter {
+        return this.internalMock.object;
+    }
+
+    public setupRegisterCallbackForMessage(messageType: string): void {
+        this.internalMock
+            .setup(interpreter =>
+                interpreter.registerTypeToPayloadCallback(messageType, It.isAny()),
+            )
+            .verifiable(Times.once());
+    }
+
+    public simulateMessage(
+        messageType: string,
+        payload: unknown,
+        tabId?: number,
+    ): void | Promise<void> {
+        const callback = this.messageCallbacksMap[messageType];
+        if (callback == null) {
+            throw new Error(`No callback was registered for message ${messageType}`);
+        }
+
+        return callback(payload, tabId);
+    }
+
+    public verifyAll(): void {
+        this.internalMock.verifyAll();
+    }
+}

--- a/src/tests/unit/tests/background/global-action-creators/mock-interpreter.ts
+++ b/src/tests/unit/tests/background/global-action-creators/mock-interpreter.ts
@@ -25,14 +25,6 @@ export class MockInterpreter {
         return this.internalMock.object;
     }
 
-    public setupRegisterCallbackForMessage(messageType: string): void {
-        this.internalMock
-            .setup(interpreter =>
-                interpreter.registerTypeToPayloadCallback(messageType, It.isAny()),
-            )
-            .verifiable(Times.once());
-    }
-
     public simulateMessage(
         messageType: string,
         payload: unknown,
@@ -44,9 +36,5 @@ export class MockInterpreter {
         }
 
         return callback(payload, tabId);
-    }
-
-    public verifyAll(): void {
-        this.internalMock.verifyAll();
     }
 }

--- a/src/tests/unit/tests/background/global-action-creators/mock-interpreter.ts
+++ b/src/tests/unit/tests/background/global-action-creators/mock-interpreter.ts
@@ -3,7 +3,7 @@
 
 import { Interpreter } from 'background/interpreter';
 import { PayloadCallback } from 'common/message';
-import { IMock, It, Mock, Times } from 'typemoq';
+import { IMock, It, Mock } from 'typemoq';
 import { DictionaryStringTo } from 'types/common-types';
 
 export class MockInterpreter {

--- a/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
@@ -7,20 +7,22 @@ import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-hand
 import { TelemetryData } from 'common/extension-telemetry-events';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock } from 'typemoq';
 
-import { createSyncActionMock, createInterpreterMock } from './action-creator-test-helpers';
+import { createSyncActionMock } from './action-creator-test-helpers';
 
 describe('PermissionsStateActionCreator', () => {
     let permissionsStateActionsMock: IMock<PermissionsStateActions>;
+    let interpreterMock: MockInterpreter;
 
     beforeEach(() => {
         permissionsStateActionsMock = Mock.ofType<PermissionsStateActions>();
+        interpreterMock = new MockInterpreter();
     });
 
-    it('handles getStoreState message', () => {
+    it('handles getStoreState message', async () => {
         const expectedMessage = getStoreStateMessage(StoreNames.PermissionsStateStore);
-        const interpreterMock = createInterpreterMock(expectedMessage, null);
         const getCurrentStateMock = createSyncActionMock(undefined);
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
         const testSubject = new PermissionsStateActionCreator(
@@ -31,18 +33,19 @@ describe('PermissionsStateActionCreator', () => {
 
         testSubject.registerCallbacks();
 
+        await interpreterMock.simulateMessage(expectedMessage, null);
+
         getCurrentStateMock.verifyAll();
     });
 
     it.each([true, false])(
         'handles SetPermissionsState message for payload %p',
-        (permissionState: boolean) => {
+        async (permissionState: boolean) => {
             const expectedMessage = Messages.PermissionsState.SetPermissionsState;
             const payload: SetAllUrlsPermissionStatePayload = {
                 hasAllUrlAndFilePermissions: permissionState,
                 telemetry: {} as TelemetryData,
             };
-            const interpreterMock = createInterpreterMock(expectedMessage, payload);
             const setPermissionsStateMock = createSyncActionMock(payload);
             const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
             setupActionsMock('setPermissionsState', setPermissionsStateMock.object);
@@ -53,6 +56,8 @@ describe('PermissionsStateActionCreator', () => {
             );
 
             testSubject.registerCallbacks();
+
+            await interpreterMock.simulateMessage(expectedMessage, payload);
 
             setPermissionsStateMock.verifyAll();
         },

--- a/src/tests/unit/tests/debug-tools/action-creators/debug-tools-action-creator.test.ts
+++ b/src/tests/unit/tests/debug-tools/action-creators/debug-tools-action-creator.test.ts
@@ -3,12 +3,12 @@
 import { Messages } from 'common/messages';
 import { DebugToolsActionCreator } from 'debug-tools/action-creators/debug-tools-action-creator';
 import { DebugToolsController } from 'debug-tools/controllers/debug-tools-controller';
-import { createInterpreterMock } from 'tests/unit/tests/background/global-action-creators/action-creator-test-helpers';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { Mock, Times } from 'typemoq';
 
 describe('DebugToolsActionCreator', () => {
-    it('handles Message.DebugTools.Open', () => {
-        const interpreterMock = createInterpreterMock(Messages.DebugTools.Open, undefined);
+    it('handles Message.DebugTools.Open', async () => {
+        const interpreterMock = new MockInterpreter();
         const debugToolsControllerMock = Mock.ofType<DebugToolsController>();
 
         const testSubject = new DebugToolsActionCreator(
@@ -17,6 +17,8 @@ describe('DebugToolsActionCreator', () => {
         );
 
         testSubject.registerCallback();
+
+        await interpreterMock.simulateMessage(Messages.DebugTools.Open, undefined);
 
         debugToolsControllerMock.verify(controller => controller.showDebugTools(), Times.once());
     });


### PR DESCRIPTION
#### Details

Replace `createInterpreterMock` with a new `MockInterpreter` class in unit tests

##### Motivation

Currently, most tests for -ActionCreator classes use `createInterpreterMock`, which calls a callback as it is registered in the interpreter with `registerTypeToPayloadCallback`. This works fine for synchronous callbacks, but there is no way to await an async call back with this strategy, since `registerTypeToPayloadCallback` is synchronous. Currently, the few ActionCreators that register async callbacks just use `awaitSettledPromises()` to ensure that the async callback completes.

This PR creates a mock wrapper class that separates callback registration from actually calling the callback, so async callbacks can be awaited without using `awaitSettledPromises`. This also makes the sequence of events clearer in the tests.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
