### PR TITLE
chore(deps): Bump electron version to 19.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
         "appium-adb": "^9.10.2",
         "axe-core": "4.4.1",
         "classnames": "^2.3.2",
-        "electron": "19.0.7",
+        "electron": "19.0.11",
         "electron-log": "^4.4.8",
         "electron-updater": "^5.2.1",
         "idb-keyval": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
         "appium-adb": "^9.10.2",
         "axe-core": "4.4.1",
         "classnames": "^2.3.2",
-        "electron": "19.0.11",
+        "electron": "19.1.3",
         "electron-log": "^4.4.8",
         "electron-updater": "^5.2.1",
         "idb-keyval": "^6.2.0",

--- a/pipeline/scripts/electron-build-id.js
+++ b/pipeline/scripts/electron-build-id.js
@@ -6,4 +6,4 @@ This number identifies an internally-maintained Electron build
 used in our releases. Each Electron update in package.json requires
 a corresponding change here.
 */
-exports.electronBuildId = '14306133';
+exports.electronBuildId = '16272414';

--- a/src/tests/electron/tests/framework-no-codecs.test.ts
+++ b/src/tests/electron/tests/framework-no-codecs.test.ts
@@ -58,8 +58,8 @@ it('electron versions in package.json and build id are updated together', async 
     };
     expect(versions).toMatchInlineSnapshot(`
         {
-          "electronBuildId": "14306133",
-          "electronVersion": "19.0.7",
+          "electronBuildId": "16272414",
+          "electronVersion": "19.1.3",
         }
     `);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5573,10 +5573,10 @@ electron-updater@^5.2.1:
     semver "^7.3.5"
     typed-emitter "^2.1.0"
 
-electron@19.0.11:
-  version "19.0.11"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.11.tgz#0c0a52abc08694fd38916d9270baf45bb7752a27"
-  integrity sha512-GPM6C1Ze17/gR4koTE171MxrI5unYfFRgXQdkMdpWM2Cd55LMUrVa0QHCsfKpsaloufv9T65lsOn0uZuzCw5UA==
+electron@19.1.3:
+  version "19.1.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.1.3.tgz#90a2b6c3d738789d657477d87d1539f008be6536"
+  integrity sha512-P2kfFc8UqVvPHE1w9qTZSPNpfOqd+CK34K3wBqJwokzYdVBLsVkbIoLxyByjJ/cU35WaeCL5bsI8kXALfPvebw==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5573,10 +5573,10 @@ electron-updater@^5.2.1:
     semver "^7.3.5"
     typed-emitter "^2.1.0"
 
-electron@19.0.7:
-  version "19.0.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.7.tgz#c7a7841646adc6457de70b93661cc400bfdf9d38"
-  integrity sha512-Wyg+oGkY8cWYmm8tVka6CZmhJxnyUx+Us2ALyWiY4w73+dO9XUNB/c7vQNIm1Uk/DLMn9vFzgvcS9YtOOMqpbg==
+electron@19.0.11:
+  version "19.0.11"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.11.tgz#0c0a52abc08694fd38916d9270baf45bb7752a27"
+  integrity sha512-GPM6C1Ze17/gR4koTE171MxrI5unYfFRgXQdkMdpWM2Cd55LMUrVa0QHCsfKpsaloufv9T65lsOn0uZuzCw5UA==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
#### Details

Bump electron version from 19.0.7 to 19.1.3.

Unified unsigned release pipeline test run: https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=39898&view=results

##### Motivation

Security alert

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
