### PR TITLE
chore: add combine-dependabot-prs workflow

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+name: "Combine Dependabot PRs"
+on:
+  schedule:
+    - cron: '15,30,45,0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  combine-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+      - uses: maadhattah/combine-dependabot-prs@e4dc7e045b018ee1e963a1a67bccbbf8ff3b176f
+        with:
+          branchPrefix: "dependabot"
+          mustBeGreen: true
+          combineBranchName: combined-prs-${{ github.run_id }}
+          ignoreLabel: "nocombine"
+          baseBranch: "main"
+          openPR: true

--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -4,7 +4,7 @@
 name: "Combine Dependabot PRs"
 on:
   schedule:
-    - cron: '15,30,45,0 * * * *'
+    - cron: '0 13 * * 1'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   combine-prs:
+    if: github.event_name != 'schedule' || github.repository_owner == 'microsoft'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.3

--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -17,6 +17,6 @@ jobs:
           branchPrefix: "dependabot"
           mustBeGreen: true
           combineBranchName: combined-prs-${{ github.run_id }}
-          ignoreLabel: "nocombine"
+          ignoreLabel: "pr: do not combine"
           baseBranch: "main"
           openPR: true


### PR DESCRIPTION
#### Details

Add a new workflow to automatically combine dependabot PRs into a single PR. Any PR with a failing build or the `pr: do not combine` label will be excluded from the new combined PR.

This workflow runs automatically every Monday at 1PM UTC (6AM PST), or it can be run manually from the "actions" tab in the repo.

##### Motivation

Reduce the number of dependabot commits in the repo

##### Context

This action is already used in the [accessibility-insights-service](https://github.com/microsoft/accessibility-insights-service) repo on a manual trigger. After a discussion, our team has decided to experiment with using this action on an automatic trigger in our other repos.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn null:autoadd`
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
