### PR TITLE
feat(adhoc-tools-accessible-names): display accessible names of native elements

### DIFF
--- a/src/ad-hoc-visualizations/accessible-names/visualization.tsx
+++ b/src/ad-hoc-visualizations/accessible-names/visualization.tsx
@@ -34,7 +34,7 @@ export const AccessibleNamesAdHocVisualization: VisualizationConfiguration = {
     getTestStatus: data => data.enabled,
     shouldShowExportReport: () => false,
     displayableData: {
-        title: 'Accessible Names',
+        title: 'Accessible names',
         enableMessage: 'Calculating accessible names...',
         toggleLabel: 'Show accessible names',
         linkToDetailsViewText: 'How to test accessible names',

--- a/src/scanner/custom-rules/display-accessible-names.ts
+++ b/src/scanner/custom-rules/display-accessible-names.ts
@@ -15,8 +15,9 @@ export const accessibleNamesConfiguration: RuleConfiguration = {
     ],
     rule: {
         id: accessibleNamesCheckId,
+        //this list of roles and elements was derived from the ARIA 1.2 documentation (Roles supporting name from author or content): https://www.w3.org/TR/wai-aria-1.2/#namefromauthor
         selector:
-            '[role=alert], [role=alertdialog], [role=application], [role=article], [role=banner], [role=blockquote], [role=button], [role=cell], [role=checkbox], [role=columnheader], [role=combobox], [role=command], [role=complementary], [role=composite], [role=contentinfo], [role=definition], [role=dialog], [role=directory],[role=document], [role=feed], [role=figure], figure, [role=form], form,[role=grid], table, [role=gridcell], td, [role=group], fieldset, [role=heading], h1,h2, h3, h4, h5, h6, [role=img],img,[role=input], [role=landmark], [role=link], a, link, [role=list], ol, ul, [role=listbox], [role=listitem], li, [role=log], [role=main], [role=marquee],[role=math], [role=meter], meter, [role=menu], [role=menubar], [role=menuitem], [role=menuitemcheckbox], [role=menuitemradio], [role=navigation], nav, [role=note], [role=option], option, [role=progressbar], [role=radio], [role=radiogroup], [role=range], [role=region], section, [role=row], tr, [role=rowgroup], tbody, tfoot, thead, [role=rowheader], th[scope="row"], [role=scrollbar], [role=searchbox], input[type="search"], [role=search], [role=select], [role=sectionhead], [role=separator], hr, [role=slider], [role=status], [role=spinbutton, [role=switch], [role=tab], [role=table], [role=tablelist], [role=tabpanel], [role=term], dfn, td, [role=textbox], textarea, input[type="text"], th[scope="col"], [role=time], time, [role=timer], [role=toolbar], [role=tooltip], [role=tree], [role=treegrid], [role=treeitem], input,[role=input],[role=window]',
+            '[role=alert], [role=alertdialog], [role=application], [role=article], article, [role=banner], [role=blockquote], blockquote, [role=button], button, [role=cell], [role=checkbox], [role=columnheader], [role=combobox], [role=command], [role=complementary], [role=composite], [role=contentinfo], [role=definition], [role=dialog], [role=directory],[role=document], [role=feed], [role=figure], figure, [role=form], form,[role=grid], table, [role=gridcell], td, [role=group], fieldset, [role=heading], h1,h2, h3, h4, h5, h6, [role=img],img,[role=input], [role=landmark], [role=link], a, link, [role=list], ol, ul, [role=listbox], [role=listitem], li, [role=log], [role=main], [role=marquee],[role=math], [role=meter], meter, [role=menu], [role=menubar], [role=menuitem], [role=menuitemcheckbox], [role=menuitemradio], [role=navigation], nav, [role=note], [role=option], option, [role=progressbar], [role=radio], [role=radiogroup], [role=range], [role=region], section, [role=row], tr, [role=rowgroup], tbody, tfoot, thead, [role=rowheader], th[scope="row"], [role=scrollbar], [role=searchbox], [role=search], [role=select], select, [role=sectionhead], [role=separator], hr, [role=slider], [role=status], [role=spinbutton, [role=switch], [role=tab], [role=table], [role=tablelist], [role=tabpanel], [role=term], dfn, td, [role=textbox], textarea, th, [role=time], time, [role=timer], [role=toolbar], [role=tooltip], [role=tree], [role=treegrid], [role=treeitem], input,[role=input],[role=window]',
         enabled: false,
         any: [accessibleNamesCheckId],
         matches: hasAccessibleName,
@@ -24,6 +25,7 @@ export const accessibleNamesConfiguration: RuleConfiguration = {
 };
 
 function hasAccessibleName(node: HTMLElement): boolean {
+    // this list of roles and elements were derived from the ARIA 1.2 docummentation (Roles which cannot be named): https://www.w3.org/TR/wai-aria-1.2/#namefromprohibited
     const nameProhibitedSelectors: string =
         'caption, figcaption, [role=caption], code, [role=code], del, [role=deletion], em, [role=emphasis],[role=generic], ins, [role=insertion], p, [role=paragraph], [role=presentation], [role=strong], strong, sub, sup, [role=subscript], [role=superscript], [role=none]';
     if (axe.utils.matchesSelector(node, nameProhibitedSelectors)) {
@@ -34,7 +36,7 @@ function hasAccessibleName(node: HTMLElement): boolean {
     }
     if (
         (node.tagName.toLowerCase() === 'div' || node.tagName.toLowerCase() === 'span') &&
-        node.getAttribute('role') === null
+        node.hasAttribute('role') === false
     ) {
         return false;
     }

--- a/src/scanner/custom-rules/display-accessible-names.ts
+++ b/src/scanner/custom-rules/display-accessible-names.ts
@@ -15,7 +15,7 @@ export const accessibleNamesConfiguration: RuleConfiguration = {
     ],
     rule: {
         id: accessibleNamesCheckId,
-        //this list of roles and elements was derived from the ARIA 1.2 documentation (Roles supporting name from author or content): https://www.w3.org/TR/wai-aria-1.2/#namefromauthor
+        //this list of roles and elements was derived from the ARIA 1.2 documentation (Section 5.2.8.4: Roles supporting name from author or content): https://www.w3.org/TR/wai-aria-1.2/#namefromauthor
         selector:
             '[role=alert], [role=alertdialog], [role=application], [role=article], article, [role=banner], [role=blockquote], blockquote, [role=button], button, [role=cell], [role=checkbox], [role=columnheader], [role=combobox], [role=command], [role=complementary], [role=composite], [role=contentinfo], [role=definition], [role=dialog], [role=directory],[role=document], [role=feed], [role=figure], figure, [role=form], form,[role=grid], table, [role=gridcell], td, [role=group], fieldset, [role=heading], h1,h2, h3, h4, h5, h6, [role=img],img,[role=input], [role=landmark], [role=link], a, link, [role=list], ol, ul, [role=listbox], [role=listitem], li, [role=log], [role=main], [role=marquee],[role=math], [role=meter], meter, [role=menu], [role=menubar], [role=menuitem], [role=menuitemcheckbox], [role=menuitemradio], [role=navigation], nav, [role=note], [role=option], option, [role=progressbar], [role=radio], [role=radiogroup], [role=range], [role=region], section, [role=row], tr, [role=rowgroup], tbody, tfoot, thead, [role=rowheader], th[scope="row"], [role=scrollbar], [role=searchbox], [role=search], [role=select], select, [role=sectionhead], [role=separator], hr, [role=slider], [role=status], [role=spinbutton, [role=switch], [role=tab], [role=table], [role=tablelist], [role=tabpanel], [role=term], dfn, td, [role=textbox], textarea, th, [role=time], time, [role=timer], [role=toolbar], [role=tooltip], [role=tree], [role=treegrid], [role=treeitem], input,[role=input],[role=window]',
         enabled: false,
@@ -25,19 +25,13 @@ export const accessibleNamesConfiguration: RuleConfiguration = {
 };
 
 function hasAccessibleName(node: HTMLElement): boolean {
-    // this list of roles and elements were derived from the ARIA 1.2 docummentation (Roles which cannot be named): https://www.w3.org/TR/wai-aria-1.2/#namefromprohibited
+    // this list of roles and elements were derived from the ARIA 1.2 documentation (Section 5.2.8.6: Roles which cannot be named): https://www.w3.org/TR/wai-aria-1.2/#namefromprohibited
     const nameProhibitedSelectors: string =
         'caption, figcaption, [role=caption], code, [role=code], del, [role=deletion], em, [role=emphasis],[role=generic], ins, [role=insertion], p, [role=paragraph], [role=presentation], [role=strong], strong, sub, sup, [role=subscript], [role=superscript], [role=none]';
     if (axe.utils.matchesSelector(node, nameProhibitedSelectors)) {
         return false;
     }
     if (AxeUtils.getAccessibleText(node) === '') {
-        return false;
-    }
-    if (
-        (node.tagName.toLowerCase() === 'div' || node.tagName.toLowerCase() === 'span') &&
-        node.hasAttribute('role') === false
-    ) {
         return false;
     }
     return true;

--- a/src/scanner/custom-rules/display-accessible-names.ts
+++ b/src/scanner/custom-rules/display-accessible-names.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import axe from 'axe-core';
 import * as AxeUtils from '../axe-utils';
 import { RuleConfiguration } from '../iruleresults';
 
@@ -14,55 +15,30 @@ export const accessibleNamesConfiguration: RuleConfiguration = {
     ],
     rule: {
         id: accessibleNamesCheckId,
-        selector: createSelector(),
+        selector:
+            '[role=alert], [role=alertdialog], [role=application], [role=article], [role=banner], [role=blockquote], [role=button], [role=cell], [role=checkbox], [role=columnheader], [role=combobox], [role=command], [role=complementary], [role=composite], [role=contentinfo], [role=definition], [role=dialog], [role=directory],[role=document], [role=feed], [role=figure], figure, [role=form], form,[role=grid], table, [role=gridcell], td, [role=group], fieldset, [role=heading], h1,h2, h3, h4, h5, h6, [role=img],img,[role=input], [role=landmark], [role=link], a, link, [role=list], ol, ul, [role=listbox], [role=listitem], li, [role=log], [role=main], [role=marquee],[role=math], [role=meter], meter, [role=menu], [role=menubar], [role=menuitem], [role=menuitemcheckbox], [role=menuitemradio], [role=navigation], nav, [role=note], [role=option], option, [role=progressbar], [role=radio], [role=radiogroup], [role=range], [role=region], section, [role=row], tr, [role=rowgroup], tbody, tfoot, thead, [role=rowheader], th[scope="row"], [role=scrollbar], [role=searchbox], input[type="search"], [role=search], [role=select], [role=sectionhead], [role=separator], hr, [role=slider], [role=status], [role=spinbutton, [role=switch], [role=tab], [role=table], [role=tablelist], [role=tabpanel], [role=term], dfn, td, [role=textbox], textarea, input[type="text"], th[scope="col"], [role=time], time, [role=timer], [role=toolbar], [role=tooltip], [role=tree], [role=treegrid], [role=treeitem], input,[role=input],[role=window]',
         enabled: false,
         any: [accessibleNamesCheckId],
+        matches: hasAccessibleName,
     },
 };
 
-function createSelector(): string {
-    const roles = [
-        'alertdialog',
-        'application',
-        'button',
-        'checkbox',
-        'columnheader',
-        'combobox',
-        'dialog',
-        'grid',
-        'heading',
-        'img',
-        'link',
-        'listbox',
-        'marquee',
-        'meter',
-        'menuitem',
-        'menuitemcheckbox',
-        'menuitemradio',
-        'option',
-        'progressbar',
-        'radio',
-        'radiogroup',
-        'region',
-        'rowheader',
-        'searchbox',
-        'slider',
-        'spinbutton',
-        'switch',
-        'table',
-        'tabpanel',
-        'textbox',
-        'tooltip',
-        'tree',
-        'treegrid',
-        'treeitem',
-    ];
-
-    const selectors: string[] = [];
-    roles.forEach((role: string) => {
-        selectors.push('[role=' + role + ']', role);
-    });
-    return selectors.join(',');
+function hasAccessibleName(node: HTMLElement): boolean {
+    const nameProhibitedSelectors: string =
+        'caption, figcaption, [role=caption], code, [role=code], del, [role=deletion], em, [role=emphasis],[role=generic], ins, [role=insertion], p, [role=paragraph], [role=presentation], [role=strong], strong, sub, sup, [role=subscript], [role=superscript], [role=none]';
+    if (axe.utils.matchesSelector(node, nameProhibitedSelectors)) {
+        return false;
+    }
+    if (AxeUtils.getAccessibleText(node) === '') {
+        return false;
+    }
+    if (
+        (node.tagName.toLowerCase() === 'div' || node.tagName.toLowerCase() === 'span') &&
+        node.getAttribute('role') === null
+    ) {
+        return false;
+    }
+    return true;
 }
 
 function evaluateAccessibleNames(node: HTMLElement): boolean {

--- a/src/tests/end-to-end/test-resources/accessible-names/accessible-names.html
+++ b/src/tests/end-to-end/test-resources/accessible-names/accessible-names.html
@@ -1,0 +1,20 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Accessible names</title>
+    </head>
+
+    <body role="main">
+        <h1>Page heading</h1>
+        <div role="heading">Has role and should be highlighted</div>
+        <div>No role. Shouldn't be highlighted</div>
+        <button>Submit</button>
+        <p>This is just a paragraph. It should not have an Accessible name</p>
+        <h4 aria-hidden="true">Heading has empty accessible name</h4>
+    </body>
+</html>

--- a/src/tests/unit/tests/scanner/custom-rules/display-accessible-names.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/display-accessible-names.test.ts
@@ -48,20 +48,6 @@ describe('evaluateAccessibleNames', () => {
         expect(result).toBe(false);
     });
 
-    it('should not match because element does not have role attribute', () => {
-        document.body.innerHTML = `<div>Some text</div>`;
-        const node = document.querySelector(`div`);
-        const result = withAxeSetup(() => accessibleNamesConfiguration.rule.matches(node, null));
-        expect(result).toBe(false);
-    });
-
-    it('should not match because element does not have role attribute', () => {
-        document.body.innerHTML = `<span>Some text</span>`;
-        const node = document.querySelector(`span`);
-        const result = withAxeSetup(() => accessibleNamesConfiguration.rule.matches(node, null));
-        expect(result).toBe(false);
-    });
-
     it('should match because element has accessible name and accurate role', () => {
         document.body.innerHTML = `<div role="button" aria-labelled-by="click">Some text</div>`;
         const node = document.querySelector(`div`);

--- a/src/tests/unit/tests/scanner/custom-rules/display-accessible-names.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/display-accessible-names.test.ts
@@ -33,4 +33,39 @@ describe('evaluateAccessibleNames', () => {
         expect(checkResultData).toBe(true);
         dataSetterMock.verifyAll();
     });
+
+    it('should not match because element role is none', () => {
+        document.body.innerHTML = `<h1 role="none">heading</h1>`;
+        const node = document.querySelector(`h1`);
+        const result = withAxeSetup(() => accessibleNamesConfiguration.rule.matches(node, null));
+        expect(result).toBe(false);
+    });
+
+    it('should not match because hidden element accesible name is empty', () => {
+        document.body.innerHTML = `<button role="button" aria-hidden=true>Click this</button>`;
+        const node = document.querySelector(`button`);
+        const result = withAxeSetup(() => accessibleNamesConfiguration.rule.matches(node, null));
+        expect(result).toBe(false);
+    });
+
+    it('should not match because element does not have role attribute', () => {
+        document.body.innerHTML = `<div>Some text</div>`;
+        const node = document.querySelector(`div`);
+        const result = withAxeSetup(() => accessibleNamesConfiguration.rule.matches(node, null));
+        expect(result).toBe(false);
+    });
+
+    it('should not match because element does not have role attribute', () => {
+        document.body.innerHTML = `<span>Some text</span>`;
+        const node = document.querySelector(`span`);
+        const result = withAxeSetup(() => accessibleNamesConfiguration.rule.matches(node, null));
+        expect(result).toBe(false);
+    });
+
+    it('should match because element has accessible name and accurate role', () => {
+        document.body.innerHTML = `<div role="button" aria-labelled-by="click">Some text</div>`;
+        const node = document.querySelector(`div`);
+        const result = withAxeSetup(() => accessibleNamesConfiguration.rule.matches(node, null));
+        expect(result).toBe(true);
+    });
 });


### PR DESCRIPTION
#### Details
This PR modifies the list of elements or selectors whose accessible names can be shown on the target page.
<!-- Usually a sentence or two describing what the PR changes -->

##### Motivation
Feature request #4864 
<!-- This can be as simple as "addresses issue #123" -->

##### Context
This PR is in relation the new ad hoc tool feature that displays accessible names of different UI components. Rather than querying only elements with explicit roles that indicate whether or not those elements should have accessible names, this PR also handles the querying of native elements that require/ can have accessible names. It also handles the case of empty accessible names of elements, by not displaying such empty strings. A later PR will handle redirection to the right page when "How to test accessible names" link is clicked.
<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS

Image showing accessible names displayed on target page:
![snip1](https://user-images.githubusercontent.com/81589466/184248068-e62932df-cfcf-4ad9-aa70-3e764bd67696.png)

Image showing a situation where a div element has a role:
![divElmt](https://user-images.githubusercontent.com/81589466/184422092-8649e203-dc36-4a0d-8b0e-60727255fc27.png)

