### PR TITLE
fix(mv3-part-8): Check for defined telemetry trace

### DIFF
--- a/src/background/telemetry/app-insights-telemetry-client.ts
+++ b/src/background/telemetry/app-insights-telemetry-client.ts
@@ -54,7 +54,9 @@ export class AppInsightsTelemetryClient implements TelemetryClient {
         this.initialized = true;
 
         this.applicationInsights.loadAppInsights();
-        this.applicationInsights.context.telemetryTrace.name = '';
+        if (this.applicationInsights.context.telemetryTrace) {
+            this.applicationInsights.context.telemetryTrace.name = '';
+        }
         this.applicationInsights.addTelemetryInitializer((telemetryItem: ITelemetryItem) => {
             const originalBaseData = telemetryItem?.baseData ?? {};
             telemetryItem.baseData = {

--- a/src/tests/unit/tests/background/telemetry/app-insights-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/app-insights-telemetry-client.test.ts
@@ -216,7 +216,7 @@ describe('AppInsights telemetry client tests', () => {
         appInsightsStrictMock
             .setup(ai => ai.context)
             .returns(() => getAppInsightsContext())
-            .verifiable(Times.once());
+            .verifiable(Times.exactly(2));
     }
 
     function getAppInsightsContext(): ITelemetryContext {


### PR DESCRIPTION
#### Details

Bug in sending telemetry for mv3 extensions: 
```
serviceWorker.bundle.js:683 Error while processing browser RuntimeOnMessage event:  TypeError: Cannot set properties of undefined (setting 'name')
```

##### Motivation

Fix mv3 bug

##### Context

It's not clear why `this.applicationInsights.context.telemetryTrace` is undefined in mv3 extensions but not mv2 extensions, but checked with @madalynrose (who added this line) and it appears to be non-vital, so we should be safe to only set the name when telemetryTrace is defined.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
