### PR TITLE
fix(mv3-part-8): Only stop tab stops requirement results processor in teardown when defined

### DIFF
--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -73,7 +73,9 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
     public async teardown(): Promise<void> {
         this.debouncedProcessTabEvents?.cancel();
         await this.tabStopListenerRunner.stop();
-        await this.tabStopsRequirementResultProcessor.stop();
+        if (this.tabStopsRequirementResultProcessor) {
+            await this.tabStopsRequirementResultProcessor.stop();
+        }
 
         const payload: ScanBasePayload = {
             key: this.config.key,

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -251,6 +251,48 @@ describe('TabStopsAnalyzer', () => {
         });
     });
 
+    describe('teardown', () => {
+        let expectedTeardownMessage: Message;
+
+        beforeEach(() => {
+            expectedTeardownMessage = {
+                messageType: configStub.analyzerTerminatedMessageType,
+                payload: {
+                    key: configStub.key,
+                    testType: configStub.testType,
+                },
+            };
+
+            tabStopsListenerMock.setup(m => m.stop()).verifiable(Times.once());
+            setupSendMessageMock(expectedTeardownMessage);
+        });
+
+        it('stops processors when teardown() is invoked', async () => {
+            tabStopsRequirementResultProcessorMock.setup(m => m.stop()).verifiable(Times.once());
+
+            await testSubject.teardown();
+
+            verifyAll();
+        });
+
+        it('does not stop tabStopsRequirementResultProcessor when it is null', async () => {
+            testSubject = new TabStopsAnalyzer(
+                configStub,
+                tabStopsListenerMock.object,
+                sendMessageMock.object,
+                scanIncompleteWarningDetectorMock.object,
+                failTestOnErrorLogger,
+                tabStopsDoneAnalyzingTrackerMock.object,
+                null,
+                debounceFaker.debounce,
+            );
+
+            await testSubject.teardown();
+
+            verifyAll();
+        });
+    });
+
     function verifyAll(): void {
         tabStopsDoneAnalyzingTrackerMock.verifyAll();
         tabStopsListenerMock.verifyAll();


### PR DESCRIPTION
#### Details

Discovered a bug in mv3 testing with the following repro steps:

- Open assessment-> focus-> visible focus
- Turn on visual helper and tab through the page a few times
- Either allow service worker to go idle or shut it down manually
- Select start over-> start over Focus
- See unhandled error in target page: 
```
tab-stops-analyzer.ts:76 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'stop')
    at TabStopsAnalyzer.teardown (tab-stops-analyzer.ts:76:55)
```

##### Motivation

Fix mv3 bug

##### Context

N/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
