### PR TITLE
feat(adhoc-tools-accessible-names): Allow customizable chrome shortcut for Accessible names

### DIFF
--- a/src/tests/unit/common/sample-test-data.ts
+++ b/src/tests/unit/common/sample-test-data.ts
@@ -13,4 +13,5 @@ export const ShortcutCommandsTestData: chrome.commands.Command[] = [
     { description: 'Toggle Tab stops', name: '04_toggle-tabStops', shortcut: '' },
     { description: 'Toggle Color', name: '05_toggle-color', shortcut: '' },
     { description: 'Toggle Needs review', name: '06_toggle-needsReview', shortcut: '' },
+    { description: 'Toggle Accessible names', name: '07_toggle-accessibleNames', shortcut: '' },
 ];


### PR DESCRIPTION
#### Details
This PR allows the user to add a custom shortcut for the accessible names toggle.
<!-- Usually a sentence or two describing what the PR changes -->

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
![shortcut1](https://user-images.githubusercontent.com/81589466/187306865-bb91ab36-2349-4f32-9569-c4ab68baa6ff.png)
![shortcut2](https://user-images.githubusercontent.com/81589466/187306866-71e6fba4-dc8a-4e0f-a0a5-54b6d8083a71.png)