### PR TITLE
feat(mv3-part-5): Convert PermissionsStateActions to async

### DIFF
--- a/src/background/actions/permissions-state-actions.ts
+++ b/src/background/actions/permissions-state-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 
 export class PermissionsStateActions {
-    public readonly getCurrentState = new SyncAction<void>();
-    public readonly setPermissionsState = new SyncAction<SetAllUrlsPermissionStatePayload>();
+    public readonly getCurrentState = new AsyncAction<void>();
+    public readonly setPermissionsState = new AsyncAction<SetAllUrlsPermissionStatePayload>();
 }

--- a/src/background/global-action-creators/permissions-state-action-creator.ts
+++ b/src/background/global-action-creators/permissions-state-action-creator.ts
@@ -26,12 +26,14 @@ export class PermissionsStateActionCreator {
         );
     }
 
-    private onGetCurrentState = (): void => {
-        this.permissionsStateActions.getCurrentState.invoke();
+    private onGetCurrentState = async (): Promise<void> => {
+        await this.permissionsStateActions.getCurrentState.invoke();
     };
 
-    private onSetPermissionsState = (payload: SetAllUrlsPermissionStatePayload): void => {
-        this.permissionsStateActions.setPermissionsState.invoke(payload);
+    private onSetPermissionsState = async (
+        payload: SetAllUrlsPermissionStatePayload,
+    ): Promise<void> => {
+        await this.permissionsStateActions.setPermissionsState.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(ALL_URLS_PERMISSION_UPDATED, payload);
     };
 }

--- a/src/background/stores/global/permissions-state-store.ts
+++ b/src/background/stores/global/permissions-state-store.ts
@@ -40,7 +40,9 @@ export class PermissionsStateStore extends PersistentStore<PermissionsStateStore
         this.permissionsStateActions.setPermissionsState.addListener(this.onSetPermissionsState);
     }
 
-    private onSetPermissionsState = (payload: SetAllUrlsPermissionStatePayload): void => {
+    private onSetPermissionsState = async (
+        payload: SetAllUrlsPermissionStatePayload,
+    ): Promise<void> => {
         if (this.state.hasAllUrlAndFilePermissions !== payload.hasAllUrlAndFilePermissions) {
             this.state.hasAllUrlAndFilePermissions = payload.hasAllUrlAndFilePermissions;
             this.emitChanged();

--- a/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
@@ -9,8 +9,7 @@ import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock } from 'typemoq';
-
-import { createSyncActionMock } from './action-creator-test-helpers';
+import { createAsyncActionMock } from './action-creator-test-helpers';
 
 describe('PermissionsStateActionCreator', () => {
     let permissionsStateActionsMock: IMock<PermissionsStateActions>;
@@ -23,7 +22,7 @@ describe('PermissionsStateActionCreator', () => {
 
     it('handles getStoreState message', async () => {
         const expectedMessage = getStoreStateMessage(StoreNames.PermissionsStateStore);
-        const getCurrentStateMock = createSyncActionMock(undefined);
+        const getCurrentStateMock = createAsyncActionMock(undefined);
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
         const testSubject = new PermissionsStateActionCreator(
             interpreterMock.object,
@@ -46,7 +45,7 @@ describe('PermissionsStateActionCreator', () => {
                 hasAllUrlAndFilePermissions: permissionState,
                 telemetry: {} as TelemetryData,
             };
-            const setPermissionsStateMock = createSyncActionMock(payload);
+            const setPermissionsStateMock = createAsyncActionMock(payload);
             const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
             setupActionsMock('setPermissionsState', setPermissionsStateMock.object);
             const testSubject = new PermissionsStateActionCreator(


### PR DESCRIPTION
#### Details

Convert PermissionsStateActions from SyncAction to AsyncAction

##### Motivation

Feature work

##### Context

N/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
