### PR TITLE
chore: remove outdated todo note

### DIFF
--- a/src/reports/components/fast-pass-report-summary.tsx
+++ b/src/reports/components/fast-pass-report-summary.tsx
@@ -67,7 +67,7 @@ export class FastPassReportSummary extends React.Component<FastPassReportSummary
 
         const stats: Partial<OutcomeStats> = {
             fail: totalfailedAutomatedChecks + totalFailedTabInstancesCount,
-            incomplete: incompleteAutomatedChecks + totalIncompleteTabCount, //incomplete automated checks to be added in 1906107
+            incomplete: incompleteAutomatedChecks + totalIncompleteTabCount,
             pass: passedAutomatedChecks + totalPassedTabCount,
         };
 


### PR DESCRIPTION
#### Details

Removing an outdated todo note from a previous feature. 

##### Motivation

Clean up 🧹

##### Context

The work the note was referencing has been completed in #5034 and can now be removed. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
