### PR TITLE
feat(medium-pass-1): add visualization types for quick assess/medium pass

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -5,7 +5,11 @@ import { loadTheme, setFocusVisibility } from '@fluentui/react';
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
 import { Assessments } from 'assessments/assessments';
 import { assessmentsProviderWithFeaturesEnabled } from 'assessments/assessments-feature-flag-filter';
-import { MediumPassRequirementKeys } from 'assessments/medium-pass-requirements';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import {
+    MediumPassRequirementKeys,
+    MediumPassRequirementMap,
+} from 'assessments/medium-pass-requirements';
 import { UserConfigurationActions } from 'background/actions/user-configuration-actions';
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
@@ -341,6 +345,7 @@ if (tabId != null) {
             );
             const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
                 Assessments,
+                assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
             );
             const assessmentDefaultMessageGenerator = new AssessmentDefaultMessageGenerator();
             const assessmentInstanceTableHandler = new AssessmentInstanceTableHandler(

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -13,11 +13,7 @@ import { InstanceIdToInstanceDataMap } from 'common/types/store-data/assessment-
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import { DecoratedAxeNodeResult } from 'common/types/store-data/visualization-scan-result-data';
-import {
-    AssessmentScanData,
-    ScanData,
-    TestsEnabledState,
-} from 'common/types/store-data/visualization-store-data';
+import { AssessmentScanData, ScanData } from 'common/types/store-data/visualization-store-data';
 import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import {
     VisualizationInstanceProcessor,
@@ -155,12 +151,8 @@ export class AssessmentBuilder {
             return requirementConfig.getNotificationMessage(selectorMap);
         };
 
-        const getStoreData: (data: TestsEnabledState) => ScanData = data =>
-            data.assessments[`${key}Assessment`];
-
         const visualizationConfiguration: AssessmentVisualizationConfiguration = {
             testViewType: 'Assessment',
-            getStoreData: getStoreData,
             enableTest: AssessmentBuilder.enableTest,
             disableTest: AssessmentBuilder.disableTest,
             getTestStatus: AssessmentBuilder.getTestStatus,
@@ -235,9 +227,6 @@ export class AssessmentBuilder {
             return requirementConfig.getNotificationMessage(selectorMap);
         };
 
-        const getStoreData: (data: TestsEnabledState) => ScanData = data =>
-            data.assessments[assessment.storeDataKey];
-
         const visualizationConfiguration: AssessmentVisualizationConfiguration = {
             testViewType: 'Assessment',
             getAssessmentData: data => data.assessments[key],
@@ -246,7 +235,6 @@ export class AssessmentBuilder {
                 thisAssessment.fullAxeResultsMap = selectorMap;
                 thisAssessment.generatedAssessmentInstancesMap = instanceMap;
             },
-            getStoreData: getStoreData,
             enableTest: AssessmentBuilder.enableTest,
             disableTest: AssessmentBuilder.disableTest,
             getTestStatus: AssessmentBuilder.getTestStatus,

--- a/src/assessments/assessments-requirements-filter.ts
+++ b/src/assessments/assessments-requirements-filter.ts
@@ -1,28 +1,39 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AutomatedChecks } from 'assessments/automated-checks/assessment';
+import { VisualizationType } from 'common/types/visualization-type';
+import { DictionaryStringTo } from 'types/common-types';
 
 import { AssessmentsProviderImpl } from './assessments-provider';
 import { AssessmentsProvider } from './types/assessments-provider';
 
-// the assessmentProvider passed into this function should already
-// have been passed through the filter for feature flags
 export function assessmentsProviderForRequirements(
     assessmentProvider: AssessmentsProvider,
-    requirementKeys: string[],
+    requirementToVisualizationTypeMap: DictionaryStringTo<VisualizationType>,
 ): AssessmentsProvider {
     const assessments = assessmentProvider
         .all()
         .map(assessment => {
+            let type: VisualizationType;
+            const requirements = assessment.requirements.filter(req => {
+                if (requirementToVisualizationTypeMap[req.key]) {
+                    type = requirementToVisualizationTypeMap[req.key];
+                    return true;
+                }
+                return false;
+            });
+
             return {
                 ...assessment,
-                requirements: assessment.requirements.filter(requirement =>
-                    requirementKeys.includes(requirement.key),
-                ),
+                requirements,
+                visualizationType: type,
             };
         })
         .filter(assessment => assessment.requirements.length > 0);
-    assessments.unshift(AutomatedChecks);
+
+    const mediumPassAutomatedChecks = { ...AutomatedChecks };
+    mediumPassAutomatedChecks.visualizationType = VisualizationType.AutomatedChecksMediumPass;
+    assessments.unshift(mediumPassAutomatedChecks);
 
     return AssessmentsProviderImpl.Create(assessments);
 }

--- a/src/assessments/medium-pass-requirements.ts
+++ b/src/assessments/medium-pass-requirements.ts
@@ -7,6 +7,8 @@ import { KeyboardInteractionTestStep } from 'assessments/keyboard-interaction/te
 import { LinksTestStep } from 'assessments/links/test-steps/test-steps';
 import { RepetitiveContentTestStep } from 'assessments/repetitive-content/test-steps/test-steps';
 import { visibleFfocusOrderTestStep } from 'assessments/visible-focus-order/test-steps/test-steps';
+import { VisualizationType } from 'common/types/visualization-type';
+import { DictionaryStringTo } from 'types/common-types';
 
 export const MediumPassRequirementKeys: string[] = [
     KeyboardInteractionTestStep.keyboardNavigation,
@@ -19,3 +21,16 @@ export const MediumPassRequirementKeys: string[] = [
     RepetitiveContentTestStep.bypassBlocks,
     AdaptableContentTestStep.reflow,
 ];
+
+export const MediumPassRequirementMap: DictionaryStringTo<VisualizationType> = {
+    [KeyboardInteractionTestStep.keyboardNavigation]:
+        VisualizationType.KeyboardInteractionMediumPass,
+    [LinksTestStep.linkPurpose]: VisualizationType.LinksMediumPass,
+    [ImagesTestStep.imageFunction]: VisualizationType.ImagesMediumPass,
+    [visibleFfocusOrderTestStep.visibleFocus]: VisualizationType.VisibleFocusOrderMediumPass,
+    [AdaptableContentTestStep.contrast]: VisualizationType.AdaptableContentMediumPass,
+    [HeadingsTestStep.missingHeadings]: VisualizationType.HeadingsMediumPass,
+    [HeadingsTestStep.headingLevel]: VisualizationType.HeadingsMediumPass,
+    [RepetitiveContentTestStep.bypassBlocks]: VisualizationType.RepetitiveContentMediumPass,
+    [AdaptableContentTestStep.reflow]: VisualizationType.AdaptableContentMediumPass,
+};

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import { BackgroundMessageDistributor } from 'background/background-message-distributor';
 import { BrowserMessageBroadcasterFactory } from 'background/browser-message-broadcaster-factory';
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
@@ -157,7 +159,10 @@ async function initializeAsync(): Promise<void> {
 
     const tabContextManager = new TabContextManager();
 
-    const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(Assessments);
+    const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
+        Assessments,
+        assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+    );
     const notificationCreator = new NotificationCreator(
         browserAdapter,
         visualizationConfigurationFactory,

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -88,6 +88,7 @@ export class VisualizationStore extends PersistentStore<VisualizationStoreData> 
         const tests: TestsEnabledState = {
             adhoc: {},
             assessments: {},
+            mediumPass: {},
         };
 
         if (this.visualizationConfigurationFactory != null) {
@@ -100,6 +101,10 @@ export class VisualizationStore extends PersistentStore<VisualizationStoreData> 
 
             Object.keys(tests.assessments).forEach(key => {
                 tests.assessments[key].stepStatus = {};
+            });
+
+            Object.keys(tests.mediumPass).forEach(key => {
+                tests.mediumPass[key].stepStatus = {};
             });
         }
 
@@ -132,7 +137,7 @@ export class VisualizationStore extends PersistentStore<VisualizationStoreData> 
         const configuration = this.visualizationConfigurationFactory.getConfiguration(test);
         const scanData = configuration.getStoreData(this.state.tests);
 
-        if (this.isAssessment(configuration)) {
+        if (!this.isAdhoc(configuration)) {
             const assessmentScanData = configuration.getStoreData(
                 this.state.tests,
             ) as AssessmentScanData;
@@ -166,7 +171,7 @@ export class VisualizationStore extends PersistentStore<VisualizationStoreData> 
     private disableAssessmentVisualizationsWithoutEmitting(): void {
         EnumHelper.getNumericValues(VisualizationType).forEach((test: number) => {
             const configuration = this.visualizationConfigurationFactory.getConfiguration(test);
-            const shouldDisableTest = this.isAssessment(configuration);
+            const shouldDisableTest = !this.isAdhoc(configuration);
             if (shouldDisableTest) {
                 this.toggleTestOff(test);
             }
@@ -207,8 +212,8 @@ export class VisualizationStore extends PersistentStore<VisualizationStoreData> 
         await this.emitChanged();
     }
 
-    private isAssessment(config: VisualizationConfiguration): boolean {
-        return config.testMode === TestMode.Assessments;
+    private isAdhoc(config: VisualizationConfiguration): boolean {
+        return config.testMode === TestMode.Adhoc;
     }
 
     private onUpdateSelectedPivot = async (payload: UpdateSelectedPivot): Promise<void> => {

--- a/src/common/configs/assessment-visualization-configuration.ts
+++ b/src/common/configs/assessment-visualization-configuration.ts
@@ -11,7 +11,7 @@ import { DrawerProvider } from '../../injected/visualization/drawer-provider';
 import { DictionaryStringTo } from '../../types/common-types';
 import { IAnalyzerTelemetryCallback } from '../types/analyzer-telemetry-callbacks';
 import { AssessmentData, AssessmentStoreData } from '../types/store-data/assessment-result-data';
-import { ScanData, TestsEnabledState } from '../types/store-data/visualization-store-data';
+import { ScanData } from '../types/store-data/visualization-store-data';
 import { TelemetryProcessor } from '../types/telemetry-processor';
 import { TestViewOverrides, TestViewType } from '../types/test-view-type';
 
@@ -19,7 +19,6 @@ export interface AssessmentVisualizationConfiguration {
     key: string;
     testViewType: TestViewType;
     testViewOverrides?: TestViewOverrides;
-    getStoreData: (data: TestsEnabledState) => ScanData;
     enableTest: (data: ScanData, payload: ToggleActionPayload) => void;
     disableTest: (data: ScanData, step?: string) => void;
     getTestStatus: (data: ScanData, step?: string) => boolean;

--- a/src/common/configs/web-visualization-configuration-factory.ts
+++ b/src/common/configs/web-visualization-configuration-factory.ts
@@ -9,6 +9,7 @@ import { NeedsReviewAdHocVisualization } from 'ad-hoc-visualizations/needs-revie
 import { TabStopsAdHocVisualization } from 'ad-hoc-visualizations/tab-stops/visualization';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
+import { TestsEnabledState } from 'common/types/store-data/visualization-store-data';
 import { find, forOwn, values } from 'lodash';
 import { DictionaryNumberTo, DictionaryStringTo } from '../../types/common-types';
 import { VisualizationType } from '../types/visualization-type';
@@ -24,7 +25,7 @@ export class WebVisualizationConfigurationFactory implements VisualizationConfig
 
     constructor(
         private readonly fullAssessmentProvider: AssessmentsProvider,
-        private readonly mediumPassProvider?: AssessmentsProvider,
+        private readonly mediumPassProvider: AssessmentsProvider,
     ) {
         this.configurationByType = {
             [VisualizationType.Color]: ColorAdHocVisualization,
@@ -74,7 +75,7 @@ export class WebVisualizationConfigurationFactory implements VisualizationConfig
             });
         });
 
-        this.mediumPassProvider?.all().forEach(assessment => {
+        this.mediumPassProvider.all().forEach(assessment => {
             const testConfig = this.buildAssessmentConfiguration(assessment, TestMode.MediumPass);
 
             assessment.requirements.forEach(requirementConfig => {
@@ -94,6 +95,10 @@ export class WebVisualizationConfigurationFactory implements VisualizationConfig
             return `${testMode}-${requirement.key}`;
         };
 
+        const getStoreData = (data: TestsEnabledState) => {
+            return data[testMode][config.key];
+        };
+
         const defaults = {
             testMode,
             chromeCommand: null,
@@ -108,6 +113,7 @@ export class WebVisualizationConfigurationFactory implements VisualizationConfig
             },
             shouldShowExportReport: null,
             getIdentifier,
+            getStoreData,
         };
 
         return { ...config, ...defaults };

--- a/src/common/types/store-data/visualization-store-data.ts
+++ b/src/common/types/store-data/visualization-store-data.ts
@@ -32,4 +32,7 @@ export interface TestsEnabledState {
     adhoc: {
         [key: string]: ScanData;
     };
+    mediumPass: {
+        [key: string]: AssessmentScanData;
+    };
 }

--- a/src/common/types/visualization-type.ts
+++ b/src/common/types/visualization-type.ts
@@ -32,4 +32,12 @@ export enum VisualizationType {
     ContrastAssessment,
     NeedsReview,
     AccessibleNames,
+    KeyboardInteractionMediumPass,
+    LinksMediumPass,
+    ImagesMediumPass,
+    VisibleFocusOrderMediumPass,
+    AdaptableContentMediumPass,
+    HeadingsMediumPass,
+    RepetitiveContentMediumPass,
+    AutomatedChecksMediumPass,
 }

--- a/src/injected/is-visualization-enabled.ts
+++ b/src/injected/is-visualization-enabled.ts
@@ -24,12 +24,12 @@ export const isVisualizationEnabled: IsVisualizationEnabledCallback = (
     const scanData = config.getStoreData(visualizationState.tests);
     return (
         config.getTestStatus(scanData, step) &&
-        (!isAssessment(config) ||
+        (isAdhoc(config) ||
             assessmentState.persistedTabInfo === null ||
             tabState.id === assessmentState.persistedTabInfo.id)
     );
 };
 
-function isAssessment(config: VisualizationConfiguration): boolean {
-    return config.testMode === TestMode.Assessments;
+function isAdhoc(config: VisualizationConfiguration): boolean {
+    return config.testMode === TestMode.Adhoc;
 }

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -55,6 +55,8 @@ import { DrawerUtils } from './visualization/drawer-utils';
 import { RootContainerCreator } from './visualization/root-container-creator';
 
 // Required to initialize axe-core with our ruleset/branding
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import 'scanner/exposed-apis';
 
 export class WindowInitializer {
@@ -115,6 +117,7 @@ export class WindowInitializer {
 
         this.visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
             Assessments,
+            assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
         );
 
         const backchannelWindowMessageTranslator = new BackchannelWindowMessageTranslator(

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { getRTL } from '@fluentui/utilities';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import * as axe from 'axe-core';
 import { BrowserAdapterFactory } from 'common/browser-adapters/browser-adapter-factory';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
@@ -55,8 +57,6 @@ import { DrawerUtils } from './visualization/drawer-utils';
 import { RootContainerCreator } from './visualization/root-container-creator';
 
 // Required to initialize axe-core with our ruleset/branding
-import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
-import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import 'scanner/exposed-apis';
 
 export class WindowInitializer {

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 import { loadTheme } from '@fluentui/react';
 import { Assessments } from 'assessments/assessments';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { DocumentManipulator } from 'common/document-manipulator';
@@ -164,6 +166,7 @@ export class PopupInitializer {
 
         const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
             Assessments,
+            assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
         );
         const launchPadRowConfigurationFactory = new LaunchPadRowConfigurationFactory();
 

--- a/src/tests/unit/common/visualization-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-store-data-builder.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import { VisualizationStore } from 'background/stores/visualization-store';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { cloneDeep, forOwn } from 'lodash';
@@ -19,7 +21,10 @@ export class VisualizationStoreDataBuilder extends BaseDataBuilder<Visualization
             null,
             null,
             null,
-            new WebVisualizationConfigurationFactory(Assessments),
+            new WebVisualizationConfigurationFactory(
+                Assessments,
+                assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+            ),
             null,
             null,
             null,

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -335,6 +335,40 @@ exports[`DetailsViewBody render render 1`] = `
                 "stepStatus": {},
               },
             },
+            "mediumPass": {
+              "adaptableContentAssessment": {
+                "enabled": false,
+                "stepStatus": {},
+              },
+              "automatedChecks": {
+                "enabled": false,
+                "stepStatus": {},
+              },
+              "headingsAssessment": {
+                "enabled": false,
+                "stepStatus": {},
+              },
+              "imageAssessment": {
+                "enabled": false,
+                "stepStatus": {},
+              },
+              "keyboardInteractionAssessment": {
+                "enabled": false,
+                "stepStatus": {},
+              },
+              "linksAssessment": {
+                "enabled": false,
+                "stepStatus": {},
+              },
+              "repetitiveContentAssessment": {
+                "enabled": false,
+                "stepStatus": {},
+              },
+              "visibleFocusOrderAssessment": {
+                "enabled": false,
+                "stepStatus": {},
+              },
+            },
           },
         }
       }
@@ -660,6 +694,40 @@ exports[`DetailsViewBody render render 1`] = `
                   "stepStatus": {},
                 },
                 "timedEventsAssessment": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "visibleFocusOrderAssessment": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+              },
+              "mediumPass": {
+                "adaptableContentAssessment": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "automatedChecks": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "headingsAssessment": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "imageAssessment": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "keyboardInteractionAssessment": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "linksAssessment": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "repetitiveContentAssessment": {
                   "enabled": false,
                   "stepStatus": {},
                 },
@@ -1000,6 +1068,40 @@ exports[`DetailsViewBody render render 1`] = `
                       "stepStatus": {},
                     },
                     "timedEventsAssessment": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "visibleFocusOrderAssessment": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                  },
+                  "mediumPass": {
+                    "adaptableContentAssessment": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "automatedChecks": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "headingsAssessment": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "imageAssessment": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "keyboardInteractionAssessment": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "linksAssessment": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "repetitiveContentAssessment": {
                       "enabled": false,
                       "stepStatus": {},
                     },

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -386,6 +386,40 @@ exports[`DetailsViewContent render renders normally 1`] = `
               "stepStatus": {},
             },
           },
+          "mediumPass": {
+            "adaptableContentAssessment": {
+              "enabled": false,
+              "stepStatus": {},
+            },
+            "automatedChecks": {
+              "enabled": false,
+              "stepStatus": {},
+            },
+            "headingsAssessment": {
+              "enabled": false,
+              "stepStatus": {},
+            },
+            "imageAssessment": {
+              "enabled": false,
+              "stepStatus": {},
+            },
+            "keyboardInteractionAssessment": {
+              "enabled": false,
+              "stepStatus": {},
+            },
+            "linksAssessment": {
+              "enabled": false,
+              "stepStatus": {},
+            },
+            "repetitiveContentAssessment": {
+              "enabled": false,
+              "stepStatus": {},
+            },
+            "visibleFocusOrderAssessment": {
+              "enabled": false,
+              "stepStatus": {},
+            },
+          },
         },
       }
     }

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -94,7 +94,6 @@ describe('AssessmentBuilderTest', () => {
         const config = manual.getVisualizationConfiguration();
         const scanData = { enabled: true, stepStatus: { key: true } } as AssessmentScanData;
         const vizStoreData = { assessments: { manualAssessmentKeyAssessment: scanData } } as any;
-        expect(config.getStoreData(vizStoreData)).toEqual(scanData);
 
         const testRequirement = 'testRequirement';
         config.enableTest(scanData, {
@@ -259,6 +258,7 @@ describe('AssessmentBuilderTest', () => {
         const vizStoreData = {
             assessments: { headingsAssessment: scanData },
             adhoc: {},
+            mediumPass: {},
         } as TestsEnabledState;
 
         config.getAnalyzer(providerMock.object, requirement1.key);
@@ -277,7 +277,6 @@ describe('AssessmentBuilderTest', () => {
         expect(vizStoreData.assessments.headingsAssessment.enabled).toBe(true);
         expect(vizStoreData.assessments.headingsAssessment.stepStatus[testRequirement]).toBe(true);
 
-        expect(config.getStoreData(vizStoreData)).toEqual(scanData);
         expect(config.telemetryProcessor(telemetryFactoryStub as TelemetryDataFactory)).toEqual(
             telemetryFactoryStub.forAssessmentRequirementScan,
         );

--- a/src/tests/unit/tests/assessments/assessments-requirements-filter.test.ts
+++ b/src/tests/unit/tests/assessments/assessments-requirements-filter.test.ts
@@ -87,9 +87,9 @@ describe('filter by requirements', () => {
                 return;
             }
 
-            let baseAssessment = baseProvider.forKey(createdAssessment.key);
-            let baseConfig = baseAssessment.getVisualizationConfiguration();
-            let createdConfig = createdAssessment.getVisualizationConfiguration();
+            const baseAssessment = baseProvider.forKey(createdAssessment.key);
+            const baseConfig = baseAssessment.getVisualizationConfiguration();
+            const createdConfig = createdAssessment.getVisualizationConfiguration();
             expect(createdConfig).toMatchObject(baseConfig);
         });
     }

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import { ActionCreator } from 'background/actions/action-creator';
 import { ActionHub } from 'background/actions/action-hub';
 import {
@@ -1308,7 +1310,10 @@ class ActionCreatorValidator {
             this.detailsViewControllerStrictMock.object,
             this.telemetryEventHandlerStrictMock.object,
             this.notificationCreatorStrictMock.object,
-            new WebVisualizationConfigurationFactory(Assessments),
+            new WebVisualizationConfigurationFactory(
+                Assessments,
+                assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+            ),
             this.targetTabControllerStrictMock.object,
             this.loggerMock.object,
         );

--- a/src/tests/unit/tests/background/is-an-assessment-selected.test.ts
+++ b/src/tests/unit/tests/background/is-an-assessment-selected.test.ts
@@ -16,6 +16,7 @@ describe('isAnAssessmentSelectedTest', () => {
                 },
             },
             assessments: {},
+            mediumPass: {},
         };
 
         const actual = isAnAssessmentSelected(testData);
@@ -31,6 +32,7 @@ describe('isAnAssessmentSelectedTest', () => {
                     stepStatus: {},
                 },
             },
+            mediumPass: {},
         };
 
         const actual = isAnAssessmentSelected(testData);
@@ -47,6 +49,7 @@ describe('isAnAssessmentSelectedTest', () => {
                     stepStatus: {},
                 },
             },
+            mediumPass: {},
         };
 
         const actual = isAnAssessmentSelected(testData);

--- a/src/tests/unit/tests/background/keyboard-shortcut-handler.test.ts
+++ b/src/tests/unit/tests/background/keyboard-shortcut-handler.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import { KeyboardShortcutHandler } from 'background/keyboard-shortcut-handler';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
 import { TabContextStoreHub } from 'background/stores/tab-context-store-hub';
@@ -51,7 +53,10 @@ describe('KeyboardShortcutHandler', () => {
     const testSource: TelemetryEventSource = TelemetryEventSource.ShortcutCommand;
 
     beforeEach(() => {
-        visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(Assessments);
+        visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
+            Assessments,
+            assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+        );
 
         visualizationStoreMock = Mock.ofType(VisualizationStore, MockBehavior.Strict);
         visualizationStoreMock.setup(vs => vs.getState()).returns(() => storeState);
@@ -115,7 +120,10 @@ describe('KeyboardShortcutHandler', () => {
             browserAdapterMock.object,
             urlValidatorMock.object,
             notificationCreatorMock.object,
-            new WebVisualizationConfigurationFactory(Assessments),
+            new WebVisualizationConfigurationFactory(
+                Assessments,
+                assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+            ),
             new TelemetryDataFactory(),
             userConfigurationStoreMock.object,
             commandsAdapterMock.object,

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
 import { HeadingsTestStep } from 'assessments/headings/test-steps/test-steps';
 import { LandmarkTestStep } from 'assessments/landmarks/test-steps/test-steps';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import {
     AssessmentToggleActionPayload,
     ToggleActionPayload,
@@ -58,7 +60,6 @@ describe('VisualizationStoreTest ', () => {
                 detailsViewType: viewType,
                 pivotType: finalPivot,
             };
-
             const storeTester =
                 createStoreTesterForVisualizationActions(actionName).withActionParam(payload);
             await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
@@ -834,7 +835,10 @@ describe('VisualizationStoreTest ', () => {
                 new VisualizationActions(),
                 actions,
                 new InjectionActions(),
-                new WebVisualizationConfigurationFactory(Assessments),
+                new WebVisualizationConfigurationFactory(
+                    Assessments,
+                    assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+                ),
                 null,
                 null,
                 null,
@@ -853,7 +857,10 @@ describe('VisualizationStoreTest ', () => {
                 actions,
                 new TabActions(),
                 new InjectionActions(),
-                new WebVisualizationConfigurationFactory(Assessments),
+                new WebVisualizationConfigurationFactory(
+                    Assessments,
+                    assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+                ),
                 null,
                 null,
                 null,
@@ -872,7 +879,10 @@ describe('VisualizationStoreTest ', () => {
                 new VisualizationActions(),
                 new TabActions(),
                 actions,
-                new WebVisualizationConfigurationFactory(Assessments),
+                new WebVisualizationConfigurationFactory(
+                    Assessments,
+                    assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+                ),
                 null,
                 null,
                 null,

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import { BrowserMessageBroadcasterFactory } from 'background/browser-message-broadcaster-factory';
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
 import { PersistedData } from 'background/get-persisted-data';
@@ -35,9 +37,10 @@ import { StoreUpdateMessage } from '../../../../common/types/store-update-messag
 import { VisualizationType } from '../../../../common/types/visualization-type';
 
 function getConfigs(visualizationType: VisualizationType): VisualizationConfiguration {
-    return new WebVisualizationConfigurationFactory(Assessments).getConfiguration(
-        visualizationType,
-    );
+    return new WebVisualizationConfigurationFactory(
+        Assessments,
+        assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+    ).getConfiguration(visualizationType);
 }
 
 describe('TabContextFactoryTest', () => {

--- a/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
+++ b/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
@@ -266,7 +266,7 @@ describe('WebVisualizationConfigurationFactory', () => {
             `${TestMode.MediumPass}-${requirementKey}`,
         );
         expect(returnedConfiguration.getStoreData(testData)).toEqual(
-            testData.mediumPass[`${visualizationKeyStub}Assessment`],
+            testData.mediumPass[visualizationKeyStub],
         );
     });
 

--- a/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
+++ b/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
@@ -17,10 +17,10 @@ import {
 } from '../../../../../common/types/store-data/assessment-result-data';
 import {
     ScanData,
-    VisualizationStoreData,
+    TestsEnabledState,
+    TestsScanData,
 } from '../../../../../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { VisualizationStoreDataBuilder } from '../../../common/visualization-store-data-builder';
 
 describe('WebVisualizationConfigurationFactory', () => {
     let testObject: WebVisualizationConfigurationFactory;
@@ -47,24 +47,22 @@ describe('WebVisualizationConfigurationFactory', () => {
 
     test('getStoreData for color', () => {
         const visualizationType = VisualizationType.Color;
-        const getExpectedData: (data: VisualizationStoreData) => ScanData = data =>
-            data.tests.adhoc.color;
+        const getExpectedData: (data: TestsEnabledState) => ScanData = data => data.adhoc.color;
 
         testGetStoreData(visualizationType, getExpectedData);
     });
 
     test('getStoreData for headings', () => {
         const visualizationType = VisualizationType.Headings;
-        const getExpectedData: (data: VisualizationStoreData) => ScanData = data =>
-            data.tests.adhoc.headings;
+        const getExpectedData: (data: TestsEnabledState) => ScanData = data => data.adhoc.headings;
 
         testGetStoreData(visualizationType, getExpectedData);
     });
 
     test('getStoreData for headingsAssessment', () => {
         const visualizationType = VisualizationType.HeadingsAssessment;
-        const getExpectedData: (data: VisualizationStoreData) => ScanData = data =>
-            data.tests.assessments.headingsAssessment;
+        const getExpectedData: (data: TestsEnabledState) => ScanData = data =>
+            data.assessments.headingsAssessment;
 
         testGetStoreData(visualizationType, getExpectedData);
     });
@@ -95,24 +93,21 @@ describe('WebVisualizationConfigurationFactory', () => {
 
     test('getStoreData for issues', () => {
         const visualizationType = VisualizationType.Issues;
-        const getExpectedData: (data: VisualizationStoreData) => ScanData = data =>
-            data.tests.adhoc.issues;
+        const getExpectedData: (data: TestsEnabledState) => ScanData = data => data.adhoc.issues;
 
         testGetStoreData(visualizationType, getExpectedData);
     });
 
     test('getStoreData for landmarks', () => {
         const visualizationType = VisualizationType.Landmarks;
-        const getExpectedData: (data: VisualizationStoreData) => ScanData = data =>
-            data.tests.adhoc.landmarks;
+        const getExpectedData: (data: TestsEnabledState) => ScanData = data => data.adhoc.landmarks;
 
         testGetStoreData(visualizationType, getExpectedData);
     });
 
     test('getStoreData for tabStops', () => {
         const visualizationType = VisualizationType.TabStops;
-        const getExpectedData: (data: VisualizationStoreData) => ScanData = data =>
-            data.tests.adhoc.tabStops;
+        const getExpectedData: (data: TestsEnabledState) => ScanData = data => data.adhoc.tabStops;
 
         testGetStoreData(visualizationType, getExpectedData);
     });
@@ -238,10 +233,24 @@ describe('WebVisualizationConfigurationFactory', () => {
 
     test('getConfiguration for mediumPass', () => {
         const type = VisualizationType.HeadingsAssessment;
+        const requirementKey = 'some requirement key';
+        const visualizationKeyStub = 'some key';
         const assessmentStub = {
             title: 'some title',
-            getVisualizationConfiguration: () => ({ key: 'some key' }),
+            getVisualizationConfiguration: () => ({ key: visualizationKeyStub }),
+            requirements: [
+                {
+                    key: requirementKey,
+                },
+            ],
         } as Assessment;
+        const testData = {
+            [TestMode.MediumPass]: {
+                [visualizationKeyStub]: {
+                    enabled: true,
+                },
+            } as TestsScanData,
+        } as TestsEnabledState;
         const expectedDefaults = getAssessmentDefaults(assessmentStub.title, TestMode.MediumPass);
         const expected = {
             ...assessmentStub.getVisualizationConfiguration(),
@@ -250,7 +259,15 @@ describe('WebVisualizationConfigurationFactory', () => {
         mediumPassProviderMock.reset();
         mediumPassProviderMock.setup(m => m.isValidType(type)).returns(() => true);
         mediumPassProviderMock.setup(m => m.forType(type)).returns(() => assessmentStub);
-        expect(testObject.getConfiguration(type)).toMatchObject(expected);
+
+        const returnedConfiguration = testObject.getConfiguration(type);
+        expect(returnedConfiguration).toMatchObject(expected);
+        expect(returnedConfiguration.getIdentifier(requirementKey)).toEqual(
+            `${TestMode.MediumPass}-${requirementKey}`,
+        );
+        expect(returnedConfiguration.getStoreData(testData)).toEqual(
+            testData.mediumPass[`${visualizationKeyStub}Assessment`],
+        );
     });
 
     test('getConfigurationByKey for adhoc visualizations', () => {
@@ -288,13 +305,17 @@ describe('WebVisualizationConfigurationFactory', () => {
 
     function testGetStoreData(
         visualizationType: VisualizationType,
-        getExpectedData: (data: VisualizationStoreData) => ScanData,
+        getExpectedData: (data: TestsEnabledState) => ScanData,
     ): void {
-        const data = new VisualizationStoreDataBuilder().withEnable(visualizationType).build();
-
         const configuration = testObject.getConfiguration(visualizationType);
-
-        const scanData = configuration.getStoreData(data.tests);
+        const data = {
+            [configuration.testMode]: {
+                [configuration.key]: {
+                    enabled: true,
+                },
+            },
+        } as any;
+        const scanData = configuration.getStoreData(data);
 
         const expected = getExpectedData(data);
 

--- a/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
+++ b/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 import { Link } from '@fluentui/react';
 import { Assessments } from 'assessments/assessments';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import { VisualizationToggle } from 'common/components/visualization-toggle';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
@@ -28,7 +30,10 @@ import { ShortcutCommandsTestData } from '../../../common/sample-test-data';
 import { VisualizationStoreDataBuilder } from '../../../common/visualization-store-data-builder';
 
 describe('DiagnosticViewToggleTest', () => {
-    const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(Assessments);
+    const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
+        Assessments,
+        assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+    );
     const testTelemetrySource: TelemetryEventSource = -1 as TelemetryEventSource;
     const eventStubFactory = new EventStubFactory();
 
@@ -341,6 +346,7 @@ class DiagnosticViewTogglePropsBuilder {
     private data: VisualizationStoreData = new VisualizationStoreDataBuilder().build();
     private visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
         Assessments,
+        assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
     );
     private defaultVisualizationConfigurationFactoryMock =
         Mock.ofType<VisualizationConfigurationFactory>();

--- a/src/tests/unit/tests/popup/handlers/diagnostic-view-toggle-click-handler.test.ts
+++ b/src/tests/unit/tests/popup/handlers/diagnostic-view-toggle-click-handler.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { It, Mock } from 'typemoq';
 
@@ -53,7 +55,10 @@ describe('DiagnosticViewToggleClickHandlerTest', () => {
         const testObject = new DiagnosticViewClickHandler(
             telemetryFactoryMock.object,
             visualizationActionCreatorMock.object,
-            new WebVisualizationConfigurationFactory(Assessments),
+            new WebVisualizationConfigurationFactory(
+                Assessments,
+                assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+            ),
         );
         testObject.toggleVisualization(visualizationStoreData, visualizationType, event);
 
@@ -98,7 +103,10 @@ describe('DiagnosticViewToggleClickHandlerTest', () => {
         const testObject = new DiagnosticViewClickHandler(
             telemetryFactoryMock.object,
             visualizationActionCreatorMock.object,
-            new WebVisualizationConfigurationFactory(Assessments),
+            new WebVisualizationConfigurationFactory(
+                Assessments,
+                assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+            ),
         );
         testObject.toggleVisualization(visualizationStoreData, visualizationType, event);
 

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -75,7 +75,6 @@
         "./src/assessments/custom-widgets/design-pattern.ts",
         "./src/assessments/custom-widgets/test-steps/test-steps.ts",
         "./src/assessments/errors/test-steps/test-steps.ts",
-        "./src/assessments/headings/headings-instance-details-column-renderer.tsx",
         "./src/assessments/headings/test-steps/test-steps.ts",
         "./src/assessments/images/test-steps/test-steps.ts",
         "./src/assessments/keyboard-interaction/test-steps/test-steps.ts",

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -75,6 +75,7 @@
         "./src/assessments/custom-widgets/design-pattern.ts",
         "./src/assessments/custom-widgets/test-steps/test-steps.ts",
         "./src/assessments/errors/test-steps/test-steps.ts",
+        "./src/assessments/headings/headings-instance-details-column-renderer.tsx",
         "./src/assessments/headings/test-steps/test-steps.ts",
         "./src/assessments/images/test-steps/test-steps.ts",
         "./src/assessments/keyboard-interaction/test-steps/test-steps.ts",


### PR DESCRIPTION
#### Details

Adding new visualization types necessitates changes in many places. Generally speaking the changes fall into the following camps:
- VisualizationConfigurationFactory should not throw errors when a new visualization type is used for `getConfiguration`. This requires the medium pass provider be implemented and as such many changes in this PR are signature updates for the creation of the factory.
- `getStoreData` needs to be updated as this is another place where Assessment and QuickAssess will differ. As such, they've been removed from assessment-builder and moved to the config factory.
- Consequently this also means we must update the visualization store to contain mediumPass data.
- The requirement filter is modified to amend the VisualizationType on the configs and now uses a requirement/testStep to VisualizationType map to do so.
- Another minor change: checking the TestMode to be Adhoc instead of Assessment as QuickAssess and Assessment will share the same behavior. Don't feel super strong about this change but it made sense to me to at least rename these methods where applicable.

##### Motivation

Feature work.

##### Context

Overwriting the VisualizationType in the written Assessment configurations is not ideal. Ultimately, landed with this because we should move to an architecture where the assessment objects themselves do not contain VisualizationType but are also added/amended with some mapping. The changes made here do not make that work harder in the future so I went ahead with this for now.

This still uses medium pass in the naming because it was written before the quick assess name change; should not be an issue to change later.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
