### PR TITLE
feat(medium-pass-1): create SharedAssessmentActionMessageCreator

### DIFF
--- a/src/DetailsView/actions/assessment-action-message-creator.ts
+++ b/src/DetailsView/actions/assessment-action-message-creator.ts
@@ -1,52 +1,32 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import {
-    AddFailureInstancePayload,
-    AddResultDescriptionPayload,
-    AssessmentActionInstancePayload,
-    AssessmentToggleActionPayload,
-    BaseActionPayload,
-    ChangeInstanceSelectionPayload,
-    ChangeInstanceStatusPayload,
-    ChangeRequirementStatusPayload,
-    EditFailureInstancePayload,
-    ExpandTestNavPayload,
-    LoadAssessmentPayload,
-    RemoveFailureInstancePayload,
-    SelectGettingStartedPayload,
-    SelectTestSubviewPayload,
-    ToggleActionPayload,
-} from 'background/actions/action-payloads';
-import { DevToolActionMessageCreator } from 'common/message-creators/dev-tool-action-message-creator';
 import { Messages } from 'common/messages';
 import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import { FailureInstanceData } from 'common/types/failure-instance-data';
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import { VersionedAssessmentData } from 'common/types/versioned-assessment-data';
 import { VisualizationType } from 'common/types/visualization-type';
+import { SharedAssessmentActionMessageCreator } from 'DetailsView/actions/shared-assessment-action-message-creator';
 import * as React from 'react';
-import { DetailsViewRightContentPanelType } from '../../common/types/store-data/details-view-right-content-panel-type';
 
-export class AssessmentActionMessageCreator extends DevToolActionMessageCreator {
+export class AssessmentActionMessageCreator {
+    private sharedAssessmentActionMessageCreator: SharedAssessmentActionMessageCreator;
+
+    constructor(sharedAssessmentActionMessageCreator: SharedAssessmentActionMessageCreator) {
+        this.sharedAssessmentActionMessageCreator = sharedAssessmentActionMessageCreator;
+    }
     public selectRequirement(
         event: React.MouseEvent<HTMLElement>,
         selectedRequirement: string,
         visualizationType: VisualizationType,
     ): void {
-        const payload: SelectTestSubviewPayload = {
-            telemetry: this.telemetryFactory.forSelectRequirement(
-                event,
-                visualizationType,
-                selectedRequirement,
-            ),
-            selectedTestSubview: selectedRequirement,
-            selectedTest: visualizationType,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SelectTestRequirement,
-            payload: payload,
-        });
+        const messageType = Messages.Assessment.SelectTestRequirement;
+        this.sharedAssessmentActionMessageCreator.selectRequirement(
+            event,
+            selectedRequirement,
+            visualizationType,
+            messageType,
+        );
     }
 
     public selectNextRequirement(
@@ -54,65 +34,40 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         nextRequirement: string,
         visualizationType: VisualizationType,
     ): void {
-        const payload: SelectTestSubviewPayload = {
-            telemetry: this.telemetryFactory.forSelectRequirement(
-                event,
-                visualizationType,
-                nextRequirement,
-            ),
-            selectedTestSubview: nextRequirement,
-            selectedTest: visualizationType,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SelectNextRequirement,
-            payload: payload,
-        });
+        const messageType = Messages.Assessment.SelectNextRequirement;
+        this.sharedAssessmentActionMessageCreator.selectNextRequirement(
+            event,
+            nextRequirement,
+            visualizationType,
+            messageType,
+        );
     }
 
     public selectGettingStarted(
         event: React.MouseEvent<HTMLElement>,
         visualizationType: VisualizationType,
     ): void {
-        const payload: SelectGettingStartedPayload = {
-            telemetry: this.telemetryFactory.forSelectGettingStarted(event, visualizationType),
-            selectedTest: visualizationType,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SelectGettingStarted,
-            payload: payload,
-        });
+        const messageType = Messages.Assessment.SelectGettingStarted;
+        this.sharedAssessmentActionMessageCreator.selectGettingStarted(
+            event,
+            visualizationType,
+            messageType,
+        );
     }
 
     public expandTestNav(visualizationType: VisualizationType): void {
-        const payload: ExpandTestNavPayload = {
-            selectedTest: visualizationType,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ExpandTestNav,
-            payload: payload,
-        });
+        const messageType = Messages.Assessment.ExpandTestNav;
+        this.sharedAssessmentActionMessageCreator.expandTestNav(visualizationType, messageType);
     }
 
     public collapseTestNav(): void {
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.CollapseTestNav,
-        });
+        const messageType = Messages.Assessment.CollapseTestNav;
+        this.sharedAssessmentActionMessageCreator.collapseTestNav(messageType);
     }
 
     public startOverTest(event: SupportedMouseEvent, test: VisualizationType): void {
-        const telemetry = this.telemetryFactory.forAssessmentActionFromDetailsView(test, event);
-        const payload: ToggleActionPayload = {
-            test,
-            telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.StartOverTest,
-            payload,
-        });
+        const messageType = Messages.Assessment.StartOverTest;
+        this.sharedAssessmentActionMessageCreator.startOverTest(event, test, messageType);
     }
 
     public enableVisualHelper(
@@ -121,45 +76,29 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         shouldScan = true,
         sendTelemetry = true,
     ): void {
-        const telemetry = sendTelemetry
-            ? this.telemetryFactory.forAssessmentActionFromDetailsViewNoTriggeredBy(test)
-            : undefined;
-        const payload: AssessmentToggleActionPayload = {
+        const messageType = shouldScan
+            ? Messages.Assessment.EnableVisualHelper
+            : Messages.Assessment.EnableVisualHelperWithoutScan;
+        this.sharedAssessmentActionMessageCreator.enableVisualHelper(
             test,
             requirement,
-            telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: shouldScan
-                ? Messages.Assessment.EnableVisualHelper
-                : Messages.Assessment.EnableVisualHelperWithoutScan,
-            payload,
-        });
+            sendTelemetry,
+            messageType,
+        );
     }
 
     public disableVisualHelpersForTest(test: VisualizationType): void {
-        const payload: ToggleActionPayload = {
-            test,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.DisableVisualHelperForTest,
-            payload,
-        });
+        const messageType = Messages.Assessment.DisableVisualHelperForTest;
+        this.sharedAssessmentActionMessageCreator.disableVisualHelpersForTest(test, messageType);
     }
 
     public disableVisualHelper(test: VisualizationType, requirement: string): void {
-        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
-        const payload: ToggleActionPayload = {
+        const messageType = Messages.Assessment.DisableVisualHelper;
+        this.sharedAssessmentActionMessageCreator.disableVisualHelper(
             test,
-            telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.DisableVisualHelper,
-            payload,
-        });
+            requirement,
+            messageType,
+        );
     }
 
     public changeManualTestStatus = (
@@ -168,19 +107,14 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         requirement: string,
         selector: string,
     ): void => {
-        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
-        const payload: ChangeInstanceStatusPayload = {
+        const messageType = Messages.Assessment.ChangeStatus;
+        this.sharedAssessmentActionMessageCreator.changeManualTestStatus(
+            status,
             test,
             requirement,
-            status,
             selector,
-            telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeStatus,
-            payload,
-        });
+            messageType,
+        );
     };
 
     public changeManualRequirementStatus = (
@@ -188,18 +122,13 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         test: VisualizationType,
         requirement: string,
     ): void => {
-        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
-        const payload: ChangeRequirementStatusPayload = {
+        const messageType = Messages.Assessment.ChangeRequirementStatus;
+        this.sharedAssessmentActionMessageCreator.changeManualRequirementStatus(
+            status,
             test,
             requirement,
-            status,
-            telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeRequirementStatus,
-            payload,
-        });
+            messageType,
+        );
     };
 
     public undoManualTestStatusChange = (
@@ -207,35 +136,25 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         requirement: string,
         selector: string,
     ): void => {
-        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
-        const payload: AssessmentActionInstancePayload = {
+        const messageType = Messages.Assessment.Undo;
+        this.sharedAssessmentActionMessageCreator.undoManualTestStatusChange(
             test,
             requirement,
             selector,
-            telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.Undo,
-            payload,
-        });
+            messageType,
+        );
     };
 
     public undoManualRequirementStatusChange = (
         test: VisualizationType,
         requirement: string,
     ): void => {
-        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
-        const payload: ChangeRequirementStatusPayload = {
-            test: test,
-            requirement: requirement,
-            telemetry: telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.UndoChangeRequirementStatus,
-            payload,
-        });
+        const messageType = Messages.Assessment.UndoChangeRequirementStatus;
+        this.sharedAssessmentActionMessageCreator.undoManualRequirementStatusChange(
+            test,
+            requirement,
+            messageType,
+        );
     };
 
     public changeAssessmentVisualizationState = (
@@ -244,30 +163,19 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         requirement: string,
         selector: string,
     ): void => {
-        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
-        const payload: ChangeInstanceSelectionPayload = {
+        const messageType = Messages.Assessment.ChangeVisualizationState;
+        this.sharedAssessmentActionMessageCreator.changeAssessmentVisualizationState(
+            isVisualizationEnabled,
             test,
             requirement,
-            isVisualizationEnabled,
             selector,
-            telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeVisualizationState,
-            payload,
-        });
+            messageType,
+        );
     };
 
     public addResultDescription(description: string): void {
-        const payload: AddResultDescriptionPayload = {
-            description,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.AddResultDescription,
-            payload,
-        });
+        const messageType = Messages.Assessment.AddResultDescription;
+        this.sharedAssessmentActionMessageCreator.addResultDescription(description, messageType);
     }
 
     public addFailureInstance(
@@ -275,18 +183,13 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         test: VisualizationType,
         requirement: string,
     ): void {
-        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
-        const payload: AddFailureInstancePayload = {
+        const messageType = Messages.Assessment.AddFailureInstance;
+        this.sharedAssessmentActionMessageCreator.addFailureInstance(
+            instanceData,
             test,
             requirement,
-            instanceData,
-            telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.AddFailureInstance,
-            payload,
-        });
+            messageType,
+        );
     }
 
     public removeFailureInstance = (
@@ -294,18 +197,13 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         requirement: string,
         id: string,
     ): void => {
-        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
-        const payload: RemoveFailureInstancePayload = {
+        const messageType = Messages.Assessment.RemoveFailureInstance;
+        this.sharedAssessmentActionMessageCreator.removeFailureInstance(
             test,
             requirement,
             id,
-            telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.RemoveFailureInstance,
-            payload,
-        });
+            messageType,
+        );
     };
 
     public editFailureInstance = (
@@ -314,33 +212,23 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         requirement: string,
         id: string,
     ): void => {
-        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
-        const payload: EditFailureInstancePayload = {
+        const messageType = Messages.Assessment.EditFailureInstance;
+        this.sharedAssessmentActionMessageCreator.editFailureInstance(
+            instanceData,
             test,
             requirement,
             id,
-            instanceData,
-            telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.EditFailureInstance,
-            payload,
-        });
+            messageType,
+        );
     };
 
     public passUnmarkedInstances(test: VisualizationType, requirement: string): void {
-        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
-        const payload: ToggleActionPayload = {
+        const messageType = Messages.Assessment.PassUnmarkedInstances;
+        this.sharedAssessmentActionMessageCreator.passUnmarkedInstances(
             test,
             requirement,
-            telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.PassUnmarkedInstances,
-            payload,
-        });
+            messageType,
+        );
     }
 
     public changeAssessmentVisualizationStateForAll(
@@ -348,29 +236,18 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         test: VisualizationType,
         requirement: string,
     ): void {
-        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
-        const payload: Omit<ChangeInstanceSelectionPayload, 'selector'> = {
-            test: test,
-            requirement: requirement,
-            isVisualizationEnabled: isVisualizationEnabled,
-            telemetry: telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeVisualizationStateForAll,
-            payload,
-        });
+        const messageType = Messages.Assessment.ChangeVisualizationStateForAll;
+        this.sharedAssessmentActionMessageCreator.changeAssessmentVisualizationStateForAll(
+            isVisualizationEnabled,
+            test,
+            requirement,
+            messageType,
+        );
     }
 
     public continuePreviousAssessment = (event: React.MouseEvent<any>): void => {
-        const telemetry = this.telemetryFactory.fromDetailsView(event);
-        const payload: BaseActionPayload = {
-            telemetry: telemetry,
-        };
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ContinuePreviousAssessment,
-            payload,
-        });
+        const messageType = Messages.Assessment.ContinuePreviousAssessment;
+        this.sharedAssessmentActionMessageCreator.continuePreviousAssessment(event, messageType);
     };
 
     public loadAssessment = (
@@ -378,51 +255,23 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         tabId: number,
         detailsViewId: string,
     ): void => {
-        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
-        const payload: LoadAssessmentPayload = {
-            telemetry: telemetry,
-            versionedAssessmentData: assessmentData,
+        const messageType = Messages.Assessment.LoadAssessment;
+        this.sharedAssessmentActionMessageCreator.loadAssessment(
+            assessmentData,
             tabId,
             detailsViewId,
-        };
-        const setDetailsViewRightContentPanelPayload: DetailsViewRightContentPanelType = 'Overview';
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
-            payload: setDetailsViewRightContentPanelPayload,
-        });
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.LoadAssessment,
-            payload,
-        });
+            messageType,
+        );
     };
 
     public saveAssessment = (event: React.MouseEvent<any>): void => {
-        const telemetry = this.telemetryFactory.fromDetailsView(event);
-        const payload: BaseActionPayload = {
-            telemetry: telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SaveAssessment,
-            payload,
-        });
+        const messageType = Messages.Assessment.SaveAssessment;
+        this.sharedAssessmentActionMessageCreator.saveAssessment(event, messageType);
     };
 
     public startOverAllAssessments = (event: React.MouseEvent<any>): void => {
-        const telemetry = this.telemetryFactory.fromDetailsView(event);
-        const setDetailsViewRightContentPanelPayload: DetailsViewRightContentPanelType = 'Overview';
-        const startOverAllAssessmentsActionPayload: BaseActionPayload = {
-            telemetry: telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
-            payload: setDetailsViewRightContentPanelPayload,
-        });
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.StartOverAllAssessments,
-            payload: startOverAllAssessmentsActionPayload,
-        });
+        const messageType = Messages.Assessment.StartOverAllAssessments;
+        this.sharedAssessmentActionMessageCreator.startOverAllAssessments(event, messageType);
     };
 
     public cancelStartOver = (
@@ -430,26 +279,17 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         test: VisualizationType,
         requirement: string,
     ): void => {
-        const telemetry = this.telemetryFactory.forCancelStartOver(event, test, requirement);
-        const payload: BaseActionPayload = {
-            telemetry: telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.CancelStartOver,
-            payload,
-        });
+        const messageType = Messages.Assessment.CancelStartOver;
+        this.sharedAssessmentActionMessageCreator.cancelStartOver(
+            event,
+            test,
+            requirement,
+            messageType,
+        );
     };
 
     public cancelStartOverAllAssessments = (event: React.MouseEvent<any>): void => {
-        const telemetry = this.telemetryFactory.fromDetailsView(event);
-        const payload: BaseActionPayload = {
-            telemetry: telemetry,
-        };
-
-        this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.CancelStartOverAllAssessments,
-            payload,
-        });
+        const messageType = Messages.Assessment.CancelStartOverAllAssessments;
+        this.sharedAssessmentActionMessageCreator.cancelStartOverAllAssessments(event, messageType);
     };
 }

--- a/src/DetailsView/actions/shared-assessment-action-message-creator.ts
+++ b/src/DetailsView/actions/shared-assessment-action-message-creator.ts
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 import {
     SelectTestSubviewPayload,
@@ -26,7 +27,6 @@ import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import { VersionedAssessmentData } from 'common/types/versioned-assessment-data';
 import { VisualizationType } from 'common/types/visualization-type';
 
-// Licensed under the MIT License.
 export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCreator {
     public selectRequirement(
         event: React.MouseEvent<HTMLElement>,

--- a/src/DetailsView/actions/shared-assessment-action-message-creator.ts
+++ b/src/DetailsView/actions/shared-assessment-action-message-creator.ts
@@ -1,0 +1,455 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+import {
+    SelectTestSubviewPayload,
+    SelectGettingStartedPayload,
+    ExpandTestNavPayload,
+    ToggleActionPayload,
+    AssessmentToggleActionPayload,
+    ChangeInstanceStatusPayload,
+    ChangeRequirementStatusPayload,
+    AssessmentActionInstancePayload,
+    ChangeInstanceSelectionPayload,
+    AddResultDescriptionPayload,
+    AddFailureInstancePayload,
+    RemoveFailureInstancePayload,
+    EditFailureInstancePayload,
+    BaseActionPayload,
+    LoadAssessmentPayload,
+} from 'background/actions/action-payloads';
+import { DevToolActionMessageCreator } from 'common/message-creators/dev-tool-action-message-creator';
+import { Messages } from 'common/messages';
+import { SupportedMouseEvent } from 'common/telemetry-data-factory';
+import { FailureInstanceData } from 'common/types/failure-instance-data';
+import { DetailsViewRightContentPanelType } from 'common/types/store-data/details-view-right-content-panel-type';
+import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
+import { VersionedAssessmentData } from 'common/types/versioned-assessment-data';
+import { VisualizationType } from 'common/types/visualization-type';
+
+// Licensed under the MIT License.
+export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCreator {
+    public selectRequirement(
+        event: React.MouseEvent<HTMLElement>,
+        selectedRequirement: string,
+        visualizationType: VisualizationType,
+    ): void {
+        const payload: SelectTestSubviewPayload = {
+            telemetry: this.telemetryFactory.forSelectRequirement(
+                event,
+                visualizationType,
+                selectedRequirement,
+            ),
+            selectedTestSubview: selectedRequirement,
+            selectedTest: visualizationType,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.SelectTestRequirement,
+            payload: payload,
+        });
+    }
+
+    public selectNextRequirement(
+        event: React.MouseEvent<HTMLElement>,
+        nextRequirement: string,
+        visualizationType: VisualizationType,
+    ): void {
+        const payload: SelectTestSubviewPayload = {
+            telemetry: this.telemetryFactory.forSelectRequirement(
+                event,
+                visualizationType,
+                nextRequirement,
+            ),
+            selectedTestSubview: nextRequirement,
+            selectedTest: visualizationType,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.SelectNextRequirement,
+            payload: payload,
+        });
+    }
+
+    public selectGettingStarted(
+        event: React.MouseEvent<HTMLElement>,
+        visualizationType: VisualizationType,
+    ): void {
+        const payload: SelectGettingStartedPayload = {
+            telemetry: this.telemetryFactory.forSelectGettingStarted(event, visualizationType),
+            selectedTest: visualizationType,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.SelectGettingStarted,
+            payload: payload,
+        });
+    }
+
+    public expandTestNav(visualizationType: VisualizationType): void {
+        const payload: ExpandTestNavPayload = {
+            selectedTest: visualizationType,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.ExpandTestNav,
+            payload: payload,
+        });
+    }
+
+    public collapseTestNav(): void {
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.CollapseTestNav,
+        });
+    }
+
+    public startOverTest(event: SupportedMouseEvent, test: VisualizationType): void {
+        const telemetry = this.telemetryFactory.forAssessmentActionFromDetailsView(test, event);
+        const payload: ToggleActionPayload = {
+            test,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.StartOverTest,
+            payload,
+        });
+    }
+
+    public enableVisualHelper(
+        test: VisualizationType,
+        requirement: string,
+        shouldScan = true,
+        sendTelemetry = true,
+    ): void {
+        const telemetry = sendTelemetry
+            ? this.telemetryFactory.forAssessmentActionFromDetailsViewNoTriggeredBy(test)
+            : undefined;
+        const payload: AssessmentToggleActionPayload = {
+            test,
+            requirement,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: shouldScan
+                ? Messages.Assessment.EnableVisualHelper
+                : Messages.Assessment.EnableVisualHelperWithoutScan,
+            payload,
+        });
+    }
+
+    public disableVisualHelpersForTest(test: VisualizationType): void {
+        const payload: ToggleActionPayload = {
+            test,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.DisableVisualHelperForTest,
+            payload,
+        });
+    }
+
+    public disableVisualHelper(test: VisualizationType, requirement: string): void {
+        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
+        const payload: ToggleActionPayload = {
+            test,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.DisableVisualHelper,
+            payload,
+        });
+    }
+
+    public changeManualTestStatus = (
+        status: ManualTestStatus,
+        test: VisualizationType,
+        requirement: string,
+        selector: string,
+    ): void => {
+        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
+        const payload: ChangeInstanceStatusPayload = {
+            test,
+            requirement,
+            status,
+            selector,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.ChangeStatus,
+            payload,
+        });
+    };
+
+    public changeManualRequirementStatus = (
+        status: ManualTestStatus,
+        test: VisualizationType,
+        requirement: string,
+    ): void => {
+        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
+        const payload: ChangeRequirementStatusPayload = {
+            test,
+            requirement,
+            status,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.ChangeRequirementStatus,
+            payload,
+        });
+    };
+
+    public undoManualTestStatusChange = (
+        test: VisualizationType,
+        requirement: string,
+        selector: string,
+    ): void => {
+        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
+        const payload: AssessmentActionInstancePayload = {
+            test,
+            requirement,
+            selector,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.Undo,
+            payload,
+        });
+    };
+
+    public undoManualRequirementStatusChange = (
+        test: VisualizationType,
+        requirement: string,
+    ): void => {
+        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
+        const payload: ChangeRequirementStatusPayload = {
+            test: test,
+            requirement: requirement,
+            telemetry: telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.UndoChangeRequirementStatus,
+            payload,
+        });
+    };
+
+    public changeAssessmentVisualizationState = (
+        isVisualizationEnabled: boolean,
+        test: VisualizationType,
+        requirement: string,
+        selector: string,
+    ): void => {
+        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
+        const payload: ChangeInstanceSelectionPayload = {
+            test,
+            requirement,
+            isVisualizationEnabled,
+            selector,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.ChangeVisualizationState,
+            payload,
+        });
+    };
+
+    public addResultDescription(description: string): void {
+        const payload: AddResultDescriptionPayload = {
+            description,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.AddResultDescription,
+            payload,
+        });
+    }
+
+    public addFailureInstance(
+        instanceData: FailureInstanceData,
+        test: VisualizationType,
+        requirement: string,
+    ): void {
+        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
+        const payload: AddFailureInstancePayload = {
+            test,
+            requirement,
+            instanceData,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.AddFailureInstance,
+            payload,
+        });
+    }
+
+    public removeFailureInstance = (
+        test: VisualizationType,
+        requirement: string,
+        id: string,
+    ): void => {
+        const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
+        const payload: RemoveFailureInstancePayload = {
+            test,
+            requirement,
+            id,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.RemoveFailureInstance,
+            payload,
+        });
+    };
+
+    public editFailureInstance = (
+        instanceData: FailureInstanceData,
+        test: VisualizationType,
+        requirement: string,
+        id: string,
+    ): void => {
+        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
+        const payload: EditFailureInstancePayload = {
+            test,
+            requirement,
+            id,
+            instanceData,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.EditFailureInstance,
+            payload,
+        });
+    };
+
+    public passUnmarkedInstances(test: VisualizationType, requirement: string): void {
+        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
+        const payload: ToggleActionPayload = {
+            test,
+            requirement,
+            telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.PassUnmarkedInstances,
+            payload,
+        });
+    }
+
+    public changeAssessmentVisualizationStateForAll(
+        isVisualizationEnabled: boolean,
+        test: VisualizationType,
+        requirement: string,
+    ): void {
+        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
+        const payload: Omit<ChangeInstanceSelectionPayload, 'selector'> = {
+            test: test,
+            requirement: requirement,
+            isVisualizationEnabled: isVisualizationEnabled,
+            telemetry: telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.ChangeVisualizationStateForAll,
+            payload,
+        });
+    }
+
+    public continuePreviousAssessment = (event: React.MouseEvent<any>): void => {
+        const telemetry = this.telemetryFactory.fromDetailsView(event);
+        const payload: BaseActionPayload = {
+            telemetry: telemetry,
+        };
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.ContinuePreviousAssessment,
+            payload,
+        });
+    };
+
+    public loadAssessment = (
+        assessmentData: VersionedAssessmentData,
+        tabId: number,
+        detailsViewId: string,
+    ): void => {
+        const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
+        const payload: LoadAssessmentPayload = {
+            telemetry: telemetry,
+            versionedAssessmentData: assessmentData,
+            tabId,
+            detailsViewId,
+        };
+        const setDetailsViewRightContentPanelPayload: DetailsViewRightContentPanelType = 'Overview';
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
+            payload: setDetailsViewRightContentPanelPayload,
+        });
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.LoadAssessment,
+            payload,
+        });
+    };
+
+    public saveAssessment = (event: React.MouseEvent<any>): void => {
+        const telemetry = this.telemetryFactory.fromDetailsView(event);
+        const payload: BaseActionPayload = {
+            telemetry: telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.SaveAssessment,
+            payload,
+        });
+    };
+
+    public startOverAllAssessments = (event: React.MouseEvent<any>): void => {
+        const telemetry = this.telemetryFactory.fromDetailsView(event);
+        const setDetailsViewRightContentPanelPayload: DetailsViewRightContentPanelType = 'Overview';
+        const startOverAllAssessmentsActionPayload: BaseActionPayload = {
+            telemetry: telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
+            payload: setDetailsViewRightContentPanelPayload,
+        });
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.StartOverAllAssessments,
+            payload: startOverAllAssessmentsActionPayload,
+        });
+    };
+
+    public cancelStartOver = (
+        event: React.MouseEvent<any>,
+        test: VisualizationType,
+        requirement: string,
+    ): void => {
+        const telemetry = this.telemetryFactory.forCancelStartOver(event, test, requirement);
+        const payload: BaseActionPayload = {
+            telemetry: telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.CancelStartOver,
+            payload,
+        });
+    };
+
+    public cancelStartOverAllAssessments = (event: React.MouseEvent<any>): void => {
+        const telemetry = this.telemetryFactory.fromDetailsView(event);
+        const payload: BaseActionPayload = {
+            telemetry: telemetry,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.CancelStartOverAllAssessments,
+            payload,
+        });
+    };
+}

--- a/src/DetailsView/actions/shared-assessment-action-message-creator.ts
+++ b/src/DetailsView/actions/shared-assessment-action-message-creator.ts
@@ -32,6 +32,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         event: React.MouseEvent<HTMLElement>,
         selectedRequirement: string,
         visualizationType: VisualizationType,
+        messageType: string,
     ): void {
         const payload: SelectTestSubviewPayload = {
             telemetry: this.telemetryFactory.forSelectRequirement(
@@ -44,7 +45,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SelectTestRequirement,
+            messageType: messageType,
             payload: payload,
         });
     }
@@ -53,6 +54,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         event: React.MouseEvent<HTMLElement>,
         nextRequirement: string,
         visualizationType: VisualizationType,
+        messageType: string,
     ): void {
         const payload: SelectTestSubviewPayload = {
             telemetry: this.telemetryFactory.forSelectRequirement(
@@ -65,7 +67,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SelectNextRequirement,
+            messageType,
             payload: payload,
         });
     }
@@ -73,6 +75,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
     public selectGettingStarted(
         event: React.MouseEvent<HTMLElement>,
         visualizationType: VisualizationType,
+        messageType: string,
     ): void {
         const payload: SelectGettingStartedPayload = {
             telemetry: this.telemetryFactory.forSelectGettingStarted(event, visualizationType),
@@ -80,29 +83,33 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SelectGettingStarted,
+            messageType,
             payload: payload,
         });
     }
 
-    public expandTestNav(visualizationType: VisualizationType): void {
+    public expandTestNav(visualizationType: VisualizationType, messageType: string): void {
         const payload: ExpandTestNavPayload = {
             selectedTest: visualizationType,
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ExpandTestNav,
+            messageType,
             payload: payload,
         });
     }
 
-    public collapseTestNav(): void {
+    public collapseTestNav(messageType: string): void {
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.CollapseTestNav,
+            messageType,
         });
     }
 
-    public startOverTest(event: SupportedMouseEvent, test: VisualizationType): void {
+    public startOverTest(
+        event: SupportedMouseEvent,
+        test: VisualizationType,
+        messageType: string,
+    ): void {
         const telemetry = this.telemetryFactory.forAssessmentActionFromDetailsView(test, event);
         const payload: ToggleActionPayload = {
             test,
@@ -110,7 +117,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.StartOverTest,
+            messageType,
             payload,
         });
     }
@@ -118,8 +125,8 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
     public enableVisualHelper(
         test: VisualizationType,
         requirement: string,
-        shouldScan = true,
         sendTelemetry = true,
+        messageType: string,
     ): void {
         const telemetry = sendTelemetry
             ? this.telemetryFactory.forAssessmentActionFromDetailsViewNoTriggeredBy(test)
@@ -131,25 +138,27 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: shouldScan
-                ? Messages.Assessment.EnableVisualHelper
-                : Messages.Assessment.EnableVisualHelperWithoutScan,
+            messageType,
             payload,
         });
     }
 
-    public disableVisualHelpersForTest(test: VisualizationType): void {
+    public disableVisualHelpersForTest(test: VisualizationType, messageType: string): void {
         const payload: ToggleActionPayload = {
             test,
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.DisableVisualHelperForTest,
+            messageType,
             payload,
         });
     }
 
-    public disableVisualHelper(test: VisualizationType, requirement: string): void {
+    public disableVisualHelper(
+        test: VisualizationType,
+        requirement: string,
+        messageType: string,
+    ): void {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: ToggleActionPayload = {
             test,
@@ -157,7 +166,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.DisableVisualHelper,
+            messageType,
             payload,
         });
     }
@@ -167,6 +176,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         test: VisualizationType,
         requirement: string,
         selector: string,
+        messageType: string,
     ): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: ChangeInstanceStatusPayload = {
@@ -178,7 +188,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeStatus,
+            messageType,
             payload,
         });
     };
@@ -187,6 +197,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         status: ManualTestStatus,
         test: VisualizationType,
         requirement: string,
+        messageType: string,
     ): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: ChangeRequirementStatusPayload = {
@@ -197,7 +208,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeRequirementStatus,
+            messageType,
             payload,
         });
     };
@@ -206,6 +217,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         test: VisualizationType,
         requirement: string,
         selector: string,
+        messageType: string,
     ): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: AssessmentActionInstancePayload = {
@@ -216,7 +228,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.Undo,
+            messageType,
             payload,
         });
     };
@@ -224,6 +236,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
     public undoManualRequirementStatusChange = (
         test: VisualizationType,
         requirement: string,
+        messageType: string,
     ): void => {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: ChangeRequirementStatusPayload = {
@@ -233,7 +246,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.UndoChangeRequirementStatus,
+            messageType,
             payload,
         });
     };
@@ -243,6 +256,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         test: VisualizationType,
         requirement: string,
         selector: string,
+        messageType: string,
     ): void => {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: ChangeInstanceSelectionPayload = {
@@ -254,18 +268,18 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeVisualizationState,
+            messageType,
             payload,
         });
     };
 
-    public addResultDescription(description: string): void {
+    public addResultDescription(description: string, messageType: string): void {
         const payload: AddResultDescriptionPayload = {
             description,
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.AddResultDescription,
+            messageType,
             payload,
         });
     }
@@ -274,6 +288,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         instanceData: FailureInstanceData,
         test: VisualizationType,
         requirement: string,
+        messageType: string,
     ): void {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: AddFailureInstancePayload = {
@@ -284,7 +299,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.AddFailureInstance,
+            messageType,
             payload,
         });
     }
@@ -293,6 +308,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         test: VisualizationType,
         requirement: string,
         id: string,
+        messageType: string,
     ): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: RemoveFailureInstancePayload = {
@@ -303,7 +319,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.RemoveFailureInstance,
+            messageType,
             payload,
         });
     };
@@ -313,6 +329,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         test: VisualizationType,
         requirement: string,
         id: string,
+        messageType: string,
     ): void => {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: EditFailureInstancePayload = {
@@ -324,12 +341,16 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.EditFailureInstance,
+            messageType,
             payload,
         });
     };
 
-    public passUnmarkedInstances(test: VisualizationType, requirement: string): void {
+    public passUnmarkedInstances(
+        test: VisualizationType,
+        requirement: string,
+        messageType: string,
+    ): void {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: ToggleActionPayload = {
             test,
@@ -338,7 +359,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.PassUnmarkedInstances,
+            messageType,
             payload,
         });
     }
@@ -347,6 +368,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         isVisualizationEnabled: boolean,
         test: VisualizationType,
         requirement: string,
+        messageType: string,
     ): void {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: Omit<ChangeInstanceSelectionPayload, 'selector'> = {
@@ -357,18 +379,21 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeVisualizationStateForAll,
+            messageType,
             payload,
         });
     }
 
-    public continuePreviousAssessment = (event: React.MouseEvent<any>): void => {
+    public continuePreviousAssessment = (
+        event: React.MouseEvent<any>,
+        messageType: string,
+    ): void => {
         const telemetry = this.telemetryFactory.fromDetailsView(event);
         const payload: BaseActionPayload = {
             telemetry: telemetry,
         };
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ContinuePreviousAssessment,
+            messageType,
             payload,
         });
     };
@@ -377,6 +402,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         assessmentData: VersionedAssessmentData,
         tabId: number,
         detailsViewId: string,
+        messageType: string,
     ): void => {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: LoadAssessmentPayload = {
@@ -391,24 +417,24 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
             payload: setDetailsViewRightContentPanelPayload,
         });
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.LoadAssessment,
+            messageType,
             payload,
         });
     };
 
-    public saveAssessment = (event: React.MouseEvent<any>): void => {
+    public saveAssessment = (event: React.MouseEvent<any>, messageType: string): void => {
         const telemetry = this.telemetryFactory.fromDetailsView(event);
         const payload: BaseActionPayload = {
             telemetry: telemetry,
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SaveAssessment,
+            messageType,
             payload,
         });
     };
 
-    public startOverAllAssessments = (event: React.MouseEvent<any>): void => {
+    public startOverAllAssessments = (event: React.MouseEvent<any>, messageType: string): void => {
         const telemetry = this.telemetryFactory.fromDetailsView(event);
         const setDetailsViewRightContentPanelPayload: DetailsViewRightContentPanelType = 'Overview';
         const startOverAllAssessmentsActionPayload: BaseActionPayload = {
@@ -420,7 +446,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
             payload: setDetailsViewRightContentPanelPayload,
         });
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.StartOverAllAssessments,
+            messageType,
             payload: startOverAllAssessmentsActionPayload,
         });
     };
@@ -429,6 +455,7 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         event: React.MouseEvent<any>,
         test: VisualizationType,
         requirement: string,
+        messageType: string,
     ): void => {
         const telemetry = this.telemetryFactory.forCancelStartOver(event, test, requirement);
         const payload: BaseActionPayload = {
@@ -436,19 +463,22 @@ export class SharedAssessmentActionMessageCreator extends DevToolActionMessageCr
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.CancelStartOver,
+            messageType,
             payload,
         });
     };
 
-    public cancelStartOverAllAssessments = (event: React.MouseEvent<any>): void => {
+    public cancelStartOverAllAssessments = (
+        event: React.MouseEvent<any>,
+        messageType: string,
+    ): void => {
         const telemetry = this.telemetryFactory.fromDetailsView(event);
         const payload: BaseActionPayload = {
             telemetry: telemetry,
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.CancelStartOverAllAssessments,
+            messageType,
             payload,
         });
     };

--- a/src/tests/unit/tests/DetailsView/actions/shared-assessment-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/shared-assessment-action-message-creator.test.ts
@@ -1,0 +1,844 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { HeadingsTestStep } from 'assessments/headings/test-steps/test-steps';
+import { LoadAssessmentPayload } from 'background/actions/action-payloads';
+import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { VersionedAssessmentData } from 'common/types/versioned-assessment-data';
+import { SharedAssessmentActionMessageCreator } from 'DetailsView/actions/shared-assessment-action-message-creator';
+import { IMock, It, Mock, Times } from 'typemoq';
+import {
+    AssessmentTelemetryData,
+    BaseTelemetryData,
+    RequirementActionTelemetryData,
+    RequirementSelectTelemetryData,
+    SelectGettingStartedTelemetryData,
+    TelemetryEventSource,
+    TriggeredByNotApplicable,
+} from '../../../../../common/extension-telemetry-events';
+import { Messages } from '../../../../../common/messages';
+import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
+import { VisualizationType } from '../../../../../common/types/visualization-type';
+import { EventStubFactory } from '../../../common/event-stub-factory';
+
+describe('SharedAssessmentActionMessageCreatorTest', () => {
+    const eventStubFactory = new EventStubFactory();
+    const testSource: TelemetryEventSource = -1 as TelemetryEventSource;
+    let telemetryFactoryMock: IMock<TelemetryDataFactory>;
+    let dispatcherMock: IMock<ActionMessageDispatcher>;
+    let testSubject: SharedAssessmentActionMessageCreator;
+
+    beforeEach(() => {
+        dispatcherMock = Mock.ofType<ActionMessageDispatcher>();
+        telemetryFactoryMock = Mock.ofType(TelemetryDataFactory);
+        testSubject = new SharedAssessmentActionMessageCreator(
+            telemetryFactoryMock.object,
+            dispatcherMock.object,
+        );
+    });
+
+    test('selectRequirement', () => {
+        const view = VisualizationType.Headings;
+        const selectedRequirement = HeadingsTestStep.headingFunction;
+        const event = eventStubFactory.createKeypressEvent() as any;
+        const telemetry: RequirementSelectTelemetryData = {
+            triggeredBy: 'keypress',
+            selectedTest: VisualizationType[view],
+            selectedRequirement: selectedRequirement,
+            source: testSource,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.SelectTestRequirement,
+            payload: {
+                telemetry: telemetry,
+                selectedTestSubview: selectedRequirement,
+                selectedTest: view,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tf => tf.forSelectRequirement(event, view, selectedRequirement))
+            .returns(() => telemetry);
+
+        testSubject.selectRequirement(event, HeadingsTestStep.headingFunction, view);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('selectNextRequirement', () => {
+        const view = VisualizationType.Headings;
+        const selectedRequirement = HeadingsTestStep.headingFunction;
+        const event = eventStubFactory.createKeypressEvent() as any;
+        const telemetry: RequirementSelectTelemetryData = {
+            triggeredBy: 'keypress',
+            selectedTest: VisualizationType[view],
+            selectedRequirement: selectedRequirement,
+            source: testSource,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.SelectNextRequirement,
+            payload: {
+                telemetry: telemetry,
+                selectedTestSubview: selectedRequirement,
+                selectedTest: view,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tf => tf.forSelectRequirement(event, view, selectedRequirement))
+            .returns(() => telemetry);
+
+        testSubject.selectNextRequirement(event, HeadingsTestStep.headingFunction, view);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('selectGettingStarted', () => {
+        const view = VisualizationType.Headings;
+        const event = eventStubFactory.createKeypressEvent() as any;
+        const telemetry: SelectGettingStartedTelemetryData = {
+            triggeredBy: 'keypress',
+            selectedTest: VisualizationType[view],
+            source: testSource,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.SelectGettingStarted,
+            payload: {
+                telemetry: telemetry,
+                selectedTest: view,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tf => tf.forSelectGettingStarted(event, view))
+            .returns(() => telemetry);
+
+        testSubject.selectGettingStarted(event, view);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('expandTestNav', () => {
+        const view = VisualizationType.Headings;
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.ExpandTestNav,
+            payload: {
+                selectedTest: view,
+            },
+        };
+
+        testSubject.expandTestNav(view);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('collapseTestNav', () => {
+        const expectedMessage = {
+            messageType: Messages.Assessment.CollapseTestNav,
+        };
+
+        testSubject.collapseTestNav();
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('startOverTest', () => {
+        const event = eventStubFactory.createMouseClickEvent() as any;
+        const telemetry: AssessmentTelemetryData = {
+            triggeredBy: 'mouseclick',
+            source: TelemetryEventSource.DetailsView,
+            selectedTest: VisualizationType[VisualizationType.HeadingsAssessment],
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.StartOverTest,
+            payload: {
+                test: VisualizationType.HeadingsAssessment,
+                telemetry,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tf =>
+                tf.forAssessmentActionFromDetailsView(VisualizationType.HeadingsAssessment, event),
+            )
+            .returns(() => telemetry);
+
+        testSubject.startOverTest(event, VisualizationType.HeadingsAssessment);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('enableVisualHelper', () => {
+        const requirement = 'fake-requirement-name';
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+            selectedTest: VisualizationType[VisualizationType.HeadingsAssessment],
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.EnableVisualHelper,
+            payload: {
+                test: VisualizationType.HeadingsAssessment,
+                requirement,
+                telemetry,
+            },
+        };
+        telemetryFactoryMock
+            .setup(tf =>
+                tf.forAssessmentActionFromDetailsViewNoTriggeredBy(
+                    VisualizationType.HeadingsAssessment,
+                ),
+            )
+            .returns(() => telemetry);
+
+        testSubject.enableVisualHelper(VisualizationType.HeadingsAssessment, requirement);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('enableVisualHelper without scan', () => {
+        const requirement = 'fake-requirement-name';
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+            selectedTest: VisualizationType[VisualizationType.HeadingsAssessment],
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.EnableVisualHelperWithoutScan,
+            payload: {
+                test: VisualizationType.HeadingsAssessment,
+                requirement,
+                telemetry,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tf =>
+                tf.forAssessmentActionFromDetailsViewNoTriggeredBy(
+                    VisualizationType.HeadingsAssessment,
+                ),
+            )
+            .returns(() => telemetry);
+
+        testSubject.enableVisualHelper(VisualizationType.HeadingsAssessment, requirement, false);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('enableVisualHelper, with scan, without telemetry', () => {
+        const requirement = 'fake-requirement-name';
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.EnableVisualHelper,
+            payload: {
+                test: VisualizationType.HeadingsAssessment,
+                requirement,
+                telemetry: undefined,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tf =>
+                tf.forAssessmentActionFromDetailsViewNoTriggeredBy(
+                    VisualizationType.HeadingsAssessment,
+                ),
+            )
+            .verifiable(Times.never());
+
+        testSubject.enableVisualHelper(
+            VisualizationType.HeadingsAssessment,
+            requirement,
+            true,
+            false,
+        );
+
+        telemetryFactoryMock.verifyAll();
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('enableVisualHelper, without scan, without telemetry', () => {
+        const requirement = 'fake-requirement-name';
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.EnableVisualHelperWithoutScan,
+            payload: {
+                test: VisualizationType.HeadingsAssessment,
+                requirement,
+                telemetry: undefined,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tf =>
+                tf.forAssessmentActionFromDetailsViewNoTriggeredBy(
+                    VisualizationType.HeadingsAssessment,
+                ),
+            )
+            .verifiable(Times.never());
+
+        testSubject.enableVisualHelper(
+            VisualizationType.HeadingsAssessment,
+            requirement,
+            false,
+            false,
+        );
+
+        telemetryFactoryMock.verifyAll();
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('disableVisualHelpersForTest', () => {
+        const expectedMessage = {
+            messageType: Messages.Assessment.DisableVisualHelperForTest,
+            payload: {
+                test: VisualizationType.HeadingsAssessment,
+            },
+        };
+
+        testSubject.disableVisualHelpersForTest(VisualizationType.HeadingsAssessment);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('disableVisualHelper', () => {
+        const test = -1;
+        const requirement = 'requirement';
+        const telemetry = {};
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.DisableVisualHelper,
+            payload: {
+                test: test,
+                telemetry,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tfm => tfm.forRequirementFromDetailsView(test, requirement))
+            .returns(() => telemetry as RequirementActionTelemetryData);
+
+        testSubject.disableVisualHelper(test, requirement);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('changeManualTestStatus', () => {
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+            selectedTest: VisualizationType[1],
+            selectedRequirement: 'requirement',
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.ChangeStatus,
+            payload: {
+                test: 1,
+                requirement: 'requirement',
+                status: 1,
+                selector: 'selector',
+                telemetry: telemetry,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tfm => tfm.forRequirementFromDetailsView(1, 'requirement'))
+            .returns(() => telemetry);
+
+        testSubject.changeManualTestStatus(1, 1, 'requirement', 'selector');
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('changeManualTestRequirementStatus', () => {
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+            selectedTest: VisualizationType[1],
+            selectedRequirement: 'requirement',
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.ChangeRequirementStatus,
+            payload: {
+                test: 1,
+                requirement: 'requirement',
+                status: 1,
+                telemetry: telemetry,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tfm => tfm.forRequirementFromDetailsView(1, 'requirement'))
+            .returns(() => telemetry);
+
+        testSubject.changeManualRequirementStatus(1, 1, 'requirement');
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('undoManualTestStatusChange', () => {
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+            selectedTest: VisualizationType[1],
+            selectedRequirement: 'requirement',
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.Undo,
+            payload: {
+                test: 1,
+                requirement: 'requirement',
+                selector: 'selector',
+                telemetry: telemetry,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tfm => tfm.forRequirementFromDetailsView(1, 'requirement'))
+            .returns(() => telemetry);
+
+        testSubject.undoManualTestStatusChange(1, 'requirement', 'selector');
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('undoManualRequirementStatusChange', () => {
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.UndoChangeRequirementStatus,
+            payload: {
+                test: 1,
+                requirement: 'requirement',
+                telemetry: telemetry,
+            },
+        };
+
+        setupTelemetryFactory('fromDetailsViewNoTriggeredBy', telemetry);
+
+        testSubject.undoManualRequirementStatusChange(1, 'requirement');
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('changeAssessmentVisualizationState', () => {
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.ChangeVisualizationState,
+            payload: {
+                test: 1,
+                requirement: 'requirement',
+                isVisualizationEnabled: true,
+                selector: 'selector',
+                telemetry: telemetry,
+            },
+        };
+
+        setupTelemetryFactory('fromDetailsViewNoTriggeredBy', telemetry);
+
+        testSubject.changeAssessmentVisualizationState(true, 1, 'requirement', 'selector');
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('addResultDescription', () => {
+        const persistedDescription = 'persisted description';
+        const expectedMessage = {
+            messageType: Messages.Assessment.AddResultDescription,
+            payload: {
+                description: persistedDescription,
+            },
+        };
+
+        testSubject.addResultDescription(persistedDescription);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('addFailureInstance', () => {
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+            selectedRequirement: 'requirement',
+            selectedTest: 'test',
+        };
+
+        const instanceData = {
+            failureDescription: 'description',
+            path: 'path',
+            snippet: 'snippet',
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.AddFailureInstance,
+            payload: {
+                test: 1,
+                requirement: 'requirement',
+                instanceData: instanceData,
+                telemetry: telemetry,
+            },
+        };
+        telemetryFactoryMock
+            .setup(tf => tf.forRequirementFromDetailsView(1, 'requirement'))
+            .returns(() => telemetry);
+
+        testSubject.addFailureInstance(instanceData, 1, 'requirement');
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('removeFailureInstance', () => {
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+            selectedRequirement: 'requirement',
+            selectedTest: 'test',
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.RemoveFailureInstance,
+            payload: {
+                test: 1,
+                requirement: 'requirement',
+                id: '1',
+                telemetry: telemetry,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tf => tf.forRequirementFromDetailsView(1, 'requirement'))
+            .returns(() => telemetry);
+
+        testSubject.removeFailureInstance(1, 'requirement', '1');
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('editFailureInstance', () => {
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+        };
+
+        const instanceData = {
+            failureDescription: 'des',
+            path: 'path',
+            snippet: 'snippet',
+        };
+        const expectedMessage = {
+            messageType: Messages.Assessment.EditFailureInstance,
+            payload: {
+                test: 1,
+                requirement: 'requirement',
+                id: '1',
+                instanceData: instanceData,
+                telemetry: telemetry,
+            },
+        };
+
+        setupTelemetryFactory('fromDetailsViewNoTriggeredBy', telemetry);
+
+        testSubject.editFailureInstance(instanceData, 1, 'requirement', '1');
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('passUnmarkedInstances', () => {
+        const test = VisualizationType.Headings;
+        const requirement = 'missingHeadings';
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.PassUnmarkedInstances,
+            payload: {
+                test: test,
+                requirement: requirement,
+                telemetry: telemetry,
+            },
+        };
+
+        setupTelemetryFactory('fromDetailsViewNoTriggeredBy', telemetry);
+
+        testSubject.passUnmarkedInstances(test, requirement);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('changeAssessmentVisualizationStateForAll', () => {
+        const telemetry = {
+            source: TelemetryEventSource.DetailsView,
+            triggeredBy: TriggeredByNotApplicable,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.ChangeVisualizationStateForAll,
+            payload: {
+                test: 1,
+                requirement: 'requirement',
+                isVisualizationEnabled: true,
+                telemetry: telemetry,
+            },
+        };
+
+        setupTelemetryFactory('fromDetailsViewNoTriggeredBy', telemetry);
+
+        testSubject.changeAssessmentVisualizationStateForAll(true, 1, 'requirement');
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('continuePreviousAssessment', () => {
+        const event = eventStubFactory.createMouseClickEvent() as any;
+        const telemetry: BaseTelemetryData = {
+            triggeredBy: 'mouseclick',
+            source: TelemetryEventSource.DetailsView,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.ContinuePreviousAssessment,
+            payload: {
+                telemetry,
+            },
+        };
+
+        telemetryFactoryMock.setup(tf => tf.fromDetailsView(event)).returns(() => telemetry);
+
+        testSubject.continuePreviousAssessment(event);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('loadAssessment', () => {
+        const assessmentData: VersionedAssessmentData = {
+            version: 2,
+            assessmentData: {} as AssessmentStoreData,
+        };
+        const tabId = -1;
+        const telemetry: BaseTelemetryData = {
+            triggeredBy: TriggeredByNotApplicable,
+            source: TelemetryEventSource.DetailsView,
+        };
+
+        const expectedMessageToLoadAssessment = {
+            messageType: Messages.Assessment.LoadAssessment,
+            payload: {
+                tabId,
+                versionedAssessmentData: {
+                    version: 2,
+                    assessmentData: {} as AssessmentStoreData,
+                },
+                telemetry,
+                detailsViewId: 'testId',
+            } as LoadAssessmentPayload,
+        };
+        const expectedMessageToGoToOverview = {
+            messageType: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
+            payload: 'Overview',
+        };
+
+        telemetryFactoryMock
+            .setup(tf => tf.fromDetailsViewNoTriggeredBy())
+            .returns(() => telemetry);
+
+        testSubject.loadAssessment(assessmentData, tabId, 'testId');
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessageToLoadAssessment)),
+            Times.once(),
+        );
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessageToGoToOverview)),
+            Times.once(),
+        );
+    });
+
+    test('startOverAllAssessments', () => {
+        const event = eventStubFactory.createMouseClickEvent() as any;
+        const telemetry: BaseTelemetryData = {
+            triggeredBy: 'mouseclick',
+            source: TelemetryEventSource.DetailsView,
+        };
+
+        const expectedMessageToStartOverAllAssessments = {
+            messageType: Messages.Assessment.StartOverAllAssessments,
+            payload: {
+                telemetry,
+            },
+        };
+        const expectedMessageToSetDetailsViewRightContentPanel = {
+            messageType: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
+            payload: 'Overview',
+        };
+
+        telemetryFactoryMock.setup(tf => tf.fromDetailsView(event)).returns(() => telemetry);
+
+        testSubject.startOverAllAssessments(event);
+
+        dispatcherMock.verify(
+            dispatcher =>
+                dispatcher.dispatchMessage(It.isValue(expectedMessageToStartOverAllAssessments)),
+            Times.once(),
+        );
+        dispatcherMock.verify(
+            dispatcher =>
+                dispatcher.dispatchMessage(
+                    It.isValue(expectedMessageToSetDetailsViewRightContentPanel),
+                ),
+            Times.once(),
+        );
+    });
+
+    test('cancelStartOver', () => {
+        const event = eventStubFactory.createMouseClickEvent() as any;
+        const test = -1;
+        const requirement = 'selected requirement';
+        const telemetry: RequirementSelectTelemetryData = {
+            triggeredBy: 'mouseclick',
+            source: TelemetryEventSource.DetailsView,
+            selectedTest: 'selected test',
+            selectedRequirement: requirement,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.CancelStartOver,
+            payload: {
+                telemetry,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tf => tf.forCancelStartOver(event, test, requirement))
+            .returns(() => telemetry);
+
+        testSubject.cancelStartOver(event, test, requirement);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('cancelStartOverAssessment', () => {
+        const event = eventStubFactory.createMouseClickEvent() as any;
+        const telemetry: BaseTelemetryData = {
+            triggeredBy: 'mouseclick',
+            source: TelemetryEventSource.DetailsView,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.CancelStartOverAllAssessments,
+            payload: {
+                telemetry,
+            },
+        };
+
+        telemetryFactoryMock.setup(tf => tf.fromDetailsView(event)).returns(() => telemetry);
+
+        testSubject.cancelStartOverAllAssessments(event);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    function setupTelemetryFactory(
+        methodName: keyof TelemetryDataFactory,
+        telemetry: any,
+        event?: any,
+    ): void {
+        const setupFunc = event ? tfm => tfm[methodName](event) : tfm => tfm[methodName]();
+        telemetryFactoryMock.setup(setupFunc).returns(() => telemetry);
+    }
+});

--- a/src/tests/unit/tests/DetailsView/actions/shared-assessment-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/shared-assessment-action-message-creator.test.ts
@@ -24,6 +24,7 @@ import { EventStubFactory } from '../../../common/event-stub-factory';
 describe('SharedAssessmentActionMessageCreatorTest', () => {
     const eventStubFactory = new EventStubFactory();
     const testSource: TelemetryEventSource = -1 as TelemetryEventSource;
+    const messageType: string = 'test-message-type';
     let telemetryFactoryMock: IMock<TelemetryDataFactory>;
     let dispatcherMock: IMock<ActionMessageDispatcher>;
     let testSubject: SharedAssessmentActionMessageCreator;
@@ -49,7 +50,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.SelectTestRequirement,
+            messageType,
             payload: {
                 telemetry: telemetry,
                 selectedTestSubview: selectedRequirement,
@@ -61,7 +62,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             .setup(tf => tf.forSelectRequirement(event, view, selectedRequirement))
             .returns(() => telemetry);
 
-        testSubject.selectRequirement(event, HeadingsTestStep.headingFunction, view);
+        testSubject.selectRequirement(event, HeadingsTestStep.headingFunction, view, messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -81,7 +82,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.SelectNextRequirement,
+            messageType,
             payload: {
                 telemetry: telemetry,
                 selectedTestSubview: selectedRequirement,
@@ -93,7 +94,12 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             .setup(tf => tf.forSelectRequirement(event, view, selectedRequirement))
             .returns(() => telemetry);
 
-        testSubject.selectNextRequirement(event, HeadingsTestStep.headingFunction, view);
+        testSubject.selectNextRequirement(
+            event,
+            HeadingsTestStep.headingFunction,
+            view,
+            messageType,
+        );
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -111,7 +117,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.SelectGettingStarted,
+            messageType,
             payload: {
                 telemetry: telemetry,
                 selectedTest: view,
@@ -122,7 +128,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             .setup(tf => tf.forSelectGettingStarted(event, view))
             .returns(() => telemetry);
 
-        testSubject.selectGettingStarted(event, view);
+        testSubject.selectGettingStarted(event, view, messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -134,13 +140,13 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         const view = VisualizationType.Headings;
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ExpandTestNav,
+            messageType,
             payload: {
                 selectedTest: view,
             },
         };
 
-        testSubject.expandTestNav(view);
+        testSubject.expandTestNav(view, messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -150,10 +156,10 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
 
     test('collapseTestNav', () => {
         const expectedMessage = {
-            messageType: Messages.Assessment.CollapseTestNav,
+            messageType,
         };
 
-        testSubject.collapseTestNav();
+        testSubject.collapseTestNav(messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -170,7 +176,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.StartOverTest,
+            messageType,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 telemetry,
@@ -183,7 +189,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             )
             .returns(() => telemetry);
 
-        testSubject.startOverTest(event, VisualizationType.HeadingsAssessment);
+        testSubject.startOverTest(event, VisualizationType.HeadingsAssessment, messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -200,7 +206,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.EnableVisualHelper,
+            messageType,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 requirement,
@@ -214,87 +220,25 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
                 ),
             )
             .returns(() => telemetry);
-
-        testSubject.enableVisualHelper(VisualizationType.HeadingsAssessment, requirement);
-
-        dispatcherMock.verify(
-            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
-            Times.once(),
-        );
-    });
-
-    test('enableVisualHelper without scan', () => {
-        const requirement = 'fake-requirement-name';
-        const telemetry = {
-            source: TelemetryEventSource.DetailsView,
-            triggeredBy: TriggeredByNotApplicable,
-            selectedTest: VisualizationType[VisualizationType.HeadingsAssessment],
-        };
-
-        const expectedMessage = {
-            messageType: Messages.Assessment.EnableVisualHelperWithoutScan,
-            payload: {
-                test: VisualizationType.HeadingsAssessment,
-                requirement,
-                telemetry,
-            },
-        };
-
-        telemetryFactoryMock
-            .setup(tf =>
-                tf.forAssessmentActionFromDetailsViewNoTriggeredBy(
-                    VisualizationType.HeadingsAssessment,
-                ),
-            )
-            .returns(() => telemetry);
-
-        testSubject.enableVisualHelper(VisualizationType.HeadingsAssessment, requirement, false);
-
-        dispatcherMock.verify(
-            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
-            Times.once(),
-        );
-    });
-
-    test('enableVisualHelper, with scan, without telemetry', () => {
-        const requirement = 'fake-requirement-name';
-
-        const expectedMessage = {
-            messageType: Messages.Assessment.EnableVisualHelper,
-            payload: {
-                test: VisualizationType.HeadingsAssessment,
-                requirement,
-                telemetry: undefined,
-            },
-        };
-
-        telemetryFactoryMock
-            .setup(tf =>
-                tf.forAssessmentActionFromDetailsViewNoTriggeredBy(
-                    VisualizationType.HeadingsAssessment,
-                ),
-            )
-            .verifiable(Times.never());
 
         testSubject.enableVisualHelper(
             VisualizationType.HeadingsAssessment,
             requirement,
             true,
-            false,
+            messageType,
         );
 
-        telemetryFactoryMock.verifyAll();
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
             Times.once(),
         );
     });
 
-    test('enableVisualHelper, without scan, without telemetry', () => {
+    test('enableVisualHelper, without telemetry', () => {
         const requirement = 'fake-requirement-name';
 
         const expectedMessage = {
-            messageType: Messages.Assessment.EnableVisualHelperWithoutScan,
+            messageType,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 requirement,
@@ -314,7 +258,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             VisualizationType.HeadingsAssessment,
             requirement,
             false,
-            false,
+            messageType,
         );
 
         telemetryFactoryMock.verifyAll();
@@ -326,13 +270,13 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
 
     test('disableVisualHelpersForTest', () => {
         const expectedMessage = {
-            messageType: Messages.Assessment.DisableVisualHelperForTest,
+            messageType,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
             },
         };
 
-        testSubject.disableVisualHelpersForTest(VisualizationType.HeadingsAssessment);
+        testSubject.disableVisualHelpersForTest(VisualizationType.HeadingsAssessment, messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -346,7 +290,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         const telemetry = {};
 
         const expectedMessage = {
-            messageType: Messages.Assessment.DisableVisualHelper,
+            messageType,
             payload: {
                 test: test,
                 telemetry,
@@ -357,7 +301,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             .setup(tfm => tfm.forRequirementFromDetailsView(test, requirement))
             .returns(() => telemetry as RequirementActionTelemetryData);
 
-        testSubject.disableVisualHelper(test, requirement);
+        testSubject.disableVisualHelper(test, requirement, messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -374,7 +318,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ChangeStatus,
+            messageType,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -388,7 +332,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             .setup(tfm => tfm.forRequirementFromDetailsView(1, 'requirement'))
             .returns(() => telemetry);
 
-        testSubject.changeManualTestStatus(1, 1, 'requirement', 'selector');
+        testSubject.changeManualTestStatus(1, 1, 'requirement', 'selector', messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -405,7 +349,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ChangeRequirementStatus,
+            messageType,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -418,7 +362,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             .setup(tfm => tfm.forRequirementFromDetailsView(1, 'requirement'))
             .returns(() => telemetry);
 
-        testSubject.changeManualRequirementStatus(1, 1, 'requirement');
+        testSubject.changeManualRequirementStatus(1, 1, 'requirement', messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -435,7 +379,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.Undo,
+            messageType,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -448,7 +392,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             .setup(tfm => tfm.forRequirementFromDetailsView(1, 'requirement'))
             .returns(() => telemetry);
 
-        testSubject.undoManualTestStatusChange(1, 'requirement', 'selector');
+        testSubject.undoManualTestStatusChange(1, 'requirement', 'selector', messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -463,7 +407,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.UndoChangeRequirementStatus,
+            messageType,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -473,7 +417,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
 
         setupTelemetryFactory('fromDetailsViewNoTriggeredBy', telemetry);
 
-        testSubject.undoManualRequirementStatusChange(1, 'requirement');
+        testSubject.undoManualRequirementStatusChange(1, 'requirement', messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -488,7 +432,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ChangeVisualizationState,
+            messageType,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -500,7 +444,13 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
 
         setupTelemetryFactory('fromDetailsViewNoTriggeredBy', telemetry);
 
-        testSubject.changeAssessmentVisualizationState(true, 1, 'requirement', 'selector');
+        testSubject.changeAssessmentVisualizationState(
+            true,
+            1,
+            'requirement',
+            'selector',
+            messageType,
+        );
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -511,13 +461,13 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
     test('addResultDescription', () => {
         const persistedDescription = 'persisted description';
         const expectedMessage = {
-            messageType: Messages.Assessment.AddResultDescription,
+            messageType,
             payload: {
                 description: persistedDescription,
             },
         };
 
-        testSubject.addResultDescription(persistedDescription);
+        testSubject.addResultDescription(persistedDescription, messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -540,7 +490,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.AddFailureInstance,
+            messageType,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -552,7 +502,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             .setup(tf => tf.forRequirementFromDetailsView(1, 'requirement'))
             .returns(() => telemetry);
 
-        testSubject.addFailureInstance(instanceData, 1, 'requirement');
+        testSubject.addFailureInstance(instanceData, 1, 'requirement', messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -569,7 +519,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.RemoveFailureInstance,
+            messageType,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -582,7 +532,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             .setup(tf => tf.forRequirementFromDetailsView(1, 'requirement'))
             .returns(() => telemetry);
 
-        testSubject.removeFailureInstance(1, 'requirement', '1');
+        testSubject.removeFailureInstance(1, 'requirement', '1', messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -602,7 +552,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             snippet: 'snippet',
         };
         const expectedMessage = {
-            messageType: Messages.Assessment.EditFailureInstance,
+            messageType,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -614,7 +564,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
 
         setupTelemetryFactory('fromDetailsViewNoTriggeredBy', telemetry);
 
-        testSubject.editFailureInstance(instanceData, 1, 'requirement', '1');
+        testSubject.editFailureInstance(instanceData, 1, 'requirement', '1', messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -631,7 +581,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.PassUnmarkedInstances,
+            messageType,
             payload: {
                 test: test,
                 requirement: requirement,
@@ -641,7 +591,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
 
         setupTelemetryFactory('fromDetailsViewNoTriggeredBy', telemetry);
 
-        testSubject.passUnmarkedInstances(test, requirement);
+        testSubject.passUnmarkedInstances(test, requirement, messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -656,7 +606,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ChangeVisualizationStateForAll,
+            messageType,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -667,7 +617,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
 
         setupTelemetryFactory('fromDetailsViewNoTriggeredBy', telemetry);
 
-        testSubject.changeAssessmentVisualizationStateForAll(true, 1, 'requirement');
+        testSubject.changeAssessmentVisualizationStateForAll(true, 1, 'requirement', messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -683,7 +633,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ContinuePreviousAssessment,
+            messageType,
             payload: {
                 telemetry,
             },
@@ -691,7 +641,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
 
         telemetryFactoryMock.setup(tf => tf.fromDetailsView(event)).returns(() => telemetry);
 
-        testSubject.continuePreviousAssessment(event);
+        testSubject.continuePreviousAssessment(event, messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -711,7 +661,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessageToLoadAssessment = {
-            messageType: Messages.Assessment.LoadAssessment,
+            messageType,
             payload: {
                 tabId,
                 versionedAssessmentData: {
@@ -731,7 +681,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             .setup(tf => tf.fromDetailsViewNoTriggeredBy())
             .returns(() => telemetry);
 
-        testSubject.loadAssessment(assessmentData, tabId, 'testId');
+        testSubject.loadAssessment(assessmentData, tabId, 'testId', messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessageToLoadAssessment)),
@@ -751,7 +701,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessageToStartOverAllAssessments = {
-            messageType: Messages.Assessment.StartOverAllAssessments,
+            messageType,
             payload: {
                 telemetry,
             },
@@ -763,7 +713,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
 
         telemetryFactoryMock.setup(tf => tf.fromDetailsView(event)).returns(() => telemetry);
 
-        testSubject.startOverAllAssessments(event);
+        testSubject.startOverAllAssessments(event, messageType);
 
         dispatcherMock.verify(
             dispatcher =>
@@ -791,7 +741,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.CancelStartOver,
+            messageType,
             payload: {
                 telemetry,
             },
@@ -801,7 +751,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
             .setup(tf => tf.forCancelStartOver(event, test, requirement))
             .returns(() => telemetry);
 
-        testSubject.cancelStartOver(event, test, requirement);
+        testSubject.cancelStartOver(event, test, requirement, messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -817,7 +767,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.CancelStartOverAllAssessments,
+            messageType,
             payload: {
                 telemetry,
             },
@@ -825,7 +775,7 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
 
         telemetryFactoryMock.setup(tf => tf.fromDetailsView(event)).returns(() => telemetry);
 
-        testSubject.cancelStartOverAllAssessments(event);
+        testSubject.cancelStartOverAllAssessments(event, messageType);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),

--- a/src/tests/unit/tests/DetailsView/actions/shared-assessment-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/shared-assessment-action-message-creator.test.ts
@@ -693,6 +693,30 @@ describe('SharedAssessmentActionMessageCreatorTest', () => {
         );
     });
 
+    test('saveAssessment', () => {
+        const event = eventStubFactory.createMouseClickEvent() as any;
+        const telemetry: BaseTelemetryData = {
+            triggeredBy: 'mouseclick',
+            source: TelemetryEventSource.DetailsView,
+        };
+
+        const expectedMessageToSaveAssessment = {
+            messageType,
+            payload: {
+                telemetry,
+            },
+        };
+
+        telemetryFactoryMock.setup(tf => tf.fromDetailsView(event)).returns(() => telemetry);
+
+        testSubject.saveAssessment(event, messageType);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessageToSaveAssessment)),
+            Times.once(),
+        );
+    });
+
     test('startOverAllAssessments', () => {
         const event = eventStubFactory.createMouseClickEvent() as any;
         const telemetry: BaseTelemetryData = {


### PR DESCRIPTION
#### Details

This PR creates a `SharedAssessmentActionMessageCreator` that will be used by the `AssessmentActionMessageCreator` and `QuickAssessActionMessageCreator` (to be created in a future PR). Doing this will allow us to reuse the same/shared code for creating action messages, when the only difference between the two is the message type.

##### Motivation

Feature work

##### Context

To reduce the scope of the PRs, updating `AssessmentActionMessageCreator` to consume `SharedAssessmentActionMessageCreator` will be done in a future PR, as well as creating the `QuickAssessActionMessageCreator` (separate future PR).

This implementation uses composition rather than inheritance, to minimize dependencies on the classes. For example, if the `AssessmentActionMessageCreator` and `QuickAssessActionMessageCreator` were to both inherit from `SharedAssessmentActionMessageCreator`, making a change in the SharedAssessmentAMC might require updates to both AssessmentAMC and QuickAssessAMC.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
