### PR TITLE
feat(medium-pass-1): Quick Assess Overview

### DIFF
--- a/src/DetailsView/components/details-view-right-panel.ts
+++ b/src/DetailsView/components/details-view-right-panel.ts
@@ -49,36 +49,32 @@ export type GetDetailsRightPanelConfigurationProps = {
     detailsViewRightContentPanel: DetailsViewRightContentPanelType;
 };
 
-const TestViewPanel: DetailsRightPanelConfiguration = {
-    RightPanel: TestViewContainer,
-    GetTitle: getTestViewTitle,
-    GetLeftNavSelectedKey: getTestViewKey,
-    GetStartOverContextualMenuItemKeys: () => ['assessment', 'test'],
-};
-
-const detailsViewOverviewConfiguration: {
-    [key in DetailsViewPivotType]: DetailsRightPanelConfiguration;
+const detailsViewTypeContentMap: {
+    [key in DetailsViewRightContentPanelType]: DetailsRightPanelConfiguration;
 } = {
-    [DetailsViewPivotType.assessment]: {
+    Overview: {
         RightPanel: OverviewContainer,
         GetTitle: getOverviewTitle,
         GetLeftNavSelectedKey: getOverviewKey,
         GetStartOverContextualMenuItemKeys: () => ['assessment'],
     },
-    [DetailsViewPivotType.mediumPass]: {
-        RightPanel: OverviewContainer,
-        GetTitle: getOverviewTitle,
-        GetLeftNavSelectedKey: getOverviewKey,
-        GetStartOverContextualMenuItemKeys: () => ['assessment'],
+    TestView: {
+        RightPanel: TestViewContainer,
+        GetTitle: getTestViewTitle,
+        GetLeftNavSelectedKey: getTestViewKey,
+        GetStartOverContextualMenuItemKeys: () => ['assessment', 'test'],
     },
-    [DetailsViewPivotType.fastPass]: TestViewPanel,
 };
 
 export const GetDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration = (
     props: GetDetailsRightPanelConfigurationProps,
 ) => {
-    if (props.detailsViewRightContentPanel === 'TestView') {
-        return TestViewPanel;
+    if (
+        props.selectedDetailsViewPivot === DetailsViewPivotType.assessment ||
+        props.selectedDetailsViewPivot === DetailsViewPivotType.mediumPass
+    ) {
+        return detailsViewTypeContentMap[props.detailsViewRightContentPanel];
     }
-    return detailsViewOverviewConfiguration[props.selectedDetailsViewPivot];
+
+    return detailsViewTypeContentMap.TestView;
 };

--- a/src/DetailsView/components/details-view-right-panel.ts
+++ b/src/DetailsView/components/details-view-right-panel.ts
@@ -29,10 +29,11 @@ export type DetailsViewContentDeps = OverviewContainerDeps &
     TestViewContainerDeps &
     TargetChangeDialogDeps;
 
-export type RightPanelProps = Omit<TestViewContainerProps, 'deps'> &
-    Omit<OverviewContainerProps, 'deps'> & {
-        deps: OverviewContainerDeps | TestViewContainerDeps;
-    };
+export type RightPanelProps =
+    | Omit<TestViewContainerProps, 'deps'>
+    | (Omit<OverviewContainerProps, 'deps'> & {
+          deps: OverviewContainerDeps | TestViewContainerDeps;
+      });
 
 export type DetailsRightPanelConfiguration = Readonly<{
     RightPanel: ReactFCWithDisplayName<RightPanelProps>;

--- a/src/DetailsView/components/details-view-right-panel.ts
+++ b/src/DetailsView/components/details-view-right-panel.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsFeatureFlagFilter } from 'assessments/assessments-feature-flag-filter';
+import { AssessmentsRequirementsFilter } from 'assessments/assessments-requirements-filter';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { DetailsViewRightContentPanelType } from 'common/types/store-data/details-view-right-content-panel-type';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { OverviewSummaryReportModel } from 'reports/assessment-report-model';
+import { GetAssessmentSummaryModelFromProviderAndStoreData } from 'reports/get-assessment-summary-model';
+import { GetQuickAssessSummaryModelFromProviderAndStoreData } from 'reports/get-quick-assess-summary-model';
 import { ReactFCWithDisplayName } from '../../common/react/named-fc';
 import { DetailsViewPivotType } from '../../common/types/store-data/details-view-pivot-type';
 import {
@@ -34,8 +42,38 @@ export type RightPanelProps = Omit<TestViewContainerProps, 'deps'> &
         deps: OverviewContainerDeps | TestViewContainerDeps;
     };
 
+export type GetFilteredProviderDeps = {
+    assessmentsProvider: AssessmentsProvider;
+    assessmentsProviderWithFeaturesEnabled: AssessmentsFeatureFlagFilter;
+    assessmentsProviderForRequirements: AssessmentsRequirementsFilter;
+    quickAssessRequirementKeys: string[];
+};
+
+export type GetFilteredProviderProps = {
+    deps: GetFilteredProviderDeps;
+    featureFlagStoreData: FeatureFlagStoreData;
+};
+
+export type GetSummaryModelFromStoreDataDeps = {
+    assessmentsProvider: AssessmentsProvider;
+    getAssessmentSummaryModelFromProviderAndStoreData: GetAssessmentSummaryModelFromProviderAndStoreData;
+    getQuickAssessSummaryModelFromProviderAndStoreData: GetQuickAssessSummaryModelFromProviderAndStoreData;
+    quickAssessRequirementKeys: string[];
+};
+
+export type GetSummaryModelFromStoreDataProps = {
+    deps: GetSummaryModelFromStoreDataDeps;
+    assessmentStoreData: AssessmentStoreData;
+};
+
 export type DetailsRightPanelConfiguration = Readonly<{
     RightPanel: ReactFCWithDisplayName<RightPanelProps>;
+    RightPanelProps?: {
+        getFilteredProvider?: (props: GetFilteredProviderProps) => AssessmentsProvider;
+        getSummaryModelFromProviderAndStoreData?: (
+            props: GetSummaryModelFromStoreDataProps,
+        ) => OverviewSummaryReportModel;
+    };
     GetTitle: (props: GetTestViewTitleProps) => string;
     GetLeftNavSelectedKey: (props: GetLeftNavSelectedKeyProps) => string;
     GetStartOverContextualMenuItemKeys: () => string[];
@@ -49,32 +87,64 @@ export type GetDetailsRightPanelConfigurationProps = {
     detailsViewRightContentPanel: DetailsViewRightContentPanelType;
 };
 
-const detailsViewTypeContentMap: {
-    [key in DetailsViewRightContentPanelType]: DetailsRightPanelConfiguration;
+const TestViewPanel: DetailsRightPanelConfiguration = {
+    RightPanel: TestViewContainer,
+    GetTitle: getTestViewTitle,
+    GetLeftNavSelectedKey: getTestViewKey,
+    GetStartOverContextualMenuItemKeys: () => ['assessment', 'test'],
+};
+
+const detailsViewOverviewConfiguration: {
+    [key in DetailsViewPivotType]: DetailsRightPanelConfiguration;
 } = {
-    Overview: {
+    [DetailsViewPivotType.assessment]: {
         RightPanel: OverviewContainer,
+        RightPanelProps: {
+            getFilteredProvider: (props: GetFilteredProviderProps) =>
+                props.deps.assessmentsProviderWithFeaturesEnabled(
+                    props.deps.assessmentsProvider,
+                    props.featureFlagStoreData,
+                ),
+            getSummaryModelFromProviderAndStoreData: (props: GetSummaryModelFromStoreDataProps) =>
+                props.deps.getAssessmentSummaryModelFromProviderAndStoreData(
+                    props.deps.assessmentsProvider,
+                    props.assessmentStoreData,
+                ),
+        },
         GetTitle: getOverviewTitle,
         GetLeftNavSelectedKey: getOverviewKey,
         GetStartOverContextualMenuItemKeys: () => ['assessment'],
     },
-    TestView: {
-        RightPanel: TestViewContainer,
-        GetTitle: getTestViewTitle,
-        GetLeftNavSelectedKey: getTestViewKey,
-        GetStartOverContextualMenuItemKeys: () => ['assessment', 'test'],
+    [DetailsViewPivotType.mediumPass]: {
+        RightPanel: OverviewContainer,
+        RightPanelProps: {
+            getFilteredProvider: (props: GetFilteredProviderProps) =>
+                props.deps.assessmentsProviderForRequirements(
+                    props.deps.assessmentsProviderWithFeaturesEnabled(
+                        props.deps.assessmentsProvider,
+                        props.featureFlagStoreData,
+                    ),
+                    props.deps.quickAssessRequirementKeys,
+                ),
+            getSummaryModelFromProviderAndStoreData: (props: GetSummaryModelFromStoreDataProps) =>
+                props.deps.getQuickAssessSummaryModelFromProviderAndStoreData(
+                    props.deps.assessmentsProvider,
+                    props.assessmentStoreData,
+                    props.deps.quickAssessRequirementKeys,
+                ),
+        },
+        GetTitle: getOverviewTitle,
+        GetLeftNavSelectedKey: getOverviewKey,
+        GetStartOverContextualMenuItemKeys: () => ['assessment'],
     },
+    [DetailsViewPivotType.fastPass]: TestViewPanel,
 };
 
 export const GetDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration = (
     props: GetDetailsRightPanelConfigurationProps,
 ) => {
-    if (
-        props.selectedDetailsViewPivot === DetailsViewPivotType.assessment ||
-        props.selectedDetailsViewPivot === DetailsViewPivotType.mediumPass
-    ) {
-        return detailsViewTypeContentMap[props.detailsViewRightContentPanel];
+    if (props.detailsViewRightContentPanel === 'TestView') {
+        return TestViewPanel;
     }
-
-    return detailsViewTypeContentMap.TestView;
+    return detailsViewOverviewConfiguration[props.selectedDetailsViewPivot];
 };

--- a/src/DetailsView/components/details-view-right-panel.ts
+++ b/src/DetailsView/components/details-view-right-panel.ts
@@ -69,7 +69,10 @@ const detailsViewTypeContentMap: {
 export const GetDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration = (
     props: GetDetailsRightPanelConfigurationProps,
 ) => {
-    if (props.selectedDetailsViewPivot === DetailsViewPivotType.assessment) {
+    if (
+        props.selectedDetailsViewPivot === DetailsViewPivotType.assessment ||
+        props.selectedDetailsViewPivot === DetailsViewPivotType.mediumPass
+    ) {
         return detailsViewTypeContentMap[props.detailsViewRightContentPanel];
     }
 

--- a/src/DetailsView/components/details-view-right-panel.ts
+++ b/src/DetailsView/components/details-view-right-panel.ts
@@ -68,7 +68,7 @@ export type GetSummaryModelFromStoreDataProps = {
 
 export type DetailsRightPanelConfiguration = Readonly<{
     RightPanel: ReactFCWithDisplayName<RightPanelProps>;
-    RightPanelProps?: {
+    OverviewSummaryDataProps?: {
         getFilteredProvider?: (props: GetFilteredProviderProps) => AssessmentsProvider;
         getSummaryModelFromProviderAndStoreData?: (
             props: GetSummaryModelFromStoreDataProps,
@@ -99,7 +99,7 @@ const detailsViewOverviewConfiguration: {
 } = {
     [DetailsViewPivotType.assessment]: {
         RightPanel: OverviewContainer,
-        RightPanelProps: {
+        OverviewSummaryDataProps: {
             getFilteredProvider: (props: GetFilteredProviderProps) =>
                 props.deps.assessmentsProviderWithFeaturesEnabled(
                     props.deps.assessmentsProvider,
@@ -117,7 +117,7 @@ const detailsViewOverviewConfiguration: {
     },
     [DetailsViewPivotType.mediumPass]: {
         RightPanel: OverviewContainer,
-        RightPanelProps: {
+        OverviewSummaryDataProps: {
             getFilteredProvider: (props: GetFilteredProviderProps) =>
                 props.deps.assessmentsProviderForRequirements(
                     props.deps.assessmentsProviderWithFeaturesEnabled(

--- a/src/DetailsView/components/details-view-right-panel.ts
+++ b/src/DetailsView/components/details-view-right-panel.ts
@@ -1,14 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsFeatureFlagFilter } from 'assessments/assessments-feature-flag-filter';
-import { AssessmentsRequirementsFilter } from 'assessments/assessments-requirements-filter';
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { DetailsViewRightContentPanelType } from 'common/types/store-data/details-view-right-content-panel-type';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { OverviewSummaryReportModel } from 'reports/assessment-report-model';
-import { GetAssessmentSummaryModelFromProviderAndStoreData } from 'reports/get-assessment-summary-model';
-import { GetQuickAssessSummaryModelFromProviderAndStoreData } from 'reports/get-quick-assess-summary-model';
 import { ReactFCWithDisplayName } from '../../common/react/named-fc';
 import { DetailsViewPivotType } from '../../common/types/store-data/details-view-pivot-type';
 import {
@@ -42,38 +34,8 @@ export type RightPanelProps = Omit<TestViewContainerProps, 'deps'> &
         deps: OverviewContainerDeps | TestViewContainerDeps;
     };
 
-export type GetFilteredProviderDeps = {
-    assessmentsProvider: AssessmentsProvider;
-    assessmentsProviderWithFeaturesEnabled: AssessmentsFeatureFlagFilter;
-    assessmentsProviderForRequirements: AssessmentsRequirementsFilter;
-    quickAssessRequirementKeys: string[];
-};
-
-export type GetFilteredProviderProps = {
-    deps: GetFilteredProviderDeps;
-    featureFlagStoreData: FeatureFlagStoreData;
-};
-
-export type GetSummaryModelFromStoreDataDeps = {
-    assessmentsProvider: AssessmentsProvider;
-    getAssessmentSummaryModelFromProviderAndStoreData: GetAssessmentSummaryModelFromProviderAndStoreData;
-    getQuickAssessSummaryModelFromProviderAndStoreData: GetQuickAssessSummaryModelFromProviderAndStoreData;
-    quickAssessRequirementKeys: string[];
-};
-
-export type GetSummaryModelFromStoreDataProps = {
-    deps: GetSummaryModelFromStoreDataDeps;
-    assessmentStoreData: AssessmentStoreData;
-};
-
 export type DetailsRightPanelConfiguration = Readonly<{
     RightPanel: ReactFCWithDisplayName<RightPanelProps>;
-    OverviewSummaryDataProps?: {
-        getFilteredProvider?: (props: GetFilteredProviderProps) => AssessmentsProvider;
-        getSummaryModelFromProviderAndStoreData?: (
-            props: GetSummaryModelFromStoreDataProps,
-        ) => OverviewSummaryReportModel;
-    };
     GetTitle: (props: GetTestViewTitleProps) => string;
     GetLeftNavSelectedKey: (props: GetLeftNavSelectedKeyProps) => string;
     GetStartOverContextualMenuItemKeys: () => string[];
@@ -99,40 +61,12 @@ const detailsViewOverviewConfiguration: {
 } = {
     [DetailsViewPivotType.assessment]: {
         RightPanel: OverviewContainer,
-        OverviewSummaryDataProps: {
-            getFilteredProvider: (props: GetFilteredProviderProps) =>
-                props.deps.assessmentsProviderWithFeaturesEnabled(
-                    props.deps.assessmentsProvider,
-                    props.featureFlagStoreData,
-                ),
-            getSummaryModelFromProviderAndStoreData: (props: GetSummaryModelFromStoreDataProps) =>
-                props.deps.getAssessmentSummaryModelFromProviderAndStoreData(
-                    props.deps.assessmentsProvider,
-                    props.assessmentStoreData,
-                ),
-        },
         GetTitle: getOverviewTitle,
         GetLeftNavSelectedKey: getOverviewKey,
         GetStartOverContextualMenuItemKeys: () => ['assessment'],
     },
     [DetailsViewPivotType.mediumPass]: {
         RightPanel: OverviewContainer,
-        OverviewSummaryDataProps: {
-            getFilteredProvider: (props: GetFilteredProviderProps) =>
-                props.deps.assessmentsProviderForRequirements(
-                    props.deps.assessmentsProviderWithFeaturesEnabled(
-                        props.deps.assessmentsProvider,
-                        props.featureFlagStoreData,
-                    ),
-                    props.deps.quickAssessRequirementKeys,
-                ),
-            getSummaryModelFromProviderAndStoreData: (props: GetSummaryModelFromStoreDataProps) =>
-                props.deps.getQuickAssessSummaryModelFromProviderAndStoreData(
-                    props.deps.assessmentsProvider,
-                    props.assessmentStoreData,
-                    props.deps.quickAssessRequirementKeys,
-                ),
-        },
         GetTitle: getOverviewTitle,
         GetLeftNavSelectedKey: getOverviewKey,
         GetStartOverContextualMenuItemKeys: () => ['assessment'],

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -24,6 +24,10 @@ import {
 } from 'DetailsView/components/load-assessment-button-factory';
 import { MediumPassCommandBar } from 'DetailsView/components/medium-pass-command-bar';
 import {
+    GetOverviewSummaryData,
+    getOverviewSummaryDataForPivot,
+} from 'DetailsView/components/overview-content/get-overview-summary-data';
+import {
     getReportExportDialogForAssessment,
     getReportExportDialogForFastPass,
     getReportExportDialogForMediumPass,
@@ -90,6 +94,7 @@ export type DetailsViewSwitcherNavConfiguration = Readonly<{
     warningConfiguration: WarningConfiguration;
     leftNavHamburgerButton: ReactFCWithDisplayName<ExpandCollpaseLeftNavButtonProps>;
     analyzerMessageConfiguration: AnalyzerMessageConfiguration;
+    getOverviewSummaryData: GetOverviewSummaryData;
 }>;
 
 type InternalDetailsViewSwitcherNavConfiguration = Omit<
@@ -118,6 +123,7 @@ const detailsViewSwitcherNavs: {
         warningConfiguration: assessmentWarningConfiguration,
         leftNavHamburgerButton: AssessmentLeftNavHamburgerButton,
         analyzerMessageConfiguration: AssessmentVisualizationMessageTypes,
+        getOverviewSummaryData: getOverviewSummaryDataForPivot(DetailsViewPivotType.assessment),
     },
     [DetailsViewPivotType.mediumPass]: {
         CommandBar: MediumPassCommandBar,
@@ -131,6 +137,7 @@ const detailsViewSwitcherNavs: {
         warningConfiguration: quickAssessWarningConfiguration,
         leftNavHamburgerButton: MediumPassLeftNavHamburgerButton,
         analyzerMessageConfiguration: MediumPassVisualizationMessageTypes,
+        getOverviewSummaryData: getOverviewSummaryDataForPivot(DetailsViewPivotType.mediumPass),
     },
     [DetailsViewPivotType.fastPass]: {
         CommandBar: AutomatedChecksCommandBar,
@@ -144,6 +151,7 @@ const detailsViewSwitcherNavs: {
         warningConfiguration: fastpassWarningConfiguration,
         leftNavHamburgerButton: FastPassLeftNavHamburgerButton,
         analyzerMessageConfiguration: AdhocVisualizationMessageTypes,
+        getOverviewSummaryData: () => null,
     },
 };
 

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -14,7 +14,10 @@ import {
     ReportExportDialogFactory,
     SaveAssessmentButtonFactory,
 } from 'DetailsView/components/details-view-command-bar';
-import { MediumPassLeftNav } from 'DetailsView/components/left-nav/medium-pass-left-nav';
+import {
+    MediumPassLeftNav,
+    MediumPassLeftNavDeps,
+} from 'DetailsView/components/left-nav/medium-pass-left-nav';
 import {
     getLoadButtonForAssessment,
     getNullLoadButton,
@@ -43,6 +46,7 @@ import {
 import {
     assessmentWarningConfiguration,
     fastpassWarningConfiguration,
+    quickAssessWarningConfiguration,
     WarningConfiguration,
 } from 'DetailsView/components/warning-configuration';
 import {
@@ -70,7 +74,7 @@ import {
     GetSelectedDetailsViewProps,
 } from './left-nav/get-selected-details-view';
 
-export type LeftNavDeps = AssessmentLeftNavDeps & FastPassLeftNavDeps;
+export type LeftNavDeps = AssessmentLeftNavDeps & FastPassLeftNavDeps & MediumPassLeftNavDeps;
 export type LeftNavProps = AssessmentLeftNavProps & FastPassLeftNavProps;
 type InternalLeftNavProps = AssessmentLeftNavProps | FastPassLeftNavProps;
 
@@ -124,7 +128,7 @@ const detailsViewSwitcherNavs: {
         StartOverComponentFactory: AssessmentStartOverFactory,
         LeftNav: MediumPassLeftNav,
         getSelectedDetailsView: getAssessmentSelectedDetailsView,
-        warningConfiguration: assessmentWarningConfiguration,
+        warningConfiguration: quickAssessWarningConfiguration,
         leftNavHamburgerButton: MediumPassLeftNavHamburgerButton,
         analyzerMessageConfiguration: MediumPassVisualizationMessageTypes,
     },

--- a/src/DetailsView/components/iframe-warning.tsx
+++ b/src/DetailsView/components/iframe-warning.tsx
@@ -44,6 +44,16 @@ export type AssessmentIframeWarningProps = {
     test: VisualizationType;
 };
 
+export type QuickAssessIframeWarningDeps = {
+    allUrlsPermissionHandler: AllUrlsPermissionHandler;
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+};
+
+export type QuickAssessIframeWarningProps = {
+    deps: QuickAssessIframeWarningDeps;
+    test: VisualizationType;
+};
+
 export const AssessmentIframeWarning = NamedFC<AssessmentIframeWarningProps>(
     'AssessmentIframeWarning',
     props => {
@@ -52,6 +62,23 @@ export const AssessmentIframeWarning = NamedFC<AssessmentIframeWarningProps>(
         const onAllowPermissionsClick = async (event: SupportedMouseEvent) => {
             const rescanTest = () => {
                 deps.assessmentActionMessageCreator.startOverTest(event, test);
+            };
+
+            await deps.allUrlsPermissionHandler.requestAllUrlsPermission(event, rescanTest);
+        };
+
+        return <IframeWarning onAllowPermissionsClick={onAllowPermissionsClick} />;
+    },
+);
+
+export const QuickAssessIframeWarning = NamedFC<QuickAssessIframeWarningProps>(
+    'QuickAssessIframeWarning',
+    props => {
+        const { deps, test } = props;
+
+        const onAllowPermissionsClick = async (event: SupportedMouseEvent) => {
+            const rescanTest = () => {
+                deps.detailsViewActionMessageCreator.startOverTest(event, test);
             };
 
             await deps.allUrlsPermissionHandler.requestAllUrlsPermission(event, rescanTest);

--- a/src/DetailsView/components/iframe-warning.tsx
+++ b/src/DetailsView/components/iframe-warning.tsx
@@ -47,6 +47,7 @@ export type AssessmentIframeWarningProps = {
 export type QuickAssessIframeWarningDeps = {
     allUrlsPermissionHandler: AllUrlsPermissionHandler;
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+    assessmentActionMessageCreator: AssessmentActionMessageCreator;
 };
 
 export type QuickAssessIframeWarningProps = {
@@ -78,7 +79,7 @@ export const QuickAssessIframeWarning = NamedFC<QuickAssessIframeWarningProps>(
 
         const onAllowPermissionsClick = async (event: SupportedMouseEvent) => {
             const rescanTest = () => {
-                deps.detailsViewActionMessageCreator.startOverTest(event, test);
+                deps.assessmentActionMessageCreator.startOverTest(event, test);
             };
 
             await deps.allUrlsPermissionHandler.requestAllUrlsPermission(event, rescanTest);

--- a/src/DetailsView/components/overview-content/get-overview-summary-data.ts
+++ b/src/DetailsView/components/overview-content/get-overview-summary-data.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AssessmentsFeatureFlagFilter } from 'assessments/assessments-feature-flag-filter';
+import { AssessmentsRequirementsFilter } from 'assessments/assessments-requirements-filter';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { OverviewSummaryReportModel } from 'reports/assessment-report-model';
+import { GetAssessmentSummaryModelFromProviderAndStoreData } from 'reports/get-assessment-summary-model';
+import { GetQuickAssessSummaryModelFromProviderAndStoreData } from 'reports/get-quick-assess-summary-model';
+
+export type GetOverviewSummaryDataDeps = {
+    assessmentsProvider: AssessmentsProvider;
+    assessmentsProviderWithFeaturesEnabled: AssessmentsFeatureFlagFilter;
+    assessmentsProviderForRequirements: AssessmentsRequirementsFilter;
+    getAssessmentSummaryModelFromProviderAndStoreData: GetAssessmentSummaryModelFromProviderAndStoreData;
+    getQuickAssessSummaryModelFromProviderAndStoreData: GetQuickAssessSummaryModelFromProviderAndStoreData;
+    quickAssessRequirementKeys: string[];
+};
+
+export type GetOverviewSummaryDataProps = {
+    deps: GetOverviewSummaryDataDeps;
+    assessmentStoreData: AssessmentStoreData;
+    featureFlagStoreData: FeatureFlagStoreData;
+};
+
+export type GetOverviewSummaryData = (
+    props: GetOverviewSummaryDataProps,
+) => OverviewSummaryReportModel;
+
+export const getOverviewSummaryDataForPivot: (
+    selectedPivotType: DetailsViewPivotType,
+) => GetOverviewSummaryData =
+    (selectedPivotType: DetailsViewPivotType) => (props: GetOverviewSummaryDataProps) => {
+        const filteredFeatureFlagProvider = props.deps.assessmentsProviderWithFeaturesEnabled(
+            props.deps.assessmentsProvider,
+            props.featureFlagStoreData,
+        );
+        if (selectedPivotType === DetailsViewPivotType.assessment) {
+            return props.deps.getAssessmentSummaryModelFromProviderAndStoreData(
+                filteredFeatureFlagProvider,
+                props.assessmentStoreData,
+            );
+        } else {
+            const filteredRequirementsProvider = props.deps.assessmentsProviderForRequirements(
+                filteredFeatureFlagProvider,
+                props.deps.quickAssessRequirementKeys,
+            );
+            return props.deps.getQuickAssessSummaryModelFromProviderAndStoreData(
+                filteredRequirementsProvider,
+                props.assessmentStoreData,
+                props.deps.quickAssessRequirementKeys,
+            );
+        }
+    };

--- a/src/DetailsView/components/overview-content/overview-content-container.tsx
+++ b/src/DetailsView/components/overview-content/overview-content-container.tsx
@@ -10,13 +10,9 @@ import { AssessmentStoreData } from 'common/types/store-data/assessment-result-d
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
-import {
-    GetFilteredProviderProps,
-    GetSummaryModelFromStoreDataProps,
-} from 'DetailsView/components/details-view-right-panel';
+import { GetOverviewSummaryData } from 'DetailsView/components/overview-content/get-overview-summary-data';
 import * as React from 'react';
 
-import { OverviewSummaryReportModel } from 'reports/assessment-report-model';
 import { AssessmentReportSummary } from 'reports/components/assessment-report-summary';
 import { GetAssessmentSummaryModelFromProviderAndStoreData } from 'reports/get-assessment-summary-model';
 import { GetQuickAssessSummaryModelFromProviderAndStoreData } from 'reports/get-quick-assess-summary-model';
@@ -61,10 +57,7 @@ export interface OverviewContainerProps {
     assessmentStoreData: AssessmentStoreData;
     tabStoreData: TabStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
-    getFilteredProvider?: (props: GetFilteredProviderProps) => AssessmentsProvider;
-    getSummaryModelFromProviderAndStoreData?: (
-        props: GetSummaryModelFromStoreDataProps,
-    ) => OverviewSummaryReportModel;
+    getSummaryData?: GetOverviewSummaryData;
 }
 
 export const overviewContainerAutomationId = 'overviewContainerAutomationId';
@@ -77,15 +70,10 @@ export const OverviewContainer = NamedFC<OverviewContainerProps>('OverviewContai
         url: tabStoreData.url,
         title: tabStoreData.title,
     };
-
-    const filteredProvider = props.getFilteredProvider({
+    const summaryData = props.getSummaryData({
         deps,
-        featureFlagStoreData,
-    });
-    const summaryData = props.getSummaryModelFromProviderAndStoreData({
-        deps,
-        assessmentsProvider: filteredProvider,
         assessmentStoreData,
+        featureFlagStoreData,
     });
 
     return (

--- a/src/DetailsView/components/overview-content/overview-content-container.tsx
+++ b/src/DetailsView/components/overview-content/overview-content-container.tsx
@@ -57,7 +57,7 @@ export interface OverviewContainerProps {
     assessmentStoreData: AssessmentStoreData;
     tabStoreData: TabStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
-    getSummaryData?: GetOverviewSummaryData;
+    getSummaryData: GetOverviewSummaryData;
 }
 
 export const overviewContainerAutomationId = 'overviewContainerAutomationId';

--- a/src/DetailsView/components/warning-configuration.tsx
+++ b/src/DetailsView/components/warning-configuration.tsx
@@ -9,6 +9,7 @@ import {
     FastPassIframeWarning,
     FastPassIframeWarningDeps,
     FastPassIframeWarningProps,
+    QuickAssessIframeWarning,
 } from 'DetailsView/components/iframe-warning';
 
 export type ScanIncompleteWarningMessageBarProps =
@@ -28,4 +29,8 @@ export const assessmentWarningConfiguration: WarningConfiguration = {
 
 export const fastpassWarningConfiguration: WarningConfiguration = {
     'missing-required-cross-origin-permissions': FastPassIframeWarning,
+};
+
+export const quickAssessWarningConfiguration: WarningConfiguration = {
+    'missing-required-cross-origin-permissions': QuickAssessIframeWarning,
 };

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -134,7 +134,7 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
     private renderRightPanel(): JSX.Element {
         return (
             <this.props.rightPanelConfiguration.RightPanel
-                {...this.props.rightPanelConfiguration.RightPanelProps}
+                {...this.props.rightPanelConfiguration.OverviewSummaryDataProps}
                 {...this.props}
             />
         );

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -132,10 +132,11 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
     }
 
     private renderRightPanel(): JSX.Element {
+        const { switcherNavConfiguration } = this.props;
         return (
             <this.props.rightPanelConfiguration.RightPanel
-                {...this.props.rightPanelConfiguration.OverviewSummaryDataProps}
                 {...this.props}
+                getSummaryData={switcherNavConfiguration.getOverviewSummaryData}
             />
         );
     }

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -132,6 +132,11 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
     }
 
     private renderRightPanel(): JSX.Element {
-        return <this.props.rightPanelConfiguration.RightPanel {...this.props} />;
+        return (
+            <this.props.rightPanelConfiguration.RightPanel
+                {...this.props.rightPanelConfiguration.RightPanelProps}
+                {...this.props}
+            />
+        );
     }
 }

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -80,6 +80,10 @@ import {
     getAssessmentSummaryModelFromProviderAndStatusData,
     getAssessmentSummaryModelFromProviderAndStoreData,
 } from 'reports/get-assessment-summary-model';
+import {
+    getQuickAssessSummaryModelFromProviderAndStoreData,
+    getQuickAssessSummaryModelFromProviderAndStatusData,
+} from 'reports/get-quick-assess-summary-model';
 import { ReactStaticRenderer } from 'reports/react-static-renderer';
 import { ReportGenerator } from 'reports/report-generator';
 import { WebReportNameGenerator } from 'reports/report-name-generator';
@@ -541,8 +545,12 @@ if (tabId != null) {
                 loadAssessmentHelper,
                 getAssessmentSummaryModelFromProviderAndStoreData:
                     getAssessmentSummaryModelFromProviderAndStoreData,
+                getQuickAssessSummaryModelFromProviderAndStoreData:
+                    getQuickAssessSummaryModelFromProviderAndStoreData,
                 getAssessmentSummaryModelFromProviderAndStatusData:
                     getAssessmentSummaryModelFromProviderAndStatusData,
+                getQuickAssessSummaryModelFromProviderAndStatusData:
+                    getQuickAssessSummaryModelFromProviderAndStatusData,
                 visualizationConfigurationFactory,
                 getDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration,
                 navLinkHandler: new NavLinkHandler(

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -6,6 +6,7 @@ import Ajv from 'ajv';
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
 import { Assessments } from 'assessments/assessments';
 import { assessmentsProviderWithFeaturesEnabled } from 'assessments/assessments-feature-flag-filter';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
 import { MediumPassRequirementKeys } from 'assessments/medium-pass-requirements';
 import { UserConfigurationActions } from 'background/actions/user-configuration-actions';
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
@@ -528,6 +529,7 @@ if (tabId != null) {
                 assessmentActionMessageCreator,
                 tabStopRequirementActionMessageCreator,
                 assessmentsProvider: Assessments,
+                mediumPassRequirementKeys: MediumPassRequirementKeys,
                 actionInitiators,
                 assessmentDefaultMessageGenerator: assessmentDefaultMessageGenerator,
                 issueDetailsTextGenerator,
@@ -554,6 +556,7 @@ if (tabId != null) {
                 outcomeTypeFromTestStatus,
                 outcomeStatsFromManualTestStatus,
                 assessmentsProviderWithFeaturesEnabled,
+                assessmentsProviderForRequirements,
                 outcomeTypeSemanticsFromTestStatus,
                 getInnerTextFromJsxElement,
                 storesHub,
@@ -606,7 +609,7 @@ if (tabId != null) {
                 cardsViewController,
                 cardFooterMenuItemsBuilder,
                 issueFilingDialogPropsFactory: getIssueFilingDialogProps,
-                mediumPassRequirementKeys: MediumPassRequirementKeys,
+                quickAssessRequirementKeys: MediumPassRequirementKeys,
             };
 
             const renderer = new DetailsViewRenderer(

--- a/src/assessments/assessments-feature-flag-filter.ts
+++ b/src/assessments/assessments-feature-flag-filter.ts
@@ -16,6 +16,11 @@ function assessmentIsFeatureEnabled(
         every(assessment.featureFlag.required, f => flags[f]);
 }
 
+export type AssessmentsFeatureFlagFilter = (
+    assessmentsProvider: AssessmentsProvider,
+    featureFlagStoreData: FeatureFlagStoreData,
+) => AssessmentsProvider;
+
 export function assessmentsProviderWithFeaturesEnabled(
     assessmentProvider: AssessmentsProvider,
     flags: FeatureFlagStoreData,

--- a/src/assessments/assessments-requirements-filter.ts
+++ b/src/assessments/assessments-requirements-filter.ts
@@ -5,6 +5,11 @@ import { AutomatedChecks } from 'assessments/automated-checks/assessment';
 import { AssessmentsProviderImpl } from './assessments-provider';
 import { AssessmentsProvider } from './types/assessments-provider';
 
+export type AssessmentsRequirementsFilter = (
+    assessmentsProvider: AssessmentsProvider,
+    requirementKeys: string[],
+) => AssessmentsProvider;
+
 // the assessmentProvider passed into this function should already
 // have been passed through the filter for feature flags
 export function assessmentsProviderForRequirements(

--- a/src/reports/get-quick-assess-summary-model.ts
+++ b/src/reports/get-quick-assess-summary-model.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AutomatedChecks } from 'assessments/automated-checks/assessment';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import {
+    AssessmentStatusData,
+    getAssessmentSummaryModelFromResults,
+} from 'reports/get-assessment-summary-model';
+import * as Model from './assessment-report-model';
+
+export type GetQuickAssessSummaryModelFromProviderAndStoreData = (
+    assessmentsProvider: AssessmentsProvider,
+    assessmentStoreData: AssessmentStoreData,
+    requirementKeys: string[],
+) => Model.OverviewSummaryReportModel;
+
+export type GetQuickAssessSummaryModelFromProviderAndStatusData = (
+    assessmentsProvider: AssessmentsProvider,
+    statusData: AssessmentStatusData,
+    requirementKeys: string[],
+) => Model.OverviewSummaryReportModel;
+
+export function getQuickAssessSummaryModelFromProviderAndStoreData(
+    assessmentsProvider: AssessmentsProvider,
+    quickAssessStoreData: AssessmentStoreData,
+    requirementKeys: string[],
+): Model.OverviewSummaryReportModel {
+    const automatedChecksAssessment = assessmentsProvider.forKey(AutomatedChecks.key);
+    const automatedChecksResult = {
+        title: automatedChecksAssessment.title,
+        storeData: {
+            testStepStatus:
+                quickAssessStoreData.assessments[automatedChecksAssessment.key].testStepStatus,
+        },
+    };
+    const quickAssessResults = requirementKeys.map(requirementKey => {
+        const assessment = assessmentsProvider.forRequirementKey(requirementKey);
+        const requirement = assessmentsProvider.getStep(
+            assessment.visualizationType,
+            requirementKey,
+        );
+        return {
+            title: requirement.name,
+            storeData: {
+                testStepStatus: {
+                    [requirementKey]:
+                        quickAssessStoreData.assessments[assessment.key].testStepStatus[
+                            requirementKey
+                        ],
+                },
+            },
+        };
+    });
+    quickAssessResults.unshift(automatedChecksResult);
+
+    return getAssessmentSummaryModelFromResults(quickAssessResults);
+}
+
+export function getQuickAssessSummaryModelFromProviderAndStatusData(
+    quickAssessProvider: AssessmentsProvider,
+    statusData: AssessmentStatusData,
+    requirementKeys: string[],
+): Model.OverviewSummaryReportModel {
+    const automatedChecksAssessment = quickAssessProvider.forKey(AutomatedChecks.key);
+    const automatedChecksResult = {
+        title: automatedChecksAssessment.title,
+        storeData: {
+            testStepStatus: statusData[automatedChecksAssessment.key],
+        },
+    };
+    const quickAssessResults = requirementKeys.map(requirementKey => {
+        const assessment = quickAssessProvider.forRequirementKey(requirementKey);
+        const requirement = quickAssessProvider.getStep(
+            assessment.visualizationType,
+            requirementKey,
+        );
+        return {
+            title: requirement.name,
+            storeData: {
+                testStepStatus: {
+                    [requirementKey]: statusData[assessment.key][requirementKey],
+                },
+            },
+        };
+    });
+    quickAssessResults.unshift(automatedChecksResult);
+
+    return getAssessmentSummaryModelFromResults(quickAssessResults);
+}

--- a/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
@@ -1,5 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { OverviewSummaryReportModel } from 'reports/assessment-report-model';
+import { Mock, MockBehavior, Times } from 'typemoq';
 import { DetailsViewPivotType } from '../../../../../common/types/store-data/details-view-pivot-type';
 import {
     DetailsRightPanelConfiguration,
@@ -18,6 +22,63 @@ import {
 
 describe('DetailsViewRightPanelTests', () => {
     describe('GetDetailsRightPanelConfiguration', () => {
+        it.each([
+            DetailsViewPivotType.assessment,
+            DetailsViewPivotType.mediumPass,
+            DetailsViewPivotType.fastPass,
+        ])(
+            'GetDetailsRightPanelConfiguration for pivotType %s correctly returns Overview object',
+            pivotType => {
+                const testSubject = GetDetailsRightPanelConfiguration({
+                    selectedDetailsViewPivot: pivotType,
+                    detailsViewRightContentPanel: 'Overview',
+                });
+                if (pivotType === DetailsViewPivotType.fastPass) {
+                    validateTestView(testSubject);
+                } else {
+                    validateOverview(testSubject);
+                }
+            },
+        );
+
+        it.each([DetailsViewPivotType.assessment, DetailsViewPivotType.mediumPass])(
+            'GetDetailsRightPanelConfiguration.OverviewSummaryProps.getFilteredProvider for pivotType %s calls the correct deps functions with correct props',
+            pivotType => {
+                const testSubject = GetDetailsRightPanelConfiguration({
+                    selectedDetailsViewPivot: pivotType,
+                    detailsViewRightContentPanel: 'Overview',
+                });
+
+                validateGetFilteredProviderForPivot(pivotType, testSubject);
+            },
+        );
+
+        it.each([DetailsViewPivotType.assessment, DetailsViewPivotType.mediumPass])(
+            'GetDetailsRightPanelConfiguration.OverviewSummaryProps.getSummaryModelFromProviderAndStoreData for pivotType %s calls the correct deps functions with correct props',
+            pivotType => {
+                const testSubject = GetDetailsRightPanelConfiguration({
+                    selectedDetailsViewPivot: pivotType,
+                    detailsViewRightContentPanel: 'Overview',
+                });
+
+                validateGetSummaryModelFromStoreDataForPivot(pivotType, testSubject);
+            },
+        );
+        it.each([
+            DetailsViewPivotType.assessment,
+            DetailsViewPivotType.mediumPass,
+            DetailsViewPivotType.fastPass,
+        ])(
+            'GetDetailsRightPanelConfiguration for pivotType %s correctly returns TestView object',
+            pivotType => {
+                const testSubject = GetDetailsRightPanelConfiguration({
+                    selectedDetailsViewPivot: pivotType,
+                    detailsViewRightContentPanel: 'TestView',
+                });
+
+                validateTestView(testSubject);
+            },
+        );
         it('GetDetailsRightPanelConfiguration: return TestView object when fast pass is selected', () => {
             const testSubject = GetDetailsRightPanelConfiguration({
                 selectedDetailsViewPivot: DetailsViewPivotType.fastPass,
@@ -58,5 +119,94 @@ describe('DetailsViewRightPanelTests', () => {
         expect(configuration.GetTitle).toEqual(getOverviewTitle);
         expect(configuration.RightPanel).toEqual(OverviewContainer);
         expect(configuration.GetStartOverContextualMenuItemKeys()).toEqual(['assessment']);
+    }
+
+    function validateGetFilteredProviderForPivot(
+        pivotType: DetailsViewPivotType,
+        configuration: DetailsRightPanelConfiguration,
+    ): void {
+        const assessmentsProviderWithFeaturesEnabledMock = Mock.ofInstance(
+            (provider, featureFlagData) => null,
+            MockBehavior.Strict,
+        );
+        const assessmentsProviderForRequirementsMock = Mock.ofInstance(
+            (provider, requirements) => null,
+            MockBehavior.Strict,
+        );
+        const featureFlagStoreDataStub = {};
+        const assessmentsProviderStub = {} as AssessmentsProvider;
+        const filteredProvider = {} as AssessmentsProvider;
+        const quickAssessRequirementKeysStub = [];
+        assessmentsProviderWithFeaturesEnabledMock
+            .setup(mock => mock(assessmentsProviderStub, featureFlagStoreDataStub))
+            .returns(() => filteredProvider)
+            .verifiable(Times.exactly(1));
+        assessmentsProviderForRequirementsMock
+            .setup(mock => mock(filteredProvider, quickAssessRequirementKeysStub))
+            .returns(() => filteredProvider)
+            .verifiable(
+                pivotType === DetailsViewPivotType.assessment ? Times.never() : Times.once(),
+            );
+        configuration.OverviewSummaryDataProps.getFilteredProvider({
+            deps: {
+                assessmentsProvider: assessmentsProviderStub,
+                assessmentsProviderForRequirements: assessmentsProviderForRequirementsMock.object,
+                assessmentsProviderWithFeaturesEnabled:
+                    assessmentsProviderWithFeaturesEnabledMock.object,
+                quickAssessRequirementKeys: quickAssessRequirementKeysStub,
+            },
+            featureFlagStoreData: featureFlagStoreDataStub,
+        });
+        assessmentsProviderForRequirementsMock.verifyAll();
+        assessmentsProviderWithFeaturesEnabledMock.verifyAll();
+    }
+
+    function validateGetSummaryModelFromStoreDataForPivot(
+        pivotType: DetailsViewPivotType,
+        configuration: DetailsRightPanelConfiguration,
+    ): void {
+        const getAssessmentSummaryModelFromProviderAndStoreDataMock = Mock.ofInstance(
+            (provider, storeData) => null,
+            MockBehavior.Strict,
+        );
+        const getQuickAssessSummaryModelFromProviderAndStoreDataMock = Mock.ofInstance(
+            (provider, storeData, requirementKeys) => null,
+            MockBehavior.Strict,
+        );
+        const assessmentStoreDataStub = {} as AssessmentStoreData;
+        const assessmentsProviderStub = {} as AssessmentsProvider;
+        const quickAssessRequirementKeysStub: string[] = [];
+        const resultDataStub = {} as OverviewSummaryReportModel;
+        getAssessmentSummaryModelFromProviderAndStoreDataMock
+            .setup(mock => mock(assessmentsProviderStub, assessmentStoreDataStub))
+            .returns(() => resultDataStub)
+            .verifiable(
+                pivotType === DetailsViewPivotType.assessment ? Times.once() : Times.never(),
+            );
+        getQuickAssessSummaryModelFromProviderAndStoreDataMock
+            .setup(mock =>
+                mock(
+                    assessmentsProviderStub,
+                    assessmentStoreDataStub,
+                    quickAssessRequirementKeysStub,
+                ),
+            )
+            .returns(() => resultDataStub)
+            .verifiable(
+                pivotType === DetailsViewPivotType.assessment ? Times.never() : Times.once(),
+            );
+        configuration.OverviewSummaryDataProps.getSummaryModelFromProviderAndStoreData({
+            deps: {
+                assessmentsProvider: assessmentsProviderStub,
+                getQuickAssessSummaryModelFromProviderAndStoreData:
+                    getQuickAssessSummaryModelFromProviderAndStoreDataMock.object,
+                getAssessmentSummaryModelFromProviderAndStoreData:
+                    getAssessmentSummaryModelFromProviderAndStoreDataMock.object,
+                quickAssessRequirementKeys: quickAssessRequirementKeysStub,
+            },
+            assessmentStoreData: assessmentStoreDataStub,
+        });
+        getQuickAssessSummaryModelFromProviderAndStoreDataMock.verifyAll();
+        getAssessmentSummaryModelFromProviderAndStoreDataMock.verifyAll();
     }
 });

--- a/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
@@ -1,9 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
-import { OverviewSummaryReportModel } from 'reports/assessment-report-model';
-import { Mock, MockBehavior, Times } from 'typemoq';
 import { DetailsViewPivotType } from '../../../../../common/types/store-data/details-view-pivot-type';
 import {
     DetailsRightPanelConfiguration,
@@ -22,63 +18,6 @@ import {
 
 describe('DetailsViewRightPanelTests', () => {
     describe('GetDetailsRightPanelConfiguration', () => {
-        it.each([
-            DetailsViewPivotType.assessment,
-            DetailsViewPivotType.mediumPass,
-            DetailsViewPivotType.fastPass,
-        ])(
-            'GetDetailsRightPanelConfiguration for pivotType %s correctly returns Overview object',
-            pivotType => {
-                const testSubject = GetDetailsRightPanelConfiguration({
-                    selectedDetailsViewPivot: pivotType,
-                    detailsViewRightContentPanel: 'Overview',
-                });
-                if (pivotType === DetailsViewPivotType.fastPass) {
-                    validateTestView(testSubject);
-                } else {
-                    validateOverview(testSubject);
-                }
-            },
-        );
-
-        it.each([DetailsViewPivotType.assessment, DetailsViewPivotType.mediumPass])(
-            'GetDetailsRightPanelConfiguration.OverviewSummaryProps.getFilteredProvider for pivotType %s calls the correct deps functions with correct props',
-            pivotType => {
-                const testSubject = GetDetailsRightPanelConfiguration({
-                    selectedDetailsViewPivot: pivotType,
-                    detailsViewRightContentPanel: 'Overview',
-                });
-
-                validateGetFilteredProviderForPivot(pivotType, testSubject);
-            },
-        );
-
-        it.each([DetailsViewPivotType.assessment, DetailsViewPivotType.mediumPass])(
-            'GetDetailsRightPanelConfiguration.OverviewSummaryProps.getSummaryModelFromProviderAndStoreData for pivotType %s calls the correct deps functions with correct props',
-            pivotType => {
-                const testSubject = GetDetailsRightPanelConfiguration({
-                    selectedDetailsViewPivot: pivotType,
-                    detailsViewRightContentPanel: 'Overview',
-                });
-
-                validateGetSummaryModelFromStoreDataForPivot(pivotType, testSubject);
-            },
-        );
-        it.each([
-            DetailsViewPivotType.assessment,
-            DetailsViewPivotType.mediumPass,
-            DetailsViewPivotType.fastPass,
-        ])(
-            'GetDetailsRightPanelConfiguration for pivotType %s correctly returns TestView object',
-            pivotType => {
-                const testSubject = GetDetailsRightPanelConfiguration({
-                    selectedDetailsViewPivot: pivotType,
-                    detailsViewRightContentPanel: 'TestView',
-                });
-
-                validateTestView(testSubject);
-            },
-        );
         it('GetDetailsRightPanelConfiguration: return TestView object when fast pass is selected', () => {
             const testSubject = GetDetailsRightPanelConfiguration({
                 selectedDetailsViewPivot: DetailsViewPivotType.fastPass,
@@ -97,9 +36,27 @@ describe('DetailsViewRightPanelTests', () => {
             validateTestView(testSubject);
         });
 
-        it('GetDetailsRightPanelConfiguration: return TestView object when assessment selected', () => {
+        it('GetDetailsRightPanelConfiguration: return TestView object when mediumPass selected', () => {
+            const testSubject = GetDetailsRightPanelConfiguration({
+                selectedDetailsViewPivot: DetailsViewPivotType.mediumPass,
+                detailsViewRightContentPanel: 'TestView',
+            });
+
+            validateTestView(testSubject);
+        });
+
+        it('GetDetailsRightPanelConfiguration: return Overview object when assessment selected', () => {
             const testSubject = GetDetailsRightPanelConfiguration({
                 selectedDetailsViewPivot: DetailsViewPivotType.assessment,
+                detailsViewRightContentPanel: 'Overview',
+            });
+
+            validateOverview(testSubject);
+        });
+
+        it('GetDetailsRightPanelConfiguration: return Overview object when mediumPass selected', () => {
+            const testSubject = GetDetailsRightPanelConfiguration({
+                selectedDetailsViewPivot: DetailsViewPivotType.mediumPass,
                 detailsViewRightContentPanel: 'Overview',
             });
 
@@ -119,94 +76,5 @@ describe('DetailsViewRightPanelTests', () => {
         expect(configuration.GetTitle).toEqual(getOverviewTitle);
         expect(configuration.RightPanel).toEqual(OverviewContainer);
         expect(configuration.GetStartOverContextualMenuItemKeys()).toEqual(['assessment']);
-    }
-
-    function validateGetFilteredProviderForPivot(
-        pivotType: DetailsViewPivotType,
-        configuration: DetailsRightPanelConfiguration,
-    ): void {
-        const assessmentsProviderWithFeaturesEnabledMock = Mock.ofInstance(
-            (provider, featureFlagData) => null,
-            MockBehavior.Strict,
-        );
-        const assessmentsProviderForRequirementsMock = Mock.ofInstance(
-            (provider, requirements) => null,
-            MockBehavior.Strict,
-        );
-        const featureFlagStoreDataStub = {};
-        const assessmentsProviderStub = {} as AssessmentsProvider;
-        const filteredProvider = {} as AssessmentsProvider;
-        const quickAssessRequirementKeysStub = [];
-        assessmentsProviderWithFeaturesEnabledMock
-            .setup(mock => mock(assessmentsProviderStub, featureFlagStoreDataStub))
-            .returns(() => filteredProvider)
-            .verifiable(Times.exactly(1));
-        assessmentsProviderForRequirementsMock
-            .setup(mock => mock(filteredProvider, quickAssessRequirementKeysStub))
-            .returns(() => filteredProvider)
-            .verifiable(
-                pivotType === DetailsViewPivotType.assessment ? Times.never() : Times.once(),
-            );
-        configuration.OverviewSummaryDataProps.getFilteredProvider({
-            deps: {
-                assessmentsProvider: assessmentsProviderStub,
-                assessmentsProviderForRequirements: assessmentsProviderForRequirementsMock.object,
-                assessmentsProviderWithFeaturesEnabled:
-                    assessmentsProviderWithFeaturesEnabledMock.object,
-                quickAssessRequirementKeys: quickAssessRequirementKeysStub,
-            },
-            featureFlagStoreData: featureFlagStoreDataStub,
-        });
-        assessmentsProviderForRequirementsMock.verifyAll();
-        assessmentsProviderWithFeaturesEnabledMock.verifyAll();
-    }
-
-    function validateGetSummaryModelFromStoreDataForPivot(
-        pivotType: DetailsViewPivotType,
-        configuration: DetailsRightPanelConfiguration,
-    ): void {
-        const getAssessmentSummaryModelFromProviderAndStoreDataMock = Mock.ofInstance(
-            (provider, storeData) => null,
-            MockBehavior.Strict,
-        );
-        const getQuickAssessSummaryModelFromProviderAndStoreDataMock = Mock.ofInstance(
-            (provider, storeData, requirementKeys) => null,
-            MockBehavior.Strict,
-        );
-        const assessmentStoreDataStub = {} as AssessmentStoreData;
-        const assessmentsProviderStub = {} as AssessmentsProvider;
-        const quickAssessRequirementKeysStub: string[] = [];
-        const resultDataStub = {} as OverviewSummaryReportModel;
-        getAssessmentSummaryModelFromProviderAndStoreDataMock
-            .setup(mock => mock(assessmentsProviderStub, assessmentStoreDataStub))
-            .returns(() => resultDataStub)
-            .verifiable(
-                pivotType === DetailsViewPivotType.assessment ? Times.once() : Times.never(),
-            );
-        getQuickAssessSummaryModelFromProviderAndStoreDataMock
-            .setup(mock =>
-                mock(
-                    assessmentsProviderStub,
-                    assessmentStoreDataStub,
-                    quickAssessRequirementKeysStub,
-                ),
-            )
-            .returns(() => resultDataStub)
-            .verifiable(
-                pivotType === DetailsViewPivotType.assessment ? Times.never() : Times.once(),
-            );
-        configuration.OverviewSummaryDataProps.getSummaryModelFromProviderAndStoreData({
-            deps: {
-                assessmentsProvider: assessmentsProviderStub,
-                getQuickAssessSummaryModelFromProviderAndStoreData:
-                    getQuickAssessSummaryModelFromProviderAndStoreDataMock.object,
-                getAssessmentSummaryModelFromProviderAndStoreData:
-                    getAssessmentSummaryModelFromProviderAndStoreDataMock.object,
-                quickAssessRequirementKeys: quickAssessRequirementKeysStub,
-            },
-            assessmentStoreData: assessmentStoreDataStub,
-        });
-        getQuickAssessSummaryModelFromProviderAndStoreDataMock.verifyAll();
-        getAssessmentSummaryModelFromProviderAndStoreDataMock.verifyAll();
     }
 });

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OverviewContainer component is defined and matches snapshot 1`] = `
+exports[`OverviewContainer component is defined and matches snapshot for pivotType 2 1`] = `
 <div
   className="overview"
   data-automation-id="overviewContainerAutomationId"
@@ -15,10 +15,28 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
         "assessmentsProvider": {
           "all": [Function],
         },
+        "assessmentsProviderForRequirements": [Function],
         "assessmentsProviderWithFeaturesEnabled": [Function],
         "detailsViewActionMessageCreator": {},
         "detailsViewId": undefined,
-        "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
+        "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction] {
+          "calls": [
+            [
+              {},
+              {
+                "persistedTabInfo": {},
+              },
+            ],
+          ],
+          "results": [
+            {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
+        "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction],
+        "quickAssessRequirementKeys": [],
         "urlParser": {},
       }
     }
@@ -35,7 +53,9 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
     className="overviewTextSummarySection"
   >
     <OverviewHeading />
-    <AssessmentReportSummary />
+    <AssessmentReportSummary
+      selectedPivot={2}
+    />
   </section>
   <section
     className="overviewHelpSection"
@@ -50,10 +70,148 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
           "assessmentsProvider": {
             "all": [Function],
           },
+          "assessmentsProviderForRequirements": [Function],
+          "assessmentsProviderWithFeaturesEnabled": [Function],
+          "detailsViewActionMessageCreator": {},
+          "detailsViewId": undefined,
+          "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction] {
+            "calls": [
+              [
+                {},
+                {
+                  "persistedTabInfo": {},
+                },
+              ],
+            ],
+            "results": [
+              {
+                "type": "return",
+                "value": undefined,
+              },
+            ],
+          },
+          "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction],
+          "quickAssessRequirementKeys": [],
+          "urlParser": {},
+        }
+      }
+      linkDataSource={
+        [
+          {
+            "href": "https://go.microsoft.com/fwlink/?linkid=2082219",
+            "text": "Getting started",
+          },
+          {
+            "href": "https://go.microsoft.com/fwlink/?linkid=2082220",
+            "text": "How to complete a test",
+          },
+          {
+            "href": "https://go.microsoft.com/fwlink/?linkid=2077941",
+            "text": "Ask a question",
+          },
+          {
+            "href": "https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/",
+            "text": "New WCAG 2.1 success criteria",
+          },
+        ]
+      }
+    />
+  </section>
+</div>
+`;
+
+exports[`OverviewContainer component is defined and matches snapshot for pivotType 3 1`] = `
+<div
+  className="overview"
+  data-automation-id="overviewContainerAutomationId"
+>
+  <TargetChangeDialog
+    deps={
+      {
+        "actionInitiators": {
+          "openExternalLink": [MockFunction],
+        },
+        "assessmentsProvider": {
+          "all": [Function],
+        },
+        "assessmentsProviderForRequirements": [Function],
+        "assessmentsProviderWithFeaturesEnabled": [Function],
+        "detailsViewActionMessageCreator": {},
+        "detailsViewId": undefined,
+        "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
+        "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction] {
+          "calls": [
+            [
+              {},
+              {
+                "persistedTabInfo": {},
+              },
+              [],
+            ],
+          ],
+          "results": [
+            {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
+        "quickAssessRequirementKeys": [],
+        "urlParser": {},
+      }
+    }
+    newTab={
+      {
+        "id": -1,
+        "title": "some title",
+        "url": "some url",
+      }
+    }
+    prevTab={{}}
+  />
+  <section
+    className="overviewTextSummarySection"
+  >
+    <OverviewHeading />
+    <AssessmentReportSummary
+      selectedPivot={3}
+    />
+  </section>
+  <section
+    className="overviewHelpSection"
+  >
+    <OverviewHelpSection
+      deps={
+        {
+          "actionInitiators": {
+            "openExternalLink": [MockFunction],
+          },
+          "assessmentsProvider": {
+            "all": [Function],
+          },
+          "assessmentsProviderForRequirements": [Function],
           "assessmentsProviderWithFeaturesEnabled": [Function],
           "detailsViewActionMessageCreator": {},
           "detailsViewId": undefined,
           "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
+          "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction] {
+            "calls": [
+              [
+                {},
+                {
+                  "persistedTabInfo": {},
+                },
+                [],
+              ],
+            ],
+            "results": [
+              {
+                "type": "return",
+                "value": undefined,
+              },
+            ],
+          },
+          "quickAssessRequirementKeys": [],
           "urlParser": {},
         }
       }

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
@@ -11,11 +11,12 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
         "actionInitiators": {
           "openExternalLink": [MockFunction],
         },
+        "assessmentActionMessageCreator": {},
         "assessmentsProvider": {
           "all": [Function],
         },
-        "assessmentsProviderForRequirements": [Function],
-        "assessmentsProviderWithFeaturesEnabled": [Function],
+        "assessmentsProviderForRequirements": [MockFunction],
+        "assessmentsProviderWithFeaturesEnabled": [MockFunction],
         "detailsViewActionMessageCreator": {},
         "detailsViewId": undefined,
         "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
@@ -37,110 +38,8 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
     className="overviewTextSummarySection"
   >
     <OverviewHeading />
-    <AssessmentReportSummary />
-  </section>
-  <section
-    className="overviewHelpSection"
-  >
-    <OverviewHelpSection
-      deps={
-        {
-          "actionInitiators": {
-            "openExternalLink": [MockFunction],
-          },
-          "assessmentsProvider": {
-            "all": [Function],
-          },
-          "assessmentsProviderForRequirements": [Function],
-          "assessmentsProviderWithFeaturesEnabled": [Function],
-          "detailsViewActionMessageCreator": {},
-          "detailsViewId": undefined,
-          "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
-          "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction],
-          "quickAssessRequirementKeys": [],
-          "urlParser": {},
-        }
-      }
-      linkDataSource={
-        [
-          {
-            "href": "https://go.microsoft.com/fwlink/?linkid=2082219",
-            "text": "Getting started",
-          },
-          {
-            "href": "https://go.microsoft.com/fwlink/?linkid=2082220",
-            "text": "How to complete a test",
-          },
-          {
-            "href": "https://go.microsoft.com/fwlink/?linkid=2077941",
-            "text": "Ask a question",
-          },
-          {
-            "href": "https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/",
-            "text": "New WCAG 2.1 success criteria",
-          },
-        ]
-      }
-    />
-  </section>
-</div>
-`;
-
-exports[`OverviewContainer component is defined and matches snapshot for pivotType 2 1`] = `
-<div
-  className="overview"
-  data-automation-id="overviewContainerAutomationId"
->
-  <TargetChangeDialog
-    deps={
-      {
-        "actionInitiators": {
-          "openExternalLink": [MockFunction],
-        },
-        "assessmentActionMessageCreator": {},
-        "assessmentsProvider": {
-          "all": [Function],
-        },
-        "assessmentsProviderForRequirements": [Function],
-        "assessmentsProviderWithFeaturesEnabled": [Function],
-        "detailsViewActionMessageCreator": {},
-        "detailsViewId": undefined,
-        "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction] {
-          "calls": [
-            [
-              {},
-              {
-                "persistedTabInfo": {},
-              },
-            ],
-          ],
-          "results": [
-            {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        },
-        "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction],
-        "quickAssessRequirementKeys": [],
-        "urlParser": {},
-      }
-    }
-    newTab={
-      {
-        "id": -1,
-        "title": "some title",
-        "url": "some url",
-      }
-    }
-    prevTab={{}}
-  />
-  <section
-    className="overviewTextSummarySection"
-  >
-    <OverviewHeading />
     <AssessmentReportSummary
-      selectedPivot={2}
+      summary={{}}
     />
   </section>
   <section
@@ -156,147 +55,12 @@ exports[`OverviewContainer component is defined and matches snapshot for pivotTy
           "assessmentsProvider": {
             "all": [Function],
           },
-          "assessmentsProviderForRequirements": [Function],
-          "assessmentsProviderWithFeaturesEnabled": [Function],
-          "detailsViewActionMessageCreator": {},
-          "detailsViewId": undefined,
-          "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction] {
-            "calls": [
-              [
-                {},
-                {
-                  "persistedTabInfo": {},
-                },
-              ],
-            ],
-            "results": [
-              {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
-          },
-          "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction],
-          "quickAssessRequirementKeys": [],
-          "urlParser": {},
-        }
-      }
-      linkDataSource={
-        [
-          {
-            "href": "https://go.microsoft.com/fwlink/?linkid=2082219",
-            "text": "Getting started",
-          },
-          {
-            "href": "https://go.microsoft.com/fwlink/?linkid=2082220",
-            "text": "How to complete a test",
-          },
-          {
-            "href": "https://go.microsoft.com/fwlink/?linkid=2077941",
-            "text": "Ask a question",
-          },
-          {
-            "href": "https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/",
-            "text": "New WCAG 2.1 success criteria",
-          },
-        ]
-      }
-    />
-  </section>
-</div>
-`;
-
-exports[`OverviewContainer component is defined and matches snapshot for pivotType 3 1`] = `
-<div
-  className="overview"
-  data-automation-id="overviewContainerAutomationId"
->
-  <TargetChangeDialog
-    deps={
-      {
-        "actionInitiators": {
-          "openExternalLink": [MockFunction],
-        },
-        "assessmentsProvider": {
-          "all": [Function],
-        },
-        "assessmentsProviderForRequirements": [Function],
-        "assessmentsProviderWithFeaturesEnabled": [Function],
-        "detailsViewActionMessageCreator": {},
-        "detailsViewId": undefined,
-        "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
-        "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction] {
-          "calls": [
-            [
-              {},
-              {
-                "persistedTabInfo": {},
-              },
-              [],
-            ],
-          ],
-          "results": [
-            {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        },
-        "quickAssessRequirementKeys": [],
-        "urlParser": {},
-      }
-    }
-    newTab={
-      {
-        "id": -1,
-        "title": "some title",
-        "url": "some url",
-      }
-    }
-    prevTab={{}}
-  />
-  <section
-    className="overviewTextSummarySection"
-  >
-    <OverviewHeading />
-    <AssessmentReportSummary
-      selectedPivot={3}
-    />
-  </section>
-  <section
-    className="overviewHelpSection"
-  >
-    <OverviewHelpSection
-      deps={
-        {
-          "actionInitiators": {
-            "openExternalLink": [MockFunction],
-          },
-          "assessmentsProvider": {
-            "all": [Function],
-          },
-          "assessmentsProviderForRequirements": [Function],
-          "assessmentsProviderWithFeaturesEnabled": [Function],
+          "assessmentsProviderForRequirements": [MockFunction],
+          "assessmentsProviderWithFeaturesEnabled": [MockFunction],
           "detailsViewActionMessageCreator": {},
           "detailsViewId": undefined,
           "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
-          "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction] {
-            "calls": [
-              [
-                {},
-                {
-                  "persistedTabInfo": {},
-                },
-                [],
-              ],
-            ],
-            "results": [
-              {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
-          },
+          "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction],
           "quickAssessRequirementKeys": [],
           "urlParser": {},
         }

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
@@ -1,5 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OverviewContainer component is defined and matches snapshot 1`] = `
+<div
+  className="overview"
+  data-automation-id="overviewContainerAutomationId"
+>
+  <TargetChangeDialog
+    deps={
+      {
+        "actionInitiators": {
+          "openExternalLink": [MockFunction],
+        },
+        "assessmentsProvider": {
+          "all": [Function],
+        },
+        "assessmentsProviderForRequirements": [Function],
+        "assessmentsProviderWithFeaturesEnabled": [Function],
+        "detailsViewActionMessageCreator": {},
+        "detailsViewId": undefined,
+        "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
+        "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction],
+        "quickAssessRequirementKeys": [],
+        "urlParser": {},
+      }
+    }
+    newTab={
+      {
+        "id": -1,
+        "title": "some title",
+        "url": "some url",
+      }
+    }
+    prevTab={{}}
+  />
+  <section
+    className="overviewTextSummarySection"
+  >
+    <OverviewHeading />
+    <AssessmentReportSummary />
+  </section>
+  <section
+    className="overviewHelpSection"
+  >
+    <OverviewHelpSection
+      deps={
+        {
+          "actionInitiators": {
+            "openExternalLink": [MockFunction],
+          },
+          "assessmentsProvider": {
+            "all": [Function],
+          },
+          "assessmentsProviderForRequirements": [Function],
+          "assessmentsProviderWithFeaturesEnabled": [Function],
+          "detailsViewActionMessageCreator": {},
+          "detailsViewId": undefined,
+          "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
+          "getQuickAssessSummaryModelFromProviderAndStoreData": [MockFunction],
+          "quickAssessRequirementKeys": [],
+          "urlParser": {},
+        }
+      }
+      linkDataSource={
+        [
+          {
+            "href": "https://go.microsoft.com/fwlink/?linkid=2082219",
+            "text": "Getting started",
+          },
+          {
+            "href": "https://go.microsoft.com/fwlink/?linkid=2082220",
+            "text": "How to complete a test",
+          },
+          {
+            "href": "https://go.microsoft.com/fwlink/?linkid=2077941",
+            "text": "Ask a question",
+          },
+          {
+            "href": "https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/",
+            "text": "New WCAG 2.1 success criteria",
+          },
+        ]
+      }
+    />
+  </section>
+</div>
+`;
+
 exports[`OverviewContainer component is defined and matches snapshot for pivotType 2 1`] = `
 <div
   className="overview"

--- a/src/tests/unit/tests/DetailsView/components/overview-content/get-overview-summary-data.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/get-overview-summary-data.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import {
+    AssessmentStoreData,
+    PersistedTabInfo,
+} from 'common/types/store-data/assessment-result-data';
+import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
+import {
+    GetOverviewSummaryDataDeps,
+    getOverviewSummaryDataForPivot,
+} from 'DetailsView/components/overview-content/get-overview-summary-data';
+import { OverviewSummaryReportModel } from 'reports/assessment-report-model';
+import { Mock, MockBehavior, Times } from 'typemoq';
+
+describe('getOverviewSummaryDataForPivot', () => {
+    const assessmentsProvider: AssessmentsProvider = {} as AssessmentsProvider;
+
+    const filteredFlagProvider = {} as AssessmentsProvider;
+    const filteredRequirementsProvider = {} as AssessmentsProvider;
+    const assessmentsProviderWithFeaturesEnabledMock = Mock.ofInstance(
+        (provider, featureFlagData) => null,
+        MockBehavior.Strict,
+    );
+    const assessmentsProviderForRequirementsMock = Mock.ofInstance(
+        (provider, requirementKeys) => null,
+        MockBehavior.Strict,
+    );
+    const getAssessmentSummaryModelFromProviderAndStoreDataMock = Mock.ofInstance(
+        (deps, assessmentStoreData) => null,
+        MockBehavior.Strict,
+    );
+    const getQuickAssessSummaryModelFromProviderAndStoreDataMock = Mock.ofInstance(
+        (deps, assessmentStoreData, requirementKeys) => null,
+        MockBehavior.Strict,
+    );
+    const quickAssessRequirementKeysStub = [];
+    const deps: GetOverviewSummaryDataDeps = {
+        assessmentsProvider: assessmentsProvider,
+        getAssessmentSummaryModelFromProviderAndStoreData:
+            getAssessmentSummaryModelFromProviderAndStoreDataMock.object,
+        getQuickAssessSummaryModelFromProviderAndStoreData:
+            getQuickAssessSummaryModelFromProviderAndStoreDataMock.object,
+        assessmentsProviderWithFeaturesEnabled: assessmentsProviderWithFeaturesEnabledMock.object,
+        assessmentsProviderForRequirements: assessmentsProviderForRequirementsMock.object,
+        quickAssessRequirementKeys: quickAssessRequirementKeysStub,
+    };
+
+    const featureFlagDataStub = {};
+
+    const assessmentStoreData: AssessmentStoreData = {
+        persistedTabInfo: {} as PersistedTabInfo,
+    } as AssessmentStoreData;
+
+    const summaryData = {} as OverviewSummaryReportModel;
+
+    beforeEach(() => {
+        assessmentsProviderWithFeaturesEnabledMock.reset();
+        assessmentsProviderForRequirementsMock.reset();
+        getAssessmentSummaryModelFromProviderAndStoreDataMock.reset();
+        getQuickAssessSummaryModelFromProviderAndStoreDataMock.reset();
+    });
+    it.each([DetailsViewPivotType.assessment, DetailsViewPivotType.mediumPass])(
+        'calls the correct functions for pivotType=%s',
+        pivotType => {
+            assessmentsProviderWithFeaturesEnabledMock
+                .setup(ap => ap(assessmentsProvider, featureFlagDataStub))
+                .returns(() => filteredFlagProvider)
+                .verifiable(Times.once());
+            getAssessmentSummaryModelFromProviderAndStoreDataMock
+                .setup(mock => mock(filteredFlagProvider, assessmentStoreData))
+                .returns(() => summaryData)
+                .verifiable(
+                    pivotType === DetailsViewPivotType.assessment ? Times.once() : Times.never(),
+                );
+            assessmentsProviderForRequirementsMock
+                .setup(ap => ap(filteredFlagProvider, quickAssessRequirementKeysStub))
+                .returns(() => filteredRequirementsProvider)
+                .verifiable(
+                    pivotType === DetailsViewPivotType.assessment ? Times.never() : Times.once(),
+                );
+            getQuickAssessSummaryModelFromProviderAndStoreDataMock
+                .setup(mock =>
+                    mock(
+                        filteredRequirementsProvider,
+                        assessmentStoreData,
+                        quickAssessRequirementKeysStub,
+                    ),
+                )
+                .returns(() => summaryData)
+                .verifiable(
+                    pivotType === DetailsViewPivotType.assessment ? Times.never() : Times.once(),
+                );
+            getOverviewSummaryDataForPivot(pivotType)({
+                deps,
+                assessmentStoreData,
+                featureFlagStoreData: featureFlagDataStub,
+            });
+            assessmentsProviderWithFeaturesEnabledMock.verifyAll();
+            assessmentsProviderForRequirementsMock.verifyAll();
+            getAssessmentSummaryModelFromProviderAndStoreDataMock.verifyAll();
+            getQuickAssessSummaryModelFromProviderAndStoreDataMock.verifyAll();
+        },
+    );
+});

--- a/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentActionMessageCreator } from 'DetailsView/actions/assessment-action-message-creator';
+import { GetOverviewSummaryDataProps } from 'DetailsView/components/overview-content/get-overview-summary-data';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { OverviewSummaryReportModel } from 'reports/assessment-report-model';
 import { Mock, MockBehavior } from 'typemoq';
 
 import {
@@ -40,22 +42,11 @@ describe('OverviewContainer', () => {
         all: () => [],
     } as any;
 
-    const filteredProvider = {} as AssessmentsProvider;
     const detailsViewActionMessageCreator = {} as DetailsViewActionMessageCreator;
     const assessmentActionMessageCreator = {} as AssessmentActionMessageCreator;
-    const assessmentsProviderWithFeaturesEnabledMock = Mock.ofInstance(
-        (provider, featureFlagData) => null,
-        MockBehavior.Strict,
-    );
-    const assessmentsProviderForRequirementsMock = Mock.ofInstance(
-        (provider, requirements) => null,
-        MockBehavior.Strict,
-    );
-    const getFilteredProviderMock = Mock.ofInstance(props => null, MockBehavior.Strict);
-    const getSummaryModelFromProviderAndStoreDataMock = Mock.ofInstance(
-        props => null,
-        MockBehavior.Strict,
-    );
+    const assessmentsProviderWithFeaturesEnabledMock = jest.fn();
+    const assessmentsProviderForRequirementsMock = jest.fn();
+    const getSummaryDataMock = Mock.ofInstance(props => null, MockBehavior.Strict);
     const getAssessmentSummaryModelFromProviderAndStoreData = jest.fn();
     const getQuickAssessSummaryModelFromProviderAndStoreData = jest.fn();
     const quickAssessRequirementKeysStub = [];
@@ -69,8 +60,8 @@ describe('OverviewContainer', () => {
             getQuickAssessSummaryModelFromProviderAndStoreData,
         detailsViewActionMessageCreator,
         urlParser: urlParserMock,
-        assessmentsProviderWithFeaturesEnabled: assessmentsProviderWithFeaturesEnabledMock.object,
-        assessmentsProviderForRequirements: assessmentsProviderForRequirementsMock.object,
+        assessmentsProviderWithFeaturesEnabled: assessmentsProviderWithFeaturesEnabledMock,
+        assessmentsProviderForRequirements: assessmentsProviderForRequirementsMock,
         detailsViewId: undefined,
         quickAssessRequirementKeys: quickAssessRequirementKeysStub,
     };
@@ -81,12 +72,14 @@ describe('OverviewContainer', () => {
         persistedTabInfo: {} as PersistedTabInfo,
     } as AssessmentStoreData;
 
-    getFilteredProviderMock
-        .setup(mock => mock({ deps, featureFlagStoreData: featureFlagDataStub }))
-        .returns(() => filteredProvider);
-    getSummaryModelFromProviderAndStoreDataMock.setup(mock =>
-        mock({ deps, assessmentsProvider: filteredProvider, assessmentStoreData }),
-    );
+    const summaryData = {} as OverviewSummaryReportModel;
+    const summaryDataProps = {
+        deps,
+        assessmentStoreData,
+        featureFlagStoreData: featureFlagDataStub,
+    } as GetOverviewSummaryDataProps;
+
+    getSummaryDataMock.setup(mock => mock(summaryDataProps)).returns(() => summaryData);
 
     let component: JSX.Element;
 
@@ -97,14 +90,12 @@ describe('OverviewContainer', () => {
                 assessmentStoreData={assessmentStoreData}
                 featureFlagStoreData={featureFlagDataStub}
                 tabStoreData={tabStoreDataStub}
-                getFilteredProvider={getFilteredProviderMock.object}
-                getSummaryModelFromProviderAndStoreData={
-                    getSummaryModelFromProviderAndStoreDataMock.object
-                }
+                getSummaryData={getSummaryDataMock.object}
             />
         );
         const wrapper = shallow(component);
         expect(component).toBeDefined();
         expect(wrapper.getElement()).toMatchSnapshot();
+        getSummaryDataMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentActionMessageCreator } from 'DetailsView/actions/assessment-action-message-creator';
+import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock, MockBehavior } from 'typemoq';
@@ -47,18 +48,27 @@ describe('OverviewContainer', () => {
         (provider, featureFlagData) => null,
         MockBehavior.Strict,
     );
+    const assessmentsProviderForRequirementsMock = Mock.ofInstance(
+        (provider, requirements) => null,
+        MockBehavior.Strict,
+    );
     const getAssessmentSummaryModelFromProviderAndStoreData = jest.fn();
-
+    const getQuickAssessSummaryModelFromProviderAndStoreData = jest.fn();
+    const quickAssessRequirementKeysStub = [];
     const deps: OverviewContainerDeps = {
         assessmentsProvider: assessmentsProvider,
         actionInitiators: overviewHelpSectionDeps.actionInitiators,
         getAssessmentSummaryModelFromProviderAndStoreData:
             getAssessmentSummaryModelFromProviderAndStoreData,
         assessmentActionMessageCreator,
+        getQuickAssessSummaryModelFromProviderAndStoreData:
+            getQuickAssessSummaryModelFromProviderAndStoreData,
         detailsViewActionMessageCreator,
         urlParser: urlParserMock,
         assessmentsProviderWithFeaturesEnabled: assessmentsProviderWithFeaturesEnabledMock.object,
+        assessmentsProviderForRequirements: assessmentsProviderForRequirementsMock.object,
         detailsViewId: undefined,
+        quickAssessRequirementKeys: quickAssessRequirementKeysStub,
     };
 
     const featureFlagDataStub = {};
@@ -71,18 +81,27 @@ describe('OverviewContainer', () => {
         .setup(mock => mock(assessmentsProvider, featureFlagDataStub))
         .returns(() => filteredProvider);
 
-    const component = (
-        <OverviewContainer
-            deps={deps}
-            assessmentStoreData={assessmentStoreData}
-            featureFlagStoreData={featureFlagDataStub}
-            tabStoreData={tabStoreDataStub}
-        />
-    );
-    const wrapper = shallow(component);
+    assessmentsProviderForRequirementsMock
+        .setup(mock => mock(filteredProvider, quickAssessRequirementKeysStub))
+        .returns(() => filteredProvider);
 
-    test('component is defined and matches snapshot', () => {
-        expect(component).toBeDefined();
-        expect(wrapper.getElement()).toMatchSnapshot();
-    });
+    let component: JSX.Element;
+
+    it.each([DetailsViewPivotType.assessment, DetailsViewPivotType.mediumPass])(
+        'component is defined and matches snapshot for pivotType %s',
+        selectedPivot => {
+            component = (
+                <OverviewContainer
+                    deps={deps}
+                    assessmentStoreData={assessmentStoreData}
+                    featureFlagStoreData={featureFlagDataStub}
+                    tabStoreData={tabStoreDataStub}
+                    selectedPivot={selectedPivot}
+                />
+            );
+            const wrapper = shallow(component);
+            expect(component).toBeDefined();
+            expect(wrapper.getElement()).toMatchSnapshot();
+        },
+    );
 });

--- a/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentActionMessageCreator } from 'DetailsView/actions/assessment-action-message-creator';
-import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock, MockBehavior } from 'typemoq';
@@ -52,6 +51,11 @@ describe('OverviewContainer', () => {
         (provider, requirements) => null,
         MockBehavior.Strict,
     );
+    const getFilteredProviderMock = Mock.ofInstance(props => null, MockBehavior.Strict);
+    const getSummaryModelFromProviderAndStoreDataMock = Mock.ofInstance(
+        props => null,
+        MockBehavior.Strict,
+    );
     const getAssessmentSummaryModelFromProviderAndStoreData = jest.fn();
     const getQuickAssessSummaryModelFromProviderAndStoreData = jest.fn();
     const quickAssessRequirementKeysStub = [];
@@ -77,31 +81,30 @@ describe('OverviewContainer', () => {
         persistedTabInfo: {} as PersistedTabInfo,
     } as AssessmentStoreData;
 
-    assessmentsProviderWithFeaturesEnabledMock
-        .setup(mock => mock(assessmentsProvider, featureFlagDataStub))
+    getFilteredProviderMock
+        .setup(mock => mock({ deps, featureFlagStoreData: featureFlagDataStub }))
         .returns(() => filteredProvider);
-
-    assessmentsProviderForRequirementsMock
-        .setup(mock => mock(filteredProvider, quickAssessRequirementKeysStub))
-        .returns(() => filteredProvider);
+    getSummaryModelFromProviderAndStoreDataMock.setup(mock =>
+        mock({ deps, assessmentsProvider: filteredProvider, assessmentStoreData }),
+    );
 
     let component: JSX.Element;
 
-    it.each([DetailsViewPivotType.assessment, DetailsViewPivotType.mediumPass])(
-        'component is defined and matches snapshot for pivotType %s',
-        selectedPivot => {
-            component = (
-                <OverviewContainer
-                    deps={deps}
-                    assessmentStoreData={assessmentStoreData}
-                    featureFlagStoreData={featureFlagDataStub}
-                    tabStoreData={tabStoreDataStub}
-                    selectedPivot={selectedPivot}
-                />
-            );
-            const wrapper = shallow(component);
-            expect(component).toBeDefined();
-            expect(wrapper.getElement()).toMatchSnapshot();
-        },
-    );
+    it('component is defined and matches snapshot', () => {
+        component = (
+            <OverviewContainer
+                deps={deps}
+                assessmentStoreData={assessmentStoreData}
+                featureFlagStoreData={featureFlagDataStub}
+                tabStoreData={tabStoreDataStub}
+                getFilteredProvider={getFilteredProviderMock.object}
+                getSummaryModelFromProviderAndStoreData={
+                    getSummaryModelFromProviderAndStoreDataMock.object
+                }
+            />
+        );
+        const wrapper = shallow(component);
+        expect(component).toBeDefined();
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
 });

--- a/src/tests/unit/tests/reports/__snapshots__/get-quick-assess-summary-model.test.ts.snap
+++ b/src/tests/unit/tests/reports/__snapshots__/get-quick-assess-summary-model.test.ts.snap
@@ -1,0 +1,305 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getQuickAssessSummaryModel getAssessmentSummaryModelFromProviderAndStoreData handles multiple requirements completed for all requirements included 1`] = `
+{
+  "byPercentage": {
+    "fail": 50,
+    "incomplete": 29,
+    "pass": 21,
+  },
+  "byRequirement": {
+    "fail": 5,
+    "incomplete": 2,
+    "pass": 3,
+  },
+  "reportSummaryDetailsData": [
+    {
+      "displayName": "Automated Checks",
+      "fail": 2,
+      "incomplete": 0,
+      "pass": 2,
+    },
+    {
+      "displayName": "Step 1A",
+      "fail": 0,
+      "incomplete": 0,
+      "pass": 1,
+    },
+    {
+      "displayName": "Step 2A",
+      "fail": 1,
+      "incomplete": 0,
+      "pass": 0,
+    },
+    {
+      "displayName": "Step 2B",
+      "fail": 1,
+      "incomplete": 0,
+      "pass": 0,
+    },
+    {
+      "displayName": "Step 2C",
+      "fail": 0,
+      "incomplete": 1,
+      "pass": 0,
+    },
+    {
+      "displayName": "Step 2D",
+      "fail": 0,
+      "incomplete": 1,
+      "pass": 0,
+    },
+    {
+      "displayName": "Step 2E",
+      "fail": 1,
+      "incomplete": 0,
+      "pass": 0,
+    },
+  ],
+}
+`;
+
+exports[`getQuickAssessSummaryModel getAssessmentSummaryModelFromProviderAndStoreData handles multiple requirements completed for empty requirements included 1`] = `
+{
+  "byPercentage": {
+    "fail": 50,
+    "incomplete": 0,
+    "pass": 50,
+  },
+  "byRequirement": {
+    "fail": 2,
+    "incomplete": 0,
+    "pass": 2,
+  },
+  "reportSummaryDetailsData": [
+    {
+      "displayName": "Automated Checks",
+      "fail": 2,
+      "incomplete": 0,
+      "pass": 2,
+    },
+  ],
+}
+`;
+
+exports[`getQuickAssessSummaryModel getAssessmentSummaryModelFromProviderAndStoreData handles multiple requirements completed for one requirement included 1`] = `
+{
+  "byPercentage": {
+    "fail": 25,
+    "incomplete": 0,
+    "pass": 75,
+  },
+  "byRequirement": {
+    "fail": 2,
+    "incomplete": 0,
+    "pass": 3,
+  },
+  "reportSummaryDetailsData": [
+    {
+      "displayName": "Automated Checks",
+      "fail": 2,
+      "incomplete": 0,
+      "pass": 2,
+    },
+    {
+      "displayName": "Step 1A",
+      "fail": 0,
+      "incomplete": 0,
+      "pass": 1,
+    },
+  ],
+}
+`;
+
+exports[`getQuickAssessSummaryModel getAssessmentSummaryModelFromProviderAndStoreData handles multiple requirements completed for some requirements included 1`] = `
+{
+  "byPercentage": {
+    "fail": 38,
+    "incomplete": 24,
+    "pass": 38,
+  },
+  "byRequirement": {
+    "fail": 3,
+    "incomplete": 1,
+    "pass": 3,
+  },
+  "reportSummaryDetailsData": [
+    {
+      "displayName": "Automated Checks",
+      "fail": 2,
+      "incomplete": 0,
+      "pass": 2,
+    },
+    {
+      "displayName": "Step 1A",
+      "fail": 0,
+      "incomplete": 0,
+      "pass": 1,
+    },
+    {
+      "displayName": "Step 2C",
+      "fail": 0,
+      "incomplete": 1,
+      "pass": 0,
+    },
+    {
+      "displayName": "Step 2E",
+      "fail": 1,
+      "incomplete": 0,
+      "pass": 0,
+    },
+  ],
+}
+`;
+
+exports[`getQuickAssessSummaryModel getQuickAssessSummaryModelFromProviderAndStatusData handles all requirements included in assessment 1`] = `
+{
+  "byPercentage": {
+    "fail": 50,
+    "incomplete": 29,
+    "pass": 21,
+  },
+  "byRequirement": {
+    "fail": 5,
+    "incomplete": 2,
+    "pass": 3,
+  },
+  "reportSummaryDetailsData": [
+    {
+      "displayName": "Automated Checks",
+      "fail": 2,
+      "incomplete": 0,
+      "pass": 2,
+    },
+    {
+      "displayName": "Step 1A",
+      "fail": 0,
+      "incomplete": 0,
+      "pass": 1,
+    },
+    {
+      "displayName": "Step 2A",
+      "fail": 1,
+      "incomplete": 0,
+      "pass": 0,
+    },
+    {
+      "displayName": "Step 2B",
+      "fail": 1,
+      "incomplete": 0,
+      "pass": 0,
+    },
+    {
+      "displayName": "Step 2C",
+      "fail": 0,
+      "incomplete": 1,
+      "pass": 0,
+    },
+    {
+      "displayName": "Step 2D",
+      "fail": 0,
+      "incomplete": 1,
+      "pass": 0,
+    },
+    {
+      "displayName": "Step 2E",
+      "fail": 1,
+      "incomplete": 0,
+      "pass": 0,
+    },
+  ],
+}
+`;
+
+exports[`getQuickAssessSummaryModel getQuickAssessSummaryModelFromProviderAndStatusData handles empty requirements included in assessment 1`] = `
+{
+  "byPercentage": {
+    "fail": 50,
+    "incomplete": 0,
+    "pass": 50,
+  },
+  "byRequirement": {
+    "fail": 2,
+    "incomplete": 0,
+    "pass": 2,
+  },
+  "reportSummaryDetailsData": [
+    {
+      "displayName": "Automated Checks",
+      "fail": 2,
+      "incomplete": 0,
+      "pass": 2,
+    },
+  ],
+}
+`;
+
+exports[`getQuickAssessSummaryModel getQuickAssessSummaryModelFromProviderAndStatusData handles one requirement included in assessment 1`] = `
+{
+  "byPercentage": {
+    "fail": 25,
+    "incomplete": 0,
+    "pass": 75,
+  },
+  "byRequirement": {
+    "fail": 2,
+    "incomplete": 0,
+    "pass": 3,
+  },
+  "reportSummaryDetailsData": [
+    {
+      "displayName": "Automated Checks",
+      "fail": 2,
+      "incomplete": 0,
+      "pass": 2,
+    },
+    {
+      "displayName": "Step 1A",
+      "fail": 0,
+      "incomplete": 0,
+      "pass": 1,
+    },
+  ],
+}
+`;
+
+exports[`getQuickAssessSummaryModel getQuickAssessSummaryModelFromProviderAndStatusData handles some requirements included in assessment 1`] = `
+{
+  "byPercentage": {
+    "fail": 38,
+    "incomplete": 24,
+    "pass": 38,
+  },
+  "byRequirement": {
+    "fail": 3,
+    "incomplete": 1,
+    "pass": 3,
+  },
+  "reportSummaryDetailsData": [
+    {
+      "displayName": "Automated Checks",
+      "fail": 2,
+      "incomplete": 0,
+      "pass": 2,
+    },
+    {
+      "displayName": "Step 1A",
+      "fail": 0,
+      "incomplete": 0,
+      "pass": 1,
+    },
+    {
+      "displayName": "Step 2C",
+      "fail": 0,
+      "incomplete": 1,
+      "pass": 0,
+    },
+    {
+      "displayName": "Step 2E",
+      "fail": 1,
+      "incomplete": 0,
+      "pass": 0,
+    },
+  ],
+}
+`;

--- a/src/tests/unit/tests/reports/get-quick-assess-summary-model.test.ts
+++ b/src/tests/unit/tests/reports/get-quick-assess-summary-model.test.ts
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AutomatedChecks } from 'assessments/automated-checks/assessment';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { Assessment } from 'assessments/types/iassessment';
+import { Requirement } from 'assessments/types/requirement';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { ManualTestStatus, TestStepData } from 'common/types/store-data/manual-test-status';
+import {
+    AssessmentStatusData,
+    AssessmentSummaryResult,
+} from 'reports/get-assessment-summary-model';
+
+import {
+    getQuickAssessSummaryModelFromProviderAndStatusData,
+    getQuickAssessSummaryModelFromProviderAndStoreData,
+} from 'reports/get-quick-assess-summary-model';
+import { IMock, It, Mock } from 'typemoq';
+
+type IRequirementSubsetForSummary = Pick<Requirement, 'name'>;
+type IAssessmentSubsetForSummary = Pick<Assessment, 'title' | 'key' | 'visualizationType'> & {
+    requirements: IRequirementSubsetForSummary[];
+};
+
+describe('getQuickAssessSummaryModel', () => {
+    const mockAssessmentsProvider: IMock<AssessmentsProvider> = Mock.ofType<AssessmentsProvider>();
+    const sampleTestStepData: { [key: string]: TestStepData } = {
+        pass: {
+            stepFinalResult: ManualTestStatus.PASS,
+            isStepScanned: true,
+        },
+        fail: {
+            stepFinalResult: ManualTestStatus.FAIL,
+            isStepScanned: true,
+        },
+        incomplete: {
+            stepFinalResult: ManualTestStatus.UNKNOWN,
+            isStepScanned: true,
+        },
+        unscanned: {
+            stepFinalResult: ManualTestStatus.UNKNOWN,
+            isStepScanned: false,
+        },
+    };
+
+    const sampleRequirements = {
+        step1a: {
+            name: 'Step 1A',
+            key: 'step1a',
+        },
+        step2a: {
+            name: 'Step 2A',
+            key: 'step2a',
+        },
+        step2b: {
+            name: 'Step 2B',
+            key: 'step2b',
+        },
+        step2c: {
+            name: 'Step 2C',
+            key: 'step2c',
+        },
+        step2d: {
+            name: 'Step 2D',
+            key: 'step2d',
+        },
+        step2e: {
+            name: 'Step 2E',
+            key: 'step2e',
+        },
+    };
+
+    const sampleAssessments: { [key: string]: IAssessmentSubsetForSummary } = {
+        automatedChecks: {
+            title: 'Automated Checks',
+            key: AutomatedChecks.key,
+            visualizationType: 0,
+            requirements: [
+                { name: 'Any', key: 'any' },
+                { name: 'Name', key: 'name' },
+                { name: 'Will', key: 'will' },
+                { name: 'Do', key: 'do' },
+            ],
+        },
+        test1: {
+            title: 'Test 1',
+            key: 'test1',
+            visualizationType: 1,
+            requirements: [sampleRequirements.step1a],
+        },
+        test2: {
+            title: 'Test 2',
+            key: 'test2',
+            visualizationType: 2,
+            requirements: [
+                sampleRequirements.step2a,
+                sampleRequirements.step2b,
+                sampleRequirements.step2c,
+                sampleRequirements.step2d,
+                sampleRequirements.step2e,
+            ],
+        },
+    };
+
+    const sampleResults: { [key: string]: AssessmentSummaryResult } = {
+        [sampleAssessments.test1.key]: {
+            title: sampleAssessments.test1.title,
+            storeData: {
+                testStepStatus: {
+                    step1a: sampleTestStepData.pass,
+                },
+            },
+        },
+        [sampleAssessments.test2.key]: {
+            title: sampleAssessments.test2.title,
+            storeData: {
+                testStepStatus: {
+                    step2a: sampleTestStepData.fail,
+                    step2b: sampleTestStepData.fail,
+                    step2c: sampleTestStepData.incomplete,
+                    step2d: sampleTestStepData.unscanned,
+                    step2e: sampleTestStepData.fail,
+                },
+            },
+        },
+        [sampleAssessments.automatedChecks.key]: {
+            title: sampleAssessments.automatedChecks.title,
+            storeData: {
+                testStepStatus: {
+                    any: sampleTestStepData.pass,
+                    name: sampleTestStepData.pass,
+                    will: sampleTestStepData.fail,
+                    do: sampleTestStepData.fail,
+                },
+            },
+        },
+    };
+
+    const quickAssessAllRequirementKeysStub = Object.keys(sampleRequirements);
+    const quickAssessSomeRequirementKeysStub = [
+        sampleRequirements.step1a.key,
+        sampleRequirements.step2c.key,
+        sampleRequirements.step2e.key,
+    ];
+    const quickAssessSingleRequirementKeyStub = [sampleRequirements.step1a.key];
+
+    const multipleAssessmentsAll: IAssessmentSubsetForSummary[] = [
+        sampleAssessments.automatedChecks,
+        sampleAssessments.test1,
+        sampleAssessments.test2,
+    ];
+    const multipleRequirementsStatusData: AssessmentStatusData = {
+        [sampleAssessments.automatedChecks.key]:
+            sampleResults[sampleAssessments.automatedChecks.key].storeData.testStepStatus,
+        [sampleAssessments.test1.key]:
+            sampleResults[sampleAssessments.test1.key].storeData.testStepStatus,
+        [sampleAssessments.test2.key]:
+            sampleResults[sampleAssessments.test2.key].storeData.testStepStatus,
+    } as any;
+    const multipleRequirementsStoreData: AssessmentStoreData = {
+        assessments: {
+            [sampleAssessments.automatedChecks.key]: {
+                testStepStatus:
+                    sampleResults[sampleAssessments.automatedChecks.key].storeData.testStepStatus,
+            },
+            [sampleAssessments.test1.key]: {
+                testStepStatus: sampleResults[sampleAssessments.test1.key].storeData.testStepStatus,
+            },
+            [sampleAssessments.test2.key]: {
+                testStepStatus: sampleResults[sampleAssessments.test2.key].storeData.testStepStatus,
+            },
+        },
+    } as any;
+
+    function setupMockAssessmentsProvider() {
+        mockAssessmentsProvider
+            .setup(ap => ap.all())
+            .returns(() => multipleAssessmentsAll as Assessment[]);
+        mockAssessmentsProvider
+            .setup(ap => ap.forKey(AutomatedChecks.key))
+            .returns(() => sampleAssessments.automatedChecks as Assessment);
+        mockAssessmentsProvider
+            .setup(ap => ap.forRequirementKey(It.isAnyString()))
+            .returns((requirementKey: string) => {
+                const testKey = `test${requirementKey.charAt(requirementKey.length - 2)}`;
+                return sampleAssessments[testKey] as Assessment;
+            });
+        mockAssessmentsProvider
+            .setup(ap => ap.getStep(It.isAnyNumber(), It.isAnyString()))
+            .returns((visualizationType, requirementKey: string) => {
+                return sampleRequirements[requirementKey] as Requirement;
+            });
+    }
+
+    describe('getAssessmentSummaryModelFromProviderAndStoreData', () => {
+        beforeEach(() => {
+            mockAssessmentsProvider.reset();
+        });
+
+        it.each`
+            name                    | quickAssessRequirementKeysStub
+            ${'empty requirements'} | ${[]}
+            ${'one requirement'}    | ${quickAssessSingleRequirementKeyStub}
+            ${'all requirements'}   | ${quickAssessAllRequirementKeysStub}
+            ${'some requirements'}  | ${quickAssessSomeRequirementKeysStub}
+        `(
+            'handles multiple requirements completed for $name included',
+            ({ quickAssessRequirementKeysStub }) => {
+                setupMockAssessmentsProvider();
+                const actual = getQuickAssessSummaryModelFromProviderAndStoreData(
+                    mockAssessmentsProvider.object,
+                    multipleRequirementsStoreData,
+                    quickAssessRequirementKeysStub,
+                );
+
+                expect(actual).toMatchSnapshot();
+            },
+        );
+    });
+
+    describe('getQuickAssessSummaryModelFromProviderAndStatusData', () => {
+        beforeEach(() => {
+            mockAssessmentsProvider.reset();
+        });
+        it.each`
+            name                    | quickAssessRequirementKeysStub
+            ${'empty requirements'} | ${[]}
+            ${'one requirement'}    | ${quickAssessSingleRequirementKeyStub}
+            ${'all requirements'}   | ${quickAssessAllRequirementKeysStub}
+            ${'some requirements'}  | ${quickAssessSomeRequirementKeysStub}
+        `('handles $name included in assessment', ({ quickAssessRequirementKeysStub }) => {
+            setupMockAssessmentsProvider();
+            const actual = getQuickAssessSummaryModelFromProviderAndStatusData(
+                mockAssessmentsProvider.object,
+                multipleRequirementsStatusData,
+                quickAssessRequirementKeysStub,
+            );
+
+            expect(actual).toMatchSnapshot();
+        });
+    });
+});


### PR DESCRIPTION
#### Details
 
![Quick Assess Overview screenshot](https://user-images.githubusercontent.com/3230904/202027059-3ed193ea-209f-4454-9f91-72dfe99af69b.png)

This PR:
* customizes `OverviewContainer` to display filtered requirements for Quick Assess
* adapts the summary model to correctly calculate % complete for Quick Assess

##### Motivation

Feature work 🚀 

##### Context

This PR adjusts the `DetailsViewRightPanel` to show `Overview` for Quick Assess but does not pass in Quick Assess store data. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
