### PR TITLE
chore: add waitForSelector in color-contrast e2e

### DIFF
--- a/src/tests/end-to-end/tests/details-view/color-contrast.test.ts
+++ b/src/tests/end-to-end/tests/details-view/color-contrast.test.ts
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { formatPageElementForSnapshot } from 'tests/common/element-snapshot-formatter';
-import {
-    detailsViewSelectors,
-    fastPassAutomatedChecksSelectors,
-} from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
+import { fastPassAutomatedChecksSelectors } from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
 import { DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS } from 'tests/end-to-end/common/timeouts';
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
@@ -39,9 +36,6 @@ describe('Color Contrast Violations', () => {
         await browser.newPopupPage(targetPage);
         const detailsViewPage = await browser.newDetailsViewPage(targetPage);
         await detailsViewPage.clickSelector(fastPassAutomatedChecksSelectors.startOverButton);
-        await detailsViewPage.waitForSelector(detailsViewSelectors.automatedChecksResultSection, {
-            timeout: DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
-        });
         await detailsViewPage.waitForSelector(fastPassAutomatedChecksSelectors.ruleDetail, {
             timeout: DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
         });

--- a/src/tests/end-to-end/tests/details-view/color-contrast.test.ts
+++ b/src/tests/end-to-end/tests/details-view/color-contrast.test.ts
@@ -42,6 +42,9 @@ describe('Color Contrast Violations', () => {
         await detailsViewPage.waitForSelector(detailsViewSelectors.automatedChecksResultSection, {
             timeout: DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
         });
+        await detailsViewPage.waitForSelector(fastPassAutomatedChecksSelectors.ruleDetail, {
+            timeout: DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
+        });
 
         const ruleDetails = await detailsViewPage.getSelectorElements(
             fastPassAutomatedChecksSelectors.ruleDetail,


### PR DESCRIPTION
#### Details

I noticed some flakiness with the color-contrast `e2e-web-tests (2/2)` in a few open pull requests, examples:

- https://github.com/microsoft/accessibility-insights-web/runs/7925646083?check_suite_focus=true
- https://github.com/microsoft/accessibility-insights-web/runs/7923564837?check_suite_focus=true
- https://github.com/microsoft/accessibility-insights-web/runs/7953552098?check_suite_focus=true

By adding `waitForSelector`, we can make sure the data appears in time for the tests.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

Reduce test flakiness.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
