### PR TITLE
refactor(medium-pass-1): refactor name out of assessment store

### DIFF
--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -58,15 +58,9 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         persistedData: AssessmentStoreData,
         private readonly initialAssessmentStoreDataGenerator: InitialAssessmentStoreDataGenerator,
         logger: Logger,
+        name: StoreNames,
     ) {
-        super(
-            StoreNames.AssessmentStore,
-            persistedData,
-            idbInstance,
-            IndexedDBDataKeys.assessmentStore,
-            logger,
-            true,
-        );
+        super(name, persistedData, idbInstance, IndexedDBDataKeys.assessmentStore, logger, true);
     }
 
     protected override generateDefaultState(

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -4,6 +4,7 @@ import { PermissionsStateStore } from 'background/stores/global/permissions-stat
 import { FeatureFlagDefaultsHelper } from 'common/feature-flag-defaults-helper';
 import { getAllFeatureFlagDetails } from 'common/feature-flags';
 import { Logger } from 'common/logging/logger';
+import { StoreNames } from 'common/stores/store-names';
 import { BaseStore } from '../../../common/base-store';
 import { BrowserAdapter } from '../../../common/browser-adapters/browser-adapter';
 import { StorageAdapter } from '../../../common/browser-adapters/storage-adapter';
@@ -84,6 +85,7 @@ export class GlobalStoreHub implements StoreHub {
             persistedData.assessmentStoreData,
             new InitialAssessmentStoreDataGenerator(assessmentsProvider.all()),
             logger,
+            StoreNames.AssessmentStore,
         );
         this.userConfigurationStore = new UserConfigurationStore(
             persistedData.userConfigurationData,

--- a/src/tests/unit/common/assessment-store-data-builder.ts
+++ b/src/tests/unit/common/assessment-store-data-builder.ts
@@ -5,6 +5,7 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentDataConverter } from 'background/assessment-data-converter';
 import { InitialAssessmentStoreDataGenerator } from 'background/initial-assessment-store-data-generator';
 import { AssessmentStore } from 'background/stores/assessment-store';
+import { StoreNames } from 'common/stores/store-names';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
 import {
@@ -33,6 +34,7 @@ export class AssessmentsStoreDataBuilder extends BaseDataBuilder<AssessmentStore
             null,
             initialAssessmentStoreDataGenerator || this.getPreparedMock(),
             failTestOnErrorLogger,
+            StoreNames.AssessmentStore,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -114,7 +114,19 @@ describe('AssessmentStore', () => {
     });
 
     test('getId', () => {
-        const testObject = createStoreWithNullParams(AssessmentStore);
+        const testObject = new AssessmentStore(
+            null,
+            null,
+            assessmentDataConverterMock.object,
+            assessmentDataRemoverMock.object,
+            assessmentsProviderMock.object,
+            null,
+            null,
+            initialAssessmentStoreDataGeneratorMock.object,
+            failTestOnErrorLogger,
+            StoreNames.AssessmentStore,
+        );
+
         expect(testObject.getId()).toEqual(StoreNames[StoreNames.AssessmentStore]);
     });
 
@@ -132,6 +144,7 @@ describe('AssessmentStore', () => {
             null,
             initialAssessmentStoreDataGeneratorMock.object,
             failTestOnErrorLogger,
+            StoreNames.AssessmentStore,
         );
 
         const actualState = testObject.getDefaultState();
@@ -227,6 +240,7 @@ describe('AssessmentStore', () => {
             persisted,
             initialAssessmentStoreDataGeneratorMock.object,
             failTestOnErrorLogger,
+            StoreNames.AssessmentStore,
         );
         const actualState = testObject.getDefaultState();
 
@@ -2234,6 +2248,7 @@ describe('AssessmentStore', () => {
                 persistedData,
                 initialAssessmentStoreDataGeneratorMock.object,
                 failTestOnErrorLogger,
+                StoreNames.AssessmentStore,
             );
         return new AssessmentStoreTester(
             AssessmentActions,


### PR DESCRIPTION
#### Details

Name is specified in constructor, such that AssessmentStore can be reused for MediumPass.
##### Motivation
feature work
##### Context

Medium Pass store will be another instance of the assessment store, to share its structure (in a future PR). The name is utilized for message passing/updating appropriate state and as such must be unique amongst instances.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
