### PR TITLE
fix: Fix visualizations for elements that include semicolons/commas

### DIFF
--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BoundingRectangle } from 'electron/platform/android/android-scan-results';
+import { Target } from 'scanner/iruleresults';
 import { DictionaryStringTo } from 'types/common-types';
 import { GuidanceLink } from './guidance-links';
 import { ScanIncompleteWarningId } from './scan-incomplete-warnings';
@@ -86,6 +87,7 @@ export type StoredInstancePropertyBag = InstancePropertyBag;
 export type UnifiedIdentifiers = {
     identifier: string;
     conciseName: string;
+    target?: Target;
 } & InstancePropertyBag;
 
 export type UnifiedDescriptors = {

--- a/src/injected/adapters/scan-results-to-unified-results.ts
+++ b/src/injected/adapters/scan-results-to-unified-results.ts
@@ -120,6 +120,7 @@ export class ConvertScanResultsToUnifiedResults {
                 identifier: cssSelector,
                 conciseName: IssueFilingUrlStringUtils.getSelectorLastPart(cssSelector),
                 'css-selector': cssSelector,
+                target: nodeResult.target,
             },
             descriptors: {
                 snippet: nodeResult.snippet || nodeResult.html,

--- a/src/injected/element-based-view-model-creator.ts
+++ b/src/injected/element-based-view-model-creator.ts
@@ -72,7 +72,9 @@ export class ElementBasedViewModelCreator {
     };
 
     private getTarget(unifiedResult: UnifiedResult): Target {
-        return TargetHelper.getTargetFromSelector(unifiedResult.identifiers['css-selector'])!;
+        return unifiedResult.identifiers.target
+            ? unifiedResult.identifiers.target
+            : TargetHelper.getTargetFromSelector(unifiedResult.identifiers['css-selector'])!;
     }
 
     private getIdentifier(unifiedResult: UnifiedResult): string {

--- a/src/tests/end-to-end/test-resources/uncommon-characters.html
+++ b/src/tests/end-to-end/test-resources/uncommon-characters.html
@@ -1,0 +1,16 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+<!DOCTYPE html>
+<html>
+    <body>
+        <h1>Page with uncommon characters</h1>
+
+        <h2>Semicolon</h2>
+        <p id="semicolon;id;" style="color: #ccc">low-contrast text with semicolon id</p>
+
+        <h2>Comma</h2>
+        <p id="comma,id," style="color: #ccc">low-contrast text with comma id</p>
+    </body>
+</html>

--- a/src/tests/end-to-end/tests/target-page/__snapshots__/visualization-boxes.test.ts.snap
+++ b/src/tests/end-to-end/tests/target-page/__snapshots__/visualization-boxes.test.ts.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Target Page visualization boxes visualization boxes are shown over elements with uncommon characters in selector 1`] = `
+<DocumentFragment>
+  <div
+    id="insights-shadow-container"
+  >
+    <link
+      href="{{EXTENSION_URL_BASE}}/injected/styles/default/injected.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <link
+      href="{{EXTENSION_URL_BASE}}/bundle/injected.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <div
+      class="insights-container insights-highlight-container insights-issues"
+    >
+      <div
+        class="insights-highlight-box"
+        style="outline-style: solid; outline-color: rgb(232, 17, 35); top: {{ENVIRONMENT_SENSITIVE_POSITION}}px; left: {{ENVIRONMENT_SENSITIVE_POSITION}}px; min-width: {{ENVIRONMENT_SENSITIVE_POSITION}}px; min-height: {{ENVIRONMENT_SENSITIVE_POSITION}}px;"
+        title="Failed rules: color-contrast"
+      >
+        <div
+          class="insights-highlight-text failure-label"
+          style="background: rgb(232, 17, 35); color: rgb(255, 255, 255); width: 2em !important; cursor: pointer !important; text-align: center !important;"
+        >
+          !
+        </div>
+      </div>
+      <div
+        class="insights-highlight-box"
+        style="outline-style: solid; outline-color: rgb(232, 17, 35); top: {{ENVIRONMENT_SENSITIVE_POSITION}}px; left: {{ENVIRONMENT_SENSITIVE_POSITION}}px; min-width: {{ENVIRONMENT_SENSITIVE_POSITION}}px; min-height: {{ENVIRONMENT_SENSITIVE_POSITION}}px;"
+        title="Failed rules: color-contrast"
+      >
+        <div
+          class="insights-highlight-text failure-label"
+          style="background: rgb(232, 17, 35); color: rgb(255, 255, 255); width: 2em !important; cursor: pointer !important; text-align: center !important;"
+        >
+          !
+        </div>
+      </div>
+      <div
+        class="insights-highlight-box"
+        style="outline-style: solid; outline-color: rgb(232, 17, 35); top: {{ENVIRONMENT_SENSITIVE_POSITION}}px; left: {{ENVIRONMENT_SENSITIVE_POSITION}}px; min-width: {{ENVIRONMENT_SENSITIVE_POSITION}}px; min-height: {{ENVIRONMENT_SENSITIVE_POSITION}}px;"
+        title="Failed rules: document-title, html-has-lang"
+      >
+        <div
+          class="insights-highlight-text failure-label"
+          style="background: rgb(232, 17, 35); color: rgb(255, 255, 255); width: 2em !important; cursor: pointer !important; text-align: center !important;"
+        >
+          !
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Target Page visualization boxes visualization boxes are shown over nested shadow dom elements 1`] = `
 <DocumentFragment>
   <div

--- a/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
+++ b/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
@@ -78,4 +78,20 @@ describe('Target Page visualization boxes', () => {
 
         expect(await targetPage.waitForShadowRootHtmlSnapshot()).toMatchSnapshot();
     });
+
+    test('visualization boxes are shown over elements with uncommon characters in selector', async () => {
+        targetPage = await browser.newTargetPage({ testResourcePath: 'uncommon-characters.html' });
+
+        popupPage = await browser.newPopupPage(targetPage);
+        await popupPage.gotoAdhocPanel();
+
+        await popupPage.enableToggleByAriaLabel('Automated checks');
+
+        await targetPage.waitForSelectorInShadowRoot(
+            TargetPageInjectedComponentSelectors.insightsVisualizationContainer,
+            { state: 'attached' },
+        );
+
+        expect(await targetPage.waitForShadowRootHtmlSnapshot()).toMatchSnapshot();
+    });
 });

--- a/src/tests/unit/tests/injected/adapters/__snapshots__/scan-results-to-unified-results.test.ts.snap
+++ b/src/tests/unit/tests/injected/adapters/__snapshots__/scan-results-to-unified-results.test.ts.snap
@@ -12,6 +12,10 @@ Array [
       "conciseName": "id1",
       "css-selector": "target1;id1",
       "identifier": "target1;id1",
+      "target": Array [
+        "target1",
+        "id1",
+      ],
     },
     "resolution": Object {
       "howToFixSummary": "how to fix 1",
@@ -29,6 +33,10 @@ Array [
       "conciseName": "id2",
       "css-selector": "target2;id2",
       "identifier": "target2;id2",
+      "target": Array [
+        "target2",
+        "id2",
+      ],
     },
     "resolution": Object {
       "howToFixSummary": "how to fix 2",
@@ -46,6 +54,10 @@ Array [
       "conciseName": "id3",
       "css-selector": "target3;id3",
       "identifier": "target3;id3",
+      "target": Array [
+        "target3",
+        "id3",
+      ],
     },
     "resolution": Object {
       "howToFixSummary": "how to fix 3",
@@ -63,6 +75,10 @@ Array [
       "conciseName": "passTarget2",
       "css-selector": "passTarget1;passTarget2",
       "identifier": "passTarget1;passTarget2",
+      "target": Array [
+        "passTarget1",
+        "passTarget2",
+      ],
     },
     "resolution": Object {
       "howToFixSummary": undefined,
@@ -87,6 +103,9 @@ Array [
       "conciseName": "incompleteTarget1",
       "css-selector": "incompleteTarget1",
       "identifier": "incompleteTarget1",
+      "target": Array [
+        "incompleteTarget1",
+      ],
     },
     "resolution": Object {
       "howToFixSummary": undefined,
@@ -104,6 +123,10 @@ Array [
       "conciseName": "id1",
       "css-selector": "target1;id1",
       "identifier": "target1;id1",
+      "target": Array [
+        "target1",
+        "id1",
+      ],
     },
     "resolution": Object {
       "howToFixSummary": "how to fix 1",
@@ -121,6 +144,10 @@ Array [
       "conciseName": "id2",
       "css-selector": "target2;id2",
       "identifier": "target2;id2",
+      "target": Array [
+        "target2",
+        "id2",
+      ],
     },
     "resolution": Object {
       "howToFixSummary": "how to fix 2",
@@ -138,6 +165,10 @@ Array [
       "conciseName": "id3",
       "css-selector": "target3;id3",
       "identifier": "target3;id3",
+      "target": Array [
+        "target3",
+        "id3",
+      ],
     },
     "resolution": Object {
       "howToFixSummary": "how to fix 3",

--- a/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
+++ b/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
@@ -209,4 +209,46 @@ describe('ElementBasedViewModelCreator', () => {
             testSubject.getElementBasedViewModel(scanResultStoreData, cardSelectionData),
         ).toEqual(expectedResult);
     });
+
+    test('getElementBasedViewModel: preserves target if present', () => {
+        const unifiedResult = cloneDeep(exampleUnifiedResult);
+        const expectedTarget = [['target1', 'target2']];
+        unifiedResult.identifiers.target = expectedTarget;
+        const ruleStub = { id: unifiedResult.ruleId } as UnifiedRule;
+        const unifiedRules = [ruleStub];
+        const identifierStub = unifiedResult.identifiers['css-selector'];
+        const decoratedResultStub = {} as DecoratedAxeNodeResult;
+        const scanResultStoreData = {
+            results: [unifiedResult],
+            rules: unifiedRules,
+        } as UnifiedScanResultStoreData;
+        const cardSelectionViewData = {
+            resultsHighlightStatus: { [unifiedResult.uid]: 'visible' },
+        } as CardSelectionViewData;
+
+        getHighlightedResultInstanceIdsMock
+            .setup(mock =>
+                mock(cardSelectionData, scanResultStoreData, isResultHighlightUnavailableStub),
+            )
+            .returns(() => cardSelectionViewData);
+
+        getDecoratedAxeNodeCallbackMock
+            .setup(mock => mock(unifiedResult, ruleStub, identifierStub))
+            .returns(() => decoratedResultStub);
+
+        const expectedResult = {
+            [identifierStub]: {
+                isFailure: true,
+                isVisualizationEnabled: true,
+                target: expectedTarget,
+                ruleResults: {
+                    [ruleStub.id]: decoratedResultStub,
+                },
+            },
+        };
+
+        expect(
+            testSubject.getElementBasedViewModel(scanResultStoreData, cardSelectionData),
+        ).toEqual(expectedResult);
+    });
 });


### PR DESCRIPTION
#### Details

Fixes visualizations for elements that include special characters in their selectors. This addresses issue #5735 as well as an instance @pownkel was running into in which automated checks visualizations were not showing up on some github PR web pages (for example, https://github.com/microsoft/accessibility-insights-web/pull/5745)

##### Motivation

Addresses issue #5735

##### Context

https://github.com/microsoft/accessibility-insights-web/pull/5728 allowed us to preserve the target in the state that we receive it from axe throughout our logic instead of serializing it into a string as we used to do. This PR removes one more instance of stringifying then converting the target string back into an array. We want to get rid of this logic because it doesn't work with elements that have special characters in their selectors, including semicolons and commas. 

We can't completely remove the `getTargetFromSelector` logic (which does the conversion from a target string to a target array) because of some unified logic that does not have the target array, but these changes ensure that `getTargetFromSelector` is not used in the web extension. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5735
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
