### PR TITLE
fix: only call createObjectURL when needed

### DIFF
--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -102,7 +102,6 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
                 <ExportDropdown
                     htmlFileName={props.htmlFileName}
                     jsonFileName={props.jsonFileName}
-                    fileURLProvider={props.deps.fileURLProvider}
                     featureFlagStoreData={props.featureFlagStoreData}
                     htmlFileURL={htmlFileUrl}
                     jsonFileURL={jsonFileUrl}

--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -63,13 +63,22 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
         props.onDescriptionChange(value);
     };
 
-    const htmlFileUrl = props.deps.fileURLProvider.provideURL([props.htmlExportData], 'text/html');
     const exportService = props.reportExportServices.find(s => s.key === serviceKey);
     const ExportForm = exportService ? exportService.exportForm : null;
     const exportToCodepen =
         props.featureFlagStoreData[FeatureFlags.exportReportOptions] &&
         props.reportExportServices.some(s => s.key === 'codepen');
     const exportToJSON = props.reportExportServices.some(s => s.key === 'json');
+
+    let htmlFileUrl = '#';
+    let jsonFileUrl = '#';
+    if (props.isOpen) {
+        htmlFileUrl = props.deps.fileURLProvider.provideURL([props.htmlExportData], 'text/html');
+        jsonFileUrl = props.deps.fileURLProvider.provideURL(
+            [props.jsonExportData],
+            'application/json',
+        );
+    }
 
     const getSingleExportToHtmlButton = () => {
         return (
@@ -95,8 +104,8 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
                     jsonFileName={props.jsonFileName}
                     fileURLProvider={props.deps.fileURLProvider}
                     featureFlagStoreData={props.featureFlagStoreData}
-                    htmlExportData={props.htmlExportData}
-                    jsonExportData={props.jsonExportData}
+                    htmlFileURL={htmlFileUrl}
+                    jsonFileURL={jsonFileUrl}
                     generateExports={props.generateExports}
                     onExportLinkClick={onExportLinkClick}
                     reportExportServices={props.reportExportServices}

--- a/src/DetailsView/components/export-dropdown.tsx
+++ b/src/DetailsView/components/export-dropdown.tsx
@@ -25,8 +25,8 @@ export interface ExportDropdownProps {
     reportExportServices: ReportExportService[];
     htmlFileName: string;
     jsonFileName: string;
-    htmlExportData: string;
-    jsonExportData: string;
+    htmlFileURL: string;
+    jsonFileURL: string;
     fileURLProvider: FileURLProvider;
     featureFlagStoreData: FeatureFlagStoreData;
 }
@@ -76,22 +76,14 @@ export class ExportDropdown extends React.Component<ExportDropdownProps, ExportD
     }
 
     private getMenuItems(): IContextualMenuItem[] {
-        const {
-            featureFlagStoreData,
-            htmlExportData,
-            jsonExportData,
-            htmlFileName,
-            jsonFileName,
-            fileURLProvider,
-        } = this.props;
+        const { featureFlagStoreData, htmlFileURL, jsonFileURL, htmlFileName, jsonFileName } =
+            this.props;
 
         const exportToCodepen = featureFlagStoreData[FeatureFlags.exportReportOptions];
-        const htmlFileUrl = fileURLProvider.provideURL([htmlExportData], 'text/html');
-        const jsonFileUrl = fileURLProvider.provideURL([jsonExportData], 'application/json');
 
         const items: IContextualMenuItem[] = [];
-        this.tryAddMenuItemForKey('html', items, htmlFileUrl, htmlFileName);
-        this.tryAddMenuItemForKey('json', items, jsonFileUrl, jsonFileName);
+        this.tryAddMenuItemForKey('html', items, htmlFileURL, htmlFileName);
+        this.tryAddMenuItemForKey('json', items, jsonFileURL, jsonFileName);
 
         if (exportToCodepen) {
             this.tryAddMenuItemForKey('codepen', items);

--- a/src/DetailsView/components/export-dropdown.tsx
+++ b/src/DetailsView/components/export-dropdown.tsx
@@ -3,7 +3,6 @@
 
 import { ContextualMenu, IContextualMenuItem, IPoint, PrimaryButton } from '@fluentui/react';
 import { FeatureFlags } from 'common/feature-flags';
-import { FileURLProvider } from 'common/file-url-provider';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import * as React from 'react';
 import {
@@ -27,7 +26,6 @@ export interface ExportDropdownProps {
     jsonFileName: string;
     htmlFileURL: string;
     jsonFileURL: string;
-    fileURLProvider: FileURLProvider;
     featureFlagStoreData: FeatureFlagStoreData;
 }
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
@@ -1,48 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ExportDialog renders with CodePen export form 1`] = `
-<form
-  action="https://codepen.io/pen/define"
-  method="POST"
-  rel="noopener"
-  style={
-    {
-      "visibility": "hidden",
-    }
-  }
-  target="_blank"
->
-  <input
-    name="data"
-    type="hidden"
-    value="{"title":"THE REPORT FILE NAME","description":"description","html":"fake html","editors":"100"}"
-  />
-  <button
-    type="submit"
-  />
-</form>
-`;
-
-exports[`ExportDialog renders with export dropdown 1`] = `
-"<Dialog hidden={false} onDismiss={[Function: onDismiss]} dialogContentProps={{...}} modalProps={{...}}>
-  <StyledTextFieldBase multiline={true} autoFocus={true} rows={8} resizable={false} onChange={[Function: onDescriptionChange]} value="description" ariaLabel="Provide result description" />
-  <StyledDialogFooterBase>
-    <ExportDropdown htmlFileName="THE REPORT FILE NAME" jsonFileName="JSON file name" fileURLProvider={[Function: function () {
-                        var args = [];
-                        for (var _i = 0; _i < arguments.length; _i++) {
-                            args[_i] = arguments[_i];
-                        }
-                        _this._interceptor.removeInvocation(invocation_1);
-                        var method = new MethodInfo(target, p);
-                        var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
-                        _this._interceptor.intercept(methodInvocation);
-                        return methodInvocation.returnValue;
-                    }] { provideURL: [Function (anonymous)], [Symbol(Symbol.toStringTag)]: [Function: bound toString] }} featureFlagStoreData={{...}} htmlExportData="fake html" jsonExportData="fake json" generateExports={[Function: proxy]} onExportLinkClick={[Function: onExportLinkClick]} reportExportServices={{...}} />
-  </StyledDialogFooterBase>
-</Dialog>"
-`;
-
-exports[`ExportDialog renders with open false 1`] = `
+exports[`ExportDialog renders With dialog closed 1`] = `
 <Dialog
   dialogContentProps={
     {
@@ -74,7 +32,7 @@ exports[`ExportDialog renders with open false 1`] = `
     <CustomizedPrimaryButton
       data-automation-id="single-export-to-html-button"
       download="THE REPORT FILE NAME"
-      href="fake-url"
+      href="#"
       onClick={[Function]}
     >
       Export
@@ -83,7 +41,7 @@ exports[`ExportDialog renders with open false 1`] = `
 </Dialog>
 `;
 
-exports[`ExportDialog renders with open true 1`] = `
+exports[`ExportDialog renders With dialog open 1`] = `
 <Dialog
   dialogContentProps={
     {
@@ -115,7 +73,7 @@ exports[`ExportDialog renders with open true 1`] = `
     <CustomizedPrimaryButton
       data-automation-id="single-export-to-html-button"
       download="THE REPORT FILE NAME"
-      href="fake-url"
+      href="html url"
       onClick={[Function]}
     >
       Export
@@ -124,11 +82,43 @@ exports[`ExportDialog renders with open true 1`] = `
 </Dialog>
 `;
 
+exports[`ExportDialog renders with CodePen export form 1`] = `
+<form
+  action="https://codepen.io/pen/define"
+  method="POST"
+  rel="noopener"
+  style={
+    {
+      "visibility": "hidden",
+    }
+  }
+  target="_blank"
+>
+  <input
+    name="data"
+    type="hidden"
+    value="{"title":"THE REPORT FILE NAME","description":"description","html":"fake html","editors":"100"}"
+  />
+  <button
+    type="submit"
+  />
+</form>
+`;
+
+exports[`ExportDialog renders with export dropdown 1`] = `
+"<Dialog hidden={false} onDismiss={[Function: onDismiss]} dialogContentProps={{...}} modalProps={{...}}>
+  <StyledTextFieldBase multiline={true} autoFocus={true} rows={8} resizable={false} onChange={[Function: onDescriptionChange]} value="description" ariaLabel="Provide result description" />
+  <StyledDialogFooterBase>
+    <ExportDropdown htmlFileName="THE REPORT FILE NAME" jsonFileName="JSON file name" featureFlagStoreData={{...}} htmlFileURL="html url" jsonFileURL="json url" generateExports={[Function: proxy]} onExportLinkClick={[Function: onExportLinkClick]} reportExportServices={{...}} />
+  </StyledDialogFooterBase>
+</Dialog>"
+`;
+
 exports[`ExportDialog renders without export dropdown due to lack of service 1`] = `
 "<Dialog hidden={false} onDismiss={[Function: onDismiss]} dialogContentProps={{...}} modalProps={{...}}>
   <StyledTextFieldBase multiline={true} autoFocus={true} rows={8} resizable={false} onChange={[Function: onDescriptionChange]} value="description" ariaLabel="Provide result description" />
   <StyledDialogFooterBase>
-    <CustomizedPrimaryButton onClick={[Function: onClick]} download="THE REPORT FILE NAME" href="fake-url" data-automation-id="single-export-to-html-button">
+    <CustomizedPrimaryButton onClick={[Function: onClick]} download="THE REPORT FILE NAME" href="html url" data-automation-id="single-export-to-html-button">
       Export
     </CustomizedPrimaryButton>
   </StyledDialogFooterBase>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
@@ -124,3 +124,102 @@ exports[`ExportDialog renders without export dropdown due to lack of service 1`]
   </StyledDialogFooterBase>
 </Dialog>"
 `;
+
+exports[`ExportDialog user interaction renders immediately after dialog closed with htmlOnly=false 1`] = `
+<Dialog
+  dialogContentProps={
+    {
+      "subText": "Optional: please describe the result (it will be saved in the report).",
+      "title": "Provide result description",
+      "type": 0,
+    }
+  }
+  hidden={true}
+  modalProps={
+    {
+      "containerClassName": "exportDialog",
+      "isBlocking": false,
+      "onDismissed": [Function],
+    }
+  }
+  onDismiss={[Function]}
+>
+  <StyledTextFieldBase
+    ariaLabel="Provide result description"
+    autoFocus={true}
+    multiline={true}
+    onChange={[Function]}
+    resizable={false}
+    rows={8}
+    value="description"
+  />
+  <StyledDialogFooterBase>
+    <React.Fragment>
+      <ExportDropdown
+        featureFlagStoreData={{}}
+        generateExports={[Function]}
+        htmlFileName="THE REPORT FILE NAME"
+        htmlFileURL="html url"
+        jsonFileName="JSON file name"
+        jsonFileURL="json url"
+        onExportLinkClick={[Function]}
+        reportExportServices={
+          [
+            {
+              "exportForm": [Function],
+              "generateMenuItem": [Function],
+              "key": "html",
+            },
+            {
+              "exportForm": [Function],
+              "generateMenuItem": [Function],
+              "key": "json",
+            },
+          ]
+        }
+      />
+    </React.Fragment>
+  </StyledDialogFooterBase>
+</Dialog>
+`;
+
+exports[`ExportDialog user interaction renders immediately after dialog closed with htmlOnly=true 1`] = `
+<Dialog
+  dialogContentProps={
+    {
+      "subText": "Optional: please describe the result (it will be saved in the report).",
+      "title": "Provide result description",
+      "type": 0,
+    }
+  }
+  hidden={true}
+  modalProps={
+    {
+      "containerClassName": "exportDialog",
+      "isBlocking": false,
+      "onDismissed": [Function],
+    }
+  }
+  onDismiss={[Function]}
+>
+  <StyledTextFieldBase
+    ariaLabel="Provide result description"
+    autoFocus={true}
+    multiline={true}
+    onChange={[Function]}
+    resizable={false}
+    rows={8}
+    value="description"
+  />
+  <StyledDialogFooterBase>
+    <CustomizedPrimaryButton
+      data-automation-id="single-export-to-html-button"
+      download="THE REPORT FILE NAME"
+      href="html url"
+      onClick={[Function]}
+    >
+      Export
+    </CustomizedPrimaryButton>
+  </StyledDialogFooterBase>
+</Dialog>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dropdown.test.tsx.snap
@@ -19,13 +19,13 @@ exports[`ExportDropdown handles click to show menu with feature flags 1`] = `
       [
         {
           "download": "A file name",
-          "href": "a file url",
+          "href": "html file url",
           "key": "html",
           "onClick": [Function],
         },
         {
           "download": "json file name",
-          "href": undefined,
+          "href": "json file url",
           "key": "json",
           "onClick": [Function],
         },
@@ -62,7 +62,7 @@ exports[`ExportDropdown handles click to show menu with feature flags but missin
       [
         {
           "download": "A file name",
-          "href": "a file url",
+          "href": "html file url",
           "key": "html",
           "onClick": [Function],
         },
@@ -99,7 +99,7 @@ exports[`ExportDropdown handles click to show menu without feature flags 1`] = `
       [
         {
           "download": "A file name",
-          "href": "a file url",
+          "href": "html file url",
           "key": "html",
           "onClick": [Function],
         },

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -205,6 +205,23 @@ describe('ExportDialog', () => {
             generateExportsMock.verifyAll();
         });
 
+        it.each([true, false])(
+            'renders immediately after dialog closed with htmlOnly=%s',
+            htmlOnly => {
+                if (htmlOnly) {
+                    onlyIncludeHtmlService();
+                }
+                setupGenerateFileUrls();
+
+                const validateAfterUpdate = () => {
+                    expect(wrapper.getElement()).toMatchSnapshot();
+                };
+
+                const wrapper = shallow(<ExportDialog {...props} />);
+                wrapper.setProps({ isOpen: false }, validateAfterUpdate);
+            },
+        );
+
         it('handles text changes for the description', () => {
             props.isOpen = true;
             setupGenerateFileUrls();

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -46,6 +46,17 @@ describe('ExportDialog', () => {
         ] as ReportExportService[];
     };
 
+    const setupGenerateFileUrls = () => {
+        fileProviderMock
+            .setup(provider => provider.provideURL([props.htmlExportData], 'text/html'))
+            .returns(() => 'html url')
+            .verifiable(Times.atLeastOnce());
+        fileProviderMock
+            .setup(provider => provider.provideURL([props.jsonExportData], 'application/json'))
+            .returns(() => 'json url')
+            .verifiable(Times.atLeastOnce());
+    };
+
     beforeEach(() => {
         onCloseMock.reset();
         onDescriptionChangeMock.reset();
@@ -77,15 +88,22 @@ describe('ExportDialog', () => {
     });
 
     describe('renders', () => {
-        const isOpenOptions = [true, false];
-
-        it.each(isOpenOptions)('with open %p', isOpen => {
-            props.isOpen = isOpen;
+        it('With dialog closed', () => {
+            props.isOpen = false;
             onlyIncludeHtmlService();
             fileProviderMock
-                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
-                .returns(() => 'fake-url')
-                .verifiable(Times.once());
+                .setup(f => f.provideURL(It.isAny(), It.isAny()))
+                .verifiable(Times.never());
+            const wrapper = shallow(<ExportDialog {...props} />);
+            expect(wrapper.getElement()).toMatchSnapshot();
+
+            fileProviderMock.verifyAll();
+        });
+
+        it('With dialog open', () => {
+            props.isOpen = true;
+            onlyIncludeHtmlService();
+            setupGenerateFileUrls();
             const wrapper = shallow(<ExportDialog {...props} />);
             expect(wrapper.getElement()).toMatchSnapshot();
 
@@ -99,10 +117,8 @@ describe('ExportDialog', () => {
                 .verifiable(Times.once());
 
             props.isOpen = true;
-            fileProviderMock
-                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
-                .returns(() => 'fake-url')
-                .verifiable(Times.once());
+            setupGenerateFileUrls();
+
             const wrapper = shallow(<ExportDialog {...props} />);
             const elem = wrapper.debug();
             expect(elem).toMatchSnapshot();
@@ -118,10 +134,7 @@ describe('ExportDialog', () => {
                 .verifiable(Times.once());
 
             props.isOpen = true;
-            fileProviderMock
-                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
-                .returns(() => 'fake-url')
-                .verifiable(Times.once());
+            setupGenerateFileUrls();
             const wrapper = shallow(<ExportDialog {...props} />);
             expect(wrapper.debug()).toMatchSnapshot();
 
@@ -145,12 +158,13 @@ describe('ExportDialog', () => {
     });
 
     describe('user interaction', () => {
+        beforeEach(() => {
+            props.isOpen = true;
+        });
+
         it('closes the dialog onDismiss', () => {
             onCloseMock.setup(oc => oc()).verifiable(Times.once());
-            fileProviderMock
-                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
-                .returns(() => 'fake-url')
-                .verifiable(Times.once());
+            setupGenerateFileUrls();
             generateExportsMock.setup(getter => getter()).verifiable(Times.never());
             const wrapper = shallow(<ExportDialog {...props} />);
 
@@ -171,10 +185,7 @@ describe('ExportDialog', () => {
                 .verifiable(Times.once());
 
             onCloseMock.setup(oc => oc()).verifiable(Times.once());
-            fileProviderMock
-                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
-                .returns(() => 'fake-url')
-                .verifiable(Times.exactly(2));
+            setupGenerateFileUrls();
             generateExportsMock.setup(getter => getter()).verifiable(Times.once());
 
             exportResultsClickedTelemetryMock
@@ -196,10 +207,7 @@ describe('ExportDialog', () => {
 
         it('handles text changes for the description', () => {
             props.isOpen = true;
-            fileProviderMock
-                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
-                .returns(() => 'fake-url')
-                .verifiable(Times.once());
+            setupGenerateFileUrls();
             const changedDescription = 'changed-description';
             onDescriptionChangeMock
                 .setup(handler => handler(It.isValue(changedDescription)))

--- a/src/tests/unit/tests/DetailsView/components/export-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dropdown.test.tsx
@@ -3,7 +3,6 @@
 
 import { ContextualMenu, PrimaryButton } from '@fluentui/react';
 import { FeatureFlags } from 'common/feature-flags';
-import { FileURLProvider } from 'common/file-url-provider';
 import { ExportDropdown, ExportDropdownProps } from 'DetailsView/components/export-dropdown';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -15,7 +14,6 @@ import {
 import { Mock } from 'typemoq';
 
 describe('ExportDropdown', () => {
-    const fileProviderMock = Mock.ofType<FileURLProvider>();
     const generateExportsMock = Mock.ofType<() => void>();
     const event = {
         currentTarget: 'test target',
@@ -49,15 +47,11 @@ describe('ExportDropdown', () => {
             reportExportServices: null,
             htmlFileName: 'A file name',
             jsonFileName: 'json file name',
-            htmlExportData: '<some html>',
-            jsonExportData: '{}',
+            htmlFileURL: 'html file url',
+            jsonFileURL: 'json file url',
             generateExports: generateExportsMock.object,
-            fileURLProvider: fileProviderMock.object,
             featureFlagStoreData: {},
         };
-        fileProviderMock
-            .setup(f => f.provideURL(['<some html>'], 'text/html'))
-            .returns(() => 'a file url');
     });
 
     it('renders without menu items', () => {


### PR DESCRIPTION
#### Details

Currently, the export dialog calls `window.URL.createObjectURL()` on every rerender, even when the dialog is not visible. This PR makes sure it is only called when the dialog is visible.

##### Motivation

I've been seeing some performance issues from `createObjectURL` occasionally taking 1-2 seconds to complete and delaying the UI from updating. It doesn't happen often, and only in the Manifest V3 build of the extension. In particular, if I run automated checks on a page with a lot of iframes (such as cnn.com), and select "start over" immediately after the scan completes, the UI doesn't update for about a second because `createObjectURL` runs extremely slowly _only_ in the update cycle after the visualizer is re-enabled. The lag is less obvious on faster machines, but it still appears slightly slower than the MV2 extension. This PR fixes that issue.

Below are two screen captures of the Automated checks view in which the "Start over" button is clicked repeatedly. The first is before this PR, the second is after, to demonstrate the reduction in lag.

https://user-images.githubusercontent.com/55459788/193152116-fceee8ca-1996-4c07-92be-a8db33e97fb1.mp4

https://user-images.githubusercontent.com/55459788/193152127-d98e2961-14de-4cf3-9783-04b4b19d6f3a.mp4

##### Context

I suspect the lag is the result of some implementation details with chrome's, `window` API, but I don't have enough information to guess what it could be or why it only happens in Manifest V3.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
