### PR TITLE
fix(mv3-part6): Register exception telemetry listener event handlers synchronously

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -125,7 +125,8 @@ async function initialize(): Promise<void> {
 
     const usageLogger = new UsageLogger(browserAdapter, DateProvider.getCurrentDate, logger);
 
-    const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
+    const telemetryEventHandler = new TelemetryEventHandler();
+    telemetryEventHandler.initialize(telemetryClient);
 
     const telemetrySanitizer = new ExceptionTelemetrySanitizer(browserAdapter.getExtensionId());
     const exceptionTelemetryListener = new SendingExceptionTelemetryListener(

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -30,15 +30,17 @@ import { AxeInfo } from 'common/axe-info';
 import { BackgroundBrowserEventManager } from 'common/browser-adapters/background-browser-event-manager';
 import { BrowserAdapterFactory } from 'common/browser-adapters/browser-adapter-factory';
 import { EventResponseFactory } from 'common/browser-adapters/event-response-factory';
+import { WebExtensionBrowserAdapter } from 'common/browser-adapters/webextension-browser-adapter';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { DateProvider } from 'common/date-provider';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { getIndexedDBStore } from 'common/indexedDB/get-indexeddb-store';
 import { IndexedDBAPI, IndexedDBUtil } from 'common/indexedDB/indexedDB';
 import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { NavigatorUtils } from 'common/navigator-utils';
 import { NotificationCreator } from 'common/notification-creator';
-import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
+import { createDefaultPromiseFactory, PromiseFactory } from 'common/promises/promise-factory';
 import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { ExceptionTelemetrySanitizer } from 'common/telemetry/exception-telemetry-sanitizer';
 import { UrlParser } from 'common/url-parser';
@@ -49,18 +51,35 @@ import UAParser from 'ua-parser-js';
 import { deprecatedStorageDataKeys, storageDataKeys } from './local-storage-data-keys';
 import { cleanKeysFromStorage } from './user-stored-data-cleaner';
 
-async function initialize(): Promise<void> {
+let logger: Logger;
+let promiseFactory: PromiseFactory;
+let eventResponseFactory: EventResponseFactory;
+let browserEventManager: BackgroundBrowserEventManager;
+let browserAdapter: WebExtensionBrowserAdapter;
+let telemetryEventHandler: TelemetryEventHandler;
+
+function initializeSync(): void {
     const userAgentParser = new UAParser(globalThis.navigator.userAgent);
     const browserAdapterFactory = new BrowserAdapterFactory(userAgentParser);
-    const logger = createDefaultLogger();
-    const promiseFactory = createDefaultPromiseFactory();
-    const eventResponseFactory = new EventResponseFactory(promiseFactory);
-    const browserEventManager = new BackgroundBrowserEventManager(
+    logger = createDefaultLogger();
+    promiseFactory = createDefaultPromiseFactory();
+    eventResponseFactory = new EventResponseFactory(promiseFactory);
+    browserEventManager = new BackgroundBrowserEventManager(
         promiseFactory,
         eventResponseFactory,
         logger,
     );
-    const browserAdapter = browserAdapterFactory.makeFromUserAgent(browserEventManager);
+    browserAdapter = browserAdapterFactory.makeFromUserAgent(browserEventManager);
+
+    telemetryEventHandler = new TelemetryEventHandler();
+
+    const telemetrySanitizer = new ExceptionTelemetrySanitizer(browserAdapter.getExtensionId());
+    const exceptionTelemetryListener = new SendingExceptionTelemetryListener(
+        telemetryEventHandler,
+        TelemetryEventSource.Background,
+        telemetrySanitizer,
+    );
+    exceptionTelemetryListener.initialize(logger);
 
     // It is important that the browser listeners gets preregistered *before* any "await" statement.
     //
@@ -68,7 +87,9 @@ async function initialize(): Promise<void> {
     // the browser may decide that the worker is "done" as soon as the synchronous part of initialization finishes
     // and tear down the worker before we tell it which events to wake us back up for.
     browserEventManager.preregisterBrowserListeners(browserAdapter.allSupportedEvents());
+}
 
+async function initializeAsync(): Promise<void> {
     // This only removes keys that are unused by current versions of the extension, so it's okay for it to race with everything else
     const cleanKeysFromStoragePromise = cleanKeysFromStorage(
         browserAdapter,
@@ -78,7 +99,7 @@ async function initialize(): Promise<void> {
     const urlValidator = new UrlValidator(browserAdapter);
     const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(getIndexedDBStore());
 
-    // // These can run concurrently, both because they are read-only and because they use different types of underlying storage
+    // These can run concurrently, both because they are read-only and because they use different types of underlying storage
     const persistedDataPromise = getAllPersistedData(indexedDBInstance);
     const userDataPromise = browserAdapter.getUserData(storageDataKeys); // localStorage
     const persistedData = await persistedDataPromise; //indexedDB
@@ -110,18 +131,9 @@ async function initialize(): Promise<void> {
         consoleTelemetryClient,
         debugToolsTelemetryClient,
     ]);
+    telemetryEventHandler.initialize(telemetryClient);
 
     const usageLogger = new UsageLogger(browserAdapter, DateProvider.getCurrentDate, logger);
-
-    const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
-
-    const telemetrySanitizer = new ExceptionTelemetrySanitizer(browserAdapter.getExtensionId());
-    const exceptionTelemetryListener = new SendingExceptionTelemetryListener(
-        telemetryEventHandler,
-        TelemetryEventSource.Background,
-        telemetrySanitizer,
-    );
-    exceptionTelemetryListener.initialize(logger);
 
     const browserSpec = new NavigatorUtils(navigator, logger).getBrowserSpec();
 
@@ -254,6 +266,7 @@ async function initialize(): Promise<void> {
     globalThis.insightsUserConfiguration = globalContext.userConfigurationController;
 }
 
-initialize()
+initializeSync();
+initializeAsync()
     .then(() => console.log('Background initialization completed successfully'))
     .catch((e: Error) => console.error('Background initialization failed: ', e));

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -266,7 +266,12 @@ async function initializeAsync(): Promise<void> {
     globalThis.insightsUserConfiguration = globalContext.userConfigurationController;
 }
 
-initializeSync();
+try {
+    initializeSync();
+    console.log('Sync background initialization completed successfully');
+} catch (e) {
+    console.error('Sync background initialization failed: ', e);
+}
 initializeAsync()
-    .then(() => console.log('Background initialization completed successfully'))
-    .catch((e: Error) => console.error('Background initialization failed: ', e));
+    .then(() => console.log('Async background initialization completed successfully'))
+    .catch((e: Error) => console.error('Async background initialization failed: ', e));

--- a/src/background/telemetry/telemetry-event-handler.ts
+++ b/src/background/telemetry/telemetry-event-handler.ts
@@ -8,7 +8,11 @@ import { BaseActionPayload } from '../actions/action-payloads';
 import { TelemetryClient } from './telemetry-client';
 
 export class TelemetryEventHandler {
-    constructor(private readonly telemetryClient: TelemetryClient) {}
+    private telemetryClient: TelemetryClient;
+
+    public initialize(telemetryClient: TelemetryClient): void {
+        this.telemetryClient = telemetryClient;
+    }
 
     public enableTelemetry(): void {
         this.telemetryClient.enableTelemetry();

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -334,7 +334,8 @@ getGlobalPersistedData(indexedDBInstance, indexedDBDataKeysToFetch, {
         const telemetryClient = getTelemetryClient(applicationTelemetryDataFactory, [
             consoleTelemetryClient,
         ]);
-        const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
+        const telemetryEventHandler = new TelemetryEventHandler();
+        telemetryEventHandler.initialize(telemetryClient);
 
         const userConfigurationActionCreator = new UserConfigurationActionCreator(
             userConfigActions,

--- a/src/tests/unit/tests/background/telemetry/telemetry-event-handler.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-event-handler.test.ts
@@ -125,7 +125,8 @@ describe('TelemetryEventHandlerTest', () => {
     }
 
     function createAndEnableTelemetryEventHandler(): TelemetryEventHandler {
-        const telemetryEventHandler = new TelemetryEventHandler(telemetryClientStrictMock.object);
+        const telemetryEventHandler = new TelemetryEventHandler();
+        telemetryEventHandler.initialize(telemetryClientStrictMock.object);
         telemetryClientStrictMock.setup(ai => ai.enableTelemetry()).verifiable(Times.once());
 
         telemetryEventHandler.enableTelemetry();


### PR DESCRIPTION
#### Details

Right now the way we register the exception telemetry listener in the mv3 extension causes the following warnings:

> exception-telemetry-listener.ts:30 Event handler of 'error' event must be added on the initial evaluation of worker script.
initialize @ exception-telemetry-listener.ts:30
exception-telemetry-listener.ts:48 Event handler of 'unhandledrejection' event must be added on the initial evaluation of worker script.

This is a new warning in mv3 (does not repro with mv2) and is caused because the exception telemetry listener is [initialized in an async function](https://github.com/microsoft/accessibility-insights-web/blob/main/src/background/service-worker-init.ts#L124) and the [initialization adds global event listeners](https://github.com/microsoft/accessibility-insights-web/blob/main/src/common/telemetry/exception-telemetry-listener.ts#L48). The solution is to initialize the exception telemetry listener synchronously on service worker startup.

##### Motivation

Fix warning in mv3 extension.

##### Context

This warning seems to be a false alarm in this case and these changes should not have any functional effect besides removing the warning.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
