### PR TITLE
fix(mv3-part-8): Fix activate extension keyboard shortcut in mv3

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -475,6 +475,48 @@ module.exports = function (grunt) {
             },
         });
 
+        const commands = {
+            '01_toggle-issues': {
+                suggested_key: {
+                    windows: 'Alt+Shift+1',
+                    mac: 'Alt+Shift+1',
+                    chromeos: 'Alt+Shift+1',
+                    linux: 'Alt+Shift+1',
+                },
+                description: 'Toggle Automated checks',
+            },
+            '02_toggle-landmarks': {
+                suggested_key: {
+                    windows: 'Alt+Shift+2',
+                    mac: 'Alt+Shift+2',
+                    chromeos: 'Alt+Shift+2',
+                    linux: 'Alt+Shift+2',
+                },
+                description: 'Toggle Landmarks',
+            },
+            '03_toggle-headings': {
+                suggested_key: {
+                    windows: 'Alt+Shift+3',
+                    mac: 'Alt+Shift+3',
+                    chromeos: 'Alt+Shift+3',
+                    linux: 'Alt+Shift+3',
+                },
+                description: 'Toggle Headings',
+            },
+            '04_toggle-tabStops': {
+                description: 'Toggle Tab stops',
+            },
+            '05_toggle-color': {
+                description: 'Toggle Color',
+            },
+            '06_toggle-needsReview': {
+                description: 'Toggle Needs review',
+            },
+            '07_toggle-accessibleNames': {
+                description: 'Toggle Accessible names',
+            },
+        };
+
         if (config.options.manifestVersion === 3) {
             // Settings that are specific to MV3
             merge(manifestJSON, {
@@ -512,6 +554,18 @@ module.exports = function (grunt) {
                         matches: ['<all_urls>'],
                     },
                 ],
+                commands: {
+                    _execute_action: {
+                        suggested_key: {
+                            windows: 'Alt+Shift+K',
+                            mac: 'Alt+Shift+K',
+                            chromeos: 'Alt+Shift+K',
+                            linux: 'Alt+Shift+K',
+                        },
+                        description: 'Activate the extension',
+                    },
+                    ...commands,
+                },
             });
         } else {
             // Settings that are specific to MV2. Note that many of these settings--especially the
@@ -542,6 +596,18 @@ module.exports = function (grunt) {
                 content_security_policy:
                     "script-src 'self' 'unsafe-eval' https://az416426.vo.msecnd.net; object-src 'self'",
                 optional_permissions: ['*://*/*'],
+                commands: {
+                    _execute_browser_action: {
+                        suggested_key: {
+                            windows: 'Alt+Shift+K',
+                            mac: 'Alt+Shift+K',
+                            chromeos: 'Alt+Shift+K',
+                            linux: 'Alt+Shift+K',
+                        },
+                        description: 'Activate the extension',
+                    },
+                    ...commands,
+                },
             });
         }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,55 +9,5 @@
         "128": "icons/brand/blue/brand-blue-128px.png"
     },
     "devtools_page": "Devtools/devtools.html",
-    "permissions": ["storage", "webNavigation", "tabs", "notifications", "activeTab"],
-    "commands": {
-        "_execute_browser_action": {
-            "suggested_key": {
-                "windows": "Alt+Shift+K",
-                "mac": "Alt+Shift+K",
-                "chromeos": "Alt+Shift+K",
-                "linux": "Alt+Shift+K"
-            },
-            "description": "Activate the extension"
-        },
-        "01_toggle-issues": {
-            "suggested_key": {
-                "windows": "Alt+Shift+1",
-                "mac": "Alt+Shift+1",
-                "chromeos": "Alt+Shift+1",
-                "linux": "Alt+Shift+1"
-            },
-            "description": "Toggle Automated checks"
-        },
-        "02_toggle-landmarks": {
-            "suggested_key": {
-                "windows": "Alt+Shift+2",
-                "mac": "Alt+Shift+2",
-                "chromeos": "Alt+Shift+2",
-                "linux": "Alt+Shift+2"
-            },
-            "description": "Toggle Landmarks"
-        },
-        "03_toggle-headings": {
-            "suggested_key": {
-                "windows": "Alt+Shift+3",
-                "mac": "Alt+Shift+3",
-                "chromeos": "Alt+Shift+3",
-                "linux": "Alt+Shift+3"
-            },
-            "description": "Toggle Headings"
-        },
-        "04_toggle-tabStops": {
-            "description": "Toggle Tab stops"
-        },
-        "05_toggle-color": {
-            "description": "Toggle Color"
-        },
-        "06_toggle-needsReview": {
-            "description": "Toggle Needs review"
-        },
-        "07_toggle-accessibleNames": {
-            "description": "Toggle Accessible names"
-        }
-    }
+    "permissions": ["storage", "webNavigation", "tabs", "notifications", "activeTab"]
 }


### PR DESCRIPTION
#### Details

Prior to this change there were multiple slots for "Activate the extension" when configuring keyboard shortcut and only one actually worked. This was because we were using a mv2 specific API for that action, switching to the mv3 version fixes things. 

Before:
<img width="509" alt="BuggyShortcut" src="https://user-images.githubusercontent.com/16010855/189700871-52905c03-096f-48dd-aa9c-06b560c050e3.png">

After:
<img width="508" alt="FixedActivateExtShortcut" src="https://user-images.githubusercontent.com/16010855/189700899-385f9721-4988-4a2f-a739-2b78055e7344.png">

##### Motivation

Fix mv3 issue.

##### Context

Chrome docs briefly mention this change here: https://developer.chrome.com/docs/extensions/reference/commands/#action-commands.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
