### PR TITLE
feat(mv3-part7): Fix mv3 host permissions formatting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -471,7 +471,7 @@ module.exports = function (grunt) {
                 background: {
                     service_worker: 'bundle/serviceWorker.bundle.js',
                 },
-                host_permissions: ['*://*/*'],
+                host_permissions: ['<all_urls>'],
                 web_accessible_resources: [
                     {
                         resources: [

--- a/src/background/injector-controller.ts
+++ b/src/background/injector-controller.ts
@@ -44,15 +44,15 @@ export class InjectorController {
                 tabId: tabId,
             }).result;
 
-            await this.injector
-                .injectScripts(tabId)
-                .then(async () => {
-                    await this.interpreter.interpret({
-                        messageType: Messages.Visualizations.State.InjectionCompleted,
-                        tabId: tabId,
-                    }).result;
-                })
-                .catch(this.logger.error);
+            try {
+                await this.injector.injectScripts(tabId);
+                await this.interpreter.interpret({
+                    messageType: Messages.Visualizations.State.InjectionCompleted,
+                    tabId: tabId,
+                }).result;
+            } catch (e) {
+                this.logger.error(e);
+            }
         }
 
         this.oldInspectType = inspectStoreState.inspectMode;

--- a/src/background/injector-controller.ts
+++ b/src/background/injector-controller.ts
@@ -44,7 +44,7 @@ export class InjectorController {
                 tabId: tabId,
             }).result;
 
-            this.injector
+            await this.injector
                 .injectScripts(tabId)
                 .then(async () => {
                     await this.interpreter.interpret({

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -35,9 +35,8 @@ describe('InjectorControllerTest', () => {
 
         validator.buildInjectorController().initialize();
         validator.setupVerifyInjectionStartedActionCalled(tabId);
-        await validator.visualizationInjectCallback();
         validator.setupVerifyInjectionCompletedActionCalled(tabId);
-        await validator.invokeInjectedPromise();
+        await validator.visualizationInjectCallback();
         validator.verifyAll();
     });
 
@@ -52,9 +51,8 @@ describe('InjectorControllerTest', () => {
 
         validator.buildInjectorController().initialize();
         validator.setupVerifyInjectionStartedActionCalled(tabId);
-        await validator.inspectInjectCallback();
         validator.setupVerifyInjectionCompletedActionCalled(tabId);
-        await validator.invokeInjectedPromise();
+        await validator.inspectInjectCallback();
         validator.verifyAll();
     });
 
@@ -73,7 +71,6 @@ describe('InjectorControllerTest', () => {
             .setupVerifyInjectionStartedActionCalled(tabId);
         validator.buildInjectorController().initialize();
         await validator.inspectInjectCallback();
-        await validator.invokeInjectedPromise();
         validator.verifyAll();
         validator.resetVerify();
 
@@ -124,8 +121,6 @@ class InjectorControllerValidator {
     private mockInterpreter = Mock.ofType(Interpreter, MockBehavior.Strict);
     private mockInspectStore = Mock.ofType(InspectStore, MockBehavior.Strict);
     private mockTabStore = Mock.ofType(TabStore, MockBehavior.Strict);
-    private injectedScriptsDeferred: Promise<void>;
-    private injectedScriptsDeferredResolver: () => void;
     public visualizationInjectCallback: () => Promise<void>;
     public inspectInjectCallback: () => Promise<void>;
 
@@ -241,20 +236,12 @@ class InjectorControllerValidator {
         calledWithTabId: number,
         numTimes: number,
     ): InjectorControllerValidator {
-        this.injectedScriptsDeferred = new Promise(resolve => {
-            this.injectedScriptsDeferredResolver = resolve;
-        });
         this.mockInjector
             .setup(injector => injector.injectScripts(calledWithTabId))
-            .returns(() => this.injectedScriptsDeferred)
+            .returns(() => Promise.resolve())
             .verifiable(Times.exactly(numTimes));
 
         return this;
-    }
-
-    public async invokeInjectedPromise(): Promise<void> {
-        this.injectedScriptsDeferredResolver();
-        return await this.injectedScriptsDeferred;
     }
 
     public verifyAll(): void {


### PR DESCRIPTION
#### Details

Discovered the following bug in the mv3 extension while debuging e2e tests:

1. Open all-cross-origin-iframe.html test resource
2. Run fastpass
3. See details view seems to be scanning forever, errors in service worker:

```
error injecting /bundle/injected.css: Error: Cannot access contents of url "file:///C:/code/accessibility-insights-web/src/tests/end-to-end/test-resources/all-cross-origin-iframe.html". Extension manifest must request permission to access this host. Error: Cannot access contents of url "file:///C:/code/accessibility-insights-web/src/tests/end-to-end/test-resources/all-cross-origin-iframe.html". Extension manifest must request permission to access this host.

error injecting /bundle/injected.bundle.js: Error: Cannot access contents of url "file:///C:/code/accessibility-insights-web/src/tests/end-to-end/test-resources/all-cross-origin-iframe.html". Extension manifest must request permission to access this host. Error: Cannot access contents of url "file:///C:/code/accessibility-insights-web/src/tests/end-to-end/test-resources/all-cross-origin-iframe.html". Extension manifest must request permission to access this host.
```

##### Motivation

Feature work

##### Context

It looks like we tried to map the mv2 extension permissions directly to the mv3 format, but the mv3 format requires different formatting. Also noticed during debugging that we're not properly awaiting injection, so fixing that as well.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
