### PR TITLE
fix(mv3-part-7): Import config script in service worker init

### DIFF
--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -267,6 +267,13 @@ async function initializeAsync(): Promise<void> {
 }
 
 try {
+    importScripts('../insights.config.js');
+    console.log('Set insights configuration successfully');
+} catch (e) {
+    console.error('Failed to set up configuration: ', e);
+}
+
+try {
     initializeSync();
     console.log('Sync background initialization completed successfully');
 } catch (e) {


### PR DESCRIPTION
#### Details

With the mv2 extensions we include the insights.js.config script in the head of [background.html ](https://github.com/microsoft/accessibility-insights-web/blob/main/src/background/background.html#L8)so that our global configuration values are set right away. Since there isn't anything analogous in mv3, we were not calling insights.js.config at all prior to this change, meaning (among other things) telemetry was showing the build as unknown instead of devmv3 or canarymv3.

##### Motivation

Feature work

##### Context

N/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
