### PR TITLE
feat(mv3-part6): make injector controller explicitly async

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -17,7 +17,6 @@ import { WebVisualizationConfigurationFactory } from 'common/configs/web-visuali
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { ExceptionTelemetrySanitizer } from 'common/telemetry/exception-telemetry-sanitizer';
 import { UrlParser } from 'common/url-parser';
-import { WindowUtils } from 'common/window-utils';
 import UAParser from 'ua-parser-js';
 import { AxeInfo } from '../common/axe-info';
 import { DateProvider } from '../common/date-provider';
@@ -76,8 +75,6 @@ async function initialize(): Promise<void> {
         browserAdapter,
         deprecatedStorageDataKeys,
     );
-
-    const windowUtils = new WindowUtils();
 
     const urlValidator = new UrlValidator(browserAdapter);
     const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(getIndexedDBStore());
@@ -239,7 +236,6 @@ async function initialize(): Promise<void> {
         promiseFactory,
         logger,
         usageLogger,
-        windowUtils.setTimeout,
         persistedData,
         indexedDBInstance,
         persistData,

--- a/src/background/injector-controller.ts
+++ b/src/background/injector-controller.ts
@@ -39,10 +39,10 @@ export class InjectorController {
             inspectStoreInjectingRequested || visualizationStoreState.injectingRequested;
 
         if (isInjectingRequested && !visualizationStoreState.injectingStarted) {
-            this.interpreter.interpret({
+            await this.interpreter.interpret({
                 messageType: Messages.Visualizations.State.InjectionStarted,
                 tabId: tabId,
-            });
+            }).result;
 
             this.injector
                 .injectScripts(tabId)

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -224,7 +224,6 @@ async function initialize(): Promise<void> {
         promiseFactory,
         logger,
         usageLogger,
-        globalThis.setTimeout.bind(this),
         persistedData,
         indexedDBInstance,
         true,

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -50,7 +50,6 @@ export class TabContextFactory {
         private readonly promiseFactory: PromiseFactory,
         private readonly logger: Logger,
         private readonly usageLogger: UsageLogger,
-        private readonly setTimeout: (handler: Function, timeout: number) => number,
         private readonly persistedData: PersistedData,
         private readonly indexedDBInstance: IndexedDBAPI,
         private readonly persistStoreData: boolean,
@@ -178,7 +177,6 @@ export class TabContextFactory {
             interpreter,
             storeHub.tabStore,
             storeHub.inspectStore,
-            this.setTimeout,
             this.logger,
         );
 

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -179,6 +179,7 @@ class InjectorControllerValidator {
                     }),
                 ),
             )
+            .returns(() => ({ messageHandled: true, result: undefined }))
             .verifiable(Times.exactly(numTimes));
 
         return this;

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -11,7 +11,6 @@ import { Messages } from 'common/messages';
 import { InspectMode } from 'common/types/store-data/inspect-modes';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
-import { itIsFunction } from 'tests/unit/common/it-is-function';
 import { VisualizationStoreDataBuilder } from 'tests/unit/common/visualization-store-data-builder';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
 
@@ -23,7 +22,7 @@ describe('InjectorControllerTest', () => {
         validator = new InjectorControllerValidator();
     });
 
-    test('initialize: inject occurs', async () => {
+    test('initialize: injectingRequested is true = inject occurs', async () => {
         const visualizationData = new VisualizationStoreDataBuilder()
             .with('injectingRequested', true)
             .build();
@@ -32,20 +31,12 @@ describe('InjectorControllerTest', () => {
             .setupTabStore({ id: tabId })
             .setupVizStoreGetState(visualizationData)
             .setupInspectStore({ inspectMode: InspectMode.off })
-            .setupInjectScriptsCall(tabId, 2)
-            .setupTimeoutHandler(2);
+            .setupInjectScriptsCall(tabId, 1);
 
         validator.buildInjectorController().initialize();
-        validator.verifyAll();
-
-        validator.resetVerify();
-        validator.setupVerifyInjectionStartedActionCalled(tabId, 2);
-        validator.invokeWindowTimeoutHandler();
-        validator.invokeWindowTimeoutHandler();
-        validator.verifyAll();
-
-        validator.resetVerify();
-        validator.setupVerifyInjectionCompletedActionCalled(tabId, 2);
+        validator.setupVerifyInjectionStartedActionCalled(tabId);
+        await validator.visualizationInjectCallback();
+        validator.setupVerifyInjectionCompletedActionCalled(tabId);
         await validator.invokeInjectedPromise();
         validator.verifyAll();
     });
@@ -57,49 +48,45 @@ describe('InjectorControllerTest', () => {
             .setupTabStore({ id: tabId })
             .setupVizStoreGetState(visualizationData)
             .setupInspectStore({ inspectMode: InspectMode.scopingAddInclude })
-            .setupInjectScriptsCall(tabId, 1)
-            .setupTimeoutHandler(1);
+            .setupInjectScriptsCall(tabId, 1);
 
         validator.buildInjectorController().initialize();
-        validator.verifyAll();
-
-        validator.resetVerify();
         validator.setupVerifyInjectionStartedActionCalled(tabId);
-        validator.invokeWindowTimeoutHandler();
-        validator.verifyAll();
-
-        validator.resetVerify();
+        await validator.inspectInjectCallback();
         validator.setupVerifyInjectionCompletedActionCalled(tabId);
         await validator.invokeInjectedPromise();
         validator.verifyAll();
     });
 
-    test("inject doesn't occur when inspect mode changed to off", async () => {
+    test("inject doesn't occur when inspect mode is unchanged", async () => {
         const visualizationData = new VisualizationStoreDataBuilder()
             .with('injectingRequested', false)
             .build();
 
+        // Inject once to setup internal state.
         validator
             .setupTabStore({ id: tabId })
             .setupVizStoreGetState(visualizationData)
-            .setupInspectStore({ inspectMode: InspectMode.scopingAddInclude })
+            .setupInspectStore({ inspectMode: InspectMode.scopingAddExclude })
             .setupVerifyInjectionCompletedActionCalled(tabId)
             .setupInjectScriptsCall(tabId, 1)
-            .setupTimeoutHandler(2);
-
+            .setupVerifyInjectionStartedActionCalled(tabId);
         validator.buildInjectorController().initialize();
-        validator.resetVerify();
-        validator.setupVerifyInjectionStartedActionCalled(tabId);
-        validator.invokeWindowTimeoutHandler();
-        validator.verifyAll();
-
-        validator.resetVerify();
-        validator.setupVerifyInjectionCompletedActionCalled(tabId);
+        await validator.inspectInjectCallback();
         await validator.invokeInjectedPromise();
+        validator.verifyAll();
+        validator.resetVerify();
+
+        validator
+            .setupTabStore({ id: tabId })
+            .setupVizStoreGetState(visualizationData)
+            .setupInspectStore({ inspectMode: InspectMode.scopingAddExclude })
+            .setupInjectScriptsCall(tabId, 0);
+        await validator.inspectInjectCallback();
         validator.verifyAll();
     });
 
-    test('initialize: already injecting => no inject', () => {
+    test('initialize: already injecting => no inject', async () => {
         const visualizationData = new VisualizationStoreDataBuilder()
             .with('injectingRequested', true)
             .with('injectingStarted', true)
@@ -111,14 +98,13 @@ describe('InjectorControllerTest', () => {
             .setupVizStoreGetState(visualizationData);
 
         validator.buildInjectorController().initialize();
-
+        await validator.inspectInjectCallback();
         validator.verifyAll();
     });
 
-    test('initialize: injectingInProgress is false => no inject', () => {
+    test('initialize: injectingRequested is false and inspect mode is off => no inject', async () => {
         const visualizationData = new VisualizationStoreDataBuilder()
             .with('injectingRequested', false)
-            .with('injectingStarted', true)
             .build();
 
         validator
@@ -127,6 +113,7 @@ describe('InjectorControllerTest', () => {
             .setupVizStoreGetState(visualizationData);
 
         validator.buildInjectorController().initialize();
+        await validator.inspectInjectCallback();
         validator.verifyAll();
     });
 });
@@ -139,9 +126,8 @@ class InjectorControllerValidator {
     private mockTabStore = Mock.ofType(TabStore, MockBehavior.Strict);
     private injectedScriptsDeferred: Promise<void>;
     private injectedScriptsDeferredResolver: () => void;
-
-    private mockSetTimeout = Mock.ofType<(handler: Function, timeout: number) => number>();
-    private setTimeoutHandler: Function;
+    public visualizationInjectCallback: () => Promise<void>;
+    public inspectInjectCallback: () => Promise<void>;
 
     public buildInjectorController(): InjectorController {
         this.mockVisualizationStore
@@ -153,7 +139,7 @@ class InjectorControllerValidator {
                 ),
             )
             .callback(inject => {
-                inject();
+                this.visualizationInjectCallback = inject;
             })
             .verifiable();
 
@@ -166,7 +152,7 @@ class InjectorControllerValidator {
                 ),
             )
             .callback(inject => {
-                inject();
+                this.inspectInjectCallback = inject;
             })
             .verifiable();
 
@@ -176,20 +162,8 @@ class InjectorControllerValidator {
             this.mockInterpreter.object,
             this.mockTabStore.object,
             this.mockInspectStore.object,
-            this.mockSetTimeout.object,
             failTestOnErrorLogger,
         );
-    }
-
-    public setupTimeoutHandler(times: number): InjectorControllerValidator {
-        this.mockSetTimeout
-            .setup(x => x(itIsFunction, It.isAnyNumber()))
-            .callback(handler => {
-                this.setTimeoutHandler = handler;
-            })
-            .verifiable(Times.exactly(times));
-
-        return this;
     }
 
     public setupVerifyInjectionStartedActionCalled(
@@ -227,10 +201,6 @@ class InjectorControllerValidator {
             .verifiable(Times.exactly(numTimes));
 
         return this;
-    }
-
-    public invokeWindowTimeoutHandler(): void {
-        this.setTimeoutHandler();
     }
 
     public setupInspectStore(returnState): InjectorControllerValidator {
@@ -292,7 +262,6 @@ class InjectorControllerValidator {
         this.mockTabStore.verifyAll();
         this.mockInjector.verifyAll();
         this.mockInterpreter.verifyAll();
-        this.mockSetTimeout.verifyAll();
     }
 
     public resetVerify(): void {
@@ -301,6 +270,5 @@ class InjectorControllerValidator {
         this.mockTabStore.reset();
         this.mockInjector.reset();
         this.mockInterpreter.reset();
-        this.mockSetTimeout.reset();
     }
 }

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -43,7 +43,6 @@ describe('TabContextFactoryTest', () => {
     let mockLogger: IMock<Logger>;
     let mockUsageLogger: IMock<UsageLogger>;
     let mockNotificationCreator: IMock<NotificationCreator>;
-    let mockSetTimeout: IMock<(handler: Function, timeout: number) => number>;
     let mockDBInstance: IMock<IndexedDBAPI>;
     let mockBroadcasterFactory: IMock<BrowserMessageBroadcasterFactory>;
     let persistedDataStub: PersistedData;
@@ -54,7 +53,6 @@ describe('TabContextFactoryTest', () => {
         mockUsageLogger = Mock.ofType<UsageLogger>();
         mockDetailsViewController = Mock.ofType<ExtensionDetailsViewController>();
         mockNotificationCreator = Mock.ofType<NotificationCreator>();
-        mockSetTimeout = Mock.ofType<(handler: Function, timeout: number) => number>();
         mockDBInstance = Mock.ofType<IndexedDBAPI>();
         mockBroadcasterFactory = Mock.ofType<BrowserMessageBroadcasterFactory>();
         persistedDataStub = {} as PersistedData;
@@ -121,7 +119,6 @@ describe('TabContextFactoryTest', () => {
             promiseFactoryMock.object,
             mockLogger.object,
             mockUsageLogger.object,
-            mockSetTimeout.object,
             persistedDataStub,
             mockDBInstance.object,
             true,


### PR DESCRIPTION
#### Details

Makes inject async.
##### Motivation

Feature work.
##### Context

This method is async but not explicitly so. Changing it now such that we can make it clear moving forward which stores need to be async and which do not. Did some smoke testing in both mv3 and mv2 version of the extension; no errors were found.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
