### PR TITLE
feat(mv3-part-6): Make scoping and permission state actions async

### DIFF
--- a/src/background/actions/permissions-state-actions.ts
+++ b/src/background/actions/permissions-state-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 
 export class PermissionsStateActions {
-    public readonly getCurrentState = new SyncAction<void>();
-    public readonly setPermissionsState = new SyncAction<SetAllUrlsPermissionStatePayload>();
+    public readonly getCurrentState = new AsyncAction<void>();
+    public readonly setPermissionsState = new AsyncAction<SetAllUrlsPermissionStatePayload>();
 }

--- a/src/background/actions/scoping-actions.ts
+++ b/src/background/actions/scoping-actions.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { BaseActionPayload } from './action-payloads';
 
 export interface ScopingPayload extends BaseActionPayload {
@@ -9,7 +9,7 @@ export interface ScopingPayload extends BaseActionPayload {
 }
 
 export class ScopingActions {
-    public readonly addSelector = new SyncAction<ScopingPayload>();
-    public readonly deleteSelector = new SyncAction<ScopingPayload>();
-    public readonly getCurrentState = new SyncAction<void>();
+    public readonly addSelector = new AsyncAction<ScopingPayload>();
+    public readonly deleteSelector = new AsyncAction<ScopingPayload>();
+    public readonly getCurrentState = new AsyncAction<void>();
 }

--- a/src/background/global-action-creators/permissions-state-action-creator.ts
+++ b/src/background/global-action-creators/permissions-state-action-creator.ts
@@ -26,12 +26,14 @@ export class PermissionsStateActionCreator {
         );
     }
 
-    private onGetCurrentState = (): void => {
-        this.permissionsStateActions.getCurrentState.invoke();
+    private onGetCurrentState = async (): Promise<void> => {
+        await this.permissionsStateActions.getCurrentState.invoke();
     };
 
-    private onSetPermissionsState = (payload: SetAllUrlsPermissionStatePayload): void => {
-        this.permissionsStateActions.setPermissionsState.invoke(payload);
+    private onSetPermissionsState = async (
+        payload: SetAllUrlsPermissionStatePayload,
+    ): Promise<void> => {
+        await this.permissionsStateActions.setPermissionsState.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(ALL_URLS_PERMISSION_UPDATED, payload);
     };
 }

--- a/src/background/global-action-creators/scoping-action-creator.ts
+++ b/src/background/global-action-creators/scoping-action-creator.ts
@@ -26,15 +26,15 @@ export class ScopingActionCreator {
         );
     }
 
-    private onGetScopingState = (): void => {
-        this.scopingActions.getCurrentState.invoke();
+    private onGetScopingState = async (): Promise<void> => {
+        await this.scopingActions.getCurrentState.invoke();
     };
 
-    private onAddSelector = (payload: ScopingPayload): void => {
-        this.scopingActions.addSelector.invoke(payload);
+    private onAddSelector = async (payload: ScopingPayload): Promise<void> => {
+        await this.scopingActions.addSelector.invoke(payload);
     };
 
-    private onDeleteSelector = (payload: ScopingPayload): void => {
-        this.scopingActions.deleteSelector.invoke(payload);
+    private onDeleteSelector = async (payload: ScopingPayload): Promise<void> => {
+        await this.scopingActions.deleteSelector.invoke(payload);
     };
 }

--- a/src/background/stores/global/permissions-state-store.ts
+++ b/src/background/stores/global/permissions-state-store.ts
@@ -40,7 +40,9 @@ export class PermissionsStateStore extends PersistentStore<PermissionsStateStore
         this.permissionsStateActions.setPermissionsState.addListener(this.onSetPermissionsState);
     }
 
-    private onSetPermissionsState = (payload: SetAllUrlsPermissionStatePayload): void => {
+    private onSetPermissionsState = async (
+        payload: SetAllUrlsPermissionStatePayload,
+    ): Promise<void> => {
         if (this.state.hasAllUrlAndFilePermissions !== payload.hasAllUrlAndFilePermissions) {
             this.state.hasAllUrlAndFilePermissions = payload.hasAllUrlAndFilePermissions;
             this.emitChanged();

--- a/src/background/stores/global/scoping-store.ts
+++ b/src/background/stores/global/scoping-store.ts
@@ -54,7 +54,7 @@ export class ScopingStore extends PersistentStore<ScopingStoreData> {
         this.scopingActions.deleteSelector.addListener(this.onDeleteSelector);
     }
 
-    private onAddSelector = (payload: ScopingPayload): void => {
+    private onAddSelector = async (payload: ScopingPayload): Promise<void> => {
         let shouldUpdate: boolean = true;
         _.forEach(Object.keys(this.state.selectors[payload.inputType]), key => {
             if (_.isEqual(this.state.selectors[payload.inputType][key], payload.selector)) {
@@ -68,7 +68,7 @@ export class ScopingStore extends PersistentStore<ScopingStoreData> {
         }
     };
 
-    private onDeleteSelector = (payload: ScopingPayload): void => {
+    private onDeleteSelector = async (payload: ScopingPayload): Promise<void> => {
         _.forEach(Object.keys(this.state.selectors[payload.inputType]), key => {
             if (_.isEqual(this.state.selectors[payload.inputType][key], payload.selector)) {
                 this.state.selectors[payload.inputType].splice(key, 1);

--- a/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
@@ -9,7 +9,7 @@ import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock } from 'typemoq';
-import { createSyncActionMock } from './action-creator-test-helpers';
+import { createAsyncActionMock } from './action-creator-test-helpers';
 
 describe('PermissionsStateActionCreator', () => {
     let permissionsStateActionsMock: IMock<PermissionsStateActions>;
@@ -22,7 +22,7 @@ describe('PermissionsStateActionCreator', () => {
 
     it('handles getStoreState message', async () => {
         const expectedMessage = getStoreStateMessage(StoreNames.PermissionsStateStore);
-        const getCurrentStateMock = createSyncActionMock(undefined);
+        const getCurrentStateMock = createAsyncActionMock(undefined);
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
         const testSubject = new PermissionsStateActionCreator(
             interpreterMock.object,
@@ -45,7 +45,7 @@ describe('PermissionsStateActionCreator', () => {
                 hasAllUrlAndFilePermissions: permissionState,
                 telemetry: {} as TelemetryData,
             };
-            const setPermissionsStateMock = createSyncActionMock(payload);
+            const setPermissionsStateMock = createAsyncActionMock(payload);
             const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
             setupActionsMock('setPermissionsState', setPermissionsStateMock.object);
             const testSubject = new PermissionsStateActionCreator(

--- a/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
@@ -8,7 +8,7 @@ import { IMock, It, Mock } from 'typemoq';
 
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import { createSyncActionMock } from './action-creator-test-helpers';
+import { createAsyncActionMock } from './action-creator-test-helpers';
 
 describe('ScopingActionCreator', () => {
     let interpreterMock: IMock<Interpreter>;
@@ -28,7 +28,7 @@ describe('ScopingActionCreator', () => {
 
         setupInterpreterMock(expectedMessage);
 
-        const getCurrentStateMock = createSyncActionMock(undefined);
+        const getCurrentStateMock = createAsyncActionMock(undefined);
 
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
 
@@ -47,7 +47,7 @@ describe('ScopingActionCreator', () => {
 
         setupInterpreterMock(expectedMessage, payload);
 
-        const addSelectorMock = createSyncActionMock(payload);
+        const addSelectorMock = createAsyncActionMock(payload);
 
         setupActionsMock('addSelector', addSelectorMock.object);
 
@@ -66,7 +66,7 @@ describe('ScopingActionCreator', () => {
 
         setupInterpreterMock(expectedMessage, payload);
 
-        const deleteSelectorMock = createSyncActionMock(payload);
+        const deleteSelectorMock = createAsyncActionMock(payload);
 
         setupActionsMock('deleteSelector', deleteSelectorMock.object);
 


### PR DESCRIPTION
#### Details

Reverts #5878 and #5881

##### Motivation

Feature work - reverting these actions back to async because they call PersistentStore's emitChanged(), which we realized will need to be async regardless of whether any async listeners are registered to the store.

##### Context

See above

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
