### PR TITLE
chore: rephrase parsing instructions in assessments

### DIFF
--- a/src/assessments/parsing/test-steps/parsing.tsx
+++ b/src/assessments/parsing/test-steps/parsing.tsx
@@ -49,12 +49,14 @@ const howToTest: JSX.Element = (
                 </p>
             </li>
             <li>
-                Run the first bookmarklet in the browser tab containing your target page. It will
-                send the page's DOM to the checker and show the results in a new browser tab.
+                Go to the browser tab containing your target page and, in that browser window,
+                select the first bookmarklet. It will send the page's DOM to the checker and show
+                the results in a new browser tab.
             </li>
             <li>
-                Run the second bookmarklet in the browser tab containing the checker results. It
-                will filter the results to show only WCAG parsing errors.
+                Go to the browser tab containing the checker results and, in that browser window,
+                select the second bookmarklet. It will filter the results to show only WCAG parsing
+                errors.
             </li>
             <li>
                 Examine the filtered results to verify that there are no errors related to:


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
chore: rephrase parsing instructions in assessments

as suggested under https://github.com/microsoft/accessibility-insights-web/issues/6130#issuecomment-1276871238
> Suggestion: maybe "Go to the browser tab containing your target page and, in that browser window, select the first bookmarklet"?

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
closes #6130 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
Instructions shown to user during **Parsing Assessments**
<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
currently;
https://github.com/microsoft/accessibility-insights-web/blob/7ef8ee7aa066968ef0085ab2a72d5505a397a83c/src/assessments/parsing/test-steps/parsing.tsx#L52-L56

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #6130 
- [-] Ran `yarn null:autoadd`
- [-] Ran `yarn fastpass`
- [-] Added/updated relevant unit test(s) (and ran `yarn test`)
- [-] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [-] (UI changes only) Added screenshots/GIFs to description above
- [-] (UI changes only) Verified usability with NVDA/JAWS
