### PR TITLE
fix(mv3-part-7): make getDispatchUpdateEvent synchronous

### DIFF
--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -56,7 +56,7 @@ export class TabContextFactory {
         private readonly urlParser: UrlParser,
     ) {}
 
-    public async createTabContext(tabId: number): Promise<TabContext> {
+    public createTabContext(tabId: number): TabContext {
         const interpreter = new Interpreter();
         const actionsHub = new ActionHub();
         const storeHub = new TabContextStoreHub(
@@ -200,7 +200,7 @@ export class TabContextFactory {
 
         injectorController.initialize();
         const dispatcher = new StateDispatcher(messageBroadcaster, storeHub, this.logger);
-        await dispatcher.initialize();
+        dispatcher.initialize();
 
         const devToolsMonitor = new DevToolsMonitor(
             tabId,

--- a/src/background/tab-context-manager.ts
+++ b/src/background/tab-context-manager.ts
@@ -8,12 +8,9 @@ import { TabToContextMap } from './tab-context';
 export class TabContextManager {
     constructor(private readonly targetPageTabIdToContextMap: TabToContextMap = {}) {}
 
-    public async addTabContextIfNotExists(
-        tabId: number,
-        tabContextFactory: TabContextFactory,
-    ): Promise<void> {
+    public addTabContextIfNotExists(tabId: number, tabContextFactory: TabContextFactory): void {
         if (!(tabId in this.targetPageTabIdToContextMap)) {
-            const tabContext = await tabContextFactory.createTabContext(tabId);
+            const tabContext = tabContextFactory.createTabContext(tabId);
             this.targetPageTabIdToContextMap[tabId] = tabContext;
         }
     }

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -27,10 +27,9 @@ export class TargetPageController {
             parseInt(knownTab),
         );
 
-        const promises = knownTabIds.map(tabId =>
+        knownTabIds.forEach(tabId =>
             this.tabContextManager.addTabContextIfNotExists(tabId, this.tabContextFactory),
         );
-        await Promise.all(promises);
 
         const tabs = await this.browserAdapter.tabsQuery({});
 
@@ -144,7 +143,7 @@ export class TargetPageController {
     };
 
     private handleTabUrlUpdate = async (tabId: number): Promise<void> => {
-        await this.tabContextManager.addTabContextIfNotExists(tabId, this.tabContextFactory);
+        this.tabContextManager.addTabContextIfNotExists(tabId, this.tabContextFactory);
         await this.sendTabUrlUpdatedAction(tabId);
         await this.addKnownTabId(tabId);
     };

--- a/src/common/state-dispatcher.ts
+++ b/src/common/state-dispatcher.ts
@@ -12,24 +12,23 @@ export class StateDispatcher {
         private readonly logger: Logger,
     ) {}
 
-    public async initialize(): Promise<void> {
-        const promises = this.stores
-            .getAllStores()
-            .map(store => this.addDispatchListenerToStore(store));
-        await Promise.all(promises);
+    public initialize(): void {
+        this.stores.getAllStores().forEach(store => this.addDispatchListenerToStore(store));
     }
 
-    private async addDispatchListenerToStore(store: BaseStore<any, Promise<void>>): Promise<void> {
+    private addDispatchListenerToStore(store: BaseStore<any, Promise<void>>): void {
         const dispatchStateUpdateDelegate = this.getDispatchStateUpdateEvent(store);
-        store.addChangedListener(dispatchStateUpdateDelegate);
-        await dispatchStateUpdateDelegate();
+        store.addChangedListener(async () => dispatchStateUpdateDelegate());
+        dispatchStateUpdateDelegate();
     }
 
-    private getDispatchStateUpdateEvent = (
-        store: BaseStore<any, Promise<void>>,
-    ): (() => Promise<void>) => {
-        return async () => {
-            await this.broadcastMessage({
+    private getDispatchStateUpdateEvent = (store: BaseStore<any, Promise<void>>): (() => void) => {
+        return () => {
+            // This message can be fire-and-forget because it's sent
+            // from the background service worker to other contexts, so
+            // the message won't be lost if the service worker goes idle
+            // while it is being processed
+            this.broadcastMessage({
                 storeId: store.getId(),
                 messageType: storeUpdateMessageType,
                 storeType: this.stores.getStoreType(),

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -125,7 +125,7 @@ describe('TabContextFactoryTest', () => {
             null,
         );
 
-        const tabContext = await testObject.createTabContext(tabId);
+        const tabContext = testObject.createTabContext(tabId);
 
         broadcastMock.verifyAll();
         broadcastMock.reset();

--- a/src/tests/unit/tests/background/tab-context-manager.test.ts
+++ b/src/tests/unit/tests/background/tab-context-manager.test.ts
@@ -42,9 +42,9 @@ describe(TabContextManager, () => {
             const tabContextStub = {} as TabContext;
             tabContextFactoryMock
                 .setup(t => t.createTabContext(tabId))
-                .returns(() => Promise.resolve(tabContextStub))
+                .returns(() => tabContextStub)
                 .verifiable(Times.once());
-            await testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
+            testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
 
             expect(tabToContextMap[tabId]).toBe(tabContextStub);
         });
@@ -54,7 +54,7 @@ describe(TabContextManager, () => {
 
             tabContextFactoryMock.setup(t => t.createTabContext(tabId)).verifiable(Times.never());
 
-            await testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
+            testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
 
             expect(tabToContextMap[tabId]).toBe(tabContextMock.object);
         });
@@ -64,7 +64,7 @@ describe(TabContextManager, () => {
 
             tabContextFactoryMock.setup(t => t.createTabContext(tabId)).verifiable(Times.never());
 
-            await testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
+            testSubject.addTabContextIfNotExists(tabId, tabContextFactoryMock.object);
 
             expect(tabToContextMap[tabId]).toBeUndefined();
         });

--- a/src/tests/unit/tests/common/state-dispatcher.test.ts
+++ b/src/tests/unit/tests/common/state-dispatcher.test.ts
@@ -55,7 +55,7 @@ describe('StateDispatcherTest', () => {
             storeHubStrictMock.object,
             loggerMock.object,
         );
-        await stateDispatcher.initialize();
+        stateDispatcher.initialize();
 
         storeMock.verifyAll();
         broadcastMock.verifyAll();
@@ -100,7 +100,7 @@ describe('StateDispatcherTest', () => {
             storeHubMock.object,
             loggerMock.object,
         );
-        await stateDispatcher.initialize();
+        stateDispatcher.initialize();
 
         broadcastMock.reset();
         broadcastMock
@@ -154,7 +154,7 @@ describe('StateDispatcherTest', () => {
             storeHubMock.object,
             loggerMock.object,
         );
-        await stateDispatcher.initialize();
+        stateDispatcher.initialize();
 
         broadcastMock.reset();
         broadcastMock.setup(m => m(It.isAny())).returns(() => Promise.reject(expectedError));


### PR DESCRIPTION
#### Details

Remove await when background sends store update messages.

##### Motivation

This fixes a bug in canary which caused the details view UI to be unresponsive for ~30 seconds after the tab stops visualizer was turned on. The user could toggle the visualizer off (with no effect), but could not change details view tabs.

##### Context

We don't need to wait for a response from this message because it is sent from, instead of to, the background service worker. If the service worker goes idle after sending the store update, the message will still be processed by the context it is sent to.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
