### PR TITLE
fix: Work around codeql github action timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,8 @@ jobs:
 
     - uses: github/codeql-action/init@v2
       timeout-minutes: 2
+      with:
+        trap-caching: false
     
     - uses: github/codeql-action/autobuild@v2
       timeout-minutes: 2


### PR DESCRIPTION
#### Details

The codeql action has been timing out in our CI consistently since this weekend. It appears that it's the same issue described in the description of https://github.com/github/codeql-action/pull/1373, so since the work around implemented in that PR has not yet been released, I'm working around it here by just temporarily disabling trap caching. 

##### Motivation

Work around codeql timeouts

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn null:autoadd`
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
