### PR TITLE
feat(mv3-part-5): Convert PathSnippetActions to async

### DIFF
--- a/src/background/actions/path-snippet-action-creator.ts
+++ b/src/background/actions/path-snippet-action-creator.ts
@@ -30,19 +30,19 @@ export class PathSnippetActionCreator {
         );
     }
 
-    private onAddPathForValidation = (payload: string): void => {
-        this.pathSnippetActions.onAddPath.invoke(payload);
+    private onAddPathForValidation = async (payload: string): Promise<void> => {
+        await this.pathSnippetActions.onAddPath.invoke(payload);
     };
 
-    private onAddCorrespondingSnippet = (payload: string): void => {
-        this.pathSnippetActions.onAddSnippet.invoke(payload);
+    private onAddCorrespondingSnippet = async (payload: string): Promise<void> => {
+        await this.pathSnippetActions.onAddSnippet.invoke(payload);
     };
 
-    private onGetPathSnippetCurrentState = (): void => {
-        this.pathSnippetActions.getCurrentState.invoke();
+    private onGetPathSnippetCurrentState = async (): Promise<void> => {
+        await this.pathSnippetActions.getCurrentState.invoke();
     };
 
-    private onClearPathSnippetData = (): void => {
-        this.pathSnippetActions.onClearData.invoke();
+    private onClearPathSnippetData = async (): Promise<void> => {
+        await this.pathSnippetActions.onClearData.invoke();
     };
 }

--- a/src/background/actions/path-snippet-actions.ts
+++ b/src/background/actions/path-snippet-actions.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 
 export class PathSnippetActions {
-    public readonly getCurrentState = new SyncAction<void>();
-    public readonly onAddPath = new SyncAction<string>();
-    public readonly onAddSnippet = new SyncAction<string>();
-    public readonly onClearData = new SyncAction<void>();
+    public readonly getCurrentState = new AsyncAction<void>();
+    public readonly onAddPath = new AsyncAction<string>();
+    public readonly onAddSnippet = new AsyncAction<string>();
+    public readonly onClearData = new AsyncAction<void>();
 }

--- a/src/background/stores/path-snippet-store.ts
+++ b/src/background/stores/path-snippet-store.ts
@@ -47,12 +47,15 @@ export class PathSnippetStore extends PersistentStore<PathSnippetStoreData> {
         this.pathSnippetActions.onClearData.addListener(this.onClearState);
     }
 
-    private onChangeProperty = (property: keyof PathSnippetStoreData, payload: string): void => {
+    private onChangeProperty = async (
+        property: keyof PathSnippetStoreData,
+        payload: string,
+    ): Promise<void> => {
         this.state[property] = payload;
         this.emitChanged();
     };
 
-    private onClearState = () => {
+    private onClearState = async (): Promise<void> => {
         this.state = this.getDefaultState();
         this.emitChanged();
     };

--- a/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
@@ -7,7 +7,7 @@ import { IMock, Mock } from 'typemoq';
 
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('PathSnippetActionCreatorTest', () => {
     let interpreterMock: MockInterpreter;
@@ -19,7 +19,7 @@ describe('PathSnippetActionCreatorTest', () => {
     it('handles AddPathForValidation message', async () => {
         const payload = 'test path';
 
-        const onAddPathMock = createSyncActionMock(payload);
+        const onAddPathMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('onAddPath', onAddPathMock.object);
 
         const newTestObject = new PathSnippetActionCreator(
@@ -37,7 +37,7 @@ describe('PathSnippetActionCreatorTest', () => {
     it('handles AddCorrespondingSnippet message', async () => {
         const payload = 'test snippet';
 
-        const onAddSnippetMock = createSyncActionMock(payload);
+        const onAddSnippetMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('onAddSnippet', onAddSnippetMock.object);
 
         const newTestObject = new PathSnippetActionCreator(
@@ -56,7 +56,7 @@ describe('PathSnippetActionCreatorTest', () => {
     });
 
     it('handles GetPathSnippetCurrentState message', async () => {
-        const getCurrentStateMock = createSyncActionMock(undefined);
+        const getCurrentStateMock = createAsyncActionMock(undefined);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
 
         const newTestObject = new PathSnippetActionCreator(
@@ -75,7 +75,7 @@ describe('PathSnippetActionCreatorTest', () => {
     });
 
     it('handles ClearPathSnippetData message', async () => {
-        const onClearDataMock = createSyncActionMock(undefined);
+        const onClearDataMock = createAsyncActionMock(undefined);
         const actionsMock = createActionsMock('onClearData', onClearDataMock.object);
 
         const newTestObject = new PathSnippetActionCreator(


### PR DESCRIPTION
#### Details

Convert PathSnippetActions from SyncAction to AsyncAction

##### Motivation

Feature work

##### Context

N/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
