### PR TITLE
feat(medium-pass-1): register MediumPass callbacks in ActionCreator

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -169,6 +169,42 @@ export class ActionCreator {
             Messages.Assessment.EnableVisualHelperWithoutScan,
             this.onEnableVisualHelperWithoutScan,
         );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.MediumPass.AssessmentScanCompleted,
+            this.onQuickAssessScanCompleted,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.MediumPass.StartOverTest,
+            this.onStartOver,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.MediumPass.CancelStartOver,
+            this.onCancelStartOver,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.MediumPass.StartOverAllAssessments,
+            this.onStartOverQuickAssess,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.MediumPass.CancelStartOverAllAssessments,
+            this.onCancelStartOverQuickAssess,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.MediumPass.EnableVisualHelper,
+            this.onEnableVisualHelper,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.MediumPass.DisableVisualHelperForTest,
+            this.onDisableVisualHelpersForTest,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.MediumPass.DisableVisualHelper,
+            this.onDisableVisualHelper,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.MediumPass.EnableVisualHelperWithoutScan,
+            this.onEnableVisualHelperWithoutScan,
+        );
 
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Inspect.SetHoveredOverSelector,
@@ -228,8 +264,22 @@ export class ActionCreator {
         );
     };
 
+    private onStartOverQuickAssess = async (payload: ToggleActionPayload): Promise<void> => {
+        const eventName = TelemetryEvents.START_OVER_MEDIUM_PASS;
+        this.telemetryEventHandler.publishTelemetry(eventName, payload);
+        await this.visualizationActions.disableAssessmentVisualizations.invoke(
+            null,
+            this.executingScope,
+        );
+    };
+
     private onCancelStartOverAllAssessments = (payload: BaseActionPayload): void => {
         const eventName = TelemetryEvents.CANCEL_START_OVER_ASSESSMENT;
+        this.telemetryEventHandler.publishTelemetry(eventName, payload);
+    };
+
+    private onCancelStartOverQuickAssess = (payload: BaseActionPayload): void => {
+        const eventName = TelemetryEvents.CANCEL_START_OVER_MEDIUM_PASS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
     };
 
@@ -245,6 +295,22 @@ export class ActionCreator {
         tabId: number,
     ): Promise<void> => {
         const eventName = TelemetryEvents.ASSESSMENT_SCAN_COMPLETED;
+        this.telemetryEventHandler.publishTelemetry(eventName, payload);
+        await this.visualizationActions.scanCompleted.invoke(null, this.executingScope);
+        this.notificationCreator.createNotificationByVisualizationKey(
+            payload.selectorMap,
+            payload.key,
+            payload.testType,
+            payload.scanIncompleteWarnings,
+        );
+        await this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
+    };
+
+    private onQuickAssessScanCompleted = async (
+        payload: ScanCompletedPayload<any>,
+        tabId: number,
+    ): Promise<void> => {
+        const eventName = TelemetryEvents.MEDIUM_PASS_SCAN_COMPLETED;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         await this.visualizationActions.scanCompleted.invoke(null, this.executingScope);
         this.notificationCreator.createNotificationByVisualizationKey(

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -135,7 +135,7 @@ export class ActionCreator {
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Assessment.AssessmentScanCompleted,
-            this.onAssessmentScanCompleted,
+            this.onAssessmentScanCompletedForAssessment,
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Assessment.StartOverTest,
@@ -147,11 +147,11 @@ export class ActionCreator {
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Assessment.StartOverAllAssessments,
-            this.onStartOverAllAssessments,
+            this.onStartOverAllAssessmentsForAssessment,
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Assessment.CancelStartOverAllAssessments,
-            this.onCancelStartOverAllAssessments,
+            this.onCancelStartOverAllAssessmentsForAssessment,
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Assessment.EnableVisualHelper,
@@ -171,7 +171,7 @@ export class ActionCreator {
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.MediumPass.AssessmentScanCompleted,
-            this.onQuickAssessScanCompleted,
+            this.onAssessmentScanCompletedForQuickAssess,
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.MediumPass.StartOverTest,
@@ -183,11 +183,11 @@ export class ActionCreator {
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.MediumPass.StartOverAllAssessments,
-            this.onStartOverQuickAssess,
+            this.onStartOverAllAssessmentsForQuickAssess,
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.MediumPass.CancelStartOverAllAssessments,
-            this.onCancelStartOverQuickAssess,
+            this.onCancelStartOverAllAssessmentsForQuickAssess,
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.MediumPass.EnableVisualHelper,
@@ -255,8 +255,10 @@ export class ActionCreator {
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
     };
 
-    private onStartOverAllAssessments = async (payload: ToggleActionPayload): Promise<void> => {
-        const eventName = TelemetryEvents.START_OVER_ASSESSMENT;
+    private onStartOverAllAssessments = async (
+        payload: ToggleActionPayload,
+        eventName: string,
+    ): Promise<void> => {
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         await this.visualizationActions.disableAssessmentVisualizations.invoke(
             null,
@@ -264,23 +266,34 @@ export class ActionCreator {
         );
     };
 
-    private onStartOverQuickAssess = async (payload: ToggleActionPayload): Promise<void> => {
-        const eventName = TelemetryEvents.START_OVER_MEDIUM_PASS;
+    private onStartOverAllAssessmentsForAssessment = async (
+        payload: ToggleActionPayload,
+    ): Promise<void> => {
+        await this.onStartOverAllAssessments(payload, TelemetryEvents.START_OVER_ASSESSMENT);
+    };
+
+    private onStartOverAllAssessmentsForQuickAssess = async (
+        payload: ToggleActionPayload,
+    ): Promise<void> => {
+        await this.onStartOverAllAssessments(payload, TelemetryEvents.START_OVER_MEDIUM_PASS);
+    };
+
+    private onCancelStartOverAllAssessments = (
+        payload: BaseActionPayload,
+        eventName: string,
+    ): void => {
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.visualizationActions.disableAssessmentVisualizations.invoke(
-            null,
-            this.executingScope,
+    };
+
+    private onCancelStartOverAllAssessmentsForAssessment = (payload: BaseActionPayload): void => {
+        this.onCancelStartOverAllAssessments(payload, TelemetryEvents.CANCEL_START_OVER_ASSESSMENT);
+    };
+
+    private onCancelStartOverAllAssessmentsForQuickAssess = (payload: BaseActionPayload): void => {
+        this.onCancelStartOverAllAssessments(
+            payload,
+            TelemetryEvents.CANCEL_START_OVER_MEDIUM_PASS,
         );
-    };
-
-    private onCancelStartOverAllAssessments = (payload: BaseActionPayload): void => {
-        const eventName = TelemetryEvents.CANCEL_START_OVER_ASSESSMENT;
-        this.telemetryEventHandler.publishTelemetry(eventName, payload);
-    };
-
-    private onCancelStartOverQuickAssess = (payload: BaseActionPayload): void => {
-        const eventName = TelemetryEvents.CANCEL_START_OVER_MEDIUM_PASS;
-        this.telemetryEventHandler.publishTelemetry(eventName, payload);
     };
 
     private onDetailsViewClosed = async (): Promise<void> => {
@@ -293,8 +306,8 @@ export class ActionCreator {
     private onAssessmentScanCompleted = async (
         payload: ScanCompletedPayload<any>,
         tabId: number,
+        eventName: string,
     ): Promise<void> => {
-        const eventName = TelemetryEvents.ASSESSMENT_SCAN_COMPLETED;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         await this.visualizationActions.scanCompleted.invoke(null, this.executingScope);
         this.notificationCreator.createNotificationByVisualizationKey(
@@ -306,20 +319,26 @@ export class ActionCreator {
         await this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
     };
 
-    private onQuickAssessScanCompleted = async (
+    private onAssessmentScanCompletedForAssessment = async (
         payload: ScanCompletedPayload<any>,
         tabId: number,
     ): Promise<void> => {
-        const eventName = TelemetryEvents.MEDIUM_PASS_SCAN_COMPLETED;
-        this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        await this.visualizationActions.scanCompleted.invoke(null, this.executingScope);
-        this.notificationCreator.createNotificationByVisualizationKey(
-            payload.selectorMap,
-            payload.key,
-            payload.testType,
-            payload.scanIncompleteWarnings,
+        await this.onAssessmentScanCompleted(
+            payload,
+            tabId,
+            TelemetryEvents.ASSESSMENT_SCAN_COMPLETED,
         );
-        await this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
+    };
+
+    private onAssessmentScanCompletedForQuickAssess = async (
+        payload: ScanCompletedPayload<any>,
+        tabId: number,
+    ): Promise<void> => {
+        await this.onAssessmentScanCompleted(
+            payload,
+            tabId,
+            TelemetryEvents.MEDIUM_PASS_SCAN_COMPLETED,
+        );
     };
 
     private onTabbedElementAdded = async (payload: AddTabbedElementPayload): Promise<void> => {

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -169,6 +169,7 @@ export class ActionCreator {
             Messages.Assessment.EnableVisualHelperWithoutScan,
             this.onEnableVisualHelperWithoutScan,
         );
+
         this.interpreter.registerTypeToPayloadCallback(
             Messages.MediumPass.AssessmentScanCompleted,
             this.onAssessmentScanCompletedForQuickAssess,

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -647,46 +647,57 @@ describe('ActionCreatorTest', () => {
         validator.verifyAll();
     });
 
-    test('registerCallback for onStartOverAssessment', async () => {
-        const tabId = 1;
-        const payload: ChangeInstanceStatusPayload = {
-            test: VisualizationType.HeadingsAssessment,
-            status: null,
-            requirement: null,
-            selector: null,
-        };
-        const disableActionName = 'disableVisualization';
+    describe('onStartOverAssessment', () => {
+        const testCases = [Messages.Assessment.StartOverTest, Messages.MediumPass.StartOverTest];
 
-        const validator = new ActionCreatorValidator()
-            .setupActionOnVisualizationActions(disableActionName)
-            .setupVisualizationActionWithInvokeParameter(disableActionName, payload.test)
-            .setupTelemetrySend(TelemetryEvents.START_OVER_TEST, payload, 1);
-        const actionCreator = validator.buildActionCreator();
+        test.each(testCases)('registerCallback with %s', async eventType => {
+            const tabId = 1;
+            const payload: ChangeInstanceStatusPayload = {
+                test: VisualizationType.HeadingsAssessment,
+                status: null,
+                requirement: null,
+                selector: null,
+            };
+            const disableActionName = 'disableVisualization';
 
-        actionCreator.registerCallbacks();
+            const validator = new ActionCreatorValidator()
+                .setupActionOnVisualizationActions(disableActionName)
+                .setupVisualizationActionWithInvokeParameter(disableActionName, payload.test)
+                .setupTelemetrySend(TelemetryEvents.START_OVER_TEST, payload, 1);
+            const actionCreator = validator.buildActionCreator();
 
-        await validator.simulateMessage(Messages.Assessment.StartOverTest, payload, tabId);
+            actionCreator.registerCallbacks();
 
-        validator.verifyAll();
+            await validator.simulateMessage(eventType, payload, tabId);
+
+            validator.verifyAll();
+        });
     });
 
-    test('registerCallback for onCancelStartOverAssessment', async () => {
-        const tabId = 1;
-        const payload: BaseActionPayload = {};
+    describe('onCancelStartOverAssessment', () => {
+        const testCases = [
+            Messages.Assessment.CancelStartOver,
+            Messages.MediumPass.CancelStartOver,
+        ];
 
-        const validator = new ActionCreatorValidator().setupTelemetrySend(
-            TelemetryEvents.CANCEL_START_OVER_TEST,
-            payload,
-            tabId,
-        );
+        test.each(testCases)('registerCallback with %s', async eventType => {
+            const tabId = 1;
+            const payload: BaseActionPayload = {};
 
-        const actionCreator = validator.buildActionCreator();
+            const validator = new ActionCreatorValidator().setupTelemetrySend(
+                TelemetryEvents.CANCEL_START_OVER_TEST,
+                payload,
+                tabId,
+            );
 
-        actionCreator.registerCallbacks();
+            const actionCreator = validator.buildActionCreator();
 
-        await validator.simulateMessage(Messages.Assessment.CancelStartOver, payload, tabId);
+            actionCreator.registerCallbacks();
 
-        validator.verifyAll();
+            await validator.simulateMessage(eventType, payload, tabId);
+
+            validator.verifyAll();
+        });
     });
 
     test('registerCallback for onStartOverAllAssessments', async () => {
@@ -769,90 +780,110 @@ describe('ActionCreatorTest', () => {
         validator.verifyAll();
     });
 
-    test('registerCallback for onEnableVisualHelper', async () => {
-        const tabId = 1;
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.HeadingsAssessment,
-        };
-        const actionName = 'enableVisualization';
+    describe('onEnableVisualHelper', () => {
+        const testCases = [
+            Messages.Assessment.EnableVisualHelper,
+            Messages.MediumPass.EnableVisualHelper,
+        ];
 
-        const validator = new ActionCreatorValidator()
-            .setupActionOnVisualizationActions(actionName)
-            .setupVisualizationActionWithInvokeParameter(actionName, payload);
-        const actionCreator = validator.buildActionCreator();
+        test.each(testCases)('registerCallback with %s', async eventType => {
+            const tabId = 1;
+            const payload: ToggleActionPayload = {
+                test: VisualizationType.HeadingsAssessment,
+            };
+            const actionName = 'enableVisualization';
 
-        actionCreator.registerCallbacks();
+            const validator = new ActionCreatorValidator()
+                .setupActionOnVisualizationActions(actionName)
+                .setupVisualizationActionWithInvokeParameter(actionName, payload);
+            const actionCreator = validator.buildActionCreator();
 
-        await validator.simulateMessage(Messages.Assessment.EnableVisualHelper, payload, tabId);
+            actionCreator.registerCallbacks();
 
-        validator.verifyAll();
+            await validator.simulateMessage(eventType, payload, tabId);
+
+            validator.verifyAll();
+        });
     });
 
-    test('registerCallback for onEnableVisualHelperWithoutScan', async () => {
-        const tabId = 1;
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.HeadingsAssessment,
-        };
-        const actionName = 'enableVisualizationWithoutScan';
-
-        const validator = new ActionCreatorValidator()
-            .setupActionOnVisualizationActions(actionName)
-            .setupVisualizationActionWithInvokeParameter(actionName, payload);
-        const actionCreator = validator.buildActionCreator();
-
-        actionCreator.registerCallbacks();
-
-        await validator.simulateMessage(
+    describe('onEnableVisualHelperWithoutScan', () => {
+        const testCases = [
             Messages.Assessment.EnableVisualHelperWithoutScan,
-            payload,
-            tabId,
-        );
+            Messages.MediumPass.EnableVisualHelperWithoutScan,
+        ];
 
-        validator.verifyAll();
+        test.each(testCases)('registerCallback with %s', async eventType => {
+            const tabId = 1;
+            const payload: ToggleActionPayload = {
+                test: VisualizationType.HeadingsAssessment,
+            };
+            const actionName = 'enableVisualizationWithoutScan';
+
+            const validator = new ActionCreatorValidator()
+                .setupActionOnVisualizationActions(actionName)
+                .setupVisualizationActionWithInvokeParameter(actionName, payload);
+            const actionCreator = validator.buildActionCreator();
+
+            actionCreator.registerCallbacks();
+
+            await validator.simulateMessage(eventType, payload, tabId);
+
+            validator.verifyAll();
+        });
     });
 
-    test('registerCallback for onDisableVisualHelper', async () => {
-        const tabId = 1;
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.HeadingsAssessment,
-        };
-        const actionName = 'disableVisualization';
+    describe('onDisableVisualHelper', () => {
+        const testCases = [
+            Messages.Assessment.DisableVisualHelper,
+            Messages.MediumPass.DisableVisualHelper,
+        ];
 
-        const validator = new ActionCreatorValidator()
-            .setupActionOnVisualizationActions(actionName)
-            .setupVisualizationActionWithInvokeParameter(actionName, payload.test)
-            .setupTelemetrySend(TelemetryEvents.DISABLE_VISUAL_HELPER, payload, 1);
+        test.each(testCases)('registerCallback with %s', async eventType => {
+            const tabId = 1;
+            const payload: ToggleActionPayload = {
+                test: VisualizationType.HeadingsAssessment,
+            };
+            const actionName = 'disableVisualization';
 
-        const actionCreator = validator.buildActionCreator();
+            const validator = new ActionCreatorValidator()
+                .setupActionOnVisualizationActions(actionName)
+                .setupVisualizationActionWithInvokeParameter(actionName, payload.test)
+                .setupTelemetrySend(TelemetryEvents.DISABLE_VISUAL_HELPER, payload, 1);
 
-        actionCreator.registerCallbacks();
+            const actionCreator = validator.buildActionCreator();
 
-        await validator.simulateMessage(Messages.Assessment.DisableVisualHelper, payload, tabId);
+            actionCreator.registerCallbacks();
 
-        validator.verifyAll();
+            await validator.simulateMessage(eventType, payload, tabId);
+
+            validator.verifyAll();
+        });
     });
 
-    test('registerCallback for onDisableVisualHelpersForTest', async () => {
-        const tabId = 1;
-        const payload: ToggleActionPayload = {
-            test: VisualizationType.HeadingsAssessment,
-        };
-        const actionName = 'disableVisualization';
-
-        const validator = new ActionCreatorValidator()
-            .setupActionOnVisualizationActions(actionName)
-            .setupVisualizationActionWithInvokeParameter(actionName, payload.test);
-        const actionCreator = validator.buildActionCreator();
-
-        actionCreator.registerCallbacks();
-
-        await validator.simulateMessage(
+    describe('onDisableVisualHelpersForTest', () => {
+        const testCases = [
             Messages.Assessment.DisableVisualHelperForTest,
-            payload,
-            tabId,
-        );
+            Messages.MediumPass.DisableVisualHelperForTest,
+        ];
 
-        validator.verifyAll();
+        test.each(testCases)('registerCallback with %s', async eventType => {
+            const tabId = 1;
+            const payload: ToggleActionPayload = {
+                test: VisualizationType.HeadingsAssessment,
+            };
+            const actionName = 'disableVisualization';
+
+            const validator = new ActionCreatorValidator()
+                .setupActionOnVisualizationActions(actionName)
+                .setupVisualizationActionWithInvokeParameter(actionName, payload.test);
+            const actionCreator = validator.buildActionCreator();
+
+            actionCreator.registerCallbacks();
+
+            await validator.simulateMessage(eventType, payload, tabId);
+
+            validator.verifyAll();
+        });
     });
 
     test('registerCallback for switch focus back to target', async () => {

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -620,7 +620,7 @@ describe('ActionCreatorTest', () => {
             ],
         ];
 
-        test.each(testCases)('registerCallback with %s', async (eventType, telemetryEvent) => {
+        test.each(testCases)('registerCallback with %s', async (eventName, telemetryEvent) => {
             const tabId = -1;
             const telemetryData: BaseTelemetryData = {
                 triggeredBy: 'stub triggered by' as TriggeredBy,
@@ -650,7 +650,7 @@ describe('ActionCreatorTest', () => {
 
             actionCreator.registerCallbacks();
 
-            await validator.simulateMessage(eventType, payload, tabId);
+            await validator.simulateMessage(eventName, payload, tabId);
 
             validator.verifyAll();
         });
@@ -659,7 +659,7 @@ describe('ActionCreatorTest', () => {
     describe('onStartOverAssessment', () => {
         const testCases = [Messages.Assessment.StartOverTest, Messages.MediumPass.StartOverTest];
 
-        test.each(testCases)('registerCallback with %s', async eventType => {
+        test.each(testCases)('registerCallback with %s', async eventName => {
             const tabId = 1;
             const payload: ChangeInstanceStatusPayload = {
                 test: VisualizationType.HeadingsAssessment,
@@ -677,7 +677,7 @@ describe('ActionCreatorTest', () => {
 
             actionCreator.registerCallbacks();
 
-            await validator.simulateMessage(eventType, payload, tabId);
+            await validator.simulateMessage(eventName, payload, tabId);
 
             validator.verifyAll();
         });
@@ -689,7 +689,7 @@ describe('ActionCreatorTest', () => {
             Messages.MediumPass.CancelStartOver,
         ];
 
-        test.each(testCases)('registerCallback with %s', async eventType => {
+        test.each(testCases)('registerCallback with %s', async eventName => {
             const tabId = 1;
             const payload: BaseActionPayload = {};
 
@@ -703,7 +703,7 @@ describe('ActionCreatorTest', () => {
 
             actionCreator.registerCallbacks();
 
-            await validator.simulateMessage(eventType, payload, tabId);
+            await validator.simulateMessage(eventName, payload, tabId);
 
             validator.verifyAll();
         });
@@ -715,7 +715,7 @@ describe('ActionCreatorTest', () => {
             [Messages.MediumPass.StartOverAllAssessments, TelemetryEvents.START_OVER_MEDIUM_PASS],
         ];
 
-        test.each(testCases)('registerCallback with %s', async (eventType, telemetryEvent) => {
+        test.each(testCases)('registerCallback with %s', async (eventName, telemetryEvent) => {
             const tabId = 1;
             const payload: ChangeInstanceStatusPayload = {
                 test: VisualizationType.HeadingsAssessment,
@@ -733,7 +733,7 @@ describe('ActionCreatorTest', () => {
 
             actionCreator.registerCallbacks();
 
-            await validator.simulateMessage(eventType, payload, tabId);
+            await validator.simulateMessage(eventName, payload, tabId);
 
             validator.verifyAll();
         });
@@ -751,7 +751,7 @@ describe('ActionCreatorTest', () => {
             ],
         ];
 
-        test.each(testCases)('registerCallback with %s', async (eventType, telemetryEvent) => {
+        test.each(testCases)('registerCallback with %s', async (eventName, telemetryEvent) => {
             const tabId = 1;
             const payload: BaseActionPayload = {};
 
@@ -765,7 +765,7 @@ describe('ActionCreatorTest', () => {
 
             actionCreator.registerCallbacks();
 
-            await validator.simulateMessage(eventType, payload, tabId);
+            await validator.simulateMessage(eventName, payload, tabId);
 
             validator.verifyAll();
         });
@@ -807,7 +807,7 @@ describe('ActionCreatorTest', () => {
             Messages.MediumPass.EnableVisualHelper,
         ];
 
-        test.each(testCases)('registerCallback with %s', async eventType => {
+        test.each(testCases)('registerCallback with %s', async eventName => {
             const tabId = 1;
             const payload: ToggleActionPayload = {
                 test: VisualizationType.HeadingsAssessment,
@@ -821,7 +821,7 @@ describe('ActionCreatorTest', () => {
 
             actionCreator.registerCallbacks();
 
-            await validator.simulateMessage(eventType, payload, tabId);
+            await validator.simulateMessage(eventName, payload, tabId);
 
             validator.verifyAll();
         });
@@ -833,7 +833,7 @@ describe('ActionCreatorTest', () => {
             Messages.MediumPass.EnableVisualHelperWithoutScan,
         ];
 
-        test.each(testCases)('registerCallback with %s', async eventType => {
+        test.each(testCases)('registerCallback with %s', async eventName => {
             const tabId = 1;
             const payload: ToggleActionPayload = {
                 test: VisualizationType.HeadingsAssessment,
@@ -847,7 +847,7 @@ describe('ActionCreatorTest', () => {
 
             actionCreator.registerCallbacks();
 
-            await validator.simulateMessage(eventType, payload, tabId);
+            await validator.simulateMessage(eventName, payload, tabId);
 
             validator.verifyAll();
         });
@@ -859,7 +859,7 @@ describe('ActionCreatorTest', () => {
             Messages.MediumPass.DisableVisualHelper,
         ];
 
-        test.each(testCases)('registerCallback with %s', async eventType => {
+        test.each(testCases)('registerCallback with %s', async eventName => {
             const tabId = 1;
             const payload: ToggleActionPayload = {
                 test: VisualizationType.HeadingsAssessment,
@@ -875,7 +875,7 @@ describe('ActionCreatorTest', () => {
 
             actionCreator.registerCallbacks();
 
-            await validator.simulateMessage(eventType, payload, tabId);
+            await validator.simulateMessage(eventName, payload, tabId);
 
             validator.verifyAll();
         });
@@ -887,7 +887,7 @@ describe('ActionCreatorTest', () => {
             Messages.MediumPass.DisableVisualHelperForTest,
         ];
 
-        test.each(testCases)('registerCallback with %s', async eventType => {
+        test.each(testCases)('registerCallback with %s', async eventName => {
             const tabId = 1;
             const payload: ToggleActionPayload = {
                 test: VisualizationType.HeadingsAssessment,
@@ -901,7 +901,7 @@ describe('ActionCreatorTest', () => {
 
             actionCreator.registerCallbacks();
 
-            await validator.simulateMessage(eventType, payload, tabId);
+            await validator.simulateMessage(eventName, payload, tabId);
 
             validator.verifyAll();
         });

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -608,43 +608,52 @@ describe('ActionCreatorTest', () => {
         validator.verifyAll();
     });
 
-    test('registerCallback for onAssessmentScanCompleted', async () => {
-        const tabId = -1;
-        const telemetryData: BaseTelemetryData = {
-            triggeredBy: 'stub triggered by' as TriggeredBy,
-            source: testSource,
-        };
+    describe('onAssessmentScanCompleted', () => {
+        const testCases = [
+            [
+                Messages.Assessment.AssessmentScanCompleted,
+                TelemetryEvents.ASSESSMENT_SCAN_COMPLETED,
+            ],
+            [
+                Messages.MediumPass.AssessmentScanCompleted,
+                TelemetryEvents.MEDIUM_PASS_SCAN_COMPLETED,
+            ],
+        ];
 
-        const payload: ScanCompletedPayload<any> = {
-            telemetry: telemetryData,
-            selectorMap: {},
-            scanResult: null,
-            testType: VisualizationType.HeadingsAssessment,
-            key: 'key',
-            scanIncompleteWarnings: [],
-        };
+        test.each(testCases)('registerCallback with %s', async (eventType, telemetryEvent) => {
+            const tabId = -1;
+            const telemetryData: BaseTelemetryData = {
+                triggeredBy: 'stub triggered by' as TriggeredBy,
+                source: testSource,
+            };
 
-        const validator = new ActionCreatorValidator()
-            .setupTelemetrySend(TelemetryEvents.ASSESSMENT_SCAN_COMPLETED, payload, tabId)
-            .setupCreateNotificationByVisualizationKey(
-                payload.selectorMap,
-                payload.key,
-                payload.testType,
-                payload.scanIncompleteWarnings,
-            )
-            .setupShowTargetTab(tabId, payload.testType, payload.key);
+            const payload: ScanCompletedPayload<any> = {
+                telemetry: telemetryData,
+                selectorMap: {},
+                scanResult: null,
+                testType: VisualizationType.HeadingsAssessment,
+                key: 'key',
+                scanIncompleteWarnings: [],
+            };
 
-        const actionCreator = validator.buildActionCreator();
+            const validator = new ActionCreatorValidator()
+                .setupTelemetrySend(telemetryEvent, payload, tabId)
+                .setupCreateNotificationByVisualizationKey(
+                    payload.selectorMap,
+                    payload.key,
+                    payload.testType,
+                    payload.scanIncompleteWarnings,
+                )
+                .setupShowTargetTab(tabId, payload.testType, payload.key);
 
-        actionCreator.registerCallbacks();
+            const actionCreator = validator.buildActionCreator();
 
-        await validator.simulateMessage(
-            Messages.Assessment.AssessmentScanCompleted,
-            payload,
-            tabId,
-        );
+            actionCreator.registerCallbacks();
 
-        validator.verifyAll();
+            await validator.simulateMessage(eventType, payload, tabId);
+
+            validator.verifyAll();
+        });
     });
 
     describe('onStartOverAssessment', () => {
@@ -700,54 +709,66 @@ describe('ActionCreatorTest', () => {
         });
     });
 
-    test('registerCallback for onStartOverAllAssessments', async () => {
-        const tabId = 1;
-        const payload: ChangeInstanceStatusPayload = {
-            test: VisualizationType.HeadingsAssessment,
-            status: null,
-            requirement: null,
-            selector: null,
-        };
-        const disableActionName = 'disableAssessmentVisualizations';
+    describe('onStartOverAllAssessments', () => {
+        const testCases = [
+            [Messages.Assessment.StartOverAllAssessments, TelemetryEvents.START_OVER_ASSESSMENT],
+            [Messages.MediumPass.StartOverAllAssessments, TelemetryEvents.START_OVER_MEDIUM_PASS],
+        ];
 
-        const validator = new ActionCreatorValidator()
-            .setupActionOnVisualizationActions(disableActionName)
-            .setupVisualizationActionWithInvokeParameter(disableActionName, null)
-            .setupTelemetrySend(TelemetryEvents.START_OVER_ASSESSMENT, payload, 1);
-        const actionCreator = validator.buildActionCreator();
+        test.each(testCases)('registerCallback with %s', async (eventType, telemetryEvent) => {
+            const tabId = 1;
+            const payload: ChangeInstanceStatusPayload = {
+                test: VisualizationType.HeadingsAssessment,
+                status: null,
+                requirement: null,
+                selector: null,
+            };
+            const disableActionName = 'disableAssessmentVisualizations';
 
-        actionCreator.registerCallbacks();
+            const validator = new ActionCreatorValidator()
+                .setupActionOnVisualizationActions(disableActionName)
+                .setupVisualizationActionWithInvokeParameter(disableActionName, null)
+                .setupTelemetrySend(telemetryEvent, payload, 1);
+            const actionCreator = validator.buildActionCreator();
 
-        await validator.simulateMessage(
-            Messages.Assessment.StartOverAllAssessments,
-            payload,
-            tabId,
-        );
+            actionCreator.registerCallbacks();
 
-        validator.verifyAll();
+            await validator.simulateMessage(eventType, payload, tabId);
+
+            validator.verifyAll();
+        });
     });
 
-    test('registerCallback for onCancelStartOverAllAssessments', async () => {
-        const tabId = 1;
-        const payload: BaseActionPayload = {};
+    describe('onCancelStartOverAllAssessments', () => {
+        const testCases = [
+            [
+                Messages.Assessment.CancelStartOverAllAssessments,
+                TelemetryEvents.CANCEL_START_OVER_ASSESSMENT,
+            ],
+            [
+                Messages.MediumPass.CancelStartOverAllAssessments,
+                TelemetryEvents.CANCEL_START_OVER_MEDIUM_PASS,
+            ],
+        ];
 
-        const validator = new ActionCreatorValidator().setupTelemetrySend(
-            TelemetryEvents.CANCEL_START_OVER_ASSESSMENT,
-            payload,
-            tabId,
-        );
+        test.each(testCases)('registerCallback with %s', async (eventType, telemetryEvent) => {
+            const tabId = 1;
+            const payload: BaseActionPayload = {};
 
-        const actionCreator = validator.buildActionCreator();
+            const validator = new ActionCreatorValidator().setupTelemetrySend(
+                telemetryEvent,
+                payload,
+                tabId,
+            );
 
-        actionCreator.registerCallbacks();
+            const actionCreator = validator.buildActionCreator();
 
-        await validator.simulateMessage(
-            Messages.Assessment.CancelStartOverAllAssessments,
-            payload,
-            tabId,
-        );
+            actionCreator.registerCallbacks();
 
-        validator.verifyAll();
+            await validator.simulateMessage(eventType, payload, tabId);
+
+            validator.verifyAll();
+        });
     });
 
     test('registerCallback for onRescanVisualization', async () => {


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
This PR ensures that the MediumPass/QuickAssess equivalents of Assessment callbacks are registered in ActionCreator

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Part of feature work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
