### PR TITLE
chore: Update mac environment from 10.15 to 11

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -13,7 +13,7 @@ trigger:
 
 variables:
     windowsImage: 'windows-2019'
-    macImage: 'macOS-10.15'
+    macImage: 'macOS-11'
     linuxImage: 'ubuntu-18.04'
 
 jobs:

--- a/pipeline/build-all-job-per-environment.yaml
+++ b/pipeline/build-all-job-per-environment.yaml
@@ -3,7 +3,7 @@
 parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2019'
-    macImage: 'macOS-10.15'
+    macImage: 'macOS-11'
     linuxImage: 'ubuntu-18.04'
 
 jobs:

--- a/pipeline/e2e-job-per-environment.yaml
+++ b/pipeline/e2e-job-per-environment.yaml
@@ -4,7 +4,7 @@
 parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2019'
-    macImage: 'macOS-10.15'
+    macImage: 'macOS-11'
     linuxImage: 'ubuntu-18.04'
 
 jobs:

--- a/pipeline/unified/build-unsigned-release-packages.yaml
+++ b/pipeline/unified/build-unsigned-release-packages.yaml
@@ -10,7 +10,7 @@ trigger: none
 strategy:
     matrix:
         windows: { vmImage: 'windows-latest', platform: 'windows' }
-        mac: { vmImage: 'macOS-10.15', platform: 'mac' }
+        mac: { vmImage: 'macOS-11', platform: 'mac' }
         linux: { vmImage: 'ubuntu-18.04', platform: 'linux' }
 
 pool:

--- a/pipeline/unified/channel/sign-release-package-mac.yaml
+++ b/pipeline/unified/channel/sign-release-package-mac.yaml
@@ -9,7 +9,7 @@ parameters:
 jobs:
     - job: ${{ parameters.signedArtifactName }}
       pool:
-          vmImage: macOS-10.15
+          vmImage: macOS-11
       steps:
           - template: ../../install-node-prerequisites.yaml
 

--- a/pipeline/unified/unified-e2e-job-per-environment.yaml
+++ b/pipeline/unified/unified-e2e-job-per-environment.yaml
@@ -4,7 +4,7 @@
 parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2019'
-    macImage: 'macOS-10.15'
+    macImage: 'macOS-11'
     linuxImage: 'ubuntu-18.04'
 
 jobs:


### PR DESCRIPTION
#### Details

MacOS 10.15 is being phased out as a virtual environment. We're getting the following warnings in our builds:
```
The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead. For more details see https://github.com/actions/virtual-environments/issues/5583
```

This PR simply changes all instances of `macOS-10.15` to `macOS-11`.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
We could use `macOS-latest` to avoid having to touch these files in the future, but deprecations are infrequent and having an explicit version makes it easier to identify cases where tests potentially fail after changing OS versions.

We could use `macOS-12`, but that would leave downlevel clients with no testing in our pipeline. Since most of our internal testing will be on macOS 12 (required for security reasons), using `macOS-11` is a cheap and easy way to get version coverage.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
