### PR TITLE
feat(mv3-part-6): Make visualization scan result and card selection actions async again

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -257,7 +257,10 @@ export class ActionCreator {
     };
 
     private onTabbedElementAdded = async (payload: AddTabbedElementPayload): Promise<void> => {
-        this.visualizationScanResultActions.addTabbedElement.invoke(payload, this.executingScope);
+        await this.visualizationScanResultActions.addTabbedElement.invoke(
+            payload,
+            this.executingScope,
+        );
     };
 
     private onRecordingCompleted = (payload: BaseActionPayload): void => {
@@ -268,7 +271,10 @@ export class ActionCreator {
     };
 
     private onRecordingTerminated = async (payload: BaseActionPayload): Promise<void> => {
-        this.visualizationScanResultActions.disableTabStop.invoke(payload, this.executingScope);
+        await this.visualizationScanResultActions.disableTabStop.invoke(
+            payload,
+            this.executingScope,
+        );
     };
 
     private onUpdateFocusedInstance = async (payload: string[]): Promise<void> => {
@@ -281,7 +287,10 @@ export class ActionCreator {
     ): Promise<void> => {
         const telemetryEventName = TelemetryEvents.ADHOC_SCAN_COMPLETED;
         this.telemetryEventHandler.publishTelemetry(telemetryEventName, payload);
-        this.visualizationScanResultActions.scanCompleted.invoke(payload, this.executingScope);
+        await this.visualizationScanResultActions.scanCompleted.invoke(
+            payload,
+            this.executingScope,
+        );
         await this.visualizationActions.scanCompleted.invoke(null, this.executingScope);
         this.notificationCreator.createNotificationByVisualizationKey(
             payload.selectorMap,
@@ -294,7 +303,7 @@ export class ActionCreator {
 
     private onScrollRequested = async (): Promise<void> => {
         await this.visualizationActions.scrollRequested.invoke(null, this.executingScope);
-        this.cardSelectionActions.resetFocusedIdentifier.invoke(null, this.executingScope);
+        await this.cardSelectionActions.resetFocusedIdentifier.invoke(null, this.executingScope);
         await this.needsReviewCardSelectionActions.resetFocusedIdentifier.invoke(
             null,
             this.executingScope,
@@ -400,7 +409,7 @@ export class ActionCreator {
     };
 
     private getScanResultsCurrentState = async (): Promise<void> => {
-        this.visualizationScanResultActions.getCurrentState.invoke(null, this.executingScope);
+        await this.visualizationScanResultActions.getCurrentState.invoke(null, this.executingScope);
     };
 
     private onSetHoveredOverSelector = async (payload: string[]): Promise<void> => {

--- a/src/background/actions/card-selection-action-creator.ts
+++ b/src/background/actions/card-selection-action-creator.ts
@@ -47,38 +47,38 @@ export class CardSelectionActionCreator {
         );
     }
 
-    private onGetCurrentState = (): void => {
-        this.cardSelectionActions.getCurrentState.invoke(null);
+    private onGetCurrentState = async (): Promise<void> => {
+        await this.cardSelectionActions.getCurrentState.invoke(null);
     };
 
-    private onCardSelectionToggle = (payload: CardSelectionPayload): void => {
-        this.cardSelectionActions.toggleCardSelection.invoke(payload);
+    private onCardSelectionToggle = async (payload: CardSelectionPayload): Promise<void> => {
+        await this.cardSelectionActions.toggleCardSelection.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.CARD_SELECTION_TOGGLED,
             payload,
         );
     };
 
-    private onRuleExpansionToggle = (payload: RuleExpandCollapsePayload): void => {
-        this.cardSelectionActions.toggleRuleExpandCollapse.invoke(payload);
+    private onRuleExpansionToggle = async (payload: RuleExpandCollapsePayload): Promise<void> => {
+        await this.cardSelectionActions.toggleRuleExpandCollapse.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.RULE_EXPANSION_TOGGLED,
             payload,
         );
     };
 
-    private onToggleVisualHelper = (payload: BaseActionPayload): void => {
-        this.cardSelectionActions.toggleVisualHelper.invoke(null);
+    private onToggleVisualHelper = async (payload: BaseActionPayload): Promise<void> => {
+        await this.cardSelectionActions.toggleVisualHelper.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.VISUAL_HELPER_TOGGLED, payload);
     };
 
-    private onCollapseAllRules = (payload: BaseActionPayload): void => {
-        this.cardSelectionActions.collapseAllRules.invoke(null);
+    private onCollapseAllRules = async (payload: BaseActionPayload): Promise<void> => {
+        await this.cardSelectionActions.collapseAllRules.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_COLLAPSED, payload);
     };
 
-    private onExpandAllRules = (payload: BaseActionPayload): void => {
-        this.cardSelectionActions.expandAllRules.invoke(null);
+    private onExpandAllRules = async (payload: BaseActionPayload): Promise<void> => {
+        await this.cardSelectionActions.expandAllRules.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_EXPANDED, payload);
     };
 }

--- a/src/background/actions/card-selection-actions.ts
+++ b/src/background/actions/card-selection-actions.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { CardSelectionPayload, RuleExpandCollapsePayload } from './action-payloads';
 
 export class CardSelectionActions {
-    public readonly getCurrentState = new SyncAction();
-    public readonly navigateToNewCardsView = new SyncAction();
-    public readonly toggleRuleExpandCollapse = new SyncAction<RuleExpandCollapsePayload>();
-    public readonly toggleCardSelection = new SyncAction<CardSelectionPayload>();
-    public readonly collapseAllRules = new SyncAction();
-    public readonly expandAllRules = new SyncAction();
-    public readonly toggleVisualHelper = new SyncAction();
-    public readonly resetFocusedIdentifier = new SyncAction();
+    public readonly getCurrentState = new AsyncAction();
+    public readonly navigateToNewCardsView = new AsyncAction();
+    public readonly toggleRuleExpandCollapse = new AsyncAction<RuleExpandCollapsePayload>();
+    public readonly toggleCardSelection = new AsyncAction<CardSelectionPayload>();
+    public readonly collapseAllRules = new AsyncAction();
+    public readonly expandAllRules = new AsyncAction();
+    public readonly toggleVisualHelper = new AsyncAction();
+    public readonly resetFocusedIdentifier = new AsyncAction();
 }

--- a/src/background/actions/visualization-scan-result-actions.ts
+++ b/src/background/actions/visualization-scan-result-actions.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { ScanCompletedPayload } from '../../injected/analyzers/analyzer';
 import { AddTabbedElementPayload } from './action-payloads';
 
 export class VisualizationScanResultActions {
-    public readonly scanCompleted = new SyncAction<ScanCompletedPayload<any>>();
-    public readonly getCurrentState = new SyncAction();
-    public readonly addTabbedElement = new SyncAction<AddTabbedElementPayload>();
-    public readonly disableTabStop = new SyncAction();
+    public readonly scanCompleted = new AsyncAction<ScanCompletedPayload<any>>();
+    public readonly getCurrentState = new AsyncAction();
+    public readonly addTabbedElement = new AsyncAction<AddTabbedElementPayload>();
+    public readonly disableTabStop = new AsyncAction();
 }

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -81,7 +81,9 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         });
     };
 
-    private toggleRuleExpandCollapse = (payload: RuleExpandCollapsePayload): void => {
+    private toggleRuleExpandCollapse = async (
+        payload: RuleExpandCollapsePayload,
+    ): Promise<void> => {
         if (!payload || !this.state.rules?.[payload.ruleId]) {
             return;
         }
@@ -97,7 +99,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private toggleCardSelection = (payload: CardSelectionPayload): void => {
+    private toggleCardSelection = async (payload: CardSelectionPayload): Promise<void> => {
         if (
             !payload ||
             !this.state.rules?.[payload.ruleId] ||
@@ -119,7 +121,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private collapseAllRules = (): void => {
+    private collapseAllRules = async (): Promise<void> => {
         if (!this.state.rules) {
             return;
         }
@@ -132,7 +134,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private expandAllRules = (): void => {
+    private expandAllRules = async (): Promise<void> => {
         if (!this.state.rules) {
             return;
         }
@@ -144,7 +146,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private toggleVisualHelper = (): void => {
+    private toggleVisualHelper = async (): Promise<void> => {
         this.state.visualHelperEnabled = !this.state.visualHelperEnabled;
 
         if (!this.state.visualHelperEnabled) {
@@ -182,12 +184,12 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         this.emitChanged();
     };
 
-    private onResetFocusedIdentifier = (): void => {
+    private onResetFocusedIdentifier = async (): Promise<void> => {
         this.state.focusedResultUid = null;
         this.emitChanged();
     };
 
-    private onNavigateToNewCardsView = (): void => {
+    private onNavigateToNewCardsView = async (): Promise<void> => {
         this.state.focusedResultUid = null;
 
         if (this.state.rules) {

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -130,7 +130,7 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         this.tabActions.existingTabUpdated.addListener(this.onExistingTabUpdated);
     }
 
-    private onTabStopsDisabled = (): void => {
+    private onTabStopsDisabled = async (): Promise<void> => {
         this.state.tabStops.tabbedElements = null;
         this.emitChanged();
     };
@@ -146,7 +146,7 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         this.emitChanged();
     };
 
-    private onAddTabbedElement = (payload: AddTabbedElementPayload): void => {
+    private onAddTabbedElement = async (payload: AddTabbedElementPayload): Promise<void> => {
         if (!this.state.tabStops.tabbedElements) {
             this.state.tabStops.tabbedElements = [];
         }
@@ -246,7 +246,7 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         this.emitChanged();
     };
 
-    private onScanCompleted = (payload: ScanCompletedPayload<any>): void => {
+    private onScanCompleted = async (payload: ScanCompletedPayload<any>): Promise<void> => {
         const selectorMap = payload.selectorMap;
         const result = payload.scanResult;
         const selectedRows = this.getRowToRuleResultMap(selectorMap);

--- a/src/electron/common/left-nav-item-factory.ts
+++ b/src/electron/common/left-nav-item-factory.ts
@@ -25,7 +25,7 @@ const createLeftNavItem = (
         displayName: config.contentPageInfo.title,
         featureFlag: config.featureFlag,
         onSelect: async () => {
-            actionCreator.itemSelected(config.key);
+            await actionCreator.itemSelected(config.key);
             await tabStopsActionCreator.resetTabStopsToDefaultState();
         },
     };

--- a/src/electron/flux/action-creator/left-nav-action-creator.ts
+++ b/src/electron/flux/action-creator/left-nav-action-creator.ts
@@ -11,9 +11,9 @@ export class LeftNavActionCreator {
         private readonly cardSelectionActions: CardSelectionActions,
     ) {}
 
-    public itemSelected = (itemKey: LeftNavItemKey) => {
+    public itemSelected = async (itemKey: LeftNavItemKey) => {
         this.leftNavActions.itemSelected.invoke(itemKey);
-        this.cardSelectionActions.navigateToNewCardsView.invoke(null);
+        await this.cardSelectionActions.navigateToNewCardsView.invoke(null);
     };
 
     public setLeftNavVisible = (value: boolean) =>

--- a/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
@@ -13,7 +13,7 @@ import { Messages } from 'common/messages';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
 
-import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('CardSelectionActionCreator', () => {
     const tabId = -2;
@@ -30,7 +30,7 @@ describe('CardSelectionActionCreator', () => {
             resultInstanceUid: 'test-instance-uuid',
             ruleId: 'test-rule-id',
         };
-        const toggleCardSelectionMock = createSyncActionMock(payload);
+        const toggleCardSelectionMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock(
             'toggleCardSelection',
             toggleCardSelectionMock.object,
@@ -61,7 +61,7 @@ describe('CardSelectionActionCreator', () => {
         const payload: RuleExpandCollapsePayload = {
             ruleId: 'test-rule-id',
         };
-        const ruleExpansionToggleMock = createSyncActionMock(payload);
+        const ruleExpansionToggleMock = createAsyncActionMock(payload);
         const actionsMock = createActionsMock(
             'toggleRuleExpandCollapse',
             ruleExpansionToggleMock.object,
@@ -90,7 +90,7 @@ describe('CardSelectionActionCreator', () => {
 
     test('onToggleVisualHelper', async () => {
         const payloadStub: BaseActionPayload = {};
-        const toggleVisualHelperMock = createSyncActionMock(null);
+        const toggleVisualHelperMock = createAsyncActionMock(null);
         const actionsMock = createActionsMock('toggleVisualHelper', toggleVisualHelperMock.object);
 
         const testSubject = new CardSelectionActionCreator(
@@ -116,7 +116,7 @@ describe('CardSelectionActionCreator', () => {
 
     test('onCollapseAllRules', async () => {
         const payloadStub: BaseActionPayload = {};
-        const collapseAllRulesActionMock = createSyncActionMock(null);
+        const collapseAllRulesActionMock = createAsyncActionMock(null);
         const actionsMock = createActionsMock(
             'collapseAllRules',
             collapseAllRulesActionMock.object,
@@ -145,7 +145,7 @@ describe('CardSelectionActionCreator', () => {
 
     test('onExpandAllRules', async () => {
         const payloadStub: BaseActionPayload = {};
-        const expandAllRulesActionMock = createSyncActionMock(null);
+        const expandAllRulesActionMock = createAsyncActionMock(null);
         const actionsMock = createActionsMock('expandAllRules', expandAllRulesActionMock.object);
 
         const testSubject = new CardSelectionActionCreator(

--- a/src/tests/unit/tests/electron/flux/action-creator/left-nav-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/left-nav-action-creator.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
+import { AsyncAction } from 'common/flux/async-action';
 import { SyncAction } from 'common/flux/sync-action';
 import { LeftNavActionCreator } from 'electron/flux/action-creator/left-nav-action-creator';
 import { LeftNavActions } from 'electron/flux/action/left-nav-actions';
@@ -32,7 +33,7 @@ describe('LeftNavActionCreator', () => {
             .returns(() => itemSelectedMock.object)
             .verifiable();
 
-        const navigateToNewCardsViewMock = Mock.ofType<SyncAction<void>>();
+        const navigateToNewCardsViewMock = Mock.ofType<AsyncAction<void>>();
         cardSelectionActionsMock
             .setup(actions => actions.navigateToNewCardsView)
             .returns(() => navigateToNewCardsViewMock.object)


### PR DESCRIPTION
#### Details

Reverts #5896

##### Motivation

Feature work - reverting these actions back to async because they call PersistentStore's emitChanged(), which we realized will need to be async regardless of whether any async listeners are registered to the store.

##### Context

See above

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
