### PR TITLE
feat(medium-pass-1): Create new instances of data infrastructure used in the extension background for Quick Assess 

### DIFF
--- a/src/DetailsView/components/left-nav/details-view-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.tsx
@@ -21,6 +21,7 @@ export type DetailsViewLeftNavDeps = {
         assessmentProvider: AssessmentsProvider,
         flags: FeatureFlagStoreData,
     ) => AssessmentsProvider;
+    mediumPassRequirementKeys: string[];
 } & LeftNavDeps &
     SwitcherDeps;
 

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -6,6 +6,7 @@ import Ajv from 'ajv';
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
 import { Assessments } from 'assessments/assessments';
 import { assessmentsProviderWithFeaturesEnabled } from 'assessments/assessments-feature-flag-filter';
+import { MediumPassRequirementKeys } from 'assessments/medium-pass-requirements';
 import { UserConfigurationActions } from 'background/actions/user-configuration-actions';
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
@@ -594,6 +595,7 @@ if (tabId != null) {
                 cardsViewController,
                 cardFooterMenuItemsBuilder,
                 issueFilingDialogPropsFactory: getIssueFilingDialogProps,
+                mediumPassRequirementKeys: MediumPassRequirementKeys,
             };
 
             const renderer = new DetailsViewRenderer(

--- a/src/background/IndexedDBDataKeys.ts
+++ b/src/background/IndexedDBDataKeys.ts
@@ -3,6 +3,7 @@
 export class IndexedDBDataKeys {
     // Global keys
     public static readonly assessmentStore: string = 'assessmentStoreData';
+    public static readonly quickAssessStore: string = 'quickAssessStoreData';
     public static readonly userConfiguration: string = 'userConfiguration';
     public static readonly installation: string = 'installationData';
     public static readonly unifiedFeatureFlags: string = 'featureFlags';
@@ -37,6 +38,7 @@ export class IndexedDBDataKeys {
 
     public static readonly globalKeys: string[] = [
         IndexedDBDataKeys.assessmentStore,
+        IndexedDBDataKeys.quickAssessStore,
         IndexedDBDataKeys.userConfiguration,
         IndexedDBDataKeys.installation,
         IndexedDBDataKeys.unifiedFeatureFlags,

--- a/src/background/actions/global-action-hub.ts
+++ b/src/background/actions/global-action-hub.ts
@@ -14,6 +14,7 @@ export class GlobalActionHub {
     public launchPanelStateActions: LaunchPanelStateActions;
     public scopingActions: ScopingActions;
     public assessmentActions: AssessmentActions;
+    public quickAssessActions: AssessmentActions;
     public userConfigurationActions: UserConfigurationActions;
     public permissionsStateActions: PermissionsStateActions;
 
@@ -23,6 +24,7 @@ export class GlobalActionHub {
         this.launchPanelStateActions = new LaunchPanelStateActions();
         this.scopingActions = new ScopingActions();
         this.assessmentActions = new AssessmentActions();
+        this.quickAssessActions = new AssessmentActions();
         this.userConfigurationActions = new UserConfigurationActions();
         this.permissionsStateActions = new PermissionsStateActions();
     }

--- a/src/background/actions/quick-assess-action-creator.ts
+++ b/src/background/actions/quick-assess-action-creator.ts
@@ -66,7 +66,7 @@ export class MediumPassActionCreator {
             this.onCollapseTestNav,
         );
         this.interpreter.registerTypeToPayloadCallback(
-            getStoreStateMessage(StoreNames.MediumPassStore),
+            getStoreStateMessage(StoreNames.QuickAssessStore),
             this.onGetAssessmentCurrentState,
         );
         this.interpreter.registerTypeToPayloadCallback(

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -27,6 +27,7 @@ export interface PersistedData {
         [tabId: number]: TabSpecificPersistedData;
     };
     assessmentStoreData: AssessmentStoreData;
+    quickAssessStoreData: AssessmentStoreData;
     userConfigurationData: UserConfigurationStoreData;
     installationData: InstallationData;
     featureFlags: FeatureFlagStoreData;
@@ -53,6 +54,7 @@ export interface TabSpecificPersistedData {
 
 const keyToPersistedDataMappingOverrides = {
     [IndexedDBDataKeys.assessmentStore]: 'assessmentStoreData',
+    [IndexedDBDataKeys.quickAssessStore]: 'quickAssessStoreData',
     [IndexedDBDataKeys.installation]: 'installationData',
     [IndexedDBDataKeys.unifiedFeatureFlags]: 'featureFlags',
     [IndexedDBDataKeys.knownTabIds]: 'knownTabIds',

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -96,6 +96,11 @@ export class GlobalContextFactory {
             globalActionsHub.assessmentActions,
             telemetryEventHandler,
         );
+        const quickAssessActionCreator = new AssessmentActionCreator(
+            interpreter,
+            globalActionsHub.quickAssessActions,
+            telemetryEventHandler,
+        );
         const userConfigurationActionCreator = new UserConfigurationActionCreator(
             globalActionsHub.userConfigurationActions,
             telemetryEventHandler,
@@ -118,6 +123,7 @@ export class GlobalContextFactory {
         issueFilingActionCreator.registerCallbacks();
         actionCreator.registerCallbacks();
         assessmentActionCreator.registerCallbacks();
+        quickAssessActionCreator.registerCallbacks();
         registerUserConfigurationMessageCallback(interpreter, userConfigurationActionCreator);
         scopingActionCreator.registerCallback();
         featureFlagsActionCreator.registerCallbacks();

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { MediumPassActionCreator } from 'background/actions/quick-assess-action-creator';
 import { BrowserPermissionsTracker } from 'background/browser-permissions-tracker';
 import { Logger } from 'common/logging/logger';
 import { DebugToolsActionCreator } from 'debug-tools/action-creators/debug-tools-action-creator';
@@ -96,7 +97,7 @@ export class GlobalContextFactory {
             globalActionsHub.assessmentActions,
             telemetryEventHandler,
         );
-        const quickAssessActionCreator = new AssessmentActionCreator(
+        const quickAssessActionCreator = new MediumPassActionCreator(
             interpreter,
             globalActionsHub.quickAssessActions,
             telemetryEventHandler,

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -33,6 +33,7 @@ export class GlobalStoreHub implements StoreHub {
     public launchPanelStore: LaunchPanelStore;
     public scopingStore: ScopingStore;
     public assessmentStore: AssessmentStore;
+    public quickAssessStore: AssessmentStore;
     public userConfigurationStore: UserConfigurationStore;
     public permissionsStateStore: PermissionsStateStore;
 
@@ -87,6 +88,18 @@ export class GlobalStoreHub implements StoreHub {
             logger,
             StoreNames.AssessmentStore,
         );
+        this.quickAssessStore = new AssessmentStore(
+            browserAdapter,
+            globalActionHub.assessmentActions,
+            new AssessmentDataConverter(generateUID),
+            new AssessmentDataRemover(),
+            assessmentsProvider,
+            indexedDbInstance,
+            persistedData.quickAssessStoreData,
+            new InitialAssessmentStoreDataGenerator(assessmentsProvider.all()),
+            logger,
+            StoreNames.QuickAssessStore,
+        );
         this.userConfigurationStore = new UserConfigurationStore(
             persistedData.userConfigurationData,
             globalActionHub.userConfigurationActions,
@@ -108,6 +121,7 @@ export class GlobalStoreHub implements StoreHub {
         this.launchPanelStore.initialize();
         this.scopingStore.initialize();
         this.assessmentStore.initialize();
+        this.quickAssessStore.initialize();
         this.userConfigurationStore.initialize();
         this.permissionsStateStore.initialize();
     }
@@ -119,6 +133,7 @@ export class GlobalStoreHub implements StoreHub {
             this.launchPanelStore,
             this.scopingStore,
             this.assessmentStore,
+            this.quickAssessStore,
             this.userConfigurationStore,
             this.permissionsStateStore,
         ];

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -90,7 +90,7 @@ export class GlobalStoreHub implements StoreHub {
         );
         this.quickAssessStore = new AssessmentStore(
             browserAdapter,
-            globalActionHub.assessmentActions,
+            globalActionHub.quickAssessActions,
             new AssessmentDataConverter(generateUID),
             new AssessmentDataRemover(),
             assessmentsProvider,

--- a/src/common/stores/store-names.ts
+++ b/src/common/stores/store-names.ts
@@ -30,5 +30,5 @@ export enum StoreNames {
     NeedsReviewScanResultStore,
     NeedsReviewCardSelectionStore,
     CardsViewStore,
-    MediumPassStore,
+    QuickAssessStore,
 }

--- a/src/tests/unit/tests/background/actions/quick-assess-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/quick-assess-action-creator.test.ts
@@ -17,7 +17,7 @@ import {
     ToggleActionPayload,
 } from 'background/actions/action-payloads';
 import { AssessmentActions } from 'background/actions/assessment-actions';
-import { MediumPassActionCreator } from 'background/actions/medium-pass-action-creator';
+import { MediumPassActionCreator } from 'background/actions/quick-assess-action-creator';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import * as TelemetryEvents from 'common/extension-telemetry-events';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
@@ -531,7 +531,7 @@ describe('MediumPassActionCreatorTest', () => {
         testSubject.registerCallbacks();
 
         await interpreterMock.simulateMessage(
-            getStoreStateMessage(StoreNames.MediumPassStore),
+            getStoreStateMessage(StoreNames.QuickAssessStore),
             null,
         );
 

--- a/src/tests/unit/tests/background/get-persisted-data.test.ts
+++ b/src/tests/unit/tests/background/get-persisted-data.test.ts
@@ -22,6 +22,7 @@ import { UserConfigurationStoreData } from '../../../../common/types/store-data/
 describe('GetPersistedDataTest', () => {
     let indexedDBInstanceStrictMock: IMock<IndexedDBAPI>;
     let assessmentStoreData: AssessmentStoreData;
+    let quickAssessStoreData: AssessmentStoreData;
     let userConfigurationData: UserConfigurationStoreData;
     let installationData: InstallationData;
     let permissionsStateStoreData: PermissionsStateStoreData;
@@ -30,6 +31,12 @@ describe('GetPersistedDataTest', () => {
 
     beforeEach(() => {
         assessmentStoreData = {
+            assessmentNavState: null,
+            assessments: null,
+            persistedTabInfo: {} as PersistedTabInfo,
+            resultDescription: '',
+        };
+        quickAssessStoreData = {
             assessmentNavState: null,
             assessments: null,
             persistedTabInfo: {} as PersistedTabInfo,
@@ -63,12 +70,16 @@ describe('GetPersistedDataTest', () => {
         it('propagates the results of IndexedDBAPI.getItem for the appropriate keys', async () => {
             const indexedDataKeysToFetch = [
                 IndexedDBDataKeys.assessmentStore,
+                IndexedDBDataKeys.quickAssessStore,
                 IndexedDBDataKeys.userConfiguration,
             ];
 
             indexedDBInstanceStrictMock
                 .setup(i => i.getItem(IndexedDBDataKeys.assessmentStore))
                 .returns(async () => assessmentStoreData);
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.quickAssessStore))
+                .returns(async () => quickAssessStoreData);
             indexedDBInstanceStrictMock
                 .setup(i => i.getItem(IndexedDBDataKeys.userConfiguration))
                 .returns(async () => userConfigurationData);
@@ -80,6 +91,7 @@ describe('GetPersistedDataTest', () => {
 
             expect(data).toEqual({
                 assessmentStoreData: assessmentStoreData,
+                quickAssessStoreData: quickAssessStoreData,
                 userConfigurationData: userConfigurationData,
             } as PersistedData);
         });
@@ -135,6 +147,7 @@ describe('GetPersistedDataTest', () => {
 
             expect(data).toEqual({
                 assessmentStoreData: assessmentStoreData,
+                quickAssessStoreData: quickAssessStoreData,
                 knownTabIds: {},
                 userConfigurationData: {},
                 commandStoreData: {},
@@ -175,6 +188,7 @@ describe('GetPersistedDataTest', () => {
             };
             expect(data).toEqual({
                 assessmentStoreData: assessmentStoreData,
+                quickAssessStoreData: quickAssessStoreData,
                 knownTabIds: knownTabIds,
                 userConfigurationData: {},
                 commandStoreData: {},
@@ -191,6 +205,9 @@ describe('GetPersistedDataTest', () => {
             indexedDBInstanceStrictMock
                 .setup(i => i.getItem(IndexedDBDataKeys.assessmentStore))
                 .returns(async () => assessmentStoreData);
+            indexedDBInstanceStrictMock
+                .setup(i => i.getItem(IndexedDBDataKeys.quickAssessStore))
+                .returns(async () => quickAssessStoreData);
             IndexedDBDataKeys.globalKeys.forEach(key => {
                 if (
                     key !== IndexedDBDataKeys.knownTabIds &&

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -113,6 +113,7 @@ class GlobalActionCreatorValidator {
     private featureFlagActionsContainerMock = Mock.ofType(FeatureFlagActions);
     private launchPanelStateActionsContainerMock = Mock.ofType(LaunchPanelStateActions);
     private assessmentActionsContainerMock = Mock.ofType(AssessmentActions);
+    private quickAssessActionsContainerMock = Mock.ofType(AssessmentActions);
     private userConfigActionsContainerMock = Mock.ofType(UserConfigurationActions);
     private permissionsStateActionsContainerMock = Mock.ofType(PermissionsStateActions);
     private interpreterMock = Mock.ofType<Interpreter>();
@@ -126,6 +127,7 @@ class GlobalActionCreatorValidator {
         launchPanelStateActions: this.launchPanelStateActionsContainerMock.object,
         scopingActions: null,
         assessmentActions: this.assessmentActionsContainerMock.object,
+        quickAssessActions: this.quickAssessActionsContainerMock.object,
         userConfigurationActions: this.userConfigActionsContainerMock.object,
         permissionsStateActions: this.permissionsStateActionsContainerMock.object,
     };

--- a/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
@@ -41,6 +41,12 @@ describe('GlobalStoreHubTest', () => {
                 assessments: null,
                 resultDescription: '',
             },
+            quickAssessStoreData: {
+                persistedTabInfo: {} as PersistedTabInfo,
+                assessmentNavState: null,
+                assessments: null,
+                resultDescription: '',
+            },
             userConfigurationData: {
                 enableTelemetry: true,
                 isFirstTime: false,
@@ -65,7 +71,7 @@ describe('GlobalStoreHubTest', () => {
         );
         const allStores = testSubject.getAllStores();
 
-        expect(allStores.length).toBe(7);
+        expect(allStores.length).toBe(8);
         expect(testSubject.getStoreType()).toEqual(StoreType.GlobalStore);
 
         verifyStoreExists(allStores, FeatureFlagStore);
@@ -112,7 +118,11 @@ describe('GlobalStoreHubTest', () => {
         storeType,
     ): BaseStore<StoreType, Promise<void>> {
         const matchingStores = stores.filter(s => s instanceof storeType);
-        expect(matchingStores.length).toBe(1);
+        if (storeType !== AssessmentStore) {
+            expect(matchingStores.length).toBe(1);
+        } else {
+            expect(matchingStores.length).toBe(2);
+        }
         return matchingStores[0];
     }
 });


### PR DESCRIPTION
#### Details

This PR creates new instances of `AssessmentActionCreator` and `AssessmentStore` to store and update Quick Assess data. 


##### Motivation

Feature work 🚀 

##### Context

The background page/service worker set up stores and actions during initialization. Though the Quick Assess data displayed to the user will have a much smaller list of requirements, data in the backend will include all `Assessment`s and `Requirement`s to ensure that any data requested is available, same as we do for Assessment.

As of now, no data is populated. A later PR will call the actions to update and save the data.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
