### PR TITLE
feat(medium-pass-1): move onDetailsViewInitialized to GlobalActionCreator

### DIFF
--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -22,13 +22,12 @@ import {
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
     ExpandTestNavPayload,
+    LoadAssessmentPayload,
     OnDetailsViewOpenPayload,
     RemoveFailureInstancePayload,
     SelectGettingStartedPayload,
     SelectTestSubviewPayload,
     ToggleActionPayload,
-    LoadAssessmentPayload,
-    OnDetailsViewInitializedPayload,
 } from './action-payloads';
 import { AssessmentActions } from './assessment-actions';
 
@@ -146,10 +145,6 @@ export class AssessmentActionCreator {
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Visualizations.DetailsView.Select,
             this.onPivotChildSelected,
-        );
-        this.interpreter.registerTypeToPayloadCallback(
-            Messages.Visualizations.DetailsView.Initialize,
-            this.onDetailsViewInitialized,
         );
         this.interpreter.registerTypeToPayloadCallback(
             AssessmentMessages.SaveAssessment,
@@ -354,11 +349,5 @@ export class AssessmentActionCreator {
 
     private onPivotChildSelected = async (payload: OnDetailsViewOpenPayload): Promise<void> => {
         await this.assessmentActions.updateSelectedPivotChild.invoke(payload, this.executingScope);
-    };
-
-    private onDetailsViewInitialized = async (
-        payload: OnDetailsViewInitializedPayload,
-    ): Promise<void> => {
-        await this.assessmentActions.updateDetailsViewId.invoke(payload, this.executingScope);
     };
 }

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -756,30 +756,6 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles DetailsViewInitialize message', async () => {
-        const payload: OnDetailsViewInitializedPayload = {
-            detailsViewId: 'testId',
-        } as OnDetailsViewInitializedPayload;
-
-        const detailsViewInitMock = createAsyncActionMock(payload, actionExecutingScope);
-        const actionsMock = createActionsMock('updateDetailsViewId', detailsViewInitMock.object);
-
-        const testSubject = new AssessmentActionCreator(
-            interpreterMock.object,
-            actionsMock.object,
-            telemetryEventHandlerMock.object,
-        );
-
-        testSubject.registerCallbacks();
-
-        await interpreterMock.simulateMessage(
-            Messages.Visualizations.DetailsView.Initialize,
-            payload,
-        );
-
-        detailsViewInitMock.verifyAll();
-    });
-
     it('handles LoadAssessment message', async () => {
         const payload = {
             tabId: 1,

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -10,13 +10,12 @@ import {
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
     ExpandTestNavPayload,
-    OnDetailsViewInitializedPayload,
+    LoadAssessmentPayload,
     OnDetailsViewOpenPayload,
     RemoveFailureInstancePayload,
     SelectGettingStartedPayload,
     SelectTestSubviewPayload,
     ToggleActionPayload,
-    LoadAssessmentPayload,
 } from 'background/actions/action-payloads';
 import { AssessmentActionCreator } from 'background/actions/assessment-action-creator';
 import { AssessmentActions } from 'background/actions/assessment-actions';


### PR DESCRIPTION
#### Details

As a follow-up to #6177, this PR moves the `onDetailsViewInitialized` callback from `AssessmentActionCreator` to `GlobalActionCreator` so it can call `updateDetailsViewId` on both the assessmentActions and quickAssessmentActions. This ensures that the persisted tab info is updated in both the Assessment and Quick Assess stores when the `DetailsViewActionMessageCreator` is initialized in `details-view-initializer.ts`.

##### Motivation

Part of feature work

##### Context

From Wahaj's comment in #6177: 
"For context: the initialize message is for making sure we show the dialog for target change (in assessments) when you open assessment from a new details view tab. This started from us mainly looking to make sure that a user would see the continue/start new dialog when they start a new browsing session (but now extends to show the dialog for a new details view tab).

In this case, we should only have one message that is sent on details view (and handle it with both assessment and medium pass actions in an action-creator), which Lisa has now covered."

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
