### PR TITLE
chore: Update core actions and configure Dependabot to update github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,3 +73,9 @@ updates:
   - dependency-name: "@types/react-dom"
     versions:
     - ">=17.0.0"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+    timezone: "America/Los_Angeles" # Pacific Time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-20.04
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       timeout-minutes: 2
 
     - uses: actions/setup-dotnet@v2
       with: { dotnet-version: "${{ env.DOTNET_SDK_VERSION }}" }
       timeout-minutes: 2
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with: { node-version: "${{ env.NODE_VERSION }}" }
       timeout-minutes: 2
 
@@ -36,7 +36,7 @@ jobs:
       timeout-minutes: 1
 
     - name: restore yarn cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ steps.yarn-cache-path.outputs.dir }}
@@ -55,7 +55,7 @@ jobs:
       timeout-minutes: 10
 
     - name: upload artifact build-results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-results
         path: drop
@@ -71,10 +71,10 @@ jobs:
         shard-index: [1, 2]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       timeout-minutes: 2
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with: { node-version: "${{ env.NODE_VERSION }}" }
       timeout-minutes: 2
 
@@ -84,7 +84,7 @@ jobs:
       timeout-minutes: 1
 
     - name: restore yarn cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ steps.yarn-cache-path.outputs.dir }}
@@ -103,7 +103,7 @@ jobs:
       timeout-minutes: 10
 
     - name: upload artifact unit-tests-results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: unit-tests-${{ matrix.shard-index }}-results
@@ -118,10 +118,10 @@ jobs:
     steps:
     # This only needs to be present so codecov can use the source tree for some post-processing
     # This job doesn't require that we install dependencies
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       timeout-minutes: 2
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with: { node-version: "${{ env.NODE_VERSION }}" }
       timeout-minutes: 2
 
@@ -144,10 +144,10 @@ jobs:
     runs-on: ubuntu-20.04
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       timeout-minutes: 2
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with: { node-version: "${{ env.NODE_VERSION }}" }
       timeout-minutes: 2
 
@@ -157,7 +157,7 @@ jobs:
       timeout-minutes: 1
 
     - name: restore yarn cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ steps.yarn-cache-path.outputs.dir }}
@@ -192,7 +192,7 @@ jobs:
   codeql:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       timeout-minutes: 2
 
     - uses: github/codeql-action/init@v2
@@ -214,10 +214,10 @@ jobs:
         shard-index: [1, 2]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       timeout-minutes: 2
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with: { node-version: "${{ env.NODE_VERSION }}" }
       timeout-minutes: 2
 
@@ -243,7 +243,7 @@ jobs:
       timeout-minutes: 10
 
     - name: upload artifact e2e-web-tests-results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: e2e-web-tests-${{ matrix.shard-index }}-results
@@ -251,7 +251,7 @@ jobs:
       timeout-minutes: 3
 
     - name: upload artifact e2e-web-tests-debug-logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
         name: e2e-web-tests-${{ matrix.shard-index }}-debug-logs
@@ -270,10 +270,10 @@ jobs:
         shard-index: [1, 2]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       timeout-minutes: 2
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with: { node-version: "${{ env.NODE_VERSION }}" }
       timeout-minutes: 2
 
@@ -299,7 +299,7 @@ jobs:
       timeout-minutes: 10
 
     - name: upload artifact e2e-mv3-web-tests-results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: e2e-mv3-web-tests-${{ matrix.shard-index }}-results
@@ -307,7 +307,7 @@ jobs:
       timeout-minutes: 3
 
     - name: upload artifact e2e-mv3-web-tests-debug-logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
         name: e2e-mv3-web-tests-${{ matrix.shard-index }}-debug-logs
@@ -329,14 +329,14 @@ jobs:
         shard-index: [1, 2]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       timeout-minutes: 2
 
     - uses: actions/setup-dotnet@v2
       with: { dotnet-version: "${{ env.DOTNET_SDK_VERSION }}" }
       timeout-minutes: 2
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with: { node-version: "${{ env.NODE_VERSION }}" }
       timeout-minutes: 2
 
@@ -346,7 +346,7 @@ jobs:
       timeout-minutes: 1
 
     - name: restore yarn cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ steps.yarn-cache-path.outputs.dir }}
@@ -376,7 +376,7 @@ jobs:
       timeout-minutes: 15
 
     - name: upload artifact e2e-unified-tests-results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: e2e-unified-tests-${{ matrix.shard-index }}-results
@@ -387,10 +387,10 @@ jobs:
     runs-on: ubuntu-20.04
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       timeout-minutes: 2
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with: { node-version: "${{ env.NODE_VERSION }}" }
       timeout-minutes: 2
 
@@ -400,7 +400,7 @@ jobs:
       timeout-minutes: 1
 
     - name: restore yarn cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ steps.yarn-cache-path.outputs.dir }}
@@ -420,7 +420,7 @@ jobs:
       timeout-minutes: 5
 
     - name: upload artifact e2e-report-tests-results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: e2e-report-tests-results


### PR DESCRIPTION
#### Details

This pull request updates actions as recommended and configures Dependabot to keep github-actions updated for us.

There are several github-actions that are emitting the following warning:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-node, actions/upload-artifact

For the updated actions, each saw an update to Node 16 in v3 and no other notable breaking changes. The list below contains the changelogs or releases for the updated actions:

- https://github.com/actions/checkout/blob/main/CHANGELOG.md#v300 
- https://github.com/actions/setup-node/releases/tag/v3.0.0
- https://github.com/actions/upload-artifact/releases/tag/v3.0.0
- https://github.com/actions/cache/releases/tag/v3.0.0


##### Motivation

Keep actions up-to-date.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
