### PR TITLE
feat(mv3-part7): Fix mv3 e2e test failures

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -467,11 +467,18 @@ module.exports = function (grunt) {
                         40: config.options.icon48,
                     },
                 },
-                permissions: ['notifications', 'scripting', 'storage', 'tabs', 'webNavigation'],
+                permissions: [
+                    'notifications',
+                    'scripting',
+                    'storage',
+                    'tabs',
+                    'webNavigation',
+                    'activeTab',
+                ],
                 background: {
                     service_worker: 'bundle/serviceWorker.bundle.js',
                 },
-                host_permissions: ['*://*/*'],
+                optional_host_permissions: ['<all_urls>'],
                 web_accessible_resources: [
                     {
                         resources: [

--- a/src/tests/end-to-end/common/browser.ts
+++ b/src/tests/end-to-end/common/browser.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { setTimeout } from 'timers/promises';
 import * as Playwright from 'playwright';
 import { ChromiumBrowserContext } from 'playwright';
 import { BackgroundContext } from 'tests/end-to-end/common/page-controllers/background-context';
@@ -18,18 +19,16 @@ import { Page } from './page-controllers/page';
 import { PopupPage, popupPageRelativeUrl } from './page-controllers/popup-page';
 import { TargetPage, targetPageUrl, TargetPageUrlOptions } from './page-controllers/target-page';
 
-import { setTimeout } from 'timers/promises';
-
 export class Browser {
     private memoizedBackgroundPage: BackgroundPage;
     private memoizedServiceWorker: ServiceWorker;
     private pages: Array<Page> = [];
     private underlyingBrowserContext: Playwright.BrowserContext | null;
-    private readonly MANIFEST_VERSION = process.env.WEB_E2E_TARGET;
 
     constructor(
         private readonly browserInstanceId: string,
         underlyingBrowserContext: Playwright.BrowserContext,
+        private readonly manifestV3: boolean,
         private readonly onClose?: () => Promise<void>,
     ) {
         this.underlyingBrowserContext = underlyingBrowserContext;
@@ -61,7 +60,7 @@ export class Browser {
     }
 
     public async background(): Promise<BackgroundContext> {
-        if (this.MANIFEST_VERSION?.includes('mv3')) {
+        if (this.manifestV3) {
             if (this.memoizedServiceWorker) {
                 return this.memoizedServiceWorker;
             }

--- a/src/tests/end-to-end/common/browser.ts
+++ b/src/tests/end-to-end/common/browser.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { setTimeout } from 'timers/promises';
+import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
 import * as Playwright from 'playwright';
 import { ChromiumBrowserContext } from 'playwright';
 import { BackgroundContext } from 'tests/end-to-end/common/page-controllers/background-context';
@@ -10,6 +11,7 @@ import {
     hasServiceWorkerUrl,
     ServiceWorker,
 } from 'tests/end-to-end/common/page-controllers/service-worker';
+import { DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS } from 'tests/end-to-end/common/timeouts';
 import { browserLogPath } from './browser-factory';
 import { forceTestFailure } from './force-test-failure';
 import { BackgroundPage, hasBackgroundPageUrl } from './page-controllers/background-page';
@@ -18,8 +20,6 @@ import { DetailsViewPage, detailsViewRelativeUrl } from './page-controllers/deta
 import { Page } from './page-controllers/page';
 import { PopupPage, popupPageRelativeUrl } from './page-controllers/popup-page';
 import { TargetPage, targetPageUrl, TargetPageUrlOptions } from './page-controllers/target-page';
-import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
-import { DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS } from 'tests/end-to-end/common/timeouts';
 
 export class Browser {
     private memoizedBackgroundPage: BackgroundPage;

--- a/src/tests/end-to-end/common/browser.ts
+++ b/src/tests/end-to-end/common/browser.ts
@@ -18,6 +18,8 @@ import { Page } from './page-controllers/page';
 import { PopupPage, popupPageRelativeUrl } from './page-controllers/popup-page';
 import { TargetPage, targetPageUrl, TargetPageUrlOptions } from './page-controllers/target-page';
 
+import { setTimeout } from 'timers/promises';
+
 export class Browser {
     private memoizedBackgroundPage: BackgroundPage;
     private memoizedServiceWorker: ServiceWorker;
@@ -189,6 +191,12 @@ export class Browser {
 
     private async getActivePageTabId(): Promise<number> {
         const backgroundPage = await this.background();
+
+        // Check chrome.tabs is initialized
+        while (await backgroundPage.evaluate(() => chrome.tabs == null, null)) {
+            await setTimeout(50);
+        }
+
         return await backgroundPage.evaluate(() => {
             return new Promise(resolve => {
                 chrome.tabs.query({ active: true, currentWindow: true }, tabs =>

--- a/src/tests/end-to-end/common/manifest-instance.ts
+++ b/src/tests/end-to-end/common/manifest-instance.ts
@@ -1,32 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as fs from 'fs';
-import * as util from 'util';
+export interface ManifestInstance {
+    addTemporaryPermission(permissionToAdd: string): ManifestInstance;
 
-export class ManifestInstance {
-    private static readFile = util.promisify(fs.readFile);
-    private static writeFile = util.promisify(fs.writeFile);
-
-    public static async parse(manifestPath: string): Promise<chrome.runtime.ManifestV2> {
-        const buffer = await ManifestInstance.readFile(manifestPath);
-        const parsedManifest: chrome.runtime.ManifestV2 = JSON.parse(buffer.toString());
-        return parsedManifest;
-    }
-
-    public constructor(private readonly content: chrome.runtime.ManifestV2) {}
-
-    public addTemporaryPermission(permissionToAdd: string): ManifestInstance {
-        if (this.content.permissions == null) {
-            this.content.permissions = [];
-        }
-        this.content.permissions.push(permissionToAdd);
-
-        return this;
-    }
-
-    public async writeTo(destinationPath: string): Promise<void> {
-        const serializedContent = JSON.stringify(this.content, null, 2);
-
-        await ManifestInstance.writeFile(destinationPath, serializedContent);
-    }
+    writeTo(destinationPath: string): Promise<void>;
 }

--- a/src/tests/end-to-end/common/mv2-manifest-instance.ts
+++ b/src/tests/end-to-end/common/mv2-manifest-instance.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as fs from 'fs';
+import * as util from 'util';
+import { ManifestInstance } from 'tests/end-to-end/common/manifest-instance';
+
+export class ManifestV2Instance implements ManifestInstance {
+    private static readFile = util.promisify(fs.readFile);
+    private static writeFile = util.promisify(fs.writeFile);
+
+    public static async parse(manifestPath: string): Promise<chrome.runtime.ManifestV2> {
+        const buffer = await ManifestV2Instance.readFile(manifestPath);
+        const parsedManifest: chrome.runtime.ManifestV2 = JSON.parse(buffer.toString());
+        return parsedManifest;
+    }
+
+    public constructor(private readonly content: chrome.runtime.ManifestV2) {}
+
+    public addTemporaryPermission(permissionToAdd: string): ManifestV2Instance {
+        if (this.content.permissions == null) {
+            this.content.permissions = [];
+        }
+        this.content.permissions.push(permissionToAdd);
+
+        return this;
+    }
+
+    public async writeTo(destinationPath: string): Promise<void> {
+        const serializedContent = JSON.stringify(this.content, null, 2);
+
+        await ManifestV2Instance.writeFile(destinationPath, serializedContent);
+    }
+}

--- a/src/tests/end-to-end/common/mv3-manifest-instance.ts
+++ b/src/tests/end-to-end/common/mv3-manifest-instance.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as fs from 'fs';
+import * as util from 'util';
+import { ManifestInstance } from 'tests/end-to-end/common/manifest-instance';
+
+export class ManifestV3Instance implements ManifestInstance {
+    private static readFile = util.promisify(fs.readFile);
+    private static writeFile = util.promisify(fs.writeFile);
+
+    public static async parse(manifestPath: string): Promise<chrome.runtime.ManifestV3> {
+        const buffer = await ManifestV3Instance.readFile(manifestPath);
+        const parsedManifest: chrome.runtime.ManifestV3 = JSON.parse(buffer.toString());
+        return parsedManifest;
+    }
+
+    public constructor(private readonly content: chrome.runtime.ManifestV3) {}
+
+    public addTemporaryPermission(permissionToAdd: string): ManifestV3Instance {
+        if (this.content.host_permissions == null) {
+            this.content.host_permissions = [];
+        }
+        this.content.host_permissions.push(permissionToAdd);
+
+        return this;
+    }
+
+    public async writeTo(destinationPath: string): Promise<void> {
+        const serializedContent = JSON.stringify(this.content, null, 3);
+
+        await ManifestV3Instance.writeFile(destinationPath, serializedContent);
+    }
+}

--- a/tools/strict-null-checks/import-finder.js
+++ b/tools/strict-null-checks/import-finder.js
@@ -22,7 +22,10 @@ function getImportsForFile(parentFilePath, srcRoot) {
         .map(importedFile => importedFile.fileName)
         .filter(fileName => !/\.scss$/.test(fileName)) // remove css imports
         .filter(fileName => /\//.test(fileName)) // remove node modules (the import must contain '/')
-        .filter(fileName => !/^(@fluentui|lodash|react-dom|axe-core|@microsoft)\//.test(fileName)) // remove node module usages with slashes in name
+        .filter(
+            fileName =>
+                !/^(@fluentui|lodash|react-dom|axe-core|@microsoft|timers)\//.test(fileName),
+        ) // remove node module usages with slashes in name
         .map(fileName => {
             if (/(^\.\/)|(^\.\.\/)/.test(fileName)) {
                 return path.join(path.dirname(parentFilePath), fileName);

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -520,6 +520,8 @@
         "./src/tests/end-to-end/common/extension-paths.ts",
         "./src/tests/end-to-end/common/force-test-failure.ts",
         "./src/tests/end-to-end/common/manifest-instance.ts",
+        "./src/tests/end-to-end/common/mv2-manifest-instance.ts",
+        "./src/tests/end-to-end/common/mv3-manifest-instance.ts",
         "./src/tests/end-to-end/common/page-controllers/background-context.ts",
         "./src/tests/end-to-end/common/page-controllers/content-page.ts",
         "./src/tests/end-to-end/common/page-controllers/context.ts",


### PR DESCRIPTION
#### Details

Fix 2 mv3 bugs uncovered by running e2e tests on the mv3 extension (added in https://github.com/microsoft/accessibility-insights-web/pull/5965). The 2 bugs are described below and addressed in the 2 commits separately.

##### Motivation

Feature work.

##### Context

Failing cross origins iframe tests:

- This bug can be repro'ed by running mv3 extension manually. Repro steps: (1) Open all-cross-origin-iframe.html test resource (2) Run fastpass (3) See details view seems to be scanning forever, errors in service worker:
```
error injecting /bundle/injected.css: Error: Cannot access contents of url "file:///C:/code/accessibility-insights-web/src/tests/end-to-end/test-resources/all-cross-origin-iframe.html". Extension manifest must request permission to access this host. Error: Cannot access contents of url "file:///C:/code/accessibility-insights-web/src/tests/end-to-end/test-resources/all-cross-origin-iframe.html". Extension manifest must request permission to access this host.
```
```
error injecting /bundle/injected.bundle.js: Error: Cannot access contents of url "file:///C:/code/accessibility-insights-web/src/tests/end-to-end/test-resources/all-cross-origin-iframe.html". Extension manifest must request permission to access this host. Error: Cannot access contents of url "file:///C:/code/accessibility-insights-web/src/tests/end-to-end/test-resources/all-cross-origin-iframe.html". Extension manifest must request permission to access this host.
```

- Another side effect of this bug is that the yellow banner asking the user to grant permission to access iframes is not appearing at all in the mv3 extension at the moment.
- The cause was the permissions we were setting in the mv3 manifest. For mv2, we always request the activeTab permission (https://github.com/microsoft/accessibility-insights-web/blob/main/src/manifest.json#L12) and conditionally gain `optional_permissions: ['*://*/*']` if a user grants access to iframes from the yellow banner. Prior to this change, we were not requesting `activeTab` permissions for mv3 and we were requiring host permissions instead of making them optional. This PR fixes those mv3 permissions such that they are now analogous to those in the mv2 extension.
- The differing permission formats in mv2 and mv3 also necessitated changes to how we handle editing the manifest in out e2e test logic, which ended up being the bulk of the changes in this PR. 


Failing first time dialog tests: 
- This is a test specific bug, it does not repro when running the mv3 extension manually.
- Tests were attempting to run a script that referenced `chrome.tabs` before the service worker was fully started up and while `chrome.tabs` was still undefined. Fix was to check to ensure `chrome.tabs` is defined before running script.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
