### PR TITLE
refactor(mv3-part-5): Assessment store improvements

### DIFF
--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -142,7 +142,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.state = this.initialAssessmentStoreDataGenerator.generateInitialState(
             payload.versionedAssessmentData.assessmentData,
         );
-        if (this.state.persistedTabInfo !== undefined) {
+        if (this.state.persistedTabInfo != null) {
             this.state.persistedTabInfo.detailsViewId = payload.detailsViewId;
         } else {
             this.state.persistedTabInfo = { detailsViewId: payload.detailsViewId };

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -115,27 +115,20 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         this.assessmentActions.updateDetailsViewId.addListener(this.onUpdateDetailsViewId);
     }
 
-    private updateTargetTabWithId(tabId: number): void {
-        this.browserAdapter.getTab(
-            tabId,
-            tab => {
-                this.state.persistedTabInfo = {
-                    id: tab.id,
-                    url: tab.url,
-                    title: tab.title,
-                    detailsViewId: this.state.persistedTabInfo?.detailsViewId,
-                };
+    private async updateTargetTabWithId(tabId: number): Promise<void> {
+        const tab = await this.browserAdapter.getTabAsync(tabId);
+        this.state.persistedTabInfo = {
+            id: tab.id,
+            url: tab.url,
+            title: tab.title,
+            detailsViewId: this.state.persistedTabInfo?.detailsViewId,
+        };
 
-                this.emitChanged();
-            },
-            () => {
-                throw new Error(`tab with Id ${tabId} not found`);
-            },
-        );
+        this.emitChanged();
     }
 
     private onContinuePreviousAssessment = async (tabId: number): Promise<void> => {
-        this.updateTargetTabWithId(tabId);
+        await this.updateTargetTabWithId(tabId);
     };
 
     private onLoadAssessment = async (payload: LoadAssessmentPayload): Promise<void> => {
@@ -147,12 +140,12 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         } else {
             this.state.persistedTabInfo = { detailsViewId: payload.detailsViewId };
         }
-        this.updateTargetTabWithId(payload.tabId);
+        await this.updateTargetTabWithId(payload.tabId);
     };
 
     private onUpdateTargetTabId = async (tabId: number): Promise<void> => {
         if (this.state.persistedTabInfo == null || this.state.persistedTabInfo.id !== tabId) {
-            this.updateTargetTabWithId(tabId);
+            await this.updateTargetTabWithId(tabId);
         }
     };
 
@@ -446,7 +439,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         const detailsViewId = this.state.persistedTabInfo.detailsViewId;
         this.state = this.generateDefaultState(null);
         this.state.persistedTabInfo = { detailsViewId };
-        this.updateTargetTabWithId(targetTabId);
+        await this.updateTargetTabWithId(targetTabId);
     };
 
     private onUpdateDetailsViewId = async (

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -34,7 +34,6 @@ export interface BrowserAdapter {
     createTabInNewWindow(url: string): Promise<Tabs.Tab>;
     switchToTab(tabId: number): Promise<void>;
     updateTab(tabId: number, updateProperties: Tabs.UpdateUpdatePropertiesType): Promise<Tabs.Tab>;
-    getTab(tabId: number, onResolve: (tab: chrome.tabs.Tab) => void, onReject?: () => void): void;
     getTabAsync(tabId: number): Promise<chrome.tabs.Tab>;
     updateWindow(
         windowId: number,

--- a/src/common/browser-adapters/webextension-browser-adapter.ts
+++ b/src/common/browser-adapters/webextension-browser-adapter.ts
@@ -79,22 +79,6 @@ export abstract class WebExtensionBrowserAdapter
         return browser.tabs.query(query);
     }
 
-    public getTab(
-        tabId: number,
-        onResolve: (tab: chrome.tabs.Tab) => void,
-        onReject?: () => void,
-    ): void {
-        chrome.tabs.get(tabId, tab => {
-            if (tab) {
-                onResolve(tab);
-            } else {
-                if (onReject != null) {
-                    onReject();
-                }
-            }
-        });
-    }
-
     public async getTabAsync(tabId: number): Promise<chrome.tabs.Tab> {
         return new Promise((resolve, reject) => {
             chrome.tabs.get(tabId, tab => {

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -15,7 +15,7 @@ import { Runtime, Tabs, Windows } from 'webextension-polyfill';
 export type SimulatedBrowserAdapter = IMock<BrowserAdapter> & {
     // Tests may modify this state directly; updates will be reflected in the following default mock implementations:
     //   * this.object.getAllWindows
-    //   * this.object.getTab
+    //   * this.object.getTabAsync
     //   * this.object.tabsQuery
     //
     // Tests are responsible for maintaining self-consistency (ie, ensuring all tabs have corresponding windows)
@@ -82,16 +82,6 @@ export function createSimulatedBrowserAdapter(
     mock.setup(m => m.getRuntimeLastError()).returns(() => undefined);
     mock.setup(m => m.getAllWindows(It.isAny())).returns(() =>
         Promise.resolve(mock.windows as Windows.Window[]),
-    );
-    mock.setup(m => m.getTab(It.isAny(), It.isAny(), It.isAny())).returns(
-        (tabId, resolve, reject) => {
-            const matchingTabs = mock.tabs!.filter(tab => tab.id === tabId);
-            if (matchingTabs.length === 1) {
-                resolve(matchingTabs[0]);
-            } else if (reject != null) {
-                reject();
-            }
-        },
     );
     mock.setup(m => m.getTabAsync(It.isAny())).returns(async tabId => {
         const matchingTabs = mock.tabs!.filter(tab => tab.id === tabId);

--- a/src/tests/unit/tests/background/stores/__snapshots__/assessment-store.test.ts.snap
+++ b/src/tests/unit/tests/background/stores/__snapshots__/assessment-store.test.ts.snap
@@ -4,4 +4,6 @@ exports[`AssessmentStore onResetAllAssessmentsData 1`] = `"tab with Id 1000 not 
 
 exports[`AssessmentStore onResetAllAssessmentsData with persisted data 1`] = `"tab with Id 1000 not found"`;
 
-exports[`AssessmentStore onUpdateTargetTabId 1`] = `"tab with Id 1000 not found"`;
+exports[`AssessmentStore onUpdateTargetTabId with persisted tab={ tabId: 2000 } 1`] = `"tab with Id 1000 not found"`;
+
+exports[`AssessmentStore onUpdateTargetTabId with persisted tab=undefined 1`] = `"tab with Id 1000 not found"`;

--- a/src/tests/unit/tests/background/stores/__snapshots__/assessment-store.test.ts.snap
+++ b/src/tests/unit/tests/background/stores/__snapshots__/assessment-store.test.ts.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`AssessmentStore onResetAllAssessmentsData 1`] = `"tab with Id 1000 not found"`;
-
-exports[`AssessmentStore onResetAllAssessmentsData with persisted data 1`] = `"tab with Id 1000 not found"`;
-
-exports[`AssessmentStore onUpdateTargetTabId with persisted tab={ tabId: 2000 } 1`] = `"tab with Id 1000 not found"`;
-
-exports[`AssessmentStore onUpdateTargetTabId with persisted tab=undefined 1`] = `"tab with Id 1000 not found"`;

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -2139,40 +2139,46 @@ describe('AssessmentStore', () => {
         await storeTester.testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    it.each([true, false])('onUpdateDetailsViewId', async includeStartData => {
-        const payload: OnDetailsViewInitializedPayload = {
-            detailsViewId: 'testId',
-        } as OnDetailsViewInitializedPayload;
-        const tabId = 1000;
-        const url = 'url';
-        const title = 'title';
+    it.each([true, false])(
+        'onUpdateDetailsViewId with includeStartData=%s',
+        async includeStartData => {
+            const payload: OnDetailsViewInitializedPayload = {
+                detailsViewId: 'testId',
+            } as OnDetailsViewInitializedPayload;
+            const tabId = 1000;
+            const url = 'url';
+            const title = 'title';
 
-        const initialDataBuilder = new AssessmentsStoreDataBuilder(
-            assessmentsProvider,
-            assessmentDataConverterMock.object,
-        );
-        if (includeStartData) {
-            initialDataBuilder.withTargetTab(tabId, url, title, 'initialId');
-        } else {
-            initialDataBuilder.withTargetTab(undefined, undefined, undefined, 'initialId');
-        }
-        const initialState = initialDataBuilder.build();
+            const initialDataBuilder = new AssessmentsStoreDataBuilder(
+                assessmentsProvider,
+                assessmentDataConverterMock.object,
+            );
+            if (includeStartData) {
+                initialDataBuilder.withTargetTab(tabId, url, title, 'initialId');
+            }
+            const initialState = initialDataBuilder.build();
 
-        const finalDataBuilder = new AssessmentsStoreDataBuilder(
-            assessmentsProvider,
-            assessmentDataConverterMock.object,
-        );
-        if (includeStartData) {
-            finalDataBuilder.withTargetTab(tabId, url, title, payload.detailsViewId);
-        } else {
-            finalDataBuilder.withTargetTab(undefined, undefined, undefined, payload.detailsViewId);
-        }
-        const finalState = finalDataBuilder.build();
+            const finalDataBuilder = new AssessmentsStoreDataBuilder(
+                assessmentsProvider,
+                assessmentDataConverterMock.object,
+            );
+            let finalState: AssessmentStoreData;
+            if (includeStartData) {
+                finalDataBuilder.withTargetTab(tabId, url, title, payload.detailsViewId);
+                finalState = finalDataBuilder.build();
+            } else {
+                finalState = finalDataBuilder.build();
+                // Set this manually so we don't have extra undefined fields
+                finalState.persistedTabInfo = { detailsViewId: payload.detailsViewId };
+            }
 
-        const storeTester =
-            createStoreTesterForAssessmentActions('updateDetailsViewId').withActionParam(payload);
-        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
-    });
+            const storeTester =
+                createStoreTesterForAssessmentActions('updateDetailsViewId').withActionParam(
+                    payload,
+                );
+            await storeTester.testListenerToBeCalledOnce(initialState, finalState);
+        },
+    );
 
     function setupDataGeneratorMock(
         persistedData: AssessmentStoreData,


### PR DESCRIPTION
#### Details

- Replace the last use of getTab with getTabAsync, and remove getTab from BrowserAdapter
- Add unit tests for some uncovered lines/branches in AssessmentStore

##### Motivation

getTabAsync was added in #5538, but we were unable to completely remove the synchronous getTab function because AssessmentStore calls it as an action callback, and all action callbacks were synchronous at the time. Now that we have AsyncAction, we can use getTabAsync instead.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
