### PR TITLE
feat(mv3-part-5): Add key to scope for scanCompleted action

### DIFF
--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -293,11 +293,14 @@ export class AssessmentActionCreator {
         tabId: number,
     ): Promise<void> => {
         await this.assessmentActions.updateTargetTabId.invoke(tabId, this.executingScope);
-        await this.assessmentActions.scanCompleted.invoke(payload, this.executingScope);
+        await this.assessmentActions.scanCompleted.invoke(
+            payload,
+            `${this.executingScope}-${payload.key}`,
+        );
     };
 
-    private onGetAssessmentCurrentState = (): void => {
-        this.assessmentActions.getCurrentState.invoke(null, this.executingScope);
+    private onGetAssessmentCurrentState = async (): Promise<void> => {
+        await this.assessmentActions.getCurrentState.invoke(null, this.executingScope);
     };
 
     private onSelectTestRequirement = async (payload: SelectTestSubviewPayload): Promise<void> => {

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -292,11 +292,9 @@ export class AssessmentActionCreator {
         payload: ScanCompletedPayload<any>,
         tabId: number,
     ): Promise<void> => {
-        await this.assessmentActions.updateTargetTabId.invoke(tabId, this.executingScope);
-        await this.assessmentActions.scanCompleted.invoke(
-            payload,
-            `${this.executingScope}-${payload.key}`,
-        );
+        const scope = `${this.executingScope}-${payload.key}`;
+        await this.assessmentActions.updateTargetTabId.invoke(tabId, scope);
+        await this.assessmentActions.scanCompleted.invoke(payload, scope);
     };
 
     private onGetAssessmentCurrentState = async (): Promise<void> => {

--- a/src/background/actions/assessment-actions.ts
+++ b/src/background/actions/assessment-actions.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AsyncAction } from 'common/flux/async-action';
-import { SyncAction } from 'common/flux/sync-action';
 import {
     ScanBasePayload,
     ScanCompletedPayload,
@@ -41,8 +40,7 @@ export class AssessmentActions {
         new AsyncAction<ChangeInstanceSelectionPayload>();
     public readonly undoInstanceStatusChange = new AsyncAction<AssessmentActionInstancePayload>();
     public readonly undoRequirementStatusChange = new AsyncAction<ChangeRequirementStatusPayload>();
-    // Leaving this sync for now until BaseStoreImpl.onGetCurrentState() can be converted to async
-    public readonly getCurrentState = new SyncAction<void>();
+    public readonly getCurrentState = new AsyncAction<void>();
     public readonly scanCompleted = new AsyncAction<ScanCompletedPayload<null>>();
     public readonly resetData = new AsyncAction<ToggleActionPayload>();
     public readonly resetAllAssessmentsData = new AsyncAction<number>();

--- a/src/background/interpreter.ts
+++ b/src/background/interpreter.ts
@@ -15,7 +15,6 @@ export class Interpreter {
 
     public interpret(message: InterpreterMessage): InterpreterResponse {
         if (this.messageToActionMapping[message.messageType]) {
-            console.log(message);
             return {
                 messageHandled: true,
                 result: this.messageToActionMapping[message.messageType](

--- a/src/background/interpreter.ts
+++ b/src/background/interpreter.ts
@@ -15,6 +15,7 @@ export class Interpreter {
 
     public interpret(message: InterpreterMessage): InterpreterResponse {
         if (this.messageToActionMapping[message.messageType]) {
+            console.log(message);
             return {
                 messageHandled: true,
                 result: this.messageToActionMapping[message.messageType](

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -35,10 +35,7 @@ import {
 } from 'injected/analyzers/analyzer';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import {
-    createAsyncActionMock,
-    createSyncActionMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('AssessmentActionCreatorTest', () => {
     let assessmentActionsMock: IMock<AssessmentActions>;
@@ -500,7 +497,7 @@ describe('AssessmentActionCreatorTest', () => {
         } as ScanCompletedPayload<any>;
 
         const updateTabIdActionMock = createAsyncActionMock(testTabId, actionExecutingScope);
-        const scanCompleteMock = createAsyncActionMock(payload, actionExecutingScope);
+        const scanCompleteMock = createAsyncActionMock(payload, `${actionExecutingScope}-test-key`);
 
         setupAssessmentActionsMock('scanCompleted', scanCompleteMock);
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
@@ -523,7 +520,7 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles GetCurrentState message', async () => {
-        const getCurrentStateMock = createSyncActionMock<void>(null, actionExecutingScope);
+        const getCurrentStateMock = createAsyncActionMock<void>(null, actionExecutingScope);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
 
         const testSubject = new AssessmentActionCreator(

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -495,9 +495,10 @@ describe('AssessmentActionCreatorTest', () => {
         const payload: ScanCompletedPayload<any> = {
             key: 'test-key',
         } as ScanCompletedPayload<any>;
+        const expectedScope = `${actionExecutingScope}-test-key`;
 
-        const updateTabIdActionMock = createAsyncActionMock(testTabId, actionExecutingScope);
-        const scanCompleteMock = createAsyncActionMock(payload, `${actionExecutingScope}-test-key`);
+        const updateTabIdActionMock = createAsyncActionMock(testTabId, expectedScope);
+        const scanCompleteMock = createAsyncActionMock(payload, expectedScope);
 
         setupAssessmentActionsMock('scanCompleted', scanCompleteMock);
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);


### PR DESCRIPTION
#### Details

Add the key from the payload to the action executing scope for scanCompleted callbacks

##### Motivation

This fixes a scope conflict when Automated Checks runs in Assessment, and several scanCompleted messages are sent concurrently.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
