### PR TITLE
feat(mv3-part6): Revert visualization scan result and card selection actions to sync

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -257,10 +257,7 @@ export class ActionCreator {
     };
 
     private onTabbedElementAdded = async (payload: AddTabbedElementPayload): Promise<void> => {
-        await this.visualizationScanResultActions.addTabbedElement.invoke(
-            payload,
-            this.executingScope,
-        );
+        this.visualizationScanResultActions.addTabbedElement.invoke(payload, this.executingScope);
     };
 
     private onRecordingCompleted = (payload: BaseActionPayload): void => {
@@ -271,10 +268,7 @@ export class ActionCreator {
     };
 
     private onRecordingTerminated = async (payload: BaseActionPayload): Promise<void> => {
-        await this.visualizationScanResultActions.disableTabStop.invoke(
-            payload,
-            this.executingScope,
-        );
+        this.visualizationScanResultActions.disableTabStop.invoke(payload, this.executingScope);
     };
 
     private onUpdateFocusedInstance = async (payload: string[]): Promise<void> => {
@@ -287,10 +281,7 @@ export class ActionCreator {
     ): Promise<void> => {
         const telemetryEventName = TelemetryEvents.ADHOC_SCAN_COMPLETED;
         this.telemetryEventHandler.publishTelemetry(telemetryEventName, payload);
-        await this.visualizationScanResultActions.scanCompleted.invoke(
-            payload,
-            this.executingScope,
-        );
+        this.visualizationScanResultActions.scanCompleted.invoke(payload, this.executingScope);
         await this.visualizationActions.scanCompleted.invoke(null, this.executingScope);
         this.notificationCreator.createNotificationByVisualizationKey(
             payload.selectorMap,
@@ -303,7 +294,7 @@ export class ActionCreator {
 
     private onScrollRequested = async (): Promise<void> => {
         await this.visualizationActions.scrollRequested.invoke(null, this.executingScope);
-        await this.cardSelectionActions.resetFocusedIdentifier.invoke(null, this.executingScope);
+        this.cardSelectionActions.resetFocusedIdentifier.invoke(null, this.executingScope);
         await this.needsReviewCardSelectionActions.resetFocusedIdentifier.invoke(
             null,
             this.executingScope,
@@ -409,7 +400,7 @@ export class ActionCreator {
     };
 
     private getScanResultsCurrentState = async (): Promise<void> => {
-        await this.visualizationScanResultActions.getCurrentState.invoke(null, this.executingScope);
+        this.visualizationScanResultActions.getCurrentState.invoke(null, this.executingScope);
     };
 
     private onSetHoveredOverSelector = async (payload: string[]): Promise<void> => {

--- a/src/background/actions/card-selection-action-creator.ts
+++ b/src/background/actions/card-selection-action-creator.ts
@@ -47,38 +47,38 @@ export class CardSelectionActionCreator {
         );
     }
 
-    private onGetCurrentState = async (): Promise<void> => {
-        await this.cardSelectionActions.getCurrentState.invoke(null);
+    private onGetCurrentState = (): void => {
+        this.cardSelectionActions.getCurrentState.invoke(null);
     };
 
-    private onCardSelectionToggle = async (payload: CardSelectionPayload): Promise<void> => {
-        await this.cardSelectionActions.toggleCardSelection.invoke(payload);
+    private onCardSelectionToggle = (payload: CardSelectionPayload): void => {
+        this.cardSelectionActions.toggleCardSelection.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.CARD_SELECTION_TOGGLED,
             payload,
         );
     };
 
-    private onRuleExpansionToggle = async (payload: RuleExpandCollapsePayload): Promise<void> => {
-        await this.cardSelectionActions.toggleRuleExpandCollapse.invoke(payload);
+    private onRuleExpansionToggle = (payload: RuleExpandCollapsePayload): void => {
+        this.cardSelectionActions.toggleRuleExpandCollapse.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.RULE_EXPANSION_TOGGLED,
             payload,
         );
     };
 
-    private onToggleVisualHelper = async (payload: BaseActionPayload): Promise<void> => {
-        await this.cardSelectionActions.toggleVisualHelper.invoke(null);
+    private onToggleVisualHelper = (payload: BaseActionPayload): void => {
+        this.cardSelectionActions.toggleVisualHelper.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.VISUAL_HELPER_TOGGLED, payload);
     };
 
-    private onCollapseAllRules = async (payload: BaseActionPayload): Promise<void> => {
-        await this.cardSelectionActions.collapseAllRules.invoke(null);
+    private onCollapseAllRules = (payload: BaseActionPayload): void => {
+        this.cardSelectionActions.collapseAllRules.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_COLLAPSED, payload);
     };
 
-    private onExpandAllRules = async (payload: BaseActionPayload): Promise<void> => {
-        await this.cardSelectionActions.expandAllRules.invoke(null);
+    private onExpandAllRules = (payload: BaseActionPayload): void => {
+        this.cardSelectionActions.expandAllRules.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_EXPANDED, payload);
     };
 }

--- a/src/background/actions/card-selection-actions.ts
+++ b/src/background/actions/card-selection-actions.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AsyncAction } from 'common/flux/async-action';
+import { SyncAction } from 'common/flux/sync-action';
 import { CardSelectionPayload, RuleExpandCollapsePayload } from './action-payloads';
 
 export class CardSelectionActions {
-    public readonly getCurrentState = new AsyncAction();
-    public readonly navigateToNewCardsView = new AsyncAction();
-    public readonly toggleRuleExpandCollapse = new AsyncAction<RuleExpandCollapsePayload>();
-    public readonly toggleCardSelection = new AsyncAction<CardSelectionPayload>();
-    public readonly collapseAllRules = new AsyncAction();
-    public readonly expandAllRules = new AsyncAction();
-    public readonly toggleVisualHelper = new AsyncAction();
-    public readonly resetFocusedIdentifier = new AsyncAction();
+    public readonly getCurrentState = new SyncAction();
+    public readonly navigateToNewCardsView = new SyncAction();
+    public readonly toggleRuleExpandCollapse = new SyncAction<RuleExpandCollapsePayload>();
+    public readonly toggleCardSelection = new SyncAction<CardSelectionPayload>();
+    public readonly collapseAllRules = new SyncAction();
+    public readonly expandAllRules = new SyncAction();
+    public readonly toggleVisualHelper = new SyncAction();
+    public readonly resetFocusedIdentifier = new SyncAction();
 }

--- a/src/background/actions/visualization-scan-result-actions.ts
+++ b/src/background/actions/visualization-scan-result-actions.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AsyncAction } from 'common/flux/async-action';
+import { SyncAction } from 'common/flux/sync-action';
 import { ScanCompletedPayload } from '../../injected/analyzers/analyzer';
 import { AddTabbedElementPayload } from './action-payloads';
 
 export class VisualizationScanResultActions {
-    public readonly scanCompleted = new AsyncAction<ScanCompletedPayload<any>>();
-    public readonly getCurrentState = new AsyncAction();
-    public readonly addTabbedElement = new AsyncAction<AddTabbedElementPayload>();
-    public readonly disableTabStop = new AsyncAction();
+    public readonly scanCompleted = new SyncAction<ScanCompletedPayload<any>>();
+    public readonly getCurrentState = new SyncAction();
+    public readonly addTabbedElement = new SyncAction<AddTabbedElementPayload>();
+    public readonly disableTabStop = new SyncAction();
 }

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -81,9 +81,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         });
     };
 
-    private toggleRuleExpandCollapse = async (
-        payload: RuleExpandCollapsePayload,
-    ): Promise<void> => {
+    private toggleRuleExpandCollapse = (payload: RuleExpandCollapsePayload): void => {
         if (!payload || !this.state.rules?.[payload.ruleId]) {
             return;
         }
@@ -99,7 +97,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private toggleCardSelection = async (payload: CardSelectionPayload): Promise<void> => {
+    private toggleCardSelection = (payload: CardSelectionPayload): void => {
         if (
             !payload ||
             !this.state.rules?.[payload.ruleId] ||
@@ -121,7 +119,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private collapseAllRules = async (): Promise<void> => {
+    private collapseAllRules = (): void => {
         if (!this.state.rules) {
             return;
         }
@@ -134,7 +132,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private expandAllRules = async (): Promise<void> => {
+    private expandAllRules = (): void => {
         if (!this.state.rules) {
             return;
         }
@@ -146,7 +144,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private toggleVisualHelper = async (): Promise<void> => {
+    private toggleVisualHelper = (): void => {
         this.state.visualHelperEnabled = !this.state.visualHelperEnabled;
 
         if (!this.state.visualHelperEnabled) {
@@ -184,12 +182,12 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private onResetFocusedIdentifier = async (): Promise<void> => {
+    private onResetFocusedIdentifier = (): void => {
         this.state.focusedResultUid = null;
         this.emitChanged();
     };
 
-    private onNavigateToNewCardsView = async (): Promise<void> => {
+    private onNavigateToNewCardsView = (): void => {
         this.state.focusedResultUid = null;
 
         if (this.state.rules) {

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -130,7 +130,7 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         this.tabActions.existingTabUpdated.addListener(this.onExistingTabUpdated);
     }
 
-    private onTabStopsDisabled = async (): Promise<void> => {
+    private onTabStopsDisabled = (): void => {
         this.state.tabStops.tabbedElements = null;
         this.emitChanged();
     };
@@ -146,7 +146,7 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         this.emitChanged();
     };
 
-    private onAddTabbedElement = async (payload: AddTabbedElementPayload): Promise<void> => {
+    private onAddTabbedElement = (payload: AddTabbedElementPayload): void => {
         if (!this.state.tabStops.tabbedElements) {
             this.state.tabStops.tabbedElements = [];
         }
@@ -246,7 +246,7 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         this.emitChanged();
     };
 
-    private onScanCompleted = async (payload: ScanCompletedPayload<any>): Promise<void> => {
+    private onScanCompleted = (payload: ScanCompletedPayload<any>): void => {
         const selectorMap = payload.selectorMap;
         const result = payload.scanResult;
         const selectedRows = this.getRowToRuleResultMap(selectorMap);

--- a/src/electron/common/left-nav-item-factory.ts
+++ b/src/electron/common/left-nav-item-factory.ts
@@ -25,7 +25,7 @@ const createLeftNavItem = (
         displayName: config.contentPageInfo.title,
         featureFlag: config.featureFlag,
         onSelect: async () => {
-            await actionCreator.itemSelected(config.key);
+            actionCreator.itemSelected(config.key);
             await tabStopsActionCreator.resetTabStopsToDefaultState();
         },
     };

--- a/src/electron/flux/action-creator/left-nav-action-creator.ts
+++ b/src/electron/flux/action-creator/left-nav-action-creator.ts
@@ -11,9 +11,9 @@ export class LeftNavActionCreator {
         private readonly cardSelectionActions: CardSelectionActions,
     ) {}
 
-    public itemSelected = async (itemKey: LeftNavItemKey) => {
+    public itemSelected = (itemKey: LeftNavItemKey) => {
         this.leftNavActions.itemSelected.invoke(itemKey);
-        await this.cardSelectionActions.navigateToNewCardsView.invoke(null);
+        this.cardSelectionActions.navigateToNewCardsView.invoke(null);
     };
 
     public setLeftNavVisible = (value: boolean) =>

--- a/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
@@ -13,7 +13,7 @@ import { Messages } from 'common/messages';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
 
-import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('CardSelectionActionCreator', () => {
     const tabId = -2;
@@ -30,7 +30,7 @@ describe('CardSelectionActionCreator', () => {
             resultInstanceUid: 'test-instance-uuid',
             ruleId: 'test-rule-id',
         };
-        const toggleCardSelectionMock = createAsyncActionMock(payload);
+        const toggleCardSelectionMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'toggleCardSelection',
             toggleCardSelectionMock.object,
@@ -61,7 +61,7 @@ describe('CardSelectionActionCreator', () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'test-rule-id',
         };
-        const ruleExpansionToggleMock = createAsyncActionMock(payload);
+        const ruleExpansionToggleMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'toggleRuleExpandCollapse',
             ruleExpansionToggleMock.object,
@@ -90,7 +90,7 @@ describe('CardSelectionActionCreator', () => {
 
     test('onToggleVisualHelper', async () => {
         const payloadStub: BaseActionPayload = {};
-        const toggleVisualHelperMock = createAsyncActionMock(null);
+        const toggleVisualHelperMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('toggleVisualHelper', toggleVisualHelperMock.object);
 
         const testSubject = new CardSelectionActionCreator(
@@ -116,7 +116,7 @@ describe('CardSelectionActionCreator', () => {
 
     test('onCollapseAllRules', async () => {
         const payloadStub: BaseActionPayload = {};
-        const collapseAllRulesActionMock = createAsyncActionMock(null);
+        const collapseAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock(
             'collapseAllRules',
             collapseAllRulesActionMock.object,
@@ -145,7 +145,7 @@ describe('CardSelectionActionCreator', () => {
 
     test('onExpandAllRules', async () => {
         const payloadStub: BaseActionPayload = {};
-        const expandAllRulesActionMock = createAsyncActionMock(null);
+        const expandAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('expandAllRules', expandAllRulesActionMock.object);
 
         const testSubject = new CardSelectionActionCreator(

--- a/src/tests/unit/tests/electron/flux/action-creator/left-nav-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/left-nav-action-creator.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
-import { AsyncAction } from 'common/flux/async-action';
 import { SyncAction } from 'common/flux/sync-action';
 import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { LeftNavActions } from 'electron/flux/action/left-nav-actions';
@@ -33,7 +32,7 @@ describe('LeftNavActionCreator', () => {
             .returns(() => itemSelectedMock.object)
             .verifiable();
 
-        const navigateToNewCardsViewMock = Mock.ofType<AsyncAction<void>>();
+        const navigateToNewCardsViewMock = Mock.ofType<SyncAction<void>>();
         cardSelectionActionsMock
             .setup(actions => actions.navigateToNewCardsView)
             .returns(() => navigateToNewCardsViewMock.object)


### PR DESCRIPTION
#### Details

Visualization scan result and card selection stores do not do any async work, therefore reverting actions to be sync. 

##### Motivation

Feature work.

##### Context

See https://github.com/microsoft/accessibility-insights-web/pull/5877

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
