### PR TITLE
chore: e2e tests for reflowable card buttons

### DIFF
--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -89,6 +89,10 @@ export const fastPassAutomatedChecksSelectors = {
     iframeWarning: getAutomationIdSelector(IframeWarningContainerAutomationId),
     expandButton: getAutomationIdSelector(collapsibleButtonAutomationId),
     recommendationsCard: getAutomationIdSelector(recommendationsAutomationId),
+    cardFooterKebabButton: {
+        collapsed: 'button[aria-label*="More Actions for failure instance"][aria-expanded=false]',
+        expanded: 'button[aria-label*="More Actions for failure instance"][aria-expanded=true]',
+    },
 };
 
 export const tabStopsSelectors = {

--- a/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
+++ b/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
@@ -1,13 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { getNarrowModeThresholdsForWeb } from 'common/narrow-mode-thresholds';
+import { TargetPage } from 'tests/end-to-end/common/page-controllers/target-page';
+import {
+    DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS,
+    DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
+} from 'tests/end-to-end/common/timeouts';
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
-import { navMenuSelectors } from '../../common/element-identifiers/details-view-selectors';
+import {
+    detailsViewSelectors,
+    fastPassAutomatedChecksSelectors,
+    navMenuSelectors,
+} from '../../common/element-identifiers/details-view-selectors';
 import { DetailsViewPage } from '../../common/page-controllers/details-view-page';
 import { scanForAccessibilityIssues } from '../../common/scan-for-accessibility-issues';
 
-describe('Details View -> Assessment -> Reflow', () => {
+describe('Details View ->', () => {
     let browser: Browser;
     let detailsViewPage: DetailsViewPage;
     const height = 400;
@@ -18,53 +27,125 @@ describe('Details View -> Assessment -> Reflow', () => {
             suppressFirstTimeDialog: true,
             addExtraPermissionsToManifest: 'fake-activeTab',
         });
-
-        detailsViewPage = (await browser.newAssessment()).detailsViewPage;
     });
 
     afterAll(async () => {
         await browser?.close();
     });
 
-    const { commandBarMenuButtonSelectors, hamburgerMenuButtonSelectors } = navMenuSelectors;
-
-    const commandBarWindowWidth = narrowModeThresholds.collapseCommandBarThreshold - 1;
-    const hamburgerButtonWindowWidth = narrowModeThresholds.collapseHeaderAndNavThreshold - 1;
-
-    describe.each`
-        componentName           | componentSelectors               | width
-        ${'command bar button'} | ${commandBarMenuButtonSelectors} | ${commandBarWindowWidth}
-        ${'hamburger button'}   | ${hamburgerMenuButtonSelectors}  | ${hamburgerButtonWindowWidth}
-    `('With $componentName visible', ({ componentName, componentSelectors, width }) => {
+    describe('Assessment -> Reflow', () => {
         beforeAll(async () => {
-            await detailsViewPage.setViewport(width, height);
-            await detailsViewPage.waitForSelector(componentSelectors.collapsed);
+            detailsViewPage = (await browser.newAssessment()).detailsViewPage;
         });
 
-        it.each([true, false])(
-            `should pass accessibility validation with high contrast mode=%s`,
-            async highContrastMode => {
-                await scanForA11yIssuesWithHighContrast(highContrastMode);
-            },
-        );
+        afterAll(async () => {
+            await detailsViewPage.close();
+        });
 
-        describe(`with ${componentName} expanded`, () => {
+        const { commandBarMenuButtonSelectors, hamburgerMenuButtonSelectors } = navMenuSelectors;
+
+        const commandBarWindowWidth = narrowModeThresholds.collapseCommandBarThreshold - 1;
+        const hamburgerButtonWindowWidth = narrowModeThresholds.collapseHeaderAndNavThreshold - 1;
+
+        describe.each`
+            componentName           | componentSelectors               | width
+            ${'command bar button'} | ${commandBarMenuButtonSelectors} | ${commandBarWindowWidth}
+            ${'hamburger button'}   | ${hamburgerMenuButtonSelectors}  | ${hamburgerButtonWindowWidth}
+        `('With $componentName visible', ({ componentName, componentSelectors, width }) => {
             beforeAll(async () => {
-                await setButtonExpandedState(componentSelectors, true);
-            });
-
-            afterAll(async () => {
-                await setButtonExpandedState(componentSelectors, false);
+                await resizeDetailsView(width, componentSelectors.collapsed);
             });
 
             it.each([true, false])(
-                `should pass accessibility validation with command bar menu open and high contrast mode=%s`,
+                `should pass accessibility validation with high contrast mode=%s`,
                 async highContrastMode => {
                     await scanForA11yIssuesWithHighContrast(highContrastMode);
                 },
             );
+
+            describe(`with ${componentName} expanded`, () => {
+                beforeAll(async () => {
+                    await setButtonExpandedState(componentSelectors, true);
+                });
+
+                afterAll(async () => {
+                    await setButtonExpandedState(componentSelectors, false);
+                });
+
+                it.each([true, false])(
+                    `should pass accessibility validation with command bar menu open and high contrast mode=%s`,
+                    async highContrastMode => {
+                        await scanForA11yIssuesWithHighContrast(highContrastMode);
+                    },
+                );
+            });
         });
     });
+
+    describe('Fastpass -> Reflow', () => {
+        let targetPage: TargetPage;
+
+        const cardFooterWindowWidth = narrowModeThresholds.collapseCardFooterThreshold - 1;
+        const cardFooterSelectors = fastPassAutomatedChecksSelectors.cardFooterKebabButton;
+
+        beforeAll(async () => {
+            targetPage = await browser.newTargetPage({
+                testResourcePath: 'all.html',
+            });
+            await browser.newPopupPage(targetPage);
+            detailsViewPage = await browser.newDetailsViewPage(targetPage);
+            await detailsViewPage.waitForSelector(
+                detailsViewSelectors.automatedChecksResultSection,
+                {
+                    timeout: DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
+                },
+            );
+            await detailsViewPage.waitForSelector(fastPassAutomatedChecksSelectors.expandButton, {
+                timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS,
+            });
+
+            await resizeDetailsView(cardFooterWindowWidth);
+            await expandCard();
+        });
+
+        afterAll(async () => {
+            await detailsViewPage.close();
+            await targetPage.close();
+        });
+
+        describe.each([true, false])('With high contrast mode=%s', highContrastMode => {
+            it('and card kebab menu collapsed', async () => {
+                await scanForA11yIssuesWithHighContrast(highContrastMode);
+            });
+
+            it('and card kebab menu expanded', async () => {
+                await setButtonExpandedState(cardFooterSelectors, true);
+
+                await scanForA11yIssuesWithHighContrast(highContrastMode);
+
+                await setButtonExpandedState(cardFooterSelectors, false);
+            });
+        });
+
+        async function expandCard(): Promise<void> {
+            await detailsViewPage.waitForSelector(fastPassAutomatedChecksSelectors.expandButton, {
+                timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS,
+            });
+
+            await detailsViewPage.clickSelector(fastPassAutomatedChecksSelectors.expandButton);
+            await detailsViewPage.waitForSelector(cardFooterSelectors.collapsed);
+        }
+    });
+
+    async function resizeDetailsView(
+        screenWidth: number,
+        expectedSelector?: string,
+    ): Promise<void> {
+        await detailsViewPage.setViewport(screenWidth, height);
+        if (expectedSelector) {
+            await detailsViewPage.waitForSelector(expectedSelector);
+        }
+    }
 
     async function scanForA11yIssuesWithHighContrast(highContrastMode: boolean): Promise<void> {
         await browser.setHighContrastMode(highContrastMode);


### PR DESCRIPTION
#### Details

Add e2e tests for different reflow states of the card footer kebab button

##### Motivation

Automatically detect a11y issues in new reflow components

##### Context

The new reflow components/states were added in #5966

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
