### PR TITLE
chore: Enable and fix `no-descending-specificity` stylelint rule

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -13,9 +13,6 @@ module.exports = {
             '^(ms-([A-Z][a-z0-9]*)(-[a-z0-9]+)*)|(([a-z][a-z0-9]*)(-[a-z0-9]+)*)$', // Allows: kebab case and ms-Kebab-case
         'declaration-property-max-values': { padding: 1, margin: 1 }, // Limit shorthand to improve readability
 
-        // TO BE ENABLED: Recommended fixes
-        'no-descending-specificity': null,
-
         // STRETCH GOAL: limit shorthand for border-width, border-radius, border-color, border-style, grid-gap
         // Example: 'declaration-property-max-values': {  'border-width': 1 }
 

--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -652,9 +652,6 @@
         position: relative;
         top: 3px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section .text {
         word-break: break-all;
       }

--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -155,13 +155,6 @@
         color: var(--neutral-100);
       }
 
-      .high-contrast-theme .insights-link:hover {
-        text-decoration: underline;
-      }
-      .high-contrast-theme .is-selected .status-icon {
-        color: var(--black) !important;
-      }
-
       .insights-link {
         color: var(--link) !important;
         text-decoration: none;
@@ -174,6 +167,13 @@
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
+      }
+
+      .high-contrast-theme .insights-link:hover {
+        text-decoration: underline;
+      }
+      .high-contrast-theme .is-selected .status-icon {
+        color: var(--black) !important;
       }
 
       .insights-code {
@@ -643,9 +643,6 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section li {
         display: inline-block;
         padding-top: 12px;
@@ -654,6 +651,9 @@
         padding-right: 12px;
         position: relative;
         top: 3px;
+      }
+      .scan-details-section ul :first-child li {
+        padding-top: 16px;
       }
       .scan-details-section .text {
         word-break: break-all;
@@ -770,6 +770,20 @@
           display: none;
         }
       }
+      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
+      .collapsible-container
+        .collapsible-control[aria-expanded="false"]::before {
+        display: inline-block;
+        border-right: 1px solid var(--secondary-text);
+        border-bottom: 1px solid var(--secondary-text);
+        min-width: 7px;
+        width: 7px;
+        height: 7px;
+        content: "";
+        transform-origin: 50% 50%;
+        transition: transform 0.1s linear 0s;
+      }
+
       .summary-section {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
@@ -791,25 +805,6 @@
         margin-left: 16px;
       }
 
-      .collapsible-container:not(.collapsible-rule-details-group)
-        .collapsible-control {
-        padding-left: 2px;
-        padding-right: 16px;
-        position: relative;
-      }
-      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
-      .collapsible-container
-        .collapsible-control[aria-expanded="false"]::before {
-        display: inline-block;
-        border-right: 1px solid var(--secondary-text);
-        border-bottom: 1px solid var(--secondary-text);
-        min-width: 7px;
-        width: 7px;
-        height: 7px;
-        content: "";
-        transform-origin: 50% 50%;
-        transition: transform 0.1s linear 0s;
-      }
       .collapsible-container .collapsible-control {
         font-family: "Segoe UI Web (West European)", "Segoe UI", -apple-system,
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
@@ -823,6 +818,12 @@
       }
       .collapsible-container .collapsible-control:hover {
         background-color: var(--neutral-alpha-4);
+      }
+      .collapsible-container:not(.collapsible-rule-details-group)
+        .collapsible-control {
+        padding-left: 2px;
+        padding-right: 16px;
+        position: relative;
       }
       .collapsible-container
         .collapsible-control[aria-expanded="false"]::before {
@@ -962,18 +963,18 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--AUXXt {
-        padding-left: 0;
-        list-style: none;
-      }
-      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
-        margin-bottom: 4px;
-      }
       .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
       .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .multi-line-text-no-bullet--AUXXt {
+        padding-left: 0;
+        list-style: none;
+      }
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
       .combination-lists--boK5y {
@@ -1078,6 +1079,14 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      .kebab-menu-icon--RzpyN {
+        flex-grow: 1;
+      }
+      @media screen and (forced-colors: active) {
+        .kebab-menu-icon--RzpyN {
+          color: buttontext;
+        }
+      }
       .kebab-menu-button--e-7v- {
         margin-right: 8px;
         width: 32px;
@@ -1093,14 +1102,6 @@
         .kebab-menu-button--e-7v-.is-expanded .kebab-menu-icon--RzpyN,
         .kebab-menu-button--e-7v-:hover .kebab-menu-icon--RzpyN {
           color: highlight;
-        }
-      }
-      .kebab-menu-icon--RzpyN {
-        flex-grow: 1;
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu-icon--RzpyN {
-          color: buttontext;
         }
       }
       @media screen and (forced-colors: active) {

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -652,9 +652,6 @@
         position: relative;
         top: 3px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section .text {
         word-break: break-all;
       }

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -155,13 +155,6 @@
         color: var(--neutral-100);
       }
 
-      .high-contrast-theme .insights-link:hover {
-        text-decoration: underline;
-      }
-      .high-contrast-theme .is-selected .status-icon {
-        color: var(--black) !important;
-      }
-
       .insights-link {
         color: var(--link) !important;
         text-decoration: none;
@@ -174,6 +167,13 @@
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
+      }
+
+      .high-contrast-theme .insights-link:hover {
+        text-decoration: underline;
+      }
+      .high-contrast-theme .is-selected .status-icon {
+        color: var(--black) !important;
       }
 
       .insights-code {
@@ -643,9 +643,6 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section li {
         display: inline-block;
         padding-top: 12px;
@@ -654,6 +651,9 @@
         padding-right: 12px;
         position: relative;
         top: 3px;
+      }
+      .scan-details-section ul :first-child li {
+        padding-top: 16px;
       }
       .scan-details-section .text {
         word-break: break-all;
@@ -770,6 +770,20 @@
           display: none;
         }
       }
+      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
+      .collapsible-container
+        .collapsible-control[aria-expanded="false"]::before {
+        display: inline-block;
+        border-right: 1px solid var(--secondary-text);
+        border-bottom: 1px solid var(--secondary-text);
+        min-width: 7px;
+        width: 7px;
+        height: 7px;
+        content: "";
+        transform-origin: 50% 50%;
+        transition: transform 0.1s linear 0s;
+      }
+
       .summary-section {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
@@ -791,25 +805,6 @@
         margin-left: 16px;
       }
 
-      .collapsible-container:not(.collapsible-rule-details-group)
-        .collapsible-control {
-        padding-left: 2px;
-        padding-right: 16px;
-        position: relative;
-      }
-      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
-      .collapsible-container
-        .collapsible-control[aria-expanded="false"]::before {
-        display: inline-block;
-        border-right: 1px solid var(--secondary-text);
-        border-bottom: 1px solid var(--secondary-text);
-        min-width: 7px;
-        width: 7px;
-        height: 7px;
-        content: "";
-        transform-origin: 50% 50%;
-        transition: transform 0.1s linear 0s;
-      }
       .collapsible-container .collapsible-control {
         font-family: "Segoe UI Web (West European)", "Segoe UI", -apple-system,
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
@@ -823,6 +818,12 @@
       }
       .collapsible-container .collapsible-control:hover {
         background-color: var(--neutral-alpha-4);
+      }
+      .collapsible-container:not(.collapsible-rule-details-group)
+        .collapsible-control {
+        padding-left: 2px;
+        padding-right: 16px;
+        position: relative;
       }
       .collapsible-container
         .collapsible-control[aria-expanded="false"]::before {
@@ -962,18 +963,18 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--AUXXt {
-        padding-left: 0;
-        list-style: none;
-      }
-      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
-        margin-bottom: 4px;
-      }
       .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
       .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .multi-line-text-no-bullet--AUXXt {
+        padding-left: 0;
+        list-style: none;
+      }
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
       .combination-lists--boK5y {
@@ -1078,6 +1079,14 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      .kebab-menu-icon--RzpyN {
+        flex-grow: 1;
+      }
+      @media screen and (forced-colors: active) {
+        .kebab-menu-icon--RzpyN {
+          color: buttontext;
+        }
+      }
       .kebab-menu-button--e-7v- {
         margin-right: 8px;
         width: 32px;
@@ -1093,14 +1102,6 @@
         .kebab-menu-button--e-7v-.is-expanded .kebab-menu-icon--RzpyN,
         .kebab-menu-button--e-7v-:hover .kebab-menu-icon--RzpyN {
           color: highlight;
-        }
-      }
-      .kebab-menu-icon--RzpyN {
-        flex-grow: 1;
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu-icon--RzpyN {
-          color: buttontext;
         }
       }
       @media screen and (forced-colors: active) {

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -652,9 +652,6 @@
         position: relative;
         top: 3px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section .text {
         word-break: break-all;
       }

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -155,13 +155,6 @@
         color: var(--neutral-100);
       }
 
-      .high-contrast-theme .insights-link:hover {
-        text-decoration: underline;
-      }
-      .high-contrast-theme .is-selected .status-icon {
-        color: var(--black) !important;
-      }
-
       .insights-link {
         color: var(--link) !important;
         text-decoration: none;
@@ -174,6 +167,13 @@
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
+      }
+
+      .high-contrast-theme .insights-link:hover {
+        text-decoration: underline;
+      }
+      .high-contrast-theme .is-selected .status-icon {
+        color: var(--black) !important;
       }
 
       .insights-code {
@@ -643,9 +643,6 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section li {
         display: inline-block;
         padding-top: 12px;
@@ -654,6 +651,9 @@
         padding-right: 12px;
         position: relative;
         top: 3px;
+      }
+      .scan-details-section ul :first-child li {
+        padding-top: 16px;
       }
       .scan-details-section .text {
         word-break: break-all;
@@ -770,6 +770,20 @@
           display: none;
         }
       }
+      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
+      .collapsible-container
+        .collapsible-control[aria-expanded="false"]::before {
+        display: inline-block;
+        border-right: 1px solid var(--secondary-text);
+        border-bottom: 1px solid var(--secondary-text);
+        min-width: 7px;
+        width: 7px;
+        height: 7px;
+        content: "";
+        transform-origin: 50% 50%;
+        transition: transform 0.1s linear 0s;
+      }
+
       .summary-section {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
@@ -791,25 +805,6 @@
         margin-left: 16px;
       }
 
-      .collapsible-container:not(.collapsible-rule-details-group)
-        .collapsible-control {
-        padding-left: 2px;
-        padding-right: 16px;
-        position: relative;
-      }
-      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
-      .collapsible-container
-        .collapsible-control[aria-expanded="false"]::before {
-        display: inline-block;
-        border-right: 1px solid var(--secondary-text);
-        border-bottom: 1px solid var(--secondary-text);
-        min-width: 7px;
-        width: 7px;
-        height: 7px;
-        content: "";
-        transform-origin: 50% 50%;
-        transition: transform 0.1s linear 0s;
-      }
       .collapsible-container .collapsible-control {
         font-family: "Segoe UI Web (West European)", "Segoe UI", -apple-system,
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
@@ -823,6 +818,12 @@
       }
       .collapsible-container .collapsible-control:hover {
         background-color: var(--neutral-alpha-4);
+      }
+      .collapsible-container:not(.collapsible-rule-details-group)
+        .collapsible-control {
+        padding-left: 2px;
+        padding-right: 16px;
+        position: relative;
       }
       .collapsible-container
         .collapsible-control[aria-expanded="false"]::before {
@@ -962,18 +963,18 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--AUXXt {
-        padding-left: 0;
-        list-style: none;
-      }
-      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
-        margin-bottom: 4px;
-      }
       .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
       .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .multi-line-text-no-bullet--AUXXt {
+        padding-left: 0;
+        list-style: none;
+      }
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
       .combination-lists--boK5y {
@@ -1078,6 +1079,14 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      .kebab-menu-icon--RzpyN {
+        flex-grow: 1;
+      }
+      @media screen and (forced-colors: active) {
+        .kebab-menu-icon--RzpyN {
+          color: buttontext;
+        }
+      }
       .kebab-menu-button--e-7v- {
         margin-right: 8px;
         width: 32px;
@@ -1093,14 +1102,6 @@
         .kebab-menu-button--e-7v-.is-expanded .kebab-menu-icon--RzpyN,
         .kebab-menu-button--e-7v-:hover .kebab-menu-icon--RzpyN {
           color: highlight;
-        }
-      }
-      .kebab-menu-icon--RzpyN {
-        flex-grow: 1;
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu-icon--RzpyN {
-          color: buttontext;
         }
       }
       @media screen and (forced-colors: active) {

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -652,9 +652,6 @@
         position: relative;
         top: 3px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section .text {
         word-break: break-all;
       }

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -155,13 +155,6 @@
         color: var(--neutral-100);
       }
 
-      .high-contrast-theme .insights-link:hover {
-        text-decoration: underline;
-      }
-      .high-contrast-theme .is-selected .status-icon {
-        color: var(--black) !important;
-      }
-
       .insights-link {
         color: var(--link) !important;
         text-decoration: none;
@@ -174,6 +167,13 @@
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
+      }
+
+      .high-contrast-theme .insights-link:hover {
+        text-decoration: underline;
+      }
+      .high-contrast-theme .is-selected .status-icon {
+        color: var(--black) !important;
       }
 
       .insights-code {
@@ -643,9 +643,6 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section li {
         display: inline-block;
         padding-top: 12px;
@@ -654,6 +651,9 @@
         padding-right: 12px;
         position: relative;
         top: 3px;
+      }
+      .scan-details-section ul :first-child li {
+        padding-top: 16px;
       }
       .scan-details-section .text {
         word-break: break-all;
@@ -770,6 +770,20 @@
           display: none;
         }
       }
+      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
+      .collapsible-container
+        .collapsible-control[aria-expanded="false"]::before {
+        display: inline-block;
+        border-right: 1px solid var(--secondary-text);
+        border-bottom: 1px solid var(--secondary-text);
+        min-width: 7px;
+        width: 7px;
+        height: 7px;
+        content: "";
+        transform-origin: 50% 50%;
+        transition: transform 0.1s linear 0s;
+      }
+
       .summary-section {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
@@ -791,25 +805,6 @@
         margin-left: 16px;
       }
 
-      .collapsible-container:not(.collapsible-rule-details-group)
-        .collapsible-control {
-        padding-left: 2px;
-        padding-right: 16px;
-        position: relative;
-      }
-      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
-      .collapsible-container
-        .collapsible-control[aria-expanded="false"]::before {
-        display: inline-block;
-        border-right: 1px solid var(--secondary-text);
-        border-bottom: 1px solid var(--secondary-text);
-        min-width: 7px;
-        width: 7px;
-        height: 7px;
-        content: "";
-        transform-origin: 50% 50%;
-        transition: transform 0.1s linear 0s;
-      }
       .collapsible-container .collapsible-control {
         font-family: "Segoe UI Web (West European)", "Segoe UI", -apple-system,
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
@@ -823,6 +818,12 @@
       }
       .collapsible-container .collapsible-control:hover {
         background-color: var(--neutral-alpha-4);
+      }
+      .collapsible-container:not(.collapsible-rule-details-group)
+        .collapsible-control {
+        padding-left: 2px;
+        padding-right: 16px;
+        position: relative;
       }
       .collapsible-container
         .collapsible-control[aria-expanded="false"]::before {
@@ -962,18 +963,18 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--AUXXt {
-        padding-left: 0;
-        list-style: none;
-      }
-      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
-        margin-bottom: 4px;
-      }
       .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
       .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .multi-line-text-no-bullet--AUXXt {
+        padding-left: 0;
+        list-style: none;
+      }
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
       .combination-lists--boK5y {
@@ -1078,6 +1079,14 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      .kebab-menu-icon--RzpyN {
+        flex-grow: 1;
+      }
+      @media screen and (forced-colors: active) {
+        .kebab-menu-icon--RzpyN {
+          color: buttontext;
+        }
+      }
       .kebab-menu-button--e-7v- {
         margin-right: 8px;
         width: 32px;
@@ -1093,14 +1102,6 @@
         .kebab-menu-button--e-7v-.is-expanded .kebab-menu-icon--RzpyN,
         .kebab-menu-button--e-7v-:hover .kebab-menu-icon--RzpyN {
           color: highlight;
-        }
-      }
-      .kebab-menu-icon--RzpyN {
-        flex-grow: 1;
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu-icon--RzpyN {
-          color: buttontext;
         }
       }
       @media screen and (forced-colors: active) {

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -652,9 +652,6 @@
         position: relative;
         top: 3px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section .text {
         word-break: break-all;
       }

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -155,13 +155,6 @@
         color: var(--neutral-100);
       }
 
-      .high-contrast-theme .insights-link:hover {
-        text-decoration: underline;
-      }
-      .high-contrast-theme .is-selected .status-icon {
-        color: var(--black) !important;
-      }
-
       .insights-link {
         color: var(--link) !important;
         text-decoration: none;
@@ -174,6 +167,13 @@
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
+      }
+
+      .high-contrast-theme .insights-link:hover {
+        text-decoration: underline;
+      }
+      .high-contrast-theme .is-selected .status-icon {
+        color: var(--black) !important;
       }
 
       .insights-code {
@@ -643,9 +643,6 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section li {
         display: inline-block;
         padding-top: 12px;
@@ -654,6 +651,9 @@
         padding-right: 12px;
         position: relative;
         top: 3px;
+      }
+      .scan-details-section ul :first-child li {
+        padding-top: 16px;
       }
       .scan-details-section .text {
         word-break: break-all;
@@ -770,6 +770,20 @@
           display: none;
         }
       }
+      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
+      .collapsible-container
+        .collapsible-control[aria-expanded="false"]::before {
+        display: inline-block;
+        border-right: 1px solid var(--secondary-text);
+        border-bottom: 1px solid var(--secondary-text);
+        min-width: 7px;
+        width: 7px;
+        height: 7px;
+        content: "";
+        transform-origin: 50% 50%;
+        transition: transform 0.1s linear 0s;
+      }
+
       .summary-section {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
@@ -791,25 +805,6 @@
         margin-left: 16px;
       }
 
-      .collapsible-container:not(.collapsible-rule-details-group)
-        .collapsible-control {
-        padding-left: 2px;
-        padding-right: 16px;
-        position: relative;
-      }
-      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
-      .collapsible-container
-        .collapsible-control[aria-expanded="false"]::before {
-        display: inline-block;
-        border-right: 1px solid var(--secondary-text);
-        border-bottom: 1px solid var(--secondary-text);
-        min-width: 7px;
-        width: 7px;
-        height: 7px;
-        content: "";
-        transform-origin: 50% 50%;
-        transition: transform 0.1s linear 0s;
-      }
       .collapsible-container .collapsible-control {
         font-family: "Segoe UI Web (West European)", "Segoe UI", -apple-system,
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
@@ -823,6 +818,12 @@
       }
       .collapsible-container .collapsible-control:hover {
         background-color: var(--neutral-alpha-4);
+      }
+      .collapsible-container:not(.collapsible-rule-details-group)
+        .collapsible-control {
+        padding-left: 2px;
+        padding-right: 16px;
+        position: relative;
       }
       .collapsible-container
         .collapsible-control[aria-expanded="false"]::before {
@@ -962,18 +963,18 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--AUXXt {
-        padding-left: 0;
-        list-style: none;
-      }
-      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
-        margin-bottom: 4px;
-      }
       .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
       .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .multi-line-text-no-bullet--AUXXt {
+        padding-left: 0;
+        list-style: none;
+      }
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
       .combination-lists--boK5y {
@@ -1078,6 +1079,14 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      .kebab-menu-icon--RzpyN {
+        flex-grow: 1;
+      }
+      @media screen and (forced-colors: active) {
+        .kebab-menu-icon--RzpyN {
+          color: buttontext;
+        }
+      }
       .kebab-menu-button--e-7v- {
         margin-right: 8px;
         width: 32px;
@@ -1093,14 +1102,6 @@
         .kebab-menu-button--e-7v-.is-expanded .kebab-menu-icon--RzpyN,
         .kebab-menu-button--e-7v-:hover .kebab-menu-icon--RzpyN {
           color: highlight;
-        }
-      }
-      .kebab-menu-icon--RzpyN {
-        flex-grow: 1;
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu-icon--RzpyN {
-          color: buttontext;
         }
       }
       @media screen and (forced-colors: active) {

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -652,9 +652,6 @@
         position: relative;
         top: 3px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section .text {
         word-break: break-all;
       }

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -155,13 +155,6 @@
         color: var(--neutral-100);
       }
 
-      .high-contrast-theme .insights-link:hover {
-        text-decoration: underline;
-      }
-      .high-contrast-theme .is-selected .status-icon {
-        color: var(--black) !important;
-      }
-
       .insights-link {
         color: var(--link) !important;
         text-decoration: none;
@@ -174,6 +167,13 @@
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
+      }
+
+      .high-contrast-theme .insights-link:hover {
+        text-decoration: underline;
+      }
+      .high-contrast-theme .is-selected .status-icon {
+        color: var(--black) !important;
       }
 
       .insights-code {
@@ -643,9 +643,6 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section li {
         display: inline-block;
         padding-top: 12px;
@@ -654,6 +651,9 @@
         padding-right: 12px;
         position: relative;
         top: 3px;
+      }
+      .scan-details-section ul :first-child li {
+        padding-top: 16px;
       }
       .scan-details-section .text {
         word-break: break-all;
@@ -770,6 +770,20 @@
           display: none;
         }
       }
+      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
+      .collapsible-container
+        .collapsible-control[aria-expanded="false"]::before {
+        display: inline-block;
+        border-right: 1px solid var(--secondary-text);
+        border-bottom: 1px solid var(--secondary-text);
+        min-width: 7px;
+        width: 7px;
+        height: 7px;
+        content: "";
+        transform-origin: 50% 50%;
+        transition: transform 0.1s linear 0s;
+      }
+
       .summary-section {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
@@ -791,25 +805,6 @@
         margin-left: 16px;
       }
 
-      .collapsible-container:not(.collapsible-rule-details-group)
-        .collapsible-control {
-        padding-left: 2px;
-        padding-right: 16px;
-        position: relative;
-      }
-      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
-      .collapsible-container
-        .collapsible-control[aria-expanded="false"]::before {
-        display: inline-block;
-        border-right: 1px solid var(--secondary-text);
-        border-bottom: 1px solid var(--secondary-text);
-        min-width: 7px;
-        width: 7px;
-        height: 7px;
-        content: "";
-        transform-origin: 50% 50%;
-        transition: transform 0.1s linear 0s;
-      }
       .collapsible-container .collapsible-control {
         font-family: "Segoe UI Web (West European)", "Segoe UI", -apple-system,
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
@@ -823,6 +818,12 @@
       }
       .collapsible-container .collapsible-control:hover {
         background-color: var(--neutral-alpha-4);
+      }
+      .collapsible-container:not(.collapsible-rule-details-group)
+        .collapsible-control {
+        padding-left: 2px;
+        padding-right: 16px;
+        position: relative;
       }
       .collapsible-container
         .collapsible-control[aria-expanded="false"]::before {
@@ -962,18 +963,18 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--AUXXt {
-        padding-left: 0;
-        list-style: none;
-      }
-      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
-        margin-bottom: 4px;
-      }
       .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
       .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .multi-line-text-no-bullet--AUXXt {
+        padding-left: 0;
+        list-style: none;
+      }
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
       .combination-lists--boK5y {
@@ -1078,6 +1079,14 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      .kebab-menu-icon--RzpyN {
+        flex-grow: 1;
+      }
+      @media screen and (forced-colors: active) {
+        .kebab-menu-icon--RzpyN {
+          color: buttontext;
+        }
+      }
       .kebab-menu-button--e-7v- {
         margin-right: 8px;
         width: 32px;
@@ -1093,14 +1102,6 @@
         .kebab-menu-button--e-7v-.is-expanded .kebab-menu-icon--RzpyN,
         .kebab-menu-button--e-7v-:hover .kebab-menu-icon--RzpyN {
           color: highlight;
-        }
-      }
-      .kebab-menu-icon--RzpyN {
-        flex-grow: 1;
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu-icon--RzpyN {
-          color: buttontext;
         }
       }
       @media screen and (forced-colors: active) {

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -652,9 +652,6 @@
         position: relative;
         top: 3px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section .text {
         word-break: break-all;
       }

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -155,13 +155,6 @@
         color: var(--neutral-100);
       }
 
-      .high-contrast-theme .insights-link:hover {
-        text-decoration: underline;
-      }
-      .high-contrast-theme .is-selected .status-icon {
-        color: var(--black) !important;
-      }
-
       .insights-link {
         color: var(--link) !important;
         text-decoration: none;
@@ -174,6 +167,13 @@
       .insights-link:hover {
         color: var(--link-hover) !important;
         text-decoration: underline;
+      }
+
+      .high-contrast-theme .insights-link:hover {
+        text-decoration: underline;
+      }
+      .high-contrast-theme .is-selected .status-icon {
+        color: var(--black) !important;
       }
 
       .insights-code {
@@ -643,9 +643,6 @@
         font-size: 17px;
         line-height: 24px;
       }
-      .scan-details-section ul :first-child li {
-        padding-top: 16px;
-      }
       .scan-details-section li {
         display: inline-block;
         padding-top: 12px;
@@ -654,6 +651,9 @@
         padding-right: 12px;
         position: relative;
         top: 3px;
+      }
+      .scan-details-section ul :first-child li {
+        padding-top: 16px;
       }
       .scan-details-section .text {
         word-break: break-all;
@@ -770,6 +770,20 @@
           display: none;
         }
       }
+      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
+      .collapsible-container
+        .collapsible-control[aria-expanded="false"]::before {
+        display: inline-block;
+        border-right: 1px solid var(--secondary-text);
+        border-bottom: 1px solid var(--secondary-text);
+        min-width: 7px;
+        width: 7px;
+        height: 7px;
+        content: "";
+        transform-origin: 50% 50%;
+        transition: transform 0.1s linear 0s;
+      }
+
       .summary-section {
         box-shadow: 0 0.3px 0.9px rgba(0, 0, 0, 0.108),
           0 1.6px 3.6px rgba(0, 0, 0, 0.132);
@@ -791,25 +805,6 @@
         margin-left: 16px;
       }
 
-      .collapsible-container:not(.collapsible-rule-details-group)
-        .collapsible-control {
-        padding-left: 2px;
-        padding-right: 16px;
-        position: relative;
-      }
-      .collapsible-container .collapsible-control[aria-expanded="true"]::before,
-      .collapsible-container
-        .collapsible-control[aria-expanded="false"]::before {
-        display: inline-block;
-        border-right: 1px solid var(--secondary-text);
-        border-bottom: 1px solid var(--secondary-text);
-        min-width: 7px;
-        width: 7px;
-        height: 7px;
-        content: "";
-        transform-origin: 50% 50%;
-        transition: transform 0.1s linear 0s;
-      }
       .collapsible-container .collapsible-control {
         font-family: "Segoe UI Web (West European)", "Segoe UI", -apple-system,
           BlinkMacSystemFont, Roboto, "Helvetica Neue", Helvetica, Ubuntu, Arial,
@@ -823,6 +818,12 @@
       }
       .collapsible-container .collapsible-control:hover {
         background-color: var(--neutral-alpha-4);
+      }
+      .collapsible-container:not(.collapsible-rule-details-group)
+        .collapsible-control {
+        padding-left: 2px;
+        padding-right: 16px;
+        position: relative;
       }
       .collapsible-container
         .collapsible-control[aria-expanded="false"]::before {
@@ -962,18 +963,18 @@
       }
 
       /* css-modules:src/common/components/cards/rich-resolution-content */
-      .multi-line-text-no-bullet--AUXXt {
-        padding-left: 0;
-        list-style: none;
-      }
-      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
-        margin-bottom: 4px;
-      }
       .multi-line-text-yes-bullet--TXyX- {
         padding-left: 16px;
       }
       .multi-line-text-yes-bullet--TXyX- li {
         list-style-type: disc;
+        margin-bottom: 4px;
+      }
+      .multi-line-text-no-bullet--AUXXt {
+        padding-left: 0;
+        list-style: none;
+      }
+      .multi-line-text-no-bullet--AUXXt li:not(:last-child) {
         margin-bottom: 4px;
       }
       .combination-lists--boK5y {
@@ -1078,6 +1079,14 @@
       }
 
       /* css-modules:src/common/components/cards/card-kebab-menu-button */
+      .kebab-menu-icon--RzpyN {
+        flex-grow: 1;
+      }
+      @media screen and (forced-colors: active) {
+        .kebab-menu-icon--RzpyN {
+          color: buttontext;
+        }
+      }
       .kebab-menu-button--e-7v- {
         margin-right: 8px;
         width: 32px;
@@ -1093,14 +1102,6 @@
         .kebab-menu-button--e-7v-.is-expanded .kebab-menu-icon--RzpyN,
         .kebab-menu-button--e-7v-:hover .kebab-menu-icon--RzpyN {
           color: highlight;
-        }
-      }
-      .kebab-menu-icon--RzpyN {
-        flex-grow: 1;
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu-icon--RzpyN {
-          color: buttontext;
         }
       }
       @media screen and (forced-colors: active) {

--- a/src/DetailsView/components/left-nav/common-left-nav-link.scss
+++ b/src/DetailsView/components/left-nav/common-left-nav-link.scss
@@ -4,10 +4,6 @@
 @import '../../../common/styles/colors.scss';
 @import '../../../common/styles/common.scss';
 
-:global(.is-selected) .left-nav-link-container {
-    color: $always-black;
-}
-
 .left-nav-link-container {
     margin-left: 10px;
     color: $primary-text;
@@ -16,6 +12,10 @@
     justify-content: flex-start;
     min-height: 44px;
     align-items: center;
+
+    :global(.is-selected) & {
+        color: $always-black;
+    }
 
     .link-icon {
         font-size: 24px;

--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -26,6 +26,10 @@
             width: unset;
         }
 
+        button {
+            text-align: left;
+        }
+
         button.ms-Nav-link {
             width: 100%;
         }
@@ -65,6 +69,10 @@
             }
 
             &.is-selected {
+                .ms-Button-label {
+                    color: $always-black;
+                }
+
                 a,
                 button {
                     background-color: $communication-tint-40;
@@ -84,10 +92,6 @@
                     border-left: $pivot-item-left-border-width $pivot-item-border-style
                         $communication-primary;
                 }
-
-                .ms-Button-label {
-                    color: $always-black;
-                }
             }
         }
 
@@ -97,10 +101,6 @@
 
         .ms-Pivot-icon {
             font-size: 9px;
-        }
-
-        button {
-            text-align: left;
         }
     }
 }

--- a/src/DetailsView/components/left-nav/left-nav-icon.scss
+++ b/src/DetailsView/components/left-nav/left-nav-icon.scss
@@ -3,15 +3,6 @@
 
 @import '../../../common/styles/common.scss';
 
-:global(.ms-Nav-compositeLink.is-selected),
-li :global(.is-expanded) {
-    .index-circle {
-        color: $neutral-0;
-        background: $index-circle-background;
-        border-color: $neutral-0;
-    }
-}
-
 .index-circle {
     display: inline-block;
     border-radius: 50%;
@@ -23,4 +14,11 @@ li :global(.is-expanded) {
     color: $secondary-text;
     background: $neutral-0;
     text-align: center;
+
+    li :global(.is-expanded) &,
+    :global(.ms-Nav-compositeLink.is-selected) & {
+        color: $neutral-0;
+        background: $index-circle-background;
+        border-color: $neutral-0;
+    }
 }

--- a/src/DetailsView/components/switcher.scss
+++ b/src/DetailsView/components/switcher.scss
@@ -7,6 +7,15 @@
     border-radius: 2px;
 }
 
+.switcher-dropdown-option {
+    display: flex;
+    flex-direction: row;
+
+    i {
+        margin-right: 8px;
+    }
+}
+
 // The two layers of class selector and the explicit enumeration of the states are both
 // required to beat the specificity of office fabric styles
 .left-nav-switcher .left-nav-switcher-dropdown {
@@ -46,14 +55,5 @@
 
         outline: 1px $neutral-alpha-90 solid;
         outline-offset: -5px;
-    }
-}
-
-.switcher-dropdown-option {
-    display: flex;
-    flex-direction: row;
-
-    i {
-        margin-right: 8px;
     }
 }

--- a/src/common/components/cards/card-kebab-menu-button.scss
+++ b/src/common/components/cards/card-kebab-menu-button.scss
@@ -2,6 +2,13 @@
 // Licensed under the MIT License.
 @import '../../styles/colors.scss';
 
+.kebab-menu-icon {
+    flex-grow: 1; // Center the custom SVG
+    @media screen and (forced-colors: active) {
+        color: buttontext;
+    }
+}
+
 .kebab-menu-button {
     margin-right: 8px;
 
@@ -23,13 +30,6 @@
         @media screen and (forced-colors: active) {
             color: highlight;
         }
-    }
-}
-
-.kebab-menu-icon {
-    flex-grow: 1; // Center the custom SVG
-    @media screen and (forced-colors: active) {
-        color: buttontext;
     }
 }
 

--- a/src/common/components/cards/rich-resolution-content.scss
+++ b/src/common/components/cards/rich-resolution-content.scss
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-.multi-line-text-no-bullet {
-    padding-left: 0;
-    list-style: none;
-
-    li:not(:last-child) {
-        margin-bottom: 4px;
-    }
-}
-
 .multi-line-text-yes-bullet {
     padding-left: 16px;
 
     li {
         list-style-type: disc;
+        margin-bottom: 4px;
+    }
+}
+
+.multi-line-text-no-bullet {
+    padding-left: 0;
+    list-style: none;
+
+    li:not(:last-child) {
         margin-bottom: 4px;
     }
 }

--- a/src/common/components/selector-input-list.scss
+++ b/src/common/components/selector-input-list.scss
@@ -39,16 +39,16 @@
         width: 55%;
     }
 
+    .textbox-add-selector-button {
+        width: 35%;
+    }
+
     .add-selector-buttons {
         width: 40%;
 
         .textbox-add-selector-button {
             width: 80%;
         }
-    }
-
-    .textbox-add-selector-button {
-        width: 35%;
     }
 }
 

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -43,3 +43,9 @@ $fast-pass-right-panel-margin-top: 24px !default;
     font-weight: $font-weight-semi-bold;
     font-size: 17px;
 }
+
+@mixin is-mac-os {
+    :global(.is-mac-os) & {
+        @content;
+    }
+}

--- a/src/common/styles/root-level-only/global-styles.scss
+++ b/src/common/styles/root-level-only/global-styles.scss
@@ -26,6 +26,18 @@ button::after {
     color: $neutral-100;
 }
 
+.insights-link {
+    // marking important to override office fabric style
+    color: $link !important;
+    text-decoration: none;
+    @include fluent-forced-color-adjust-override;
+
+    &:hover {
+        color: $link-hover !important;
+        text-decoration: underline;
+    }
+}
+
 .high-contrast-theme {
     .insights-link {
         &:hover {
@@ -37,18 +49,6 @@ button::after {
         .status-icon {
             color: $high-contrast-icon-color !important;
         }
-    }
-}
-
-.insights-link {
-    // marking important to override office fabric style
-    color: $link !important;
-    text-decoration: none;
-    @include fluent-forced-color-adjust-override;
-
-    &:hover {
-        color: $link-hover !important;
-        text-decoration: underline;
     }
 }
 

--- a/src/electron/views/common/window-title/window-title.scss
+++ b/src/electron/views/common/window-title/window-title.scss
@@ -1,25 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../../../common/styles/colors.scss';
+@import '../../../../common/styles/common.scss';
 @import '../../../../common/styles/fonts.scss';
 @import './window-title-const.scss';
-
-:global(.is-mac-os) .window-title {
-    height: $mac-title-height;
-
-    .title-container {
-        padding-left: 60px;
-    }
-
-    .header-text {
-        line-height: 18px;
-        font-size: 12px;
-    }
-
-    :global(.header-icon) {
-        height: 12px;
-    }
-}
 
 .window-title {
     flex-grow: 0;
@@ -32,9 +16,16 @@
     -webkit-app-region: drag;
     -webkit-user-select: none;
 
+    @include is-mac-os {
+        height: $mac-title-height;
+    }
+
     .title-container {
         display: flex;
         align-items: center;
+        @include is-mac-os {
+            padding-left: 60px;
+        }
 
         > * {
             padding-left: 10px;
@@ -61,10 +52,17 @@
         font-weight: $font-weight-semi-bold;
         line-height: 19.3px;
         margin: 0;
+        @include is-mac-os {
+            line-height: 18px;
+            font-size: 12px;
+        }
     }
 
     :global(.header-icon) {
         height: 17px;
+        @include is-mac-os {
+            height: 12px;
+        }
     }
 
     button {

--- a/src/electron/views/left-nav/fluent-left-nav.scss
+++ b/src/electron/views/left-nav/fluent-left-nav.scss
@@ -6,6 +6,10 @@
 .left-nav-panel-host {
     top: $default-title-height;
 
+    @include is-mac-os {
+        top: $mac-title-height;
+    }
+
     .left-nav-panel {
         :global(.ms-Panel-main) {
             width: calc(#{$details-view-left-nav-width} + #{$details-view-left-nav-border-width});
@@ -24,11 +28,5 @@
         .nav-menu {
             color: $primary-text;
         }
-    }
-}
-
-:global(.is-mac-os) {
-    .left-nav-panel-host {
-        top: $mac-title-height;
     }
 }

--- a/src/electron/views/results/results-view.scss
+++ b/src/electron/views/results/results-view.scss
@@ -4,23 +4,20 @@
 @import '../../../common/styles/common.scss';
 @import '../common/window-title/window-title-const.scss';
 
-:global(.is-mac-os) {
-    .settings-panel-layer-host {
-        top: $mac-title-height !important;
-    }
-
-    .application-view {
-        height: calc(100% - (#{$mac-title-height}));
-    }
-}
-
 .settings-panel-layer-host {
     top: $default-title-height !important;
+    @include is-mac-os {
+        top: $mac-title-height !important;
+    }
 }
 
 .application-view {
     display: flex;
     height: calc(100% - (#{$default-title-height}));
+
+    @include is-mac-os {
+        height: calc(100% - (#{$mac-title-height}));
+    }
 }
 
 .results-view {

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -108,14 +108,6 @@
         }
     }
 
-    .insights-dialog-main-override .insights-dialog-button-inspect.is-disabled svg path {
-        fill: $neutral-30 !important;
-
-        @media screen and (forced-colors: active) {
-            fill: inherit !important;
-        }
-    }
-
     .insights-dialog-main-override .file-issue-button,
     .insights-dialog-main-override .copy-issue-details-button {
         margin-left: 8px !important;
@@ -139,6 +131,14 @@
                 stroke: ButtonText !important;
                 fill: ButtonFace !important;
             }
+        }
+    }
+
+    .insights-dialog-main-override .insights-dialog-button-inspect.is-disabled svg path {
+        fill: $neutral-30 !important;
+
+        @media screen and (forced-colors: active) {
+            fill: inherit !important;
         }
     }
 
@@ -167,6 +167,18 @@
         font-size: 12px !important;
         color: $negative-outcome !important;
         font-weight: $font-weight-semi-bold !important;
+    }
+
+    .insights-highlight-container,
+    .insights-highlight-container svg {
+        position: absolute !important;
+        @include max-z-index-1;
+
+        top: 0 !important;
+        left: 0 !important;
+        overflow: visible !important;
+        pointer-events: none !important;
+        visibility: visible !important;
     }
 
     .insights-dialog-main-override {
@@ -243,18 +255,6 @@
         }
     }
 
-    .insights-highlight-container,
-    .insights-highlight-container svg {
-        position: absolute !important;
-        @include max-z-index-1;
-
-        top: 0 !important;
-        left: 0 !important;
-        overflow: visible !important;
-        pointer-events: none !important;
-        visibility: visible !important;
-    }
-
     .insights-highlight-container .insights-highlight-box {
         visibility: visible !important;
         position: absolute !important;
@@ -267,6 +267,14 @@
         }
     }
 
+    .insights-highlight-container .insights-highlight-text {
+        @include ms-high-contrast-override {
+            forced-color-adjust: none;
+            color: HighlightText !important;
+            background-color: Highlight !important;
+        }
+    }
+
     .insights-highlight-container .insights-highlight-box .insights-highlight-text {
         cursor: default !important;
         pointer-events: all !important;
@@ -275,14 +283,6 @@
         float: right !important;
         position: relative !important;
         text-align: center !important;
-    }
-
-    .insights-highlight-container .insights-highlight-text {
-        @include ms-high-contrast-override {
-            forced-color-adjust: none;
-            color: HighlightText !important;
-            background-color: Highlight !important;
-        }
     }
 
     :host {

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -154,6 +154,11 @@ html {
     font-size: 16px;
 }
 
+#popup-container .ms-Link {
+    color: $communication-primary;
+    font-weight: 600;
+}
+
 #popup-container .main-section {
     margin-left: 14px;
     margin-right: 14px;
@@ -273,17 +278,10 @@ button[disabled]:focus:not(.ms-ContextualMenu-link) {
     margin-bottom: 20px;
 }
 
-#popup-container {
-    .ms-Link {
-        color: $communication-primary;
-        font-weight: 600;
-    }
-
-    .launch-pad-title {
-        font-size: 14px;
-        font-weight: 600;
-        margin-bottom: -4px;
-    }
+#popup-container .launch-pad-title {
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: -4px;
 }
 
 #popup-container #new-launch-pad {

--- a/src/reports/automated-checks-report.scss
+++ b/src/reports/automated-checks-report.scss
@@ -32,6 +32,18 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     }
 }
 
+%common-control-chevron {
+    display: inline-block;
+    border-right: 1px solid $secondary-text;
+    border-bottom: 1px solid $secondary-text;
+    min-width: 7px;
+    width: 7px;
+    height: 7px;
+    content: '';
+    transform-origin: 50% 50%;
+    transition: transform 0.1s linear 0s;
+}
+
 .summary-section {
     @include box-shadow;
 
@@ -63,26 +75,6 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
         transform: $property;
     }
 
-    &:not(.collapsible-rule-details-group) {
-        .collapsible-control {
-            padding-left: 2px;
-            padding-right: 16px;
-            position: relative;
-        }
-    }
-
-    %common-control-chevron {
-        display: inline-block;
-        border-right: 1px solid $secondary-text;
-        border-bottom: 1px solid $secondary-text;
-        min-width: 7px;
-        width: 7px;
-        height: 7px;
-        content: '';
-        transform-origin: 50% 50%;
-        transition: transform 0.1s linear 0s;
-    }
-
     .collapsible-control {
         font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont,
             Roboto, 'Helvetica Neue', Helvetica, Ubuntu, Arial, sans-serif, 'Apple Color Emoji',
@@ -96,6 +88,14 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
 
         &:hover {
             background-color: $neutral-alpha-4;
+        }
+    }
+
+    &:not(.collapsible-rule-details-group) {
+        .collapsible-control {
+            padding-left: 2px;
+            padding-right: 16px;
+            position: relative;
         }
     }
 

--- a/src/reports/components/report-sections/details-section.scss
+++ b/src/reports/components/report-sections/details-section.scss
@@ -28,10 +28,6 @@
         line-height: 24px;
     }
 
-    ul :first-child li {
-        padding-top: 16px;
-    }
-
     li {
         display: inline-block;
         padding-top: 12px;
@@ -41,6 +37,10 @@
             position: relative;
             top: 3px;
         }
+    }
+
+    ul :first-child li {
+        padding-top: 16px;
     }
 
     .text {

--- a/src/reports/components/report-sections/details-section.scss
+++ b/src/reports/components/report-sections/details-section.scss
@@ -39,10 +39,6 @@
         }
     }
 
-    ul :first-child li {
-        padding-top: 16px;
-    }
-
     .text {
         word-break: break-all;
     }

--- a/src/views/content/content.scss
+++ b/src/views/content/content.scss
@@ -74,6 +74,12 @@
     }
 
     .content-hyperlinks {
+        .insights-link {
+            line-height: 20px;
+            margin-bottom: 6px;
+            display: block;
+        }
+
         .content-inline {
             line-height: 20px;
             margin-bottom: 6px;
@@ -81,12 +87,6 @@
             .insights-link {
                 display: inline;
             }
-        }
-
-        .insights-link {
-            line-height: 20px;
-            margin-bottom: 6px;
-            display: block;
         }
     }
 


### PR DESCRIPTION
#### Details

- Enable and fix [no-descending-specificity/](https://stylelint.io/user-guide/rules/list/no-descending-specificity/) stylelint rule which disallows selectors of lower specificity from coming after overriding selectors of higher specificity.
- Create `is-mac-os` mixin to reduce repeated code when writing styles for iOS and improve readability.

##### Motivation

Part of https://github.com/microsoft/accessibility-insights-web/issues/5187 as an incremental task to enable stylelint rules.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5187 
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
