### PR TITLE
fix: improve e2e tests by waiting for failed instances count in tab stops test

### DIFF
--- a/src/tests/end-to-end/tests/details-view/automated-tabstops.test.ts
+++ b/src/tests/end-to-end/tests/details-view/automated-tabstops.test.ts
@@ -55,6 +55,7 @@ describe('Automated TabStops Results', () => {
 
             await detailsViewPage.waitForSelector(tabStopsSelectors.automatedChecksResultSection);
             await detailsViewPage.clickSelector(tabStopsSelectors.failedInstancesExpandButton);
+            await detailsViewPage.waitForSelector(tabStopsSelectors.failedInstancesContent);
 
             const ruleDetails = await detailsViewPage.getSelectorElements(
                 tabStopsSelectors.failedInstancesContent,
@@ -76,6 +77,7 @@ describe('Automated TabStops Results', () => {
 
             await detailsViewPage.waitForSelector(tabStopsSelectors.automatedChecksResultSection);
             await detailsViewPage.clickSelector(tabStopsSelectors.failedInstancesExpandButton);
+            await detailsViewPage.waitForSelector(tabStopsSelectors.failedInstancesContent);
 
             const ruleDetails = await detailsViewPage.getSelectorElements(
                 tabStopsSelectors.failedInstancesContent,
@@ -104,6 +106,7 @@ describe('Automated TabStops Results', () => {
 
             await detailsViewPage.waitForSelector(tabStopsSelectors.automatedChecksResultSection);
             await detailsViewPage.clickSelector(tabStopsSelectors.failedInstancesExpandButton);
+            await detailsViewPage.waitForSelector(tabStopsSelectors.failedInstancesContent);
 
             const ruleDetails = await detailsViewPage.getSelectorElements(
                 tabStopsSelectors.failedInstancesContent,


### PR DESCRIPTION
#### Details

Fixes some transient issues in e2e tests.

##### Motivation

Improves e2e tests

##### Context

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
