### PR TITLE
chore: update Links to Design Pattern > Assessment

### DIFF
--- a/src/assessments/custom-widgets/custom-widgets-column-renderer.tsx
+++ b/src/assessments/custom-widgets/custom-widgets-column-renderer.tsx
@@ -55,94 +55,90 @@ function makeFlatDesignPatternString(patterns: DesignPattern[]): string {
 }
 
 const roleToDesignPatternsMapping: DictionaryStringTo<DesignPattern[]> = {
-    alert: [{ designPattern: 'Alert', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#alert' }],
+    alert: [{ designPattern: 'Alert', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/alert' }],
     alertdialog: [
         {
-            designPattern: 'Alert or Message Dialog',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#alertdialog',
+            designPattern: 'Alert and Message Dialogs',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog',
         },
     ],
     button: [
         {
             designPattern: 'Accordion',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#accordion',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/accordion',
         },
-        { designPattern: 'Button', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#button' },
+        { designPattern: 'Button', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/button' },
         {
             designPattern: 'Disclosure (Show/Hide)',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#disclosure',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/disclosure',
         },
         {
             designPattern: 'Menu Button',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/menubutton',
         },
     ],
     checkbox: [
         {
             designPattern: 'Checkbox',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#checkbox',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/checkbox',
         },
     ],
     combobox: [
         {
             designPattern: 'Combo Box',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#combobox',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/combobox',
         },
     ],
     dialog: [
         {
             designPattern: 'Dialog (Modal)',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal',
         },
     ],
-    feed: [{ designPattern: 'Feed', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#feed' }],
-    grid: [{ designPattern: 'Grid', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#grid' }],
-    link: [{ designPattern: 'Link', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#link' }],
+    feed: [{ designPattern: 'Feed', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/feed' }],
+    grid: [{ designPattern: 'Grid', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/grid' }],
+    link: [{ designPattern: 'Link', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/link' }],
     listbox: [
-        { designPattern: 'Listbox', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#Listbox' },
+        { designPattern: 'Listbox', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/listbox' },
     ],
-    menu: [{ designPattern: 'Menu', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#menu' }],
-    menubar: [
-        { designPattern: 'Menu Bar', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#menu' },
-    ],
+    menu: [{ designPattern: 'Menu', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/menu' }],
+    menubar: [{ designPattern: 'Menu Bar', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/menu' }],
     radiogroup: [
         {
             designPattern: 'Radio Group',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#radiobutton',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton',
         },
     ],
     separator: [
         {
             designPattern: 'Window Splitter',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#windowsplitter',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter',
         },
     ],
     slider: [
-        { designPattern: 'Slider', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#slider' },
+        { designPattern: 'Slider', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/slider' },
         {
             designPattern: 'Slider (Multi-thumb)',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#sliderwothumb',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb',
         },
     ],
     spinbutton: [
         {
             designPattern: 'Spinbutton',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#spinbutton',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton',
         },
     ],
-    tablist: [
-        { designPattern: 'Tabs', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel' },
-    ],
+    tablist: [{ designPattern: 'Tabs', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel' }],
     toolbar: [
-        { designPattern: 'Toolbar', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#toolbar' },
+        { designPattern: 'Toolbar', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/toolbar' },
     ],
     tooltip: [
-        { designPattern: 'Tooltip', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#tooltip' },
+        { designPattern: 'Tooltip', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/tooltip' },
     ],
     tree: [
         {
             designPattern: 'Tree View',
-            URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#TreeView',
+            URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/treeview',
         },
     ],
 };

--- a/src/assessments/custom-widgets/custom-widgets-column-renderer.tsx
+++ b/src/assessments/custom-widgets/custom-widgets-column-renderer.tsx
@@ -58,7 +58,7 @@ const roleToDesignPatternsMapping: DictionaryStringTo<DesignPattern[]> = {
     alert: [{ designPattern: 'Alert', URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/alert' }],
     alertdialog: [
         {
-            designPattern: 'Alert and Message Dialogs',
+            designPattern: 'Alert or Message Dialog',
             URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog',
         },
     ],

--- a/src/tests/unit/tests/assessments/custom-widgets/custom-widgets-column-renderer.test.tsx
+++ b/src/tests/unit/tests/assessments/custom-widgets/custom-widgets-column-renderer.test.tsx
@@ -62,19 +62,19 @@ describe('CustomWidgetsColumnRenderer', () => {
         const expectedValues = [
             {
                 designPattern: 'Accordion',
-                URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#accordion',
+                URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/accordion',
             },
             {
                 designPattern: 'Button',
-                URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#button',
+                URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/button',
             },
             {
                 designPattern: 'Disclosure (Show/Hide)',
-                URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#disclosure',
+                URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/disclosure',
             },
             {
                 designPattern: 'Menu Button',
-                URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton',
+                URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/menubutton',
             },
         ];
         item.instance.propertyBag.role = 'button';
@@ -103,11 +103,11 @@ describe('CustomWidgetsColumnRenderer', () => {
         const expectedValues = [
             {
                 designPattern: 'Slider',
-                URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#slider',
+                URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/slider',
             },
             {
                 designPattern: 'Slider (Multi-thumb)',
-                URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#sliderwothumb',
+                URL: 'https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb',
             },
         ];
         item.instance.propertyBag.role = 'slider';


### PR DESCRIPTION
- [x] point to correct ARIA APG links
- [x] fix various broken links w/ (typos)
- [x] fix unit tests for the same :)

#### Details
https://github.com/microsoft/accessibility-insights-web/issues/6116#issuecomment-1293832001
> This is the [landing page link](https://www.w3.org/WAI/ARIA/apg/patterns), we would need to point to the right subpage for each pattern. For example for combobox the current link is: https://www.w3.org/TR/wai-aria-practices-1.1/#combobox the new link should be: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/

<!-- Usually a sentence or two describing what the PR changes -->

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
closes #6116 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #6116 
- [-] Ran `yarn null:autoadd`
- [-] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [-] (UI changes only) Added screenshots/GIFs to description above
- [-] (UI changes only) Verified usability with NVDA/JAWS
