### PR TITLE
refactor(medium-pass-1): add forEachConfig and medium pass provider to VisualizationConfigurationFactory

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -339,7 +339,9 @@ if (tabId != null) {
                 visualizationActionCreator,
                 telemetryFactory,
             );
-            const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
+            const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
+                Assessments,
+            );
             const assessmentDefaultMessageGenerator = new AssessmentDefaultMessageGenerator();
             const assessmentInstanceTableHandler = new AssessmentInstanceTableHandler(
                 detailsViewActionMessageCreator,

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -141,14 +141,6 @@ export class AssessmentBuilder {
             });
         };
 
-        const getIdentifier = (requirement: string) => {
-            const requirementConfig = AssessmentBuilder.getRequirementConfig(
-                requirements,
-                requirement,
-            );
-            return requirementConfig.key;
-        };
-
         const getNotificationMessage = (
             selectorMap: DictionaryStringTo<any>,
             requirement?: string,
@@ -175,7 +167,6 @@ export class AssessmentBuilder {
             getAssessmentData: data => data.assessments[key],
             key: `${key}Assessment`,
             getAnalyzer: getAnalyzer,
-            getIdentifier: getIdentifier,
             visualizationInstanceProcessor: () => VisualizationInstanceProcessor.nullProcessor,
             getDrawer: provider => provider.createNullDrawer(),
             getNotificationMessage: getNotificationMessage,
@@ -213,14 +204,6 @@ export class AssessmentBuilder {
                 });
             }
             return requirementConfig.getAnalyzer(provider);
-        };
-
-        const getIdentifier = (requirement: string) => {
-            const requirementConfig = AssessmentBuilder.getRequirementConfig(
-                requirements,
-                requirement,
-            );
-            return requirementConfig.key;
         };
 
         const getDrawer = (
@@ -271,7 +254,6 @@ export class AssessmentBuilder {
             ...assessment.visualizationConfiguration,
             key: assessment.storeDataKey,
             getAnalyzer: getAnalyzer,
-            getIdentifier: getIdentifier,
             visualizationInstanceProcessor:
                 AssessmentBuilder.getVisualizationInstanceProcessor(requirements),
             getDrawer: getDrawer,

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -148,7 +148,7 @@ async function initialize(): Promise<void> {
 
     const tabContextManager = new TabContextManager();
 
-    const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
+    const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(Assessments);
     const notificationCreator = new NotificationCreator(
         browserAdapter,
         visualizationConfigurationFactory,

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -157,7 +157,7 @@ async function initializeAsync(): Promise<void> {
 
     const tabContextManager = new TabContextManager();
 
-    const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
+    const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(Assessments);
     const notificationCreator = new NotificationCreator(
         browserAdapter,
         visualizationConfigurationFactory,

--- a/src/common/configs/assessment-visualization-configuration.ts
+++ b/src/common/configs/assessment-visualization-configuration.ts
@@ -32,7 +32,6 @@ export interface AssessmentVisualizationConfiguration {
     analyzerProgressMessageType?: string;
     telemetryProcessor?: TelemetryProcessor<IAnalyzerTelemetryCallback>;
     getAnalyzer: (analyzerProvider: AnalyzerProvider, testStep?: string) => Analyzer;
-    getIdentifier: (testStep?: string) => string;
     visualizationInstanceProcessor: (testStep?: string) => VisualizationInstanceProcessorCallback;
     getNotificationMessage: (
         selectorMap: DictionaryStringTo<any>,

--- a/src/common/configs/test-mode.ts
+++ b/src/common/configs/test-mode.ts
@@ -3,4 +3,5 @@
 export enum TestMode {
     Adhoc = 'adhoc',
     Assessments = 'assessments',
+    MediumPass = 'mediumPass',
 }

--- a/src/common/configs/visualization-configuration-factory.ts
+++ b/src/common/configs/visualization-configuration-factory.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Requirement } from 'assessments/types/requirement';
 import { DictionaryStringTo } from '../../types/common-types';
 import { VisualizationType } from '../types/visualization-type';
 import { VisualizationConfiguration } from './visualization-configuration';
@@ -12,4 +13,11 @@ export interface VisualizationConfigurationFactory {
     getConfigurationByKey(key: string): VisualizationConfiguration;
     getConfiguration(visualizationType: VisualizationType): VisualizationConfiguration;
     getChromeCommandToVisualizationTypeMap(): DictionaryStringTo<VisualizationType>;
+    forEachConfig(callback: ForEachConfigCallback): (Promise<void> | void)[];
 }
+
+export type ForEachConfigCallback = (
+    config: VisualizationConfiguration,
+    type: VisualizationType,
+    requirementConfig?: Requirement,
+) => void | Promise<void>;

--- a/src/common/configs/visualization-configuration.ts
+++ b/src/common/configs/visualization-configuration.ts
@@ -27,4 +27,5 @@ export interface VisualizationConfiguration extends AssessmentVisualizationConfi
     analyzerTerminatedMessageType?: string;
     guidance?: ContentPageComponent;
     shouldShowExportReport: () => boolean;
+    getIdentifier: (testStep?: string) => string;
 }

--- a/src/injected/analyzer-controller.ts
+++ b/src/injected/analyzer-controller.ts
@@ -5,11 +5,9 @@ import { GetDetailsSwitcherNavConfiguration } from 'DetailsView/components/detai
 import { ShadowInitializer } from 'injected/shadow-initializer';
 import { BaseStore } from '../common/base-store';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
-import { EnumHelper } from '../common/enum-helper';
 import { FeatureFlagStoreData } from '../common/types/store-data/feature-flag-store-data';
 import { ScopingStoreData } from '../common/types/store-data/scoping-store-data';
 import { VisualizationStoreData } from '../common/types/store-data/visualization-store-data';
-import { VisualizationType } from '../common/types/visualization-type';
 import { DictionaryStringTo } from '../types/common-types';
 import { AnalyzerStateUpdateHandler } from './analyzer-state-update-handler';
 import { Analyzer } from './analyzers/analyzer';
@@ -23,7 +21,6 @@ export class AnalyzerController {
     private featureFlagStore: BaseStore<FeatureFlagStoreData, Promise<void>>;
     private visualizationConfigurationFactory: VisualizationConfigurationFactory;
     private analyzerStateUpdateHandler: AnalyzerStateUpdateHandler;
-    private assessmentsProvider: AssessmentsProvider;
 
     constructor(
         visualizationstore: BaseStore<VisualizationStoreData, Promise<void>>,
@@ -42,7 +39,6 @@ export class AnalyzerController {
         this.featureFlagStore = featureFlagStore;
         this.visualizationConfigurationFactory = visualizationConfigurationFactory;
         this.analyzerProvider = analyzerProvider;
-        this.assessmentsProvider = assessmentsProvider;
         this.analyzerStateUpdateHandler = analyzerStateUpdateHandler;
         this.analyzerStateUpdateHandler.setupHandlers(this.startScan, this.teardown);
     }
@@ -82,27 +78,22 @@ export class AnalyzerController {
     };
 
     private initializeAnalyzers(): void {
-        EnumHelper.getNumericValues(VisualizationType).forEach((test: VisualizationType) => {
-            const config = this.visualizationConfigurationFactory.getConfiguration(test);
-            if (this.assessmentsProvider.isValidType(test)) {
-                this.assessmentsProvider.forType(test).requirements.forEach(stepConfig => {
-                    this.analyzers[stepConfig.key] = config.getAnalyzer(
-                        this.analyzerProvider,
-                        stepConfig.key,
-                    );
-                });
-            } else {
-                const key = config.getIdentifier();
-                this.analyzers[key] = config.getAnalyzer(this.analyzerProvider);
-            }
-        });
+        this.visualizationConfigurationFactory.forEachConfig(
+            (testConfig, type, requirementConfig) => {
+                const identifier = testConfig.getIdentifier(requirementConfig?.key);
+                this.analyzers[identifier] = testConfig.getAnalyzer(
+                    this.analyzerProvider,
+                    requirementConfig?.key,
+                );
+            },
+        );
     }
 
-    private getAnalyzerByIdentifier(key: string): Analyzer {
-        if (!this.analyzers[key]) {
+    private getAnalyzerByIdentifier(identifier: string): Analyzer {
+        if (!this.analyzers[identifier]) {
             return null;
         }
-        return this.analyzers[key];
+        return this.analyzers[identifier];
     }
 
     private hasInitializedStores(): boolean {

--- a/src/injected/analyzer-state-update-handler.ts
+++ b/src/injected/analyzer-state-update-handler.ts
@@ -1,14 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { TestMode } from '../common/configs/test-mode';
 import { VisualizationConfiguration } from '../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
-import { EnumHelper } from '../common/enum-helper';
-import {
-    AssessmentScanData,
-    VisualizationStoreData,
-} from '../common/types/store-data/visualization-store-data';
-import { VisualizationType } from '../common/types/visualization-type';
+import { VisualizationStoreData } from '../common/types/store-data/visualization-store-data';
 
 export class AnalyzerStateUpdateHandler {
     protected prevState: VisualizationStoreData;
@@ -41,19 +35,27 @@ export class AnalyzerStateUpdateHandler {
         prevState: VisualizationStoreData,
         currState: VisualizationStoreData,
     ): void {
-        const types = EnumHelper.getNumericValues<VisualizationType>(VisualizationType);
-        types.forEach(visualizationType => {
-            if (prevState != null) {
-                const configuration =
-                    this.visualizationConfigurationFactory.getConfiguration(visualizationType);
-                const keys = this.getTestKeysFromConfiguration(configuration, currState);
-                keys.forEach(testKey => {
-                    if (this.isTestTerminated(configuration, prevState, currState, testKey)) {
-                        this.teardown(configuration.getIdentifier(testKey));
-                    }
-                });
-            }
-        });
+        if (prevState == null) {
+            return;
+        }
+
+        this.visualizationConfigurationFactory.forEachConfig(
+            (configuration, type, requirementConfig) => {
+                if (
+                    !this.isTestTerminated(
+                        configuration,
+                        prevState,
+                        currState,
+                        requirementConfig?.key,
+                    )
+                ) {
+                    return;
+                }
+
+                const identifier = configuration.getIdentifier(requirementConfig?.key);
+                this.teardown(identifier);
+            },
+        );
     }
 
     private startAnalyzers(
@@ -75,32 +77,12 @@ export class AnalyzerStateUpdateHandler {
         config: VisualizationConfiguration,
         prevState: VisualizationStoreData,
         currState: VisualizationStoreData,
-        step: string,
+        requirement: string,
     ): boolean {
         const prevScanState = config.getStoreData(prevState.tests);
         const currScanState = config.getStoreData(currState.tests);
-        const prevEnabled = config.getTestStatus(prevScanState, step);
-        const currEnabled = config.getTestStatus(currScanState, step);
-        return prevState != null && prevEnabled === true && currEnabled === false;
-    }
-
-    private getTestKeysFromConfiguration(
-        config: VisualizationConfiguration,
-        currState: VisualizationStoreData,
-    ): string[] {
-        const keys = [];
-        if (this.isAssessment(config)) {
-            const prevScanState = config.getStoreData(currState.tests) as AssessmentScanData;
-            Object.keys(prevScanState.stepStatus).forEach(step => {
-                keys.push(config.getIdentifier(step));
-            });
-        } else {
-            keys.push(config.getIdentifier());
-        }
-        return keys;
-    }
-
-    private isAssessment(config: VisualizationConfiguration): boolean {
-        return config.testMode === TestMode.Assessments;
+        const prevEnabled = config.getTestStatus(prevScanState, requirement);
+        const currEnabled = config.getTestStatus(currScanState, requirement);
+        return prevEnabled === true && currEnabled === false;
     }
 }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
 import { createToolData } from 'common/application-properties-provider';
-import { EnumHelper } from 'common/enum-helper';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unavailable';
 import { Logger } from 'common/logging/logger';
@@ -13,7 +12,6 @@ import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs
 import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
 import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
-import { VisualizationType } from 'common/types/visualization-type';
 import { toolName } from 'content/strings/application';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { GetDetailsSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
@@ -260,9 +258,8 @@ export class MainWindowInitializer extends WindowInitializer {
         );
 
         const visualizationStateChangeHandler = new VisualizationStateChangeHandler(
-            EnumHelper.getNumericValues(VisualizationType),
             targetPageVisualizationUpdater.updateVisualization,
-            Assessments,
+            this.visualizationConfigurationFactory,
         );
 
         clientStoreListener.registerOnReadyToExecuteVisualizationCallback(

--- a/src/injected/visualization-state-change-handler.ts
+++ b/src/injected/visualization-state-change-handler.ts
@@ -1,35 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { VisualizationType } from 'common/types/visualization-type';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 
-import { AssessmentsProvider } from '../assessments/types/assessments-provider';
 import { TargetPageStoreData } from './client-store-listener';
 import { UpdateVisualization } from './target-page-visualization-updater';
 
 export class VisualizationStateChangeHandler {
     constructor(
-        private visualizations: VisualizationType[],
         private visualizationUpdater: UpdateVisualization,
-        private assessmentProvider: AssessmentsProvider,
+        private visualizationConfigurationFactory: VisualizationConfigurationFactory,
     ) {}
 
     public updateVisualizationsWithStoreData = async (storeData: TargetPageStoreData) => {
         if (!storeData.assessmentStoreData) {
             return;
         }
+
         await Promise.all(
-            this.visualizations.map(async visualizationType => {
-                if (this.assessmentProvider.isValidType(visualizationType)) {
-                    const stepMap = this.assessmentProvider.getStepMap(visualizationType);
-                    await Promise.all(
-                        Object.values(stepMap).map(step =>
-                            this.visualizationUpdater(visualizationType, step.key, storeData),
-                        ),
-                    );
-                } else {
-                    await this.visualizationUpdater(visualizationType, null, storeData);
-                }
-            }),
+            this.visualizationConfigurationFactory.forEachConfig(
+                async (testConfig, type, requirementConfig) => {
+                    await this.visualizationUpdater(type, requirementConfig?.key, storeData);
+                },
+            ),
         );
     };
 }

--- a/src/injected/visualization-type-drawer-registrar.ts
+++ b/src/injected/visualization-type-drawer-registrar.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
+import { Requirement } from 'assessments/types/requirement';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import {
+    ForEachConfigCallback,
+    VisualizationConfigurationFactory,
+} from '../common/configs/visualization-configuration-factory';
 import { VisualizationType } from '../common/types/visualization-type';
 import { Drawer } from './visualization/drawer';
 import { DrawerProvider } from './visualization/drawer-provider';
@@ -12,24 +16,22 @@ export class VisualizationTypeDrawerRegistrar {
     constructor(
         private registerDrawer: RegisterDrawer,
         private visualizationConfigurationFactory: VisualizationConfigurationFactory,
-        private assessmentProvider: AssessmentsProvider,
         private drawerProvider: DrawerProvider,
     ) {}
 
-    public registerType = (visualizationType: VisualizationType) => {
-        const config = this.visualizationConfigurationFactory.getConfiguration(visualizationType);
-        if (this.assessmentProvider.isValidType(visualizationType)) {
-            const steps = this.assessmentProvider.getStepMap(visualizationType);
-            Object.keys(steps).forEach(key => {
-                const step = steps[key];
-                const id = config.getIdentifier(step.key);
-                const drawer = config.getDrawer(this.drawerProvider, id);
-                this.registerDrawer(id, drawer);
-            });
-        } else {
-            const id = config.getIdentifier();
-            const drawer = config.getDrawer(this.drawerProvider);
-            this.registerDrawer(id, drawer);
-        }
+    public registerAllVisualizations = () => {
+        this.visualizationConfigurationFactory.forEachConfig(
+            this.registerVisualizationConfiguration,
+        );
+    };
+
+    private registerVisualizationConfiguration: ForEachConfigCallback = (
+        config: VisualizationConfiguration,
+        type: VisualizationType,
+        requirementConfig?: Requirement,
+    ) => {
+        const id = config.getIdentifier(requirementConfig?.key);
+        const drawer = config.getDrawer(this.drawerProvider, requirementConfig?.key);
+        this.registerDrawer(id, drawer);
     };
 }

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -115,7 +115,9 @@ export class WindowInitializer {
         );
         asyncInitializationSteps.push(this.shadowInitializer.initialize());
 
-        this.visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
+        this.visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
+            Assessments,
+        );
 
         const backchannelWindowMessageTranslator = new BackchannelWindowMessageTranslator(
             this.browserAdapter,

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -32,9 +32,7 @@ import UAParser from 'ua-parser-js';
 import { AppDataAdapter } from '../common/browser-adapters/app-data-adapter';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
-import { EnumHelper } from '../common/enum-helper';
 import { HTMLElementUtils } from '../common/html-element-utils';
-import { VisualizationType } from '../common/types/visualization-type';
 import { generateUID } from '../common/uid-generator';
 import { WindowUtils } from '../common/window-utils';
 import { Assessments } from './../assessments/assessments';
@@ -228,13 +226,10 @@ export class WindowInitializer {
         const visualizationTypeDrawerRegistrar = new VisualizationTypeDrawerRegistrar(
             this.drawingController.registerDrawer,
             this.visualizationConfigurationFactory,
-            Assessments,
             drawerProvider,
         );
 
-        EnumHelper.getNumericValues(VisualizationType).forEach(
-            visualizationTypeDrawerRegistrar.registerType,
-        );
+        visualizationTypeDrawerRegistrar.registerAllVisualizations();
 
         this.elementFinderByPosition = new ElementFinderByPosition(
             this.frameMessenger,

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { loadTheme } from '@fluentui/react';
+import { Assessments } from 'assessments/assessments';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { DocumentManipulator } from 'common/document-manipulator';
@@ -161,7 +162,9 @@ export class PopupInitializer {
             storeUpdateMessageHub,
         );
 
-        const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
+        const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
+            Assessments,
+        );
         const launchPadRowConfigurationFactory = new LaunchPadRowConfigurationFactory();
 
         const diagnosticViewClickHandler: DiagnosticViewClickHandler =

--- a/src/tests/unit/common/visualization-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-store-data-builder.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Assessments } from 'assessments/assessments';
 import { VisualizationStore } from 'background/stores/visualization-store';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { cloneDeep, forOwn } from 'lodash';
@@ -18,7 +19,7 @@ export class VisualizationStoreDataBuilder extends BaseDataBuilder<Visualization
             null,
             null,
             null,
-            new WebVisualizationConfigurationFactory(),
+            new WebVisualizationConfigurationFactory(Assessments),
             null,
             null,
             null,

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -105,7 +105,6 @@ describe('AssessmentBuilderTest', () => {
             vizStoreData.assessments.manualAssessmentKeyAssessment.stepStatus[testRequirement],
         ).toBe(true);
 
-        expect(config.getIdentifier(selectedRequirementKey)).toBe(requirement.key);
         expect(config.visualizationInstanceProcessor()).toBe(
             VisualizationInstanceProcessor.nullProcessor,
         );
@@ -282,7 +281,6 @@ describe('AssessmentBuilderTest', () => {
         expect(config.telemetryProcessor(telemetryFactoryStub as TelemetryDataFactory)).toEqual(
             telemetryFactoryStub.forAssessmentRequirementScan,
         );
-        expect(config.getIdentifier(selectedRequirementKey)).toBe(requirement1.key);
         expect(config.visualizationInstanceProcessor(selectedRequirementKey)).toBe(
             visualizationInstanceProcessorMock.object,
         );

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Assessments } from 'assessments/assessments';
 import { ActionCreator } from 'background/actions/action-creator';
 import { ActionHub } from 'background/actions/action-hub';
 import {
@@ -1307,7 +1308,7 @@ class ActionCreatorValidator {
             this.detailsViewControllerStrictMock.object,
             this.telemetryEventHandlerStrictMock.object,
             this.notificationCreatorStrictMock.object,
-            new WebVisualizationConfigurationFactory(),
+            new WebVisualizationConfigurationFactory(Assessments),
             this.targetTabControllerStrictMock.object,
             this.loggerMock.object,
         );

--- a/src/tests/unit/tests/background/keyboard-shortcut-handler.test.ts
+++ b/src/tests/unit/tests/background/keyboard-shortcut-handler.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Assessments } from 'assessments/assessments';
 import { KeyboardShortcutHandler } from 'background/keyboard-shortcut-handler';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
 import { TabContextStoreHub } from 'background/stores/tab-context-store-hub';
@@ -50,7 +51,7 @@ describe('KeyboardShortcutHandler', () => {
     const testSource: TelemetryEventSource = TelemetryEventSource.ShortcutCommand;
 
     beforeEach(() => {
-        visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
+        visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(Assessments);
 
         visualizationStoreMock = Mock.ofType(VisualizationStore, MockBehavior.Strict);
         visualizationStoreMock.setup(vs => vs.getState()).returns(() => storeState);
@@ -114,7 +115,7 @@ describe('KeyboardShortcutHandler', () => {
             browserAdapterMock.object,
             urlValidatorMock.object,
             notificationCreatorMock.object,
-            new WebVisualizationConfigurationFactory(),
+            new WebVisualizationConfigurationFactory(Assessments),
             new TelemetryDataFactory(),
             userConfigurationStoreMock.object,
             commandsAdapterMock.object,

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Assessments } from 'assessments/assessments';
 import { HeadingsTestStep } from 'assessments/headings/test-steps/test-steps';
 import { LandmarkTestStep } from 'assessments/landmarks/test-steps/test-steps';
 import {
@@ -12,6 +13,7 @@ import { InjectionActions } from 'background/actions/injection-actions';
 import { TabActions } from 'background/actions/tab-actions';
 import { VisualizationActions } from 'background/actions/visualization-actions';
 import { VisualizationStore } from 'background/stores/visualization-store';
+import { TestMode } from 'common/configs/test-mode';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { AdHocTestkeys } from 'common/types/store-data/adhoc-test-keys';
 import { cloneDeep } from 'lodash';
@@ -328,7 +330,7 @@ describe('VisualizationStoreTest ', () => {
             .withHeadingsAssessment(true, payload.requirement)
             .withHeadingsEnable()
             .with('injectingRequested', true)
-            .with('scanning', HeadingsTestStep.missingHeadings)
+            .with('scanning', `${TestMode.Assessments}-${HeadingsTestStep.missingHeadings}`)
             .build();
 
         const storeTester =
@@ -351,7 +353,7 @@ describe('VisualizationStoreTest ', () => {
             .withLandmarksAssessment(false, LandmarkTestStep.landmarkRoles)
             .withHeadingsAssessment(true, payload.requirement)
             .with('injectingRequested', true)
-            .with('scanning', HeadingsTestStep.missingHeadings)
+            .with('scanning', `${TestMode.Assessments}-${HeadingsTestStep.missingHeadings}`)
             .build();
 
         const storeTester =
@@ -374,7 +376,7 @@ describe('VisualizationStoreTest ', () => {
             .withHeadingsAssessment(false, HeadingsTestStep.headingFunction)
             .withHeadingsAssessment(true, payload.requirement)
             .with('injectingRequested', true)
-            .with('scanning', HeadingsTestStep.missingHeadings)
+            .with('scanning', `${TestMode.Assessments}-${HeadingsTestStep.missingHeadings}`)
             .build();
 
         const storeTester =
@@ -832,7 +834,7 @@ describe('VisualizationStoreTest ', () => {
                 new VisualizationActions(),
                 actions,
                 new InjectionActions(),
-                new WebVisualizationConfigurationFactory(),
+                new WebVisualizationConfigurationFactory(Assessments),
                 null,
                 null,
                 null,
@@ -851,7 +853,7 @@ describe('VisualizationStoreTest ', () => {
                 actions,
                 new TabActions(),
                 new InjectionActions(),
-                new WebVisualizationConfigurationFactory(),
+                new WebVisualizationConfigurationFactory(Assessments),
                 null,
                 null,
                 null,
@@ -870,7 +872,7 @@ describe('VisualizationStoreTest ', () => {
                 new VisualizationActions(),
                 new TabActions(),
                 actions,
-                new WebVisualizationConfigurationFactory(),
+                new WebVisualizationConfigurationFactory(Assessments),
                 null,
                 null,
                 null,

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Assessments } from 'assessments/assessments';
 import { BrowserMessageBroadcasterFactory } from 'background/browser-message-broadcaster-factory';
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
 import { PersistedData } from 'background/get-persisted-data';
@@ -34,7 +35,9 @@ import { StoreUpdateMessage } from '../../../../common/types/store-update-messag
 import { VisualizationType } from '../../../../common/types/visualization-type';
 
 function getConfigs(visualizationType: VisualizationType): VisualizationConfiguration {
-    return new WebVisualizationConfigurationFactory().getConfiguration(visualizationType);
+    return new WebVisualizationConfigurationFactory(Assessments).getConfiguration(
+        visualizationType,
+    );
 }
 
 describe('TabContextFactoryTest', () => {

--- a/src/tests/unit/tests/common/configs/__snapshots__/web-visualization-configuration-factory.test.ts.snap
+++ b/src/tests/unit/tests/common/configs/__snapshots__/web-visualization-configuration-factory.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WebVisualizationConfigurationFactory getChromeCommandToVisualizationTypeMap 1`] = `
+{
+  "01_toggle-issues": 1,
+  "02_toggle-landmarks": 2,
+  "03_toggle-headings": 0,
+  "04_toggle-tabStops": 3,
+  "05_toggle-color": 4,
+  "06_toggle-needsReview": 29,
+  "07_toggle-accessibleNames": 30,
+}
+`;
+
+exports[`WebVisualizationConfigurationFactory getChromeCommandToVisualizationTypeMap where a config does not have a chrome command 1`] = `
+{
+  "01_toggle-issues": 1,
+  "02_toggle-landmarks": 2,
+  "03_toggle-headings": 0,
+  "04_toggle-tabStops": 3,
+  "06_toggle-needsReview": 29,
+  "07_toggle-accessibleNames": 30,
+}
+`;

--- a/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
+++ b/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
@@ -1,9 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { Assessment } from 'assessments/types/iassessment';
+import { Requirement } from 'assessments/types/requirement';
+import { TestMode } from 'common/configs/test-mode';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
-import { each } from 'lodash';
-import { EnumHelper } from '../../../../../common/enum-helper';
+import { forOwn } from 'lodash';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { DictionaryNumberTo } from 'types/common-types';
 import {
     AssessmentData,
     AssessmentStoreData,
@@ -17,7 +23,18 @@ import { VisualizationType } from '../../../../../common/types/visualization-typ
 import { VisualizationStoreDataBuilder } from '../../../common/visualization-store-data-builder';
 
 describe('WebVisualizationConfigurationFactory', () => {
-    const testObject = new WebVisualizationConfigurationFactory();
+    let testObject: WebVisualizationConfigurationFactory;
+
+    let mediumPassProviderMock: IMock<AssessmentsProvider>;
+
+    beforeEach(() => {
+        mediumPassProviderMock = Mock.ofType<AssessmentsProvider>();
+        mediumPassProviderMock.setup(m => m.isValidType(It.isAny())).returns(() => false);
+        testObject = new WebVisualizationConfigurationFactory(
+            Assessments,
+            mediumPassProviderMock.object,
+        );
+    });
 
     test('get config for unsupported type', () => {
         const invalidType = -1 as VisualizationType;
@@ -124,33 +141,116 @@ describe('WebVisualizationConfigurationFactory', () => {
         testDisplayableData(VisualizationType.TabStops);
     });
 
-    test('get chrome commands to visualization type maps', () => {
+    test('getChromeCommandToVisualizationTypeMap', () => {
         const result = testObject.getChromeCommandToVisualizationTypeMap();
-
-        const types = EnumHelper.getNumericValues<VisualizationType>(VisualizationType);
-
-        each(types, visualizationType => {
-            const configuration = testObject.getConfiguration(visualizationType);
-
-            if (configuration.chromeCommand != null) {
-                expect(visualizationType).toBe(result[configuration.chromeCommand]);
-            } else {
-                expect(result[visualizationType]).toBeUndefined();
-            }
-        });
+        expect(result).toMatchSnapshot();
     });
 
-    test('getConfiguration', () => {
-        const types = EnumHelper.getNumericValues<VisualizationType>(VisualizationType);
-
-        types.forEach(visualizationType => {
-            const configuration = testObject.getConfiguration(visualizationType);
-
-            expect(configuration).toBeDefined();
-        });
+    test('getChromeCommandToVisualizationTypeMap where a config does not have a chrome command', () => {
+        const configurationByTypeStub = {
+            [VisualizationType.Color]: {} as VisualizationConfiguration,
+        } as DictionaryNumberTo<VisualizationConfiguration>;
+        (testObject as any).configurationByType = {
+            ...(testObject as any).configurationByType,
+            ...configurationByTypeStub,
+        };
+        const result = testObject.getChromeCommandToVisualizationTypeMap();
+        expect(result).toMatchSnapshot();
     });
 
-    test('getConfigurationByKey for visualizations', () => {
+    test('forEachConfig', () => {
+        const assessmentProviderMock = Mock.ofType<AssessmentsProvider>();
+        const mediumPassProviderMock = Mock.ofType<AssessmentsProvider>();
+        const callbackMock =
+            Mock.ofType<
+                (
+                    config: VisualizationConfiguration,
+                    type: VisualizationType,
+                    requirementConfig?: Requirement,
+                ) => void
+            >();
+
+        testObject = new WebVisualizationConfigurationFactory(
+            assessmentProviderMock.object,
+            mediumPassProviderMock.object,
+        );
+        const assessmentStubs = [getAssessmentStub('a-1', -1), getAssessmentStub('a-2', -2)];
+
+        assessmentProviderMock.setup(mock => mock.all()).returns(() => assessmentStubs);
+
+        testObject.forEachConfig(callbackMock.object);
+
+        verifyEachProviderConfigIsCalled(callbackMock, assessmentStubs, TestMode.Assessments);
+        forOwn(
+            (testObject as any).configurationByType,
+            (config: VisualizationConfiguration, key: string) => {
+                const type = Number(key);
+                callbackMock.verify(m => m(config, type), Times.once());
+            },
+        );
+    });
+
+    function getAssessmentStub(title: string, visualizationType: VisualizationType): Assessment {
+        const requirementsStub = [
+            {
+                key: 'req-1',
+            },
+            {
+                key: 'req-2',
+            },
+        ] as Requirement[];
+        return {
+            title,
+            visualizationType,
+            requirements: requirementsStub,
+            getVisualizationConfiguration: () => {},
+        } as Assessment;
+    }
+
+    function verifyEachProviderConfigIsCalled(
+        callbackMock: IMock<
+            (
+                config: VisualizationConfiguration,
+                type: VisualizationType,
+                requirementConfig?: Requirement,
+            ) => void
+        >,
+        assessmentStubs: Readonly<Assessment>[],
+        testMode: TestMode,
+    ) {
+        assessmentStubs.forEach(stub => {
+            stub.requirements.forEach(reqStub =>
+                callbackMock.verify(
+                    m =>
+                        m(
+                            It.isObjectWith(getAssessmentDefaults(stub.title, testMode)),
+                            stub.visualizationType,
+                            reqStub,
+                        ),
+                    Times.once(),
+                ),
+            );
+        });
+    }
+
+    test('getConfiguration for mediumPass', () => {
+        const type = VisualizationType.HeadingsAssessment;
+        const assessmentStub = {
+            title: 'some title',
+            getVisualizationConfiguration: () => ({ key: 'some key' }),
+        } as Assessment;
+        const expectedDefaults = getAssessmentDefaults(assessmentStub.title, TestMode.MediumPass);
+        const expected = {
+            ...assessmentStub.getVisualizationConfiguration(),
+            ...expectedDefaults,
+        };
+        mediumPassProviderMock.reset();
+        mediumPassProviderMock.setup(m => m.isValidType(type)).returns(() => true);
+        mediumPassProviderMock.setup(m => m.forType(type)).returns(() => assessmentStub);
+        expect(testObject.getConfiguration(type)).toMatchObject(expected);
+    });
+
+    test('getConfigurationByKey for adhoc visualizations', () => {
         const keys = ['color', 'headings', 'landmarks', 'tabStops', 'issues'];
 
         keys.forEach(key => {
@@ -196,5 +296,25 @@ describe('WebVisualizationConfigurationFactory', () => {
         const expected = getExpectedData(data);
 
         expect(scanData).toEqual(expected);
+    }
+
+    function getAssessmentDefaults(
+        expectedDisplayableTitle: string,
+        testMode: TestMode,
+    ): Partial<VisualizationConfiguration> {
+        return {
+            testMode,
+            chromeCommand: null,
+            launchPanelDisplayOrder: null,
+            adhocToolsPanelDisplayOrder: null,
+            displayableData: {
+                title: expectedDisplayableTitle,
+                noResultsFound: null,
+                enableMessage: null,
+                toggleLabel: null,
+                linkToDetailsViewText: null,
+            },
+            shouldShowExportReport: null,
+        };
     }
 });

--- a/src/tests/unit/tests/injected/visualization-type-drawer-registrar.test.ts
+++ b/src/tests/unit/tests/injected/visualization-type-drawer-registrar.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Requirement } from 'assessments/types/requirement';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
@@ -11,87 +10,68 @@ import {
 } from 'injected/visualization-type-drawer-registrar';
 import { Drawer } from 'injected/visualization/drawer';
 import { DrawerProvider } from 'injected/visualization/drawer-provider';
-import { IMock, Mock } from 'typemoq';
+import { IMock, It, Mock } from 'typemoq';
 
 describe('VisualizationTypeDrawerRegistrar', () => {
     let registerDrawerMock: IMock<RegisterDrawer>;
     let visualizationConfigFactoryMock: IMock<VisualizationConfigurationFactory>;
-    let assessmentProviderMock: IMock<AssessmentsProvider>;
     let drawerProviderMock: IMock<DrawerProvider>;
     let testSubject: VisualizationTypeDrawerRegistrar;
     let typeStub: VisualizationType;
     let configMock: IMock<VisualizationConfiguration>;
     let identifierStub: string;
     let drawerStub: Drawer;
+    let requirementStub: Requirement;
 
     beforeEach(() => {
         registerDrawerMock = Mock.ofType<RegisterDrawer>();
         visualizationConfigFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
-        assessmentProviderMock = Mock.ofType<AssessmentsProvider>();
         drawerProviderMock = Mock.ofType<DrawerProvider>();
         typeStub = -1;
         configMock = Mock.ofType<VisualizationConfiguration>();
         identifierStub = 'some id';
         drawerStub = {} as Drawer;
+        requirementStub = {
+            key: 'some requirement',
+        } as Requirement;
 
         testSubject = new VisualizationTypeDrawerRegistrar(
             registerDrawerMock.object,
             visualizationConfigFactoryMock.object,
-            assessmentProviderMock.object,
             drawerProviderMock.object,
         );
     });
 
-    test('registerDrawer: non-assessment type', () => {
+    test('registerAllVisualizations: with requirement', () => {
         visualizationConfigFactoryMock
-            .setup(mock => mock.getConfiguration(typeStub))
-            .returns(() => configMock.object);
-        assessmentProviderMock.setup(mock => mock.isValidType(typeStub)).returns(() => false);
-        configMock.setup(mock => mock.getIdentifier()).returns(() => identifierStub);
-        configMock
-            .setup(mock => mock.getDrawer(drawerProviderMock.object))
-            .returns(() => drawerStub);
-        registerDrawerMock.setup(mock => mock(identifierStub, drawerStub)).verifiable();
-
-        testSubject.registerType(typeStub);
-
-        registerDrawerMock.verifyAll();
-    });
-
-    test('registerDrawer: assessment type', () => {
-        const requirementStub = {
-            key: 'some key',
-        } as Requirement;
-        const requirementStubTwo = {
-            key: 'some other key',
-        } as Requirement;
-        const stepMapStub = {
-            [requirementStub.key]: requirementStub,
-            [requirementStubTwo.key]: requirementStubTwo,
-        };
-        const secondIdentifierStub = 'some other id';
-
-        visualizationConfigFactoryMock
-            .setup(mock => mock.getConfiguration(typeStub))
-            .returns(() => configMock.object);
-        assessmentProviderMock.setup(mock => mock.isValidType(typeStub)).returns(() => true);
-        assessmentProviderMock.setup(mock => mock.getStepMap(typeStub)).returns(() => stepMapStub);
+            .setup(m => m.forEachConfig(It.isAny()))
+            .callback(cb => {
+                cb(configMock.object, typeStub, requirementStub);
+            });
         configMock
             .setup(mock => mock.getIdentifier(requirementStub.key))
             .returns(() => identifierStub);
         configMock
-            .setup(mock => mock.getIdentifier(requirementStubTwo.key))
-            .returns(() => secondIdentifierStub);
-        configMock
-            .setup(mock => mock.getDrawer(drawerProviderMock.object, identifierStub))
-            .returns(() => drawerStub);
-        configMock
-            .setup(mock => mock.getDrawer(drawerProviderMock.object, secondIdentifierStub))
+            .setup(mock => mock.getDrawer(drawerProviderMock.object, requirementStub.key))
             .returns(() => drawerStub);
         registerDrawerMock.setup(mock => mock(identifierStub, drawerStub)).verifiable();
-        registerDrawerMock.setup(mock => mock(secondIdentifierStub, drawerStub)).verifiable();
+        testSubject.registerAllVisualizations();
 
-        testSubject.registerType(typeStub);
+        registerDrawerMock.verifyAll();
+    });
+
+    test('registerAllVisualizations: with no requirement', () => {
+        visualizationConfigFactoryMock
+            .setup(m => m.forEachConfig(It.isAny()))
+            .callback(cb => {
+                cb(configMock.object, typeStub);
+            });
+        configMock.setup(mock => mock.getIdentifier(undefined)).returns(() => identifierStub);
+        configMock
+            .setup(mock => mock.getDrawer(drawerProviderMock.object, undefined))
+            .returns(() => drawerStub);
+        registerDrawerMock.setup(mock => mock(identifierStub, drawerStub)).verifiable();
+        testSubject.registerAllVisualizations();
 
         registerDrawerMock.verifyAll();
     });

--- a/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
+++ b/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Link } from '@fluentui/react';
+import { Assessments } from 'assessments/assessments';
 import { VisualizationToggle } from 'common/components/visualization-toggle';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
@@ -27,7 +28,7 @@ import { ShortcutCommandsTestData } from '../../../common/sample-test-data';
 import { VisualizationStoreDataBuilder } from '../../../common/visualization-store-data-builder';
 
 describe('DiagnosticViewToggleTest', () => {
-    const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
+    const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(Assessments);
     const testTelemetrySource: TelemetryEventSource = -1 as TelemetryEventSource;
     const eventStubFactory = new EventStubFactory();
 
@@ -338,7 +339,9 @@ describe('DiagnosticViewToggleTest', () => {
 class DiagnosticViewTogglePropsBuilder {
     private visualizationType: VisualizationType;
     private data: VisualizationStoreData = new VisualizationStoreDataBuilder().build();
-    private visualizationConfigurationFactory = new WebVisualizationConfigurationFactory();
+    private visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
+        Assessments,
+    );
     private defaultVisualizationConfigurationFactoryMock =
         Mock.ofType<VisualizationConfigurationFactory>();
     private actionMessageCreatorMock = Mock.ofType(PopupActionMessageCreator);

--- a/src/tests/unit/tests/popup/handlers/diagnostic-view-toggle-click-handler.test.ts
+++ b/src/tests/unit/tests/popup/handlers/diagnostic-view-toggle-click-handler.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Assessments } from 'assessments/assessments';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { It, Mock } from 'typemoq';
 
@@ -52,7 +53,7 @@ describe('DiagnosticViewToggleClickHandlerTest', () => {
         const testObject = new DiagnosticViewClickHandler(
             telemetryFactoryMock.object,
             visualizationActionCreatorMock.object,
-            new WebVisualizationConfigurationFactory(),
+            new WebVisualizationConfigurationFactory(Assessments),
         );
         testObject.toggleVisualization(visualizationStoreData, visualizationType, event);
 
@@ -97,7 +98,7 @@ describe('DiagnosticViewToggleClickHandlerTest', () => {
         const testObject = new DiagnosticViewClickHandler(
             telemetryFactoryMock.object,
             visualizationActionCreatorMock.object,
-            new WebVisualizationConfigurationFactory(),
+            new WebVisualizationConfigurationFactory(Assessments),
         );
         testObject.toggleVisualization(visualizationStoreData, visualizationType, event);
 


### PR DESCRIPTION
#### Details

This PR can roughly be broken into 3 things:

1. Use constructor to pass in assessment and medium pass provider: this requires the most amount of file changes as each usage/creation of the factory needs to be changed.
2. Add the ability to loop through each configuration from the factory instead of components being responsible for this. The benefit here is that each component doing this no longer needs to be aware of the difference between assessment and not but also the structure of the assessment data.
3. Consumption of this forEachConfig method in the appropriate locations.

##### Motivation

feature work.

##### Context

1. `getIdentifier` is refactored out of AssessmentBuilder. This allows us to use test mode as a part of generating the identifier allowing for it to be unique across medium pass and assessment; removing it is the 3rd commit but adding it to config factory is in the first commit.
2. The mediumPass provider is currently optional so as not to cause issues/errors as the work on that is in the next PR. This will be removed in that PR as well.
3. I did verify that the async behavior in `VisualizationStateChangeHandler` was kept the same.
4. There is obviously a lot of potential refactoring work around the configuration factory (many tests don't mock it, we could build configs only once, we could break the building from the using/getting, etc.) but this PR is large enough as it is and I tried to maintain what we were doing in the main branch as best as I could.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
