### PR TITLE
fix: ignore null elements in tab stops visualizer

### DIFF
--- a/src/injected/visualization/center-position-calculator.ts
+++ b/src/injected/visualization/center-position-calculator.ts
@@ -25,7 +25,11 @@ export class CenterPositionCalculator {
         this.clientUtils = clientUtils;
     }
 
-    public getElementCenterPosition(targetElement: Element): Point | null {
+    public getElementCenterPosition(targetElement: Element | null): Point | null {
+        if (targetElement == null) {
+            return null;
+        }
+
         if (targetElement.tagName.toLowerCase() === 'area') {
             return this.getAreaElementCenterPosition(targetElement as HTMLAreaElement);
         }

--- a/src/injected/visualization/tabbed-item.ts
+++ b/src/injected/visualization/tabbed-item.ts
@@ -4,7 +4,7 @@ import { FocusIndicator } from './focus-indicator';
 
 export interface TabbedItem {
     selector?: string;
-    element: Element;
+    element: Element | null;
     focusIndicator?: FocusIndicator;
     tabOrder: number;
     shouldRedraw?: boolean;

--- a/src/tests/unit/tests/injected/visualization/center-position-calculator.test.ts
+++ b/src/tests/unit/tests/injected/visualization/center-position-calculator.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IPoint } from '@fluentui/utilities';
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, MockBehavior } from 'typemoq';
 import { TabbableElementsHelper } from '../../../../../common/tabbable-elements-helper';
 import { WindowUtils } from '../../../../../common/window-utils';
 import { ClientUtils } from '../../../../../injected/client-utils';
@@ -292,6 +292,16 @@ describe('CenterPositionCalculatorTest', () => {
 
         drawerUtilsMock.verifyAll();
         windowUtilsMock.verifyAll();
+    });
+
+    test('getElementCenterPosition: handles null element', () => {
+        const drawerUtilsMock = Mock.ofType(DrawerUtils, MockBehavior.Strict);
+
+        const centerPositionCalculator = createCenterPositionCalculator(drawerUtilsMock.object);
+
+        expect(centerPositionCalculator.getElementCenterPosition(null)).toBeNull();
+
+        drawerUtilsMock.verifyAll();
     });
 
     function setupDefaultWindowUtilsMock(): void {


### PR DESCRIPTION
#### Details

Ignore null elements in tab stops visualizer

##### Motivation

Currently, the tab stops visualizer ignores elements that are offscreen at the time of drawing, but does not account for elements dynamically appearing/disappearing depending on what is currently in focus.

For example, the bing.com frontpage contains a button with a tooltip that contains a link:

<img width="995" alt="Screenshot of bing.com with the 'Only Microsoft can see this' button in the bottom right circled" src="https://user-images.githubusercontent.com/55459788/189001928-a348ff6b-ffa9-469c-b25a-7735ac6e4d66.png">
<img width="222" alt="Zoomed-in screenshot of the 'Only Microsoft can see this' button, now focused with keyboard and showing a tooltip with a 'learn more' link circled" src="https://user-images.githubusercontent.com/55459788/189001932-52739e1c-b62c-455f-8cb9-95155a259f15.png">

The link is tabbable, but only exists when the tooltip is visible, so `SVGDrawer` gets a value of `null` for that element after the user tabs out of the tooltip. However, it still tries to get the center position for the null element, which throws an exception. About half the time, this causes all tab stops visualized up to that point to disappear.

This PR fixes the bug by ignoring null elements in the visualizer, the same as we do for offscreen elements.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
