### PR TITLE
feat(adhoc-tools-accessible-names): Add guidance link

### DIFF
--- a/src/ad-hoc-visualizations/accessible-names/visualization.tsx
+++ b/src/ad-hoc-visualizations/accessible-names/visualization.tsx
@@ -7,11 +7,13 @@ import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { AdHocTestkeys } from 'common/types/store-data/adhoc-test-keys';
 import { VisualizationType } from 'common/types/visualization-type';
 import { generateUID } from 'common/uid-generator';
+import { adhoc as content } from 'content/adhoc';
 import { RuleAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { ScannerUtils } from 'injected/scanner-utils';
 import { VisualizationInstanceProcessor } from 'injected/visualization-instance-processor';
 import { isEmpty } from 'lodash';
 
+const { guidance } = content.accessibleNames;
 const accessiblenamesTestKey = AdHocTestkeys.AccessibleNames;
 
 const accessibleNamesRuleAnalyzerConfiguration: RuleAnalyzerConfiguration = {
@@ -50,4 +52,5 @@ export const AccessibleNamesAdHocVisualization: VisualizationConfiguration = {
     getDrawer: provider => provider.createAccessibleNamesDrawer(),
     getSwitchToTargetTabOnScan: () => false,
     getInstanceIdentiferGenerator: () => generateUID,
+    guidance,
 };

--- a/src/content/adhoc/accessible-names/guidance.tsx
+++ b/src/content/adhoc/accessible-names/guidance.tsx
@@ -13,7 +13,7 @@ export const guidance = create(({ Markup, Link }) => (
             that use Assistive Technologies (AT) would have difficulty understanding the purpose of an element and interacting with it.
         </p>
         <p>
-            For more information about Accessible names and their computation, please check out <Link.accessileNameComputation />.
+            For more information about Accessible names and their computation, please check out <Link.accessibleNameComputation />.
         </p>
 
         <h2>About Accessible names visualization</h2>
@@ -27,16 +27,15 @@ export const guidance = create(({ Markup, Link }) => (
         <Markup.Columns>
             <Markup.Do>
                 <h3>
-                    If a widget has visible label, make sure they are programmatically related to it.{' '}
-                    <Link.WCAG21UnderstandingInfoAndRelationships /> <Link.WCAG21UnderstandingLabelInName />
+                    If a widget has visible label, make sure they are programmatically related to it. <Link.WCAG_1_3_1 />{' '}
+                    <Link.WCAG_2_5_3 />
                 </h3>
 
                 <ul>
                     <li>A widget's visible label should be included in its accessible name.</li>
                 </ul>
                 <h3>
-                    Use the widget's accessible name and/or accessible description to identify the expected input.{' '}
-                    <Link.WCAG21UnderstandingLabelsOrInstructions />
+                    Use the widget's accessible name and/or accessible description to identify the expected input. <Link.WCAG_3_3_2 />
                 </h3>
 
                 <ul>

--- a/src/content/adhoc/accessible-names/guidance.tsx
+++ b/src/content/adhoc/accessible-names/guidance.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { create, GuidanceTitle, React } from '../../common';
+
+export const guidance = create(({ Markup, Link }) => (
+    <React.Fragment>
+        <GuidanceTitle name={'Accessible names'} />
+
+        <h2>Why accessible names matter</h2>
+
+        <p>
+            The Accessible name is a short label that provides information about the purpose of a user interface element. Without it, people
+            that use Assistive Technologies (AT) would have difficulty understanding the purpose of an element and interacting with it.
+        </p>
+        <p>
+            For more information about Accessible names and their computation, please check out <Link.accessileNameComputation />.
+        </p>
+
+        <h2>About Accessible names visualization</h2>
+
+        <p>
+            The visualization in Accessibility Insights for Web enable developers to see accessibility markup that’s normally invisible. The{' '}
+            <Markup.Term>Accessible names</Markup.Term> visualization highlights elements that have accessible names and, when possible,
+            shows the accessible name. It does not highlight elements with empty, or no accessible names.
+        </p>
+
+        <Markup.Columns>
+            <Markup.Do>
+                <h3>
+                    If a widget has visible label, make sure they are programmatically related to it.{' '}
+                    <Link.WCAG21UnderstandingInfoAndRelationships /> <Link.WCAG21UnderstandingLabelInName />
+                </h3>
+
+                <ul>
+                    <li>A widget's visible label should be included in its accessible name.</li>
+                </ul>
+                <h3>
+                    Use the widget's accessible name and/or accessible description to identify the expected input.{' '}
+                    <Link.WCAG21UnderstandingLabelsOrInstructions />
+                </h3>
+
+                <ul>
+                    <li>
+                        For example, a button should indicate what action it will initiate. A text field should indicate what type of data
+                        is expected and whether a specific format is required.
+                    </li>
+                </ul>
+            </Markup.Do>
+        </Markup.Columns>
+    </React.Fragment>
+));

--- a/src/content/adhoc/accessible-names/guidance.tsx
+++ b/src/content/adhoc/accessible-names/guidance.tsx
@@ -6,7 +6,7 @@ export const guidance = create(({ Markup, Link }) => (
     <React.Fragment>
         <GuidanceTitle name={'Accessible names'} />
 
-        <h2>Why accessible names matter</h2>
+        <h2>Why Accessible names matter</h2>
 
         <p>
             The Accessible name is a short label that provides information about the purpose of a user interface element. Without it, people

--- a/src/content/adhoc/accessible-names/index.ts
+++ b/src/content/adhoc/accessible-names/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { guidance } from './guidance';
+
+export const accessibleNames = {
+    guidance,
+};

--- a/src/content/adhoc/index.ts
+++ b/src/content/adhoc/index.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { accessibleNames } from './accessible-names';
 import { color } from './color';
 import { headings } from './headings';
 import { landmarks } from './landmarks';
@@ -10,4 +11,5 @@ export const adhoc = {
     headings,
     landmarks,
     tabstops,
+    accessibleNames,
 };

--- a/src/content/link.tsx
+++ b/src/content/link.tsx
@@ -78,7 +78,7 @@ export const link = {
         'WAI-ARIA Authoring Practices 1.1: Landmark Regions',
         'https://www.w3.org/TR/wai-aria-practices-1.1/#aria_landmark',
     ),
-    accessileNameComputation: linkTo('ARIA 1.1 Important Terms Section', 'https://www.w3.org/TR/wai-aria/#terms'),
+    accessibleNameComputation: linkTo('ARIA 1.1 Important Terms Section', 'https://www.w3.org/TR/wai-aria/#terms'),
     Keyboard: linkTo('WebAIM: Keyboard Accessibility', 'https://aka.ms/webaim/keyboard-accessibility'),
     InteroperabilityWithAT: linkTo(
         'Section 508 - 502.2.2',
@@ -93,9 +93,6 @@ export const link = {
         'Understanding Success Criterion 1.4.1: Use of Color',
         'https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html',
     ),
-    WCAG21UnderstandingInfoAndRelationships: linkTo('WCAG 1.3.1', 'https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships'),
-    WCAG21UnderstandingLabelInName: linkTo('WCAG 2.5.3', 'https://www.w3.org/WAI/WCAG21/Understanding/label-in-name'),
-    WCAG21UnderstandingLabelsOrInstructions: linkTo('WCAG 3.3.2', 'https://www.w3.org/WAI/WCAG21/Understanding/label-in-name'),
     WCAG21UnderstandingAudioOnlyViewOnlyPrerecorded: linkTo(
         'Understanding Success Criterion 1.2.1: Audio-only and Video-only (Prerecorded)',
         'https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html',

--- a/src/content/link.tsx
+++ b/src/content/link.tsx
@@ -78,6 +78,7 @@ export const link = {
         'WAI-ARIA Authoring Practices 1.1: Landmark Regions',
         'https://www.w3.org/TR/wai-aria-practices-1.1/#aria_landmark',
     ),
+    accessileNameComputation: linkTo('ARIA 1.1 Important Terms Section', 'https://www.w3.org/TR/wai-aria/#terms'),
     Keyboard: linkTo('WebAIM: Keyboard Accessibility', 'https://aka.ms/webaim/keyboard-accessibility'),
     InteroperabilityWithAT: linkTo(
         'Section 508 - 502.2.2',
@@ -92,6 +93,9 @@ export const link = {
         'Understanding Success Criterion 1.4.1: Use of Color',
         'https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html',
     ),
+    WCAG21UnderstandingInfoAndRelationships: linkTo('WCAG 1.3.1', 'https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships'),
+    WCAG21UnderstandingLabelInName: linkTo('WCAG 2.5.3', 'https://www.w3.org/WAI/WCAG21/Understanding/label-in-name'),
+    WCAG21UnderstandingLabelsOrInstructions: linkTo('WCAG 3.3.2', 'https://www.w3.org/WAI/WCAG21/Understanding/label-in-name'),
     WCAG21UnderstandingAudioOnlyViewOnlyPrerecorded: linkTo(
         'Understanding Success Criterion 1.2.1: Audio-only and Video-only (Prerecorded)',
         'https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html',

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -1,5 +1,137 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Guidance Content pages adhoc/accessibleNames/guidance matches the snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        Accessible names
+      </h1>
+      <h2>
+        Why accessible names matter
+      </h2>
+      <p>
+        The Accessible name is a short label that provides information about the purpose of a user interface element. Without it, people that use Assistive Technologies (AT) would have difficulty understanding the purpose of an element and interacting with it.
+      </p>
+      <p>
+        For more information about Accessible names and their computation, please check out 
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/TR/wai-aria/#terms"
+          target="_blank"
+        >
+          ARIA 1.1 Important Terms Section
+        </a>
+        .
+      </p>
+      <h2>
+        About Accessible names visualization
+      </h2>
+      <p>
+        The visualization in Accessibility Insights for Web enable developers to see accessibility markup that’s normally invisible. The 
+        <strong>
+          Accessible names
+        </strong>
+         visualization highlights elements that have accessible names and, when possible, shows the accessible name. It does not highlight elements with empty, or no accessible names.
+      </p>
+      <div
+        class="columns"
+      >
+        <div
+          class="column"
+        >
+          <div
+            class="do-header"
+          >
+            <h2>
+              Do
+            </h2>
+            <span
+              class="check-container"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="var(--neutral-0)"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="do-section"
+          >
+            <h3>
+              If a widget has visible label, make sure they are programmatically related to it. 
+              <a
+                class="ms-Link insights-link root-000"
+                href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                target="_blank"
+              >
+                WCAG 1.3.1
+              </a>
+               
+              <a
+                class="ms-Link insights-link root-000"
+                href="https://www.w3.org/WAI/WCAG21/Understanding/label-in-name"
+                target="_blank"
+              >
+                WCAG 2.5.3
+              </a>
+            </h3>
+            <ul>
+              <li>
+                A widget's visible label should be included in its accessible name.
+              </li>
+            </ul>
+            <h3>
+              Use the widget's accessible name and/or accessible description to identify the expected input. 
+              <a
+                class="ms-Link insights-link root-000"
+                href="https://www.w3.org/WAI/WCAG21/Understanding/label-in-name"
+                target="_blank"
+              >
+                WCAG 3.3.2
+              </a>
+            </h3>
+            <ul>
+              <li>
+                For example, a button should indicate what action it will initiate. A text field should indicate what type of data is expected and whether a specific format is required.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Guidance Content pages adhoc/color/guidance matches the snapshot 1`] = `
 <DocumentFragment>
   <div

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -15,7 +15,7 @@ exports[`Guidance Content pages adhoc/accessibleNames/guidance matches the snaps
         Accessible names
       </h1>
       <h2>
-        Why accessible names matter
+        Why Accessible names matter
       </h2>
       <p>
         The Accessible name is a short label that provides information about the purpose of a user interface element. Without it, people that use Assistive Technologies (AT) would have difficulty understanding the purpose of an element and interacting with it.
@@ -110,7 +110,7 @@ exports[`Guidance Content pages adhoc/accessibleNames/guidance matches the snaps
               Use the widget's accessible name and/or accessible description to identify the expected input. 
               <a
                 class="ms-Link insights-link root-000"
-                href="https://www.w3.org/WAI/WCAG21/Understanding/label-in-name"
+                href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html"
                 target="_blank"
               >
                 WCAG 3.3.2


### PR DESCRIPTION
#### Details
This PR adds the correct link, to which a user is directed to when the "How to test Accessible names" link is clicked.
<!-- Usually a sentence or two describing what the PR changes -->

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Feature request #4864 
##### Context
When the "How to test accessible names" link is clicked, the user is redirected to a new page that has some content on why accessible names are important.
<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
![accNameGuide](https://user-images.githubusercontent.com/81589466/184687097-4cb39e93-ec01-4628-aa3e-142ce2dc844d.png)

