### PR TITLE
fix: update json export to properly parse tagName elements

### DIFF
--- a/src/reports/assessment-json-export-json-builder.ts
+++ b/src/reports/assessment-json-export-json-builder.ts
@@ -247,7 +247,7 @@ function processRequirementDescription(descriptionProps): string {
             }
         });
     } else {
-        requirementDescription += descriptionProps.children;
+        requirementDescription += descriptionProps.children ?? descriptionProps.tagName;
     }
     return requirementDescription;
 }

--- a/src/tests/unit/tests/reports/__snapshots__/assessment-json-export-json-builder.test.ts.snap
+++ b/src/tests/unit/tests/reports/__snapshots__/assessment-json-export-json-builder.test.ts.snap
@@ -337,7 +337,7 @@ exports[`Assessment JSON export builder export JSON matches snapshot 1`] = `
         },
         {
           "requirementKey": "tableSemantics",
-          "requirementDescription": "A undefined element must be coded correctly as a data table or a layout table"
+          "requirementDescription": "A table element must be coded correctly as a data table or a layout table"
         },
         {
           "requirementKey": "headers",
@@ -345,7 +345,7 @@ exports[`Assessment JSON export builder export JSON matches snapshot 1`] = `
         },
         {
           "requirementKey": "headersAttribute",
-          "requirementDescription": "The headers attribute of a undefined element must reference the correct undefined element(s)"
+          "requirementDescription": "The headers attribute of a td element must reference the correct th element(s)"
         },
         {
           "requirementKey": "lists",
@@ -357,7 +357,7 @@ exports[`Assessment JSON export builder export JSON matches snapshot 1`] = `
         },
         {
           "requirementKey": "quotes",
-          "requirementDescription": "The undefined element must not be used to style non-quote text"
+          "requirementDescription": "The blockquote element must not be used to style non-quote text"
         },
         {
           "requirementKey": "letterSpacing",


### PR DESCRIPTION
#### Details

Our Assessment JSON export mechanism surfaces the rule id and description for each requirement. The description originates as JSX and then gets converted into a string. This works fine for the majority of our requirements, where the JSX `props` contain `children` that mostly include innerText. This is not the case for several requirements that include `Markup.Tag` tags.

For example, the Semantics Assessment's "Header Attribute" Requirement includes two `Markup.Tag` tags for `td` and `th` that do not have `children`. 

```jsx
const headersAttributeDescription: JSX.Element = (
    <span>
        The <Markup.CodeTerm>headers</Markup.CodeTerm> attribute of a <Markup.Tag tagName="td" />{' '}
        element must reference the correct <Markup.Tag tagName="th" /> element(s).
    </span>
);
```

When our JSON exporter encounters tags without children, it appends "undefined" to the string:
```json 
{
   "requirementKey": "headersAttribute",
   "requirementDescription": "The headers attribute of a undefined element must reference the correct undefined element(s)"
 } 
```

This fix adapts our description builder to look for the `tagName` property if `children` does not exist.

```json
{
   "requirementKey": "headersAttribute",
   "requirementDescription": "The headers attribute of a td element must reference the correct th element(s)"
}
```

##### Motivation

Addresses issue #6122 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #6122
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
