### PR TITLE
fix(mv3-part-7): Use globalThis when updating insights config

### DIFF
--- a/deploy/Gruntfile.js
+++ b/deploy/Gruntfile.js
@@ -90,7 +90,7 @@ module.exports = function (grunt) {
 
         const copyrightHeader =
             '// Copyright (c) Microsoft Corporation. All rights reserved.\n// Licensed under the MIT License.\n';
-        const configJS = `${copyrightHeader}window.insights = ${configJSON}`;
+        const configJS = `${copyrightHeader}globalThis.insights = ${configJSON}`;
         grunt.file.write(configJSPath, configJS);
     });
 


### PR DESCRIPTION
#### Details

Update config script to use globalThis instead of window to account for service worker changes. We switched to using globalThis in one of our grunt files [in an early mv3 change](https://github.com/microsoft/accessibility-insights-web/commit/e867127a82090a674059f461241dac8e19f81784) but missed the second grunt file. 

##### Motivation

Fix mv3 telemetry

##### Context

N/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
