### PR TITLE
feat(medium-pass-1): Create base analyzer configuration in analyzer-controller and pipe into getAnalyzer

### DIFF
--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -8,12 +8,12 @@ import {
     UniquelyIdentifiableInstances,
 } from 'background/instance-identifier-generator';
 import { AssessmentVisualizationConfiguration } from 'common/configs/assessment-visualization-configuration';
-import { Messages } from 'common/messages';
 import { InstanceIdToInstanceDataMap } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import { DecoratedAxeNodeResult } from 'common/types/store-data/visualization-scan-result-data';
 import { AssessmentScanData, ScanData } from 'common/types/store-data/visualization-store-data';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import {
     VisualizationInstanceProcessor,
@@ -125,16 +125,8 @@ export class AssessmentBuilder {
         requirements.forEach(AssessmentBuilder.applyDefaultReportFieldMap);
         requirements.forEach(AssessmentBuilder.applyDefaultFunctions);
 
-        const getAnalyzer = (provider: AnalyzerProvider, requirement: string) => {
-            const requirementConfig = AssessmentBuilder.getRequirementConfig(
-                requirements,
-                requirement,
-            );
-            return provider.createBaseAnalyzer({
-                key: requirementConfig.key,
-                testType: assessment.visualizationType,
-                analyzerMessageType: Messages.Assessment.AssessmentScanCompleted,
-            });
+        const getAnalyzer = (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) => {
+            return provider.createBaseAnalyzer(analyzerConfig);
         };
 
         const getNotificationMessage = (
@@ -183,19 +175,15 @@ export class AssessmentBuilder {
         requirements.forEach(AssessmentBuilder.applyDefaultReportFieldMap);
         requirements.forEach(AssessmentBuilder.applyDefaultFunctions);
 
-        const getAnalyzer = (provider: AnalyzerProvider, requirement: string) => {
+        const getAnalyzer = (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) => {
             const requirementConfig = AssessmentBuilder.getRequirementConfig(
                 requirements,
-                requirement,
+                analyzerConfig.key,
             );
             if (requirementConfig.getAnalyzer == null) {
-                return provider.createBaseAnalyzer({
-                    key: requirementConfig.key,
-                    testType: assessment.visualizationType,
-                    analyzerMessageType: Messages.Assessment.AssessmentScanCompleted,
-                });
+                return provider.createBaseAnalyzer(analyzerConfig);
             }
-            return requirementConfig.getAnalyzer(provider);
+            return requirementConfig.getAnalyzer(provider, analyzerConfig);
         };
 
         const getDrawer = (

--- a/src/assessments/automated-checks/build-test-steps-from-rules.tsx
+++ b/src/assessments/automated-checks/build-test-steps-from-rules.tsx
@@ -6,11 +6,9 @@ import {
 } from 'assessments/common/element-column-renderers';
 import { InstanceIdentifierGenerator } from 'background/instance-identifier-generator';
 import { NewTabLink } from 'common/components/new-tab-link';
-import { Messages } from 'common/messages';
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import { DecoratedAxeNodeResult } from 'common/types/store-data/visualization-scan-result-data';
-import { VisualizationType } from 'common/types/visualization-type';
-import { RuleAnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerConfiguration, RuleAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
@@ -29,14 +27,12 @@ function buildAutomatedCheckStep(rule: ScannerRuleInfo): Requirement {
             </NewTabLink>
         </React.Fragment>
     );
-    const getAnalyzer = (provider: AnalyzerProvider) => {
+    const getAnalyzer = (provider: AnalyzerProvider, baseConfig: AnalyzerConfiguration) => {
         const analyzerConfiguration: RuleAnalyzerConfiguration = {
+            ...baseConfig,
             resultProcessor: (scanner: ScannerUtils) => scanner.getFailingOrPassingInstances,
             telemetryProcessor: telemetryFactory => telemetryFactory.forAssessmentRequirementScan,
-            analyzerMessageType: Messages.Assessment.AssessmentScanCompleted,
             rules: [rule.id],
-            key: rule.id,
-            testType: VisualizationType.AutomatedChecks,
         };
 
         return provider.createBatchedRuleAnalyzer(analyzerConfiguration);

--- a/src/assessments/types/requirement.ts
+++ b/src/assessments/types/requirement.ts
@@ -13,7 +13,7 @@ import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import { DecoratedAxeNodeResult } from 'common/types/store-data/visualization-scan-result-data';
 import { AssessmentActionMessageCreator } from 'DetailsView/actions/assessment-action-message-creator';
-import { Analyzer } from 'injected/analyzers/analyzer';
+import { Analyzer, AnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { VisualizationInstanceProcessorCallback } from 'injected/visualization-instance-processor';
 import { Drawer } from 'injected/visualization/drawer';
@@ -39,7 +39,7 @@ export interface Requirement {
     getInitialManualTestStatus?: (instances: InstanceIdToInstanceDataMap) => ManualTestStatus;
     guidanceLinks: HyperlinkDefinition[];
     columnsConfig?: InstanceTableColumn[];
-    getAnalyzer?: (provider: AnalyzerProvider) => Analyzer;
+    getAnalyzer?: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) => Analyzer;
     getVisualHelperToggle?: (props: VisualHelperToggleConfig) => JSX.Element;
     // Any results for which this returns false will be omitted from visual helper displays, but still
     // present for the purposes of instance lists or getInitialManualTestStatus. By default, all

--- a/src/common/configs/assessment-visualization-configuration.ts
+++ b/src/common/configs/assessment-visualization-configuration.ts
@@ -3,7 +3,7 @@
 import { ToggleActionPayload } from 'background/actions/action-payloads';
 import { UniquelyIdentifiableInstances } from 'background/instance-identifier-generator';
 import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete-warnings';
-import { Analyzer } from '../../injected/analyzers/analyzer';
+import { Analyzer, AnalyzerConfiguration } from '../../injected/analyzers/analyzer';
 import { AnalyzerProvider } from '../../injected/analyzers/analyzer-provider';
 import { VisualizationInstanceProcessorCallback } from '../../injected/visualization-instance-processor';
 import { Drawer } from '../../injected/visualization/drawer';
@@ -30,7 +30,10 @@ export interface AssessmentVisualizationConfiguration {
     ) => void;
     analyzerProgressMessageType?: string;
     telemetryProcessor?: TelemetryProcessor<IAnalyzerTelemetryCallback>;
-    getAnalyzer: (analyzerProvider: AnalyzerProvider, testStep?: string) => Analyzer;
+    getAnalyzer: (
+        analyzerProvider: AnalyzerProvider,
+        analyzerConfig?: AnalyzerConfiguration,
+    ) => Analyzer;
     visualizationInstanceProcessor: (testStep?: string) => VisualizationInstanceProcessorCallback;
     getNotificationMessage: (
         selectorMap: DictionaryStringTo<any>,

--- a/src/common/configs/visualization-configuration.ts
+++ b/src/common/configs/visualization-configuration.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AnalyzerMessageConfiguration } from 'injected/analyzers/get-analyzer-message-types';
 import { ContentPageComponent } from 'views/content/content-page';
 import { DictionaryStringTo } from '../../types/common-types';
 import { DisplayableVisualizationTypeData } from '../types/displayable-visualization-type-data';
@@ -28,4 +29,5 @@ export interface VisualizationConfiguration extends AssessmentVisualizationConfi
     guidance?: ContentPageComponent;
     shouldShowExportReport: () => boolean;
     getIdentifier: (requirementKey?: string) => string;
+    messageConfiguration?: AnalyzerMessageConfiguration;
 }

--- a/src/common/configs/web-visualization-configuration-factory.ts
+++ b/src/common/configs/web-visualization-configuration-factory.ts
@@ -10,6 +10,11 @@ import { TabStopsAdHocVisualization } from 'ad-hoc-visualizations/tab-stops/visu
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
 import { TestsEnabledState } from 'common/types/store-data/visualization-store-data';
+import {
+    AnalyzerMessageConfiguration,
+    AssessmentVisualizationMessageTypes,
+    MediumPassVisualizationMessageTypes,
+} from 'injected/analyzers/get-analyzer-message-types';
 import { find, forOwn, values } from 'lodash';
 import { DictionaryNumberTo, DictionaryStringTo } from '../../types/common-types';
 import { VisualizationType } from '../types/visualization-type';
@@ -45,12 +50,20 @@ export class WebVisualizationConfigurationFactory implements VisualizationConfig
     public getConfiguration(visualizationType: VisualizationType): VisualizationConfiguration {
         if (this.mediumPassProvider?.isValidType(visualizationType)) {
             const assessment = this.mediumPassProvider.forType(visualizationType);
-            return this.buildAssessmentConfiguration(assessment, TestMode.MediumPass);
+            return this.buildAssessmentConfiguration(
+                assessment,
+                TestMode.MediumPass,
+                MediumPassVisualizationMessageTypes,
+            );
         }
 
         if (this.fullAssessmentProvider.isValidType(visualizationType)) {
             const assessment = this.fullAssessmentProvider.forType(visualizationType);
-            return this.buildAssessmentConfiguration(assessment, TestMode.Assessments);
+            return this.buildAssessmentConfiguration(
+                assessment,
+                TestMode.Assessments,
+                AssessmentVisualizationMessageTypes,
+            );
         }
 
         const configuration = this.configurationByType[visualizationType];
@@ -68,7 +81,11 @@ export class WebVisualizationConfigurationFactory implements VisualizationConfig
         });
 
         this.fullAssessmentProvider.all().forEach(assessment => {
-            const testConfig = this.buildAssessmentConfiguration(assessment, TestMode.Assessments);
+            const testConfig = this.buildAssessmentConfiguration(
+                assessment,
+                TestMode.Assessments,
+                AssessmentVisualizationMessageTypes,
+            );
 
             assessment.requirements.forEach(requirementConfig => {
                 callback(testConfig, assessment.visualizationType, requirementConfig);
@@ -76,7 +93,11 @@ export class WebVisualizationConfigurationFactory implements VisualizationConfig
         });
 
         this.mediumPassProvider.all().forEach(assessment => {
-            const testConfig = this.buildAssessmentConfiguration(assessment, TestMode.MediumPass);
+            const testConfig = this.buildAssessmentConfiguration(
+                assessment,
+                TestMode.MediumPass,
+                MediumPassVisualizationMessageTypes,
+            );
 
             assessment.requirements.forEach(requirementConfig => {
                 callback(testConfig, assessment.visualizationType, requirementConfig);
@@ -87,6 +108,7 @@ export class WebVisualizationConfigurationFactory implements VisualizationConfig
     private buildAssessmentConfiguration(
         assessment: Assessment,
         testMode: TestMode,
+        messageConfiguration: AnalyzerMessageConfiguration,
     ): VisualizationConfiguration {
         const config = assessment.getVisualizationConfiguration();
 
@@ -114,6 +136,7 @@ export class WebVisualizationConfigurationFactory implements VisualizationConfig
             shouldShowExportReport: null,
             getIdentifier,
             getStoreData,
+            messageConfiguration,
         };
 
         return { ...config, ...defaults };

--- a/src/injected/analyzer-controller.ts
+++ b/src/injected/analyzer-controller.ts
@@ -88,9 +88,14 @@ export class AnalyzerController {
                 requirementConfig: Requirement,
             ) => {
                 const identifier = testConfig.getIdentifier(requirementConfig?.key);
+                const analyzerConfig = {
+                    key: requirementConfig?.key,
+                    testType: type,
+                    ...testConfig.messageConfiguration,
+                };
                 this.analyzers[identifier] = testConfig.getAnalyzer(
                     this.analyzerProvider,
-                    requirementConfig?.key,
+                    analyzerConfig,
                 );
             },
         );

--- a/src/tests/unit/common/visualization-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-store-data-builder.ts
@@ -9,7 +9,7 @@ import { cloneDeep, forOwn } from 'lodash';
 import { DetailsViewPivotType } from '../../../common/types/store-data/details-view-pivot-type';
 import {
     AssessmentScanData,
-    VisualizationStoreData
+    VisualizationStoreData,
 } from '../../../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { BaseDataBuilder } from './base-data-builder';

--- a/src/tests/unit/common/visualization-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-store-data-builder.ts
@@ -9,7 +9,7 @@ import { cloneDeep, forOwn } from 'lodash';
 import { DetailsViewPivotType } from '../../../common/types/store-data/details-view-pivot-type';
 import {
     AssessmentScanData,
-    VisualizationStoreData,
+    VisualizationStoreData
 } from '../../../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { BaseDataBuilder } from './base-data-builder';

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -10,8 +10,7 @@ import { InstanceIdentifierGenerator } from 'background/instance-identifier-gene
 import { DecoratedAxeNodeResult } from 'common/types/store-data/visualization-scan-result-data';
 import { cloneDeep } from 'lodash';
 import * as React from 'react';
-import { It, Mock, Times } from 'typemoq';
-import { Messages } from '../../../../common/messages';
+import { Mock, Times } from 'typemoq';
 import { TelemetryDataFactory } from '../../../../common/telemetry-data-factory';
 import { ManualTestStatus } from '../../../../common/types/store-data/manual-test-status';
 import {
@@ -19,12 +18,15 @@ import {
     TestsEnabledState,
 } from '../../../../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../../../../common/types/visualization-type';
-import { AnalyzerConfiguration } from '../../../../injected/analyzers/analyzer';
+import { Analyzer, AnalyzerConfiguration } from '../../../../injected/analyzers/analyzer';
 import { AnalyzerProvider } from '../../../../injected/analyzers/analyzer-provider';
 import { VisualizationInstanceProcessor } from '../../../../injected/visualization-instance-processor';
 import { DrawerProvider } from '../../../../injected/visualization/drawer-provider';
 
 describe('AssessmentBuilderTest', () => {
+    const analyzerConfigStub = {
+        analyzerMessageType: 'some message type',
+    } as AnalyzerConfiguration;
     test('Manual', () => {
         const selectedRequirementKey = 'requirement key';
         const analyzerProviderMock = Mock.ofType(AnalyzerProvider);
@@ -62,14 +64,8 @@ describe('AssessmentBuilderTest', () => {
             requirements: [],
         };
 
-        const expectedConfig: AnalyzerConfiguration = {
-            key: requirement.key,
-            testType: baseAssessment.visualizationType,
-            analyzerMessageType: Messages.Assessment.AssessmentScanCompleted,
-        };
-
         analyzerProviderMock
-            .setup(a => a.createBaseAnalyzer(It.isValue(expectedConfig)))
+            .setup(a => a.createBaseAnalyzer(analyzerConfigStub))
             .verifiable(Times.once());
 
         drawerProviderMock.setup(d => d.createNullDrawer()).verifiable(Times.once());
@@ -130,7 +126,7 @@ describe('AssessmentBuilderTest', () => {
 
         validateInstanceTableSettings(requirement);
 
-        config.getAnalyzer(analyzerProviderMock.object, selectedRequirementKey);
+        config.getAnalyzer(analyzerProviderMock.object, analyzerConfigStub);
         config.getDrawer(drawerProviderMock.object);
         const expectedData = {
             key: 'value',
@@ -151,10 +147,10 @@ describe('AssessmentBuilderTest', () => {
         const visualizationInstanceProcessorMock = Mock.ofInstance(() => null);
         const getInstanceIdentifierMock = Mock.ofInstance(() => null);
         const drawerProviderMock = Mock.ofType(DrawerProvider);
-        const getAnalyzerMock = Mock.ofInstance(provider => {
-            return null;
-        });
-        getAnalyzerMock.setup(gam => gam(providerMock.object)).verifiable(Times.once());
+        const getAnalyzerMock =
+            Mock.ofType<
+                (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) => Analyzer
+            >();
         const getDrawerMock = Mock.ofInstance((provider, ffStoreData?) => null);
         getDrawerMock
             .setup(gdm => gdm(drawerProviderMock.object, undefined))
@@ -261,13 +257,20 @@ describe('AssessmentBuilderTest', () => {
             mediumPass: {},
         } as TestsEnabledState;
 
-        config.getAnalyzer(providerMock.object, requirement1.key);
+        const requirement1AnalyzerConfig = { key: requirement1.key } as AnalyzerConfiguration;
+        getAnalyzerMock
+            .setup(gam => gam(providerMock.object, requirement1AnalyzerConfig))
+            .verifiable(Times.once());
+        config.getAnalyzer(providerMock.object, requirement1AnalyzerConfig);
         config.getDrawer(drawerProviderMock.object, requirement1.key);
 
-        providerMock.setup(pm => pm.createBaseAnalyzer(It.isAny())).verifiable(Times.once());
+        const requirement5AnalyzerConfig = { key: requirement5.key } as AnalyzerConfiguration;
+        providerMock
+            .setup(pm => pm.createBaseAnalyzer(requirement5AnalyzerConfig))
+            .verifiable(Times.once());
         drawerProviderMock.setup(pm => pm.createNullDrawer()).verifiable(Times.once());
 
-        config.getAnalyzer(providerMock.object, requirement5.key);
+        config.getAnalyzer(providerMock.object, requirement5AnalyzerConfig);
         config.getDrawer(drawerProviderMock.object, requirement5.key);
 
         const testRequirement = 'testRequirement';

--- a/src/tests/unit/tests/assessments/automated-checks/build-test-steps-from-rules.test.tsx
+++ b/src/tests/unit/tests/assessments/automated-checks/build-test-steps-from-rules.test.tsx
@@ -15,7 +15,7 @@ import { HyperlinkDefinition } from 'common/types/hyperlink-definition';
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import { DecoratedAxeNodeResult } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationType } from 'common/types/visualization-type';
-import { RuleAnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerConfiguration, RuleAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import { DrawerProvider } from 'injected/visualization/drawer-provider';
@@ -84,6 +84,11 @@ describe('buildTestStepsFromRules', () => {
             key: rule.id,
             testType: VisualizationType.AutomatedChecks,
         };
+        const givenBaseConfig: AnalyzerConfiguration = {
+            testType: VisualizationType.AutomatedChecks,
+            key: rule.id,
+            analyzerMessageType: Messages.Assessment.AssessmentScanCompleted,
+        };
 
         analyzerProviderMock
             .setup(apm => apm.createBatchedRuleAnalyzer(It.isAny()))
@@ -96,7 +101,7 @@ describe('buildTestStepsFromRules', () => {
             })
             .verifiable();
 
-        actual.getAnalyzer(analyzerProviderMock.object);
+        actual.getAnalyzer(analyzerProviderMock.object, givenBaseConfig);
         analyzerProviderMock.verifyAll();
     }
 


### PR DESCRIPTION
#### Details

Our configuration objects statically link analyzers and their communication/lifecycle methods to visualization type, message types, and requirement keys. Since these are used by our communication methods, this effectively amounts to the configuration objects, a place for business logic, containing architectural logic which we should avoid.

As such, this PR changes it such that the analyzer controller is responsible for this duty. This PR does not contain:
1. Modifying the configuration objects to remove mention of visualization type, message types, and requirement keys. This will be done in the next PR.
2. Modifying the analyzers to NOT use the message configuration passed in during `analyze`; it makes sense to re-factor this out with this change but in a future PR.

To summarize, this PR makes the analyzer controller responsible for piping the `testType`, the requirement key, and the message types through getAnalyzer but does not use this newly piped object (except for the automated checks assessment, which is updated in this PR); the only reason Automated Checks was modified was because the test was breaking and it made sense to implement while fixing.

This is useful for quick assess because we then do not need to worry about over-writing something else in the assessment definitions, except the bare-minimum (visualizationType).

##### Motivation

Feature work.

##### Context

How are these 3 properties used:
1. `testType` and `requirementKey` are used for telemetry and for creating the notification when the scan is completed.
2.  `analyzerMessageType` is used to for an action message type to signify that a scan is completed.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
