### PR TITLE
feat(mv3-part-5): Convert LeftNavActions to async

### DIFF
--- a/src/electron/flux/action-creator/left-nav-action-creator.ts
+++ b/src/electron/flux/action-creator/left-nav-action-creator.ts
@@ -12,10 +12,10 @@ export class LeftNavActionCreator {
     ) {}
 
     public itemSelected = async (itemKey: LeftNavItemKey) => {
-        this.leftNavActions.itemSelected.invoke(itemKey);
+        await this.leftNavActions.itemSelected.invoke(itemKey);
         await this.cardSelectionActions.navigateToNewCardsView.invoke(null);
     };
 
-    public setLeftNavVisible = (value: boolean) =>
-        this.leftNavActions.setLeftNavVisible.invoke(value);
+    public setLeftNavVisible = async (value: boolean) =>
+        await this.leftNavActions.setLeftNavVisible.invoke(value);
 }

--- a/src/electron/flux/action/left-nav-actions.ts
+++ b/src/electron/flux/action/left-nav-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
 
 export class LeftNavActions {
-    public readonly itemSelected = new SyncAction<LeftNavItemKey>();
-    public readonly setLeftNavVisible = new SyncAction<boolean>();
+    public readonly itemSelected = new AsyncAction<LeftNavItemKey>();
+    public readonly setLeftNavVisible = new AsyncAction<boolean>();
 }

--- a/src/electron/flux/store/left-nav-store.ts
+++ b/src/electron/flux/store/left-nav-store.ts
@@ -24,13 +24,13 @@ export class LeftNavStore extends BaseStoreImpl<LeftNavStoreData> {
         this.actions.setLeftNavVisible.addListener(this.onSetLeftNavVisible);
     }
 
-    private onItemSelected = (key: LeftNavItemKey): void => {
+    private onItemSelected = async (key: LeftNavItemKey): Promise<void> => {
         this.state.selectedKey = key;
         this.state.leftNavVisible = false;
         this.emitChanged();
     };
 
-    private onSetLeftNavVisible = (value: boolean): void => {
+    private onSetLeftNavVisible = async (value: boolean): Promise<void> => {
         this.state.leftNavVisible = value;
         this.emitChanged();
     };

--- a/src/tests/unit/tests/electron/flux/action-creator/left-nav-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/left-nav-action-creator.test.ts
@@ -3,7 +3,6 @@
 
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
 import { AsyncAction } from 'common/flux/async-action';
-import { SyncAction } from 'common/flux/sync-action';
 import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { LeftNavActions } from 'electron/flux/action/left-nav-actions';
 import { LeftNavItemKey } from 'electron/types/left-nav-item-key';
@@ -27,7 +26,7 @@ describe('LeftNavActionCreator', () => {
     });
 
     it('itemSelected', async () => {
-        const itemSelectedMock = Mock.ofType<SyncAction<LeftNavItemKey>>();
+        const itemSelectedMock = Mock.ofType<AsyncAction<LeftNavItemKey>>();
         leftNavActionsMock
             .setup(actions => actions.itemSelected)
             .returns(() => itemSelectedMock.object)
@@ -52,8 +51,8 @@ describe('LeftNavActionCreator', () => {
         cardSelectionActionsMock.verifyAll();
     });
 
-    it.each([[true], [false]])('setLeftNavVisible', testValue => {
-        const setLeftNavVisibleMock = Mock.ofType<SyncAction<boolean>>();
+    it.each([[true], [false]])('setLeftNavVisible', async testValue => {
+        const setLeftNavVisibleMock = Mock.ofType<AsyncAction<boolean>>();
         leftNavActionsMock
             .setup(actions => actions.setLeftNavVisible)
             .returns(() => setLeftNavVisibleMock.object)
@@ -61,7 +60,7 @@ describe('LeftNavActionCreator', () => {
 
         setLeftNavVisibleMock.setup(m => m.invoke(testValue)).verifiable();
 
-        actionCreator.setLeftNavVisible(testValue);
+        await actionCreator.setLeftNavVisible(testValue);
 
         setLeftNavVisibleMock.verifyAll();
         leftNavActionsMock.verifyAll();


### PR DESCRIPTION
#### Details

Convert LeftNavActions from SyncAction to AsyncAction

##### Motivation

Feature work

##### Context

N/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
