### PR TITLE
feat(mv3-part6): Revert needs review and unified scan result actions to sync

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -295,7 +295,7 @@ export class ActionCreator {
     private onScrollRequested = async (): Promise<void> => {
         await this.visualizationActions.scrollRequested.invoke(null, this.executingScope);
         this.cardSelectionActions.resetFocusedIdentifier.invoke(null, this.executingScope);
-        await this.needsReviewCardSelectionActions.resetFocusedIdentifier.invoke(
+        this.needsReviewCardSelectionActions.resetFocusedIdentifier.invoke(
             null,
             this.executingScope,
         );

--- a/src/background/actions/needs-review-card-selection-action-creator.ts
+++ b/src/background/actions/needs-review-card-selection-action-creator.ts
@@ -47,40 +47,38 @@ export class NeedsReviewCardSelectionActionCreator {
         );
     }
 
-    private onGetCurrentState = async (): Promise<void> => {
-        await this.needsReviewCardSelectionActions.getCurrentState.invoke(null);
+    private onGetCurrentState = (): void => {
+        this.needsReviewCardSelectionActions.getCurrentState.invoke(null);
     };
 
-    private onNeedsReviewCardSelectionToggle = async (
-        payload: CardSelectionPayload,
-    ): Promise<void> => {
-        await this.needsReviewCardSelectionActions.toggleCardSelection.invoke(payload);
+    private onNeedsReviewCardSelectionToggle = (payload: CardSelectionPayload): void => {
+        this.needsReviewCardSelectionActions.toggleCardSelection.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.CARD_SELECTION_TOGGLED,
             payload,
         );
     };
 
-    private onRuleExpansionToggle = async (payload: RuleExpandCollapsePayload): Promise<void> => {
-        await this.needsReviewCardSelectionActions.toggleRuleExpandCollapse.invoke(payload);
+    private onRuleExpansionToggle = (payload: RuleExpandCollapsePayload): void => {
+        this.needsReviewCardSelectionActions.toggleRuleExpandCollapse.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.RULE_EXPANSION_TOGGLED,
             payload,
         );
     };
 
-    private onToggleVisualHelper = async (payload: BaseActionPayload): Promise<void> => {
-        await this.needsReviewCardSelectionActions.toggleVisualHelper.invoke(null);
+    private onToggleVisualHelper = (payload: BaseActionPayload): void => {
+        this.needsReviewCardSelectionActions.toggleVisualHelper.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.VISUAL_HELPER_TOGGLED, payload);
     };
 
-    private onCollapseAllRules = async (payload: BaseActionPayload): Promise<void> => {
-        await this.needsReviewCardSelectionActions.collapseAllRules.invoke(null);
+    private onCollapseAllRules = (payload: BaseActionPayload): void => {
+        this.needsReviewCardSelectionActions.collapseAllRules.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_COLLAPSED, payload);
     };
 
-    private onExpandAllRules = async (payload: BaseActionPayload): Promise<void> => {
-        await this.needsReviewCardSelectionActions.expandAllRules.invoke(null);
+    private onExpandAllRules = (payload: BaseActionPayload): void => {
+        this.needsReviewCardSelectionActions.expandAllRules.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_EXPANDED, payload);
     };
 }

--- a/src/background/actions/needs-review-card-selection-actions.ts
+++ b/src/background/actions/needs-review-card-selection-actions.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AsyncAction } from 'common/flux/async-action';
+import { SyncAction } from 'common/flux/sync-action';
 import { CardSelectionPayload, RuleExpandCollapsePayload } from './action-payloads';
 
 export class NeedsReviewCardSelectionActions {
-    public readonly getCurrentState = new AsyncAction();
-    public readonly navigateToNewCardsView = new AsyncAction();
-    public readonly toggleRuleExpandCollapse = new AsyncAction<RuleExpandCollapsePayload>();
-    public readonly toggleCardSelection = new AsyncAction<CardSelectionPayload>();
-    public readonly collapseAllRules = new AsyncAction();
-    public readonly expandAllRules = new AsyncAction();
-    public readonly toggleVisualHelper = new AsyncAction();
-    public readonly resetFocusedIdentifier = new AsyncAction();
+    public readonly getCurrentState = new SyncAction();
+    public readonly navigateToNewCardsView = new SyncAction();
+    public readonly toggleRuleExpandCollapse = new SyncAction<RuleExpandCollapsePayload>();
+    public readonly toggleCardSelection = new SyncAction<CardSelectionPayload>();
+    public readonly collapseAllRules = new SyncAction();
+    public readonly expandAllRules = new SyncAction();
+    public readonly toggleVisualHelper = new SyncAction();
+    public readonly resetFocusedIdentifier = new SyncAction();
 }

--- a/src/background/actions/needs-review-scan-result-action-creator.ts
+++ b/src/background/actions/needs-review-scan-result-action-creator.ts
@@ -28,13 +28,13 @@ export class NeedsReviewScanResultActionCreator {
         );
     }
 
-    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
-        await this.needsReviewScanResultActions.scanCompleted.invoke(payload);
+    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
+        this.needsReviewScanResultActions.scanCompleted.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(SCAN_INCOMPLETE_WARNINGS, payload);
         this.notificationCreator.createNotification(payload.notificationText);
     };
 
-    private onGetScanCurrentState = async (): Promise<void> => {
-        await this.needsReviewScanResultActions.getCurrentState.invoke(null);
+    private onGetScanCurrentState = (): void => {
+        this.needsReviewScanResultActions.getCurrentState.invoke(null);
     };
 }

--- a/src/background/actions/needs-review-scan-result-actions.ts
+++ b/src/background/actions/needs-review-scan-result-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AsyncAction } from 'common/flux/async-action';
+import { SyncAction } from 'common/flux/sync-action';
 import { UnifiedScanCompletedPayload } from './action-payloads';
 
 export class NeedsReviewScanResultActions {
-    public readonly scanCompleted = new AsyncAction<UnifiedScanCompletedPayload>();
-    public readonly getCurrentState = new AsyncAction();
+    public readonly scanCompleted = new SyncAction<UnifiedScanCompletedPayload>();
+    public readonly getCurrentState = new SyncAction();
 }

--- a/src/background/actions/unified-scan-result-action-creator.ts
+++ b/src/background/actions/unified-scan-result-action-creator.ts
@@ -28,13 +28,13 @@ export class UnifiedScanResultActionCreator {
         );
     }
 
-    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
-        await this.unifiedScanResultActions.scanCompleted.invoke(payload);
+    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
+        this.unifiedScanResultActions.scanCompleted.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(SCAN_INCOMPLETE_WARNINGS, payload);
         this.notificationCreator.createNotification(payload.notificationText);
     };
 
-    private onGetScanCurrentState = async (): Promise<void> => {
-        await this.unifiedScanResultActions.getCurrentState.invoke(null);
+    private onGetScanCurrentState = (): void => {
+        this.unifiedScanResultActions.getCurrentState.invoke(null);
     };
 }

--- a/src/background/actions/unified-scan-result-actions.ts
+++ b/src/background/actions/unified-scan-result-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AsyncAction } from 'common/flux/async-action';
+import { SyncAction } from 'common/flux/sync-action';
 import { UnifiedScanCompletedPayload } from './action-payloads';
 
 export class UnifiedScanResultActions {
-    public readonly scanCompleted = new AsyncAction<UnifiedScanCompletedPayload>();
-    public readonly getCurrentState = new AsyncAction();
+    public readonly scanCompleted = new SyncAction<UnifiedScanCompletedPayload>();
+    public readonly getCurrentState = new SyncAction();
 }

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -154,7 +154,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
+    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
         this.state = this.getDefaultState();
         this.state.rules = {};
 

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -164,7 +164,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         this.emitChanged();
     };
 
-    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
+    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
         this.state = this.getDefaultState();
         this.state.rules = {};
 

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -91,9 +91,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         });
     };
 
-    private toggleRuleExpandCollapse = async (
-        payload: RuleExpandCollapsePayload,
-    ): Promise<void> => {
+    private toggleRuleExpandCollapse = (payload: RuleExpandCollapsePayload): void => {
         if (!payload || !this.state.rules?.[payload.ruleId]) {
             return;
         }
@@ -109,7 +107,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         this.emitChanged();
     };
 
-    private toggleCardSelection = async (payload: CardSelectionPayload): Promise<void> => {
+    private toggleCardSelection = (payload: CardSelectionPayload): void => {
         if (
             !payload ||
             !this.state.rules?.[payload.ruleId] ||
@@ -131,7 +129,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         this.emitChanged();
     };
 
-    private collapseAllRules = async (): Promise<void> => {
+    private collapseAllRules = (): void => {
         if (!this.state.rules) {
             return;
         }
@@ -144,7 +142,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         this.emitChanged();
     };
 
-    private expandAllRules = async (): Promise<void> => {
+    private expandAllRules = (): void => {
         if (!this.state.rules) {
             return;
         }
@@ -156,7 +154,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         this.emitChanged();
     };
 
-    private toggleVisualHelper = async (): Promise<void> => {
+    private toggleVisualHelper = (): void => {
         this.state.visualHelperEnabled = !this.state.visualHelperEnabled;
 
         if (!this.state.visualHelperEnabled) {
@@ -194,12 +192,12 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         this.emitChanged();
     };
 
-    private onResetFocusedIdentifier = async (): Promise<void> => {
+    private onResetFocusedIdentifier = (): void => {
         this.state.focusedResultUid = null;
         this.emitChanged();
     };
 
-    private onNavigateToNewCardsView = async (): Promise<void> => {
+    private onNavigateToNewCardsView = (): void => {
         this.state.focusedResultUid = null;
         if (this.state.rules) {
             for (const ruleId in this.state.rules) {

--- a/src/background/stores/needs-review-scan-result-store.ts
+++ b/src/background/stores/needs-review-scan-result-store.ts
@@ -51,7 +51,7 @@ export class NeedsReviewScanResultStore extends PersistentStore<NeedsReviewScanR
         this.tabActions.existingTabUpdated.addListener(this.onResetStoreData);
     }
 
-    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
+    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
         this.state.results = payload.scanResult;
         this.state.rules = payload.rules;
         this.state.toolInfo = payload.toolInfo;

--- a/src/background/stores/unified-scan-result-store.ts
+++ b/src/background/stores/unified-scan-result-store.ts
@@ -51,7 +51,7 @@ export class UnifiedScanResultStore extends PersistentStore<UnifiedScanResultSto
         this.tabActions.existingTabUpdated.addListener(this.onResetStoreData);
     }
 
-    private onScanCompleted = async (payload: UnifiedScanCompletedPayload): Promise<void> => {
+    private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
         this.state.results = payload.scanResult;
         this.state.rules = payload.rules;
         this.state.toolInfo = payload.toolInfo;

--- a/src/electron/flux/action-creator/scan-action-creator.ts
+++ b/src/electron/flux/action-creator/scan-action-creator.ts
@@ -11,8 +11,8 @@ export class ScanActionCreator {
         private readonly deviceConnectionActions: DeviceConnectionActions,
     ) {}
 
-    public async scan(): Promise<void> {
+    public scan(): void {
         this.deviceConnectionActions.statusUnknown.invoke(undefined, this.executingScope);
-        await this.scanActions.scanStarted.invoke(undefined, this.executingScope);
+        this.scanActions.scanStarted.invoke(undefined, this.executingScope);
     }
 }

--- a/src/electron/flux/action/scan-actions.ts
+++ b/src/electron/flux/action/scan-actions.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AsyncAction } from 'common/flux/async-action';
 import { SyncAction } from 'common/flux/sync-action';
 
 export class ScanActions {
-    public readonly scanStarted = new AsyncAction<void>();
+    public readonly scanStarted = new SyncAction<void>();
     public readonly scanCompleted = new SyncAction<void>();
     public readonly scanFailed = new SyncAction<void>();
 }

--- a/src/electron/flux/store/scan-store.ts
+++ b/src/electron/flux/store/scan-store.ts
@@ -24,7 +24,7 @@ export class ScanStore extends BaseStoreImpl<ScanStoreData> {
         this.scanActions.scanFailed.addListener(this.onScanFailed);
     }
 
-    private onScanStarted = async () => {
+    private onScanStarted = () => {
         if (this.state.status === ScanStatus.Scanning) {
             return;
         }

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -83,8 +83,8 @@ export type ResultsViewProps = {
 };
 
 export class ResultsView extends React.Component<ResultsViewProps> {
-    public async componentDidMount(): Promise<void> {
-        await this.props.deps.scanActionCreator.scan();
+    public componentDidMount(): void {
+        this.props.deps.scanActionCreator.scan();
     }
 
     public render(): JSX.Element {

--- a/src/tests/unit/tests/background/actions/needs-review-card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/needs-review-card-selection-action-creator.test.ts
@@ -13,7 +13,7 @@ import { Messages } from 'common/messages';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
 
-import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('NeedsReviewCardSelectionActionCreator', () => {
     const tabId = -2;
@@ -30,7 +30,7 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
             resultInstanceUid: 'test-instance-uuid',
             ruleId: 'test-rule-id',
         };
-        const toggleNeedsReviewCardSelectionMock = createAsyncActionMock(payload);
+        const toggleNeedsReviewCardSelectionMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'toggleCardSelection',
             toggleNeedsReviewCardSelectionMock.object,
@@ -61,7 +61,7 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'test-rule-id',
         };
-        const ruleExpansionToggleMock = createAsyncActionMock(payload);
+        const ruleExpansionToggleMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock(
             'toggleRuleExpandCollapse',
             ruleExpansionToggleMock.object,
@@ -90,7 +90,7 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
 
     test('onToggleVisualHelper', async () => {
         const payloadStub: BaseActionPayload = {};
-        const toggleVisualHelperMock = createAsyncActionMock(null);
+        const toggleVisualHelperMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('toggleVisualHelper', toggleVisualHelperMock.object);
 
         const testSubject = new NeedsReviewCardSelectionActionCreator(
@@ -116,7 +116,7 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
 
     test('onCollapseAllRules', async () => {
         const payloadStub: BaseActionPayload = {};
-        const collapseAllRulesActionMock = createAsyncActionMock(null);
+        const collapseAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock(
             'collapseAllRules',
             collapseAllRulesActionMock.object,
@@ -145,7 +145,7 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
 
     test('onExpandAllRules', async () => {
         const payloadStub: BaseActionPayload = {};
-        const expandAllRulesActionMock = createAsyncActionMock(null);
+        const expandAllRulesActionMock = createSyncActionMock(null);
         const actionsMock = createActionsMock('expandAllRules', expandAllRulesActionMock.object);
 
         const testSubject = new NeedsReviewCardSelectionActionCreator(

--- a/src/tests/unit/tests/background/actions/needs-review-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/needs-review-scan-result-action-creator.test.ts
@@ -15,7 +15,7 @@ import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
-import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('NeedsReviewScanResultActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -43,7 +43,7 @@ describe('NeedsReviewScanResultActionCreator', () => {
             telemetry,
         };
 
-        const scanCompletedMock = createAsyncActionMock(payload);
+        const scanCompletedMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('scanCompleted', scanCompletedMock.object);
 
         const testSubject = new NeedsReviewScanResultActionCreator(
@@ -71,7 +71,7 @@ describe('NeedsReviewScanResultActionCreator', () => {
     it('should handle GetState message', async () => {
         const payload = null;
 
-        const getCurrentStateMock = createAsyncActionMock<null>(payload);
+        const getCurrentStateMock = createSyncActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
 
         const testSubject = new NeedsReviewScanResultActionCreator(

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -15,7 +15,7 @@ import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
-import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('UnifiedScanResultActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -43,7 +43,7 @@ describe('UnifiedScanResultActionCreator', () => {
             telemetry,
         };
 
-        const scanCompletedMock = createAsyncActionMock(payload);
+        const scanCompletedMock = createSyncActionMock(payload);
         const actionsMock = createActionsMock('scanCompleted', scanCompletedMock.object);
 
         const testSubject = new UnifiedScanResultActionCreator(
@@ -71,7 +71,7 @@ describe('UnifiedScanResultActionCreator', () => {
     it('should handle GetState message', async () => {
         const payload = null;
 
-        const getCurrentStateMock = createAsyncActionMock<null>(payload);
+        const getCurrentStateMock = createSyncActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
 
         const testSubject = new UnifiedScanResultActionCreator(

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AsyncAction } from 'common/flux/async-action';
 import { SyncAction } from 'common/flux/sync-action';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { DeviceConnectionActions } from 'electron/flux/action/device-connection-actions';
@@ -10,7 +9,7 @@ import { IMock, Mock, Times } from 'typemoq';
 describe('ScanActionCreator', () => {
     const actionExecutingScope = 'ScanActionCreator';
     let scanActionsMock: IMock<ScanActions>;
-    let scanStartedMock: IMock<AsyncAction<void>>;
+    let scanStartedMock: IMock<SyncAction<void>>;
     let deviceConnectionActionsMock: IMock<DeviceConnectionActions>;
     let statusUnknown: IMock<SyncAction<void>>;
 
@@ -18,7 +17,7 @@ describe('ScanActionCreator', () => {
 
     beforeEach(() => {
         scanActionsMock = Mock.ofType<ScanActions>();
-        scanStartedMock = Mock.ofType<AsyncAction<void>>();
+        scanStartedMock = Mock.ofType<SyncAction<void>>();
 
         scanActionsMock.setup(actions => actions.scanStarted).returns(() => scanStartedMock.object);
 
@@ -36,7 +35,7 @@ describe('ScanActionCreator', () => {
     });
 
     it('scans', async () => {
-        await testSubject.scan();
+        testSubject.scan();
 
         scanStartedMock.verify(
             async scanStarted => scanStarted.invoke(undefined, actionExecutingScope),


### PR DESCRIPTION
#### Details

Needs review and unified scan result stores do not do any async work, therefore reverting actions to be sync. 

##### Motivation

Feature work.

##### Context

See https://github.com/microsoft/accessibility-insights-web/pull/5877

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
