### PR TITLE
feat(mv3-part7): Add mv3 production and insider build targets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,6 +53,7 @@ module.exports = function (grunt) {
                 'exec:esbuild-dev-mv3',
                 'exec:webpack-unified',
                 'exec:esbuild-prod',
+                'exec:esbuild-prod-mv3',
             ],
         },
         copy: {
@@ -167,6 +168,7 @@ module.exports = function (grunt) {
             'esbuild-dev': `node esbuild.js`,
             'esbuild-dev-mv3': `node esbuild.js --env dev-mv3`,
             'esbuild-prod': `node esbuild.js --env prod`,
+            'esbuild-prod-mv3': `node esbuild.js --env prod-mv3`,
             'esbuild-package-report': `node esbuild.js --env report`,
             'webpack-unified': `"${webpackPath}" --config-name unified`,
             'webpack-package-ui': `"${webpackPath}" --config-name package-ui`,
@@ -817,6 +819,13 @@ module.exports = function (grunt) {
         'exec:esbuild-prod',
         'build-assets',
         'drop:production',
+    ]);
+    grunt.registerTask('build-prod-mv3', [
+        'clean:intermediates',
+        'exec:generate-scss-typings',
+        'exec:esbuild-prod-mv3',
+        'build-assets',
+        'drop:production-mv3',
     ]);
     grunt.registerTask('build-unified', [
         'clean:intermediates',

--- a/esbuild.js
+++ b/esbuild.js
@@ -31,6 +31,7 @@ const devWebExtensionOutdir = path.join(__dirname, 'extension/devBundle');
 const devWebExtensionM3Outdir = path.join(__dirname, 'extension/devMv3Bundle');
 
 const prodWebExtensionOutDir = path.join(__dirname, 'extension/prodBundle');
+const prodWebExtensionM3OutDir = path.join(__dirname, 'extension/prodMV3Bundle');
 
 function isReactDevtoolsInstalled() {
     try {
@@ -79,6 +80,15 @@ switch (argsObj.env) {
         minify = true;
         sourcemap = false;
         outdir = prodWebExtensionOutDir;
+        break;
+
+    case 'prod-mv3':
+        minify = true;
+        sourcemap = false;
+        outdir = prodWebExtensionM3OutDir;
+        define = {
+            global: 'globalThis',
+        };
         break;
 
     case 'dev-mv3':

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "build:package:report": "lerna --scope accessibility-insights-report run build",
         "build:package:ui": "lerna --scope accessibility-insights-ui run build",
         "build:prod": "grunt build-prod",
+        "build:prod:mv3": "grunt build-prod-mv3",
         "change-log": "node ./tools/get-change-log-for-release.js",
         "clean": "grunt clean:*",
         "clean:mock-adb": "grunt clean:mock-adb",

--- a/targets.config.js
+++ b/targets.config.js
@@ -113,6 +113,20 @@ module.exports = {
         bundleFolder: 'prodBundle',
         mustExistFile: 'background.bundle.js',
     },
+    'insider-mv3': {
+        release: true,
+        config: {
+            options: {
+                ...commonExtensionOptions,
+                ...icons.insider,
+                manifestVersion: 3,
+                fullName: 'Accessibility Insights for Web - Insider (M3)',
+                telemetryBuildName: 'InsiderMV3',
+            },
+        },
+        bundleFolder: 'prodMv3Bundle',
+        mustExistFile: 'serviceWorker.bundle.js',
+    },
     production: {
         release: true,
         config: {
@@ -124,6 +138,20 @@ module.exports = {
         },
         bundleFolder: 'prodBundle',
         mustExistFile: 'background.bundle.js',
+    },
+    'production-mv3': {
+        release: true,
+        config: {
+            options: {
+                ...commonExtensionOptions,
+                ...icons.production,
+                manifestVersion: 3,
+                fullName: 'Accessibility Insights for Web (M3)',
+                telemetryBuildName: 'ProductionMV3',
+            },
+        },
+        bundleFolder: 'prodMv3Bundle',
+        mustExistFile: 'serviceWorker.bundle.js',
     },
     'unified-dev': {
         config: {


### PR DESCRIPTION
#### Details

Add targets for mv3 insider and production extension builds. These will eventually be used for insider/ production release pipelines. Adding these now despite not being ready for a full mv3 production release so that we can point beta testers to a mv3 insider release that is more stable than the mv3 canary (which changes daily/ with each PR).

##### Motivation

Feature work.

##### Context

N/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
