### PR TITLE
feat(mv3-part-6): Make details view store actions async

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -353,7 +353,7 @@ export class ActionCreator {
         payload: OnDetailsViewOpenPayload,
         tabId: number,
     ): Promise<void> => {
-        this.sidePanelActions.closeSidePanel.invoke('PreviewFeatures', this.executingScope);
+        await this.sidePanelActions.closeSidePanel.invoke('PreviewFeatures', this.executingScope);
         await this.visualizationActions.updateSelectedPivotChild.invoke(
             payload,
             this.executingScope,

--- a/src/background/actions/content-action-creator.ts
+++ b/src/background/actions/content-action-creator.ts
@@ -31,13 +31,13 @@ export class ContentActionCreator {
     }
 
     private onOpenContentPanel = async (payload: ContentPayload, tabId: number): Promise<void> => {
-        this.contentActions.openContentPanel.invoke(payload);
+        await this.contentActions.openContentPanel.invoke(payload);
         await this.detailsViewController.showDetailsView(tabId).catch(this.logger.error);
         this.telemetryEventHandler.publishTelemetry(CONTENT_PANEL_OPENED, payload);
     };
 
-    private onCloseContentPanel = (payload: BaseActionPayload): void => {
-        this.contentActions.closeContentPanel.invoke();
+    private onCloseContentPanel = async (payload: BaseActionPayload): Promise<void> => {
+        await this.contentActions.closeContentPanel.invoke();
         this.telemetryEventHandler.publishTelemetry(CONTENT_PANEL_CLOSED, payload);
     };
 }

--- a/src/background/actions/content-actions.ts
+++ b/src/background/actions/content-actions.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { BaseActionPayload } from './action-payloads';
 
 export interface ContentPayload extends BaseActionPayload {
@@ -9,6 +9,6 @@ export interface ContentPayload extends BaseActionPayload {
 }
 
 export class ContentActions {
-    public readonly openContentPanel = new SyncAction<ContentPayload>();
-    public readonly closeContentPanel = new SyncAction<void>();
+    public readonly openContentPanel = new AsyncAction<ContentPayload>();
+    public readonly closeContentPanel = new AsyncAction<void>();
 }

--- a/src/background/actions/details-view-action-creator.ts
+++ b/src/background/actions/details-view-action-creator.ts
@@ -81,7 +81,7 @@ export class DetailsViewActionCreator {
         payload: BaseActionPayload,
         tabId: number,
     ): Promise<void> => {
-        this.sidePanelActions.openSidePanel.invoke(panel);
+        await this.sidePanelActions.openSidePanel.invoke(panel);
         await this.detailsViewController.showDetailsView(tabId).catch(this.logger.error);
 
         const eventName = this.sidePanelToOpenPanelTelemetryEventName[panel];
@@ -94,20 +94,23 @@ export class DetailsViewActionCreator {
         Scoping: SCOPING_CLOSE,
     };
 
-    private onCloseSidePanel = (panel: SidePanel, payload: BaseActionPayload): void => {
-        this.sidePanelActions.closeSidePanel.invoke(panel);
+    private onCloseSidePanel = async (
+        panel: SidePanel,
+        payload: BaseActionPayload,
+    ): Promise<void> => {
+        await this.sidePanelActions.closeSidePanel.invoke(panel);
 
         const eventName = this.sidePanelToClosePanelTelemetryEventName[panel];
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
     };
 
-    private onSetDetailsViewRightContentPanel = (
+    private onSetDetailsViewRightContentPanel = async (
         payload: DetailsViewRightContentPanelType,
-    ): void => {
-        this.detailsViewActions.setSelectedDetailsViewRightContentPanel.invoke(payload);
+    ): Promise<void> => {
+        await this.detailsViewActions.setSelectedDetailsViewRightContentPanel.invoke(payload);
     };
 
-    private onGetDetailsViewCurrentState = (): void => {
-        this.detailsViewActions.getCurrentState.invoke(null);
+    private onGetDetailsViewCurrentState = async (): Promise<void> => {
+        await this.detailsViewActions.getCurrentState.invoke(null);
     };
 }

--- a/src/background/actions/details-view-actions.ts
+++ b/src/background/actions/details-view-actions.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { DetailsViewRightContentPanelType } from '../../common/types/store-data/details-view-right-content-panel-type';
 
 export class DetailsViewActions {
     public readonly setSelectedDetailsViewRightContentPanel =
-        new SyncAction<DetailsViewRightContentPanelType>();
-    public readonly getCurrentState = new SyncAction();
+        new AsyncAction<DetailsViewRightContentPanelType>();
+    public readonly getCurrentState = new AsyncAction();
 }

--- a/src/background/actions/side-panel-actions.ts
+++ b/src/background/actions/side-panel-actions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { SidePanel } from 'background/stores/side-panel';
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 
 export class SidePanelActions {
-    public readonly openSidePanel = new SyncAction<SidePanel>();
-    public readonly closeSidePanel = new SyncAction<SidePanel>();
+    public readonly openSidePanel = new AsyncAction<SidePanel>();
+    public readonly closeSidePanel = new AsyncAction<SidePanel>();
 }

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -83,16 +83,16 @@ export class DetailsViewStore extends PersistentStore<DetailsViewStoreData> {
         Scoping: 'isScopingOpen',
     };
 
-    private onOpenSidePanel = (sidePanel: SidePanel): void => {
+    private onOpenSidePanel = async (sidePanel: SidePanel): Promise<void> => {
         const stateKey = this.sidePanelToStateKey[sidePanel];
 
-        this.onOpen(stateKey);
+        await this.onOpen(stateKey);
     };
 
-    private onOpen = (
+    private onOpen = async (
         flagName: keyof CurrentPanel,
         mutator?: (data: DetailsViewStoreData) => void,
-    ): void => {
+    ): Promise<void> => {
         Object.keys(this.state.currentPanel).forEach(key => {
             this.state.currentPanel[key] = false;
         });
@@ -106,16 +106,16 @@ export class DetailsViewStore extends PersistentStore<DetailsViewStoreData> {
         this.emitChanged();
     };
 
-    private onCloseSidePanel = (sidePanel: SidePanel): void => {
+    private onCloseSidePanel = async (sidePanel: SidePanel): Promise<void> => {
         const stateKey = this.sidePanelToStateKey[sidePanel];
 
-        this.onClose(stateKey);
+        await this.onClose(stateKey);
     };
 
-    private onClose = (
+    private onClose = async (
         flagName: keyof CurrentPanel,
         mutator?: (data: DetailsViewStoreData) => void,
-    ): void => {
+    ): Promise<void> => {
         this.state.currentPanel[flagName] = false;
 
         if (mutator != null) {
@@ -125,9 +125,9 @@ export class DetailsViewStore extends PersistentStore<DetailsViewStoreData> {
         this.emitChanged();
     };
 
-    private onSetSelectedDetailsViewRightContentPanel = (
+    private onSetSelectedDetailsViewRightContentPanel = async (
         view: DetailsViewRightContentPanelType,
-    ): void => {
+    ): Promise<void> => {
         this.state.detailsViewRightContentPanel = view;
         this.emitChanged();
     };

--- a/src/tests/unit/tests/background/actions/content-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/content-action-creator.test.ts
@@ -10,12 +10,12 @@ import {
     CONTENT_PANEL_OPENED,
     TelemetryEventSource,
 } from 'common/extension-telemetry-events';
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { Logger } from 'common/logging/logger';
 import { Messages } from 'common/messages';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, Times } from 'typemoq';
-import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('ContentActionMessageCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -39,12 +39,12 @@ describe('ContentActionMessageCreator', () => {
 
         const tabId = -2;
 
-        let openContentPanelMock: IMock<SyncAction<ContentPayload>>;
+        let openContentPanelMock: IMock<AsyncAction<ContentPayload>>;
         let detailsViewControllerMock: IMock<ExtensionDetailsViewController>;
         let loggerMock: IMock<Logger>;
 
         beforeEach(() => {
-            openContentPanelMock = createSyncActionMock(payload);
+            openContentPanelMock = createAsyncActionMock(payload);
             actionsMock = createActionsMock('openContentPanel', openContentPanelMock.object);
             interpreterMock = new MockInterpreter();
 
@@ -104,7 +104,7 @@ describe('ContentActionMessageCreator', () => {
             },
         };
 
-        const closeContentPanelMock = createSyncActionMock<void>(undefined);
+        const closeContentPanelMock = createAsyncActionMock<void>(undefined);
         actionsMock = createActionsMock('closeContentPanel', closeContentPanelMock.object);
 
         testSubject = new ContentActionCreator(

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -17,14 +17,14 @@ import {
     TelemetryEventSource,
     TriggeredBy,
 } from 'common/extension-telemetry-events';
-import { SyncAction } from 'common/flux/sync-action';
+import { AsyncAction } from 'common/flux/async-action';
 import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { DetailsViewRightContentPanelType } from 'common/types/store-data/details-view-right-content-panel-type';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import { createSyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('DetailsViewActionCreatorTest', () => {
     let detailsViewControllerMock: IMock<ExtensionDetailsViewController>;
@@ -52,7 +52,7 @@ describe('DetailsViewActionCreatorTest', () => {
             MockBehavior.Strict,
         );
 
-        let openSidePanelMock: IMock<SyncAction<SidePanel>>;
+        let openSidePanelMock: IMock<AsyncAction<SidePanel>>;
         let sidePanelActionsMock: IMock<SidePanelActions>;
 
         describe.each`
@@ -62,7 +62,7 @@ describe('DetailsViewActionCreatorTest', () => {
             ${'Messages.Scoping.OpenPanel'}         | ${Messages.Scoping.OpenPanel}         | ${'Scoping'}         | ${SCOPING_OPEN}
         `('$messageFriendlyName', ({ actualMessage, sidePanel, telemetryEventName }) => {
             beforeEach(() => {
-                openSidePanelMock = createSyncActionMock<SidePanel>(sidePanel);
+                openSidePanelMock = createAsyncActionMock<SidePanel>(sidePanel);
                 sidePanelActionsMock = createSidePanelActionsMock(
                     'openSidePanel',
                     openSidePanelMock.object,
@@ -136,7 +136,7 @@ describe('DetailsViewActionCreatorTest', () => {
             ${'Messages.PreviewFeatures.ClosePanel'} | ${Messages.PreviewFeatures.ClosePanel} | ${'PreviewFeatures'} | ${PREVIEW_FEATURES_CLOSE}
             ${'Messages.Scoping.ClosePanel'}         | ${Messages.Scoping.ClosePanel}         | ${'Scoping'}         | ${SCOPING_CLOSE}
         `('$messageFriendlyName', async ({ actualMessage, sidePanel, telemetryEventName }) => {
-            const closeSidePanelMock = createSyncActionMock<SidePanel>(sidePanel);
+            const closeSidePanelMock = createAsyncActionMock<SidePanel>(sidePanel);
 
             const sidePanelActionsMock = createSidePanelActionsMock(
                 'closeSidePanel',
@@ -166,7 +166,7 @@ describe('DetailsViewActionCreatorTest', () => {
     it('handles Visualization.DetailsView.SetDetailsViewRightContentPanel message', async () => {
         const payload: DetailsViewRightContentPanelType = 'Overview';
 
-        const setSelectedDetailsViewRightContentPanelMock = createSyncActionMock(payload);
+        const setSelectedDetailsViewRightContentPanelMock = createAsyncActionMock(payload);
         const detailsViewActionsMock = createDetailsViewActionsMock(
             'setSelectedDetailsViewRightContentPanel',
             setSelectedDetailsViewRightContentPanelMock.object,
@@ -191,7 +191,7 @@ describe('DetailsViewActionCreatorTest', () => {
     });
 
     it('handles Visualization.DetailsView.GetState message', async () => {
-        const getCurrentStateMock = createSyncActionMock<void>(null);
+        const getCurrentStateMock = createAsyncActionMock<void>(null);
         const detailsViewActionsMock = createDetailsViewActionsMock(
             'getCurrentState',
             getCurrentStateMock.object,


### PR DESCRIPTION
#### Details

Reverts #5882

##### Motivation

Feature work - reverting these actions back to async because they call PersistentStore's emitChanged(), which we realized will need to be async regardless of whether any async listeners are registered to the store.

##### Context

See above

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
