### PR TITLE
fix: improve automated tab stops instance generation by batching getUniqueSelector

### DIFF
--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -24,7 +24,7 @@ import { SingleFrameTabStopListener } from 'injected/single-frame-tab-stop-liste
 import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 import { DefaultTabStopsRequirementEvaluator } from 'injected/tab-stops-requirement-evaluator';
 import { TabbableElementGetter } from 'injected/tabbable-element-getter';
-import { getUniqueSelector } from 'scanner/axe-utils';
+import { getAllUniqueSelectors, getUniqueSelector } from 'scanner/axe-utils';
 import { tabbable } from 'tabbable';
 import UAParser from 'ua-parser-js';
 import { AppDataAdapter } from '../common/browser-adapters/app-data-adapter';
@@ -159,6 +159,7 @@ export class WindowInitializer {
         const tabStopRequirementEvaluator = new DefaultTabStopsRequirementEvaluator(
             htmlElementUtils,
             getUniqueSelector,
+            getAllUniqueSelectors,
         );
         const focusTrapsKeydownHandler = new FocusTrapsHandler(
             tabStopRequirementEvaluator,

--- a/src/scanner/axe-utils.ts
+++ b/src/scanner/axe-utils.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as axe from 'axe-core';
-
 import { DictionaryStringTo } from '../types/common-types';
 
 export type ImageCodedAs = 'Decorative' | 'Meaningful';
@@ -133,4 +132,9 @@ export function withAxeSetup(operation: Function, rootElement?: HTMLElement) {
 // This will throw if called concurrently with an axe-core scan
 export function getUniqueSelector(element: HTMLElement): string {
     return withAxeSetup(() => axe.utils.getSelector(element));
+}
+
+// This will throw if called concurrently with an axe-core scan
+export function getAllUniqueSelectors(elements: HTMLElement[]): string[] {
+    return withAxeSetup(() => elements.map(element => axe.utils.getSelector(element)));
 }


### PR DESCRIPTION
#### Details

Creates a new axe-util API that allows us to getSelectors based on an array, meaning setup and teardown of axe is only done once.

##### Motivation

Significantly improves perf when many instances are generated by automated tab stops.

##### Context

Before:
![canaryTabStops](https://user-images.githubusercontent.com/32555133/189216341-31859de0-ea6b-4a04-ad0c-943a8d7c96a0.gif)

After:
![fixedDevTabStops](https://user-images.githubusercontent.com/32555133/189216375-538c7f3f-4b38-4474-a972-2b575c5cbd3c.gif)

I believed this perf issue existed because, upon stopping, we loop through each tabbable item we didn't see, in this case hundreds of tabbable elements, and send a separate action message to create an instance for each one. Obviously, that wouldn't be performant and we could batch this. This was kind of correct and does improve performance but for scenarios which could take 20-30s, it would only improve that by 1-2s.
 
In actuality, the main performance culprit is `getUniqueSelector`. Basically, we need to setup axe each time we use that API but the cost of doing so is high. Doing so hundreds of times, like we can do in this case, is what causes the hanging.

I did not investigate whether there are other places where we use getUniqueSelector in quick succession as there might be perf gains to be had.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
