### PR TITLE
feat(mv3-part-5): Convert TabStopsViewActions to async

### DIFF
--- a/src/DetailsView/components/tab-stops/tab-stops-failed-instance-panel.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-failed-instance-panel.tsx
@@ -51,9 +51,8 @@ export const TabStopsFailedInstancePanel = NamedFC<TabStopsFailedInstancePanelPr
                     requirementId: failureInstanceState.selectedRequirementId!,
                 });
             },
-            onChange: async (_, description) => {
-                await deps.tabStopsTestViewController.updateDescription(description);
-            },
+            onChange: async (_, description) =>
+                await deps.tabStopsTestViewController.updateDescription(description),
             onDismiss: tabStopsTestViewController.dismissPanel,
         };
 

--- a/src/DetailsView/components/tab-stops/tab-stops-failed-instance-panel.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-failed-instance-panel.tsx
@@ -51,8 +51,8 @@ export const TabStopsFailedInstancePanel = NamedFC<TabStopsFailedInstancePanelPr
                     requirementId: failureInstanceState.selectedRequirementId!,
                 });
             },
-            onChange: (_, description) => {
-                deps.tabStopsTestViewController.updateDescription(description);
+            onChange: async (_, description) => {
+                await deps.tabStopsTestViewController.updateDescription(description);
             },
             onDismiss: tabStopsTestViewController.dismissPanel,
         };

--- a/src/DetailsView/components/tab-stops/tab-stops-instance-section-props-factory.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-instance-section-props-factory.tsx
@@ -38,12 +38,12 @@ export const FastPassTabStopsInstanceSectionPropsFactory: TabStopsInstanceSectio
                 instanceId,
             );
         };
-        const onInstanceEditButtonClicked = (
+        const onInstanceEditButtonClicked = async (
             requirementId: TabStopRequirementId,
             instanceId: string,
             description: string,
         ) => {
-            deps.tabStopsTestViewController.editExistingFailureInstance({
+            await deps.tabStopsTestViewController.editExistingFailureInstance({
                 instanceId,
                 requirementId,
                 description,

--- a/src/DetailsView/components/tab-stops/tab-stops-requirements-table.tsx
+++ b/src/DetailsView/components/tab-stops/tab-stops-requirements-table.tsx
@@ -66,8 +66,8 @@ export const TabStopsRequirementsTable = NamedFC<TabStopsRequirementsTableProps>
                                     status,
                                 )
                             }
-                            onAddFailureInstanceClicked={_ =>
-                                deps.tabStopsTestViewController.createNewFailureInstancePanel(
+                            onAddFailureInstanceClicked={async _ =>
+                                await deps.tabStopsTestViewController.createNewFailureInstancePanel(
                                     item.id,
                                 )
                             }

--- a/src/DetailsView/components/tab-stops/tab-stops-test-view-controller.ts
+++ b/src/DetailsView/components/tab-stops/tab-stops-test-view-controller.ts
@@ -9,14 +9,16 @@ import {
 export class TabStopsTestViewController {
     constructor(private actions: TabStopsViewActions) {}
 
-    public createNewFailureInstancePanel: (payload: string) => void = payload =>
-        this.actions.createNewFailureInstancePanel.invoke(payload);
+    public createNewFailureInstancePanel: (payload: string) => Promise<void> = async payload =>
+        await this.actions.createNewFailureInstancePanel.invoke(payload);
 
-    public editExistingFailureInstance: (payload: EditExistingFailureInstancePayload) => void =
-        payload => this.actions.editExistingFailureInstance.invoke(payload);
+    public editExistingFailureInstance: (
+        payload: EditExistingFailureInstancePayload,
+    ) => Promise<void> = async payload =>
+        await this.actions.editExistingFailureInstance.invoke(payload);
 
-    public dismissPanel = () => this.actions.dismissPanel.invoke();
+    public dismissPanel: () => Promise<void> = async () => await this.actions.dismissPanel.invoke();
 
-    public updateDescription: (payload: string) => void = payload =>
-        this.actions.updateDescription.invoke(payload);
+    public updateDescription: (payload: string) => Promise<void> = async payload =>
+        await this.actions.updateDescription.invoke(payload);
 }

--- a/src/DetailsView/components/tab-stops/tab-stops-view-actions.ts
+++ b/src/DetailsView/components/tab-stops/tab-stops-view-actions.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 
 export interface EditExistingFailureInstancePayload {
@@ -11,9 +11,9 @@ export interface EditExistingFailureInstancePayload {
 }
 
 export class TabStopsViewActions {
-    public readonly createNewFailureInstancePanel = new SyncAction<string>();
+    public readonly createNewFailureInstancePanel = new AsyncAction<string>();
     public readonly editExistingFailureInstance =
-        new SyncAction<EditExistingFailureInstancePayload>();
-    public readonly dismissPanel = new SyncAction<void>();
-    public readonly updateDescription = new SyncAction<string>();
+        new AsyncAction<EditExistingFailureInstancePayload>();
+    public readonly dismissPanel = new AsyncAction<void>();
+    public readonly updateDescription = new AsyncAction<string>();
 }

--- a/src/DetailsView/components/tab-stops/tab-stops-view-store.ts
+++ b/src/DetailsView/components/tab-stops/tab-stops-view-store.ts
@@ -41,7 +41,9 @@ export class TabStopsViewStore extends BaseStoreImpl<TabStopsViewStoreData> {
         this.tabStopsViewActions.dismissPanel.addListener(this.onDismissPanel);
     }
 
-    private onCreateNewFailureInstancePanel = (requirementId: TabStopRequirementId) => {
+    private onCreateNewFailureInstancePanel = async (
+        requirementId: TabStopRequirementId,
+    ): Promise<void> => {
         this.state.failureInstanceState = this.getDefaultState().failureInstanceState;
         this.state.failureInstanceState.isPanelOpen = true;
         this.state.failureInstanceState.selectedRequirementId = requirementId;
@@ -49,7 +51,9 @@ export class TabStopsViewStore extends BaseStoreImpl<TabStopsViewStoreData> {
         this.emitChanged();
     };
 
-    private onEditExistingFailureInstance = (payload: EditExistingFailureInstancePayload) => {
+    private onEditExistingFailureInstance = async (
+        payload: EditExistingFailureInstancePayload,
+    ): Promise<void> => {
         this.state.failureInstanceState.isPanelOpen = true;
         this.state.failureInstanceState.selectedRequirementId = payload.requirementId;
         this.state.failureInstanceState.selectedInstanceId = payload.instanceId;
@@ -58,12 +62,12 @@ export class TabStopsViewStore extends BaseStoreImpl<TabStopsViewStoreData> {
         this.emitChanged();
     };
 
-    private onDismissPanel = () => {
+    private onDismissPanel = async (): Promise<void> => {
         this.state.failureInstanceState.isPanelOpen = false;
         this.emitChanged();
     };
 
-    private onUpdateDescription = (description: string) => {
+    private onUpdateDescription = async (description: string): Promise<void> => {
         this.state.failureInstanceState.description = description;
         this.emitChanged();
     };

--- a/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-test-view-controller.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-stops/tab-stops-test-view-controller.test.tsx
@@ -13,12 +13,12 @@ describe('TabStopsTestViewController', () => {
     let testSubject: TabStopsTestViewController;
     let tabStopActionsMock: IMock<TabStopsViewActions>;
 
-    test('createNewFailureInstancePanel', () => {
+    test('createNewFailureInstancePanel', async () => {
         const payload = 'some string';
         tabStopActionsMock = createActionsMock('createNewFailureInstancePanel');
         testSubject = new TabStopsTestViewController(tabStopActionsMock.object);
 
-        testSubject.createNewFailureInstancePanel(payload);
+        await testSubject.createNewFailureInstancePanel(payload);
 
         tabStopActionsMock.verify(
             m => m.createNewFailureInstancePanel.invoke(payload),
@@ -26,31 +26,31 @@ describe('TabStopsTestViewController', () => {
         );
     });
 
-    test('updateDescription', () => {
+    test('updateDescription', async () => {
         const payload = 'some string';
         tabStopActionsMock = createActionsMock('updateDescription');
         testSubject = new TabStopsTestViewController(tabStopActionsMock.object);
 
-        testSubject.updateDescription(payload);
+        await testSubject.updateDescription(payload);
 
         tabStopActionsMock.verify(m => m.updateDescription.invoke(payload), Times.once());
     });
 
-    test('dismissPanel', () => {
+    test('dismissPanel', async () => {
         tabStopActionsMock = createActionsMock('dismissPanel');
         testSubject = new TabStopsTestViewController(tabStopActionsMock.object);
 
-        testSubject.dismissPanel();
+        await testSubject.dismissPanel();
 
         tabStopActionsMock.verify(m => m.dismissPanel.invoke(), Times.once());
     });
 
-    test('editExistingFailureInstance', () => {
+    test('editExistingFailureInstance', async () => {
         const payload = {} as EditExistingFailureInstancePayload;
         tabStopActionsMock = createActionsMock('editExistingFailureInstance');
         testSubject = new TabStopsTestViewController(tabStopActionsMock.object);
 
-        testSubject.editExistingFailureInstance(payload);
+        await testSubject.editExistingFailureInstance(payload);
 
         tabStopActionsMock.verify(m => m.editExistingFailureInstance.invoke(payload), Times.once());
     });


### PR DESCRIPTION
#### Details

Convert TabStopsViewActions from SyncAction to AsyncAction

##### Motivation

Feature work

##### Context

N/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
