### PR TITLE
feat(mv3-part6): Revert user config store actions to be sync

### DIFF
--- a/src/background/actions/user-configuration-actions.ts
+++ b/src/background/actions/user-configuration-actions.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AsyncAction } from 'common/flux/async-action';
+import { SyncAction } from 'common/flux/sync-action';
 import {
     AutoDetectedFailuresDialogStatePayload,
     SaveIssueFilingSettingsPayload,
@@ -11,16 +11,16 @@ import {
 } from './action-payloads';
 
 export class UserConfigurationActions {
-    public readonly setAdbLocation = new AsyncAction<string>();
-    public readonly setTelemetryState = new AsyncAction<boolean>();
-    public readonly getCurrentState = new AsyncAction<void>();
-    public readonly setHighContrastMode = new AsyncAction<SetHighContrastModePayload>();
-    public readonly setNativeHighContrastMode = new AsyncAction<SetHighContrastModePayload>();
-    public readonly setIssueFilingService = new AsyncAction<SetIssueFilingServicePayload>();
+    public readonly setAdbLocation = new SyncAction<string>();
+    public readonly setTelemetryState = new SyncAction<boolean>();
+    public readonly getCurrentState = new SyncAction<void>();
+    public readonly setHighContrastMode = new SyncAction<SetHighContrastModePayload>();
+    public readonly setNativeHighContrastMode = new SyncAction<SetHighContrastModePayload>();
+    public readonly setIssueFilingService = new SyncAction<SetIssueFilingServicePayload>();
     public readonly setIssueFilingServiceProperty =
-        new AsyncAction<SetIssueFilingServicePropertyPayload>();
-    public readonly saveIssueFilingSettings = new AsyncAction<SaveIssueFilingSettingsPayload>();
-    public readonly saveWindowBounds = new AsyncAction<SaveWindowBoundsPayload>();
+        new SyncAction<SetIssueFilingServicePropertyPayload>();
+    public readonly saveIssueFilingSettings = new SyncAction<SaveIssueFilingSettingsPayload>();
+    public readonly saveWindowBounds = new SyncAction<SaveWindowBoundsPayload>();
     public readonly setAutoDetectedFailuresDialogState =
-        new AsyncAction<AutoDetectedFailuresDialogStatePayload>();
+        new SyncAction<AutoDetectedFailuresDialogStatePayload>();
 }

--- a/src/background/global-action-creators/user-configuration-action-creator.ts
+++ b/src/background/global-action-creators/user-configuration-action-creator.ts
@@ -22,40 +22,36 @@ export class UserConfigurationActionCreator {
         private readonly telemetryEventHandler: TelemetryEventHandler,
     ) {}
 
-    public getUserConfigurationState = async (): Promise<void> =>
-        await this.userConfigActions.getCurrentState.invoke();
+    public getUserConfigurationState = (): void => this.userConfigActions.getCurrentState.invoke();
 
-    public setTelemetryState = async (enableTelemetry: boolean): Promise<void> =>
-        await this.userConfigActions.setTelemetryState.invoke(enableTelemetry);
+    public setTelemetryState = (enableTelemetry: boolean): void =>
+        this.userConfigActions.setTelemetryState.invoke(enableTelemetry);
 
-    public setHighContrastMode = async (payload: SetHighContrastModePayload): Promise<void> =>
-        await this.userConfigActions.setHighContrastMode.invoke(payload);
+    public setHighContrastMode = (payload: SetHighContrastModePayload): void =>
+        this.userConfigActions.setHighContrastMode.invoke(payload);
 
-    public setNativeHighContrastMode = async (
-        payload: SetNativeHighContrastModePayload,
-    ): Promise<void> => await this.userConfigActions.setNativeHighContrastMode.invoke(payload);
+    public setNativeHighContrastMode = (payload: SetNativeHighContrastModePayload): void =>
+        this.userConfigActions.setNativeHighContrastMode.invoke(payload);
 
-    public setIssueFilingService = async (payload: SetIssueFilingServicePayload): Promise<void> =>
-        await this.userConfigActions.setIssueFilingService.invoke(payload);
+    public setIssueFilingService = (payload: SetIssueFilingServicePayload): void =>
+        this.userConfigActions.setIssueFilingService.invoke(payload);
 
-    public setIssueFilingServiceProperty = async (
-        payload: SetIssueFilingServicePropertyPayload,
-    ): Promise<void> => await this.userConfigActions.setIssueFilingServiceProperty.invoke(payload);
+    public setIssueFilingServiceProperty = (payload: SetIssueFilingServicePropertyPayload): void =>
+        this.userConfigActions.setIssueFilingServiceProperty.invoke(payload);
 
-    public saveIssueFilingSettings = async (
-        payload: SaveIssueFilingSettingsPayload,
-    ): Promise<void> => await this.userConfigActions.saveIssueFilingSettings.invoke(payload);
+    public saveIssueFilingSettings = (payload: SaveIssueFilingSettingsPayload): void =>
+        this.userConfigActions.saveIssueFilingSettings.invoke(payload);
 
-    public setAdbLocation = async (adbLocation: string): Promise<void> =>
-        await this.userConfigActions.setAdbLocation.invoke(adbLocation, this.currentScope);
+    public setAdbLocation = (adbLocation: string): void =>
+        this.userConfigActions.setAdbLocation.invoke(adbLocation, this.currentScope);
 
-    public saveWindowBounds = async (payload: SaveWindowBoundsPayload): Promise<void> =>
-        await this.userConfigActions.saveWindowBounds.invoke(payload);
+    public saveWindowBounds = (payload: SaveWindowBoundsPayload): void =>
+        this.userConfigActions.saveWindowBounds.invoke(payload);
 
-    public setAutoDetectedFailuresDialogState = async (
+    public setAutoDetectedFailuresDialogState = (
         payload: AutoDetectedFailuresDialogStatePayload,
-    ): Promise<void> => {
-        await this.userConfigActions.setAutoDetectedFailuresDialogState.invoke(payload);
+    ): void => {
+        this.userConfigActions.setAutoDetectedFailuresDialogState.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.SET_AUTO_DETECTED_FAILURES_DIALOG_STATE,
             payload,

--- a/src/background/stores/global/user-configuration-store.ts
+++ b/src/background/stores/global/user-configuration-store.ts
@@ -83,42 +83,38 @@ export class UserConfigurationStore extends PersistentStore<UserConfigurationSto
         );
     }
 
-    private onSetAdbLocation = async (location: string): Promise<void> => {
+    private onSetAdbLocation = (location: string): void => {
         this.state.adbLocation = location;
         this.emitChanged();
     };
 
-    private onSetTelemetryState = async (enableTelemetry: boolean): Promise<void> => {
+    private onSetTelemetryState = (enableTelemetry: boolean): void => {
         this.state.isFirstTime = false;
         this.state.enableTelemetry = enableTelemetry;
         this.emitChanged();
     };
 
-    private onSetHighContrastMode = async (payload: SetHighContrastModePayload): Promise<void> => {
+    private onSetHighContrastMode = (payload: SetHighContrastModePayload): void => {
         this.state.enableHighContrast = payload.enableHighContrast;
         this.state.lastSelectedHighContrast = payload.enableHighContrast;
         this.emitChanged();
     };
 
-    private onSetNativeHighContrastMode = async (
-        payload: SetNativeHighContrastModePayload,
-    ): Promise<void> => {
+    private onSetNativeHighContrastMode = (payload: SetNativeHighContrastModePayload): void => {
         this.state.enableHighContrast = payload.enableHighContrast
             ? true
             : this.state.lastSelectedHighContrast;
         this.emitChanged();
     };
 
-    private onSetIssueFilingService = async (
-        payload: SetIssueFilingServicePayload,
-    ): Promise<void> => {
+    private onSetIssueFilingService = (payload: SetIssueFilingServicePayload): void => {
         this.state.bugService = payload.issueFilingServiceName;
         this.emitChanged();
     };
 
-    private onSetIssueFilingServiceProperty = async (
+    private onSetIssueFilingServiceProperty = (
         payload: SetIssueFilingServicePropertyPayload,
-    ): Promise<void> => {
+    ): void => {
         if (!isPlainObject(this.state.bugServicePropertiesMap)) {
             this.state.bugServicePropertiesMap = {};
         }
@@ -132,16 +128,14 @@ export class UserConfigurationStore extends PersistentStore<UserConfigurationSto
         this.emitChanged();
     };
 
-    private onSaveIssueSettings = async (
-        payload: SaveIssueFilingSettingsPayload,
-    ): Promise<void> => {
+    private onSaveIssueSettings = (payload: SaveIssueFilingSettingsPayload): void => {
         const bugService = payload.issueFilingServiceName;
         this.state.bugService = bugService;
         this.state.bugServicePropertiesMap[bugService] = payload.issueFilingSettings;
         this.emitChanged();
     };
 
-    private onSaveLastWindowBounds = async (payload: SaveWindowBoundsPayload): Promise<void> => {
+    private onSaveLastWindowBounds = (payload: SaveWindowBoundsPayload): void => {
         this.state.lastWindowState = payload.windowState;
 
         // Retain these bounds only if the window is in a normal state
@@ -152,9 +146,9 @@ export class UserConfigurationStore extends PersistentStore<UserConfigurationSto
         this.emitChanged();
     };
 
-    private onSetAutoDetectedFailuresDialogState = async (
+    private onSetAutoDetectedFailuresDialogState = (
         payload: AutoDetectedFailuresDialogStatePayload,
-    ): Promise<void> => {
+    ): void => {
         this.state.showAutoDetectedFailuresDialog = payload.enabled;
 
         this.emitChanged();

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -15,7 +15,7 @@ import { UserConfigurationActionCreator } from 'background/global-action-creator
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { IMock, Mock, Times } from 'typemoq';
 import * as TelemetryEvents from '../../../../../common/extension-telemetry-events';
-import { createAsyncActionMock } from './action-creator-test-helpers';
+import { createSyncActionMock } from './action-creator-test-helpers';
 
 describe('UserConfigurationActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -24,39 +24,39 @@ describe('UserConfigurationActionCreator', () => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
     });
 
-    it('handles GetCurrentState message', async () => {
-        const getCurrentStateMock = createAsyncActionMock<void>(undefined);
+    it('handles GetCurrentState message', () => {
+        const getCurrentStateMock = createSyncActionMock<void>(undefined);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
         const testSubject = new UserConfigurationActionCreator(
             actionsMock.object,
             telemetryEventHandlerMock.object,
         );
 
-        await testSubject.getUserConfigurationState();
+        testSubject.getUserConfigurationState();
 
         getCurrentStateMock.verifyAll();
     });
 
-    it('should SetTelemetryConfig message', async () => {
+    it('should SetTelemetryConfig message', () => {
         const setTelemetryState = true;
 
-        const setTelemetryStateMock = createAsyncActionMock(setTelemetryState);
+        const setTelemetryStateMock = createSyncActionMock(setTelemetryState);
         const actionsMock = createActionsMock('setTelemetryState', setTelemetryStateMock.object);
         const testSubject = new UserConfigurationActionCreator(
             actionsMock.object,
             telemetryEventHandlerMock.object,
         );
 
-        await testSubject.setTelemetryState(setTelemetryState);
+        testSubject.setTelemetryState(setTelemetryState);
 
         setTelemetryStateMock.verifyAll();
     });
 
-    it('should SetHighContrastConfig message', async () => {
+    it('should SetHighContrastConfig message', () => {
         const payload: SetHighContrastModePayload = {
             enableHighContrast: true,
         };
-        const setHighContrastConfigMock = createAsyncActionMock(payload);
+        const setHighContrastConfigMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'setHighContrastMode',
             setHighContrastConfigMock.object,
@@ -66,16 +66,16 @@ describe('UserConfigurationActionCreator', () => {
             telemetryEventHandlerMock.object,
         );
 
-        await testSubject.setHighContrastMode(payload);
+        testSubject.setHighContrastMode(payload);
 
         setHighContrastConfigMock.verifyAll();
     });
 
-    it('should SetHighContrastConfig message', async () => {
+    it('should SetHighContrastConfig message', () => {
         const payload: SetNativeHighContrastModePayload = {
             enableHighContrast: true,
         };
-        const setNativeHighContrastConfigMock = createAsyncActionMock(payload);
+        const setNativeHighContrastConfigMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'setNativeHighContrastMode',
             setNativeHighContrastConfigMock.object,
@@ -85,34 +85,34 @@ describe('UserConfigurationActionCreator', () => {
             telemetryEventHandlerMock.object,
         );
 
-        await testSubject.setNativeHighContrastMode(payload);
+        testSubject.setNativeHighContrastMode(payload);
 
         setNativeHighContrastConfigMock.verifyAll();
     });
 
-    it('should SetBugService message', async () => {
+    it('should SetBugService message', () => {
         const payload: SetIssueFilingServicePayload = {
             issueFilingServiceName: 'none',
         };
-        const setBugServiceMock = createAsyncActionMock(payload);
+        const setBugServiceMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('setIssueFilingService', setBugServiceMock.object);
         const testSubject = new UserConfigurationActionCreator(
             actionsMock.object,
             telemetryEventHandlerMock.object,
         );
 
-        await testSubject.setIssueFilingService(payload);
+        testSubject.setIssueFilingService(payload);
 
         setBugServiceMock.verifyAll();
     });
 
-    it('should SetBugServiceProperty message', async () => {
+    it('should SetBugServiceProperty message', () => {
         const payload: SetIssueFilingServicePropertyPayload = {
             issueFilingServiceName: 'bug-service-name',
             propertyName: 'property-name',
             propertyValue: 'property-value',
         };
-        const setIssueFilingServicePropertyMock = createAsyncActionMock(payload);
+        const setIssueFilingServicePropertyMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'setIssueFilingServiceProperty',
             setIssueFilingServicePropertyMock.object,
@@ -122,17 +122,17 @@ describe('UserConfigurationActionCreator', () => {
             telemetryEventHandlerMock.object,
         );
 
-        await testSubject.setIssueFilingServiceProperty(payload);
+        testSubject.setIssueFilingServiceProperty(payload);
 
         setIssueFilingServicePropertyMock.verifyAll();
     });
 
-    it('should SaveIssueFilingSettings message', async () => {
+    it('should SaveIssueFilingSettings message', () => {
         const payload: SaveIssueFilingSettingsPayload = {
             issueFilingServiceName: 'test bug service',
             issueFilingSettings: { name: 'issueFilingSettings' },
         };
-        const setIssueFilingSettings = createAsyncActionMock(payload);
+        const setIssueFilingSettings = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'saveIssueFilingSettings',
             setIssueFilingSettings.object,
@@ -142,15 +142,15 @@ describe('UserConfigurationActionCreator', () => {
             telemetryEventHandlerMock.object,
         );
 
-        await testSubject.saveIssueFilingSettings(payload);
+        testSubject.saveIssueFilingSettings(payload);
 
         setIssueFilingSettings.verifyAll();
     });
 
-    it('should SetAdbLocation Message', async () => {
+    it('should SetAdbLocation Message', () => {
         const expectedAdbLocation = 'Somewhere over the rainbow';
 
-        const setAdbLocationConfigMock = createAsyncActionMock(
+        const setAdbLocationConfigMock = createSyncActionMock(
             expectedAdbLocation,
             'UserConfigurationActionCreator',
         );
@@ -160,18 +160,18 @@ describe('UserConfigurationActionCreator', () => {
             telemetryEventHandlerMock.object,
         );
 
-        await testSubject.setAdbLocation(expectedAdbLocation);
+        testSubject.setAdbLocation(expectedAdbLocation);
 
         setAdbLocationConfigMock.verifyAll();
     });
 
-    it('should SaveWindowBounds message', async () => {
+    it('should SaveWindowBounds message', () => {
         const payload: SaveWindowBoundsPayload = {
             windowState: 'normal',
             windowBounds: { x: 10, y: 20, height: 100, width: 150 },
         };
 
-        const saveWindowBoundsActionMock = createAsyncActionMock(payload);
+        const saveWindowBoundsActionMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'saveWindowBounds',
             saveWindowBoundsActionMock.object,
@@ -181,16 +181,16 @@ describe('UserConfigurationActionCreator', () => {
             telemetryEventHandlerMock.object,
         );
 
-        await testSubject.saveWindowBounds(payload);
+        testSubject.saveWindowBounds(payload);
 
         saveWindowBoundsActionMock.verifyAll();
     });
 
-    it('should SetAutoDetectedFailuresDialogState Message', async () => {
+    it('should SetAutoDetectedFailuresDialogState Message', () => {
         const expectedDialogState = { enabled: false };
         const expectedPayload = expectedDialogState as BaseActionPayload;
 
-        const dialogStateConfigMock = createAsyncActionMock(expectedDialogState);
+        const dialogStateConfigMock = createSyncActionMock(expectedDialogState);
         const actionsMock = createActionsMock(
             'setAutoDetectedFailuresDialogState',
             dialogStateConfigMock.object,
@@ -200,7 +200,7 @@ describe('UserConfigurationActionCreator', () => {
             telemetryEventHandlerMock.object,
         );
 
-        await testSubject.setAutoDetectedFailuresDialogState(expectedDialogState);
+        testSubject.setAutoDetectedFailuresDialogState(expectedDialogState);
 
         dialogStateConfigMock.verifyAll();
         telemetryEventHandlerMock.verify(


### PR DESCRIPTION
#### Details

The changes in https://github.com/microsoft/accessibility-insights-web/pull/5877 allow us keep any actions that don't have any async work in any listeners to remain synchronous. As a result, we want to revert actions that act on the user configuration store to be sync, since that store does not have any async work.

##### Motivation

Feature work

##### Context

We considered/ were planning on converting all actions to be async (even if they had no async work) but decided that this caused too many unnecessary changes (particularly to the electron code) so went with this solution instead. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
