### PR TITLE
chore: Enable react/jsx-key

### DIFF
--- a/eslintrc.base.js
+++ b/eslintrc.base.js
@@ -71,7 +71,7 @@ module.exports = {
         'react/prop-types': 'off',
         'react/display-name': 'off',
         'react/no-unescaped-entities': 'off',
-        'react/jsx-key': 'off',
+        'react/jsx-key': 'error',
         'react/no-access-state-in-setstate': 'error',
         'react/no-unused-state': 'error',
         'react/no-direct-mutation-state': 'off',

--- a/eslintrc.base.js
+++ b/eslintrc.base.js
@@ -42,6 +42,8 @@ module.exports = {
             },
         ],
         'no-throw-literal': 'error',
+        'react/no-access-state-in-setstate': 'error',
+        'react/no-unused-state': 'error',
 
         // Disabled due to high existing-positive count during initial tslint -> eslint migration
         '@typescript-eslint/no-explicit-any': 'off',
@@ -71,9 +73,6 @@ module.exports = {
         'react/prop-types': 'off',
         'react/display-name': 'off',
         'react/no-unescaped-entities': 'off',
-        'react/jsx-key': 'error',
-        'react/no-access-state-in-setstate': 'error',
-        'react/no-unused-state': 'error',
         'react/no-direct-mutation-state': 'off',
         'react/jsx-no-target-blank': 'off',
         'react/no-unknown-property': 'off',

--- a/src/DetailsView/tab-stops-requirements-with-instances.tsx
+++ b/src/DetailsView/tab-stops-requirements-with-instances.tsx
@@ -82,7 +82,9 @@ export const TabStopsRequirementsWithInstances = NamedFC<TabStopsRequirementsWit
                     }
                     const CollapsibleComponent = deps.collapsibleControl(collapsibleComponentProps);
 
-                    return CollapsibleComponent;
+                    return (
+                        <React.Fragment key={requirement.id}>{CollapsibleComponent}</React.Fragment>
+                    );
                 })}
             </div>
         );

--- a/src/content/test/images/images-of-text.tsx
+++ b/src/content/test/images/images-of-text.tsx
@@ -41,7 +41,7 @@ export const infoAndExamples = create(({ Markup }) => (
             }
             passText={<p>A submit button uses actual text and CSS styling to achieve the desired appearance.</p>}
             passExample={[
-                <Markup.CodeExample title="CSS">{`<style>
+                <Markup.CodeExample key="css" title="CSS">{`<style>
                 .button {
                 background-color: #4CAF50;
                 border: none;
@@ -54,7 +54,7 @@ export const infoAndExamples = create(({ Markup }) => (
                 margin: 4px 2px;
                 }
                 </style>`}</Markup.CodeExample>,
-                <Markup.CodeExample title="HTML">{`<form action="/action_page.php">
+                <Markup.CodeExample key="html" title="HTML">{`<form action="/action_page.php">
                 <p id="username">User name: <input type="text" name="uname"></p>
                 <input [type="submit" class="button"]>
                 </form>`}</Markup.CodeExample>,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/tab-stops-requirements-with-instances.test.tsx.snap
@@ -2,14 +2,18 @@
 
 exports[`TabStopsRequirementsWithInstances renders component instance count === 0 1`] = `
 <div>
-  <CollapsibleControlStub
-    headingLevel={3}
-    id="keyboard-navigation0keyboard-navigation 0 Failed test requirement description 1"
-  />
-  <CollapsibleControlStub
-    headingLevel={3}
-    id="keyboard-traps1keyboard-traps 0 Failed test requirement description 2"
-  />
+  <React.Fragment>
+    <CollapsibleControlStub
+      headingLevel={3}
+      id="keyboard-navigation0keyboard-navigation 0 Failed test requirement description 1"
+    />
+  </React.Fragment>
+  <React.Fragment>
+    <CollapsibleControlStub
+      headingLevel={3}
+      id="keyboard-traps1keyboard-traps 0 Failed test requirement description 2"
+    />
+  </React.Fragment>
 </div>
 `;
 
@@ -17,13 +21,17 @@ exports[`TabStopsRequirementsWithInstances renders empty div when instance count
 
 exports[`TabStopsRequirementsWithInstances renders when instance count > 0 1`] = `
 <div>
-  <CollapsibleControlStub
-    headingLevel={3}
-    id="keyboard-navigation0keyboard-navigation 2 Failed test requirement description 1"
-  />
-  <CollapsibleControlStub
-    headingLevel={3}
-    id="keyboard-traps1keyboard-traps 2 Failed test requirement description 2"
-  />
+  <React.Fragment>
+    <CollapsibleControlStub
+      headingLevel={3}
+      id="keyboard-navigation0keyboard-navigation 2 Failed test requirement description 1"
+    />
+  </React.Fragment>
+  <React.Fragment>
+    <CollapsibleControlStub
+      headingLevel={3}
+      id="keyboard-traps1keyboard-traps 2 Failed test requirement description 2"
+    />
+  </React.Fragment>
 </div>
 `;

--- a/src/tests/unit/tests/reports/components/report-sections/summary-results-table.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/summary-results-table.test.tsx
@@ -24,8 +24,8 @@ describe(SummaryResultsTable.displayName, () => {
             },
         ];
         const rows = [
-            ['cell1', 'cell2', <div>cell3</div>],
-            ['cell4', 'cell5', <div>cell6</div>],
+            ['cell1', 'cell2', <div key="cell3">cell3</div>],
+            ['cell4', 'cell5', <div key="cell6">cell6</div>],
         ];
         const wrapped = shallow(
             <SummaryResultsTable columns={columns} rows={rows} id="table-id" />,


### PR DESCRIPTION
#### Details

When running `yarn test` I noticed a key prop error: `Warning: Each child in a list should have a unique "key" prop.` This pull request will enable (set to `error`) and make the required fixes.

##### Motivation

Reduce `console.errors` in test output and make sure [React items have a stable identity](https://reactjs.org/docs/lists-and-keys.html#keys).

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

In looking back at the history for [react/jsx-key](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md), I believe it was disabled when switching from tslint to eslint https://github.com/microsoft/accessibility-insights-web/pull/3273 as a means to unblock the migration. Please correct me if I'm wrong :)

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
