### PR TITLE
fix: ensure hover color of contextual menu list items change in Windows High Contrast 

### DIFF
--- a/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-with-issues.snap.html
@@ -187,6 +187,13 @@
         color: var(--spinner-text);
       }
 
+      @media screen and (forced-colors: active) {
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-itemText,
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-linkText {
+          color: highlight;
+        }
+      }
+
       .guidance-tags span {
         font-size: 12px;
         font-weight: normal;
@@ -1052,11 +1059,6 @@
       @media screen and (forced-colors: active) {
         .kebab-menu-button--9Qt0a.is-expanded .kebab-menu-icon--EUIj-,
         .kebab-menu-button--9Qt0a:hover .kebab-menu-icon--EUIj- {
-          color: highlight;
-        }
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu--7coPg button:hover {
           color: highlight;
         }
       }

--- a/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/axe-results-without-issues.snap.html
@@ -187,6 +187,13 @@
         color: var(--spinner-text);
       }
 
+      @media screen and (forced-colors: active) {
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-itemText,
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-linkText {
+          color: highlight;
+        }
+      }
+
       .guidance-tags span {
         font-size: 12px;
         font-weight: normal;
@@ -1052,11 +1059,6 @@
       @media screen and (forced-colors: active) {
         .kebab-menu-button--9Qt0a.is-expanded .kebab-menu-icon--EUIj-,
         .kebab-menu-button--9Qt0a:hover .kebab-menu-icon--EUIj- {
-          color: highlight;
-        }
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu--7coPg button:hover {
           color: highlight;
         }
       }

--- a/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-baseline-aware-issues.snap.html
@@ -187,6 +187,13 @@
         color: var(--spinner-text);
       }
 
+      @media screen and (forced-colors: active) {
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-itemText,
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-linkText {
+          color: highlight;
+        }
+      }
+
       .guidance-tags span {
         font-size: 12px;
         font-weight: normal;
@@ -1052,11 +1059,6 @@
       @media screen and (forced-colors: active) {
         .kebab-menu-button--9Qt0a.is-expanded .kebab-menu-icon--EUIj-,
         .kebab-menu-button--9Qt0a:hover .kebab-menu-icon--EUIj- {
-          color: highlight;
-        }
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu--7coPg button:hover {
           color: highlight;
         }
       }

--- a/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-with-issues.snap.html
@@ -187,6 +187,13 @@
         color: var(--spinner-text);
       }
 
+      @media screen and (forced-colors: active) {
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-itemText,
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-linkText {
+          color: highlight;
+        }
+      }
+
       .guidance-tags span {
         font-size: 12px;
         font-weight: normal;
@@ -1052,11 +1059,6 @@
       @media screen and (forced-colors: active) {
         .kebab-menu-button--9Qt0a.is-expanded .kebab-menu-icon--EUIj-,
         .kebab-menu-button--9Qt0a:hover .kebab-menu-icon--EUIj- {
-          color: highlight;
-        }
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu--7coPg button:hover {
           color: highlight;
         }
       }

--- a/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/combined-results-without-issues.snap.html
@@ -187,6 +187,13 @@
         color: var(--spinner-text);
       }
 
+      @media screen and (forced-colors: active) {
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-itemText,
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-linkText {
+          color: highlight;
+        }
+      }
+
       .guidance-tags span {
         font-size: 12px;
         font-weight: normal;
@@ -1052,11 +1059,6 @@
       @media screen and (forced-colors: active) {
         .kebab-menu-button--9Qt0a.is-expanded .kebab-menu-icon--EUIj-,
         .kebab-menu-button--9Qt0a:hover .kebab-menu-icon--EUIj- {
-          color: highlight;
-        }
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu--7coPg button:hover {
           color: highlight;
         }
       }

--- a/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-with-issues.snap.html
@@ -187,6 +187,13 @@
         color: var(--spinner-text);
       }
 
+      @media screen and (forced-colors: active) {
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-itemText,
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-linkText {
+          color: highlight;
+        }
+      }
+
       .guidance-tags span {
         font-size: 12px;
         font-weight: normal;
@@ -1052,11 +1059,6 @@
       @media screen and (forced-colors: active) {
         .kebab-menu-button--9Qt0a.is-expanded .kebab-menu-icon--EUIj-,
         .kebab-menu-button--9Qt0a:hover .kebab-menu-icon--EUIj- {
-          color: highlight;
-        }
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu--7coPg button:hover {
           color: highlight;
         }
       }

--- a/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
+++ b/packages/report-e2e-tests/src/examples/summary-scan-without-issues.snap.html
@@ -187,6 +187,13 @@
         color: var(--spinner-text);
       }
 
+      @media screen and (forced-colors: active) {
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-itemText,
+        .ms-ContextualMenu button:hover .ms-ContextualMenu-linkText {
+          color: highlight;
+        }
+      }
+
       .guidance-tags span {
         font-size: 12px;
         font-weight: normal;
@@ -1052,11 +1059,6 @@
       @media screen and (forced-colors: active) {
         .kebab-menu-button--9Qt0a.is-expanded .kebab-menu-icon--EUIj-,
         .kebab-menu-button--9Qt0a:hover .kebab-menu-icon--EUIj- {
-          color: highlight;
-        }
-      }
-      @media screen and (forced-colors: active) {
-        .kebab-menu--7coPg button:hover {
           color: highlight;
         }
       }

--- a/src/common/components/cards/card-footer-instance-action-buttons.scss
+++ b/src/common/components/cards/card-footer-instance-action-buttons.scss
@@ -32,10 +32,3 @@
         }
     }
 }
-
-// Add hover state that's not yet in FluentUI to menu items:
-.kebab-menu button:hover {
-    @media screen and (forced-colors: active) {
-        color: highlight;
-    }
-}

--- a/src/common/components/cards/card-footer-instance-action-buttons.tsx
+++ b/src/common/components/cards/card-footer-instance-action-buttons.tsx
@@ -76,14 +76,12 @@ export class CardFooterInstanceActionButtons extends React.Component<CardFooterI
         return (
             <ActionButton
                 componentRef={ref => (this.kebabButtonRef = ref)}
-                className={styles.kebabMenuButton}
                 ariaLabel={this.props.kebabMenuAriaLabel || 'More actions'}
                 menuIconProps={{
                     iconName: 'MoreActionsMenuIcon',
                     className: styles.kebabMenuIcon,
                 }}
                 menuProps={{
-                    className: styles.kebabMenu,
                     directionalHint: DirectionalHint.bottomRightEdge,
                     shouldFocusOnMount: true,
                     items: this.getMenuItems(),

--- a/src/common/styles/root-level-only/global-styles.scss
+++ b/src/common/styles/root-level-only/global-styles.scss
@@ -66,7 +66,8 @@ button::after {
     }
 }
 
-// Add hover state that's not yet in FluentUI to menu items:
+// Add hover state that's not yet in FluentUI to menu items
+// GH Issue: https://github.com/microsoft/fluentui/issues/25330
 .ms-ContextualMenu button:hover {
     .ms-ContextualMenu-itemText,
     .ms-ContextualMenu-linkText {

--- a/src/common/styles/root-level-only/global-styles.scss
+++ b/src/common/styles/root-level-only/global-styles.scss
@@ -65,3 +65,12 @@ button::after {
         color: $spinner-text;
     }
 }
+
+// Add hover state that's not yet in FluentUI to menu items:
+.ms-ContextualMenu button:hover {
+    .ms-ContextualMenu-itemText, .ms-ContextualMenu-linkText {
+        @media screen and (forced-colors: active) {
+            color: highlight;
+        }
+    }
+}

--- a/src/common/styles/root-level-only/global-styles.scss
+++ b/src/common/styles/root-level-only/global-styles.scss
@@ -68,7 +68,8 @@ button::after {
 
 // Add hover state that's not yet in FluentUI to menu items:
 .ms-ContextualMenu button:hover {
-    .ms-ContextualMenu-itemText, .ms-ContextualMenu-linkText {
+    .ms-ContextualMenu-itemText,
+    .ms-ContextualMenu-linkText {
         @media screen and (forced-colors: active) {
             color: highlight;
         }

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-footer-instance-action-buttons.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-footer-instance-action-buttons.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`CardFooterInstanceActionButtons renders per snapshot with test-kebabmenuarialabel aria label passed as prop: action button menu props 1`] = `
 {
-  "className": "kebabMenu",
   "directionalHint": 6,
   "items": [
     {
@@ -22,14 +21,13 @@ exports[`CardFooterInstanceActionButtons renders per snapshot with test-kebabmen
 
 exports[`CardFooterInstanceActionButtons renders per snapshot with test-kebabmenuarialabel aria label passed as prop: component snapshot 1`] = `
 "<div onKeyDown={[Function: onKeyDown]}>
-  <CustomizedActionButton componentRef={[Function: componentRef]} className="kebabMenuButton" ariaLabel="test-kebabmenuarialabel" menuIconProps={{...}} menuProps={{...}} />
+  <CustomizedActionButton componentRef={[Function: componentRef]} ariaLabel="test-kebabmenuarialabel" menuIconProps={{...}} menuProps={{...}} />
   <Toast deps={{...}} timeoutLength={6000} />
 </div>"
 `;
 
 exports[`CardFooterInstanceActionButtons renders per snapshot with undefined aria label passed as prop: action button menu props 1`] = `
 {
-  "className": "kebabMenu",
   "directionalHint": 6,
   "items": [
     {
@@ -49,7 +47,7 @@ exports[`CardFooterInstanceActionButtons renders per snapshot with undefined ari
 
 exports[`CardFooterInstanceActionButtons renders per snapshot with undefined aria label passed as prop: component snapshot 1`] = `
 "<div onKeyDown={[Function: onKeyDown]}>
-  <CustomizedActionButton componentRef={[Function: componentRef]} className="kebabMenuButton" ariaLabel="More actions" menuIconProps={{...}} menuProps={{...}} />
+  <CustomizedActionButton componentRef={[Function: componentRef]} ariaLabel="More actions" menuIconProps={{...}} menuProps={{...}} />
   <Toast deps={{...}} timeoutLength={6000} />
 </div>"
 `;
@@ -79,7 +77,6 @@ exports[`CardFooterInstanceActionButtons with isCardFooterCollapsed=false render
 
 exports[`CardFooterInstanceActionButtons with isCardFooterCollapsed=true renders per snapshot: action button menu props 1`] = `
 {
-  "className": "kebabMenu",
   "directionalHint": 6,
   "items": [
     {
@@ -99,7 +96,7 @@ exports[`CardFooterInstanceActionButtons with isCardFooterCollapsed=true renders
 
 exports[`CardFooterInstanceActionButtons with isCardFooterCollapsed=true renders per snapshot: component snapshot 1`] = `
 "<div onKeyDown={[Function: onKeyDown]}>
-  <CustomizedActionButton componentRef={[Function: componentRef]} className="kebabMenuButton" ariaLabel="More actions" menuIconProps={{...}} menuProps={{...}} />
+  <CustomizedActionButton componentRef={[Function: componentRef]} ariaLabel="More actions" menuIconProps={{...}} menuProps={{...}} />
   <Toast deps={{...}} timeoutLength={6000} />
 </div>"
 `;


### PR DESCRIPTION
#### Details

This PR updates our stylesheets to change the color of contextual menu list items on hover for the gear icon contextual menu. Additionally, this PR moves this CSS rule to the global stylesheet to make sure this hover color is applied to all contextual menus and removes the local stylesheet changes for the kebab menu.

New Hover States:
| HC Mode | Screenshot |
|------------|--------------|
| Dusk | ![screenshot of dusk HC theme showing gear menu with a different color for "Settings" text in hover state](https://user-images.githubusercontent.com/3230904/196998091-5a116cc9-228e-4089-828b-c1dea0cff758.jpeg)|
| Aquatic | ![screenshot of aquatic HC theme showing gear menu with a different color for "Settings" text in hover state](https://user-images.githubusercontent.com/3230904/196998343-7c282e4f-197e-47de-830e-de7d27682b6c.jpeg)|
| Desert | ![screenshot of desert HC theme showing gear menu with a different color for "Settings" text in hover state](https://user-images.githubusercontent.com/3230904/196998612-bd2016ca-cac5-462e-895a-74a98fa92a8e.jpeg)|
| Night sky | ![screenshot of night sky HC theme showing gear menu with a different color for "Settings" text in hover state](https://user-images.githubusercontent.com/3230904/196998767-05d06cf5-cf54-41fe-926f-122bf7a92990.jpeg)|


##### Motivation

Addresses issue #5678 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #5678
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
