### PR TITLE
feat(mv3-part-5): Revert scoping actions to be sync

### DIFF
--- a/src/background/actions/scoping-actions.ts
+++ b/src/background/actions/scoping-actions.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AsyncAction } from 'common/flux/async-action';
+import { SyncAction } from 'common/flux/sync-action';
 import { BaseActionPayload } from './action-payloads';
 
 export interface ScopingPayload extends BaseActionPayload {
@@ -9,7 +9,7 @@ export interface ScopingPayload extends BaseActionPayload {
 }
 
 export class ScopingActions {
-    public readonly addSelector = new AsyncAction<ScopingPayload>();
-    public readonly deleteSelector = new AsyncAction<ScopingPayload>();
-    public readonly getCurrentState = new AsyncAction<void>();
+    public readonly addSelector = new SyncAction<ScopingPayload>();
+    public readonly deleteSelector = new SyncAction<ScopingPayload>();
+    public readonly getCurrentState = new SyncAction<void>();
 }

--- a/src/background/global-action-creators/scoping-action-creator.ts
+++ b/src/background/global-action-creators/scoping-action-creator.ts
@@ -26,15 +26,15 @@ export class ScopingActionCreator {
         );
     }
 
-    private onGetScopingState = async (): Promise<void> => {
-        await this.scopingActions.getCurrentState.invoke();
+    private onGetScopingState = (): void => {
+        this.scopingActions.getCurrentState.invoke();
     };
 
-    private onAddSelector = async (payload: ScopingPayload): Promise<void> => {
-        await this.scopingActions.addSelector.invoke(payload);
+    private onAddSelector = (payload: ScopingPayload): void => {
+        this.scopingActions.addSelector.invoke(payload);
     };
 
-    private onDeleteSelector = async (payload: ScopingPayload): Promise<void> => {
-        await this.scopingActions.deleteSelector.invoke(payload);
+    private onDeleteSelector = (payload: ScopingPayload): void => {
+        this.scopingActions.deleteSelector.invoke(payload);
     };
 }

--- a/src/background/stores/global/scoping-store.ts
+++ b/src/background/stores/global/scoping-store.ts
@@ -54,7 +54,7 @@ export class ScopingStore extends PersistentStore<ScopingStoreData> {
         this.scopingActions.deleteSelector.addListener(this.onDeleteSelector);
     }
 
-    private onAddSelector = async (payload: ScopingPayload): Promise<void> => {
+    private onAddSelector = (payload: ScopingPayload): void => {
         let shouldUpdate: boolean = true;
         _.forEach(Object.keys(this.state.selectors[payload.inputType]), key => {
             if (_.isEqual(this.state.selectors[payload.inputType][key], payload.selector)) {
@@ -68,7 +68,7 @@ export class ScopingStore extends PersistentStore<ScopingStoreData> {
         }
     };
 
-    private onDeleteSelector = async (payload: ScopingPayload): Promise<void> => {
+    private onDeleteSelector = (payload: ScopingPayload): void => {
         _.forEach(Object.keys(this.state.selectors[payload.inputType]), key => {
             if (_.isEqual(this.state.selectors[payload.inputType][key], payload.selector)) {
                 this.state.selectors[payload.inputType].splice(key, 1);

--- a/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
@@ -8,7 +8,7 @@ import { IMock, It, Mock } from 'typemoq';
 
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import { createAsyncActionMock } from './action-creator-test-helpers';
+import { createSyncActionMock } from './action-creator-test-helpers';
 
 describe('ScopingActionCreator', () => {
     let interpreterMock: IMock<Interpreter>;
@@ -28,7 +28,7 @@ describe('ScopingActionCreator', () => {
 
         setupInterpreterMock(expectedMessage);
 
-        const getCurrentStateMock = createAsyncActionMock(undefined);
+        const getCurrentStateMock = createSyncActionMock(undefined);
 
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
 
@@ -47,7 +47,7 @@ describe('ScopingActionCreator', () => {
 
         setupInterpreterMock(expectedMessage, payload);
 
-        const addSelectorMock = createAsyncActionMock(payload);
+        const addSelectorMock = createSyncActionMock(payload);
 
         setupActionsMock('addSelector', addSelectorMock.object);
 
@@ -66,7 +66,7 @@ describe('ScopingActionCreator', () => {
 
         setupInterpreterMock(expectedMessage, payload);
 
-        const deleteSelectorMock = createAsyncActionMock(payload);
+        const deleteSelectorMock = createSyncActionMock(payload);
 
         setupActionsMock('deleteSelector', deleteSelectorMock.object);
 


### PR DESCRIPTION
#### Details

The changes in https://github.com/microsoft/accessibility-insights-web/pull/5877 allow us keep any actions that don't have any async work in any listeners to remain synchronous. As a result, we want to revert ScopingActions to be sync, since they do not do any async work.

##### Motivation

Feature work

##### Context

We considered/ were planning on converting all actions to be async (even if they had no async work) but decided that this caused too many unnecessary changes (particularly to the electron code) so went with this solution instead. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
