### PR TITLE
chore: allow retries of install-node-prerequisites pipeline tasks

### DIFF
--- a/pipeline/install-node-prerequisites.yaml
+++ b/pipeline/install-node-prerequisites.yaml
@@ -5,6 +5,8 @@ steps:
       inputs:
           # Keep this in sync with /.github/workflows/ci.yml
           version: '6.0.301'
+      timeoutInMinutes: 2
+      retryCountOnTaskFailure: 2
 
     - task: NodeTool@0
       inputs:
@@ -12,11 +14,14 @@ steps:
           versionSpec: '16.14.2'
       displayName: use node 16.14.2
       timeoutInMinutes: 2
+      retryCountOnTaskFailure: 2
 
     - script: npm install yarn@1.22.10 -g
       displayName: install yarn as a global dependency
       timeoutInMinutes: 1
+      retryCountOnTaskFailure: 2
 
     - script: yarn install --frozen-lockfile
       displayName: install packages and dependencies
       timeoutInMinutes: 10
+      retryCountOnTaskFailure: 2


### PR DESCRIPTION
#### Details

This PR updates each task in our `install-node-prerequisites.yml` pipeline fragment to retry up to twice each, using the recently-introduced [`retryCountOnTaskFailure`](https://learn.microsoft.com/en-us/azure/devops/release-notes/2021/pipelines/sprint-195-update) pipelines syntax. Failures in these tasks are overwhelmingly the result of network connectivity flakiness, so this should help with a few occasional failures that we see across all builds (eg, the failure in this morning's unified "unsigned stage 1" pipeline)

##### Motivation

Avoid noise from flaky failures outside of our control that we'd "resolve" by retrying anyway

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn null:autoadd`
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
