### PR TITLE
fix(mv3-part-8): Only persist store data when changed

### DIFF
--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -54,10 +54,10 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         private readonly assessmentDataConverter: AssessmentDataConverter,
         private readonly assessmentDataRemover: AssessmentDataRemover,
         private readonly assessmentsProvider: AssessmentsProvider,
-        protected readonly idbInstance: IndexedDBAPI,
-        protected readonly persistedData: AssessmentStoreData,
+        idbInstance: IndexedDBAPI,
+        persistedData: AssessmentStoreData,
         private readonly initialAssessmentStoreDataGenerator: InitialAssessmentStoreDataGenerator,
-        protected readonly logger: Logger,
+        logger: Logger,
     ) {
         super(
             StoreNames.AssessmentStore,

--- a/src/tests/unit/tests/background/stores/persistent-store.test.ts
+++ b/src/tests/unit/tests/background/stores/persistent-store.test.ts
@@ -16,6 +16,10 @@ describe('PersistentStoreTest', () => {
     const loggerMock: IMock<Logger> = Mock.ofType<Logger>();
 
     describe('Persist store data', () => {
+        beforeEach(() => {
+            idbInstanceMock.reset();
+        });
+
         test('Initialize with initial state', async () => {
             const testObject = new TestStore();
 
@@ -76,6 +80,21 @@ describe('PersistentStoreTest', () => {
             idbInstanceMock.verifyAll();
         });
 
+        test('do not persist data when it has not changed', async () => {
+            const testObject = new TestStore();
+            const data = { value: 'data' };
+            await testObject.callPersistData(data);
+
+            idbInstanceMock.reset();
+            idbInstanceMock
+                .setup(db => db.setItem(It.isAny(), It.isAny()))
+                .verifiable(Times.never());
+
+            await testObject.callPersistData(data);
+
+            idbInstanceMock.verifyAll();
+        });
+
         test('emitChanged', async () => {
             const testObject = new TestStore();
             testObject.initialize();
@@ -93,9 +112,8 @@ describe('PersistentStoreTest', () => {
             const testObject = new TestStore(false);
             testObject.initialize();
             idbInstanceMock
-                .setup(db => db.setItem(indexedDBDataKey, persistedState))
-                .returns(() => Promise.resolve(true))
-                .verifiable(Times.once());
+                .setup(db => db.setItem(It.isAny(), It.isAny()))
+                .verifiable(Times.never());
 
             await testObject.callEmitChanged();
 


### PR DESCRIPTION
#### Details

Addressing assessment perf issues caused by MV3 changes to `emitChanged`. During MV3 testing we noticed that perf seems to degrade as you go through an assessment because the assessment data structure is growing and it therefore takes more time to persist data in the indexedDB. This PR mitigates this issue by minimizing the calls to indexedDB. 

##### Motivation

Address MV3 perf issue

##### Context

EmitChanged is often called for stores when no store data was actually changed, which causes us to make unnecessary calls to IndexedBD to persist data that is already saved in the database. This PR adds logic to keep track of the data we last saved to the database and only update the database when that data has changed. 

Testing results:
Scenario: Clean install of extension (nothing saved in stores) -> open new assessment against https://markreay.github.io/AU/before.html -> run assessment automated checks -> average `emitChanged` performance for each store across all calls made. Repeated 3 times for each branch and averaged.
Main branch (no caching of last persisted data):
Avg time for `emitChanged` in AssessmentStore: 184.5 ms
VisualizationStore: 159.9 ms
Pr branch (with caching of last persisted data):
AssessmentStore: 81.9 ms
VisualizationStore: 6.3 ms

These changes make more of a difference for some stores than others depending on how often the store data is actually updated. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
