### PR TITLE
refactor(medium-pass-1): refactor enableTest to not use getStoreData

### DIFF
--- a/src/ad-hoc-visualizations/accessible-names/visualization.tsx
+++ b/src/ad-hoc-visualizations/accessible-names/visualization.tsx
@@ -30,7 +30,7 @@ export const AccessibleNamesAdHocVisualization: VisualizationConfiguration = {
     key: accessiblenamesTestKey,
     testMode: TestMode.Adhoc,
     getStoreData: data => data.adhoc[accessiblenamesTestKey],
-    enableTest: data => (data.adhoc[accessiblenamesTestKey].enabled = true),
+    enableTest: data => (data.enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
     shouldShowExportReport: () => false,

--- a/src/ad-hoc-visualizations/color/visualization.tsx
+++ b/src/ad-hoc-visualizations/color/visualization.tsx
@@ -29,7 +29,7 @@ export const ColorAdHocVisualization: VisualizationConfiguration = {
     testViewType: 'AdhocStatic',
     testMode: TestMode.Adhoc,
     getStoreData: data => data.adhoc[colorTestKey],
-    enableTest: (data, _) => (data.adhoc[colorTestKey].enabled = true),
+    enableTest: (data, _) => (data.enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
     shouldShowExportReport: () => false,

--- a/src/ad-hoc-visualizations/headings/visualization.tsx
+++ b/src/ad-hoc-visualizations/headings/visualization.tsx
@@ -30,7 +30,7 @@ export const HeadingsAdHocVisualization: VisualizationConfiguration = {
     key: headingsTestKey,
     testMode: TestMode.Adhoc,
     getStoreData: data => data.adhoc[headingsTestKey],
-    enableTest: data => (data.adhoc[headingsTestKey].enabled = true),
+    enableTest: data => (data.enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
     shouldShowExportReport: () => false,

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -31,7 +31,7 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     testMode: TestMode.Adhoc,
     testViewType: 'AdhocFailure',
     getStoreData: data => data.adhoc[issuesTestKey],
-    enableTest: data => (data.adhoc[issuesTestKey].enabled = true),
+    enableTest: data => (data.enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
     shouldShowExportReport: () => true,

--- a/src/ad-hoc-visualizations/landmarks/visualization.tsx
+++ b/src/ad-hoc-visualizations/landmarks/visualization.tsx
@@ -30,7 +30,7 @@ export const LandmarksAdHocVisualization: VisualizationConfiguration = {
     key: landmarksTestKey,
     testMode: TestMode.Adhoc,
     getStoreData: data => data.adhoc[landmarksTestKey],
-    enableTest: (data, _) => (data.adhoc[landmarksTestKey].enabled = true),
+    enableTest: (data, _) => (data.enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
     shouldShowExportReport: () => false,

--- a/src/ad-hoc-visualizations/needs-review/visualization.tsx
+++ b/src/ad-hoc-visualizations/needs-review/visualization.tsx
@@ -31,7 +31,7 @@ export const NeedsReviewAdHocVisualization: VisualizationConfiguration = {
     testMode: TestMode.Adhoc,
     testViewType: 'AdhocNeedsReview',
     getStoreData: data => data.adhoc[needsReviewTestKey],
-    enableTest: data => (data.adhoc[needsReviewTestKey].enabled = true),
+    enableTest: data => (data.enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
     shouldShowExportReport: () => false,

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -31,7 +31,7 @@ export const TabStopsAdHocVisualization: VisualizationConfiguration = {
         guidance: extraGuidance,
     },
     getStoreData: data => data.adhoc[tabStopsTestKey],
-    enableTest: (data, _) => (data.adhoc[tabStopsTestKey].enabled = true),
+    enableTest: (data, _) => (data.enabled = true),
     disableTest: data => (data.enabled = false),
     getTestStatus: data => data.enabled,
     shouldShowExportReport: () => true,

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -169,11 +169,7 @@ export class AssessmentBuilder {
         const visualizationConfiguration: AssessmentVisualizationConfiguration = {
             testViewType: 'Assessment',
             getStoreData: getStoreData,
-            enableTest: (data, payload) =>
-                AssessmentBuilder.enableTest(
-                    getStoreData(data),
-                    payload as AssessmentToggleActionPayload,
-                ),
+            enableTest: AssessmentBuilder.enableTest,
             disableTest: AssessmentBuilder.disableTest,
             getTestStatus: AssessmentBuilder.getTestStatus,
             getAssessmentData: data => data.assessments[key],
@@ -268,11 +264,7 @@ export class AssessmentBuilder {
                 thisAssessment.generatedAssessmentInstancesMap = instanceMap;
             },
             getStoreData: getStoreData,
-            enableTest: (data, payload) =>
-                AssessmentBuilder.enableTest(
-                    getStoreData(data),
-                    payload as AssessmentToggleActionPayload,
-                ),
+            enableTest: AssessmentBuilder.enableTest,
             disableTest: AssessmentBuilder.disableTest,
             getTestStatus: AssessmentBuilder.getTestStatus,
             telemetryProcessor: factory => factory.forAssessmentRequirementScan,

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -203,7 +203,7 @@ export class VisualizationStore extends PersistentStore<VisualizationStoreData> 
         }
 
         this.state.injectingRequested = true;
-        configuration.enableTest(this.state.tests, payload);
+        configuration.enableTest(configuration.getStoreData(this.state.tests), payload);
         await this.emitChanged();
     }
 

--- a/src/common/configs/assessment-visualization-configuration.ts
+++ b/src/common/configs/assessment-visualization-configuration.ts
@@ -20,7 +20,7 @@ export interface AssessmentVisualizationConfiguration {
     testViewType: TestViewType;
     testViewOverrides?: TestViewOverrides;
     getStoreData: (data: TestsEnabledState) => ScanData;
-    enableTest: (data: TestsEnabledState, payload: ToggleActionPayload) => void;
+    enableTest: (data: ScanData, payload: ToggleActionPayload) => void;
     disableTest: (data: ScanData, step?: string) => void;
     getTestStatus: (data: ScanData, step?: string) => boolean;
     getAssessmentData?: (data: AssessmentStoreData) => AssessmentData;

--- a/src/common/types/store-data/visualization-store-data.ts
+++ b/src/common/types/store-data/visualization-store-data.ts
@@ -12,6 +12,8 @@ export interface AssessmentScanData extends ScanData {
     stepStatus: DictionaryStringTo<boolean>;
 }
 
+export type TestsScanData = DictionaryStringTo<AssessmentScanData | ScanData>;
+
 export interface VisualizationStoreData {
     tests: TestsEnabledState;
     scanning: string;

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -97,7 +97,7 @@ describe('AssessmentBuilderTest', () => {
         expect(config.getStoreData(vizStoreData)).toEqual(scanData);
 
         const testRequirement = 'testRequirement';
-        config.enableTest(vizStoreData, {
+        config.enableTest(scanData, {
             requirement: testRequirement,
         } as AssessmentToggleActionPayload);
         expect(vizStoreData.assessments.manualAssessmentKeyAssessment.enabled).toBe(true);
@@ -272,7 +272,7 @@ describe('AssessmentBuilderTest', () => {
         config.getDrawer(drawerProviderMock.object, requirement5.key);
 
         const testRequirement = 'testRequirement';
-        config.enableTest(vizStoreData, {
+        config.enableTest(scanData, {
             requirement: testRequirement,
         } as AssessmentToggleActionPayload);
         expect(vizStoreData.assessments.headingsAssessment.enabled).toBe(true);


### PR DESCRIPTION
#### Details

Use `ScanData` instead of calling getStoreData in enableTest.

##### Motivation

Feature work.

##### Context

This limits how many properties we may have to overwrite for MediumPass.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
