### PR TITLE
feat(medium-pass-1): refactor messages out of assessment action message creator

### DIFF
--- a/src/DetailsView/actions/assessment-action-message-creator.ts
+++ b/src/DetailsView/actions/assessment-action-message-creator.ts
@@ -18,8 +18,9 @@ import {
     ToggleActionPayload,
 } from 'background/actions/action-payloads';
 import { DevToolActionMessageCreator } from 'common/message-creators/dev-tool-action-message-creator';
-import { Messages } from 'common/messages';
-import { SupportedMouseEvent } from 'common/telemetry-data-factory';
+import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
+import { AssessmentMessages, Messages } from 'common/messages';
+import { SupportedMouseEvent, TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { FailureInstanceData } from 'common/types/failure-instance-data';
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import { VersionedAssessmentData } from 'common/types/versioned-assessment-data';
@@ -28,6 +29,14 @@ import * as React from 'react';
 import { DetailsViewRightContentPanelType } from '../../common/types/store-data/details-view-right-content-panel-type';
 
 export class AssessmentActionMessageCreator extends DevToolActionMessageCreator {
+    constructor(
+        protected readonly telemetryFactory: TelemetryDataFactory,
+        protected readonly dispatcher: ActionMessageDispatcher,
+        protected readonly messages: AssessmentMessages,
+    ) {
+        super(telemetryFactory, dispatcher);
+    }
+
     public selectRequirement(
         event: React.MouseEvent<HTMLElement>,
         selectedRequirement: string,
@@ -44,7 +53,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SelectTestRequirement,
+            messageType: this.messages.SelectTestRequirement,
             payload: payload,
         });
     }
@@ -65,7 +74,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SelectNextRequirement,
+            messageType: this.messages.SelectNextRequirement,
             payload: payload,
         });
     }
@@ -80,7 +89,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SelectGettingStarted,
+            messageType: this.messages.SelectGettingStarted,
             payload: payload,
         });
     }
@@ -91,14 +100,14 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ExpandTestNav,
+            messageType: this.messages.ExpandTestNav,
             payload: payload,
         });
     }
 
     public collapseTestNav(): void {
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.CollapseTestNav,
+            messageType: this.messages.CollapseTestNav,
         });
     }
 
@@ -110,7 +119,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.StartOverTest,
+            messageType: this.messages.StartOverTest,
             payload,
         });
     }
@@ -132,8 +141,8 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
 
         this.dispatcher.dispatchMessage({
             messageType: shouldScan
-                ? Messages.Assessment.EnableVisualHelper
-                : Messages.Assessment.EnableVisualHelperWithoutScan,
+                ? this.messages.EnableVisualHelper
+                : this.messages.EnableVisualHelperWithoutScan,
             payload,
         });
     }
@@ -144,7 +153,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.DisableVisualHelperForTest,
+            messageType: this.messages.DisableVisualHelperForTest,
             payload,
         });
     }
@@ -157,7 +166,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.DisableVisualHelper,
+            messageType: this.messages.DisableVisualHelper,
             payload,
         });
     }
@@ -178,7 +187,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeStatus,
+            messageType: this.messages.ChangeStatus,
             payload,
         });
     };
@@ -197,7 +206,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeRequirementStatus,
+            messageType: this.messages.ChangeRequirementStatus,
             payload,
         });
     };
@@ -216,7 +225,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.Undo,
+            messageType: this.messages.Undo,
             payload,
         });
     };
@@ -233,7 +242,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.UndoChangeRequirementStatus,
+            messageType: this.messages.UndoChangeRequirementStatus,
             payload,
         });
     };
@@ -254,7 +263,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeVisualizationState,
+            messageType: this.messages.ChangeVisualizationState,
             payload,
         });
     };
@@ -265,7 +274,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.AddResultDescription,
+            messageType: this.messages.AddResultDescription,
             payload,
         });
     }
@@ -284,7 +293,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.AddFailureInstance,
+            messageType: this.messages.AddFailureInstance,
             payload,
         });
     }
@@ -303,7 +312,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.RemoveFailureInstance,
+            messageType: this.messages.RemoveFailureInstance,
             payload,
         });
     };
@@ -324,7 +333,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.EditFailureInstance,
+            messageType: this.messages.EditFailureInstance,
             payload,
         });
     };
@@ -338,7 +347,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.PassUnmarkedInstances,
+            messageType: this.messages.PassUnmarkedInstances,
             payload,
         });
     }
@@ -357,7 +366,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ChangeVisualizationStateForAll,
+            messageType: this.messages.ChangeVisualizationStateForAll,
             payload,
         });
     }
@@ -368,7 +377,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
             telemetry: telemetry,
         };
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ContinuePreviousAssessment,
+            messageType: this.messages.ContinuePreviousAssessment,
             payload,
         });
     };
@@ -391,7 +400,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
             payload: setDetailsViewRightContentPanelPayload,
         });
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.LoadAssessment,
+            messageType: this.messages.LoadAssessment,
             payload,
         });
     };
@@ -403,7 +412,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.SaveAssessment,
+            messageType: this.messages.SaveAssessment,
             payload,
         });
     };
@@ -420,7 +429,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
             payload: setDetailsViewRightContentPanelPayload,
         });
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.StartOverAllAssessments,
+            messageType: this.messages.StartOverAllAssessments,
             payload: startOverAllAssessmentsActionPayload,
         });
     };
@@ -436,7 +445,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.CancelStartOver,
+            messageType: this.messages.CancelStartOver,
             payload,
         });
     };
@@ -448,7 +457,7 @@ export class AssessmentActionMessageCreator extends DevToolActionMessageCreator 
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.CancelStartOverAllAssessments,
+            messageType: this.messages.CancelStartOverAllAssessments,
             payload,
         });
     };

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -32,6 +32,7 @@ import { createDefaultLogger } from 'common/logging/default-logger';
 import { Logger } from 'common/logging/logger';
 import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
 import { NeedsReviewCardSelectionMessageCreator } from 'common/message-creators/needs-review-card-selection-message-creator';
+import { Messages } from 'common/messages';
 import { getNarrowModeThresholdsForWeb } from 'common/narrow-mode-thresholds';
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { ExceptionTelemetryListener } from 'common/telemetry/exception-telemetry-listener';
@@ -297,6 +298,7 @@ if (tabId != null) {
             const assessmentActionMessageCreator = new AssessmentActionMessageCreator(
                 telemetryFactory,
                 actionMessageDispatcher,
+                Messages.Assessment,
             );
 
             const scopingActionMessageCreator = new ScopingActionMessageCreator(

--- a/src/background/actions/quick-assess-action-creator.ts
+++ b/src/background/actions/quick-assess-action-creator.ts
@@ -74,7 +74,7 @@ export class MediumPassActionCreator {
             this.onAssessmentScanCompleted,
         );
         this.interpreter.registerTypeToPayloadCallback(
-            MediumPassMessages.StartOverAssessment,
+            MediumPassMessages.StartOverTest,
             this.onStartOverAssessment,
         );
         this.interpreter.registerTypeToPayloadCallback(

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -7,7 +7,7 @@ export const getStoreStateMessage = (storeName: StoreNames): string => {
     return `${messagePrefix}/${StoreNames[storeName]}/state/current`;
 };
 
-export type AssessmentMessages = typeof Messages.Assessment & typeof Messages.MediumPass;
+export type AssessmentMessages = typeof Messages.Assessment | typeof Messages.MediumPass;
 
 export const Messages = {
     Visualizations: {
@@ -133,7 +133,7 @@ export const Messages = {
         TrackingCompleted: `${messagePrefix}/mediumPass/tab-stops/recording-completed`,
         CancelStartOver: `${messagePrefix}/mediumPass/cancel-start-over`,
         CancelStartOverAllAssessments: `${messagePrefix}/mediumPass/cancel-start-over-all-assessments`,
-        StartOverAssessment: `${messagePrefix}/mediumPass/startOverTest`,
+        StartOverTest: `${messagePrefix}/mediumPass/startOverTest`,
         StartOverAllAssessments: `${messagePrefix}/mediumPass/startOverAllAssessments`,
         EnableVisualHelper: `${messagePrefix}/mediumPass/enableVisualHelper`,
         EnableVisualHelperWithoutScan: `${messagePrefix}/mediumPass/enableVisualHelperWithoutScan`,

--- a/src/tests/unit/tests/DetailsView/actions/assessment-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/assessment-action-message-creator.test.ts
@@ -6,6 +6,7 @@ import { ActionMessageDispatcher } from 'common/message-creators/types/dispatche
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { VersionedAssessmentData } from 'common/types/versioned-assessment-data';
 import { AssessmentActionMessageCreator } from 'DetailsView/actions/assessment-action-message-creator';
+import { keys } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
 import {
     AssessmentTelemetryData,
@@ -16,7 +17,7 @@ import {
     TelemetryEventSource,
     TriggeredByNotApplicable,
 } from '../../../../../common/extension-telemetry-events';
-import { Messages } from '../../../../../common/messages';
+import { AssessmentMessages, Messages } from '../../../../../common/messages';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { EventStubFactory } from '../../../common/event-stub-factory';
@@ -27,6 +28,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
     let telemetryFactoryMock: IMock<TelemetryDataFactory>;
     let dispatcherMock: IMock<ActionMessageDispatcher>;
     let testSubject: AssessmentActionMessageCreator;
+    const assessmentMessageStubs = getMessageStubs();
 
     beforeEach(() => {
         dispatcherMock = Mock.ofType<ActionMessageDispatcher>();
@@ -34,8 +36,18 @@ describe('AssessmentActionMessageCreatorTest', () => {
         testSubject = new AssessmentActionMessageCreator(
             telemetryFactoryMock.object,
             dispatcherMock.object,
+            assessmentMessageStubs,
         );
     });
+
+    function getMessageStubs(): AssessmentMessages {
+        const messagesMock = Mock.ofType<AssessmentMessages>();
+        const messagesStub = {} as AssessmentMessages;
+        keys(messagesMock.object).forEach(messageType => {
+            messagesStub[messageType] = `stub for ${messageType}`;
+        });
+        return messagesStub;
+    }
 
     test('selectRequirement', () => {
         const view = VisualizationType.Headings;
@@ -49,7 +61,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.SelectTestRequirement,
+            messageType: assessmentMessageStubs.SelectTestRequirement,
             payload: {
                 telemetry: telemetry,
                 selectedTestSubview: selectedRequirement,
@@ -81,7 +93,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.SelectNextRequirement,
+            messageType: assessmentMessageStubs.SelectNextRequirement,
             payload: {
                 telemetry: telemetry,
                 selectedTestSubview: selectedRequirement,
@@ -111,7 +123,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.SelectGettingStarted,
+            messageType: assessmentMessageStubs.SelectGettingStarted,
             payload: {
                 telemetry: telemetry,
                 selectedTest: view,
@@ -134,7 +146,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         const view = VisualizationType.Headings;
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ExpandTestNav,
+            messageType: assessmentMessageStubs.ExpandTestNav,
             payload: {
                 selectedTest: view,
             },
@@ -150,7 +162,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
 
     test('collapseTestNav', () => {
         const expectedMessage = {
-            messageType: Messages.Assessment.CollapseTestNav,
+            messageType: assessmentMessageStubs.CollapseTestNav,
         };
 
         testSubject.collapseTestNav();
@@ -170,7 +182,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.StartOverTest,
+            messageType: assessmentMessageStubs.StartOverTest,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 telemetry,
@@ -200,7 +212,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.EnableVisualHelper,
+            messageType: assessmentMessageStubs.EnableVisualHelper,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 requirement,
@@ -232,7 +244,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.EnableVisualHelperWithoutScan,
+            messageType: assessmentMessageStubs.EnableVisualHelperWithoutScan,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 requirement,
@@ -260,7 +272,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         const requirement = 'fake-requirement-name';
 
         const expectedMessage = {
-            messageType: Messages.Assessment.EnableVisualHelper,
+            messageType: assessmentMessageStubs.EnableVisualHelper,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 requirement,
@@ -294,7 +306,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         const requirement = 'fake-requirement-name';
 
         const expectedMessage = {
-            messageType: Messages.Assessment.EnableVisualHelperWithoutScan,
+            messageType: assessmentMessageStubs.EnableVisualHelperWithoutScan,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 requirement,
@@ -326,7 +338,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
 
     test('disableVisualHelpersForTest', () => {
         const expectedMessage = {
-            messageType: Messages.Assessment.DisableVisualHelperForTest,
+            messageType: assessmentMessageStubs.DisableVisualHelperForTest,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
             },
@@ -346,7 +358,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         const telemetry = {};
 
         const expectedMessage = {
-            messageType: Messages.Assessment.DisableVisualHelper,
+            messageType: assessmentMessageStubs.DisableVisualHelper,
             payload: {
                 test: test,
                 telemetry,
@@ -374,7 +386,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ChangeStatus,
+            messageType: assessmentMessageStubs.ChangeStatus,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -405,7 +417,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ChangeRequirementStatus,
+            messageType: assessmentMessageStubs.ChangeRequirementStatus,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -435,7 +447,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.Undo,
+            messageType: assessmentMessageStubs.Undo,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -463,7 +475,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.UndoChangeRequirementStatus,
+            messageType: assessmentMessageStubs.UndoChangeRequirementStatus,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -488,7 +500,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ChangeVisualizationState,
+            messageType: assessmentMessageStubs.ChangeVisualizationState,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -511,7 +523,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
     test('addResultDescription', () => {
         const persistedDescription = 'persisted description';
         const expectedMessage = {
-            messageType: Messages.Assessment.AddResultDescription,
+            messageType: assessmentMessageStubs.AddResultDescription,
             payload: {
                 description: persistedDescription,
             },
@@ -540,7 +552,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.AddFailureInstance,
+            messageType: assessmentMessageStubs.AddFailureInstance,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -569,7 +581,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.RemoveFailureInstance,
+            messageType: assessmentMessageStubs.RemoveFailureInstance,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -602,7 +614,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
             snippet: 'snippet',
         };
         const expectedMessage = {
-            messageType: Messages.Assessment.EditFailureInstance,
+            messageType: assessmentMessageStubs.EditFailureInstance,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -631,7 +643,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.PassUnmarkedInstances,
+            messageType: assessmentMessageStubs.PassUnmarkedInstances,
             payload: {
                 test: test,
                 requirement: requirement,
@@ -656,7 +668,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ChangeVisualizationStateForAll,
+            messageType: assessmentMessageStubs.ChangeVisualizationStateForAll,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -683,7 +695,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ContinuePreviousAssessment,
+            messageType: assessmentMessageStubs.ContinuePreviousAssessment,
             payload: {
                 telemetry,
             },
@@ -711,7 +723,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessageToLoadAssessment = {
-            messageType: Messages.Assessment.LoadAssessment,
+            messageType: assessmentMessageStubs.LoadAssessment,
             payload: {
                 tabId,
                 versionedAssessmentData: {
@@ -751,7 +763,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessageToStartOverAllAssessments = {
-            messageType: Messages.Assessment.StartOverAllAssessments,
+            messageType: assessmentMessageStubs.StartOverAllAssessments,
             payload: {
                 telemetry,
             },
@@ -791,7 +803,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.CancelStartOver,
+            messageType: assessmentMessageStubs.CancelStartOver,
             payload: {
                 telemetry,
             },
@@ -817,7 +829,7 @@ describe('AssessmentActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.CancelStartOverAllAssessments,
+            messageType: assessmentMessageStubs.CancelStartOverAllAssessments,
             payload: {
                 telemetry,
             },

--- a/src/tests/unit/tests/background/actions/quick-assess-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/quick-assess-action-creator.test.ts
@@ -458,7 +458,7 @@ describe('MediumPassActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
-        await interpreterMock.simulateMessage(MediumPassMessages.StartOverAssessment, payload);
+        await interpreterMock.simulateMessage(MediumPassMessages.StartOverTest, payload);
 
         resetDataMock.verifyAll();
     });


### PR DESCRIPTION
#### Details

Refactor message types out of assessment action message creator to be passed in at construction; allows us to pass in quick assess message types instead.

##### Motivation

Feature work.

##### Context


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
