### PR TITLE
refactor: use AllFramesMessenger for visualizers

### DIFF
--- a/src/injected/all-frame-runner.ts
+++ b/src/injected/all-frame-runner.ts
@@ -66,15 +66,17 @@ export class AllFrameRunner<T> {
     }
 
     public start = async () => {
-        await this.allFramesMessenger.initialize();
+        if (this.windowUtils.isTopWindow()) {
+            await this.allFramesMessenger.initializeAllFrames();
+        }
         const startPromise = this.listener.start();
-        await this.allFramesMessenger.sendCommandToFrames(this.startCommand);
+        await this.allFramesMessenger.sendCommandToAllFrames(this.startCommand);
         await startPromise;
     };
 
     public stop = async () => {
         const stopPromise = this.listener.stop();
-        await this.allFramesMessenger.sendCommandToFrames(this.stopCommand);
+        await this.allFramesMessenger.sendCommandToAllFrames(this.stopCommand);
         await stopPromise;
     };
 

--- a/src/injected/drawing-controller.ts
+++ b/src/injected/drawing-controller.ts
@@ -1,19 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AllFramesMessenger } from 'injected/frameCommunicators/all-frames-messenger';
 import {
     CommandMessage,
     CommandMessageResponse,
 } from 'injected/frameCommunicators/respondable-command-message-communicator';
-import { SingleFrameMessenger } from 'injected/frameCommunicators/single-frame-messenger';
 import { forOwn } from 'lodash';
-import { HTMLElementUtils } from '../common/html-element-utils';
 import { FeatureFlagStoreData } from '../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../common/types/visualization-type';
 import { DictionaryNumberTo } from '../types/common-types';
 import {
     AssessmentVisualizationInstance,
     HtmlElementAxeResultsHelper,
-    HTMLIFrameResult,
 } from './frameCommunicators/html-element-axe-results-helper';
 import { Drawer } from './visualization/drawer';
 
@@ -32,16 +30,19 @@ export class DrawingController {
     private featureFlagStoreData: FeatureFlagStoreData;
 
     constructor(
-        private readonly frameMessenger: SingleFrameMessenger,
+        private readonly allFramesMessenger: AllFramesMessenger,
         private readonly axeResultsHelper: HtmlElementAxeResultsHelper,
-        private readonly htmlElementUtils: HTMLElementUtils,
     ) {}
 
     public initialize(): void {
-        this.frameMessenger.addMessageListener(
+        this.allFramesMessenger.addMessageListener(
             DrawingController.triggerVisualizationCommand,
             this.onTriggerVisualization,
         );
+    }
+
+    public async prepareVisualization(): Promise<void> {
+        await this.allFramesMessenger.initializeAllFrames();
     }
 
     public registerDrawer = (id: string, drawer: Drawer) => {
@@ -72,41 +73,46 @@ export class DrawingController {
         configId: string,
     ): Promise<void> {
         if (elementResults) {
-            const elementResultsByFrame = this.axeResultsHelper.splitResultsByFrame(elementResults);
-
-            await Promise.all(
-                elementResultsByFrame.map(
-                    async frameResults =>
-                        await this.enableVisualizationForFrameResults(frameResults, configId),
-                ),
-            );
+            await this.enableVisualizationWithElementResults(elementResults, configId);
         } else {
-            await this.enableVisualizationInCurrentFrame(null, configId);
-
-            const childFrames = this.getChildFrames();
-            await Promise.all(
-                childFrames.map(
-                    async iframe =>
-                        await this.enableVisualizationInChildFrame(iframe, null, configId),
-                ),
-            );
+            await this.enableVisualizationForAllFrames(configId);
         }
     }
 
-    private enableVisualizationForFrameResults = async (
-        frameResults: HTMLIFrameResult,
+    private async enableVisualizationWithElementResults(
+        elementResults: AssessmentVisualizationInstance[],
         configId: string,
-    ): Promise<void> => {
-        if (frameResults.frame == null) {
-            await this.enableVisualizationInCurrentFrame(frameResults.elementResults, configId);
-        } else {
-            await this.enableVisualizationInChildFrame(
-                frameResults.frame,
-                frameResults.elementResults,
+    ): Promise<void> {
+        const elementResultsByFrame = this.axeResultsHelper.splitResultsByFrame(elementResults);
+
+        const currentFrameResults = elementResultsByFrame.find(results => results.frame == null);
+        if (currentFrameResults != null) {
+            await this.enableVisualizationInCurrentFrame(
+                currentFrameResults.elementResults,
                 configId,
             );
         }
-    };
+
+        const childFrameResults = elementResultsByFrame.filter(results => results.frame != null);
+        await this.allFramesMessenger.sendCommandToMultipleFrames(
+            DrawingController.triggerVisualizationCommand,
+            childFrameResults.map(results => results.frame),
+            (_frame, index) =>
+                this.createEnableVisualizationPayload(
+                    configId,
+                    childFrameResults[index].elementResults,
+                ),
+        );
+    }
+
+    private async enableVisualizationForAllFrames(configId: string): Promise<void> {
+        await this.enableVisualizationInCurrentFrame(null, configId);
+
+        await this.allFramesMessenger.sendCommandToAllFrames(
+            DrawingController.triggerVisualizationCommand,
+            this.createEnableVisualizationPayload(configId),
+        );
+    }
 
     private enableVisualizationInCurrentFrame = async (
         currentFrameResults: AssessmentVisualizationInstance[],
@@ -120,72 +126,37 @@ export class DrawingController {
         await drawer.drawLayout();
     };
 
-    private enableVisualizationInChildFrame = async (
-        frame: HTMLIFrameElement,
-        frameResults: AssessmentVisualizationInstance[],
+    private createEnableVisualizationPayload(
         configId: string,
-    ): Promise<void> => {
-        const message: VisualizationWindowMessage = {
-            elementResults: frameResults,
+        frameResults?: AssessmentVisualizationInstance[],
+    ): VisualizationWindowMessage {
+        return {
+            elementResults: frameResults ?? null,
             isEnabled: true,
             featureFlagStoreData: this.featureFlagStoreData,
             configId: configId,
         };
-
-        await this.frameMessenger.sendMessageToFrame(
-            frame,
-            this.createFrameRequestMessage(message),
-        );
-    };
+    }
 
     private async disableVisualization(configId: string): Promise<void> {
         this.disableVisualizationInCurrentFrame(configId);
         await this.disableVisualizationInChildFrames(configId);
     }
 
-    private createFrameRequestMessage(message: VisualizationWindowMessage): CommandMessage {
-        return {
-            command: DrawingController.triggerVisualizationCommand,
-            payload: message,
-        };
-    }
-
     private disableVisualizationInChildFrames = async (configId: string): Promise<void> => {
-        const iframes = this.getChildFrames();
-
-        await Promise.all(
-            iframes.map(async iframe => {
-                await this.disableVisualizationInChildFrame(configId, iframe);
-            }),
-        );
-    };
-
-    private disableVisualizationInChildFrame = async (
-        configId: string,
-        iframe: HTMLIFrameElement,
-    ): Promise<void> => {
-        const message: VisualizationWindowMessage = {
+        const commandPayload = {
             isEnabled: false,
             configId: configId,
         };
-
-        await this.frameMessenger.sendMessageToFrame(
-            iframe,
-            this.createFrameRequestMessage(message),
+        await this.allFramesMessenger.sendCommandToAllFrames(
+            DrawingController.triggerVisualizationCommand,
+            commandPayload,
         );
     };
 
     private disableVisualizationInCurrentFrame(configId: string): void {
         const drawer = this.getDrawer(configId);
         drawer.eraseLayout();
-    }
-
-    private getChildFrames(): HTMLIFrameElement[] {
-        return Array.from(
-            this.htmlElementUtils.getAllElementsByTagName(
-                'iframe',
-            ) as HTMLCollectionOf<HTMLIFrameElement>,
-        );
     }
 
     private getDrawer(configId: string): Drawer {

--- a/src/injected/drawing-initiator.ts
+++ b/src/injected/drawing-initiator.ts
@@ -20,6 +20,23 @@ export class DrawingInitiator {
         configId: string,
         processor: VisualizationInstanceProcessorCallback,
     ): Promise<void> => {
+        await this.drawingController.prepareVisualization();
+        await this.updateVisualization(
+            visualizationType,
+            featureFlagStoreData,
+            selectorMap,
+            configId,
+            processor,
+        );
+    };
+
+    public updateVisualization = async (
+        visualizationType: VisualizationType,
+        featureFlagStoreData: FeatureFlagStoreData,
+        selectorMap: SelectorToVisualizationMap,
+        configId: string,
+        processor: VisualizationInstanceProcessorCallback,
+    ): Promise<void> => {
         if (selectorMap == null) {
             return;
         }

--- a/src/injected/frameCommunicators/all-frames-messenger.ts
+++ b/src/injected/frameCommunicators/all-frames-messenger.ts
@@ -65,7 +65,7 @@ export class AllFramesMessenger {
     public async sendCommandToAllFrames(command: string, payload?: any): Promise<void> {
         this.validateInitialized();
 
-        const promises: Promise<unknown>[] = this.responsiveFrames.map(frame =>
+        const promises: Promise<unknown>[] = this.responsiveFrames!.map(frame =>
             this.singleFrameMessenger.sendMessageToFrame(frame, {
                 command,
                 payload,
@@ -81,9 +81,9 @@ export class AllFramesMessenger {
     ): Promise<void> {
         this.validateInitialized();
 
-        const promises: Promise<unknown>[] = frames.map((frame, index) => {
-            if (this.responsiveFrames.includes(frame)) {
-                return this.singleFrameMessenger.sendMessageToFrame(frame, {
+        const promises: Promise<unknown>[] = frames.map(async (frame, index) => {
+            if (this.responsiveFrames!.includes(frame)) {
+                await this.singleFrameMessenger.sendMessageToFrame(frame, {
                     command,
                     payload: getPayload?.(frame, index),
                 });
@@ -157,6 +157,7 @@ export class AllFramesMessenger {
             }
         });
 
+        // Timeouts are expected to happen occasionally, so we log and continue execution
         if (timeoutErrors.length > 0) {
             this.logger.error(
                 `Some iframes could not be reached within ${this.pingTimeoutMilliseconds} milliseconds. Those frames will be ignored.`,
@@ -164,8 +165,6 @@ export class AllFramesMessenger {
             );
         }
 
-        // Timeouts are expected to happen occasionally.
-        // If any other errors occur, throw an exception.
         if (unexpectedErrors.length > 0) {
             throw new AggregateError(unexpectedErrors);
         }

--- a/src/injected/frameCommunicators/all-frames-messenger.ts
+++ b/src/injected/frameCommunicators/all-frames-messenger.ts
@@ -11,6 +11,7 @@ import {
     PromiseWindowCommandMessageListener,
 } from 'injected/frameCommunicators/respondable-command-message-communicator';
 import { SingleFrameMessenger } from 'injected/frameCommunicators/single-frame-messenger';
+import { isEqual } from 'lodash';
 
 // This class provides functionality for messaging all frames in a page that can
 // respond, to handle cases where an iframe fails to load or does not have the
@@ -20,6 +21,11 @@ import { SingleFrameMessenger } from 'injected/frameCommunicators/single-frame-m
 // responded to the initial ping.
 export class AllFramesMessenger {
     private responsiveFrames: HTMLIFrameElement[] | null = null;
+    private readonly pingResponse: CommandMessageResponse = {
+        payload: {
+            status: 'ready',
+        },
+    };
 
     constructor(
         private readonly singleFrameMessenger: SingleFrameMessenger,
@@ -34,7 +40,7 @@ export class AllFramesMessenger {
     ) {
         this.addMessageListener(this.pingCommand, async () => {
             await this.findResponsiveFrames();
-            return null;
+            return this.pingResponse;
         });
     }
 
@@ -52,21 +58,44 @@ export class AllFramesMessenger {
         return this.singleFrameMessenger.sendMessageToWindow(targetWindow, message);
     }
 
-    public async initialize(): Promise<void> {
+    public async initializeAllFrames(): Promise<void> {
         await this.findResponsiveFrames();
     }
 
-    public async sendCommandToFrames(command: string): Promise<void> {
-        if (this.responsiveFrames == null) {
-            throw new Error('AllFramesMessenger is not initialized.');
-        }
+    public async sendCommandToAllFrames(command: string, payload?: any): Promise<void> {
+        this.validateInitialized();
 
         const promises: Promise<unknown>[] = this.responsiveFrames.map(frame =>
             this.singleFrameMessenger.sendMessageToFrame(frame, {
                 command,
+                payload,
             }),
         );
         await this.mergePromises(promises);
+    }
+
+    public async sendCommandToMultipleFrames(
+        command: string,
+        frames: HTMLIFrameElement[],
+        getPayload?: (frame: HTMLIFrameElement, index: number) => any,
+    ): Promise<void> {
+        this.validateInitialized();
+
+        const promises: Promise<unknown>[] = frames.map((frame, index) => {
+            if (this.responsiveFrames.includes(frame)) {
+                return this.singleFrameMessenger.sendMessageToFrame(frame, {
+                    command,
+                    payload: getPayload?.(frame, index),
+                });
+            }
+        });
+        await this.mergePromises(promises);
+    }
+
+    private validateInitialized(): void {
+        if (this.responsiveFrames == null) {
+            throw new Error('AllFramesMessenger is not initialized.');
+        }
     }
 
     private async findResponsiveFrames(): Promise<void> {
@@ -79,7 +108,15 @@ export class AllFramesMessenger {
             return;
         }
 
-        const promises: Promise<unknown>[] = Object.entries(allIFrameElements).map(([key, value]) =>
+        const pingResults = await this.pingFramesAndGetResults(allIFrameElements);
+
+        this.processPingResults(pingResults, allIFrameElements);
+    }
+
+    private pingFramesAndGetResults(
+        iframes: HTMLCollectionOf<HTMLIFrameElement>,
+    ): Promise<PromiseSettledResult<unknown>[]> {
+        const promises: Promise<unknown>[] = Object.entries(iframes).map(([_key, value]) =>
             this.promiseFactory.timeout(
                 this.singleFrameMessenger.sendMessageToFrame(value, {
                     command: this.pingCommand,
@@ -88,21 +125,34 @@ export class AllFramesMessenger {
             ),
         );
 
-        const results = await Promise.allSettled(promises);
+        return Promise.allSettled(promises);
+    }
+
+    private processPingResults(
+        pingResults: PromiseSettledResult<unknown>[],
+        allIFrameElements: HTMLCollectionOf<HTMLIFrameElement>,
+    ): void {
         this.responsiveFrames = [];
         const timeoutErrors: TimeoutError[] = [];
+        const unexpectedErrors: Error[] = [];
 
-        results.forEach((result, index) => {
+        pingResults.forEach((result, index) => {
             if (result.status === 'fulfilled') {
-                this.responsiveFrames!.push(allIFrameElements[index]);
+                const response = (result as PromiseFulfilledResult<CommandMessageResponse>).value;
+                if (isEqual(response, this.pingResponse)) {
+                    this.responsiveFrames!.push(allIFrameElements[index]);
+                } else {
+                    const error = new Error(
+                        `Recieved unexpected value for ping response: ${JSON.stringify(response)}`,
+                    );
+                    unexpectedErrors.push(error);
+                }
             } else {
                 const error = (result as PromiseRejectedResult).reason;
                 if (error instanceof TimeoutError) {
                     timeoutErrors.push(error);
                 } else {
-                    // We expect timeout errors if the frame message fails to send.
-                    // Throw if the error is anything else.
-                    throw error;
+                    unexpectedErrors.push(error);
                 }
             }
         });
@@ -112,6 +162,12 @@ export class AllFramesMessenger {
                 `Some iframes could not be reached within ${this.pingTimeoutMilliseconds} milliseconds. Those frames will be ignored.`,
                 timeoutErrors,
             );
+        }
+
+        // Timeouts are expected to happen occasionally.
+        // If any other errors occur, throw an exception.
+        if (unexpectedErrors.length > 0) {
+            throw new AggregateError(unexpectedErrors);
         }
     }
 }

--- a/src/injected/target-page-visualization-updater.ts
+++ b/src/injected/target-page-visualization-updater.ts
@@ -32,7 +32,7 @@ export type IsVisualizationNewlyEnabledCallback = (
 ) => boolean;
 
 const isVisualizationNewlyEnabled: IsVisualizationNewlyEnabledCallback = (newState, oldState) =>
-    newState.enabled && oldState?.enabled;
+    newState.enabled && !oldState?.enabled;
 
 export class TargetPageVisualizationUpdater {
     private previousVisualizationStates: TestStepVisualizationStateMap = {};

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -208,9 +208,8 @@ export class WindowInitializer {
             new DetailsDialogHandler(htmlElementUtils, this.windowUtils),
         );
         this.drawingController = new DrawingController(
-            this.frameMessenger,
+            this.allFramesMessenger,
             new HtmlElementAxeResultsHelper(htmlElementUtils, logger),
-            htmlElementUtils,
         );
         this.scrollingController = new ScrollingController(this.frameMessenger, htmlElementUtils);
         this.frameUrlFinder = new FrameUrlFinder(

--- a/src/tests/end-to-end/tests/target-page/post-message.test.ts
+++ b/src/tests/end-to-end/tests/target-page/post-message.test.ts
@@ -124,10 +124,10 @@ describe('Target Page window.postMessage behavior', () => {
 
         // Smoke test to ensure we're successfully recording at all.
         //
-        // For each of [axe.ping, axe.start-scan, insights.draw], there
+        // For each of [axe.ping, axe.start-scan, insights.ping, insights.draw], there
         // should be a request-response pair (2 messages) for each of the top-child and
-        // child-grandchild relationships, ie, 3 * 2 * 2 = 12.
-        expect(recordedMessages.length).toBe(12);
+        // child-grandchild relationships, ie, 4 * 2 * 2 = 16.
+        expect(recordedMessages.length).toBe(16);
 
         // The important test (that no messages contain HTML snippets)
         const mayContainHtmlSnippet = (msg: NestedIframeWindowMessageRecord) =>

--- a/src/tests/unit/tests/injected/__snapshots__/drawing-controller.test.ts.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/drawing-controller.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DrawingControllerTest drawer already registered 1`] = `"Drawer already registered to id: stub id"`;
+exports[`DrawingControllerTest drawer already registered 1`] = `"Drawer already registered to id: id"`;

--- a/src/tests/unit/tests/injected/drawing-controller.test.ts
+++ b/src/tests/unit/tests/injected/drawing-controller.test.ts
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { HtmlElementAxeResults } from 'common/types/store-data/visualization-scan-result-data';
+import { AllFramesMessenger } from 'injected/frameCommunicators/all-frames-messenger';
 import {
     CommandMessage,
     CommandMessageResponse,
 } from 'injected/frameCommunicators/respondable-command-message-communicator';
-import { SingleFrameMessenger } from 'injected/frameCommunicators/single-frame-messenger';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { getDefaultFeatureFlagsWeb } from '../../../../common/feature-flags';
-import { HTMLElementUtils } from '../../../../common/html-element-utils';
 import { FeatureFlagStoreData } from '../../../../common/types/store-data/feature-flag-store-data';
 import {
     DrawingController,
@@ -20,7 +19,6 @@ import {
 } from '../../../../injected/frameCommunicators/html-element-axe-results-helper';
 import { Drawer, DrawerInitData } from '../../../../injected/visualization/drawer';
 import { HighlightBoxDrawer } from '../../../../injected/visualization/highlight-box-drawer';
-import { HTMLCollectionOfBuilder } from '../../common/html-collection-of-builder';
 
 class VisualizationWindowMessageStubBuilder {
     private isEnabled: boolean;
@@ -69,22 +67,24 @@ class VisualizationWindowMessageStubBuilder {
 }
 
 describe('DrawingControllerTest', () => {
-    let frameMessengerMock: IMock<SingleFrameMessenger>;
+    const configId = 'id';
+    let allFrameMessengerMock: IMock<AllFramesMessenger>;
     let axeResultsHelperMock: IMock<HtmlElementAxeResultsHelper>;
-    let hTMLElementUtils: IMock<HTMLElementUtils>;
 
     beforeEach(() => {
-        frameMessengerMock = Mock.ofType(SingleFrameMessenger);
+        allFrameMessengerMock = Mock.ofType<AllFramesMessenger>();
         axeResultsHelperMock = Mock.ofType(HtmlElementAxeResultsHelper);
-        hTMLElementUtils = Mock.ofType(HTMLElementUtils);
+    });
+
+    afterEach(() => {
+        allFrameMessengerMock.verifyAll();
     });
 
     test('initialize', async () => {
         let addMessageListenerCallback: (
             message: CommandMessage,
         ) => Promise<CommandMessageResponse>;
-        const configId = 'id';
-        frameMessengerMock
+        allFrameMessengerMock
             .setup(fm =>
                 fm.addMessageListener(
                     It.isValue(DrawingController.triggerVisualizationCommand),
@@ -112,34 +112,35 @@ describe('DrawingControllerTest', () => {
             payload: message,
         };
 
-        hTMLElementUtils
-            .setup(dm => dm.getAllElementsByTagName(It.isValue('iframe')))
-            .returns(() => {
-                return [] as any;
-            })
-            .verifiable(Times.once());
-
         const drawerMock = Mock.ofType(HighlightBoxDrawer, MockBehavior.Strict);
         drawerMock.setup(m => m.eraseLayout()).verifiable(Times.once());
 
         const testObject = new DrawingController(
-            frameMessengerMock.object,
+            allFrameMessengerMock.object,
             axeResultsHelperMock.object,
-            hTMLElementUtils.object,
         );
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
         await addMessageListenerCallback(commandMessage);
 
-        frameMessengerMock.verifyAll();
+        allFrameMessengerMock.verifyAll();
         axeResultsHelperMock.verifyAll();
+    });
+
+    test('prepareVisualization', async () => {
+        allFrameMessengerMock.setup(f => f.initializeAllFrames()).verifiable();
+
+        const testObject = new DrawingController(
+            allFrameMessengerMock.object,
+            axeResultsHelperMock.object,
+        );
+        await testObject.prepareVisualization();
     });
 
     test('enable visualization test', async () => {
         const featureFlagStoreData = getDefaultFeatureFlagsWeb();
 
-        const configId = 'id';
         let addMessageListenerCallback: (
             message: CommandMessage,
         ) => Promise<CommandMessageResponse>;
@@ -172,8 +173,9 @@ describe('DrawingControllerTest', () => {
             },
         ];
         const drawerMock = Mock.ofType(HighlightBoxDrawer, MockBehavior.Strict);
+        let getPayloadCallback: (iframe: HTMLIFrameElement, index: number) => any;
 
-        frameMessengerMock
+        allFrameMessengerMock
             .setup(fm =>
                 fm.addMessageListener(
                     It.isValue(DrawingController.triggerVisualizationCommand),
@@ -185,21 +187,17 @@ describe('DrawingControllerTest', () => {
             })
             .verifiable(Times.once());
 
-        frameMessengerMock
+        allFrameMessengerMock
             .setup(fm =>
-                fm.sendMessageToFrame(
-                    targetFrame,
-                    It.isValue({
-                        command: DrawingController.triggerVisualizationCommand,
-                        payload: {
-                            isEnabled: true,
-                            elementResults: iframeResults,
-                            featureFlagStoreData,
-                            configId: configId,
-                        },
-                    }),
+                fm.sendCommandToMultipleFrames(
+                    DrawingController.triggerVisualizationCommand,
+                    [targetFrame],
+                    It.isAny(),
                 ),
             )
+            .returns(async (command, frame, getPayload) => {
+                getPayloadCallback = getPayload;
+            })
             .verifiable(Times.once());
 
         axeResultsHelperMock
@@ -208,10 +206,6 @@ describe('DrawingControllerTest', () => {
                 return resultsByFrames as any;
             })
             .verifiable(Times.once());
-
-        hTMLElementUtils
-            .setup(dm => dm.getAllElementsByTagName(It.isAny()))
-            .verifiable(Times.never());
 
         const expected: DrawerInitData<HtmlElementAxeResults> = {
             data: [visibleResultStub],
@@ -222,23 +216,27 @@ describe('DrawingControllerTest', () => {
         drawerMock.setup(dm => dm.drawLayout()).verifiable(Times.once());
 
         const testObject = new DrawingController(
-            frameMessengerMock.object,
+            allFrameMessengerMock.object,
             axeResultsHelperMock.object,
-            hTMLElementUtils.object,
         );
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
         await addMessageListenerCallback(commandMessage);
 
-        frameMessengerMock.verifyAll();
+        expect(getPayloadCallback(targetFrame, 0)).toEqual({
+            isEnabled: true,
+            elementResults: iframeResults,
+            featureFlagStoreData,
+            configId: configId,
+        });
+
+        allFrameMessengerMock.verifyAll();
         axeResultsHelperMock.verifyAll();
-        hTMLElementUtils.verifyAll();
         drawerMock.verifyAll();
     });
 
     test('enable visualization test when results is null - tabstops', async () => {
-        const configId = 'id';
         let addMessageListenerCallback: (
             message: CommandMessage,
         ) => Promise<CommandMessageResponse>;
@@ -251,11 +249,9 @@ describe('DrawingControllerTest', () => {
             command: DrawingController.triggerVisualizationCommand,
             payload: message,
         };
-        const iframeElement = 'iframeElement';
-        const targetFrame = iframeElement as any;
         const drawerMock = Mock.ofType(HighlightBoxDrawer, MockBehavior.Strict);
 
-        frameMessengerMock
+        allFrameMessengerMock
             .setup(fm =>
                 fm.addMessageListener(
                     It.isValue(DrawingController.triggerVisualizationCommand),
@@ -267,31 +263,20 @@ describe('DrawingControllerTest', () => {
             })
             .verifiable(Times.once());
 
-        frameMessengerMock
+        allFrameMessengerMock
             .setup(fm =>
-                fm.sendMessageToFrame(
-                    targetFrame,
-                    It.isValue({
-                        command: DrawingController.triggerVisualizationCommand,
-                        payload: {
-                            isEnabled: true,
-                            elementResults: null,
-                            featureFlagStoreData: getDefaultFeatureFlagsWeb(),
-                            configId: configId,
-                        },
-                    }),
-                ),
+                fm.sendCommandToAllFrames(DrawingController.triggerVisualizationCommand, {
+                    isEnabled: true,
+                    elementResults: null,
+                    featureFlagStoreData: getDefaultFeatureFlagsWeb(),
+                    configId: configId,
+                }),
             )
             .verifiable(Times.once());
 
         axeResultsHelperMock
             .setup(am => am.splitResultsByFrame(It.isAny()))
             .verifiable(Times.never());
-
-        hTMLElementUtils
-            .setup(dm => dm.getAllElementsByTagName('iframe'))
-            .returns(() => HTMLCollectionOfBuilder.create([iframeElement as any]))
-            .verifiable(Times.once());
 
         drawerMock
             .setup(dm =>
@@ -303,71 +288,52 @@ describe('DrawingControllerTest', () => {
         drawerMock.setup(dm => dm.drawLayout()).verifiable(Times.once());
 
         const testObject = new DrawingController(
-            frameMessengerMock.object,
+            allFrameMessengerMock.object,
             axeResultsHelperMock.object,
-            hTMLElementUtils.object,
         );
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
         await addMessageListenerCallback(commandMessageStub);
 
-        frameMessengerMock.verifyAll();
+        allFrameMessengerMock.verifyAll();
         axeResultsHelperMock.verifyAll();
-        hTMLElementUtils.verifyAll();
         drawerMock.verifyAll();
     });
 
     test('disable visualization test', async () => {
-        const configId = 'id';
         const disableMessage = new VisualizationWindowMessageStubBuilder(configId)
             .setVisualizationDisabled()
             .build();
-        const iframes = ['1'];
-        const targetFrame = iframes[0] as any;
         const drawerMock = Mock.ofType(HighlightBoxDrawer, MockBehavior.Strict);
-
-        hTMLElementUtils
-            .setup(dm => dm.getAllElementsByTagName('iframe'))
-            .returns(() => iframes as any)
-            .verifiable(Times.once());
 
         drawerMock.setup(dm => dm.drawLayout()).verifiable(Times.never());
         drawerMock.setup(dm => dm.eraseLayout()).verifiable(Times.once());
 
-        frameMessengerMock
+        allFrameMessengerMock
             .setup(fm =>
-                fm.sendMessageToFrame(
-                    targetFrame,
-                    It.isValue({
-                        command: DrawingController.triggerVisualizationCommand,
-                        payload: {
-                            isEnabled: false,
-                            configId: configId,
-                        },
-                    }),
-                ),
+                fm.sendCommandToAllFrames(DrawingController.triggerVisualizationCommand, {
+                    isEnabled: false,
+                    configId: configId,
+                }),
             )
             .verifiable(Times.once());
 
         const testObject = new DrawingController(
-            frameMessengerMock.object,
+            allFrameMessengerMock.object,
             axeResultsHelperMock.object,
-            hTMLElementUtils.object,
         );
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
         await testObject.processRequest(disableMessage);
 
-        frameMessengerMock.verifyAll();
+        allFrameMessengerMock.verifyAll();
         axeResultsHelperMock.verifyAll();
-        hTMLElementUtils.verifyAll();
         drawerMock.verifyAll();
     });
 
     test('dispose should call eraseLayout on drawers', async () => {
-        const configId = 'id';
         const enableMessage: VisualizationWindowMessage = new VisualizationWindowMessageStubBuilder(
             configId,
         )
@@ -391,16 +357,9 @@ describe('DrawingControllerTest', () => {
                 return resultsByFrames as any;
             });
 
-        const iframeElement = 'iframeElement';
-        hTMLElementUtils
-            .setup(dm => dm.getAllElementsByTagName(It.isAny()))
-            .returns(() => HTMLCollectionOfBuilder.create([iframeElement as any]))
-            .verifiable(Times.once());
-
         const testObject = new DrawingController(
-            frameMessengerMock.object,
+            allFrameMessengerMock.object,
             axeResultsHelperMock.object,
-            hTMLElementUtils.object,
         );
 
         testObject.initialize();
@@ -416,12 +375,10 @@ describe('DrawingControllerTest', () => {
     });
 
     test('drawer already registered', () => {
-        const configId = 'stub id';
         const drawerMock = Mock.ofType<Drawer>();
         const testObject = new DrawingController(
-            frameMessengerMock.object,
+            allFrameMessengerMock.object,
             axeResultsHelperMock.object,
-            hTMLElementUtils.object,
         );
         testObject.registerDrawer(configId, drawerMock.object);
         expect(() =>


### PR DESCRIPTION
#### Details

- Refactor `DrawingController` to use `AllFramesMessenger`
- Refactor `AllFramesMessenger` to validate ping responses to make sure the script is injected and responding
- distinguish `updateVisualization` from `enableVisualization` in `DrawingInitiator`: `enableVisualization` calls `initialize()` on `AllFramesMessenger` before updating so we don't ping all frames again on every update (such as with the tab stops visualizer that updates frequently)

##### Motivation

This fixes an error where DrawingController attempts to message nonresponsive frames to enable or disable the visualizer

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
