### PR TITLE
feat(mv3-part-5): Allow event handler list and store to support async and sync listeners

### DIFF
--- a/src/common/flux/event-handler-list.ts
+++ b/src/common/flux/event-handler-list.ts
@@ -1,25 +1,43 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { mergePromiseResponses } from 'common/merge-promise-responses';
+import { isPromise } from 'common/promises/is-promise';
 import { FunctionPPR } from '../../types/common-types';
 
-export class EventHandlerList<TSender, TEventArgs> {
-    private handlers: FunctionPPR<TSender, TEventArgs, any>[] = [];
+export type HandlerReturnType = void | Promise<void>;
 
-    public subscribe(handler: FunctionPPR<TSender, TEventArgs, any>): void {
+export class EventHandlerList<TSender, TEventArgs, TReturn extends HandlerReturnType = void> {
+    private handlers: FunctionPPR<TSender, TEventArgs, TReturn>[] = [];
+
+    public subscribe(handler: FunctionPPR<TSender, TEventArgs, TReturn>): void {
         if (handler) {
             this.handlers.push(handler);
         }
     }
 
-    public unsubscribe(handler: FunctionPPR<TSender, TEventArgs, any>): void {
+    public unsubscribe(handler: FunctionPPR<TSender, TEventArgs, TReturn>): void {
         if (this.handlers) {
             this.handlers = this.handlers.filter(h => h !== handler);
         }
     }
 
-    public invokeHandlers(sender: TSender, eventArgs?: TEventArgs): void {
+    public invokeHandlers(sender: TSender, eventArgs?: TEventArgs): TReturn {
         const handlersCopy = [...this.handlers];
 
-        handlersCopy.forEach(handler => handler(sender, eventArgs));
+        const results = handlersCopy.map(handler => handler(sender, eventArgs));
+
+        const asyncResults = results.filter(isPromise);
+
+        if (asyncResults.length === 1) {
+            return asyncResults[0] as TReturn;
+        }
+
+        if (asyncResults.length > 1) {
+            return mergePromiseResponses(
+                asyncResults as unknown as Promise<void>[],
+            ) as unknown as TReturn;
+        }
+
+        return undefined as TReturn;
     }
 }

--- a/src/common/flux/event-handler-list.ts
+++ b/src/common/flux/event-handler-list.ts
@@ -29,7 +29,7 @@ export class EventHandlerList<TSender, TEventArgs, TReturn extends HandlerReturn
         const asyncResults = results.filter(isPromise);
 
         if (asyncResults.length === 1) {
-            return asyncResults[0] as TReturn;
+            return asyncResults[0];
         }
 
         if (asyncResults.length > 1) {

--- a/src/common/flux/event-handler-list.ts
+++ b/src/common/flux/event-handler-list.ts
@@ -33,9 +33,7 @@ export class EventHandlerList<TSender, TEventArgs, TReturn extends HandlerReturn
         }
 
         if (asyncResults.length > 1) {
-            return mergePromiseResponses(
-                asyncResults as unknown as Promise<void>[],
-            ) as unknown as TReturn;
+            return mergePromiseResponses(asyncResults as Promise<void>[]) as TReturn;
         }
 
         return undefined as TReturn;

--- a/src/common/flux/store.ts
+++ b/src/common/flux/store.ts
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { EventHandlerList } from './event-handler-list';
+import { EventHandlerList, HandlerReturnType } from './event-handler-list';
 
-export class Store {
-    private changedHandlers = new EventHandlerList<this, unknown>();
+export class Store<TReturn extends HandlerReturnType = void> {
+    private changedHandlers = new EventHandlerList<this, unknown, TReturn>();
 
-    public addChangedListener(handler: (store: this, args?: unknown) => void): void {
+    public addChangedListener(handler: (store: this, args?: unknown) => TReturn): void {
         this.changedHandlers.subscribe(handler);
     }
 
-    public removeChangedListener(handler: (store: this, args?: unknown) => void): void {
+    public removeChangedListener(handler: (store: this, args?: unknown) => TReturn): void {
         this.changedHandlers.unsubscribe(handler);
     }
 
-    protected emitChanged(): void {
-        this.changedHandlers.invokeHandlers(this);
+    protected emitChanged(): TReturn {
+        return this.changedHandlers.invokeHandlers(this);
     }
 }

--- a/src/tests/unit/tests/common/flux/store.test.ts
+++ b/src/tests/unit/tests/common/flux/store.test.ts
@@ -1,55 +1,84 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, Times } from 'typemoq';
-
 import { Store } from '../../../../../common/flux/store';
 import { IsSameObject } from '../../../common/typemoq-helper';
 
 describe('StoreTest', () => {
-    let testObject: TestableStore;
-    let handlerMock: IMock<(store: TestableStore, args: any) => void>;
+    describe('SyncStore', () => {
+        let testObject: TestableStore<void>;
+        let handlerMock: IMock<(store: TestableStore<void>, args: any) => void>;
 
-    beforeEach(() => {
-        handlerMock = Mock.ofInstance((store, args) => {});
-        testObject = new TestableStore();
+        beforeEach(() => {
+            handlerMock = Mock.ofInstance((store, args) => {});
+            testObject = new TestableStore<void>();
+        });
+
+        test('addChangedListener', () => {
+            handlerMock
+                .setup(h => h(IsSameObject(testObject), It.isAny()))
+                .verifiable(Times.once());
+
+            testObject.addChangedListener(handlerMock.object);
+
+            testObject.emitChanged();
+
+            handlerMock.verifyAll();
+        });
+
+        test('removeChangedListener', () => {
+            handlerMock
+                .setup(h => h(IsSameObject(testObject), It.isAny()))
+                .verifiable(Times.once());
+
+            testObject.addChangedListener(handlerMock.object);
+
+            testObject.emitChanged();
+
+            handlerMock.verifyAll();
+
+            handlerMock.reset();
+
+            handlerMock.setup(h => h(It.isAny(), It.isAny())).verifiable(Times.never());
+
+            testObject.removeChangedListener(handlerMock.object);
+
+            testObject.emitChanged();
+
+            handlerMock.verifyAll();
+        });
     });
 
-    test('addChangedListener', () => {
-        handlerMock.setup(h => h(IsSameObject(testObject), It.isAny())).verifiable(Times.once());
+    describe('AsyncStore', () => {
+        let testObject: TestableStore<Promise<void>>;
+        let handlerMock: IMock<(store: TestableStore<Promise<void>>, args: any) => Promise<void>>;
 
-        testObject.addChangedListener(handlerMock.object);
+        beforeEach(() => {
+            handlerMock = Mock.ofInstance((store, args) => Promise.resolve());
+            testObject = new TestableStore<Promise<void>>();
+        });
 
-        testObject.emitChanged();
+        test('emitChanged returns a promise', async () => {
+            handlerMock
+                .setup(h => h(IsSameObject(testObject), It.isAny()))
+                .returns(h => Promise.resolve())
+                .verifiable(Times.once());
 
-        handlerMock.verifyAll();
+            testObject.addChangedListener(handlerMock.object);
+
+            const result = testObject.emitChanged();
+            await expect(result).resolves.toBeUndefined();
+
+            handlerMock.verifyAll();
+        });
     });
 
-    test('removeChangedListener', () => {
-        handlerMock.setup(h => h(IsSameObject(testObject), It.isAny())).verifiable(Times.once());
-
-        testObject.addChangedListener(handlerMock.object);
-
-        testObject.emitChanged();
-
-        handlerMock.verifyAll();
-
-        handlerMock.reset();
-
-        handlerMock.setup(h => h(It.isAny(), It.isAny())).verifiable(Times.never());
-
-        testObject.removeChangedListener(handlerMock.object);
-
-        testObject.emitChanged();
-
-        handlerMock.verifyAll();
-    });
-
-    class TestableStore extends Store {
+    class TestableStore<TReturn extends void | Promise<void>> extends Store<TReturn> {
         constructor() {
             super();
         }
-        public emitChanged(): void {
-            super.emitChanged();
+        public override emitChanged(): TReturn {
+            return super.emitChanged();
         }
     }
 });


### PR DESCRIPTION
#### Details

Allow event handler list and store to support sync or async callbacks. This PR does not change specific stores but it enables us to convert specific stores to accept async callbacks in the future. 

##### Motivation

Feature work

##### Context

We were originally planning on making all stores use async callbacks as part of the mv3 effort, but this would mean having to make a lot of unnecessary changes to both web and unified code. Instead, we're planning to switch to this approach, which will allow us to only add async callback support to stores whose callbacks actually do async work. This will result in fewer unnecessarily async actions as well as fewer changes (and no functional changes) to unified code. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
