### PR TITLE
fix: send automated tab stops results in batches

### DIFF
--- a/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
+++ b/src/DetailsView/actions/tab-stop-requirement-action-message-creator.ts
@@ -3,6 +3,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import {
+    AddTabStopInstanceArrayPayload,
     AddTabStopInstancePayload,
     BaseActionPayload,
     RemoveTabStopInstancePayload,
@@ -48,6 +49,29 @@ export class TabStopRequirementActionMessageCreator extends DevToolActionMessage
 
         this.dispatcher.dispatchMessage({
             messageType: messages.AddTabStopInstance,
+            payload,
+        });
+    }
+
+    public addTabStopInstanceArray(results: TabStopRequirementResult[]): void {
+        const resultsWithTelemetry = results.map(result => {
+            const telemetry = this.telemetryFactory.forTabStopRequirement(
+                result.requirementId,
+                this.source,
+            );
+
+            return {
+                ...result,
+                telemetry,
+            };
+        });
+
+        const payload: AddTabStopInstanceArrayPayload = {
+            results: resultsWithTelemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: messages.AddTabStopInstanceArray,
             payload,
         });
     }

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -158,11 +158,16 @@ export interface UpdateTabbingCompletedPayload extends BaseActionPayload {
 export interface UpdateNeedToCollectTabbingResultsPayload extends BaseActionPayload {
     needToCollectTabbingResults: boolean;
 }
+
 export interface AddTabStopInstancePayload extends BaseActionPayload {
     requirementId: TabStopRequirementId;
     description: string;
     selector?: string[];
     html?: string;
+}
+
+export interface AddTabStopInstanceArrayPayload {
+    results: AddTabStopInstancePayload[];
 }
 
 export interface UpdateTabStopInstancePayload extends AddTabStopInstancePayload {

--- a/src/background/actions/tab-stop-requirement-action-creator.ts
+++ b/src/background/actions/tab-stop-requirement-action-creator.ts
@@ -5,6 +5,7 @@ import { Messages } from '../../common/messages';
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import {
+    AddTabStopInstanceArrayPayload,
     AddTabStopInstancePayload,
     BaseActionPayload,
     RemoveTabStopInstancePayload,
@@ -38,6 +39,11 @@ export class TabStopRequirementActionCreator {
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Visualizations.TabStops.AddTabStopInstance,
             this.onAddTabStopInstance,
+        );
+
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.Visualizations.TabStops.AddTabStopInstanceArray,
+            this.onAddTabStopInstanceArray,
         );
 
         this.interpreter.registerTypeToPayloadCallback(
@@ -96,6 +102,18 @@ export class TabStopRequirementActionCreator {
         this.telemetryEventHandler.publishTelemetry(
             TelemetryEvents.ADD_TABSTOPS_REQUIREMENT_INSTANCE,
             payload,
+        );
+    };
+
+    private onAddTabStopInstanceArray = async (
+        payload: AddTabStopInstanceArrayPayload,
+    ): Promise<void> => {
+        await this.tabStopRequirementActions.addTabStopInstanceArray.invoke(payload);
+        payload.results.forEach(async result =>
+            this.telemetryEventHandler.publishTelemetry(
+                TelemetryEvents.ADD_TABSTOPS_REQUIREMENT_INSTANCE,
+                result,
+            ),
         );
     };
 

--- a/src/background/actions/tab-stop-requirement-action-creator.ts
+++ b/src/background/actions/tab-stop-requirement-action-creator.ts
@@ -109,6 +109,8 @@ export class TabStopRequirementActionCreator {
         payload: AddTabStopInstanceArrayPayload,
     ): Promise<void> => {
         await this.tabStopRequirementActions.addTabStopInstanceArray.invoke(payload);
+        // Report telemetry individually for each instance so it's consistent
+        // with telemetry reporting for onAddTabStopInstance
         payload.results.forEach(async result =>
             this.telemetryEventHandler.publishTelemetry(
                 TelemetryEvents.ADD_TABSTOPS_REQUIREMENT_INSTANCE,

--- a/src/background/actions/tab-stop-requirement-actions.ts
+++ b/src/background/actions/tab-stop-requirement-actions.ts
@@ -4,6 +4,7 @@
 // Licensed under the MIT License.
 import { AsyncAction } from 'common/flux/async-action';
 import {
+    AddTabStopInstanceArrayPayload,
     AddTabStopInstancePayload,
     BaseActionPayload,
     RemoveTabStopInstancePayload,
@@ -20,6 +21,7 @@ export class TabStopRequirementActions {
     public readonly updateTabStopsRequirementStatus =
         new AsyncAction<UpdateTabStopRequirementStatusPayload>();
     public readonly addTabStopInstance = new AsyncAction<AddTabStopInstancePayload>();
+    public readonly addTabStopInstanceArray = new AsyncAction<AddTabStopInstanceArrayPayload>();
     public readonly updateTabStopInstance = new AsyncAction<UpdateTabStopInstancePayload>();
     public readonly removeTabStopInstance = new AsyncAction<RemoveTabStopInstancePayload>();
     public readonly resetTabStopRequirementStatus =

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -23,6 +23,7 @@ import { DictionaryStringTo } from 'types/common-types';
 import { TabStopRequirementIds } from 'types/tab-stop-requirement-info';
 import {
     AddTabbedElementPayload,
+    AddTabStopInstanceArrayPayload,
     AddTabStopInstancePayload,
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
@@ -112,6 +113,9 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
             this.onResetTabStopRequirementStatus,
         );
         this.tabStopRequirementActions.addTabStopInstance.addListener(this.onAddTabStopInstance);
+        this.tabStopRequirementActions.addTabStopInstanceArray.addListener(
+            this.onAddTabStopInstanceArray,
+        );
         this.tabStopRequirementActions.updateTabStopInstance.addListener(
             this.onUpdateTabStopInstance,
         );
@@ -205,6 +209,18 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
     };
 
     private onAddTabStopInstance = async (payload: AddTabStopInstancePayload): Promise<void> => {
+        this.updateStateFromAddTabStopInstancePayload(payload);
+        await this.emitChanged();
+    };
+
+    private onAddTabStopInstanceArray = async (
+        payload: AddTabStopInstanceArrayPayload,
+    ): Promise<void> => {
+        payload.results.map(this.updateStateFromAddTabStopInstancePayload);
+        await this.emitChanged();
+    };
+
+    private updateStateFromAddTabStopInstancePayload = (payload: AddTabStopInstancePayload) => {
         const { requirementId, description, selector, html } = payload;
         this.state.tabStops.requirements[requirementId].status = 'fail';
         this.state.tabStops.requirements[requirementId].instances.push({
@@ -213,7 +229,6 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
             selector,
             html,
         });
-        await this.emitChanged();
     };
 
     private onUpdateTabStopInstance = async (

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -23,6 +23,7 @@ export const Messages = {
             UpdateTabStopsRequirementStatus: `${messagePrefix}/visualization/tab-stops/requirement-updated`,
             ResetTabStopsRequirementStatus: `${messagePrefix}/visualization/tab-stops/requirement-reset`,
             AddTabStopInstance: `${messagePrefix}/visualization/tab-stops/instance-added`,
+            AddTabStopInstanceArray: `${messagePrefix}/visualization/tab-stops/instance-array-added`,
             UpdateTabStopInstance: `${messagePrefix}/visualization/tab-stops/instance-updated`,
             RemoveTabStopInstance: `${messagePrefix}/visualization/tab-stops/instance-removed`,
             RequirementExpansionToggled: `${messagePrefix}/visualization/tab-stops/toggleTabStopRequirementExpand`,

--- a/src/injected/analyzers/tab-stops-orchestrator.ts
+++ b/src/injected/analyzers/tab-stops-orchestrator.ts
@@ -7,11 +7,11 @@ import { TabStopsHandler } from 'injected/analyzers/tab-stops-handler';
 import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
 
 export class TabStopRequirementOrchestrator
-    implements AllFrameRunnerTarget<AutomatedTabStopRequirementResult>
+    implements AllFrameRunnerTarget<AutomatedTabStopRequirementResult[]>
 {
     public readonly commandSuffix: string = 'TabStopRequirementOrchestrator';
     public static readonly keyboardTrapTimeout: number = 500;
-    private reportResults: (payload: AutomatedTabStopRequirementResult) => Promise<void>;
+    private reportResults: (payload: AutomatedTabStopRequirementResult[]) => Promise<void>;
 
     constructor(
         private readonly dom: Document,
@@ -28,7 +28,7 @@ export class TabStopRequirementOrchestrator
         this.dom.addEventListener('focusin', this.onFocusIn);
 
         const tabbableFocusOrderResults = this.tabStopsHandler.getTabbableFocusOrderResults();
-        await Promise.all(tabbableFocusOrderResults.map(result => this.reportResults(result)));
+        await this.reportResults(tabbableFocusOrderResults);
     };
 
     public stop = async () => {
@@ -36,22 +36,24 @@ export class TabStopRequirementOrchestrator
         this.dom.removeEventListener('focusin', this.onFocusIn);
 
         const keyboardNavigationResults = this.tabStopsHandler.getKeyboardNavigationResults();
-        await Promise.all(keyboardNavigationResults.map(result => this.reportResults(result)));
+        await this.reportResults(keyboardNavigationResults);
     };
 
     public setResultCallback = (
-        reportResultCallback: (payload: AutomatedTabStopRequirementResult) => Promise<void>,
+        reportResultCallback: (payload: AutomatedTabStopRequirementResult[]) => Promise<void>,
     ) => {
         this.reportResults = reportResultCallback;
     };
 
     public transformChildResultForParent = (
-        result: AutomatedTabStopRequirementResult,
+        results: AutomatedTabStopRequirementResult[],
         messageSourceFrame: HTMLIFrameElement,
-    ): AutomatedTabStopRequirementResult => {
+    ): AutomatedTabStopRequirementResult[] => {
         const frameSelector = this.getUniqueSelector(messageSourceFrame);
-        result.selector = [frameSelector, ...result.selector];
-        return result;
+        results.forEach(result => {
+            result.selector = [frameSelector, ...result.selector];
+        });
+        return results;
     };
 
     private onFocusIn = async (focusEvent: FocusEvent) => {
@@ -62,7 +64,7 @@ export class TabStopRequirementOrchestrator
         if (result == null) {
             return;
         }
-        await this.reportResults(result);
+        await this.reportResults([result]);
     };
 
     private onKeydown = async (e: KeyboardEvent) => {
@@ -75,6 +77,6 @@ export class TabStopRequirementOrchestrator
         if (result == null) {
             return;
         }
-        await this.reportResults(result);
+        await this.reportResults([result]);
     };
 }

--- a/src/injected/analyzers/tab-stops-orchestrator.ts
+++ b/src/injected/analyzers/tab-stops-orchestrator.ts
@@ -28,7 +28,9 @@ export class TabStopRequirementOrchestrator
         this.dom.addEventListener('focusin', this.onFocusIn);
 
         const tabbableFocusOrderResults = this.tabStopsHandler.getTabbableFocusOrderResults();
-        await this.reportResults(tabbableFocusOrderResults);
+        if (tabbableFocusOrderResults.length > 0) {
+            await this.reportResults(tabbableFocusOrderResults);
+        }
     };
 
     public stop = async () => {
@@ -36,7 +38,9 @@ export class TabStopRequirementOrchestrator
         this.dom.removeEventListener('focusin', this.onFocusIn);
 
         const keyboardNavigationResults = this.tabStopsHandler.getKeyboardNavigationResults();
-        await this.reportResults(keyboardNavigationResults);
+        if (keyboardNavigationResults.length > 0) {
+            await this.reportResults(keyboardNavigationResults);
+        }
     };
 
     public setResultCallback = (

--- a/src/injected/analyzers/tab-stops-requirement-result-processor.ts
+++ b/src/injected/analyzers/tab-stops-requirement-result-processor.ts
@@ -6,7 +6,7 @@ import { VisualizationScanResultData } from 'common/types/store-data/visualizati
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { AllFrameRunner } from 'injected/all-frame-runner';
 import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
-import { includes } from 'lodash';
+import { isEqual } from 'lodash';
 
 export class TabStopsRequirementResultProcessor {
     private seenTabStopRequirementResults: AutomatedTabStopRequirementResult[] = [];
@@ -67,9 +67,18 @@ export class TabStopsRequirementResultProcessor {
     private processTabStopRequirementResults = (
         tabStopRequirementResults: AutomatedTabStopRequirementResult[],
     ): void => {
-        const filteredResults = tabStopRequirementResults.filter(
-            result => !includes(this.seenTabStopRequirementResults, result),
-        );
+        const filteredResults = [];
+
+        tabStopRequirementResults.forEach(result => {
+            const duplicateResult = this.seenTabStopRequirementResults.some(seenResult =>
+                isEqual(seenResult, result),
+            );
+
+            if (!duplicateResult) {
+                filteredResults.push(result);
+                this.seenTabStopRequirementResults.push(result);
+            }
+        });
 
         if (filteredResults.length === 0) {
             return;

--- a/src/injected/analyzers/tab-stops-requirement-result-processor.ts
+++ b/src/injected/analyzers/tab-stops-requirement-result-processor.ts
@@ -5,7 +5,10 @@ import { BaseStore } from 'common/base-store';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { AllFrameRunner } from 'injected/all-frame-runner';
-import { AutomatedTabStopRequirementResult } from 'injected/tab-stop-requirement-result';
+import {
+    AutomatedTabStopRequirementResult,
+    TabStopRequirementResult,
+} from 'injected/tab-stop-requirement-result';
 import { isEqual } from 'lodash';
 
 export class TabStopsRequirementResultProcessor {
@@ -67,7 +70,7 @@ export class TabStopsRequirementResultProcessor {
     private processTabStopRequirementResults = (
         tabStopRequirementResults: AutomatedTabStopRequirementResult[],
     ): void => {
-        const filteredResults = [];
+        const filteredResults: TabStopRequirementResult[] = [];
 
         tabStopRequirementResults.forEach(result => {
             const duplicateResult = this.seenTabStopRequirementResults.some(seenResult =>
@@ -75,7 +78,7 @@ export class TabStopsRequirementResultProcessor {
             );
 
             if (!duplicateResult) {
-                filteredResults.push(result);
+                filteredResults.push({ ...result });
                 this.seenTabStopRequirementResults.push(result);
             }
         });

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -67,7 +67,7 @@ export class WindowInitializer {
     protected drawingController: DrawingController;
     protected scrollingController: ScrollingController;
     protected manualTabStopListener: AllFrameRunner<TabStopEvent>;
-    protected tabStopRequirementRunner: AllFrameRunner<AutomatedTabStopRequirementResult>;
+    protected tabStopRequirementRunner: AllFrameRunner<AutomatedTabStopRequirementResult[]>;
     protected frameUrlFinder: FrameUrlFinder;
     protected elementFinderByPosition: ElementFinderByPosition;
     protected elementFinderByPath: ElementFinderByPath;
@@ -186,7 +186,7 @@ export class WindowInitializer {
             focusTrapsKeydownHandler,
             getUniqueSelector,
         );
-        this.tabStopRequirementRunner = new AllFrameRunner<AutomatedTabStopRequirementResult>(
+        this.tabStopRequirementRunner = new AllFrameRunner<AutomatedTabStopRequirementResult[]>(
             this.allFramesMessenger,
             htmlElementUtils,
             this.windowUtils,

--- a/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
@@ -49,8 +49,10 @@ export class VisualizationScanResultStoreDataBuilder extends BaseDataBuilder<Vis
     public withTabStopRequirement(
         requirement: TabStopRequirementState,
     ): VisualizationScanResultStoreDataBuilder {
-        const requirementId = Object.keys(requirement)[0];
-        this.data.tabStops.requirements[requirementId] = requirement[requirementId];
+        Object.keys(requirement).forEach(requirementId => {
+            this.data.tabStops.requirements[requirementId] = requirement[requirementId];
+        });
+
         return this;
     }
 

--- a/src/tests/unit/tests/DetailsView/actions/tab-stop-requirement-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/tab-stop-requirement-action-message-creator.test.ts
@@ -16,6 +16,7 @@ import {
 } from 'injected/tab-stop-requirement-result';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
+import { TabStopRequirementId } from 'types/tab-stop-requirement-info';
 import {
     TabStopsAutomatedResultsTelemetryData,
     TelemetryEventSource,
@@ -326,5 +327,29 @@ describe('TabStopRequirementActionMessageCreatorTest', () => {
         );
 
         telemetryFactoryMock.verifyAll();
+    });
+
+    test('resetStatusForRequirement', () => {
+        const requirementId: TabStopRequirementId = 'tab-order';
+        const telemetry = {
+            source: sourceStub,
+            requirementId: requirementId,
+            triggeredBy: null,
+        };
+        const expectedMessage = {
+            messageType: Messages.Visualizations.TabStops.ResetTabStopsRequirementStatus,
+            payload: { requirementId, telemetry },
+        };
+
+        telemetryFactoryMock
+            .setup(tf => tf.forTabStopRequirement(requirementId, sourceStub))
+            .returns(() => telemetry);
+
+        testSubject.resetStatusForRequirement(requirementId);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
     });
 });

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import {
     AddTabbedElementPayload,
+    AddTabStopInstanceArrayPayload,
     AddTabStopInstancePayload,
     RemoveTabStopInstancePayload,
     ResetTabStopRequirementStatusPayload,
@@ -456,6 +457,69 @@ describe('VisualizationScanResultStoreTest', () => {
                 createStoreTesterForTabStopRequirementActions('addTabStopInstance').withActionParam(
                     payload,
                 );
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
+        });
+    });
+
+    describe('onAddTabStopInstanceArray', () => {
+        const initialState = new VisualizationScanResultStoreDataBuilder().build();
+
+        const results: AddTabStopInstancePayload[] = [
+            {
+                requirementId: 'keyboard-navigation',
+                description: 'test1',
+                selector: ['some-selector'],
+                html: 'some html',
+            },
+            {
+                requirementId: 'focus-indicator',
+                description: 'test2',
+                selector: ['some-other-selector'],
+                html: 'some other html',
+            },
+        ];
+        const payload: AddTabStopInstanceArrayPayload = {
+            results,
+        };
+
+        const requirement: TabStopRequirementState = {
+            'keyboard-navigation': {
+                status: 'unknown',
+                instances: [
+                    {
+                        description: 'test1',
+                        id: 'abc',
+                        selector: ['some-selector'],
+                        html: 'some html',
+                    },
+                ],
+                isExpanded: false,
+            },
+            'focus-indicator': {
+                status: 'unknown',
+                instances: [
+                    {
+                        description: 'test2',
+                        id: 'abc',
+                        selector: ['some-other-selector'],
+                        html: 'some other html',
+                    },
+                ],
+                isExpanded: false,
+            },
+        };
+
+        const expectedState = new VisualizationScanResultStoreDataBuilder()
+            .withTabStopRequirement(requirement)
+            .build();
+        expectedState.tabStops.requirements[results[0].requirementId].status = 'fail';
+        expectedState.tabStops.requirements[results[1].requirementId].status = 'fail';
+
+        test('adds tab stop failure instance', async () => {
+            const storeTester =
+                createStoreTesterForTabStopRequirementActions(
+                    'addTabStopInstanceArray',
+                ).withActionParam(payload);
             await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         });
     });

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -555,7 +555,7 @@ describe('VisualizationScanResultStoreTest', () => {
             .build();
 
         const storeTester =
-            createStoreTesterForTabStopRequirementActions('addTabStopInstance').withActionParam(
+            createStoreTesterForTabStopRequirementActions('updateTabStopInstance').withActionParam(
                 payload,
             );
         await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
@@ -590,7 +590,7 @@ describe('VisualizationScanResultStoreTest', () => {
             .build();
 
         const storeTester =
-            createStoreTesterForTabStopRequirementActions('addTabStopInstance').withActionParam(
+            createStoreTesterForTabStopRequirementActions('removeTabStopInstance').withActionParam(
                 payload,
             );
         await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
@@ -630,6 +630,37 @@ describe('VisualizationScanResultStoreTest', () => {
         ).withActionParam(payload);
         await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
     });
+
+    test.each([true, false])(
+        'toggleTabStopRequirementExpand with initial state isExpanded=%s',
+        async isInitiallyExpanded => {
+            const requirementId = 'keyboard-navigation';
+            const requirement: TabStopRequirementState = {
+                [requirementId]: {
+                    status: 'unknown',
+                    instances: [{ description: 'test1', id: 'abc' }],
+                    isExpanded: isInitiallyExpanded,
+                },
+            };
+            const initialState = new VisualizationScanResultStoreDataBuilder()
+                .withTabStopRequirement(requirement)
+                .build();
+
+            const expectedState = new VisualizationScanResultStoreDataBuilder()
+                .withTabStopRequirement({
+                    [requirementId]: {
+                        ...requirement[requirementId],
+                        isExpanded: !isInitiallyExpanded,
+                    },
+                })
+                .build();
+
+            const storeTester = createStoreTesterForTabStopRequirementActions(
+                'toggleTabStopRequirementExpand',
+            ).withActionParam({ requirementId });
+            await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
+        },
+    );
 
     function createStoreTesterForVisualizationScanResultActions(
         actionName: keyof VisualizationScanResultActions,


### PR DESCRIPTION
#### Details

Optimizations for tab stops results reporting
- Send automated tab stops results to background in batches instead of one at a time (minimizes disk writes for store updates)
- Send results between frames in batches instead of one at a time (minimizes frame messages and calls to getUniqueSelector, which is a time-consuming synchronous operation)

##### Motivation

Processing automated tab stops results can take a long time, especially on pages with a lot of iframes and tabbable elements. This can be seen by opening a page with a lot of iframes and tabbed elements (such as cnn.com), enabling the tab stops ad hoc visualizer and tabbing through a few elements, and then disabling it and immediately trying to enable another visualizer. On my surface laptop, on cnn.com, there is a delay of 6-8 seconds between clicking the toggle and popup UI updating to show the spinner, plus another 2-3 seconds before the visualizer shows in the page.

This PR optimizes result processing by batching the most time-consuming processes and minimizing the number of messages sent between frames and between the content script and background. This reduces the 6-8 second UI delay to less than a second, so enabling a new visualizer after disabling tab stops takes about the same amount of time as without first enabling and disabling tab stops.

##### Context

Continuation of tab stops performance improvements from #6015

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
