### PR TITLE
fix: register message listener after all stores are initialized

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -195,21 +195,6 @@ async function initialize(): Promise<void> {
     );
     keyboardShortcutHandler.initialize();
 
-    const postMessageContentRepository = new PostMessageContentRepository(
-        DateProvider.getCurrentDate,
-    );
-
-    const postMessageContentHandler = new PostMessageContentHandler(postMessageContentRepository);
-
-    const messageDistributor = new BackgroundMessageDistributor(
-        globalContext,
-        tabContextManager,
-        postMessageContentHandler,
-        browserAdapter,
-        eventResponseFactory,
-    );
-    messageDistributor.initialize();
-
     const targetTabController = new TargetTabController(
         browserAdapter,
         visualizationConfigurationFactory,
@@ -261,6 +246,21 @@ async function initialize(): Promise<void> {
         detailsViewController,
     );
     tabEventDistributor.initialize();
+
+    const postMessageContentRepository = new PostMessageContentRepository(
+        DateProvider.getCurrentDate,
+    );
+
+    const postMessageContentHandler = new PostMessageContentHandler(postMessageContentRepository);
+
+    const messageDistributor = new BackgroundMessageDistributor(
+        globalContext,
+        tabContextManager,
+        postMessageContentHandler,
+        browserAdapter,
+        eventResponseFactory,
+    );
+    messageDistributor.initialize();
 
     window.insightsFeatureFlags = globalContext.featureFlagsController;
     window.insightsUserConfiguration = globalContext.userConfigurationController;

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -260,6 +260,8 @@ async function initialize(): Promise<void> {
         browserAdapter,
         eventResponseFactory,
     );
+    // This should happen as late as possible so we don't try to distribute messages
+    // before all stores and actions have finished initializing
     messageDistributor.initialize();
 
     window.insightsFeatureFlags = globalContext.featureFlagsController;

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -258,6 +258,8 @@ async function initializeAsync(): Promise<void> {
         browserAdapter,
         eventResponseFactory,
     );
+    // This should happen as late as possible so we don't try to distribute messages
+    // before all stores and actions have finished initializing
     messageDistributor.initialize();
 
     await cleanKeysFromStoragePromise;

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -193,21 +193,6 @@ async function initializeAsync(): Promise<void> {
     );
     keyboardShortcutHandler.initialize();
 
-    const postMessageContentRepository = new PostMessageContentRepository(
-        DateProvider.getCurrentDate,
-    );
-
-    const postMessageContentHandler = new PostMessageContentHandler(postMessageContentRepository);
-
-    const messageDistributor = new BackgroundMessageDistributor(
-        globalContext,
-        tabContextManager,
-        postMessageContentHandler,
-        browserAdapter,
-        eventResponseFactory,
-    );
-    messageDistributor.initialize();
-
     const targetTabController = new TargetTabController(
         browserAdapter,
         visualizationConfigurationFactory,
@@ -259,6 +244,21 @@ async function initializeAsync(): Promise<void> {
         detailsViewController,
     );
     tabEventDistributor.initialize();
+
+    const postMessageContentRepository = new PostMessageContentRepository(
+        DateProvider.getCurrentDate,
+    );
+
+    const postMessageContentHandler = new PostMessageContentHandler(postMessageContentRepository);
+
+    const messageDistributor = new BackgroundMessageDistributor(
+        globalContext,
+        tabContextManager,
+        postMessageContentHandler,
+        browserAdapter,
+        eventResponseFactory,
+    );
+    messageDistributor.initialize();
 
     await cleanKeysFromStoragePromise;
 


### PR DESCRIPTION
#### Details

Move creation of BackgroundMessageListener to the end of background-init.ts and service-worker-init.ts

##### Motivation

We've been seeing intermittent store errors that cause the extension to freeze until the target page is refreshed. I believe this is because we're creating and registering the background message listener before everything else is fully initialized, so it's possible for the background to receive a message for a store that has not yet been initialized.

This PR moves that listener registration later in the script code, after all stores have been created and initialized. The BrowserEventManager defers events until a listener is registered, so any messages received before BackgroundMessageListener is registered will still be processed after everything is initialized.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
