### PR TITLE
fix: sanitize inspectElement property in unhandledError telemetry

### DIFF
--- a/src/common/telemetry/exception-telemetry-sanitizer.ts
+++ b/src/common/telemetry/exception-telemetry-sanitizer.ts
@@ -16,6 +16,7 @@ export class ExceptionTelemetrySanitizer {
         'selector',
         'elementSelector',
         'cssSelector',
+        'inspectElement',
     ];
     private readonly exclusionRegex: RegExp;
 


### PR DESCRIPTION
#### Details

Our `unhandledError` telemetry includes logic that attempts to prevent sending events which would include any data from the page being analyzed, since it could in theory be user-identifiable. 

We noticed while analyzing some of the telemetry that we missed a property (`inspectElement`) that includes an element selector in certain devtools-related telemetry. This PR adds that property to the sanitization list.

##### Motivation

Avoid the possibility of including PII accidentally in unhandledError telemetry

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
