### PR TITLE
fix: Fix shadow host visualization bug

### DIFF
--- a/src/common/target-helper.ts
+++ b/src/common/target-helper.ts
@@ -100,11 +100,13 @@ export class TargetHelper {
 
     private static getShadowHost = (selectors: string[], dom: Document): Element | null => {
         let shadowHost: Element | null = null;
+        let queryElement: ShadowRoot | Document = dom;
         for (let i = 0; i < selectors.length - 1; i++) {
-            shadowHost = dom.querySelector(selectors[i]);
+            shadowHost = queryElement.querySelector(selectors[i]);
             if (shadowHost == null || shadowHost.shadowRoot == null) {
                 return null;
             }
+            queryElement = shadowHost.shadowRoot;
         }
         return shadowHost;
     };

--- a/src/tests/unit/tests/common/target-helper.test.ts
+++ b/src/tests/unit/tests/common/target-helper.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { TargetHelper } from 'common/target-helper';
-import { forEach } from 'lodash';
 import { It, Mock, Times } from 'typemoq';
 
 describe(TargetHelper, () => {
@@ -65,12 +64,16 @@ describe(TargetHelper, () => {
     it.each(testScenarios)('getTargetElements', testScenario => {
         if (testScenario.expectedShadowDomElements && testScenario.expectedFinalTargetElement) {
             // Set up for element in the shadow dom
-            forEach(testScenario.expectedShadowDomElements, shadowDomElement => {
-                documentMock
-                    .setup(dm => dm.querySelector(shadowDomElement))
+            documentMock
+                .setup(dm => dm.querySelector(testScenario.expectedShadowDomElements[0]))
+                .returns(() => shadowRootElementStub)
+                .verifiable(Times.once());
+            for (let i = 1; i < testScenario.expectedShadowDomElements.length; i++) {
+                shadowRootMock
+                    .setup(dm => dm.querySelector(testScenario.expectedShadowDomElements[i]))
                     .returns(() => shadowRootElementStub)
                     .verifiable(Times.once());
-            });
+            }
 
             shadowRootMock
                 .setup(dm => dm.querySelectorAll(testScenario.expectedFinalTargetElement))
@@ -101,12 +104,16 @@ describe(TargetHelper, () => {
     it.each(testScenarios)('getTargetElement', testScenario => {
         if (testScenario.expectedShadowDomElements && testScenario.expectedFinalTargetElement) {
             // Set up for element in the shadow dom
-            forEach(testScenario.expectedShadowDomElements, shadowDomElement => {
-                documentMock
-                    .setup(dm => dm.querySelector(shadowDomElement))
+            documentMock
+                .setup(dm => dm.querySelector(testScenario.expectedShadowDomElements[0]))
+                .returns(() => shadowRootElementStub)
+                .verifiable(Times.once());
+            for (let i = 1; i < testScenario.expectedShadowDomElements.length; i++) {
+                shadowRootMock
+                    .setup(dm => dm.querySelector(testScenario.expectedShadowDomElements[i]))
                     .returns(() => shadowRootElementStub)
                     .verifiable(Times.once());
-            });
+            }
 
             shadowRootMock
                 .setup(dm => dm.querySelector(testScenario.expectedFinalTargetElement))


### PR DESCRIPTION
#### Details

Fix bug introduced by https://github.com/microsoft/accessibility-insights-web/pull/5728 in which visualizations would not appear on pages which have nested shadow dom selectors.

##### Motivation

Bug fix

##### Context

See https://github.com/microsoft/accessibility-insights-web/pull/5728.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
