### PR TITLE
feat(mv3-part-5): Convert TabStopRequirementActions to async

### DIFF
--- a/src/background/actions/tab-stop-requirement-action-creator.ts
+++ b/src/background/actions/tab-stop-requirement-action-creator.ts
@@ -71,68 +71,74 @@ export class TabStopRequirementActionCreator {
         );
     }
 
-    private onUpdateTabStopsRequirementStatus = (
+    private onUpdateTabStopsRequirementStatus = async (
         payload: UpdateTabStopRequirementStatusPayload,
-    ): void => {
-        this.tabStopRequirementActions.updateTabStopsRequirementStatus.invoke(payload);
+    ): Promise<void> => {
+        await this.tabStopRequirementActions.updateTabStopsRequirementStatus.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.UPDATE_TABSTOPS_REQUIREMENT_STATUS,
             payload,
         );
     };
 
-    private onResetTabStopsRequirementStatus = (
+    private onResetTabStopsRequirementStatus = async (
         payload: ResetTabStopRequirementStatusPayload,
-    ): void => {
-        this.tabStopRequirementActions.resetTabStopRequirementStatus.invoke(payload);
+    ): Promise<void> => {
+        await this.tabStopRequirementActions.resetTabStopRequirementStatus.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.RESET_TABSTOPS_REQUIREMENT_STATUS,
             payload,
         );
     };
 
-    private onAddTabStopInstance = (payload: AddTabStopInstancePayload): void => {
-        this.tabStopRequirementActions.addTabStopInstance.invoke(payload);
+    private onAddTabStopInstance = async (payload: AddTabStopInstancePayload): Promise<void> => {
+        await this.tabStopRequirementActions.addTabStopInstance.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.ADD_TABSTOPS_REQUIREMENT_INSTANCE,
             payload,
         );
     };
 
-    private onUpdateTabStopInstance = (payload: UpdateTabStopInstancePayload): void => {
-        this.tabStopRequirementActions.updateTabStopInstance.invoke(payload);
+    private onUpdateTabStopInstance = async (
+        payload: UpdateTabStopInstancePayload,
+    ): Promise<void> => {
+        await this.tabStopRequirementActions.updateTabStopInstance.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.UPDATE_TABSTOPS_REQUIREMENT_INSTANCE,
             payload,
         );
     };
 
-    private onRemoveTabStopInstance = (payload: RemoveTabStopInstancePayload): void => {
-        this.tabStopRequirementActions.removeTabStopInstance.invoke(payload);
+    private onRemoveTabStopInstance = async (
+        payload: RemoveTabStopInstancePayload,
+    ): Promise<void> => {
+        await this.tabStopRequirementActions.removeTabStopInstance.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.REMOVE_TABSTOPS_REQUIREMENT_INSTANCE,
             payload,
         );
     };
 
-    private onRequirementExpansionToggled = (
+    private onRequirementExpansionToggled = async (
         payload: ToggleTabStopRequirementExpandPayload,
-    ): void => {
-        this.tabStopRequirementActions.toggleTabStopRequirementExpand.invoke(payload);
+    ): Promise<void> => {
+        await this.tabStopRequirementActions.toggleTabStopRequirementExpand.invoke(payload);
     };
 
-    private onTabbingCompleted = (payload: UpdateTabbingCompletedPayload): void => {
-        this.tabStopRequirementActions.updateTabbingCompleted.invoke(payload);
+    private onTabbingCompleted = async (payload: UpdateTabbingCompletedPayload): Promise<void> => {
+        await this.tabStopRequirementActions.updateTabbingCompleted.invoke(payload);
     };
 
-    private onNeedToCollectTabbingResults = (
+    private onNeedToCollectTabbingResults = async (
         payload: UpdateNeedToCollectTabbingResultsPayload,
-    ): void => {
-        this.tabStopRequirementActions.updateNeedToCollectTabbingResults.invoke(payload);
+    ): Promise<void> => {
+        await this.tabStopRequirementActions.updateNeedToCollectTabbingResults.invoke(payload);
     };
 
-    private onAutomatedTabbingResultsCompleted = (payload: BaseActionPayload): void => {
-        this.tabStopRequirementActions.automatedTabbingResultsCompleted.invoke(payload);
+    private onAutomatedTabbingResultsCompleted = async (
+        payload: BaseActionPayload,
+    ): Promise<void> => {
+        await this.tabStopRequirementActions.automatedTabbingResultsCompleted.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.TABSTOPS_AUTOMATED_RESULTS,
             payload,

--- a/src/background/actions/tab-stop-requirement-actions.ts
+++ b/src/background/actions/tab-stop-requirement-actions.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import {
     AddTabStopInstancePayload,
     BaseActionPayload,
@@ -16,18 +16,18 @@ import {
 } from './action-payloads';
 
 export class TabStopRequirementActions {
-    public readonly getCurrentState = new SyncAction();
+    public readonly getCurrentState = new AsyncAction();
     public readonly updateTabStopsRequirementStatus =
-        new SyncAction<UpdateTabStopRequirementStatusPayload>();
-    public readonly addTabStopInstance = new SyncAction<AddTabStopInstancePayload>();
-    public readonly updateTabStopInstance = new SyncAction<UpdateTabStopInstancePayload>();
-    public readonly removeTabStopInstance = new SyncAction<RemoveTabStopInstancePayload>();
+        new AsyncAction<UpdateTabStopRequirementStatusPayload>();
+    public readonly addTabStopInstance = new AsyncAction<AddTabStopInstancePayload>();
+    public readonly updateTabStopInstance = new AsyncAction<UpdateTabStopInstancePayload>();
+    public readonly removeTabStopInstance = new AsyncAction<RemoveTabStopInstancePayload>();
     public readonly resetTabStopRequirementStatus =
-        new SyncAction<ResetTabStopRequirementStatusPayload>();
+        new AsyncAction<ResetTabStopRequirementStatusPayload>();
     public readonly toggleTabStopRequirementExpand =
-        new SyncAction<ToggleTabStopRequirementExpandPayload>();
-    public readonly updateTabbingCompleted = new SyncAction<UpdateTabbingCompletedPayload>();
+        new AsyncAction<ToggleTabStopRequirementExpandPayload>();
+    public readonly updateTabbingCompleted = new AsyncAction<UpdateTabbingCompletedPayload>();
     public readonly updateNeedToCollectTabbingResults =
-        new SyncAction<UpdateNeedToCollectTabbingResultsPayload>();
-    public readonly automatedTabbingResultsCompleted = new SyncAction<BaseActionPayload>();
+        new AsyncAction<UpdateNeedToCollectTabbingResultsPayload>();
+    public readonly automatedTabbingResultsCompleted = new AsyncAction<BaseActionPayload>();
 }

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -183,9 +183,9 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         this.emitChanged();
     };
 
-    private onUpdateTabStopRequirementStatus = (
+    private onUpdateTabStopRequirementStatus = async (
         payload: UpdateTabStopRequirementStatusPayload,
-    ): void => {
+    ): Promise<void> => {
         const { requirementId, status } = payload;
         this.state.tabStops.requirements[requirementId].status = status;
         if (status === 'pass') {
@@ -194,16 +194,16 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         this.emitChanged();
     };
 
-    private onResetTabStopRequirementStatus = (
+    private onResetTabStopRequirementStatus = async (
         payload: ResetTabStopRequirementStatusPayload,
-    ): void => {
+    ): Promise<void> => {
         const { requirementId } = payload;
         this.state.tabStops.requirements[requirementId].status = TabStopRequirementStatuses.unknown;
         this.state.tabStops.requirements[requirementId].instances = [];
         this.emitChanged();
     };
 
-    private onAddTabStopInstance = (payload: AddTabStopInstancePayload): void => {
+    private onAddTabStopInstance = async (payload: AddTabStopInstancePayload): Promise<void> => {
         const { requirementId, description, selector, html } = payload;
         this.state.tabStops.requirements[requirementId].status = 'fail';
         this.state.tabStops.requirements[requirementId].instances.push({
@@ -215,7 +215,9 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         this.emitChanged();
     };
 
-    private onUpdateTabStopInstance = (payload: UpdateTabStopInstancePayload): void => {
+    private onUpdateTabStopInstance = async (
+        payload: UpdateTabStopInstancePayload,
+    ): Promise<void> => {
         const { requirementId, id, description } = payload;
         this.state.tabStops.requirements[requirementId].instances.find(
             instance => instance.id === id,
@@ -223,7 +225,9 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         this.emitChanged();
     };
 
-    private onRemoveTabStopInstance = (payload: RemoveTabStopInstancePayload): void => {
+    private onRemoveTabStopInstance = async (
+        payload: RemoveTabStopInstancePayload,
+    ): Promise<void> => {
         const { requirementId, id } = payload;
         const newInstances = this.state.tabStops.requirements[requirementId].instances.filter(
             instance => instance.id !== id,
@@ -232,9 +236,9 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         this.emitChanged();
     };
 
-    private onToggleTabStopRequirementExpandCollapse = (
+    private onToggleTabStopRequirementExpandCollapse = async (
         payload: ToggleTabStopRequirementExpandPayload,
-    ): void => {
+    ): Promise<void> => {
         const { requirementId } = payload;
         const requirement = this.state.tabStops.requirements[requirementId];
         requirement.isExpanded = !requirement.isExpanded;
@@ -274,14 +278,16 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         return selectedRows;
     }
 
-    private onUpdateTabbingCompleted = (payload: UpdateTabbingCompletedPayload): void => {
+    private onUpdateTabbingCompleted = async (
+        payload: UpdateTabbingCompletedPayload,
+    ): Promise<void> => {
         this.state.tabStops.tabbingCompleted = payload.tabbingCompleted;
         this.emitChanged();
     };
 
-    private onUpdateNeedToCollectTabbingResults = (
+    private onUpdateNeedToCollectTabbingResults = async (
         payload: UpdateNeedToCollectTabbingResultsPayload,
-    ): void => {
+    ): Promise<void> => {
         this.state.tabStops.needToCollectTabbingResults = payload.needToCollectTabbingResults;
         this.emitChanged();
     };

--- a/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-stop-requirement-action-creator.test.ts
@@ -19,7 +19,7 @@ import { Messages } from 'common/messages';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
 
-import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('TabStopRequirementActionCreator', () => {
     const requirementId = 'focus-indicator';
@@ -38,7 +38,7 @@ describe('TabStopRequirementActionCreator', () => {
             status: 'pass',
         };
 
-        const updateTabStopRequirementStatusMock = createSyncActionMock(payload);
+        const updateTabStopRequirementStatusMock = createAsyncActionMock(payload);
 
         const actionsMock = createActionsMock(
             actionName,
@@ -75,7 +75,7 @@ describe('TabStopRequirementActionCreator', () => {
             requirementId: requirementId,
         };
 
-        const resetTabStopRequirementStatusMock = createSyncActionMock(payload);
+        const resetTabStopRequirementStatusMock = createAsyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, resetTabStopRequirementStatusMock.object);
 
@@ -111,7 +111,7 @@ describe('TabStopRequirementActionCreator', () => {
             description: 'testing',
         };
 
-        const addTabStopRequirementInstanceMock = createSyncActionMock(payload);
+        const addTabStopRequirementInstanceMock = createAsyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, addTabStopRequirementInstanceMock.object);
 
@@ -148,7 +148,7 @@ describe('TabStopRequirementActionCreator', () => {
             id: 'abc',
         };
 
-        const updateTabStopRequirementInstanceMock = createSyncActionMock(payload);
+        const updateTabStopRequirementInstanceMock = createAsyncActionMock(payload);
 
         const actionsMock = createActionsMock(
             actionName,
@@ -185,7 +185,7 @@ describe('TabStopRequirementActionCreator', () => {
             requirementId: requirementId,
         };
 
-        const onRequirementExpansionToggledMock = createSyncActionMock(payload);
+        const onRequirementExpansionToggledMock = createAsyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, onRequirementExpansionToggledMock.object);
 
@@ -213,7 +213,7 @@ describe('TabStopRequirementActionCreator', () => {
             id: 'abc',
         };
 
-        const removeTabStopRequirementInstanceMock = createSyncActionMock(payload);
+        const removeTabStopRequirementInstanceMock = createAsyncActionMock(payload);
 
         const actionsMock = createActionsMock(
             actionName,
@@ -250,7 +250,7 @@ describe('TabStopRequirementActionCreator', () => {
             tabbingCompleted: true,
         };
 
-        const onTabbingCompletedMock = createSyncActionMock(payload);
+        const onTabbingCompletedMock = createAsyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, onTabbingCompletedMock.object);
 
@@ -276,7 +276,7 @@ describe('TabStopRequirementActionCreator', () => {
             needToCollectTabbingResults: true,
         };
 
-        const onNeedToCollectTabbingResultsMock = createSyncActionMock(payload);
+        const onNeedToCollectTabbingResultsMock = createAsyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, onNeedToCollectTabbingResultsMock.object);
 
@@ -303,7 +303,7 @@ describe('TabStopRequirementActionCreator', () => {
             telemetry: {} as TelemetryEvents.TelemetryData,
         };
 
-        const instanceMock = createSyncActionMock(payload);
+        const instanceMock = createAsyncActionMock(payload);
 
         const actionsMock = createActionsMock(actionName, instanceMock.object);
 


### PR DESCRIPTION
#### Details

Convert TabStopRequirementActions from SyncAction to AsyncAction

##### Motivation

Feature work

##### Context

N/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
