### PR TITLE
feat(mv3-part7): fix issue where popup closes before dispatching message

### DIFF
--- a/src/common/message-creators/remote-action-message-dispatcher.ts
+++ b/src/common/message-creators/remote-action-message-dispatcher.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { PayloadWithEventName } from 'background/actions/action-payloads';
 import { Logger } from 'common/logging/logger';
-
 import { TelemetryData } from '../extension-telemetry-events';
 import { InterpreterMessage, Message } from '../message';
 import { Messages } from '../messages';
@@ -19,6 +18,16 @@ export class RemoteActionMessageDispatcher implements ActionMessageDispatcher {
         const interpreterMessage = this.decorateWithTabId(message);
 
         this.postMessageDelegate(interpreterMessage).catch(this.logger.error);
+    }
+
+    public async asyncDispatchMessage(message: Message): Promise<void> {
+        const interpreterMessage = this.decorateWithTabId(message);
+
+        try {
+            await this.postMessageDelegate(interpreterMessage);
+        } catch (e) {
+            this.logger.error(e);
+        }
     }
 
     public dispatchType(messageType: string): void {

--- a/src/common/message-creators/types/dispatcher.ts
+++ b/src/common/message-creators/types/dispatcher.ts
@@ -5,6 +5,7 @@ import { Message } from 'common/message';
 
 export interface ActionMessageDispatcher {
     dispatchMessage(message: Message): void;
+    asyncDispatchMessage(message: Message): Promise<void>;
     dispatchType(messageType: string): void;
     sendTelemetry(eventName: string, eventData: TelemetryData): void;
 }

--- a/src/electron/adapters/direct-action-message-dispatcher.ts
+++ b/src/electron/adapters/direct-action-message-dispatcher.ts
@@ -11,6 +11,10 @@ export class DirectActionMessageDispatcher implements ActionMessageDispatcher {
     public dispatchMessage(message: Message): void {
         this.interpreter.interpret(message);
     }
+    public asyncDispatchMessage(message: Message): Promise<void> {
+        // not needed yet on electron
+        throw new Error('Method not implemented.');
+    }
     public dispatchType(messageType: string): void {
         // not needed yet on electron
         throw new Error('Method not implemented.');

--- a/src/electron/ipc/ipc-message-dispatcher.ts
+++ b/src/electron/ipc/ipc-message-dispatcher.ts
@@ -16,7 +16,9 @@ export class IpcMessageDispatcher implements ActionMessageDispatcher {
             sink(IPC_MESSAGE_CHANNEL_NAME, message);
         }
     }
-
+    public asyncDispatchMessage(message: Message): Promise<void> {
+        throw new Error('Method not implemented (not yet required for any main process events).');
+    }
     public dispatchType(messageType: string): void {
         throw new Error('Method not implemented (not yet required for any main process events).');
     }

--- a/src/popup/actions/popup-action-message-creator.ts
+++ b/src/popup/actions/popup-action-message-creator.ts
@@ -9,9 +9,8 @@ import { ActionMessageDispatcher } from 'common/message-creators/types/dispatche
 import { Tab } from 'common/types/store-data/itab';
 import { LaunchPanelType } from 'common/types/store-data/launch-panel-store-data';
 import * as React from 'react';
-
-import { TelemetryEventSource } from '../../common/extension-telemetry-events';
 import * as TelemetryEvents from '../../common/extension-telemetry-events';
+import { TelemetryEventSource } from '../../common/extension-telemetry-events';
 import { Messages } from '../../common/messages';
 import { SupportedMouseEvent, TelemetryDataFactory } from '../../common/telemetry-data-factory';
 import { DetailsViewPivotType } from '../../common/types/store-data/details-view-pivot-type';
@@ -57,19 +56,19 @@ export class PopupActionMessageCreator {
         });
     }
 
-    public openDetailsView(
+    public async openDetailsView(
         event: SupportedMouseEvent,
         viewType: VisualizationType | null,
         source: TelemetryEventSource,
         pivotType: DetailsViewPivotType,
-    ): void {
+    ): Promise<void> {
         const payload: OnDetailsViewOpenPayload = {
             telemetry: this.telemetryFactory.forOpenDetailsView(event, viewType, source),
             detailsViewType: viewType,
             pivotType: pivotType,
         };
 
-        this.dispatcher.dispatchMessage({
+        await this.dispatcher.asyncDispatchMessage({
             messageType: visualizationMessages.DetailsView.Open,
             payload: payload,
         });

--- a/src/tests/unit/tests/popup/actions/popup-action-message-creator.test.ts
+++ b/src/tests/unit/tests/popup/actions/popup-action-message-creator.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { OnDetailsViewOpenPayload, SetLaunchPanelState } from 'background/actions/action-payloads';
-
 import {
     BaseTelemetryData,
     DetailsViewOpenTelemetryData,
@@ -85,7 +84,7 @@ describe('PopupActionMessageCreatorTest', () => {
         );
     });
 
-    test('openDetailsView', () => {
+    test('openDetailsView', async () => {
         const viewType = VisualizationType.Headings;
         const pivotType = DetailsViewPivotType.fastPass;
 
@@ -112,7 +111,7 @@ describe('PopupActionMessageCreatorTest', () => {
 
         mockWindowUtils.setup(x => x.closeWindow()).verifiable(Times.once());
 
-        testSubject.openDetailsView(
+        await testSubject.openDetailsView(
             stubKeypressEvent,
             VisualizationType.Headings,
             testSource,
@@ -120,7 +119,7 @@ describe('PopupActionMessageCreatorTest', () => {
         );
 
         actionMessageDispatcherMock.verify(
-            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            dispatcher => dispatcher.asyncDispatchMessage(It.isValue(expectedMessage)),
             Times.once(),
         );
         mockWindowUtils.verifyAll();


### PR DESCRIPTION
#### Details

Creates a new API on remote action message dispatcher to expose the async nature of dispatch message.

##### Motivation

Fixes an issue/race-condition where the popup may close before a message is dispatched, leading to that action never being acted on (i.e. opening FastPass from the launch pad).

##### Context

A general summary since there are multiple possible approaches for this fix:
- Make dispatchMessage async, which it really is, but is obfuscated (i.e. doesn't cause lint errors) due to the catch statement. This is a high-cost solution as many dependent APIs would then need to become async as well. Technically, this is "correct" but requires lots of changes.
- Make window.close async (via wrapper). This will also work because it will be added to queue after the dispatch async call. But it's unintuitive and technically there are no guarantees for the caller. This is low-cost but hacky.
- Make a new API where we expose the async nature and use async/await here. This is the chosen option because it's clear what is happening but doesn't require massive amounts of change.
- Remove window.close from popup-action-message-creator and trigger it from background which can only happen through dispatchMessage. This approach would work but requires a lot of piping for something that shouldn't have piping.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
