### PR TITLE
feat(mv3-part-5): Convert AssessmentActions to AsyncActions

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -34,6 +34,13 @@ import { InspectActions } from './inspect-actions';
 const visualizationMessages = Messages.Visualizations;
 
 export class ActionCreator {
+    // This is to be used as the scope parameter to invoke().
+    // If a message has multiple callbacks registered, all invoke() calls
+    // inside those callbacks must pass a scope parameter. Those message
+    // callbacks will run concurrently, and our Flux classes don't allow
+    // multiple invoke() calls to run in the same scope at the same time.
+    // Passing our own scope will allow multiple actions to be invoked
+    // concurrently as long as there are no infinite loops.
     private readonly executingScope = 'ActionCreator';
 
     private visualizationActions: VisualizationActions;

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -35,12 +35,8 @@ const visualizationMessages = Messages.Visualizations;
 
 export class ActionCreator {
     // This is to be used as the scope parameter to invoke().
-    // If a message has multiple callbacks registered, all invoke() calls
-    // inside those callbacks must pass a scope parameter. Those message
-    // callbacks will run concurrently, and our Flux classes don't allow
-    // multiple invoke() calls to run in the same scope at the same time.
-    // Passing our own scope will allow multiple actions to be invoked
-    // concurrently as long as there are no infinite loops.
+    // Some callbacks in this class are registered to messages with
+    // multiple callbacks (see the comment in src/common/flux/scope-mutex.ts)
     private readonly executingScope = 'ActionCreator';
 
     private visualizationActions: VisualizationActions;
@@ -180,21 +176,24 @@ export class ActionCreator {
     }
 
     private onEnableVisualHelperWithoutScan = (payload: ToggleActionPayload): void => {
-        this.visualizationActions.enableVisualizationWithoutScan.invoke(payload);
+        this.visualizationActions.enableVisualizationWithoutScan.invoke(
+            payload,
+            this.executingScope,
+        );
     };
 
     private onEnableVisualHelper = (payload: ToggleActionPayload): void => {
-        this.visualizationActions.enableVisualization.invoke(payload);
+        this.visualizationActions.enableVisualization.invoke(payload, this.executingScope);
     };
 
     private onDisableVisualHelpersForTest = (payload: ToggleActionPayload): void => {
-        this.visualizationActions.disableVisualization.invoke(payload.test);
+        this.visualizationActions.disableVisualization.invoke(payload.test, this.executingScope);
     };
 
     private onDisableVisualHelper = (payload: ToggleActionPayload): void => {
         const eventName = TelemetryEvents.DISABLE_VISUAL_HELPER;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.visualizationActions.disableVisualization.invoke(payload.test);
+        this.visualizationActions.disableVisualization.invoke(payload.test, this.executingScope);
     };
 
     private onStartOver = (payload: ToggleActionPayload): void => {
@@ -220,7 +219,7 @@ export class ActionCreator {
     };
 
     private onDetailsViewClosed = (): void => {
-        this.visualizationActions.disableAssessmentVisualizations.invoke(null);
+        this.visualizationActions.disableAssessmentVisualizations.invoke(null, this.executingScope);
     };
 
     private onAssessmentScanCompleted = async (
@@ -240,7 +239,7 @@ export class ActionCreator {
     };
 
     private onTabbedElementAdded = (payload: AddTabbedElementPayload): void => {
-        this.visualizationScanResultActions.addTabbedElement.invoke(payload);
+        this.visualizationScanResultActions.addTabbedElement.invoke(payload, this.executingScope);
     };
 
     private onRecordingCompleted = (payload: BaseActionPayload): void => {
@@ -251,11 +250,11 @@ export class ActionCreator {
     };
 
     private onRecordingTerminated = (payload: BaseActionPayload): void => {
-        this.visualizationScanResultActions.disableTabStop.invoke(payload);
+        this.visualizationScanResultActions.disableTabStop.invoke(payload, this.executingScope);
     };
 
     private onUpdateFocusedInstance = (payload: string[]): void => {
-        this.visualizationActions.updateFocusedInstance.invoke(payload);
+        this.visualizationActions.updateFocusedInstance.invoke(payload, this.executingScope);
     };
 
     private onAdHocScanCompleted = async (
@@ -264,8 +263,8 @@ export class ActionCreator {
     ): Promise<void> => {
         const telemetryEventName = TelemetryEvents.ADHOC_SCAN_COMPLETED;
         this.telemetryEventHandler.publishTelemetry(telemetryEventName, payload);
-        this.visualizationScanResultActions.scanCompleted.invoke(payload);
-        this.visualizationActions.scanCompleted.invoke(null);
+        this.visualizationScanResultActions.scanCompleted.invoke(payload, this.executingScope);
+        this.visualizationActions.scanCompleted.invoke(null, this.executingScope);
         this.notificationCreator.createNotificationByVisualizationKey(
             payload.selectorMap,
             payload.key,
@@ -276,9 +275,12 @@ export class ActionCreator {
     };
 
     private onScrollRequested = (): void => {
-        this.visualizationActions.scrollRequested.invoke(null);
-        this.cardSelectionActions.resetFocusedIdentifier.invoke(null);
-        this.needsReviewCardSelectionActions.resetFocusedIdentifier.invoke(null);
+        this.visualizationActions.scrollRequested.invoke(null, this.executingScope);
+        this.cardSelectionActions.resetFocusedIdentifier.invoke(null, this.executingScope);
+        this.needsReviewCardSelectionActions.resetFocusedIdentifier.invoke(
+            null,
+            this.executingScope,
+        );
     };
 
     private onDetailsViewOpen = async (
@@ -330,7 +332,7 @@ export class ActionCreator {
     };
 
     private onDetailsViewPivotSelected = (payload: OnDetailsViewPivotSelected): void => {
-        this.visualizationActions.updateSelectedPivot.invoke(payload);
+        this.visualizationActions.updateSelectedPivot.invoke(payload, this.executingScope);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.DETAILS_VIEW_PIVOT_ACTIVATED,
             payload,
@@ -342,28 +344,34 @@ export class ActionCreator {
         this.telemetryEventHandler.publishTelemetry(telemetryEvent, payload);
 
         if (payload.enabled) {
-            this.visualizationActions.enableVisualization.invoke(payload);
+            this.visualizationActions.enableVisualization.invoke(payload, this.executingScope);
         } else {
-            this.visualizationActions.disableVisualization.invoke(payload.test);
+            this.visualizationActions.disableVisualization.invoke(
+                payload.test,
+                this.executingScope,
+            );
         }
     };
 
     private onRescanVisualization = (payload: RescanVisualizationPayload) => {
-        this.visualizationActions.disableVisualization.invoke(payload.test);
-        this.visualizationActions.resetDataForVisualization.invoke(payload.test);
-        this.visualizationActions.enableVisualization.invoke(payload);
+        this.visualizationActions.disableVisualization.invoke(payload.test, this.executingScope);
+        this.visualizationActions.resetDataForVisualization.invoke(
+            payload.test,
+            this.executingScope,
+        );
+        this.visualizationActions.enableVisualization.invoke(payload, this.executingScope);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.RESCAN_VISUALIZATION, payload);
     };
 
     private getVisualizationToggleCurrentState = (): void => {
-        this.visualizationActions.getCurrentState.invoke(null);
+        this.visualizationActions.getCurrentState.invoke(null, this.executingScope);
     };
 
     private getScanResultsCurrentState = (): void => {
-        this.visualizationScanResultActions.getCurrentState.invoke(null);
+        this.visualizationScanResultActions.getCurrentState.invoke(null, this.executingScope);
     };
 
     private onSetHoveredOverSelector = (payload: string[]): void => {
-        this.inspectActions.setHoveredOverSelector.invoke(payload);
+        this.inspectActions.setHoveredOverSelector.invoke(payload, this.executingScope);
     };
 }

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -34,6 +34,8 @@ import { InspectActions } from './inspect-actions';
 const visualizationMessages = Messages.Visualizations;
 
 export class ActionCreator {
+    private readonly executingScope = 'ActionCreator';
+
     private visualizationActions: VisualizationActions;
     private visualizationScanResultActions: VisualizationScanResultActions;
     private adHocTestTypeToTelemetryEvent: DictionaryNumberTo<string> = {
@@ -191,7 +193,7 @@ export class ActionCreator {
     private onStartOver = (payload: ToggleActionPayload): void => {
         const eventName = TelemetryEvents.START_OVER_TEST;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.visualizationActions.disableVisualization.invoke(payload.test);
+        this.visualizationActions.disableVisualization.invoke(payload.test, this.executingScope);
     };
 
     private onCancelStartOver = (payload: BaseActionPayload): void => {
@@ -202,7 +204,7 @@ export class ActionCreator {
     private onStartOverAllAssessments = (payload: ToggleActionPayload): void => {
         const eventName = TelemetryEvents.START_OVER_ASSESSMENT;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.visualizationActions.disableAssessmentVisualizations.invoke(null);
+        this.visualizationActions.disableAssessmentVisualizations.invoke(null, this.executingScope);
     };
 
     private onCancelStartOverAllAssessments = (payload: BaseActionPayload): void => {
@@ -220,7 +222,7 @@ export class ActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.ASSESSMENT_SCAN_COMPLETED;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.visualizationActions.scanCompleted.invoke(null);
+        this.visualizationActions.scanCompleted.invoke(null, this.executingScope);
         this.notificationCreator.createNotificationByVisualizationKey(
             payload.selectorMap,
             payload.key,
@@ -312,8 +314,8 @@ export class ActionCreator {
         payload: OnDetailsViewOpenPayload,
         tabId: number,
     ): Promise<void> => {
-        this.sidePanelActions.closeSidePanel.invoke('PreviewFeatures');
-        this.visualizationActions.updateSelectedPivotChild.invoke(payload);
+        this.sidePanelActions.closeSidePanel.invoke('PreviewFeatures', this.executingScope);
+        this.visualizationActions.updateSelectedPivotChild.invoke(payload, this.executingScope);
         await this.detailsViewController
             .showDetailsView(tabId)
             .catch(e => this.logger.error(e.message, e));

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -36,12 +36,8 @@ const AssessmentMessages = Messages.Assessment;
 
 export class AssessmentActionCreator {
     // This is to be used as the scope parameter to invoke().
-    // If a message has multiple callbacks registered, all invoke() calls
-    // inside those callbacks must pass a scope parameter. Those message
-    // callbacks will run concurrently, and our Flux classes don't allow
-    // multiple invoke() calls to run in the same scope at the same time.
-    // Passing our own scope will allow multiple actions to be invoked
-    // concurrently as long as there are no infinite loops.
+    // Some callbacks in this class are registered to messages with
+    // multiple callbacks (see the comment in src/common/flux/scope-mutex.ts)
     private readonly executingScope = 'AssessmentActionCreator';
 
     constructor(
@@ -167,7 +163,7 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.CONTINUE_PREVIOUS_ASSESSMENT;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.continuePreviousAssessment.invoke(tabId);
+        await this.assessmentActions.continuePreviousAssessment.invoke(tabId, this.executingScope);
     };
 
     private onLoadAssessment = async (
@@ -176,7 +172,7 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.LOAD_ASSESSMENT;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.loadAssessment.invoke(payload);
+        await this.assessmentActions.loadAssessment.invoke(payload, this.executingScope);
     };
 
     private onSaveAssessment = (payload: BaseActionPayload): void => {
@@ -190,14 +186,14 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.PASS_UNMARKED_INSTANCES;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.updateTargetTabId.invoke(tabId);
-        await this.assessmentActions.passUnmarkedInstance.invoke(payload);
+        await this.assessmentActions.updateTargetTabId.invoke(tabId, this.executingScope);
+        await this.assessmentActions.passUnmarkedInstance.invoke(payload, this.executingScope);
     };
 
     private onEditFailureInstance = async (payload: EditFailureInstancePayload): Promise<void> => {
         const eventName = TelemetryEvents.EDIT_FAILURE_INSTANCE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.editFailureInstance.invoke(payload);
+        await this.assessmentActions.editFailureInstance.invoke(payload, this.executingScope);
     };
 
     private onRemoveFailureInstance = async (
@@ -205,19 +201,19 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.REMOVE_FAILURE_INSTANCE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.removeFailureInstance.invoke(payload);
+        await this.assessmentActions.removeFailureInstance.invoke(payload, this.executingScope);
     };
 
     private onAddFailureInstance = async (payload: AddFailureInstancePayload): Promise<void> => {
         const eventName = TelemetryEvents.ADD_FAILURE_INSTANCE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.addFailureInstance.invoke(payload);
+        await this.assessmentActions.addFailureInstance.invoke(payload, this.executingScope);
     };
 
     private onAddResultDescription = async (
         payload: AddResultDescriptionPayload,
     ): Promise<void> => {
-        await this.assessmentActions.addResultDescription.invoke(payload);
+        await this.assessmentActions.addResultDescription.invoke(payload, this.executingScope);
     };
 
     private onChangeManualRequirementStatus = async (
@@ -226,8 +222,8 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.CHANGE_INSTANCE_STATUS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.updateTargetTabId.invoke(tabId);
-        await this.assessmentActions.changeRequirementStatus.invoke(payload);
+        await this.assessmentActions.updateTargetTabId.invoke(tabId, this.executingScope);
+        await this.assessmentActions.changeRequirementStatus.invoke(payload, this.executingScope);
     };
 
     private onUndoChangeManualRequirementStatus = async (
@@ -235,7 +231,10 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.UNDO_REQUIREMENT_STATUS_CHANGE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.undoRequirementStatusChange.invoke(payload);
+        await this.assessmentActions.undoRequirementStatusChange.invoke(
+            payload,
+            this.executingScope,
+        );
     };
 
     private onUndoAssessmentInstanceStatusChange = async (
@@ -243,7 +242,7 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.UNDO_TEST_STATUS_CHANGE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.undoInstanceStatusChange.invoke(payload);
+        await this.assessmentActions.undoInstanceStatusChange.invoke(payload, this.executingScope);
     };
 
     private onChangeAssessmentInstanceStatus = async (
@@ -252,8 +251,8 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.CHANGE_INSTANCE_STATUS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.updateTargetTabId.invoke(tabId);
-        await this.assessmentActions.changeInstanceStatus.invoke(payload);
+        await this.assessmentActions.updateTargetTabId.invoke(tabId, this.executingScope);
+        await this.assessmentActions.changeInstanceStatus.invoke(payload, this.executingScope);
     };
 
     private onChangeAssessmentVisualizationState = async (
@@ -261,7 +260,10 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.changeAssessmentVisualizationState.invoke(payload);
+        await this.assessmentActions.changeAssessmentVisualizationState.invoke(
+            payload,
+            this.executingScope,
+        );
     };
 
     private onChangeVisualizationStateForAll = async (
@@ -269,7 +271,10 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS_FOR_ALL;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.assessmentActions.changeAssessmentVisualizationStateForAll.invoke(payload);
+        await this.assessmentActions.changeAssessmentVisualizationStateForAll.invoke(
+            payload,
+            this.executingScope,
+        );
     };
 
     private onStartOverAssessment = async (payload: ToggleActionPayload): Promise<void> => {
@@ -292,18 +297,18 @@ export class AssessmentActionCreator {
     };
 
     private onGetAssessmentCurrentState = (): void => {
-        this.assessmentActions.getCurrentState.invoke(null);
+        this.assessmentActions.getCurrentState.invoke(null, this.executingScope);
     };
 
     private onSelectTestRequirement = async (payload: SelectTestSubviewPayload): Promise<void> => {
-        await this.assessmentActions.selectTestSubview.invoke(payload);
+        await this.assessmentActions.selectTestSubview.invoke(payload, this.executingScope);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.SELECT_REQUIREMENT, payload);
     };
 
     private onSelectNextTestRequirement = async (
         payload: SelectTestSubviewPayload,
     ): Promise<void> => {
-        await this.assessmentActions.selectTestSubview.invoke(payload);
+        await this.assessmentActions.selectTestSubview.invoke(payload, this.executingScope);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.SELECT_NEXT_REQUIREMENT,
             payload,
@@ -313,10 +318,13 @@ export class AssessmentActionCreator {
     private onSelectGettingStarted = async (
         payload: SelectGettingStartedPayload,
     ): Promise<void> => {
-        await this.assessmentActions.selectTestSubview.invoke({
-            selectedTestSubview: gettingStartedSubview,
-            ...payload,
-        });
+        await this.assessmentActions.selectTestSubview.invoke(
+            {
+                selectedTestSubview: gettingStartedSubview,
+                ...payload,
+            },
+            this.executingScope,
+        );
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.SELECT_GETTING_STARTED,
             payload,
@@ -324,23 +332,23 @@ export class AssessmentActionCreator {
     };
 
     private onExpandTestNav = async (payload: ExpandTestNavPayload): Promise<void> => {
-        await this.assessmentActions.expandTestNav.invoke(payload);
+        await this.assessmentActions.expandTestNav.invoke(payload, this.executingScope);
     };
 
     private onCollapseTestNav = async (): Promise<void> => {
-        await this.assessmentActions.collapseTestNav.invoke(null);
+        await this.assessmentActions.collapseTestNav.invoke(null, this.executingScope);
     };
 
     private onScanUpdate = async (payload: ScanUpdatePayload): Promise<void> => {
         const telemetryEventName = 'ScanUpdate' + capitalize(payload.key);
         this.telemetryEventHandler.publishTelemetry(telemetryEventName, payload);
-        await this.assessmentActions.scanUpdate.invoke(payload);
+        await this.assessmentActions.scanUpdate.invoke(payload, this.executingScope);
     };
 
     private onTrackingCompleted = async (payload: ScanBasePayload): Promise<void> => {
         const telemetryEventName = 'TrackingCompleted' + capitalize(payload.key);
         this.telemetryEventHandler.publishTelemetry(telemetryEventName, payload);
-        await this.assessmentActions.trackingCompleted.invoke(payload);
+        await this.assessmentActions.trackingCompleted.invoke(payload, this.executingScope);
     };
 
     private onPivotChildSelected = async (payload: OnDetailsViewOpenPayload): Promise<void> => {
@@ -350,6 +358,6 @@ export class AssessmentActionCreator {
     private onDetailsViewInitialized = async (
         payload: OnDetailsViewInitializedPayload,
     ): Promise<void> => {
-        await this.assessmentActions.updateDetailsViewId.invoke(payload);
+        await this.assessmentActions.updateDetailsViewId.invoke(payload, this.executingScope);
     };
 }

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -152,16 +152,22 @@ export class AssessmentActionCreator {
         );
     }
 
-    private onContinuePreviousAssessment = (payload: BaseActionPayload, tabId: number): void => {
+    private onContinuePreviousAssessment = async (
+        payload: BaseActionPayload,
+        tabId: number,
+    ): Promise<void> => {
         const eventName = TelemetryEvents.CONTINUE_PREVIOUS_ASSESSMENT;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.continuePreviousAssessment.invoke(tabId);
+        await this.assessmentActions.continuePreviousAssessment.invoke(tabId);
     };
 
-    private onLoadAssessment = (payload: LoadAssessmentPayload, tabId: number): void => {
+    private onLoadAssessment = async (
+        payload: LoadAssessmentPayload,
+        tabId: number,
+    ): Promise<void> => {
         const eventName = TelemetryEvents.LOAD_ASSESSMENT;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.LoadAssessment.invoke(payload);
+        await this.assessmentActions.loadAssessment.invoke(payload);
     };
 
     private onSaveAssessment = (payload: BaseActionPayload): void => {
@@ -175,7 +181,7 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.PASS_UNMARKED_INSTANCES;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.updateTargetTabId.invoke(tabId);
+        await this.assessmentActions.updateTargetTabId.invoke(tabId);
         await this.assessmentActions.passUnmarkedInstance.invoke(payload);
     };
 
@@ -211,24 +217,24 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.CHANGE_INSTANCE_STATUS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.updateTargetTabId.invoke(tabId);
+        await this.assessmentActions.updateTargetTabId.invoke(tabId);
         await this.assessmentActions.changeRequirementStatus.invoke(payload);
     };
 
-    private onUndoChangeManualRequirementStatus = (
+    private onUndoChangeManualRequirementStatus = async (
         payload: ChangeRequirementStatusPayload,
-    ): void => {
+    ): Promise<void> => {
         const eventName = TelemetryEvents.UNDO_REQUIREMENT_STATUS_CHANGE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.undoRequirementStatusChange.invoke(payload);
+        await this.assessmentActions.undoRequirementStatusChange.invoke(payload);
     };
 
-    private onUndoAssessmentInstanceStatusChange = (
+    private onUndoAssessmentInstanceStatusChange = async (
         payload: AssessmentActionInstancePayload,
-    ): void => {
+    ): Promise<void> => {
         const eventName = TelemetryEvents.UNDO_TEST_STATUS_CHANGE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.undoInstanceStatusChange.invoke(payload);
+        await this.assessmentActions.undoInstanceStatusChange.invoke(payload);
     };
 
     private onChangeAssessmentInstanceStatus = async (
@@ -237,7 +243,7 @@ export class AssessmentActionCreator {
     ): Promise<void> => {
         const eventName = TelemetryEvents.CHANGE_INSTANCE_STATUS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.updateTargetTabId.invoke(tabId);
+        await this.assessmentActions.updateTargetTabId.invoke(tabId);
         await this.assessmentActions.changeInstanceStatus.invoke(payload);
     };
 
@@ -257,20 +263,23 @@ export class AssessmentActionCreator {
         await this.assessmentActions.changeAssessmentVisualizationStateForAll.invoke(payload);
     };
 
-    private onStartOverAssessment = (payload: ToggleActionPayload): void => {
-        this.assessmentActions.resetData.invoke(payload);
+    private onStartOverAssessment = async (payload: ToggleActionPayload): Promise<void> => {
+        await this.assessmentActions.resetData.invoke(payload);
     };
 
-    private onStartOverAllAssessments = (payload: ToggleActionPayload, tabId: number): void => {
-        this.assessmentActions.resetAllAssessmentsData.invoke(tabId);
+    private onStartOverAllAssessments = async (
+        payload: ToggleActionPayload,
+        tabId: number,
+    ): Promise<void> => {
+        await this.assessmentActions.resetAllAssessmentsData.invoke(tabId);
     };
 
-    private onAssessmentScanCompleted = (
+    private onAssessmentScanCompleted = async (
         payload: ScanCompletedPayload<any>,
         tabId: number,
-    ): void => {
-        this.assessmentActions.updateTargetTabId.invoke(tabId);
-        this.assessmentActions.scanCompleted.invoke(payload);
+    ): Promise<void> => {
+        await this.assessmentActions.updateTargetTabId.invoke(tabId);
+        await this.assessmentActions.scanCompleted.invoke(payload);
     };
 
     private onGetAssessmentCurrentState = (): void => {
@@ -313,23 +322,25 @@ export class AssessmentActionCreator {
         await this.assessmentActions.collapseTestNav.invoke(null);
     };
 
-    private onScanUpdate = (payload: ScanUpdatePayload): void => {
+    private onScanUpdate = async (payload: ScanUpdatePayload): Promise<void> => {
         const telemetryEventName = 'ScanUpdate' + capitalize(payload.key);
         this.telemetryEventHandler.publishTelemetry(telemetryEventName, payload);
-        this.assessmentActions.scanUpdate.invoke(payload);
+        await this.assessmentActions.scanUpdate.invoke(payload);
     };
 
-    private onTrackingCompleted = (payload: ScanBasePayload): void => {
+    private onTrackingCompleted = async (payload: ScanBasePayload): Promise<void> => {
         const telemetryEventName = 'TrackingCompleted' + capitalize(payload.key);
         this.telemetryEventHandler.publishTelemetry(telemetryEventName, payload);
-        this.assessmentActions.trackingCompleted.invoke(payload);
+        await this.assessmentActions.trackingCompleted.invoke(payload);
     };
 
-    private onPivotChildSelected = (payload: OnDetailsViewOpenPayload): void => {
-        this.assessmentActions.updateSelectedPivotChild.invoke(payload);
+    private onPivotChildSelected = async (payload: OnDetailsViewOpenPayload): Promise<void> => {
+        await this.assessmentActions.updateSelectedPivotChild.invoke(payload);
     };
 
-    private onDetailsViewInitialized = (payload: OnDetailsViewInitializedPayload): void => {
-        this.assessmentActions.updateDetailsViewId.invoke(payload);
+    private onDetailsViewInitialized = async (
+        payload: OnDetailsViewInitializedPayload,
+    ): Promise<void> => {
+        await this.assessmentActions.updateDetailsViewId.invoke(payload);
     };
 }

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -35,6 +35,8 @@ import { AssessmentActions } from './assessment-actions';
 const AssessmentMessages = Messages.Assessment;
 
 export class AssessmentActionCreator {
+    private readonly executingScope = 'AssessmentActionCreator';
+
     constructor(
         private readonly interpreter: Interpreter,
         private readonly assessmentActions: AssessmentActions,
@@ -264,22 +266,22 @@ export class AssessmentActionCreator {
     };
 
     private onStartOverAssessment = async (payload: ToggleActionPayload): Promise<void> => {
-        await this.assessmentActions.resetData.invoke(payload);
+        await this.assessmentActions.resetData.invoke(payload, this.executingScope);
     };
 
     private onStartOverAllAssessments = async (
         payload: ToggleActionPayload,
         tabId: number,
     ): Promise<void> => {
-        await this.assessmentActions.resetAllAssessmentsData.invoke(tabId);
+        await this.assessmentActions.resetAllAssessmentsData.invoke(tabId, this.executingScope);
     };
 
     private onAssessmentScanCompleted = async (
         payload: ScanCompletedPayload<any>,
         tabId: number,
     ): Promise<void> => {
-        await this.assessmentActions.updateTargetTabId.invoke(tabId);
-        await this.assessmentActions.scanCompleted.invoke(payload);
+        await this.assessmentActions.updateTargetTabId.invoke(tabId, this.executingScope);
+        await this.assessmentActions.scanCompleted.invoke(payload, this.executingScope);
     };
 
     private onGetAssessmentCurrentState = (): void => {
@@ -335,7 +337,7 @@ export class AssessmentActionCreator {
     };
 
     private onPivotChildSelected = async (payload: OnDetailsViewOpenPayload): Promise<void> => {
-        await this.assessmentActions.updateSelectedPivotChild.invoke(payload);
+        await this.assessmentActions.updateSelectedPivotChild.invoke(payload, this.executingScope);
     };
 
     private onDetailsViewInitialized = async (

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -169,17 +169,20 @@ export class AssessmentActionCreator {
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
     };
 
-    private onPassUnmarkedInstances = (payload: ToggleActionPayload, tabId: number): void => {
+    private onPassUnmarkedInstances = async (
+        payload: ToggleActionPayload,
+        tabId: number,
+    ): Promise<void> => {
         const eventName = TelemetryEvents.PASS_UNMARKED_INSTANCES;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.updateTargetTabId.invoke(tabId);
-        this.assessmentActions.passUnmarkedInstance.invoke(payload);
+        await this.assessmentActions.passUnmarkedInstance.invoke(payload);
     };
 
-    private onEditFailureInstance = (payload: EditFailureInstancePayload): void => {
+    private onEditFailureInstance = async (payload: EditFailureInstancePayload): Promise<void> => {
         const eventName = TelemetryEvents.EDIT_FAILURE_INSTANCE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.editFailureInstance.invoke(payload);
+        await this.assessmentActions.editFailureInstance.invoke(payload);
     };
 
     private onRemoveFailureInstance = async (
@@ -238,18 +241,20 @@ export class AssessmentActionCreator {
         await this.assessmentActions.changeInstanceStatus.invoke(payload);
     };
 
-    private onChangeAssessmentVisualizationState = (
+    private onChangeAssessmentVisualizationState = async (
         payload: ChangeInstanceSelectionPayload,
-    ): void => {
+    ): Promise<void> => {
         const eventName = TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.changeAssessmentVisualizationState.invoke(payload);
+        await this.assessmentActions.changeAssessmentVisualizationState.invoke(payload);
     };
 
-    private onChangeVisualizationStateForAll = (payload: ChangeInstanceSelectionPayload): void => {
+    private onChangeVisualizationStateForAll = async (
+        payload: ChangeInstanceSelectionPayload,
+    ): Promise<void> => {
         const eventName = TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS_FOR_ALL;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.changeAssessmentVisualizationStateForAll.invoke(payload);
+        await this.assessmentActions.changeAssessmentVisualizationStateForAll.invoke(payload);
     };
 
     private onStartOverAssessment = (payload: ToggleActionPayload): void => {

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -182,30 +182,34 @@ export class AssessmentActionCreator {
         this.assessmentActions.editFailureInstance.invoke(payload);
     };
 
-    private onRemoveFailureInstance = (payload: RemoveFailureInstancePayload): void => {
+    private onRemoveFailureInstance = async (
+        payload: RemoveFailureInstancePayload,
+    ): Promise<void> => {
         const eventName = TelemetryEvents.REMOVE_FAILURE_INSTANCE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.removeFailureInstance.invoke(payload);
+        await this.assessmentActions.removeFailureInstance.invoke(payload);
     };
 
-    private onAddFailureInstance = (payload: AddFailureInstancePayload): void => {
+    private onAddFailureInstance = async (payload: AddFailureInstancePayload): Promise<void> => {
         const eventName = TelemetryEvents.ADD_FAILURE_INSTANCE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.assessmentActions.addFailureInstance.invoke(payload);
+        await this.assessmentActions.addFailureInstance.invoke(payload);
     };
 
-    private onAddResultDescription = (payload: AddResultDescriptionPayload): void => {
-        this.assessmentActions.addResultDescription.invoke(payload);
+    private onAddResultDescription = async (
+        payload: AddResultDescriptionPayload,
+    ): Promise<void> => {
+        await this.assessmentActions.addResultDescription.invoke(payload);
     };
 
-    private onChangeManualRequirementStatus = (
+    private onChangeManualRequirementStatus = async (
         payload: ChangeRequirementStatusPayload,
         tabId: number,
-    ): void => {
+    ): Promise<void> => {
         const eventName = TelemetryEvents.CHANGE_INSTANCE_STATUS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.updateTargetTabId.invoke(tabId);
-        this.assessmentActions.changeRequirementStatus.invoke(payload);
+        await this.assessmentActions.changeRequirementStatus.invoke(payload);
     };
 
     private onUndoChangeManualRequirementStatus = (
@@ -224,14 +228,14 @@ export class AssessmentActionCreator {
         this.assessmentActions.undoInstanceStatusChange.invoke(payload);
     };
 
-    private onChangeAssessmentInstanceStatus = (
+    private onChangeAssessmentInstanceStatus = async (
         payload: ChangeInstanceStatusPayload,
         tabId: number,
-    ): void => {
+    ): Promise<void> => {
         const eventName = TelemetryEvents.CHANGE_INSTANCE_STATUS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.updateTargetTabId.invoke(tabId);
-        this.assessmentActions.changeInstanceStatus.invoke(payload);
+        await this.assessmentActions.changeInstanceStatus.invoke(payload);
     };
 
     private onChangeAssessmentVisualizationState = (
@@ -268,21 +272,25 @@ export class AssessmentActionCreator {
         this.assessmentActions.getCurrentState.invoke(null);
     };
 
-    private onSelectTestRequirement = (payload: SelectTestSubviewPayload): void => {
-        this.assessmentActions.selectTestSubview.invoke(payload);
+    private onSelectTestRequirement = async (payload: SelectTestSubviewPayload): Promise<void> => {
+        await this.assessmentActions.selectTestSubview.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.SELECT_REQUIREMENT, payload);
     };
 
-    private onSelectNextTestRequirement = (payload: SelectTestSubviewPayload): void => {
-        this.assessmentActions.selectTestSubview.invoke(payload);
+    private onSelectNextTestRequirement = async (
+        payload: SelectTestSubviewPayload,
+    ): Promise<void> => {
+        await this.assessmentActions.selectTestSubview.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.SELECT_NEXT_REQUIREMENT,
             payload,
         );
     };
 
-    private onSelectGettingStarted = (payload: SelectGettingStartedPayload): void => {
-        this.assessmentActions.selectTestSubview.invoke({
+    private onSelectGettingStarted = async (
+        payload: SelectGettingStartedPayload,
+    ): Promise<void> => {
+        await this.assessmentActions.selectTestSubview.invoke({
             selectedTestSubview: gettingStartedSubview,
             ...payload,
         });
@@ -292,12 +300,12 @@ export class AssessmentActionCreator {
         );
     };
 
-    private onExpandTestNav = (payload: ExpandTestNavPayload): void => {
-        this.assessmentActions.expandTestNav.invoke(payload);
+    private onExpandTestNav = async (payload: ExpandTestNavPayload): Promise<void> => {
+        await this.assessmentActions.expandTestNav.invoke(payload);
     };
 
-    private onCollapseTestNav = (): void => {
-        this.assessmentActions.collapseTestNav.invoke(null);
+    private onCollapseTestNav = async (): Promise<void> => {
+        await this.assessmentActions.collapseTestNav.invoke(null);
     };
 
     private onScanUpdate = (payload: ScanUpdatePayload): void => {

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -35,6 +35,13 @@ import { AssessmentActions } from './assessment-actions';
 const AssessmentMessages = Messages.Assessment;
 
 export class AssessmentActionCreator {
+    // This is to be used as the scope parameter to invoke().
+    // If a message has multiple callbacks registered, all invoke() calls
+    // inside those callbacks must pass a scope parameter. Those message
+    // callbacks will run concurrently, and our Flux classes don't allow
+    // multiple invoke() calls to run in the same scope at the same time.
+    // Passing our own scope will allow multiple actions to be invoked
+    // concurrently as long as there are no infinite loops.
     private readonly executingScope = 'AssessmentActionCreator';
 
     constructor(

--- a/src/background/actions/assessment-actions.ts
+++ b/src/background/actions/assessment-actions.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AsyncAction } from 'common/flux/async-action';
 import { SyncAction } from 'common/flux/sync-action';
 import {
     ScanBasePayload,
@@ -24,14 +25,14 @@ import {
 } from './action-payloads';
 
 export class AssessmentActions {
-    public readonly selectTestSubview = new SyncAction<SelectTestSubviewPayload>();
-    public readonly expandTestNav = new SyncAction<ExpandTestNavPayload>();
-    public readonly collapseTestNav = new SyncAction<null>();
-    public readonly changeInstanceStatus = new SyncAction<ChangeInstanceStatusPayload>();
-    public readonly changeRequirementStatus = new SyncAction<ChangeRequirementStatusPayload>();
-    public readonly addFailureInstance = new SyncAction<AddFailureInstancePayload>();
-    public readonly addResultDescription = new SyncAction<AddResultDescriptionPayload>();
-    public readonly removeFailureInstance = new SyncAction<RemoveFailureInstancePayload>();
+    public readonly selectTestSubview = new AsyncAction<SelectTestSubviewPayload>();
+    public readonly expandTestNav = new AsyncAction<ExpandTestNavPayload>();
+    public readonly collapseTestNav = new AsyncAction<null>();
+    public readonly changeInstanceStatus = new AsyncAction<ChangeInstanceStatusPayload>();
+    public readonly changeRequirementStatus = new AsyncAction<ChangeRequirementStatusPayload>();
+    public readonly addFailureInstance = new AsyncAction<AddFailureInstancePayload>();
+    public readonly addResultDescription = new AsyncAction<AddResultDescriptionPayload>();
+    public readonly removeFailureInstance = new AsyncAction<RemoveFailureInstancePayload>();
     public readonly editFailureInstance = new SyncAction<EditFailureInstancePayload>();
     public readonly passUnmarkedInstance = new SyncAction<ToggleActionPayload>();
     public readonly changeAssessmentVisualizationState =

--- a/src/background/actions/assessment-actions.ts
+++ b/src/background/actions/assessment-actions.ts
@@ -33,12 +33,12 @@ export class AssessmentActions {
     public readonly addFailureInstance = new AsyncAction<AddFailureInstancePayload>();
     public readonly addResultDescription = new AsyncAction<AddResultDescriptionPayload>();
     public readonly removeFailureInstance = new AsyncAction<RemoveFailureInstancePayload>();
-    public readonly editFailureInstance = new SyncAction<EditFailureInstancePayload>();
-    public readonly passUnmarkedInstance = new SyncAction<ToggleActionPayload>();
+    public readonly editFailureInstance = new AsyncAction<EditFailureInstancePayload>();
+    public readonly passUnmarkedInstance = new AsyncAction<ToggleActionPayload>();
     public readonly changeAssessmentVisualizationState =
-        new SyncAction<ChangeInstanceSelectionPayload>();
+        new AsyncAction<ChangeInstanceSelectionPayload>();
     public readonly changeAssessmentVisualizationStateForAll =
-        new SyncAction<ChangeInstanceSelectionPayload>();
+        new AsyncAction<ChangeInstanceSelectionPayload>();
     public readonly undoInstanceStatusChange = new SyncAction<AssessmentActionInstancePayload>();
     public readonly undoRequirementStatusChange = new SyncAction<ChangeRequirementStatusPayload>();
     public readonly getCurrentState = new SyncAction<void>();

--- a/src/background/actions/assessment-actions.ts
+++ b/src/background/actions/assessment-actions.ts
@@ -39,17 +39,18 @@ export class AssessmentActions {
         new AsyncAction<ChangeInstanceSelectionPayload>();
     public readonly changeAssessmentVisualizationStateForAll =
         new AsyncAction<ChangeInstanceSelectionPayload>();
-    public readonly undoInstanceStatusChange = new SyncAction<AssessmentActionInstancePayload>();
-    public readonly undoRequirementStatusChange = new SyncAction<ChangeRequirementStatusPayload>();
+    public readonly undoInstanceStatusChange = new AsyncAction<AssessmentActionInstancePayload>();
+    public readonly undoRequirementStatusChange = new AsyncAction<ChangeRequirementStatusPayload>();
+    // Leaving this sync for now until BaseStoreImpl.onGetCurrentState() can be converted to async
     public readonly getCurrentState = new SyncAction<void>();
-    public readonly scanCompleted = new SyncAction<ScanCompletedPayload<null>>();
-    public readonly resetData = new SyncAction<ToggleActionPayload>();
-    public readonly resetAllAssessmentsData = new SyncAction<number>();
-    public readonly scanUpdate = new SyncAction<ScanUpdatePayload>();
-    public readonly trackingCompleted = new SyncAction<ScanBasePayload>();
-    public readonly updateSelectedPivotChild = new SyncAction<UpdateSelectedDetailsViewPayload>();
-    public readonly updateTargetTabId = new SyncAction<number>();
-    public readonly continuePreviousAssessment = new SyncAction<number>();
-    public readonly LoadAssessment = new SyncAction<LoadAssessmentPayload>();
-    public readonly updateDetailsViewId = new SyncAction<OnDetailsViewInitializedPayload>();
+    public readonly scanCompleted = new AsyncAction<ScanCompletedPayload<null>>();
+    public readonly resetData = new AsyncAction<ToggleActionPayload>();
+    public readonly resetAllAssessmentsData = new AsyncAction<number>();
+    public readonly scanUpdate = new AsyncAction<ScanUpdatePayload>();
+    public readonly trackingCompleted = new AsyncAction<ScanBasePayload>();
+    public readonly updateSelectedPivotChild = new AsyncAction<UpdateSelectedDetailsViewPayload>();
+    public readonly updateTargetTabId = new AsyncAction<number>();
+    public readonly continuePreviousAssessment = new AsyncAction<number>();
+    public readonly loadAssessment = new AsyncAction<LoadAssessmentPayload>();
+    public readonly updateDetailsViewId = new AsyncAction<OnDetailsViewInitializedPayload>();
 }

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -111,7 +111,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.assessmentActions.continuePreviousAssessment.addListener(
             this.onContinuePreviousAssessment,
         );
-        this.assessmentActions.LoadAssessment.addListener(this.onLoadAssessment);
+        this.assessmentActions.loadAssessment.addListener(this.onLoadAssessment);
         this.assessmentActions.updateDetailsViewId.addListener(this.onUpdateDetailsViewId);
     }
 
@@ -134,11 +134,11 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         );
     }
 
-    private onContinuePreviousAssessment = (tabId: number): void => {
+    private onContinuePreviousAssessment = async (tabId: number): Promise<void> => {
         this.updateTargetTabWithId(tabId);
     };
 
-    private onLoadAssessment = (payload: LoadAssessmentPayload): void => {
+    private onLoadAssessment = async (payload: LoadAssessmentPayload): Promise<void> => {
         this.state = this.initialAssessmentStoreDataGenerator.generateInitialState(
             payload.versionedAssessmentData.assessmentData,
         );
@@ -150,13 +150,15 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.updateTargetTabWithId(payload.tabId);
     };
 
-    private onUpdateTargetTabId = (tabId: number): void => {
+    private onUpdateTargetTabId = async (tabId: number): Promise<void> => {
         if (this.state.persistedTabInfo == null || this.state.persistedTabInfo.id !== tabId) {
             this.updateTargetTabWithId(tabId);
         }
     };
 
-    private onUpdateSelectedTest = (payload: UpdateSelectedDetailsViewPayload): void => {
+    private onUpdateSelectedTest = async (
+        payload: UpdateSelectedDetailsViewPayload,
+    ): Promise<void> => {
         if (
             payload.pivotType === DetailsViewPivotType.assessment &&
             payload.detailsViewType != null
@@ -169,7 +171,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         }
     };
 
-    private onTrackingCompleted = (payload: ScanBasePayload): void => {
+    private onTrackingCompleted = async (payload: ScanBasePayload): Promise<void> => {
         const test = payload.testType;
         const step = payload.key;
         const config = this.assessmentsProvider.forType(test).getVisualizationConfiguration();
@@ -307,7 +309,9 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onUndoStepStatusChange = (payload: ChangeRequirementStatusPayload): void => {
+    private onUndoStepStatusChange = async (
+        payload: ChangeRequirementStatusPayload,
+    ): Promise<void> => {
         const config = this.assessmentsProvider
             .forType(payload.test)
             .getVisualizationConfiguration();
@@ -334,7 +338,9 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onUndoInstanceStatusChange = (payload: AssessmentActionInstancePayload): void => {
+    private onUndoInstanceStatusChange = async (
+        payload: AssessmentActionInstancePayload,
+    ): Promise<void> => {
         const config = this.assessmentsProvider
             .forType(payload.test)
             .getVisualizationConfiguration();
@@ -384,7 +390,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onScanCompleted = (payload: ScanCompletedPayload<any>): void => {
+    private onScanCompleted = async (payload: ScanCompletedPayload<any>): Promise<void> => {
         const test = payload.testType;
         const step = payload.key;
         const config = this.assessmentsProvider.forType(test).getVisualizationConfiguration();
@@ -407,7 +413,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onScanUpdate = (payload: ScanUpdatePayload): void => {
+    private onScanUpdate = async (payload: ScanUpdatePayload): Promise<void> => {
         const test = payload.testType;
         const step = payload.key;
         const config = this.assessmentsProvider.forType(test).getVisualizationConfiguration();
@@ -425,7 +431,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onResetData = (payload: ToggleActionPayload): void => {
+    private onResetData = async (payload: ToggleActionPayload): Promise<void> => {
         const test = this.assessmentsProvider.forType(payload.test);
         const config = test.getVisualizationConfiguration();
         const defaultTestStatus: AssessmentData = config.getAssessmentData(
@@ -436,14 +442,16 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onResetAllAssessmentsData = (targetTabId: number): void => {
+    private onResetAllAssessmentsData = async (targetTabId: number): Promise<void> => {
         const detailsViewId = this.state.persistedTabInfo.detailsViewId;
         this.state = this.generateDefaultState(null);
         this.state.persistedTabInfo = { detailsViewId };
         this.updateTargetTabWithId(targetTabId);
     };
 
-    private onUpdateDetailsViewId = (payload: OnDetailsViewInitializedPayload): void => {
+    private onUpdateDetailsViewId = async (
+        payload: OnDetailsViewInitializedPayload,
+    ): Promise<void> => {
         if (!this.state.persistedTabInfo) {
             this.state.persistedTabInfo = { detailsViewId: payload.detailsViewId };
         } else {

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -182,7 +182,9 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onPassUnmarkedInstances = (payload: AssessmentActionInstancePayload): void => {
+    private onPassUnmarkedInstances = async (
+        payload: AssessmentActionInstancePayload,
+    ): Promise<void> => {
         const config = this.assessmentsProvider
             .forType(payload.test)
             .getVisualizationConfiguration();
@@ -206,7 +208,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onEditFailureInstance = (payload: EditFailureInstancePayload): void => {
+    private onEditFailureInstance = async (payload: EditFailureInstancePayload): Promise<void> => {
         const config = this.assessmentsProvider
             .forType(payload.test)
             .getVisualizationConfiguration();
@@ -269,9 +271,9 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onChangeAssessmentVisualizationStateForAll = (
+    private onChangeAssessmentVisualizationStateForAll = async (
         payload: ChangeInstanceSelectionPayload,
-    ): void => {
+    ): Promise<void> => {
         const { test, requirement } = payload;
         const config = this.assessmentsProvider.forType(test).getVisualizationConfiguration();
         const assessmentDataMap = config.getAssessmentData(
@@ -317,9 +319,9 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onChangeAssessmentVisualizationState = (
+    private onChangeAssessmentVisualizationState = async (
         payload: ChangeInstanceSelectionPayload,
-    ): void => {
+    ): Promise<void> => {
         const { test, requirement } = payload;
         const config = this.assessmentsProvider.forType(test).getVisualizationConfiguration();
         const assessmentData = config.getAssessmentData(this.state);

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -226,7 +226,9 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onRemoveFailureInstance = (payload: RemoveFailureInstancePayload): void => {
+    private onRemoveFailureInstance = async (
+        payload: RemoveFailureInstancePayload,
+    ): Promise<void> => {
         const config = this.assessmentsProvider
             .forType(payload.test)
             .getVisualizationConfiguration();
@@ -243,7 +245,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onAddFailureInstance = (payload: AddFailureInstancePayload): void => {
+    private onAddFailureInstance = async (payload: AddFailureInstancePayload): Promise<void> => {
         const config = this.assessmentsProvider
             .forType(payload.test)
             .getVisualizationConfiguration();
@@ -260,7 +262,9 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onAddResultDescription = (payload: AddResultDescriptionPayload): void => {
+    private onAddResultDescription = async (
+        payload: AddResultDescriptionPayload,
+    ): Promise<void> => {
         this.state.resultDescription = payload.description;
         this.emitChanged();
     };
@@ -286,7 +290,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onChangeStepStatus = (payload: ChangeRequirementStatusPayload): void => {
+    private onChangeStepStatus = async (payload: ChangeRequirementStatusPayload): Promise<void> => {
         const config = this.assessmentsProvider
             .forType(payload.test)
             .getVisualizationConfiguration();
@@ -343,7 +347,9 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onChangeInstanceStatus = (payload: ChangeInstanceStatusPayload): void => {
+    private onChangeInstanceStatus = async (
+        payload: ChangeInstanceStatusPayload,
+    ): Promise<void> => {
         const config = this.assessmentsProvider
             .forType(payload.test)
             .getVisualizationConfiguration();
@@ -360,18 +366,18 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onSelectTestSubview = (payload: SelectTestSubviewPayload): void => {
+    private onSelectTestSubview = async (payload: SelectTestSubviewPayload): Promise<void> => {
         this.state.assessmentNavState.selectedTestType = payload.selectedTest;
         this.state.assessmentNavState.selectedTestSubview = payload.selectedTestSubview;
         this.emitChanged();
     };
 
-    private onExpandTestNav = (payload: ExpandTestNavPayload): void => {
+    private onExpandTestNav = async (payload: ExpandTestNavPayload): Promise<void> => {
         this.state.assessmentNavState.expandedTestType = payload.selectedTest;
         this.emitChanged();
     };
 
-    private onCollapseTestNav = (): void => {
+    private onCollapseTestNav = async (): Promise<void> => {
         this.state.assessmentNavState.expandedTestType = null;
         this.emitChanged();
     };

--- a/src/common/flux/scope-mutex.ts
+++ b/src/common/flux/scope-mutex.ts
@@ -6,7 +6,13 @@ import { DictionaryStringTo } from 'types/common-types';
 export class ScopeMutex {
     /**
      * A mutex to ensure that only one action in a given scope is executing at any time.
-     * This prevents cascading actions.
+     * This prevents cascading actions and infinite loops.
+     *
+     * However, with AsyncAction, it is possible for two actions to execute concurrently
+     * without one having called the other. The most obvious case when this would happen
+     * is if a message has multiple callbacks registered, more than one of which invoke
+     * actions. In this case, a different scope should be passed to invoke() in each
+     * callback to allow them to run concurrently.
      */
     private static executingScopes: DictionaryStringTo<boolean> = {};
     private static defaultScope: string = 'DEFAULT_SCOPE';

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -212,7 +212,11 @@ describe('ActionCreatorTest', () => {
                 tabId,
             ])
             .setupActionOnVisualizationActions(updateViewActionName)
-            .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
+            .setupVisualizationActionWithInvokeParameter(
+                updateViewActionName,
+                actionCreatorPayload,
+                true,
+            )
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
             .setupShowDetailsView(tabId, Promise.resolve());
 
@@ -249,7 +253,11 @@ describe('ActionCreatorTest', () => {
                 tabId,
             ])
             .setupActionOnVisualizationActions(updateViewActionName)
-            .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
+            .setupVisualizationActionWithInvokeParameter(
+                updateViewActionName,
+                actionCreatorPayload,
+                true,
+            )
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
             .setupShowDetailsView(tabId, Promise.resolve());
 
@@ -292,7 +300,11 @@ describe('ActionCreatorTest', () => {
                 tabId,
             ])
             .setupActionOnVisualizationActions(updateViewActionName)
-            .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
+            .setupVisualizationActionWithInvokeParameter(
+                updateViewActionName,
+                actionCreatorPayload,
+                true,
+            )
             .setupActionOnVisualizationActions(enablingIssuesActionName)
             .setupVisualizationActionWithInvokeParameter(
                 enablingIssuesActionName,
@@ -338,7 +350,11 @@ describe('ActionCreatorTest', () => {
                 tabId,
             ])
             .setupActionOnVisualizationActions(updateViewActionName)
-            .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
+            .setupVisualizationActionWithInvokeParameter(
+                updateViewActionName,
+                actionCreatorPayload,
+                true,
+            )
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
             .setupShowDetailsView(tabId, Promise.resolve());
 
@@ -511,11 +527,13 @@ describe('ActionCreatorTest', () => {
                 .setupVisualizationActionWithInvokeParameter(
                     updateViewActionName,
                     actionCreatorPayload,
+                    true,
                 )
                 .setupActionOnSidePanelActions(closeSidePanelActionName)
                 .setupSidePanelActionWithInvokeParameter(
                     closeSidePanelActionName,
                     'PreviewFeatures',
+                    true,
                 )
                 .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, 1)
                 .setupShowDetailsView(tabId, Promise.resolve());
@@ -541,11 +559,13 @@ describe('ActionCreatorTest', () => {
                 .setupVisualizationActionWithInvokeParameter(
                     updateViewActionName,
                     actionCreatorPayload,
+                    true,
                 )
                 .setupActionOnSidePanelActions(closeSidePanelActionName)
                 .setupSidePanelActionWithInvokeParameter(
                     closeSidePanelActionName,
                     'PreviewFeatures',
+                    true,
                 )
                 .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, 1)
                 .setupShowDetailsView(
@@ -652,7 +672,7 @@ describe('ActionCreatorTest', () => {
         const validator = new ActionCreatorValidator()
             .setupRegistrationCallback(Messages.Assessment.StartOverTest, [payload, tabId])
             .setupActionOnVisualizationActions(disableActionName)
-            .setupVisualizationActionWithInvokeParameter(disableActionName, payload.test)
+            .setupVisualizationActionWithInvokeParameter(disableActionName, payload.test, true)
             .setupTelemetrySend(TelemetryEvents.START_OVER_TEST, payload, 1);
         const actionCreator = validator.buildActionCreator();
 
@@ -692,7 +712,7 @@ describe('ActionCreatorTest', () => {
                 tabId,
             ])
             .setupActionOnVisualizationActions(disableActionName)
-            .setupVisualizationActionWithInvokeParameter(disableActionName, null)
+            .setupVisualizationActionWithInvokeParameter(disableActionName, null, true)
             .setupTelemetrySend(TelemetryEvents.START_OVER_ASSESSMENT, payload, 1);
         const actionCreator = validator.buildActionCreator();
 
@@ -908,6 +928,8 @@ describe('ActionCreatorTest', () => {
 });
 
 class ActionCreatorValidator {
+    private readonly actionExecutingScope = 'ActionCreator';
+
     private visualizationActionsContainerMock = Mock.ofType(VisualizationActions);
     private visualizationActionMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
     private devToolsActionMocks: DictionaryStringTo<IMock<Action<any, any>>> = {};
@@ -991,6 +1013,7 @@ class ActionCreatorValidator {
         actionName: string,
         expectedInvokeParam: any,
         actionsMap: DictionaryStringTo<IMock<Action<any, any>>>,
+        invokeWithScope: boolean = false,
     ): ActionCreatorValidator {
         let action = actionsMap[actionName];
 
@@ -999,7 +1022,13 @@ class ActionCreatorValidator {
             actionsMap[actionName] = action;
         }
 
-        action.setup(am => am.invoke(It.isValue(expectedInvokeParam))).verifiable(Times.once());
+        if (invokeWithScope) {
+            action
+                .setup(am => am.invoke(expectedInvokeParam, this.actionExecutingScope))
+                .verifiable(Times.once());
+        } else {
+            action.setup(am => am.invoke(expectedInvokeParam)).verifiable(Times.once());
+        }
 
         return this;
     }
@@ -1007,11 +1036,13 @@ class ActionCreatorValidator {
     public setupVisualizationActionWithInvokeParameter(
         actionName: keyof VisualizationActions,
         expectedInvokeParam: any,
+        invokeWithScope: boolean = false,
     ): ActionCreatorValidator {
         this.setupActionWithInvokeParameter(
             actionName,
             expectedInvokeParam,
             this.visualizationActionMocks,
+            invokeWithScope,
         );
         return this;
     }
@@ -1049,11 +1080,13 @@ class ActionCreatorValidator {
     public setupSidePanelActionWithInvokeParameter(
         actionName: keyof SidePanelActions,
         expectedInvokeParam: any,
+        invokeWithScope: boolean = false,
     ): ActionCreatorValidator {
         this.setupActionWithInvokeParameter(
             actionName,
             expectedInvokeParam,
             this.sidePanelActionMocks,
+            invokeWithScope,
         );
         return this;
     }

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -212,11 +212,7 @@ describe('ActionCreatorTest', () => {
                 tabId,
             ])
             .setupActionOnVisualizationActions(updateViewActionName)
-            .setupVisualizationActionWithInvokeParameter(
-                updateViewActionName,
-                actionCreatorPayload,
-                true,
-            )
+            .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
             .setupShowDetailsView(tabId, Promise.resolve());
 
@@ -253,11 +249,7 @@ describe('ActionCreatorTest', () => {
                 tabId,
             ])
             .setupActionOnVisualizationActions(updateViewActionName)
-            .setupVisualizationActionWithInvokeParameter(
-                updateViewActionName,
-                actionCreatorPayload,
-                true,
-            )
+            .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
             .setupShowDetailsView(tabId, Promise.resolve());
 
@@ -300,11 +292,7 @@ describe('ActionCreatorTest', () => {
                 tabId,
             ])
             .setupActionOnVisualizationActions(updateViewActionName)
-            .setupVisualizationActionWithInvokeParameter(
-                updateViewActionName,
-                actionCreatorPayload,
-                true,
-            )
+            .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
             .setupActionOnVisualizationActions(enablingIssuesActionName)
             .setupVisualizationActionWithInvokeParameter(
                 enablingIssuesActionName,
@@ -350,11 +338,7 @@ describe('ActionCreatorTest', () => {
                 tabId,
             ])
             .setupActionOnVisualizationActions(updateViewActionName)
-            .setupVisualizationActionWithInvokeParameter(
-                updateViewActionName,
-                actionCreatorPayload,
-                true,
-            )
+            .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
             .setupShowDetailsView(tabId, Promise.resolve());
 
@@ -527,13 +511,11 @@ describe('ActionCreatorTest', () => {
                 .setupVisualizationActionWithInvokeParameter(
                     updateViewActionName,
                     actionCreatorPayload,
-                    true,
                 )
                 .setupActionOnSidePanelActions(closeSidePanelActionName)
                 .setupSidePanelActionWithInvokeParameter(
                     closeSidePanelActionName,
                     'PreviewFeatures',
-                    true,
                 )
                 .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, 1)
                 .setupShowDetailsView(tabId, Promise.resolve());
@@ -559,13 +541,11 @@ describe('ActionCreatorTest', () => {
                 .setupVisualizationActionWithInvokeParameter(
                     updateViewActionName,
                     actionCreatorPayload,
-                    true,
                 )
                 .setupActionOnSidePanelActions(closeSidePanelActionName)
                 .setupSidePanelActionWithInvokeParameter(
                     closeSidePanelActionName,
                     'PreviewFeatures',
-                    true,
                 )
                 .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, 1)
                 .setupShowDetailsView(
@@ -672,7 +652,7 @@ describe('ActionCreatorTest', () => {
         const validator = new ActionCreatorValidator()
             .setupRegistrationCallback(Messages.Assessment.StartOverTest, [payload, tabId])
             .setupActionOnVisualizationActions(disableActionName)
-            .setupVisualizationActionWithInvokeParameter(disableActionName, payload.test, true)
+            .setupVisualizationActionWithInvokeParameter(disableActionName, payload.test)
             .setupTelemetrySend(TelemetryEvents.START_OVER_TEST, payload, 1);
         const actionCreator = validator.buildActionCreator();
 
@@ -712,7 +692,7 @@ describe('ActionCreatorTest', () => {
                 tabId,
             ])
             .setupActionOnVisualizationActions(disableActionName)
-            .setupVisualizationActionWithInvokeParameter(disableActionName, null, true)
+            .setupVisualizationActionWithInvokeParameter(disableActionName, null)
             .setupTelemetrySend(TelemetryEvents.START_OVER_ASSESSMENT, payload, 1);
         const actionCreator = validator.buildActionCreator();
 
@@ -1013,7 +993,6 @@ class ActionCreatorValidator {
         actionName: string,
         expectedInvokeParam: any,
         actionsMap: DictionaryStringTo<IMock<Action<any, any>>>,
-        invokeWithScope: boolean = false,
     ): ActionCreatorValidator {
         let action = actionsMap[actionName];
 
@@ -1022,13 +1001,9 @@ class ActionCreatorValidator {
             actionsMap[actionName] = action;
         }
 
-        if (invokeWithScope) {
-            action
-                .setup(am => am.invoke(expectedInvokeParam, this.actionExecutingScope))
-                .verifiable(Times.once());
-        } else {
-            action.setup(am => am.invoke(expectedInvokeParam)).verifiable(Times.once());
-        }
+        action
+            .setup(am => am.invoke(expectedInvokeParam, this.actionExecutingScope))
+            .verifiable(Times.once());
 
         return this;
     }
@@ -1036,13 +1011,11 @@ class ActionCreatorValidator {
     public setupVisualizationActionWithInvokeParameter(
         actionName: keyof VisualizationActions,
         expectedInvokeParam: any,
-        invokeWithScope: boolean = false,
     ): ActionCreatorValidator {
         this.setupActionWithInvokeParameter(
             actionName,
             expectedInvokeParam,
             this.visualizationActionMocks,
-            invokeWithScope,
         );
         return this;
     }
@@ -1080,13 +1053,11 @@ class ActionCreatorValidator {
     public setupSidePanelActionWithInvokeParameter(
         actionName: keyof SidePanelActions,
         expectedInvokeParam: any,
-        invokeWithScope: boolean = false,
     ): ActionCreatorValidator {
         this.setupActionWithInvokeParameter(
             actionName,
             expectedInvokeParam,
             this.sidePanelActionMocks,
-            invokeWithScope,
         );
         return this;
     }

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -45,6 +45,7 @@ describe('AssessmentActionCreatorTest', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let interpreterMock: MockInterpreter;
 
+    const actionExecutingScope = 'AssessmentActionCreator';
     const AssessmentMessages = Messages.Assessment;
     const testTabId = -1;
     const telemetryOnlyPayload: BaseActionPayload = {
@@ -441,7 +442,7 @@ describe('AssessmentActionCreatorTest', () => {
             test: -1 as VisualizationType,
         };
 
-        const resetDataMock = createAsyncActionMock(payload);
+        const resetDataMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock('resetData', resetDataMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -460,7 +461,7 @@ describe('AssessmentActionCreatorTest', () => {
     it('handles StartOverAllAssessments message', async () => {
         const payload = {};
 
-        const resetAllAssessmentsData = createAsyncActionMock(testTabId);
+        const resetAllAssessmentsData = createAsyncActionMock(testTabId, actionExecutingScope);
         const actionsMock = createActionsMock(
             'resetAllAssessmentsData',
             resetAllAssessmentsData.object,
@@ -488,8 +489,8 @@ describe('AssessmentActionCreatorTest', () => {
             key: 'test-key',
         } as ScanCompletedPayload<any>;
 
-        const updateTabIdActionMock = createAsyncActionMock(testTabId);
-        const scanCompleteMock = createAsyncActionMock(payload);
+        const updateTabIdActionMock = createAsyncActionMock(testTabId, actionExecutingScope);
+        const scanCompleteMock = createAsyncActionMock(payload, actionExecutingScope);
 
         setupAssessmentActionsMock('scanCompleted', scanCompleteMock);
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
@@ -706,7 +707,7 @@ describe('AssessmentActionCreatorTest', () => {
             pivotType: -1 as DetailsViewPivotType,
         } as OnDetailsViewOpenPayload;
 
-        const updateSelectedPivotChildMock = createAsyncActionMock(payload);
+        const updateSelectedPivotChildMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock(
             'updateSelectedPivotChild',
             updateSelectedPivotChildMock.object,

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -370,7 +370,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeInstanceSelectionPayload;
 
-        const changeAssessmentVisualizationStateMock = createSyncActionMock(payload);
+        const changeAssessmentVisualizationStateMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock(
             'changeAssessmentVisualizationState',
             changeAssessmentVisualizationStateMock.object,
@@ -403,7 +403,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeInstanceSelectionPayload;
 
-        const changeAssessmentVisualizationStateForAllMock = createSyncActionMock(payload);
+        const changeAssessmentVisualizationStateForAllMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock(
             'changeAssessmentVisualizationStateForAll',
             changeAssessmentVisualizationStateForAllMock.object,

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -6,6 +6,7 @@ import {
     AssessmentActionInstancePayload,
     BaseActionPayload,
     ChangeInstanceSelectionPayload,
+    ChangeInstanceStatusPayload,
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
     ExpandTestNavPayload,
@@ -34,7 +35,10 @@ import {
 } from 'injected/analyzers/analyzer';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createAsyncActionMock,
+    createSyncActionMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('AssessmentActionCreatorTest', () => {
     let assessmentActionsMock: IMock<AssessmentActions>;
@@ -189,7 +193,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as AddFailureInstancePayload;
 
-        const addFailureInstanceMock = createSyncActionMock(payload);
+        const addFailureInstanceMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('addFailureInstance', addFailureInstanceMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -214,7 +218,7 @@ describe('AssessmentActionCreatorTest', () => {
             description: 'test-description',
         };
 
-        const addResultDescriptionMock = createSyncActionMock(payload);
+        const addResultDescriptionMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock(
             'addResultDescription',
             addResultDescriptionMock.object,
@@ -240,7 +244,7 @@ describe('AssessmentActionCreatorTest', () => {
         } as ChangeRequirementStatusPayload;
 
         const updateTabIdActionMock = createSyncActionMock(testTabId);
-        const changeRequirementStatusMock = createSyncActionMock(payload);
+        const changeRequirementStatusMock = createAsyncActionMock(payload);
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('changeRequirementStatus', changeRequirementStatusMock);
@@ -331,13 +335,13 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles ChangeAssessmentInstanceStatus message', async () => {
-        const payload: ChangeInstanceSelectionPayload = {
+        const payload: ChangeInstanceStatusPayload = {
             selector: 'test-selector',
             ...telemetryOnlyPayload,
-        } as ChangeInstanceSelectionPayload;
+        } as ChangeInstanceStatusPayload;
 
         const updateTabIdActionMock = createSyncActionMock(testTabId);
-        const changeInstanceStatusMock = createSyncActionMock(payload);
+        const changeInstanceStatusMock = createAsyncActionMock(payload);
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('changeInstanceStatus', changeInstanceStatusMock);
@@ -531,7 +535,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as SelectTestSubviewPayload;
 
-        const selectRequirementMock = createSyncActionMock(payload);
+        const selectRequirementMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('selectTestSubview', selectRequirementMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -557,7 +561,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as SelectTestSubviewPayload;
 
-        const selectNextRequirement = createSyncActionMock(payload);
+        const selectNextRequirement = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('selectTestSubview', selectNextRequirement.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -586,7 +590,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as SelectTestSubviewPayload;
 
-        const selectRequirementMock = createSyncActionMock(actionPayload);
+        const selectRequirementMock = createAsyncActionMock(actionPayload);
         const actionsMock = createActionsMock('selectTestSubview', selectRequirementMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -611,7 +615,7 @@ describe('AssessmentActionCreatorTest', () => {
             selectedTest: 1,
         } as ExpandTestNavPayload;
 
-        const expandTestNavMock = createSyncActionMock(payload);
+        const expandTestNavMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('expandTestNav', expandTestNavMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -628,7 +632,7 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles CollapseTestNav message', async () => {
-        const collapseTestNavMock = createSyncActionMock(null);
+        const collapseTestNavMock = createAsyncActionMock(null);
         const actionsMock = createActionsMock('collapseTestNav', collapseTestNavMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -765,9 +769,9 @@ describe('AssessmentActionCreatorTest', () => {
         detailsViewInitMock.verifyAll();
     });
 
-    function setupAssessmentActionsMock(
-        actionName: keyof AssessmentActions,
-        actionMock: IMock<SyncAction<any>>,
+    function setupAssessmentActionsMock<ActionName extends keyof AssessmentActions>(
+        actionName: ActionName,
+        actionMock: IMock<AssessmentActions[ActionName]>,
     ): void {
         assessmentActionsMock
             .setup(actions => actions[actionName])

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -16,13 +16,13 @@ import {
     SelectGettingStartedPayload,
     SelectTestSubviewPayload,
     ToggleActionPayload,
+    LoadAssessmentPayload,
 } from 'background/actions/action-payloads';
 import { AssessmentActionCreator } from 'background/actions/assessment-action-creator';
 import { AssessmentActions } from 'background/actions/assessment-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import * as TelemetryEvents from 'common/extension-telemetry-events';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
-import { SyncAction } from 'common/flux/sync-action';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { gettingStartedSubview } from 'common/types/store-data/assessment-result-data';
@@ -61,8 +61,10 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles PassUnmarkedInstances message', async () => {
-        const updateTabIdActionMock = createSyncActionMock(testTabId);
-        const passUnmarkedInstanceActionMock = createSyncActionMock(telemetryOnlyPayload);
+        const updateTabIdActionMock = createAsyncActionMock(testTabId);
+        const passUnmarkedInstanceActionMock = createAsyncActionMock(
+            telemetryOnlyPayload as ToggleActionPayload,
+        );
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('passUnmarkedInstance', passUnmarkedInstanceActionMock);
@@ -94,7 +96,7 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles ContinuePreviousAssessment message', async () => {
-        const continuePreviousAssessmentMock = createSyncActionMock(testTabId);
+        const continuePreviousAssessmentMock = createAsyncActionMock(testTabId);
         const actionsMock = createActionsMock(
             'continuePreviousAssessment',
             continuePreviousAssessmentMock.object,
@@ -131,7 +133,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as EditFailureInstancePayload;
 
-        const editFailureInstanceMock = createSyncActionMock(payload);
+        const editFailureInstanceMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock(
             'editFailureInstance',
             editFailureInstanceMock.object,
@@ -164,7 +166,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as RemoveFailureInstancePayload;
 
-        const removeFailureInstanceMock = createSyncActionMock(payload);
+        const removeFailureInstanceMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock(
             'removeFailureInstance',
             removeFailureInstanceMock.object,
@@ -243,7 +245,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeRequirementStatusPayload;
 
-        const updateTabIdActionMock = createSyncActionMock(testTabId);
+        const updateTabIdActionMock = createAsyncActionMock(testTabId);
         const changeRequirementStatusMock = createAsyncActionMock(payload);
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
@@ -277,7 +279,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeRequirementStatusPayload;
 
-        const undoRequirementStatusChange = createSyncActionMock(payload);
+        const undoRequirementStatusChange = createAsyncActionMock(payload);
         const actionsMock = createActionsMock(
             'undoRequirementStatusChange',
             undoRequirementStatusChange.object,
@@ -311,7 +313,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as AssessmentActionInstancePayload;
 
-        const undoInstanceStatusChangeMock = createSyncActionMock(payload);
+        const undoInstanceStatusChangeMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock(
             'undoInstanceStatusChange',
             undoInstanceStatusChangeMock.object,
@@ -340,7 +342,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeInstanceStatusPayload;
 
-        const updateTabIdActionMock = createSyncActionMock(testTabId);
+        const updateTabIdActionMock = createAsyncActionMock(testTabId);
         const changeInstanceStatusMock = createAsyncActionMock(payload);
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
@@ -439,7 +441,7 @@ describe('AssessmentActionCreatorTest', () => {
             test: -1 as VisualizationType,
         };
 
-        const resetDataMock = createSyncActionMock(payload);
+        const resetDataMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('resetData', resetDataMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -458,7 +460,7 @@ describe('AssessmentActionCreatorTest', () => {
     it('handles StartOverAllAssessments message', async () => {
         const payload = {};
 
-        const resetAllAssessmentsData = createSyncActionMock(testTabId);
+        const resetAllAssessmentsData = createAsyncActionMock(testTabId);
         const actionsMock = createActionsMock(
             'resetAllAssessmentsData',
             resetAllAssessmentsData.object,
@@ -486,8 +488,8 @@ describe('AssessmentActionCreatorTest', () => {
             key: 'test-key',
         } as ScanCompletedPayload<any>;
 
-        const updateTabIdActionMock = createSyncActionMock(testTabId);
-        const scanCompleteMock = createSyncActionMock(payload);
+        const updateTabIdActionMock = createAsyncActionMock(testTabId);
+        const scanCompleteMock = createAsyncActionMock(payload);
 
         setupAssessmentActionsMock('scanCompleted', scanCompleteMock);
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
@@ -654,7 +656,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ScanUpdatePayload;
 
-        const scanUpdateMock = createSyncActionMock(payload);
+        const scanUpdateMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('scanUpdate', scanUpdateMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -679,7 +681,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ScanBasePayload;
 
-        const trackingCompletedMock = createSyncActionMock(payload);
+        const trackingCompletedMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('trackingCompleted', trackingCompletedMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -704,7 +706,7 @@ describe('AssessmentActionCreatorTest', () => {
             pivotType: -1 as DetailsViewPivotType,
         } as OnDetailsViewOpenPayload;
 
-        const updateSelectedPivotChildMock = createSyncActionMock(payload);
+        const updateSelectedPivotChildMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock(
             'updateSelectedPivotChild',
             updateSelectedPivotChildMock.object,
@@ -750,7 +752,7 @@ describe('AssessmentActionCreatorTest', () => {
             detailsViewId: 'testId',
         } as OnDetailsViewInitializedPayload;
 
-        const detailsViewInitMock = createSyncActionMock(payload);
+        const detailsViewInitMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('updateDetailsViewId', detailsViewInitMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -767,6 +769,35 @@ describe('AssessmentActionCreatorTest', () => {
         );
 
         detailsViewInitMock.verifyAll();
+    });
+
+    it('handles LoadAssessment message', async () => {
+        const payload = {
+            tabId: 1,
+            detailsViewId: 'testId',
+        } as LoadAssessmentPayload;
+
+        const loadAssessmentMock = createAsyncActionMock(payload);
+        const actionsMock = createActionsMock('loadAssessment', loadAssessmentMock.object);
+
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            AssessmentMessages.LoadAssessment,
+            payload,
+            testTabId,
+        );
+
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.LOAD_ASSESSMENT, payload),
+            Times.once(),
+        );
     });
 
     function setupAssessmentActionsMock<ActionName extends keyof AssessmentActions>(

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -62,9 +62,10 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles PassUnmarkedInstances message', async () => {
-        const updateTabIdActionMock = createAsyncActionMock(testTabId);
+        const updateTabIdActionMock = createAsyncActionMock(testTabId, actionExecutingScope);
         const passUnmarkedInstanceActionMock = createAsyncActionMock(
             telemetryOnlyPayload as ToggleActionPayload,
+            actionExecutingScope,
         );
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
@@ -97,7 +98,10 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles ContinuePreviousAssessment message', async () => {
-        const continuePreviousAssessmentMock = createAsyncActionMock(testTabId);
+        const continuePreviousAssessmentMock = createAsyncActionMock(
+            testTabId,
+            actionExecutingScope,
+        );
         const actionsMock = createActionsMock(
             'continuePreviousAssessment',
             continuePreviousAssessmentMock.object,
@@ -134,7 +138,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as EditFailureInstancePayload;
 
-        const editFailureInstanceMock = createAsyncActionMock(payload);
+        const editFailureInstanceMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock(
             'editFailureInstance',
             editFailureInstanceMock.object,
@@ -167,7 +171,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as RemoveFailureInstancePayload;
 
-        const removeFailureInstanceMock = createAsyncActionMock(payload);
+        const removeFailureInstanceMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock(
             'removeFailureInstance',
             removeFailureInstanceMock.object,
@@ -196,7 +200,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as AddFailureInstancePayload;
 
-        const addFailureInstanceMock = createAsyncActionMock(payload);
+        const addFailureInstanceMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock('addFailureInstance', addFailureInstanceMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -221,7 +225,7 @@ describe('AssessmentActionCreatorTest', () => {
             description: 'test-description',
         };
 
-        const addResultDescriptionMock = createAsyncActionMock(payload);
+        const addResultDescriptionMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock(
             'addResultDescription',
             addResultDescriptionMock.object,
@@ -246,8 +250,8 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeRequirementStatusPayload;
 
-        const updateTabIdActionMock = createAsyncActionMock(testTabId);
-        const changeRequirementStatusMock = createAsyncActionMock(payload);
+        const updateTabIdActionMock = createAsyncActionMock(testTabId, actionExecutingScope);
+        const changeRequirementStatusMock = createAsyncActionMock(payload, actionExecutingScope);
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('changeRequirementStatus', changeRequirementStatusMock);
@@ -280,7 +284,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeRequirementStatusPayload;
 
-        const undoRequirementStatusChange = createAsyncActionMock(payload);
+        const undoRequirementStatusChange = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock(
             'undoRequirementStatusChange',
             undoRequirementStatusChange.object,
@@ -314,7 +318,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as AssessmentActionInstancePayload;
 
-        const undoInstanceStatusChangeMock = createAsyncActionMock(payload);
+        const undoInstanceStatusChangeMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock(
             'undoInstanceStatusChange',
             undoInstanceStatusChangeMock.object,
@@ -343,8 +347,8 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeInstanceStatusPayload;
 
-        const updateTabIdActionMock = createAsyncActionMock(testTabId);
-        const changeInstanceStatusMock = createAsyncActionMock(payload);
+        const updateTabIdActionMock = createAsyncActionMock(testTabId, actionExecutingScope);
+        const changeInstanceStatusMock = createAsyncActionMock(payload, actionExecutingScope);
 
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('changeInstanceStatus', changeInstanceStatusMock);
@@ -373,7 +377,10 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeInstanceSelectionPayload;
 
-        const changeAssessmentVisualizationStateMock = createAsyncActionMock(payload);
+        const changeAssessmentVisualizationStateMock = createAsyncActionMock(
+            payload,
+            actionExecutingScope,
+        );
         const actionsMock = createActionsMock(
             'changeAssessmentVisualizationState',
             changeAssessmentVisualizationStateMock.object,
@@ -406,7 +413,10 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ChangeInstanceSelectionPayload;
 
-        const changeAssessmentVisualizationStateForAllMock = createAsyncActionMock(payload);
+        const changeAssessmentVisualizationStateForAllMock = createAsyncActionMock(
+            payload,
+            actionExecutingScope,
+        );
         const actionsMock = createActionsMock(
             'changeAssessmentVisualizationStateForAll',
             changeAssessmentVisualizationStateForAllMock.object,
@@ -513,7 +523,7 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles GetCurrentState message', async () => {
-        const getCurrentStateMock = createSyncActionMock<void>(null);
+        const getCurrentStateMock = createSyncActionMock<void>(null, actionExecutingScope);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -538,7 +548,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as SelectTestSubviewPayload;
 
-        const selectRequirementMock = createAsyncActionMock(payload);
+        const selectRequirementMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock('selectTestSubview', selectRequirementMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -564,7 +574,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as SelectTestSubviewPayload;
 
-        const selectNextRequirement = createAsyncActionMock(payload);
+        const selectNextRequirement = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock('selectTestSubview', selectNextRequirement.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -593,7 +603,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as SelectTestSubviewPayload;
 
-        const selectRequirementMock = createAsyncActionMock(actionPayload);
+        const selectRequirementMock = createAsyncActionMock(actionPayload, actionExecutingScope);
         const actionsMock = createActionsMock('selectTestSubview', selectRequirementMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -618,7 +628,7 @@ describe('AssessmentActionCreatorTest', () => {
             selectedTest: 1,
         } as ExpandTestNavPayload;
 
-        const expandTestNavMock = createAsyncActionMock(payload);
+        const expandTestNavMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock('expandTestNav', expandTestNavMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -635,7 +645,7 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles CollapseTestNav message', async () => {
-        const collapseTestNavMock = createAsyncActionMock(null);
+        const collapseTestNavMock = createAsyncActionMock(null, actionExecutingScope);
         const actionsMock = createActionsMock('collapseTestNav', collapseTestNavMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -657,7 +667,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ScanUpdatePayload;
 
-        const scanUpdateMock = createAsyncActionMock(payload);
+        const scanUpdateMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock('scanUpdate', scanUpdateMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -682,7 +692,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as ScanBasePayload;
 
-        const trackingCompletedMock = createAsyncActionMock(payload);
+        const trackingCompletedMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock('trackingCompleted', trackingCompletedMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -753,7 +763,7 @@ describe('AssessmentActionCreatorTest', () => {
             detailsViewId: 'testId',
         } as OnDetailsViewInitializedPayload;
 
-        const detailsViewInitMock = createAsyncActionMock(payload);
+        const detailsViewInitMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock('updateDetailsViewId', detailsViewInitMock.object);
 
         const testSubject = new AssessmentActionCreator(
@@ -778,7 +788,7 @@ describe('AssessmentActionCreatorTest', () => {
             detailsViewId: 'testId',
         } as LoadAssessmentPayload;
 
-        const loadAssessmentMock = createAsyncActionMock(payload);
+        const loadAssessmentMock = createAsyncActionMock(payload, actionExecutingScope);
         const actionsMock = createActionsMock('loadAssessment', loadAssessmentMock.object);
 
         const testSubject = new AssessmentActionCreator(

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -655,7 +655,7 @@ describe('AssessmentStore', () => {
             .callback((id, resolve) => resolve(tab));
 
         const storeTester =
-            createStoreTesterForAssessmentActions('LoadAssessment').withActionParam(payload);
+            createStoreTesterForAssessmentActions('loadAssessment').withActionParam(payload);
         await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 


### PR DESCRIPTION
#### Details

Convert all SyncActions in AssessmentActions to AsyncActions

##### Motivation

Feature work

##### Context

Some of the messages that AssessmentActionCreator listens for also have other listeners registered in ActionCreator. Messages are interpreted concurrently using both the global context and the tab context, and since some of the messages affected by this change have listeners in both contexts, some of the now-async actions may be invoked concurrently. This shouldn't be a problem, except that the current Action classes have built-in measures to prevent two actions from running at the same time in the same "scope." To avoid spurious exceptions, this PR adds a "scope" parameter to Action.invoke() calls inside listeners that may run concurrently with other listeners (i.e. listeners for messages that have multiple listeners registered).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
