### PR TITLE
chore: Bump Ubuntu version from 18.04 to 20.04

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -14,7 +14,7 @@ trigger:
 variables:
     windowsImage: 'windows-2019'
     macImage: 'macOS-11'
-    linuxImage: 'ubuntu-18.04'
+    linuxImage: 'ubuntu-20.04'
 
 jobs:
     - job: 'unit_tests_and_lints'

--- a/pipeline/build-all-job-per-environment.yaml
+++ b/pipeline/build-all-job-per-environment.yaml
@@ -4,7 +4,7 @@ parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2019'
     macImage: 'macOS-11'
-    linuxImage: 'ubuntu-18.04'
+    linuxImage: 'ubuntu-20.04'
 
 jobs:
     - job: 'build_all_windows${{ parameters.jobNameSuffix }}'

--- a/pipeline/build-package.template.yaml
+++ b/pipeline/build-package.template.yaml
@@ -8,7 +8,7 @@ jobs:
     - job: 'build_and_publish_package'
 
       pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-20.04'
 
       steps:
           - template: install-node-prerequisites.yaml

--- a/pipeline/e2e-job-per-environment.yaml
+++ b/pipeline/e2e-job-per-environment.yaml
@@ -5,7 +5,7 @@ parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2019'
     macImage: 'macOS-11'
-    linuxImage: 'ubuntu-18.04'
+    linuxImage: 'ubuntu-20.04'
 
 jobs:
     - job: 'e2e_tests_windows${{ parameters.jobNameSuffix }}'

--- a/pipeline/unified/build-unsigned-release-packages.yaml
+++ b/pipeline/unified/build-unsigned-release-packages.yaml
@@ -11,7 +11,7 @@ strategy:
     matrix:
         windows: { vmImage: 'windows-latest', platform: 'windows' }
         mac: { vmImage: 'macOS-11', platform: 'mac' }
-        linux: { vmImage: 'ubuntu-18.04', platform: 'linux' }
+        linux: { vmImage: 'ubuntu-20.04', platform: 'linux' }
 
 pool:
     vmImage: $(vmImage)

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -8,7 +8,7 @@ parameters:
 jobs:
     - job: ${{ parameters.signedArtifactName }}
       pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-20.04'
       steps:
           - template: ../../install-node-prerequisites.yaml
 

--- a/pipeline/unified/unified-e2e-job-per-environment.yaml
+++ b/pipeline/unified/unified-e2e-job-per-environment.yaml
@@ -5,7 +5,7 @@ parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2019'
     macImage: 'macOS-11'
-    linuxImage: 'ubuntu-18.04'
+    linuxImage: 'ubuntu-20.04'
 
 jobs:
     - job: 'electron_e2e_tests_windows${{ parameters.jobNameSuffix }}'


### PR DESCRIPTION
#### Details

Recent CI builds have been producing the following warning for each of the 5 linux-hosted steps:

```
##[warning]The ubuntu-18.04 environment is deprecated, consider switching to
ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see
https://github.com/actions/virtual-environments/issues/6002
```

This PR simply updates the ubuntu version in the `yaml` files. Validation build is [here](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=39524&view=results)

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Build environment is deprecating support for ubuntu 18.04.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
