### PR TITLE
feat(mv3-part-5): Convert WindowStateActions to async

### DIFF
--- a/src/electron/flux/action-creator/window-state-action-creator.ts
+++ b/src/electron/flux/action-creator/window-state-action-creator.ts
@@ -17,8 +17,8 @@ export class WindowStateActionCreator {
         private readonly userConfigurationStore: UserConfigurationStore,
     ) {}
 
-    public setRoute(payload: RoutePayload): void {
-        this.windowStateActions.setRoute.invoke(payload);
+    public async setRoute(payload: RoutePayload): Promise<void> {
+        await this.windowStateActions.setRoute.invoke(payload);
 
         if (payload.routeId === 'deviceConnectView') {
             this.windowFrameActionCreator.setWindowSize({ width: 600, height: 391 });
@@ -27,8 +27,8 @@ export class WindowStateActionCreator {
         }
     }
 
-    public setWindowState(payload: WindowStatePayload): void {
-        this.windowStateActions.setWindowState.invoke(payload);
+    public async setWindowState(payload: WindowStatePayload): Promise<void> {
+        await this.windowStateActions.setWindowState.invoke(payload);
     }
 
     private setWindowBoundsFromSavedWindowBounds(): void {

--- a/src/electron/flux/action/window-state-actions.ts
+++ b/src/electron/flux/action/window-state-actions.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { WindowStatePayload } from 'electron/flux/action/window-state-payload';
 import { RoutePayload } from './route-payloads';
 
 export class WindowStateActions {
-    public readonly setRoute = new SyncAction<RoutePayload>();
-    public readonly setWindowState = new SyncAction<WindowStatePayload>();
+    public readonly setRoute = new AsyncAction<RoutePayload>();
+    public readonly setWindowState = new AsyncAction<WindowStatePayload>();
 }

--- a/src/electron/flux/store/window-state-store.ts
+++ b/src/electron/flux/store/window-state-store.ts
@@ -25,7 +25,9 @@ export class WindowStateStore extends BaseStoreImpl<WindowStateStoreData> {
         this.windowStateActions.setWindowState.addListener(this.onSetWindowState);
     }
 
-    private onSetRoute = (payload: RoutePayload) => {
+    private onSetRoute: (payload: RoutePayload) => Promise<void> = async (
+        payload: RoutePayload,
+    ) => {
         if (this.state.routeId === payload.routeId) {
             return;
         }
@@ -33,7 +35,9 @@ export class WindowStateStore extends BaseStoreImpl<WindowStateStoreData> {
         this.emitChanged();
     };
 
-    private onSetWindowState = (payload: WindowStatePayload) => {
+    private onSetWindowState: (payload: WindowStatePayload) => Promise<void> = async (
+        payload: WindowStatePayload,
+    ) => {
         if (payload.currentWindowState === this.state.currentWindowState) {
             return;
         }

--- a/src/electron/ipc/ipc-renderer-shim.ts
+++ b/src/electron/ipc/ipc-renderer-shim.ts
@@ -44,16 +44,16 @@ export class IpcRendererShim {
         );
     }
 
-    private onMaximize = (): void => {
-        this.fromBrowserWindowMaximize.invoke(undefined, this.invokeScope);
+    private onMaximize = async (): Promise<void> => {
+        await this.fromBrowserWindowMaximize.invoke(undefined, this.invokeScope);
     };
 
-    private onEnterFullScreen = (): void => {
-        this.fromBrowserWindowEnterFullScreen.invoke(undefined, this.invokeScope);
+    private onEnterFullScreen = async (): Promise<void> => {
+        await this.fromBrowserWindowEnterFullScreen.invoke(undefined, this.invokeScope);
     };
 
-    private onUnmaximize = (): void => {
-        this.fromBrowserWindowUnmaximize.invoke(undefined, this.invokeScope);
+    private onUnmaximize = async (): Promise<void> => {
+        await this.fromBrowserWindowUnmaximize.invoke(undefined, this.invokeScope);
     };
 
     private onClose = async (): Promise<void> => {
@@ -67,9 +67,9 @@ export class IpcRendererShim {
 
     // Listen to these events to receive data sent TO renderer process
     public readonly fromBrowserWindowClose = new AsyncAction();
-    public readonly fromBrowserWindowMaximize = new SyncAction<void>();
-    public readonly fromBrowserWindowUnmaximize = new SyncAction<void>();
-    public readonly fromBrowserWindowEnterFullScreen = new SyncAction<void>();
+    public readonly fromBrowserWindowMaximize = new AsyncAction<void>();
+    public readonly fromBrowserWindowUnmaximize = new AsyncAction<void>();
+    public readonly fromBrowserWindowEnterFullScreen = new AsyncAction<void>();
     public readonly fromBrowserWindowWindowBoundsChanged =
         new SyncAction<WindowBoundsChangedPayload>();
 

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -190,7 +190,7 @@ const logger = createDefaultLogger();
 getGlobalPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
     ignorePersistedData: process.env.ACCESSIBILITY_INSIGHTS_ELECTRON_CLEAR_DATA === 'true', // this option is for tests to ensure they can use mock-adb
 })
-    .then((persistedData: Partial<PersistedData>) => {
+    .then(async (persistedData: Partial<PersistedData>) => {
         const installationData: InstallationData = persistedData.installationData;
 
         const applicationTelemetryDataFactory = getApplicationTelemetryDataFactory(
@@ -562,8 +562,8 @@ getGlobalPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
 
         const reportNameGenerator = new UnifiedReportNameGenerator();
 
-        const startTesting = () => {
-            windowStateActionCreator.setRoute({ routeId: 'resultsView' });
+        const startTesting = async () => {
+            await windowStateActionCreator.setRoute({ routeId: 'resultsView' });
         };
 
         const usageLogger = new UsageLogger(storageAdapter, DateProvider.getCurrentDate, logger);
@@ -611,7 +611,7 @@ getGlobalPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
         window.featureFlagsController = featureFlagsController;
 
         const renderer = new RootContainerRenderer(ReactDOM.render, document, deps);
-        renderer.render();
+        await renderer.render();
 
         sendAppInitializedTelemetryEvent(telemetryEventHandler, platformInfo);
 

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -240,8 +240,8 @@ export class ResultsView extends React.Component<ResultsViewProps> {
         return (
             <DeviceDisconnectedPopup
                 deviceName={this.getConnectedDeviceName()}
-                onRedetectDevice={() =>
-                    this.props.deps.windowStateActionCreator.setRoute({
+                onRedetectDevice={async () =>
+                    await this.props.deps.windowStateActionCreator.setRoute({
                         routeId: 'deviceConnectView',
                     })
                 }

--- a/src/electron/views/root-container/root-container-renderer.tsx
+++ b/src/electron/views/root-container/root-container-renderer.tsx
@@ -24,8 +24,8 @@ export class RootContainerRenderer {
         private readonly deps: RootContainerRendererDeps,
     ) {}
 
-    public render(): void {
-        this.deps.windowStateActionCreator.setRoute({ routeId: 'deviceConnectView' });
+    public async render(): Promise<void> {
+        await this.deps.windowStateActionCreator.setRoute({ routeId: 'deviceConnectView' });
 
         const rootContainer = this.dom.querySelector('#root-container');
         this.renderer(

--- a/src/electron/window-management/window-frame-listener.ts
+++ b/src/electron/window-management/window-frame-listener.ts
@@ -24,16 +24,16 @@ export class WindowFrameListener {
         );
     }
 
-    private onMaximize = (): void => {
-        this.windowStateActionsCreator.setWindowState({ currentWindowState: 'maximized' });
+    private onMaximize = async (): Promise<void> => {
+        await this.windowStateActionsCreator.setWindowState({ currentWindowState: 'maximized' });
     };
 
-    private onEnterFullScreen = (): void => {
-        this.windowStateActionsCreator.setWindowState({ currentWindowState: 'fullScreen' });
+    private onEnterFullScreen = async (): Promise<void> => {
+        await this.windowStateActionsCreator.setWindowState({ currentWindowState: 'fullScreen' });
     };
 
-    private onUnMaximize = (): void => {
-        this.windowStateActionsCreator.setWindowState({ currentWindowState: 'customSize' });
+    private onUnMaximize = async (): Promise<void> => {
+        await this.windowStateActionsCreator.setWindowState({ currentWindowState: 'customSize' });
     };
 
     private onWindowBoundsChanged = (payload: WindowBoundsChangedPayload): void => {

--- a/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
+import { AsyncAction } from 'common/flux/async-action';
 import { SyncAction } from 'common/flux/sync-action';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { Rectangle } from 'electron';
@@ -34,8 +35,8 @@ describe(WindowStateActionCreator, () => {
         );
     });
 
-    it('calling setRoute invokes setRoute action with given payload', () => {
-        const setRouteActionMock = Mock.ofType<SyncAction<RoutePayload>>();
+    it('calling setRoute invokes setRoute action with given payload', async () => {
+        const setRouteActionMock = Mock.ofType<AsyncAction<RoutePayload>>();
         const testPayload: RoutePayload = {
             routeId: 'resultsView',
         };
@@ -51,13 +52,13 @@ describe(WindowStateActionCreator, () => {
         userConfigurationStoreMock.setup(u => u.getState()).returns(() => userConfigStoreDataStub);
         windowFrameActionCreatorMock.setup(w => w.maximize());
 
-        testSubject.setRoute(testPayload);
+        await testSubject.setRoute(testPayload);
 
         setRouteActionMock.verifyAll();
     });
 
-    it('calling setRoute with deviceConnectView, invokes setWindowSize', () => {
-        const setRouteActionMock = Mock.ofType<SyncAction<RoutePayload>>();
+    it('calling setRoute with deviceConnectView, invokes setWindowSize', async () => {
+        const setRouteActionMock = Mock.ofType<AsyncAction<RoutePayload>>();
         const testPayload: RoutePayload = {
             routeId: 'deviceConnectView',
         };
@@ -71,14 +72,14 @@ describe(WindowStateActionCreator, () => {
             .returns(() => setRouteActionMock.object);
         setRouteActionMock.setup(s => s.invoke(testPayload)).verifiable(Times.once());
 
-        testSubject.setRoute(testPayload);
+        await testSubject.setRoute(testPayload);
 
         setRouteActionMock.verifyAll();
         windowFrameActionCreatorMock.verifyAll();
     });
 
-    it('calling setWindowState invokes setWindowState action', () => {
-        const setWindowStatePayload = Mock.ofType<SyncAction<WindowStatePayload>>();
+    it('calling setWindowState invokes setWindowState action', async () => {
+        const setWindowStatePayload = Mock.ofType<AsyncAction<WindowStatePayload>>();
         const testPayload: WindowStatePayload = {
             currentWindowState: 'maximized',
         };
@@ -88,7 +89,7 @@ describe(WindowStateActionCreator, () => {
             .returns(() => setWindowStatePayload.object);
         setWindowStatePayload.setup(s => s.invoke(testPayload)).verifiable(Times.once());
 
-        testSubject.setWindowState(testPayload);
+        await testSubject.setWindowState(testPayload);
 
         setWindowStatePayload.verifyAll();
         windowFrameActionCreatorMock.verifyAll();
@@ -112,8 +113,8 @@ describe(WindowStateActionCreator, () => {
 
         it.each(['normal', 'maximized', 'full-screen'])(
             'sets window size correctly if lastWindowBounds is specified and windowState is %s',
-            lastWindowState => {
-                setRouteNonDeviceViewCore(lastWindowState as WindowState, {
+            async lastWindowState => {
+                await setRouteNonDeviceViewCore(lastWindowState as WindowState, {
                     x: 150,
                     y: 200,
                     height: 400,
@@ -124,15 +125,15 @@ describe(WindowStateActionCreator, () => {
 
         it.each(['normal', 'maximized', 'full-screen'])(
             'sets window size correctly if lastWindowBounds is null and windowState is %s',
-            lastWindowState => {
-                setRouteNonDeviceViewCore(lastWindowState as WindowState, null);
+            async lastWindowState => {
+                await setRouteNonDeviceViewCore(lastWindowState as WindowState, null);
             },
         );
 
-        function setRouteNonDeviceViewCore(
+        async function setRouteNonDeviceViewCore(
             lastWindowState: WindowState,
             lastWindowBounds: Rectangle,
-        ): void {
+        ): Promise<void> {
             const userConfigStoreDataStub = {
                 lastWindowState: lastWindowState,
                 lastWindowBounds: lastWindowBounds,
@@ -168,7 +169,7 @@ describe(WindowStateActionCreator, () => {
                 })
                 .verifiable(shouldEnterFullScreen ? Times.once() : Times.never());
 
-            testSubject.setRoute(testPayload);
+            await testSubject.setRoute(testPayload);
 
             setRouteActionMock.verifyAll();
             windowFrameActionCreatorMock.verifyAll();

--- a/src/tests/unit/tests/electron/ipc/ipc-renderer-shim.test.ts
+++ b/src/tests/unit/tests/electron/ipc/ipc-renderer-shim.test.ts
@@ -68,21 +68,27 @@ describe(IpcRendererShim, () => {
 
         it('invoke fromBrowserWindowEnterFullScreen on enterFullScreen message from browser', () => {
             let callCount = 0;
-            testSubject.fromBrowserWindowEnterFullScreen.addListener(() => callCount++);
+            testSubject.fromBrowserWindowEnterFullScreen.addListener(async () => {
+                callCount++;
+            });
             ipcHandlers[IPC_FROMBROWSERWINDOW_ENTERFULLSCREEN_CHANNEL_NAME]();
             expect(callCount).toBe(1);
         });
 
         it('invoke fromBrowserWindowMaximize on maximize message from browser', () => {
             let callCount = 0;
-            testSubject.fromBrowserWindowMaximize.addListener(() => callCount++);
+            testSubject.fromBrowserWindowMaximize.addListener(async () => {
+                callCount++;
+            });
             ipcHandlers[IPC_FROMBROWSERWINDOW_MAXIMIZE_CHANNEL_NAME]();
             expect(callCount).toBe(1);
         });
 
         it('invoke fromBrowserWindowUnmaximize on unmaximize message from browser', () => {
             let callCount = 0;
-            testSubject.fromBrowserWindowUnmaximize.addListener(() => callCount++);
+            testSubject.fromBrowserWindowUnmaximize.addListener(async () => {
+                callCount++;
+            });
             ipcHandlers[IPC_FROMBROWSERWINDOW_UNMAXIMIZE_CHANNEL_NAME]();
             expect(callCount).toBe(1);
         });

--- a/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
@@ -15,7 +15,7 @@ import * as ReactDOM from 'react-dom';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('RootContainerRendererTest', () => {
-    test('render', () => {
+    test('render', async () => {
         const dom = document.createElement('div');
         const containerDiv = document.createElement('div');
         const documentManipulatorMock = Mock.ofType<DocumentManipulator>();
@@ -51,7 +51,7 @@ describe('RootContainerRendererTest', () => {
 
         const renderer = new RootContainerRenderer(renderMock.object, dom, deps);
 
-        renderer.render();
+        await renderer.render();
 
         renderMock.verifyAll();
         windowStateActionCreatorMock.verifyAll();


### PR DESCRIPTION
#### Details

Convert WindowStateActions from SyncAction to AsyncAction. Note that converting these actions also required converting some IpcRendererShim actions as well.

##### Motivation

Feature work

##### Context

N/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
