### PR TITLE
feat(mv3-part-5): convert DetailsViewActions to async

### DIFF
--- a/src/background/actions/details-view-action-creator.ts
+++ b/src/background/actions/details-view-action-creator.ts
@@ -104,13 +104,13 @@ export class DetailsViewActionCreator {
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
     };
 
-    private onSetDetailsViewRightContentPanel = (
+    private onSetDetailsViewRightContentPanel = async (
         payload: DetailsViewRightContentPanelType,
-    ): void => {
-        this.detailsViewActions.setSelectedDetailsViewRightContentPanel.invoke(payload);
+    ): Promise<void> => {
+        await this.detailsViewActions.setSelectedDetailsViewRightContentPanel.invoke(payload);
     };
 
-    private onGetDetailsViewCurrentState = (): void => {
-        this.detailsViewActions.getCurrentState.invoke(null);
+    private onGetDetailsViewCurrentState = async (): Promise<void> => {
+        await this.detailsViewActions.getCurrentState.invoke(null);
     };
 }

--- a/src/background/actions/details-view-actions.ts
+++ b/src/background/actions/details-view-actions.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { DetailsViewRightContentPanelType } from '../../common/types/store-data/details-view-right-content-panel-type';
 
 export class DetailsViewActions {
     public readonly setSelectedDetailsViewRightContentPanel =
-        new SyncAction<DetailsViewRightContentPanelType>();
-    public readonly getCurrentState = new SyncAction();
+        new AsyncAction<DetailsViewRightContentPanelType>();
+    public readonly getCurrentState = new AsyncAction();
 }

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -125,9 +125,9 @@ export class DetailsViewStore extends PersistentStore<DetailsViewStoreData> {
         this.emitChanged();
     };
 
-    private onSetSelectedDetailsViewRightContentPanel = (
+    private onSetSelectedDetailsViewRightContentPanel = async (
         view: DetailsViewRightContentPanelType,
-    ): void => {
+    ): Promise<void> => {
         this.state.detailsViewRightContentPanel = view;
         this.emitChanged();
     };

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -24,10 +24,7 @@ import { StoreNames } from 'common/stores/store-names';
 import { DetailsViewRightContentPanelType } from 'common/types/store-data/details-view-right-content-panel-type';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import {
-    createAsyncActionMock,
-    createSyncActionMock,
-} from '../global-action-creators/action-creator-test-helpers';
+import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('DetailsViewActionCreatorTest', () => {
     let detailsViewControllerMock: IMock<ExtensionDetailsViewController>;
@@ -169,7 +166,7 @@ describe('DetailsViewActionCreatorTest', () => {
     it('handles Visualization.DetailsView.SetDetailsViewRightContentPanel message', async () => {
         const payload: DetailsViewRightContentPanelType = 'Overview';
 
-        const setSelectedDetailsViewRightContentPanelMock = createSyncActionMock(payload);
+        const setSelectedDetailsViewRightContentPanelMock = createAsyncActionMock(payload);
         const detailsViewActionsMock = createDetailsViewActionsMock(
             'setSelectedDetailsViewRightContentPanel',
             setSelectedDetailsViewRightContentPanelMock.object,
@@ -194,7 +191,7 @@ describe('DetailsViewActionCreatorTest', () => {
     });
 
     it('handles Visualization.DetailsView.GetState message', async () => {
-        const getCurrentStateMock = createSyncActionMock<void>(null);
+        const getCurrentStateMock = createAsyncActionMock<void>(null);
         const detailsViewActionsMock = createDetailsViewActionsMock(
             'getCurrentState',
             getCurrentStateMock.object,


### PR DESCRIPTION
#### Details

Convert SyncActions in DetailsViewActions to AsyncActions

##### Motivation

Feature work

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
