### PR TITLE
feat(mv3-part-8): Remove unnecessary persist data flag

### DIFF
--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -17,7 +17,6 @@ export class ExtensionDetailsViewController implements DetailsViewController {
             tabId: number,
             message: Message,
         ) => InterpreterResponse,
-        private readonly persistStoreData: boolean,
     ) {}
 
     public async initialize(): Promise<void> {
@@ -61,12 +60,10 @@ export class ExtensionDetailsViewController implements DetailsViewController {
     }
 
     private persistTabIdToDetailsViewMap = async () => {
-        if (this.persistStoreData) {
-            await this.idbInstance.setItem(
-                IndexedDBDataKeys.tabIdToDetailsViewMap,
-                this.tabIdToDetailsViewMap,
-            );
-        }
+        await this.idbInstance.setItem(
+            IndexedDBDataKeys.tabIdToDetailsViewMap,
+            this.tabIdToDetailsViewMap,
+        );
     };
 
     public async showDetailsView(targetTabId: number): Promise<void> {

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { BrowserPermissionsTracker } from 'background/browser-permissions-tracker';
 import { Logger } from 'common/logging/logger';
-import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { DebugToolsActionCreator } from 'debug-tools/action-creators/debug-tools-action-creator';
 import { DebugToolsController } from 'debug-tools/controllers/debug-tools-controller';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
@@ -44,11 +43,9 @@ export class GlobalContextFactory {
         indexedDBInstance: IndexedDBAPI,
         persistedData: PersistedData,
         issueFilingServiceProvider: IssueFilingServiceProvider,
-        toolData: ToolData,
         storageAdapter: StorageAdapter,
         commandsAdapter: CommandsAdapter,
         logger: Logger,
-        persistStoreData: boolean,
     ): Promise<GlobalContext> {
         const interpreter = new Interpreter();
 
@@ -63,7 +60,6 @@ export class GlobalContextFactory {
             persistedData,
             storageAdapter,
             logger,
-            persistStoreData,
         );
 
         const featureFlagsController = new FeatureFlagsController(

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -25,8 +25,6 @@ import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-hand
 import { TelemetryLogger } from 'background/telemetry/telemetry-logger';
 import { TelemetryStateListener } from 'background/telemetry/telemetry-state-listener';
 import { UsageLogger } from 'background/usage-logger';
-import { createToolData } from 'common/application-properties-provider';
-import { AxeInfo } from 'common/axe-info';
 import { BackgroundBrowserEventManager } from 'common/browser-adapters/background-browser-event-manager';
 import { BrowserAdapterFactory } from 'common/browser-adapters/browser-adapter-factory';
 import { EventResponseFactory } from 'common/browser-adapters/event-response-factory';
@@ -38,14 +36,13 @@ import { getIndexedDBStore } from 'common/indexedDB/get-indexeddb-store';
 import { IndexedDBAPI, IndexedDBUtil } from 'common/indexedDB/indexedDB';
 import { createDefaultLogger } from 'common/logging/default-logger';
 import { Logger } from 'common/logging/logger';
-import { NavigatorUtils } from 'common/navigator-utils';
 import { NotificationCreator } from 'common/notification-creator';
 import { createDefaultPromiseFactory, PromiseFactory } from 'common/promises/promise-factory';
 import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { ExceptionTelemetrySanitizer } from 'common/telemetry/exception-telemetry-sanitizer';
 import { UrlParser } from 'common/url-parser';
 import { UrlValidator } from 'common/url-validator';
-import { title, toolName } from 'content/strings/application';
+import { title } from 'content/strings/application';
 import { IssueFilingServiceProviderImpl } from 'issue-filing/issue-filing-service-provider-impl';
 import UAParser from 'ua-parser-js';
 import { deprecatedStorageDataKeys, storageDataKeys } from './local-storage-data-keys';
@@ -135,16 +132,6 @@ async function initializeAsync(): Promise<void> {
 
     const usageLogger = new UsageLogger(browserAdapter, DateProvider.getCurrentDate, logger);
 
-    const browserSpec = new NavigatorUtils(navigator, logger).getBrowserSpec();
-
-    const toolData = createToolData(
-        'axe-core',
-        AxeInfo.Default.version,
-        toolName,
-        browserAdapter.getVersion(),
-        browserSpec,
-    );
-
     const globalContext = await GlobalContextFactory.createContext(
         browserAdapter,
         telemetryEventHandler,
@@ -154,11 +141,9 @@ async function initializeAsync(): Promise<void> {
         indexedDBInstance,
         persistedData,
         IssueFilingServiceProviderImpl,
-        toolData,
         browserAdapter,
         browserAdapter,
         logger,
-        true,
     );
 
     telemetryLogger.initialize(globalContext.featureFlagsController);
@@ -203,7 +188,6 @@ async function initializeAsync(): Promise<void> {
         persistedData.tabIdToDetailsViewMap ?? {},
         indexedDBInstance,
         tabContextManager.interpretMessageForTab,
-        true,
     );
     await detailsViewController.initialize();
 
@@ -223,7 +207,6 @@ async function initializeAsync(): Promise<void> {
         usageLogger,
         persistedData,
         indexedDBInstance,
-        true,
         urlParser,
     );
 
@@ -234,7 +217,6 @@ async function initializeAsync(): Promise<void> {
         logger,
         persistedData.knownTabIds ?? {},
         indexedDBInstance,
-        true,
     );
     await targetPageController.initialize();
 

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -45,8 +45,9 @@ export class GlobalStoreHub implements StoreHub {
         persistedData: PersistedData,
         storageAdapter: StorageAdapter,
         logger: Logger,
-        persistStoreData: boolean,
     ) {
+        const persistStoreData = true;
+
         this.commandStore = new CommandStore(
             globalActionHub.commandActions,
             telemetryEventHandler,

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -42,9 +42,9 @@ export class TabContextStoreHub implements StoreHub {
         indexedDBInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
         urlParser: UrlParser,
     ) {
+        const persistStoreData = true;
         const persistedTabData = persistedData.tabData ? persistedData.tabData[tabId] : null;
 
         this.visualizationStore = new VisualizationStore(

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -52,7 +52,6 @@ export class TabContextFactory {
         private readonly usageLogger: UsageLogger,
         private readonly persistedData: PersistedData,
         private readonly indexedDBInstance: IndexedDBAPI,
-        private readonly persistStoreData: boolean,
         private readonly urlParser: UrlParser,
     ) {}
 
@@ -66,7 +65,6 @@ export class TabContextFactory {
             this.indexedDBInstance,
             this.logger,
             tabId,
-            this.persistStoreData,
             this.urlParser,
         );
         const notificationCreator = new NotificationCreator(

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -19,7 +19,6 @@ export class TargetPageController {
         private readonly logger: Logger,
         private readonly knownTabs: DictionaryNumberTo<string>,
         private readonly idbInstance: IndexedDBAPI,
-        private persistStoreData: boolean,
     ) {}
 
     public async initialize(): Promise<void> {
@@ -127,18 +126,14 @@ export class TargetPageController {
         const url = await this.getUrl(tabId);
         if (this.knownTabs[tabId] === undefined || this.knownTabs[tabId] !== url) {
             this.knownTabs[tabId] = url;
-            if (this.persistStoreData) {
-                await this.idbInstance.setItem(IndexedDBDataKeys.knownTabIds, this.knownTabs);
-            }
+            await this.idbInstance.setItem(IndexedDBDataKeys.knownTabIds, this.knownTabs);
         }
     };
 
     private removeKnownTabId = async (tabId: number) => {
         if (Object.keys(this.knownTabs).includes(tabId.toString())) {
             delete this.knownTabs[tabId];
-            if (this.persistStoreData) {
-                await this.idbInstance.setItem(IndexedDBDataKeys.knownTabIds, this.knownTabs);
-            }
+            await this.idbInstance.setItem(IndexedDBDataKeys.knownTabIds, this.knownTabs);
         }
     };
 

--- a/src/tests/unit/tests/background/global-context-factory.test.ts
+++ b/src/tests/unit/tests/background/global-context-factory.test.ts
@@ -10,7 +10,6 @@ import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { LaunchPanelStore } from 'background/stores/global/launch-panel-store';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { Logger } from 'common/logging/logger';
-import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { IMock, It, Mock } from 'typemoq';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { CommandsAdapter } from '../../../../common/browser-adapters/commands-adapter';
@@ -29,7 +28,6 @@ describe('GlobalContextFactoryTest', () => {
     let issueFilingServiceProviderMock: IMock<IssueFilingServiceProvider>;
     let loggerMock: IMock<Logger>;
 
-    let toolData: ToolData;
     let userDataStub: LocalStorageData;
     let mockDBInstance: IMock<IndexedDBAPI>;
     let persistedDataStub: PersistedData;
@@ -50,7 +48,6 @@ describe('GlobalContextFactoryTest', () => {
         issueFilingServiceProviderMock = Mock.ofType(IssueFilingServiceProvider);
 
         userDataStub = {};
-        toolData = {} as ToolData;
         persistedDataStub = {} as PersistedData;
         mockDBInstance = Mock.ofType<IndexedDBAPI>();
         mockDBInstance
@@ -68,11 +65,9 @@ describe('GlobalContextFactoryTest', () => {
             mockDBInstance.object,
             persistedDataStub,
             issueFilingServiceProviderMock.object,
-            toolData,
             storageAdapterMock.object,
             commandsAdapterMock.object,
             loggerMock.object,
-            true,
         );
 
         expect(globalContext).toBeInstanceOf(GlobalContext);

--- a/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
@@ -62,7 +62,6 @@ describe('GlobalStoreHubTest', () => {
             cloneDeep(persistedDataStub),
             null,
             failTestOnErrorLogger,
-            true,
         );
         const allStores = testSubject.getAllStores();
 
@@ -88,7 +87,6 @@ describe('GlobalStoreHubTest', () => {
             cloneDeep(persistedDataStub),
             null,
             failTestOnErrorLogger,
-            true,
         );
         const allStores = testSubject.getAllStores() as BaseStoreImpl<any>[];
         const initializeMocks: Array<IMock<Function>> = [];

--- a/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-context-store-hub.test.ts
@@ -15,7 +15,6 @@ describe('TabContextStoreHubTest', () => {
             null,
             null,
             null,
-            true,
             null,
         );
     });

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -121,7 +121,6 @@ describe('TabContextFactoryTest', () => {
             mockUsageLogger.object,
             persistedDataStub,
             mockDBInstance.object,
-            true,
             null,
         );
 


### PR DESCRIPTION
#### Details

Remove mv3 feature work flags that are no longer necessary.

##### Motivation

Clean up from feature work.

##### Context

When we first began persisting store data in the indexedDB API we included a `persistData` flag in background-init in case these changes caused bugs. As we have now had these changes checked in for several months and plan on releasing the mv3 version of the extension soon, it should be safe to remove that flag now. This allows us to remove unnecessary code in several places and quite a bit of test coverage. Unfortunately, we cannot entirely remove the `persistData` flag from persistent stores, since electron reuses some of these stores and does not need to persist data.

In removing unnecessary `persistData` flags, I also noticed that `toolData` is never used in the init files, so I removed that as well. It looks like that variable has no longer been necessary in init since https://github.com/microsoft/accessibility-insights-web/pull/2733, but that PR missed actually removing it. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
