### PR TITLE
chore: Remove unused moduleNameMapper fabric properties

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -26,9 +26,6 @@ module.exports = {
     moduleDirectories: ['node_modules'],
     moduleFileExtensions: ['ts', 'js', 'json'],
     moduleNameMapper: {
-        'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
-        '@uifabric/utilities': '@uifabric/utilities/lib-commonjs',
-        '@uifabric/styling': '@uifabric/styling/lib-commonjs',
         /* Using proxy to handle css modules, as per: https://jestjs.io/docs/en/webpack#mocking-css-modules */
         '\\.(scss)$': `${__dirname}/src/tests/common/identity-obj-proxy`,
     },


### PR DESCRIPTION
#### Details

Cleans up the `moduleNameMapper` option in the Jest config by removing (now unused) fabric references.

##### Motivation

Reduce tech debt.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
