### PR TITLE
fix: let tab stops run if frame messaging fails

### DIFF
--- a/src/common/self-fast-pass.ts
+++ b/src/common/self-fast-pass.ts
@@ -78,7 +78,7 @@ class SelfFastPassAnalyzer implements Analyzer {
 
 class SelfFastPassAnalyzerProvider extends AnalyzerProvider {
     constructor(private readonly deps: SelfFastPassAnalyzerDeps) {
-        super(null, null, null, null, null, null, null, null, null, null, null, null, null);
+        super(null, null, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     public override createRuleAnalyzerUnifiedScanForNeedsReview(

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Logger } from 'common/logging/logger';
+import { PromiseFactory } from 'common/promises/promise-factory';
 import { TabStopEvent } from 'common/types/store-data/tab-stop-event';
 import { AllFrameRunner } from 'injected/all-frame-runner';
 import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
@@ -36,6 +37,7 @@ export class AnalyzerProvider {
         private readonly sendNeedsReviewResults: PostResolveCallback,
         private readonly scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
         private readonly logger: Logger,
+        private readonly promiseFactory: PromiseFactory,
     ) {
         this.tabStopsListener = tabStopsListener;
         this.scopingStore = scopingStore;
@@ -114,6 +116,7 @@ export class AnalyzerProvider {
             this.logger,
             this.tabStopsDoneAnalyzingTracker,
             null,
+            this.promiseFactory,
         );
     }
 
@@ -126,6 +129,7 @@ export class AnalyzerProvider {
             this.logger,
             this.tabStopsDoneAnalyzingTracker,
             this.tabStopsRequirementResultProcessor,
+            this.promiseFactory,
         );
     }
 

--- a/src/injected/analyzers/base-analyzer.ts
+++ b/src/injected/analyzers/base-analyzer.ts
@@ -26,7 +26,7 @@ export class BaseAnalyzer implements Analyzer {
 
     public analyze(): void {
         const results = this.getResults();
-        results.then(this.onResolve).catch(this.logger.error);
+        results.then(this.onResolve).catch(e => this.logger.error(e));
     }
 
     public teardown(): void {}

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -40,11 +40,17 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
             this.pendingTabbedElements.push(tabEvent);
             this.debouncedProcessTabEvents();
         };
-        await this.tabStopListenerRunner.start();
+
+        // Floating the promises from these two start() commands is a temporary patch
+        // for an issue where tab stops hangs if either call throws a timeout exception.
+        // Adding a try/catch would still cause the extension to hang for the 30-second
+        // frame messaging timeout.
+        // For more info, see https://github.com/microsoft/accessibility-insights-web/issues/5931
+        void this.tabStopListenerRunner.start();
 
         this.tabStopsDoneAnalyzingTracker.reset();
         if (this.tabStopsRequirementResultProcessor) {
-            await this.tabStopsRequirementResultProcessor.start();
+            void this.tabStopsRequirementResultProcessor.start();
         }
 
         return this.emptyResults;

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Logger } from 'common/logging/logger';
+import { PromiseFactory, TimeoutError } from 'common/promises/promise-factory';
 import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
 import { TabStopEvent } from 'common/types/store-data/tab-stop-event';
 import { AllFrameRunner } from 'injected/all-frame-runner';
@@ -19,6 +20,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
     private debouncedProcessTabEvents: DebouncedFunc<() => void> | null = null;
     private pendingTabbedElements: TabStopEvent[] = [];
     protected config: FocusAnalyzerConfiguration;
+    private startTimeoutMilliseconds = 500;
 
     constructor(
         config: FocusAnalyzerConfiguration,
@@ -28,6 +30,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         logger: Logger,
         private readonly tabStopsDoneAnalyzingTracker: TabStopsDoneAnalyzingTracker,
         private readonly tabStopsRequirementResultProcessor: TabStopsRequirementResultProcessor,
+        private readonly promiseFactory: PromiseFactory,
         private readonly debounceImpl: typeof debounce = debounce,
     ) {
         super(config, sendMessageDelegate, scanIncompleteWarningDetector, logger);
@@ -41,20 +44,44 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
             this.debouncedProcessTabEvents();
         };
 
-        // Floating the promises from these two start() commands is a temporary patch
-        // for an issue where tab stops hangs if either call throws a timeout exception.
-        // Adding a try/catch would still cause the extension to hang for the 30-second
-        // frame messaging timeout.
-        // For more info, see https://github.com/microsoft/accessibility-insights-web/issues/5931
-        void this.tabStopListenerRunner.start();
+        await this.runWithIgnoredTimeout(
+            this.tabStopListenerRunner.start(),
+            this.startTimeoutMilliseconds,
+            'start tabStopListenerRunner',
+        );
 
         this.tabStopsDoneAnalyzingTracker.reset();
         if (this.tabStopsRequirementResultProcessor) {
-            void this.tabStopsRequirementResultProcessor.start();
+            await this.runWithIgnoredTimeout(
+                this.tabStopsRequirementResultProcessor.start(),
+                this.startTimeoutMilliseconds,
+                'start tabStopsRequirementResultProcessor',
+            );
         }
 
         return this.emptyResults;
     };
+
+    private async runWithIgnoredTimeout(
+        promise: Promise<void>,
+        maxWaitTime: number,
+        taskDescription: string,
+    ): Promise<void> {
+        try {
+            // Try to wait for the promise to complete, but allow execution to continue if
+            // it times out. This is a temporary workaround in case frame messaging fails.
+            // For more info, see https://github.com/microsoft/accessibility-insights-web/issues/5931
+            await this.promiseFactory.timeout(promise, maxWaitTime);
+        } catch (e) {
+            if (e instanceof TimeoutError) {
+                this.logger.error(
+                    `Timeout of ${maxWaitTime} ms exceeded while attempting to ${taskDescription}. Tab stops analyzer will attempt to continue.`,
+                );
+            } else {
+                throw e;
+            }
+        }
+    }
 
     private processTabEvents = (): void => {
         this.tabStopsDoneAnalyzingTracker.addTabStopEvents(this.pendingTabbedElements);

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -6,6 +6,7 @@ import { EnumHelper } from 'common/enum-helper';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unavailable';
 import { Logger } from 'common/logging/logger';
+import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
 import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
@@ -313,6 +314,8 @@ export class MainWindowInitializer extends WindowInitializer {
             this.visualizationScanResultStoreProxy,
         );
 
+        const promiseFactory = createDefaultPromiseFactory();
+
         const analyzerProvider = new AnalyzerProvider(
             this.manualTabStopListener,
             tabStopsDoneAnalyzingTracker,
@@ -327,6 +330,7 @@ export class MainWindowInitializer extends WindowInitializer {
             unifiedResultSender.sendNeedsReviewResults,
             scanIncompleteWarningDetector,
             logger,
+            promiseFactory,
         );
 
         const analyzerStateUpdateHandler = new AnalyzerStateUpdateHandler(

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScopingStore } from 'background/stores/global/scoping-store';
+import { PromiseFactory } from 'common/promises/promise-factory';
 import { TabStopEvent } from 'common/types/store-data/tab-stop-event';
 import { AllFrameRunner } from 'injected/all-frame-runner';
 import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
@@ -41,6 +42,7 @@ describe('AnalyzerProviderTests', () => {
     let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
     let tabStopsDoneAnalyzingTrackerMock: IMock<TabStopsDoneAnalyzingTracker>;
     let tabStopsRequirementResultProcessorMock: IMock<TabStopsRequirementResultProcessor>;
+    const promiseFactoryStub = {} as PromiseFactory;
 
     beforeEach(() => {
         typeStub = -1;
@@ -74,6 +76,7 @@ describe('AnalyzerProviderTests', () => {
             sendNeedsReviewResultsMock.object,
             scanIncompleteWarningDetectorMock.object,
             failTestOnErrorLogger,
+            promiseFactoryStub,
         );
     });
 


### PR DESCRIPTION
#### Details

Add a timeout for two method calls that send frame commands for tab stops listener, and continue execution if a timeout is thrown.

##### Motivation

Patch for #5931

##### Context

This is a compromise between the two possible patches mentioned in #5931. We wait 500ms per call in the hopes that the frame message completes in that time, but if it doesn't, we continue execution instead of waiting for the full 30 second frame messaging timeout. Ideally, however, we would be able to tell before messaging the frame whether we expect to get a response.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5931
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
