### PR TITLE
feat(mv3-part-5): Only add backwards compat comment on PR open

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1497,6 +1497,12 @@
                   "src/common/types/store-data"
                 ]
               }
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
             }
           ]
         },


### PR DESCRIPTION
#### Details

Follow up to https://github.com/microsoft/accessibility-insights-web/pull/5765, ensures that the backwards compat comment is only added once. 

##### Motivation

Feature work.

##### Context

See https://github.com/microsoft/accessibility-insights-web/pull/5765

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
