### PR TITLE
fix(mv3-part-7): Fix assessment view updater bug

### DIFF
--- a/src/DetailsView/components/assessment-view-update-handler.ts
+++ b/src/DetailsView/components/assessment-view-update-handler.ts
@@ -8,6 +8,7 @@ import {
 } from 'common/types/store-data/assessment-result-data';
 import { Tab } from 'common/types/store-data/itab';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { isEqual } from 'lodash';
 import { VisualizationType } from '../../common/types/visualization-type';
 
 export interface AssessmentViewUpdateHandlerDeps {
@@ -41,15 +42,16 @@ export class AssessmentViewUpdateHandler {
     ): void {
         if (this.isStepSwitched(prevProps, currentProps)) {
             this.disableVisualHelpersForSelectedTest(prevProps);
-            this.enableSelectedStepVisualHelper(currentProps);
+            this.enableSelectedStepVisualHelper(currentProps, prevProps);
         } else {
             // Cases where visualization doesn't reappear(Navigate back, refresh). No telemetry sent.
-            this.enableSelectedStepVisualHelper(currentProps, false);
+            this.enableSelectedStepVisualHelper(currentProps, prevProps, false);
         }
     }
 
     private enableSelectedStepVisualHelper(
         props: AssessmentViewUpdateHandlerProps,
+        prevProps: AssessmentViewUpdateHandlerProps = undefined,
         sendTelemetry = true,
     ): void {
         const test = props.assessmentNavState.selectedTestType;
@@ -59,7 +61,13 @@ export class AssessmentViewUpdateHandler {
         }
 
         const isStepNotScanned = !props.assessmentData.testStepStatus[step].isStepScanned;
-        if (props.selectedRequirementIsEnabled === false || isStepNotScanned) {
+        const assessmentDataUpdated = prevProps
+            ? !isEqual(props.assessmentData, prevProps.assessmentData)
+            : true;
+        if (
+            props.selectedRequirementIsEnabled === false ||
+            (isStepNotScanned && assessmentDataUpdated)
+        ) {
             props.deps.detailsViewActionMessageCreator.enableVisualHelper(
                 test,
                 step,

--- a/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
@@ -173,6 +173,38 @@ describe('AssessmentViewTest', () => {
 
             detailsViewActionMessageCreatorMock.verifyAll();
         });
+
+        test('enable because assessment data has been updated', () => {
+            selectedRequirementIsEnabled = true;
+            const prevProps = buildProps();
+            const props = buildProps();
+
+            prevProps.assessmentData.fullAxeResultsMap = {};
+
+            detailsViewActionMessageCreatorMock
+                .setup(a =>
+                    a.enableVisualHelper(firstAssessment.visualizationType, stepName, true, false),
+                )
+                .verifiable(Times.once());
+
+            testObject.update(prevProps, props);
+
+            detailsViewActionMessageCreatorMock.verifyAll();
+        });
+
+        test('do not enable because assessment data has not been updated', () => {
+            selectedRequirementIsEnabled = true;
+            const prevProps = buildProps();
+            const props = buildProps();
+
+            detailsViewActionMessageCreatorMock
+                .setup(a => a.enableVisualHelper(It.isAny(), It.isAny(), It.isAny(), It.isAny()))
+                .verifiable(Times.never());
+
+            testObject.update(prevProps, props);
+
+            detailsViewActionMessageCreatorMock.verifyAll();
+        });
     });
 
     describe('onUnmount', () => {


### PR DESCRIPTION
#### Details

Fix mv3 bug in which partially automated requirements pages (ex. Landmarks > landmark roles) blink between results and spinner before showing results again. 

##### Motivation

Fix mv3 bug

##### Context

The root cause of this bug was that we were sending too many enable visualization messages. We send these messages in `assessment-view-update-handler` based on if the assessment store data thinks that a step has been scanned or not (`props.assessmentData.testStepStatus[step].isStepScanned`). We were seeing this bug because:

- The `assessment-view-update-handler` is called every time any store data updates
- Multiple stores have listeners for the scanCompleted action
- If any store besides the assessment store completes its updates first, it causes the `assessment-view-update-handler` to run its check against assessment store data that is in the process of being updates/ already out of date. 
- This can create a situation where the assessment store is finished with the scan but the `assessment-view-update-handler` thinks it hasn't, so it re-sends the enable visualization message, which causes a re-scan.

The solution I implemented is to only send enable visualization messages is the store update came from the assessment store. This means that we won't be confused by unrelated store updates anymore. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
