### PR TITLE
feat(mv3-part7): Add e2e mv3 test runs to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,62 @@ jobs:
           test-results/e2e/chrome-logs
           test-results/e2e/failure-screenshots
       timeout-minutes: 15 # chrome-logs is several GB, this can take a while
+
+  e2e-mv3-web-tests:
+    name: e2e-mv3-web-tests (${{ matrix.shard-index }}/${{ strategy.job-total }})
+    runs-on: ubuntu-20.04
+    container: mcr.microsoft.com/playwright:v1.24.0-focal
+    strategy:
+      fail-fast: false
+      matrix:
+        shard-index: [1, 2]
+
+    steps:
+    - uses: actions/checkout@v2
+      timeout-minutes: 2
+
+    - uses: actions/setup-node@v2
+      with: { node-version: "${{ env.NODE_VERSION }}" }
+      timeout-minutes: 2
+
+    # Intentionally omitting caching; it would need a separate, larger
+    # cache bucket to account for differences in container image and
+    # PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD, and that would eat so far into
+    # our 5GB cache quota that we'd run into issues with useful main builds'
+    # caches being evicted anytime dependabot filed a few PRs in a row.
+
+    - run: yarn install --frozen-lockfile --prefer-offline
+      timeout-minutes: 10
+
+    - run: yarn build:dev:mv3
+      timeout-minutes: 5
+
+    - name: yarn test:e2e:mv3
+      run: |
+        xvfb-run --server-args="-screen 0 1024x768x24" yarn test:e2e:mv3 --ci --shard=${{ matrix.shard-index }}/${{ strategy.job-total }}
+      env:
+        # If you need to debug Playwright/Chromium, using pw:* instead may help
+        DEBUG: pw:api
+        WEB_E2E_TARGET: 'production'
+      timeout-minutes: 10
+
+    - name: upload artifact e2e-mv3-web-tests-results
+      uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: e2e-mv3-web-tests-${{ matrix.shard-index }}-results
+        path: test-results/e2e/junit-e2e.xml
+      timeout-minutes: 3
+
+    - name: upload artifact e2e-mv3-web-tests-debug-logs
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: e2e-mv3-web-tests-${{ matrix.shard-index }}-debug-logs
+        path: |
+          test-results/e2e/chrome-logs
+          test-results/e2e/failure-screenshots
+      timeout-minutes: 15 # chrome-logs is several GB, this can take a while
   
   e2e-unified-tests:
     name: e2e-unified-tests (${{ matrix.shard-index }}/${{ strategy.job-total }})

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,14 @@ RUN yarn build:dev --no-cache
 # man page for command: https://manpages.ubuntu.com/manpages/xenial/man1/xvfb-run.1.html
 ENTRYPOINT ["/bin/sh", "-c", "xvfb-run --server-args=\"-screen 0 1024x768x24\" yarn test:e2e $@", ""]
 
+FROM setup AS web-mv3
+RUN yarn build:dev:mv3 --no-cache
+
+# since we need our chromium to run in 'headful' mode (for testing chrome extension)
+# we need a fake display (to run headful chromium), which we create by starting a Virtualized X server environment using xvfb-run
+# man page for command: https://manpages.ubuntu.com/manpages/xenial/man1/xvfb-run.1.html
+ENTRYPOINT ["/bin/sh", "-c", "xvfb-run --server-args=\"-screen 0 1024x768x24\" yarn test:e2e:mv3 $@", ""]
+
 FROM setup AS unified
 RUN apt-get update && \
     apt-get install -y dos2unix \

--- a/build.yaml
+++ b/build.yaml
@@ -145,6 +145,16 @@ jobs:
                 target: web
           - template: pipeline/e2e-test-publish-results.yaml
 
+    - job: 'e2e_mv3_web_linux'
+      pool:
+          vmImage: $(linuxImage)
+      steps:
+          - template: pipeline/install-node-prerequisites.yaml
+          - template: pipeline/run-tests-in-docker-linux.yaml
+            parameters:
+                target: web-mv3
+          - template: pipeline/e2e-test-publish-results.yaml
+
     - job: 'e2e_unified_mac'
       pool:
           vmImage: $(macImage)

--- a/pipeline/e2e-mv3-job-per-environment.yaml
+++ b/pipeline/e2e-mv3-job-per-environment.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+parameters:
+    jobNameSuffix: ''
+    windowsImage: 'windows-2019'
+    macImage: 'macOS-11'
+    linuxImage: 'ubuntu-20.04'
+
+jobs:
+    - job: 'e2e_mv3_tests_windows${{ parameters.jobNameSuffix }}'
+      pool:
+          vmImage: ${{ parameters.windowsImage }}
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-mv3-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_mv3_tests_mac${{ parameters.jobNameSuffix }}'
+      pool:
+          vmImage: ${{ parameters.macImage }}
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-mv3-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_mv3_tests_linux${{ parameters.jobNameSuffix }}'
+      pool:
+          vmImage: ${{ parameters.linuxImage }}
+      steps:
+          - template: ./run-tests-in-docker-linux.yaml
+            parameters:
+                target: web-mv3
+          - template: ./e2e-test-publish-results.yaml

--- a/pipeline/e2e-mv3-test-from-agent.yaml
+++ b/pipeline/e2e-mv3-test-from-agent.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+steps:
+    - script: yarn build:dev:mv3
+      displayName: build:dev:mv3
+      timeoutInMinutes: 5
+
+    - script: yarn test:e2e:mv3 --ci
+      displayName: run e2e mv3 tests
+      timeoutInMinutes: 15

--- a/pipeline/e2e-reliability.yaml
+++ b/pipeline/e2e-reliability.yaml
@@ -29,3 +29,18 @@ jobs:
 
     - template: ./e2e-job-per-environment.yaml
       parameters: { jobNameSuffix: _5 }
+
+    - template: ./e2e-mv3-job-per-environment.yaml
+      parameters: { jobNameSuffix: _1 }
+
+    - template: ./e2e-mv3-job-per-environment.yaml
+      parameters: { jobNameSuffix: _2 }
+
+    - template: ./e2e-mv3-job-per-environment.yaml
+      parameters: { jobNameSuffix: _3 }
+
+    - template: ./e2e-mv3-job-per-environment.yaml
+      parameters: { jobNameSuffix: _4 }
+
+    - template: ./e2e-mv3-job-per-environment.yaml
+      parameters: { jobNameSuffix: _5 }

--- a/pipeline/run-tests-in-docker-linux.yaml
+++ b/pipeline/run-tests-in-docker-linux.yaml
@@ -8,7 +8,7 @@
 # - could be applicable to any agent, but intentionally no-ops on non-linux agents
 
 parameters:
-    - name: target # should be web or unified
+    - name: target # should be web, web-mv3 or unified
       type: string
     - name: run-timeout-minutes
       type: number


### PR DESCRIPTION
#### Details

Now that we have e2e tests running on the mv3 extension and passing locally, adding those tests to CI runs.

##### Motivation

Feature work

##### Context

As we have only run mv3 e2e tests locally so far, we are not sure how reliable they will be initially. We won't merge here until they are reasonably reliable but even still it will probably be fair to merge around any mv3 e2e CI failures for now.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
