### PR TITLE
fix: Resolve moment (address ReDoS flaw)

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
         "kind-of": "^6.0.3",
         "license-check-and-add/yargs": "^15.3.1",
         "minimist": "^1.2.3",
+        "moment": "^2.29.4",
         "nth-check": ">=2.0.1",
         "plist": ">=3.0.5",
         "tar": ">=6.1.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9368,10 +9368,10 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@2.29.2:
-  version "2.29.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
-  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
+moment@2.29.2, moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 moo@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
#### Details

Address https://github.com/microsoft/accessibility-insights-web/security/dependabot/30 that calls out a potential ReDoS attack in `moment@2.29.2` (and fixed in `moment@2.29.4`). This package is consumed by `appium-support`, which is consumed by `appium-adb`. It's logical to assume that we will eventually no longer need this resolution after some time to allow both of these packages to update.. Comparing the `moment` code between 2.29.2 and 2.29.4, 2.29.3 updated a support link and 2.29.4 changed the vulnerable RegEx. Neither of these should have any potential to break our usage.

##### Motivation

Address https://github.com/microsoft/accessibility-insights-web/security/dependabot/30

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: https://github.com/microsoft/accessibility-insights-web/security/dependabot/30
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
