### PR TITLE
feat(mv3-part-5): Convert NeedsReviewScanResultActions to async

### DIFF
--- a/src/background/actions/needs-review-scan-result-action-creator.ts
+++ b/src/background/actions/needs-review-scan-result-action-creator.ts
@@ -28,13 +28,13 @@ export class NeedsReviewScanResultActionCreator {
         );
     }
 
-    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
-        this.needsReviewScanResultActions.scanCompleted.invoke(payload);
+    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
+        await this.needsReviewScanResultActions.scanCompleted.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(SCAN_INCOMPLETE_WARNINGS, payload);
         this.notificationCreator.createNotification(payload.notificationText);
     };
 
-    private onGetScanCurrentState = (): void => {
-        this.needsReviewScanResultActions.getCurrentState.invoke(null);
+    private onGetScanCurrentState = async (): Promise<void> => {
+        await this.needsReviewScanResultActions.getCurrentState.invoke(null);
     };
 }

--- a/src/background/actions/needs-review-scan-result-actions.ts
+++ b/src/background/actions/needs-review-scan-result-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { UnifiedScanCompletedPayload } from './action-payloads';
 
 export class NeedsReviewScanResultActions {
-    public readonly scanCompleted = new SyncAction<UnifiedScanCompletedPayload>();
-    public readonly getCurrentState = new SyncAction();
+    public readonly scanCompleted = new AsyncAction<UnifiedScanCompletedPayload>();
+    public readonly getCurrentState = new AsyncAction();
 }

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -164,7 +164,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         this.emitChanged();
     };
 
-    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
+    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
         this.state = this.getDefaultState();
         this.state.rules = {};
 

--- a/src/background/stores/needs-review-scan-result-store.ts
+++ b/src/background/stores/needs-review-scan-result-store.ts
@@ -51,7 +51,7 @@ export class NeedsReviewScanResultStore extends PersistentStore<NeedsReviewScanR
         this.tabActions.existingTabUpdated.addListener(this.onResetStoreData);
     }
 
-    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
+    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
         this.state.results = payload.scanResult;
         this.state.rules = payload.rules;
         this.state.toolInfo = payload.toolInfo;

--- a/src/tests/unit/tests/background/actions/needs-review-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/needs-review-scan-result-action-creator.test.ts
@@ -15,7 +15,7 @@ import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
-import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('NeedsReviewScanResultActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -43,7 +43,7 @@ describe('NeedsReviewScanResultActionCreator', () => {
             telemetry,
         };
 
-        const scanCompletedMock = createSyncActionMock(payload);
+        const scanCompletedMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('scanCompleted', scanCompletedMock.object);
 
         const testSubject = new NeedsReviewScanResultActionCreator(
@@ -71,7 +71,7 @@ describe('NeedsReviewScanResultActionCreator', () => {
     it('should handle GetState message', async () => {
         const payload = null;
 
-        const getCurrentStateMock = createSyncActionMock<null>(payload);
+        const getCurrentStateMock = createAsyncActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
 
         const testSubject = new NeedsReviewScanResultActionCreator(


### PR DESCRIPTION
#### Details

Convert NeedsReviewScanResultActions from SyncAction to AsyncAction

##### Motivation

Feature work

##### Context

N/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
