### PR TITLE
fix(mv3-part6): Clear old visualizations before rerunning axe scan

### DIFF
--- a/src/injected/analyzer-controller.ts
+++ b/src/injected/analyzer-controller.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { ShadowInitializer } from 'injected/shadow-initializer';
 import { BaseStore } from '../common/base-store';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { EnumHelper } from '../common/enum-helper';
@@ -31,6 +32,7 @@ export class AnalyzerController {
         analyzerProvider: AnalyzerProvider,
         analyzerStateUpdateHandler: AnalyzerStateUpdateHandler,
         assessmentsProvider: AssessmentsProvider,
+        private readonly shadowInitializer: ShadowInitializer,
     ) {
         this.analyzers = {};
         this.visualizationstore = visualizationstore;
@@ -65,8 +67,12 @@ export class AnalyzerController {
     };
 
     protected startScan = (id: string): void => {
+        this.shadowInitializer.removeExistingShadowHost();
+
         const analyzer = this.getAnalyzerByIdentifier(id);
         analyzer.analyze();
+
+        this.shadowInitializer.initialize();
     };
 
     private initializeAnalyzers(): void {

--- a/src/injected/analyzer-controller.ts
+++ b/src/injected/analyzer-controller.ts
@@ -72,7 +72,7 @@ export class AnalyzerController {
         const analyzer = this.getAnalyzerByIdentifier(id);
         analyzer.analyze();
 
-        this.shadowInitializer.initialize();
+        void this.shadowInitializer.initialize();
     };
 
     private initializeAnalyzers(): void {

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -344,6 +344,7 @@ export class MainWindowInitializer extends WindowInitializer {
             analyzerProvider,
             analyzerStateUpdateHandler,
             Assessments,
+            this.shadowInitializer,
         );
 
         this.analyzerController.listenToStore();

--- a/src/injected/shadow-initializer.ts
+++ b/src/injected/shadow-initializer.ts
@@ -46,7 +46,7 @@ export class ShadowInitializer {
         return shadowHostElement;
     }
 
-    private removeExistingShadowHost(): void {
+    public removeExistingShadowHost(): void {
         this.htmlElementUtils.deleteAllElements('#insights-shadow-host');
     }
 

--- a/src/tests/end-to-end/tests/details-view/color-contrast.test.ts
+++ b/src/tests/end-to-end/tests/details-view/color-contrast.test.ts
@@ -5,7 +5,10 @@ import {
     detailsViewSelectors,
     fastPassAutomatedChecksSelectors,
 } from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
-import { DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS } from 'tests/end-to-end/common/timeouts';
+import {
+    DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS,
+    DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
+} from 'tests/end-to-end/common/timeouts';
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
 import { TargetPage } from '../../common/page-controllers/target-page';
@@ -41,6 +44,10 @@ describe('Color Contrast Violations', () => {
         await detailsViewPage.clickSelector(fastPassAutomatedChecksSelectors.startOverButton);
         await detailsViewPage.waitForSelector(detailsViewSelectors.automatedChecksResultSection, {
             timeout: DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
+        });
+
+        await detailsViewPage.waitForSelector(fastPassAutomatedChecksSelectors.ruleDetail, {
+            timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS,
         });
 
         const ruleDetails = await detailsViewPage.getSelectorElements(

--- a/src/tests/unit/tests/injected/analyzer-controller.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-controller.test.ts
@@ -5,6 +5,7 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { ScopingStore } from 'background/stores/global/scoping-store';
 import { VisualizationStore } from 'background/stores/visualization-store';
+import { ShadowInitializer } from 'injected/shadow-initializer';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { BaseStore } from '../../../../common/base-store';
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
@@ -45,6 +46,7 @@ describe('AnalyzerControllerTests', () => {
     let analyzerMock: IMock<Analyzer>;
     let analyzerStateUpdateHandlerStrictMock: IMock<AnalyzerStateUpdateHandler>;
     let assessmentsMock: IMock<AssessmentsProvider>;
+    let shadowInitializerMock: IMock<ShadowInitializer>;
     let testObject: AnalyzerController;
     let teardown: (id: string) => void;
     let startScan: (id: string) => void;
@@ -71,6 +73,7 @@ describe('AnalyzerControllerTests', () => {
         visualizationStoreMock = Mock.ofType<VisualizationStore>();
         featureFlagStoreStoreMock = Mock.ofType<FeatureFlagStore>();
         scopingStoreMock = Mock.ofType<ScopingStore>(ScopingStore);
+        shadowInitializerMock = Mock.ofType<ShadowInitializer>();
 
         visualizationStoreMock.setup(sm => sm.getState()).returns(() => visualizationStoreState);
 
@@ -114,6 +117,7 @@ describe('AnalyzerControllerTests', () => {
             analyzerProviderStrictMock.object,
             analyzerStateUpdateHandlerStrictMock.object,
             assessmentsMock.object,
+            shadowInitializerMock.object,
         );
     });
 
@@ -122,6 +126,7 @@ describe('AnalyzerControllerTests', () => {
         featureFlagStoreStoreMock.verifyAll();
         scopingStoreMock.verifyAll();
         analyzerProviderStrictMock.verifyAll();
+        shadowInitializerMock.verifyAll();
         featureFlagStoreState = {};
     });
 
@@ -176,6 +181,9 @@ describe('AnalyzerControllerTests', () => {
         getAnalyzerMock.reset();
         setupAnalyzeCall();
         setupGetAnalyzerMockNeverCalled();
+
+        shadowInitializerMock.setup(m => m.removeExistingShadowHost()).verifiable(Times.once());
+        shadowInitializerMock.setup(m => m.initialize()).verifiable(Times.once());
 
         startScan(identifier);
 


### PR DESCRIPTION
#### Details

Addressing color-contrast e2e test flakiness as well as color contrast bug. Repro steps for bug before this change:

1. Open poor-color-contrast.html test resource
2. Run fastpass, see 1 color contrast requirement failed
3. Close details view (do not refresh target page)
4. Re-open details view and re-run fastpass
5. See no failures where there should be 1 color contrast requirement

##### Motivation

Bug fix

##### Context

@pownkel noticed that this bug was [introduced when updating to axe-core 4.4.1](https://github.com/microsoft/accessibility-insights-web/commit/79ff4e19e6a50daa49b60bf3879cbc17fead9267), so we suspect that it has something to do with the color-contrast/ bgOverlap changes they made in that release. It appears that when we run fastpass on the page multiple times we get different axe results because axe thinks our visualizations are overlapping with the page elements and it gets confused. This PR works around that issue by explicitly clearing our visualizations before re-running axe on the target page.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
