### PR TITLE
fix: Set report package format to cjs

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -93,7 +93,7 @@ switch (argsObj.env) {
     case 'report':
         entryFiles = { report: `${src}/reports/package/reporter-factory.ts` };
         outdir = path.join(__dirname, 'packages/report/bundle');
-        format = 'esm';
+        format = 'cjs';
 
         // esbuild doesn't have an easy way to ignore node_modules for monorepos,
         // so this plugin is necessary (marks all node_modules as external).


### PR DESCRIPTION
#### Details

While debugging https://github.com/microsoft/accessibility-insights-action/pull/1230, I noticed that the report package is now ESM. I believe this was set during the esbuild switch (ref https://github.com/microsoft/accessibility-insights-web/pull/5528) and that we will want to keep the report package (at least for now) commonjs. This PR switches the format for the report package back to cjs.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
