### PR TITLE
feat(mv3-part-5): Convert UnifiedScanResultActions to async

### DIFF
--- a/src/background/actions/unified-scan-result-action-creator.ts
+++ b/src/background/actions/unified-scan-result-action-creator.ts
@@ -28,13 +28,13 @@ export class UnifiedScanResultActionCreator {
         );
     }
 
-    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
-        this.unifiedScanResultActions.scanCompleted.invoke(payload);
+    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
+        await this.unifiedScanResultActions.scanCompleted.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(SCAN_INCOMPLETE_WARNINGS, payload);
         this.notificationCreator.createNotification(payload.notificationText);
     };
 
-    private onGetScanCurrentState = (): void => {
-        this.unifiedScanResultActions.getCurrentState.invoke(null);
+    private onGetScanCurrentState = async (): Promise<void> => {
+        await this.unifiedScanResultActions.getCurrentState.invoke(null);
     };
 }

--- a/src/background/actions/unified-scan-result-actions.ts
+++ b/src/background/actions/unified-scan-result-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { UnifiedScanCompletedPayload } from './action-payloads';
 
 export class UnifiedScanResultActions {
-    public readonly scanCompleted = new SyncAction<UnifiedScanCompletedPayload>();
-    public readonly getCurrentState = new SyncAction();
+    public readonly scanCompleted = new AsyncAction<UnifiedScanCompletedPayload>();
+    public readonly getCurrentState = new AsyncAction();
 }

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -156,7 +156,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
+    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
         this.state = this.getDefaultState();
         this.state.rules = {};
 

--- a/src/background/stores/unified-scan-result-store.ts
+++ b/src/background/stores/unified-scan-result-store.ts
@@ -51,7 +51,7 @@ export class UnifiedScanResultStore extends PersistentStore<UnifiedScanResultSto
         this.tabActions.existingTabUpdated.addListener(this.onResetStoreData);
     }
 
-    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
+    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
         this.state.results = payload.scanResult;
         this.state.rules = payload.rules;
         this.state.toolInfo = payload.toolInfo;

--- a/src/electron/flux/action-creator/scan-action-creator.ts
+++ b/src/electron/flux/action-creator/scan-action-creator.ts
@@ -12,7 +12,7 @@ export class ScanActionCreator {
     ) {}
 
     public async scan(): Promise<void> {
-        this.deviceConnectionActions.statusUnknown.invoke(null, this.executingScope);
-        await this.scanActions.scanStarted.invoke(null, this.executingScope);
+        this.deviceConnectionActions.statusUnknown.invoke(undefined, this.executingScope);
+        await this.scanActions.scanStarted.invoke(undefined, this.executingScope);
     }
 }

--- a/src/electron/flux/action-creator/scan-action-creator.ts
+++ b/src/electron/flux/action-creator/scan-action-creator.ts
@@ -9,8 +9,8 @@ export class ScanActionCreator {
         private readonly deviceConnectionActions: DeviceConnectionActions,
     ) {}
 
-    public scan(): void {
+    public async scan(): Promise<void> {
         this.deviceConnectionActions.statusUnknown.invoke();
-        this.scanActions.scanStarted.invoke();
+        await this.scanActions.scanStarted.invoke();
     }
 }

--- a/src/electron/flux/action-creator/scan-action-creator.ts
+++ b/src/electron/flux/action-creator/scan-action-creator.ts
@@ -4,13 +4,15 @@ import { DeviceConnectionActions } from 'electron/flux/action/device-connection-
 import { ScanActions } from 'electron/flux/action/scan-actions';
 
 export class ScanActionCreator {
+    private executingScope = 'ScanActionCreator';
+
     constructor(
         private readonly scanActions: ScanActions,
         private readonly deviceConnectionActions: DeviceConnectionActions,
     ) {}
 
     public async scan(): Promise<void> {
-        this.deviceConnectionActions.statusUnknown.invoke();
-        await this.scanActions.scanStarted.invoke();
+        this.deviceConnectionActions.statusUnknown.invoke(null, this.executingScope);
+        await this.scanActions.scanStarted.invoke(null, this.executingScope);
     }
 }

--- a/src/electron/flux/action/scan-actions.ts
+++ b/src/electron/flux/action/scan-actions.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AsyncAction } from 'common/flux/async-action';
 import { SyncAction } from 'common/flux/sync-action';
 
 export class ScanActions {
-    public readonly scanStarted = new SyncAction<void>();
+    public readonly scanStarted = new AsyncAction<void>();
     public readonly scanCompleted = new SyncAction<void>();
     public readonly scanFailed = new SyncAction<void>();
 }

--- a/src/electron/flux/store/scan-store.ts
+++ b/src/electron/flux/store/scan-store.ts
@@ -24,7 +24,7 @@ export class ScanStore extends BaseStoreImpl<ScanStoreData> {
         this.scanActions.scanFailed.addListener(this.onScanFailed);
     }
 
-    private onScanStarted = () => {
+    private onScanStarted = async () => {
         if (this.state.status === ScanStatus.Scanning) {
             return;
         }

--- a/src/electron/platform/android/scan-controller.ts
+++ b/src/electron/platform/android/scan-controller.ts
@@ -80,8 +80,8 @@ export class ScanController {
         const payload = this.unifiedResultsBuilder(data);
 
         await this.unifiedScanResultAction.scanCompleted.invoke(payload, this.executingScope);
-        this.scanActions.scanCompleted.invoke(null, this.executingScope);
-        this.deviceConnectionActions.statusConnected.invoke(null, this.executingScope);
+        this.scanActions.scanCompleted.invoke(undefined, this.executingScope);
+        this.deviceConnectionActions.statusConnected.invoke(undefined, this.executingScope);
     }
 
     private buildAxeInstanceCount(axeRuleResults: AxeRuleResultsData[]): InstanceCount {
@@ -134,8 +134,8 @@ export class ScanController {
             },
         });
 
-        this.scanActions.scanFailed.invoke(null, this.executingScope);
-        this.deviceConnectionActions.statusDisconnected.invoke(null, this.executingScope);
+        this.scanActions.scanFailed.invoke(undefined, this.executingScope);
+        this.deviceConnectionActions.statusDisconnected.invoke(undefined, this.executingScope);
     }
 
     private fetchScanResults = async (): Promise<AndroidScanResults> => {

--- a/src/electron/platform/android/scan-controller.ts
+++ b/src/electron/platform/android/scan-controller.ts
@@ -25,6 +25,8 @@ import { UnifiedScanCompletedPayloadBuilder } from 'electron/platform/android/un
 import { isObject } from 'lodash';
 
 export class ScanController {
+    private readonly executingScope = 'ScanController';
+
     constructor(
         private readonly scanActions: ScanActions,
         private readonly unifiedScanResultAction: UnifiedScanResultActions,
@@ -77,9 +79,9 @@ export class ScanController {
 
         const payload = this.unifiedResultsBuilder(data);
 
-        await this.unifiedScanResultAction.scanCompleted.invoke(payload);
-        this.scanActions.scanCompleted.invoke();
-        this.deviceConnectionActions.statusConnected.invoke();
+        await this.unifiedScanResultAction.scanCompleted.invoke(payload, this.executingScope);
+        this.scanActions.scanCompleted.invoke(null, this.executingScope);
+        this.deviceConnectionActions.statusConnected.invoke(null, this.executingScope);
     }
 
     private buildAxeInstanceCount(axeRuleResults: AxeRuleResultsData[]): InstanceCount {
@@ -132,8 +134,8 @@ export class ScanController {
             },
         });
 
-        this.scanActions.scanFailed.invoke();
-        this.deviceConnectionActions.statusDisconnected.invoke();
+        this.scanActions.scanFailed.invoke(null, this.executingScope);
+        this.deviceConnectionActions.statusDisconnected.invoke(null, this.executingScope);
     }
 
     private fetchScanResults = async (): Promise<AndroidScanResults> => {

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -83,8 +83,8 @@ export type ResultsViewProps = {
 };
 
 export class ResultsView extends React.Component<ResultsViewProps> {
-    public componentDidMount(): void {
-        this.props.deps.scanActionCreator.scan();
+    public async componentDidMount(): Promise<void> {
+        await this.props.deps.scanActionCreator.scan();
     }
 
     public render(): JSX.Element {

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -15,7 +15,7 @@ import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
-import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('UnifiedScanResultActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -43,7 +43,7 @@ describe('UnifiedScanResultActionCreator', () => {
             telemetry,
         };
 
-        const scanCompletedMock = createSyncActionMock(payload);
+        const scanCompletedMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock('scanCompleted', scanCompletedMock.object);
 
         const testSubject = new UnifiedScanResultActionCreator(
@@ -71,7 +71,7 @@ describe('UnifiedScanResultActionCreator', () => {
     it('should handle GetState message', async () => {
         const payload = null;
 
-        const getCurrentStateMock = createSyncActionMock<null>(payload);
+        const getCurrentStateMock = createAsyncActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
 
         const testSubject = new UnifiedScanResultActionCreator(

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -39,11 +39,11 @@ describe('ScanActionCreator', () => {
         await testSubject.scan();
 
         scanStartedMock.verify(
-            async scanStarted => scanStarted.invoke(null, actionExecutingScope),
+            async scanStarted => scanStarted.invoke(undefined, actionExecutingScope),
             Times.once(),
         );
         statusUnknown.verify(
-            statusUnknown => statusUnknown.invoke(null, actionExecutingScope),
+            statusUnknown => statusUnknown.invoke(undefined, actionExecutingScope),
             Times.once(),
         );
     });

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -8,6 +8,7 @@ import { ScanActions } from 'electron/flux/action/scan-actions';
 import { IMock, Mock, Times } from 'typemoq';
 
 describe('ScanActionCreator', () => {
+    const actionExecutingScope = 'ScanActionCreator';
     let scanActionsMock: IMock<ScanActions>;
     let scanStartedMock: IMock<AsyncAction<void>>;
     let deviceConnectionActionsMock: IMock<DeviceConnectionActions>;
@@ -37,7 +38,13 @@ describe('ScanActionCreator', () => {
     it('scans', async () => {
         await testSubject.scan();
 
-        scanStartedMock.verify(scanStarted => scanStarted.invoke(), Times.once());
-        statusUnknown.verify(statusUnknown => statusUnknown.invoke(), Times.once());
+        scanStartedMock.verify(
+            async scanStarted => scanStarted.invoke(null, actionExecutingScope),
+            Times.once(),
+        );
+        statusUnknown.verify(
+            statusUnknown => statusUnknown.invoke(null, actionExecutingScope),
+            Times.once(),
+        );
     });
 });

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AsyncAction } from 'common/flux/async-action';
 import { SyncAction } from 'common/flux/sync-action';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { DeviceConnectionActions } from 'electron/flux/action/device-connection-actions';
@@ -8,7 +9,7 @@ import { IMock, Mock, Times } from 'typemoq';
 
 describe('ScanActionCreator', () => {
     let scanActionsMock: IMock<ScanActions>;
-    let scanStartedMock: IMock<SyncAction<void>>;
+    let scanStartedMock: IMock<AsyncAction<void>>;
     let deviceConnectionActionsMock: IMock<DeviceConnectionActions>;
     let statusUnknown: IMock<SyncAction<void>>;
 
@@ -16,7 +17,7 @@ describe('ScanActionCreator', () => {
 
     beforeEach(() => {
         scanActionsMock = Mock.ofType<ScanActions>();
-        scanStartedMock = Mock.ofType<SyncAction<void>>();
+        scanStartedMock = Mock.ofType<AsyncAction<void>>();
 
         scanActionsMock.setup(actions => actions.scanStarted).returns(() => scanStartedMock.object);
 
@@ -33,8 +34,8 @@ describe('ScanActionCreator', () => {
         );
     });
 
-    it('scans', () => {
-        testSubject.scan();
+    it('scans', async () => {
+        await testSubject.scan();
 
         scanStartedMock.verify(scanStarted => scanStarted.invoke(), Times.once());
         statusUnknown.verify(statusUnknown => statusUnknown.invoke(), Times.once());

--- a/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
@@ -4,6 +4,7 @@ import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads'
 import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
+import { AsyncAction } from 'common/flux/async-action';
 import { SyncAction } from 'common/flux/sync-action';
 import { Logger } from 'common/logging/logger';
 import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete-warnings';
@@ -20,7 +21,6 @@ import { ScanController } from 'electron/platform/android/scan-controller';
 import { UnifiedScanCompletedPayloadBuilder } from 'electron/platform/android/unified-result-builder';
 import { isFunction } from 'lodash';
 import { androidScanResultExample } from 'tests/common/android-scan-result-example';
-import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { ExpectedCallType, IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('ScanController', () => {
@@ -36,7 +36,7 @@ describe('ScanController', () => {
     let loggerMock: IMock<Logger>;
 
     let scanActionsMock: IMock<ScanActions>;
-    let scanStartedMock: IMock<SyncAction<void>>;
+    let scanStartedMock: IMock<AsyncAction<void>>;
     let scanCompletedMock: IMock<SyncAction<void>>;
     let scanFailedMock: IMock<SyncAction<void>>;
 
@@ -54,10 +54,7 @@ describe('ScanController', () => {
         deviceCommunicatorMock = Mock.ofType<DeviceCommunicator>();
         scanActionsMock = Mock.ofType<ScanActions>();
 
-        scanStartedMock = Mock.ofType<SyncAction<void>>();
-        scanStartedMock
-            .setup(scanStarted => scanStarted.addListener(It.is(isFunction)))
-            .callback(listener => listener());
+        scanStartedMock = Mock.ofType<AsyncAction<void>>();
         scanCompletedMock = Mock.ofType<SyncAction<void>>();
         scanFailedMock = Mock.ofType<SyncAction<void>>();
 
@@ -177,7 +174,12 @@ describe('ScanController', () => {
             .setup(builder => builder(scanResults))
             .returns(() => unifiedPayload);
 
-        const unifiedScanCompletedMock = Mock.ofType<SyncAction<UnifiedScanCompletedPayload>>();
+        let scanStartedListener: () => Promise<void>;
+        scanStartedMock
+            .setup(scanStarted => scanStarted.addListener(It.is(isFunction)))
+            .callback(listener => (scanStartedListener = listener));
+
+        const unifiedScanCompletedMock = Mock.ofType<AsyncAction<UnifiedScanCompletedPayload>>();
         unifiedScanCompletedMock
             .setup(action => action.invoke(unifiedPayload))
             .verifiable(Times.once());
@@ -188,7 +190,8 @@ describe('ScanController', () => {
 
         testSubject.initialize();
 
-        await flushSettledPromises();
+        expect(scanStartedListener).toBeDefined();
+        await scanStartedListener();
 
         scanCompletedMock.verify(scanCompleted => scanCompleted.invoke(), Times.once());
         deviceConnectedMock.verify(m => m.invoke(), Times.once());
@@ -224,9 +227,15 @@ describe('ScanController', () => {
             )
             .verifiable(Times.once(), ExpectedCallType.InSequence);
 
+        let scanStartedListener: () => Promise<void>;
+        scanStartedMock
+            .setup(scanStarted => scanStarted.addListener(It.is(isFunction)))
+            .callback(listener => (scanStartedListener = listener));
+
         testSubject.initialize();
 
-        await flushSettledPromises();
+        expect(scanStartedListener).toBeDefined();
+        await scanStartedListener();
 
         scanFailedMock.verify(scanCompleted => scanCompleted.invoke(), Times.once());
         loggerMock.verify(logger => logger.error('scan failed: ', errorReason), Times.once());

--- a/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
@@ -195,10 +195,10 @@ describe('ScanController', () => {
         await scanStartedListener();
 
         scanCompletedMock.verify(
-            scanCompleted => scanCompleted.invoke(null, actionExecutingScope),
+            scanCompleted => scanCompleted.invoke(undefined, actionExecutingScope),
             Times.once(),
         );
-        deviceConnectedMock.verify(m => m.invoke(null, actionExecutingScope), Times.once());
+        deviceConnectedMock.verify(m => m.invoke(undefined, actionExecutingScope), Times.once());
 
         telemetryEventHandlerMock.verifyAll();
         deviceCommunicatorMock.verifyAll();
@@ -242,11 +242,11 @@ describe('ScanController', () => {
         await scanStartedListener();
 
         scanFailedMock.verify(
-            scanCompleted => scanCompleted.invoke(null, actionExecutingScope),
+            scanCompleted => scanCompleted.invoke(undefined, actionExecutingScope),
             Times.once(),
         );
         loggerMock.verify(logger => logger.error('scan failed: ', errorReason), Times.once());
-        deviceDisconnectedMock.verify(m => m.invoke(null, actionExecutingScope), Times.once());
+        deviceDisconnectedMock.verify(m => m.invoke(undefined, actionExecutingScope), Times.once());
         deviceCommunicatorMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });

--- a/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
@@ -24,6 +24,7 @@ import { androidScanResultExample } from 'tests/common/android-scan-result-examp
 import { ExpectedCallType, IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('ScanController', () => {
+    const actionExecutingScope = 'ScanController';
     const expectedScanStartedTelemetry = {
         telemetry: {
             source: TelemetryEventSource.ElectronDeviceConnect,
@@ -181,7 +182,7 @@ describe('ScanController', () => {
 
         const unifiedScanCompletedMock = Mock.ofType<AsyncAction<UnifiedScanCompletedPayload>>();
         unifiedScanCompletedMock
-            .setup(action => action.invoke(unifiedPayload))
+            .setup(action => action.invoke(unifiedPayload, actionExecutingScope))
             .verifiable(Times.once());
 
         unifiedScanResultActionsMock
@@ -193,8 +194,11 @@ describe('ScanController', () => {
         expect(scanStartedListener).toBeDefined();
         await scanStartedListener();
 
-        scanCompletedMock.verify(scanCompleted => scanCompleted.invoke(), Times.once());
-        deviceConnectedMock.verify(m => m.invoke(), Times.once());
+        scanCompletedMock.verify(
+            scanCompleted => scanCompleted.invoke(null, actionExecutingScope),
+            Times.once(),
+        );
+        deviceConnectedMock.verify(m => m.invoke(null, actionExecutingScope), Times.once());
 
         telemetryEventHandlerMock.verifyAll();
         deviceCommunicatorMock.verifyAll();
@@ -237,9 +241,12 @@ describe('ScanController', () => {
         expect(scanStartedListener).toBeDefined();
         await scanStartedListener();
 
-        scanFailedMock.verify(scanCompleted => scanCompleted.invoke(), Times.once());
+        scanFailedMock.verify(
+            scanCompleted => scanCompleted.invoke(null, actionExecutingScope),
+            Times.once(),
+        );
         loggerMock.verify(logger => logger.error('scan failed: ', errorReason), Times.once());
-        deviceDisconnectedMock.verify(m => m.invoke(), Times.once());
+        deviceDisconnectedMock.verify(m => m.invoke(null, actionExecutingScope), Times.once());
         deviceCommunicatorMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
     });


### PR DESCRIPTION
#### Details

- Convert SyncActions in UnifiedScanResultActions to AsyncActions
- Convert ScanActions.scanStarted to an AsyncAction because the listener already contains a floating promise

##### Motivation

Feature work

##### Context

ScanActions is only used in the electron app, so not all actions need to be made async, but it seemed like a good idea to convert the one that was already essentially async. I've verified this change in Unified as well.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
