### PR TITLE
refactor: revert #5933 tab stops patch

### DIFF
--- a/src/common/self-fast-pass.ts
+++ b/src/common/self-fast-pass.ts
@@ -78,7 +78,7 @@ class SelfFastPassAnalyzer implements Analyzer {
 
 class SelfFastPassAnalyzerProvider extends AnalyzerProvider {
     constructor(private readonly deps: SelfFastPassAnalyzerDeps) {
-        super(null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+        super(null, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     public override createRuleAnalyzerUnifiedScanForNeedsReview(

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Logger } from 'common/logging/logger';
-import { PromiseFactory } from 'common/promises/promise-factory';
 import { TabStopEvent } from 'common/types/store-data/tab-stop-event';
 import { AllFrameRunner } from 'injected/all-frame-runner';
 import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
@@ -37,7 +36,6 @@ export class AnalyzerProvider {
         private readonly sendNeedsReviewResults: PostResolveCallback,
         private readonly scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
         private readonly logger: Logger,
-        private readonly promiseFactory: PromiseFactory,
     ) {
         this.tabStopsListener = tabStopsListener;
         this.scopingStore = scopingStore;
@@ -116,7 +114,6 @@ export class AnalyzerProvider {
             this.logger,
             this.tabStopsDoneAnalyzingTracker,
             null,
-            this.promiseFactory,
         );
     }
 
@@ -129,7 +126,6 @@ export class AnalyzerProvider {
             this.logger,
             this.tabStopsDoneAnalyzingTracker,
             this.tabStopsRequirementResultProcessor,
-            this.promiseFactory,
         );
     }
 

--- a/src/injected/analyzers/base-analyzer.ts
+++ b/src/injected/analyzers/base-analyzer.ts
@@ -25,7 +25,7 @@ export class BaseAnalyzer implements Analyzer {
 
     public analyze(): void {
         const results = this.getResults();
-        results.then(this.onResolve).catch(e => this.logger.error(e));
+        results.then(this.onResolve).catch(this.logger.error);
     }
 
     public teardown(): void {}

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Logger } from 'common/logging/logger';
-import { PromiseFactory, TimeoutError } from 'common/promises/promise-factory';
 import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
 import { TabStopEvent } from 'common/types/store-data/tab-stop-event';
 import { AllFrameRunner } from 'injected/all-frame-runner';
@@ -20,7 +19,6 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
     private debouncedProcessTabEvents: DebouncedFunc<() => void> | null = null;
     private pendingTabbedElements: TabStopEvent[] = [];
     protected config: FocusAnalyzerConfiguration;
-    private startTimeoutMilliseconds = 500;
 
     constructor(
         config: FocusAnalyzerConfiguration,
@@ -30,7 +28,6 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         logger: Logger,
         private readonly tabStopsDoneAnalyzingTracker: TabStopsDoneAnalyzingTracker,
         private readonly tabStopsRequirementResultProcessor: TabStopsRequirementResultProcessor,
-        private readonly promiseFactory: PromiseFactory,
         private readonly debounceImpl: typeof debounce = debounce,
     ) {
         super(config, sendMessageDelegate, scanIncompleteWarningDetector, logger);
@@ -43,45 +40,15 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
             this.pendingTabbedElements.push(tabEvent);
             this.debouncedProcessTabEvents();
         };
-
-        await this.runWithIgnoredTimeout(
-            this.tabStopListenerRunner.start(),
-            this.startTimeoutMilliseconds,
-            'start tabStopListenerRunner',
-        );
+        await this.tabStopListenerRunner.start();
 
         this.tabStopsDoneAnalyzingTracker.reset();
         if (this.tabStopsRequirementResultProcessor) {
-            await this.runWithIgnoredTimeout(
-                this.tabStopsRequirementResultProcessor.start(),
-                this.startTimeoutMilliseconds,
-                'start tabStopsRequirementResultProcessor',
-            );
+            await this.tabStopsRequirementResultProcessor.start();
         }
 
         return this.emptyResults;
     };
-
-    private async runWithIgnoredTimeout(
-        promise: Promise<void>,
-        maxWaitTime: number,
-        taskDescription: string,
-    ): Promise<void> {
-        try {
-            // Try to wait for the promise to complete, but allow execution to continue if
-            // it times out. This is a temporary workaround in case frame messaging fails.
-            // For more info, see https://github.com/microsoft/accessibility-insights-web/issues/5931
-            await this.promiseFactory.timeout(promise, maxWaitTime);
-        } catch (e) {
-            if (e instanceof TimeoutError) {
-                this.logger.error(
-                    `Timeout of ${maxWaitTime} ms exceeded while attempting to ${taskDescription}. Tab stops analyzer will attempt to continue.`,
-                );
-            } else {
-                throw e;
-            }
-        }
-    }
 
     private processTabEvents = (): void => {
         this.tabStopsDoneAnalyzingTracker.addTabStopEvents(this.pendingTabbedElements);

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -6,7 +6,6 @@ import { EnumHelper } from 'common/enum-helper';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unavailable';
 import { Logger } from 'common/logging/logger';
-import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
 import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
@@ -314,8 +313,6 @@ export class MainWindowInitializer extends WindowInitializer {
             this.visualizationScanResultStoreProxy,
         );
 
-        const promiseFactory = createDefaultPromiseFactory();
-
         const analyzerProvider = new AnalyzerProvider(
             this.manualTabStopListener,
             tabStopsDoneAnalyzingTracker,
@@ -330,7 +327,6 @@ export class MainWindowInitializer extends WindowInitializer {
             unifiedResultSender.sendNeedsReviewResults,
             scanIncompleteWarningDetector,
             logger,
-            promiseFactory,
         );
 
         const analyzerStateUpdateHandler = new AnalyzerStateUpdateHandler(

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScopingStore } from 'background/stores/global/scoping-store';
-import { PromiseFactory } from 'common/promises/promise-factory';
 import { TabStopEvent } from 'common/types/store-data/tab-stop-event';
 import { AllFrameRunner } from 'injected/all-frame-runner';
 import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
@@ -42,7 +41,6 @@ describe('AnalyzerProviderTests', () => {
     let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
     let tabStopsDoneAnalyzingTrackerMock: IMock<TabStopsDoneAnalyzingTracker>;
     let tabStopsRequirementResultProcessorMock: IMock<TabStopsRequirementResultProcessor>;
-    const promiseFactoryStub = {} as PromiseFactory;
 
     beforeEach(() => {
         typeStub = -1;
@@ -76,7 +74,6 @@ describe('AnalyzerProviderTests', () => {
             sendNeedsReviewResultsMock.object,
             scanIncompleteWarningDetectorMock.object,
             failTestOnErrorLogger,
-            promiseFactoryStub,
         );
     });
 

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Logger } from 'common/logging/logger';
 import { Message } from 'common/message';
-import { PromiseFactory, TimeoutCreator, TimeoutError } from 'common/promises/promise-factory';
 import { TabStopEvent } from 'common/types/store-data/tab-stop-event';
 import { VisualizationType } from 'common/types/visualization-type';
 import { AllFrameRunner } from 'injected/all-frame-runner';
@@ -15,7 +13,6 @@ import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-
 import { flushSettledPromises } from 'tests/common/flush-settled-promises';
 import { DebounceFaker } from 'tests/unit/common/debounce-faker';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
-import { RecordingLogger } from 'tests/unit/common/recording-logger';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('TabStopsAnalyzer', () => {
@@ -30,9 +27,6 @@ describe('TabStopsAnalyzer', () => {
     let debounceFaker: DebounceFaker<() => void>;
     let tabStopsDoneAnalyzingTrackerMock: IMock<TabStopsDoneAnalyzingTracker>;
     let tabStopsRequirementResultProcessorMock: IMock<TabStopsRequirementResultProcessor>;
-    let timeoutMock: IMock<TimeoutCreator>;
-    let promiseFactoryStub: PromiseFactory;
-    const timeoutMilliseconds = 500;
 
     const tabEventStub1: TabStopEvent = {
         target: ['selector1'],
@@ -73,12 +67,16 @@ describe('TabStopsAnalyzer', () => {
             .setup(idm => idm.detectScanIncompleteWarnings())
             .returns(() => []);
 
-        timeoutMock = Mock.ofType<TimeoutCreator>();
-        promiseFactoryStub = {
-            timeout: timeoutMock.object,
-        } as PromiseFactory;
-
-        testSubject = createTabStopsAnalyzerWithLogger(failTestOnErrorLogger);
+        testSubject = new TabStopsAnalyzer(
+            configStub,
+            tabStopsListenerMock.object,
+            sendMessageMock.object,
+            scanIncompleteWarningDetectorMock.object,
+            failTestOnErrorLogger,
+            tabStopsDoneAnalyzingTrackerMock.object,
+            tabStopsRequirementResultProcessorMock.object,
+            debounceFaker.debounce,
+        );
         visualizationTypeStub = -1 as VisualizationType;
 
         emptyScanCompleteMessage = {
@@ -110,10 +108,12 @@ describe('TabStopsAnalyzer', () => {
             setupTabStopsListenerForStartTabStops();
             tabStopsDoneAnalyzingTrackerMock.setup(m => m.reset()).verifiable(Times.once());
             setupSendMessageMock(emptyScanCompleteMessage);
-            setupTimeoutWithSuccess();
         });
 
         it('emits an empty ScanCompleted message immediately on startup', async () => {
+            setupTabStopsListenerForStartTabStops();
+            setupSendMessageMock(emptyScanCompleteMessage);
+
             testSubject.analyze();
             await flushSettledPromises();
 
@@ -179,7 +179,6 @@ describe('TabStopsAnalyzer', () => {
                 failTestOnErrorLogger,
                 tabStopsDoneAnalyzingTrackerMock.object,
                 null,
-                promiseFactoryStub,
                 debounceFaker.debounce,
             );
 
@@ -211,6 +210,7 @@ describe('TabStopsAnalyzer', () => {
                 },
             };
 
+            setupTabStopsListenerForStartTabStops();
             setupSendMessageMock(emptyScanCompleteMessage);
             testSubject.analyze();
             await flushSettledPromises();
@@ -229,11 +229,12 @@ describe('TabStopsAnalyzer', () => {
         });
 
         it('emits a ScanTerminated message and stops emitting ScanUpdated messages after teardown() is invoked', async () => {
+            setupTabStopsListenerForStartTabStops();
+            setupSendMessageMock(emptyScanCompleteMessage);
             testSubject.analyze();
             await flushSettledPromises();
 
             tabStopsListenerMock.setup(tslm => tslm.stop()).verifiable(Times.once());
-            tabStopsRequirementResultProcessorMock.setup(t => t.stop()).verifiable(Times.once());
 
             setupSendMessageMock({
                 messageType: configStub.analyzerTerminatedMessageType,
@@ -241,6 +242,7 @@ describe('TabStopsAnalyzer', () => {
             });
 
             await testSubject.teardown();
+            await flushSettledPromises();
             verifyAll();
 
             simulateTabEvent(tabEventStub1); // no corresponding setupSendMessageMock
@@ -249,102 +251,10 @@ describe('TabStopsAnalyzer', () => {
         });
     });
 
-    describe('error handling', () => {
-        let recordingLogger: RecordingLogger;
-        const nonTimeoutError = new Error('Not a timeout error');
-        const timeoutError = new TimeoutError('Timeout error');
-
-        beforeEach(() => {
-            recordingLogger = new RecordingLogger();
-            testSubject = createTabStopsAnalyzerWithLogger(recordingLogger);
-        });
-
-        it('throws if TabStopsListener.start() throws non-timeout error', async () => {
-            tabStopsListenerMock
-                .setup(tslm => tslm.start())
-                .returns(async () => {
-                    throw nonTimeoutError;
-                })
-                .verifiable(Times.once());
-            tabStopsRequirementResultProcessorMock.setup(m => m.start()).verifiable(Times.never());
-            tabStopsDoneAnalyzingTrackerMock.setup(t => t.reset()).verifiable(Times.never());
-            setupTimeoutWithSuccess();
-            sendMessageMock.setup(sm => sm(It.isAny())).verifiable(Times.never());
-
-            testSubject.analyze();
-            await flushSettledPromises();
-
-            expect(recordingLogger.errorMessages).toHaveLength(1);
-            expect(recordingLogger.errorMessages[0]).toBe(nonTimeoutError);
-
-            verifyAll();
-        });
-
-        it('throws if tabStopsRequirementResultProcessorMock.start() throws non-timeout error', async () => {
-            setupTabStopsListenerForStartTabStops();
-            tabStopsRequirementResultProcessorMock
-                .setup(m => m.start())
-                .returns(async () => {
-                    throw nonTimeoutError;
-                })
-                .verifiable(Times.once());
-            tabStopsDoneAnalyzingTrackerMock.setup(t => t.reset()).verifiable(Times.once());
-            setupTimeoutWithSuccess();
-            sendMessageMock.setup(sm => sm(It.isAny())).verifiable(Times.never());
-
-            testSubject.analyze();
-            await flushSettledPromises();
-
-            expect(recordingLogger.errorMessages).toHaveLength(1);
-            expect(recordingLogger.errorMessages[0]).toBe(nonTimeoutError);
-
-            verifyAll();
-        });
-
-        it('logs TimeoutErrors and continues execution', async () => {
-            timeoutMock
-                .setup(t => t(It.isAny(), timeoutMilliseconds))
-                .throws(timeoutError)
-                .verifiable(Times.exactly(2));
-
-            setupTabStopsListenerForStartTabStops();
-            tabStopsRequirementResultProcessorMock.setup(m => m.start()).verifiable(Times.once());
-            tabStopsDoneAnalyzingTrackerMock.setup(t => t.reset()).verifiable(Times.once());
-
-            setupSendMessageMock(emptyScanCompleteMessage);
-
-            testSubject.analyze();
-            await flushSettledPromises();
-
-            expect(recordingLogger.errorMessages).toHaveLength(2);
-            expect(recordingLogger.errorMessages).toEqual([
-                'Timeout of 500 ms exceeded while attempting to start tabStopListenerRunner. Tab stops analyzer will attempt to continue.',
-                'Timeout of 500 ms exceeded while attempting to start tabStopsRequirementResultProcessor. Tab stops analyzer will attempt to continue.',
-            ]);
-
-            verifyAll();
-        });
-    });
-
-    function createTabStopsAnalyzerWithLogger(logger: Logger): TabStopsAnalyzer {
-        return new TabStopsAnalyzer(
-            configStub,
-            tabStopsListenerMock.object,
-            sendMessageMock.object,
-            scanIncompleteWarningDetectorMock.object,
-            logger,
-            tabStopsDoneAnalyzingTrackerMock.object,
-            tabStopsRequirementResultProcessorMock.object,
-            promiseFactoryStub,
-            debounceFaker.debounce,
-        );
-    }
-
     function verifyAll(): void {
         tabStopsDoneAnalyzingTrackerMock.verifyAll();
         tabStopsListenerMock.verifyAll();
         sendMessageMock.verifyAll();
-        timeoutMock.verifyAll();
     }
 
     function setupTabStopsListenerForStartTabStops(): void {
@@ -360,12 +270,5 @@ describe('TabStopsAnalyzer', () => {
             .setup(smm => smm(It.isValue(message)))
             .callback(callback)
             .verifiable();
-    }
-
-    function setupTimeoutWithSuccess(): void {
-        timeoutMock
-            .setup(t => t(It.isAny(), timeoutMilliseconds))
-            .returns(async (promise, _) => await promise)
-            .verifiable(Times.atLeastOnce());
     }
 });


### PR DESCRIPTION
#### Details

Revert #5933

##### Motivation

After #6028, this patch is no longer needed.

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
