### PR TITLE
fix: Add e2e test for nested shadow dom visualizations

### DIFF
--- a/src/tests/end-to-end/test-resources/nested-shadow-doms.html
+++ b/src/tests/end-to-end/test-resources/nested-shadow-doms.html
@@ -1,0 +1,40 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Page with Shadow DOMs</title>
+        <style>
+            .shadow-container {
+                height: 50px;
+                width: 100%;
+                border: 1px solid black;
+            }
+        </style>
+        <script>
+            function addShadowContent(id) {
+                const grandparentContainer = document.getElementById(id);
+                const grandparentShadowRoot = grandparentContainer.attachShadow({ mode: 'open' });
+                grandparentShadowRoot.innerHTML =
+                    '<div id="parent-shadow-container" class="shadow-container"></div>';
+
+                const parentContainer =
+                    grandparentShadowRoot.getElementById('parent-shadow-container');
+                const parentShadowRoot = parentContainer.attachShadow({ mode: 'open' });
+                parentShadowRoot.innerHTML = '<p style="color: #ccc">low-contrast text</p>';
+            }
+
+            window.addEventListener('DOMContentLoaded', () => {
+                addShadowContent('grandparent-shadow-container');
+            });
+        </script>
+    </head>
+
+    <body>
+        <h1>Page with nested Shadow DOMs</h1>
+        <div id="grandparent-shadow-container" class="shadow-container"></div>
+    </body>
+</html>

--- a/src/tests/end-to-end/tests/target-page/__snapshots__/visualization-boxes.test.ts.snap
+++ b/src/tests/end-to-end/tests/target-page/__snapshots__/visualization-boxes.test.ts.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Target Page visualization boxes visualization boxes are shown over nested shadow dom elements 1`] = `
+<DocumentFragment>
+  <div
+    id="insights-shadow-container"
+  >
+    <link
+      href="{{EXTENSION_URL_BASE}}/injected/styles/default/injected.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <link
+      href="{{EXTENSION_URL_BASE}}/bundle/injected.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <div
+      class="insights-container insights-highlight-container insights-issues"
+    >
+      <div
+        class="insights-highlight-box"
+        style="outline-style: solid; outline-color: rgb(232, 17, 35); top: {{ENVIRONMENT_SENSITIVE_POSITION}}px; left: {{ENVIRONMENT_SENSITIVE_POSITION}}px; min-width: {{ENVIRONMENT_SENSITIVE_POSITION}}px; min-height: {{ENVIRONMENT_SENSITIVE_POSITION}}px;"
+        title="Failed rules: color-contrast"
+      >
+        <div
+          class="insights-highlight-text failure-label"
+          style="background: rgb(232, 17, 35); color: rgb(255, 255, 255); width: 2em !important; cursor: pointer !important; text-align: center !important;"
+        >
+          !
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Target Page visualization boxes visualization boxes are shown over shadow dom elements 1`] = `
 <DocumentFragment>
   <div

--- a/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
+++ b/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
@@ -62,4 +62,20 @@ describe('Target Page visualization boxes', () => {
 
         expect(await targetPage.waitForShadowRootHtmlSnapshot()).toMatchSnapshot();
     });
+
+    test('visualization boxes are shown over nested shadow dom elements', async () => {
+        targetPage = await browser.newTargetPage({ testResourcePath: 'nested-shadow-doms.html' });
+
+        popupPage = await browser.newPopupPage(targetPage);
+        await popupPage.gotoAdhocPanel();
+
+        await popupPage.enableToggleByAriaLabel('Automated checks');
+
+        await targetPage.waitForSelectorInShadowRoot(
+            TargetPageInjectedComponentSelectors.insightsVisualizationContainer,
+            { state: 'attached' },
+        );
+
+        expect(await targetPage.waitForShadowRootHtmlSnapshot()).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Details

Follow up to https://github.com/microsoft/accessibility-insights-web/pull/5783, adding e2e test coverage for this bug fix. 

##### Motivation

Expand test coverage

##### Context

See https://github.com/microsoft/accessibility-insights-web/pull/5783

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
