### PR TITLE
feat(medium-pass-1): use analyzer configuration passed in from getAnalyzer/analyzer-controller

### DIFF
--- a/src/assessments/adaptable-content/test-steps/contrast.tsx
+++ b/src/assessments/adaptable-content/test-steps/contrast.tsx
@@ -10,12 +10,13 @@ import {
     NoValue,
     PropertyBagColumnRendererConfig,
 } from 'common/types/property-bag/property-bag-column-renderer-config';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import * as content from 'content/test/adaptable-content/contrast';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 
@@ -70,8 +71,6 @@ const contrastHowToTest: JSX.Element = (
     </div>
 );
 
-const key = AdaptableContentTestStep.contrast;
-
 const propertyBagConfig: PropertyBagColumnRendererConfig<ContrastPropertyBag>[] = [
     {
         propertyName: 'textString',
@@ -100,13 +99,12 @@ export const Contrast: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['text-contrast'],
-                key,
-                testType: VisualizationType.AdaptableContent,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getIncompleteInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/adaptable-content/test-steps/text-spacing.tsx
+++ b/src/assessments/adaptable-content/test-steps/text-spacing.tsx
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 import { AdaptableContentTestStep } from 'assessments/adaptable-content/test-steps/test-step';
 import { Requirement } from 'assessments/types/requirement';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/adaptable-content/text-spacing';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
@@ -56,12 +57,11 @@ export const TextSpacing: Requirement = {
     ...content,
     isManual: true,
     guidanceLinks: [link.WCAG_1_4_12],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['text-spacing'],
-                key: AdaptableContentTestStep.textSpacing,
-                testType: VisualizationType.AdaptableContent,
+                ...analyzerConfig,
             }),
         ),
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,

--- a/src/assessments/color/test-steps/use-of-color.tsx
+++ b/src/assessments/color/test-steps/use-of-color.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/sensory/use-of-color';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
@@ -56,12 +57,11 @@ export const UseOfColor: Requirement = {
     isManual: true,
     ...content,
     guidanceLinks: [link.WCAG_1_4_1],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['select-html'],
-                key: ColorSensoryTestStep.useOfColor,
-                testType: VisualizationType.ColorSensoryAssessment,
+                ...analyzerConfig,
             }),
         ),
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,

--- a/src/assessments/contrast/test-steps/graphics.tsx
+++ b/src/assessments/contrast/test-steps/graphics.tsx
@@ -10,10 +10,11 @@ import {
     NoValue,
     PropertyBagColumnRendererConfig,
 } from 'common/types/property-bag/property-bag-column-renderer-config';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/contrast/graphics';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -92,12 +93,11 @@ export const Graphics: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['accessible-image'],
-                key: ContrastTestStep.graphics,
-                testType: VisualizationType.ContrastAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/contrast/test-steps/state-changes.tsx
+++ b/src/assessments/contrast/test-steps/state-changes.tsx
@@ -9,10 +9,11 @@ import {
     PropertyBagColumnRendererConfig,
 } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { StateChangesPropertyBag } from 'common/types/property-bag/state-changes';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/contrast/state-changes';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 
@@ -132,13 +133,12 @@ export const StateChanges: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['link-purpose', 'native-widgets-default', 'custom-widget'],
-                key: ContrastTestStep.stateChanges,
-                testType: VisualizationType.ContrastAssessment,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createNonTextComponentDrawer(),

--- a/src/assessments/contrast/test-steps/ui-components.tsx
+++ b/src/assessments/contrast/test-steps/ui-components.tsx
@@ -9,10 +9,11 @@ import {
     PropertyBagColumnRendererConfig,
 } from 'common/types/property-bag/property-bag-column-renderer-config';
 import { UIComponentsPropertyBag } from 'common/types/property-bag/ui-components';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/contrast/ui-components';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 
@@ -106,13 +107,12 @@ export const UIComponents: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['link-purpose', 'native-widgets-default', 'custom-widget'],
-                key: ContrastTestStep.uiComponents,
-                testType: VisualizationType.ContrastAssessment,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createNonTextComponentDrawer(),

--- a/src/assessments/custom-widgets/test-steps/cues.tsx
+++ b/src/assessments/custom-widgets/test-steps/cues.tsx
@@ -3,12 +3,13 @@
 
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
 import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/custom-widgets/cues';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -114,13 +115,12 @@ export const Cues: Requirement = {
             'ariaCues',
         ),
     ],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['custom-widget'],
-                key: CustomWidgetsTestStep.cues,
-                testType: VisualizationType.CustomWidgets,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/custom-widgets/test-steps/design-pattern.tsx
+++ b/src/assessments/custom-widgets/test-steps/design-pattern.tsx
@@ -4,12 +4,13 @@
 import { NewTabLink } from 'common/components/new-tab-link';
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
 import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/custom-widgets/design-pattern';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -95,15 +96,15 @@ export const DesignPattern: Requirement = {
             'text',
         ),
     ],
-    getAnalyzer: provider =>
-        provider.createRuleAnalyzer(
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) => {
+        return provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['custom-widget'],
-                key: CustomWidgetsTestStep.designPattern,
-                testType: VisualizationType.CustomWidgets,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
-        ),
+        );
+    },
     getDrawer: provider => provider.createCustomWidgetsDrawer(),
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/custom-widgets/test-steps/expected-input.tsx
+++ b/src/assessments/custom-widgets/test-steps/expected-input.tsx
@@ -3,11 +3,12 @@
 
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
 import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import * as content from 'content/test/custom-widgets/expected-input';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -92,13 +93,12 @@ export const ExpectedInput: Requirement = {
             'describedBy',
         ),
     ],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['custom-widget'],
-                key: CustomWidgetsTestStep.label,
-                testType: VisualizationType.CustomWidgets,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/custom-widgets/test-steps/instructions.tsx
+++ b/src/assessments/custom-widgets/test-steps/instructions.tsx
@@ -3,10 +3,11 @@
 import { NewTabLink } from 'common/components/new-tab-link';
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
 import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/custom-widgets/instructions';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -108,13 +109,12 @@ export const Instructions: Requirement = {
             'describedBy',
         ),
     ],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['custom-widget'],
-                key: CustomWidgetsTestStep.instructions,
-                testType: VisualizationType.CustomWidgets,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
+++ b/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
@@ -3,12 +3,13 @@
 
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
 import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/custom-widgets/keyboard-interaction';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -83,13 +84,12 @@ export const KeyboardInteraction: Requirement = {
             'text',
         ),
     ],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['custom-widget'],
-                key: CustomWidgetsTestStep.keyboardInteraction,
-                testType: VisualizationType.CustomWidgets,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/custom-widgets/test-steps/role-state-property.tsx
+++ b/src/assessments/custom-widgets/test-steps/role-state-property.tsx
@@ -4,12 +4,13 @@
 import { NewTabLink } from 'common/components/new-tab-link';
 import { CustomWidgetPropertyBag } from 'common/types/property-bag/custom-widgets-property-bag';
 import { NoValue } from 'common/types/property-bag/property-bag-column-renderer-config';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/custom-widgets/role-state-property';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -104,13 +105,12 @@ export const RoleStateProperty: Requirement = {
             'text',
         ),
     ],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['custom-widget'],
-                key: CustomWidgetsTestStep.roleStateProperty,
-                testType: VisualizationType.CustomWidgets,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/headings/test-steps/heading-function.tsx
+++ b/src/assessments/headings/test-steps/heading-function.tsx
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 import { HeadingsAssessmentProperties } from 'common/types/store-data/assessment-result-data';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/headings/heading-function';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
@@ -72,12 +73,11 @@ export const HeadingFunction: Requirement = {
             'headingText',
         ),
     ],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['collect-headings'],
-                key: HeadingsTestStep.headingFunction,
-                testType: VisualizationType.HeadingsAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHeadingsDrawer(),

--- a/src/assessments/headings/test-steps/heading-level.tsx
+++ b/src/assessments/headings/test-steps/heading-level.tsx
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 import { HeadingsAssessmentProperties } from 'common/types/store-data/assessment-result-data';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/headings/heading-level';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
@@ -67,12 +68,11 @@ export const HeadingLevel: Requirement = {
             'headingText',
         ),
     ],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['collect-headings'],
-                key: HeadingsTestStep.headingLevel,
-                testType: VisualizationType.HeadingsAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHeadingsDrawer(),

--- a/src/assessments/headings/test-steps/no-missing-headings.tsx
+++ b/src/assessments/headings/test-steps/no-missing-headings.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/headings/no-missing-headings';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
@@ -41,12 +42,11 @@ export const NoMissingHeadings: Requirement = {
     isManual: true,
     ...content,
     guidanceLinks: [link.WCAG_1_3_1, link.WCAG_2_4_6],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['collect-headings'],
-                key: HeadingsTestStep.missingHeadings,
-                testType: VisualizationType.HeadingsAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHeadingsDrawer(),

--- a/src/assessments/images/test-steps/image-function.tsx
+++ b/src/assessments/images/test-steps/image-function.tsx
@@ -5,11 +5,12 @@ import {
     NoValue,
     PropertyBagColumnRendererConfig,
 } from 'common/types/property-bag/property-bag-column-renderer-config';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import * as content from 'content/test/images/image-function';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
@@ -94,12 +95,11 @@ export const ImageFunction: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['image-function'],
-                key,
-                testType: VisualizationType.ImagesAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/images/test-steps/images-of-text.tsx
+++ b/src/assessments/images/test-steps/images-of-text.tsx
@@ -5,12 +5,13 @@ import {
     NoValue,
     PropertyBagColumnRendererConfig,
 } from 'common/types/property-bag/property-bag-column-renderer-config';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/images/images-of-text';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
@@ -75,12 +76,11 @@ export const ImagesOfText: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['accessible-image'],
-                key,
-                testType: VisualizationType.ImagesAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/images/test-steps/text-alternative.tsx
+++ b/src/assessments/images/test-steps/text-alternative.tsx
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 import { NewTabLink } from 'common/components/new-tab-link';
 import { TextAlternativePropertyBag } from 'common/types/property-bag/text-alternative-property-bag';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import * as content from 'content/test/images/text-alternative';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import {
     NoValue,
@@ -90,8 +91,6 @@ const howToTest: JSX.Element = (
     </div>
 );
 
-const key = ImagesTestStep.textAlternative;
-
 const propertyBagConfig: PropertyBagColumnRendererConfig<TextAlternativePropertyBag>[] = [
     {
         propertyName: 'imageType',
@@ -125,12 +124,11 @@ export const TextAlternative: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['accessible-image'],
-                key,
-                testType: VisualizationType.ImagesAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/landmarks/test-steps/landmark-roles.tsx
+++ b/src/assessments/landmarks/test-steps/landmark-roles.tsx
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 
 import { LandmarksAssessmentProperties } from 'common/types/store-data/assessment-result-data';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/landmarks/landmark-roles';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
@@ -98,12 +99,11 @@ export const LandmarkRoles: Requirement = {
             pb => pb.role + (pb.label ? ': ' + pb.label : ''),
         ),
     ],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['unique-landmark'],
-                key: LandmarkTestStep.landmarkRoles,
-                testType: VisualizationType.LandmarksAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createLandmarksDrawer(),

--- a/src/assessments/landmarks/test-steps/no-repeating-content.tsx
+++ b/src/assessments/landmarks/test-steps/no-repeating-content.tsx
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 import { doesResultHaveMainRole } from 'assessments/landmarks/does-result-have-main-role';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/landmarks/no-repeating-content';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { autoPassIfNoResults } from '../../auto-pass-if-no-results';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -69,12 +70,11 @@ export const NoRepeatingContent: Requirement = {
     getInitialManualTestStatus: autoPassIfNoResults,
     isVisualizationSupportedForResult: doesResultHaveMainRole,
     guidanceLinks: [link.WCAG_1_3_1, link.WCAG_2_4_1],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['unique-landmark'],
-                key: LandmarkTestStep.noRepeatingContent,
-                testType: VisualizationType.LandmarksAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createLandmarksDrawer(),

--- a/src/assessments/landmarks/test-steps/primary-content.tsx
+++ b/src/assessments/landmarks/test-steps/primary-content.tsx
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 import { doesResultHaveMainRole } from 'assessments/landmarks/does-result-have-main-role';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/landmarks/primary-content';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { autoPassIfNoResults } from '../../auto-pass-if-no-results';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -68,12 +69,11 @@ export const PrimaryContent: Requirement = {
     getInitialManualTestStatus: autoPassIfNoResults,
     isVisualizationSupportedForResult: doesResultHaveMainRole,
     guidanceLinks: [link.WCAG_1_3_1, link.WCAG_2_4_1],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['unique-landmark'],
-                key: LandmarkTestStep.primaryContent,
-                testType: VisualizationType.LandmarksAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createLandmarksDrawer(),

--- a/src/assessments/links/test-steps/label-in-name.tsx
+++ b/src/assessments/links/test-steps/label-in-name.tsx
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 
 import { LabelInNamePropertyBag } from 'common/types/property-bag/label-in-name-property-bag';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/links/label-in-name';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import {
@@ -97,13 +98,12 @@ export const LabelInName: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['label-in-name'],
-                key: LinksTestStep.labelInName,
-                testType: VisualizationType.LinksAssessment,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/links/test-steps/link-function.tsx
+++ b/src/assessments/links/test-steps/link-function.tsx
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 import { LinkFunctionPropertyBag } from 'common/types/property-bag/link-function-property-bag';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { title } from 'content/strings/application';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/links/link-function';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import {
@@ -97,13 +98,12 @@ export const LinkFunction: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['link-function'],
-                key: LinksTestStep.linkFunction,
-                testType: VisualizationType.LinksAssessment,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/links/test-steps/link-purpose.tsx
+++ b/src/assessments/links/test-steps/link-purpose.tsx
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 import { LinkPurposePropertyBag } from 'common/types/property-bag/link-purpose-property-bag';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { title } from 'content/strings/application';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/links/link-purpose';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import {
@@ -105,13 +106,12 @@ export const LinkPurpose: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['link-purpose'],
-                key: LinksTestStep.linkPurpose,
-                testType: VisualizationType.LinksAssessment,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/native-widgets/test-steps/autocomplete.tsx
+++ b/src/assessments/native-widgets/test-steps/autocomplete.tsx
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 import { link } from 'content/link';
 import * as content from 'content/test/native-widgets/autocomplete';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 
 import { NewTabLink } from '../../../common/components/new-tab-link';
@@ -10,7 +12,6 @@ import {
     NoValue,
     PropertyBagColumnRendererConfig,
 } from '../../../common/types/property-bag/property-bag-column-renderer-config';
-import { VisualizationType } from '../../../common/types/visualization-type';
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -85,13 +86,12 @@ export const Autocomplete: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['autocomplete'],
-                key,
-                testType: VisualizationType.NativeWidgets,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/native-widgets/test-steps/cues.tsx
+++ b/src/assessments/native-widgets/test-steps/cues.tsx
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 import { AnalyzerConfigurationFactory } from 'assessments/common/analyzer-configuration-factory';
 import { CuesPropertyBag } from 'common/types/property-bag/cues';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/native-widgets/cues';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import {
@@ -113,13 +114,12 @@ export const Cues: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['cues'],
-                key: NativeWidgetsTestStep.cues,
-                testType: VisualizationType.NativeWidgets,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/native-widgets/test-steps/expected-input.tsx
+++ b/src/assessments/native-widgets/test-steps/expected-input.tsx
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 
 import { DefaultWidgetPropertyBag } from 'common/types/property-bag/default-widget';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import * as content from 'content/test/native-widgets/expected-input';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import {
@@ -85,13 +86,12 @@ export const ExpectedInput: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['native-widgets-default'],
-                key: NativeWidgetsTestStep.label,
-                testType: VisualizationType.NativeWidgets,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/native-widgets/test-steps/instructions.tsx
+++ b/src/assessments/native-widgets/test-steps/instructions.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DefaultWidgetPropertyBag } from 'common/types/property-bag/default-widget';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/native-widgets/instructions';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 
@@ -104,13 +105,12 @@ export const Instructions: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['native-widgets-default'],
-                key: NativeWidgetsTestStep.instructions,
-                testType: VisualizationType.NativeWidgets,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/native-widgets/test-steps/widget-function.tsx
+++ b/src/assessments/native-widgets/test-steps/widget-function.tsx
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 import { WidgetFunctionPropertyBag } from 'common/types/property-bag/widget-function-property-bag';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/native-widgets/widget-function';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import {
@@ -98,13 +99,12 @@ export const WidgetFunction: Requirement = {
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['widget-function'],
-                key: NativeWidgetsTestStep.widgetFunction,
-                testType: VisualizationType.NativeWidgets,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/page/test-steps/frame-titles.tsx
+++ b/src/assessments/page/test-steps/frame-titles.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FrameAssessmentProperties } from 'common/types/store-data/assessment-result-data';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
 import * as content from 'content/test/page/frame-titles';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { ScannerUtils } from 'injected/scanner-utils';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -69,13 +70,12 @@ export const FrameTitle: Requirement = {
             'frameTitle',
         ),
     ],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['get-frame-title'],
-                key: PageTestStep.frameTitle,
                 resultProcessor: (scanner: ScannerUtils) => scanner.getPassingInstances,
-                testType: VisualizationType.PageAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createFrameDrawer(),

--- a/src/assessments/page/test-steps/page-title.tsx
+++ b/src/assessments/page/test-steps/page-title.tsx
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { PageAssessmentProperties } from 'common/types/store-data/assessment-result-data';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/page/page-title';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { Term } from '../../markup';
@@ -69,12 +70,11 @@ export const PageTitle: Requirement = {
             'pageTitle',
         ),
     ],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['page-title'],
-                key: PageTestStep.pageTitle,
-                testType: VisualizationType.PageAssessment,
+                ...analyzerConfig,
             }),
         ),
 };

--- a/src/assessments/semantics/test-steps/css-content.tsx
+++ b/src/assessments/semantics/test-steps/css-content.tsx
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 import { autoPassIfNoResults } from 'assessments/auto-pass-if-no-results';
 import { NewTabLink } from 'common/components/new-tab-link';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/semantics/css-content';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
@@ -109,14 +110,14 @@ export const CssContent: Requirement = {
     getInitialManualTestStatus: autoPassIfNoResults,
     guidanceLinks: [link.WCAG_1_3_1],
     ...content,
-    getAnalyzer: provider =>
-        provider.createRuleAnalyzer(
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) => {
+        return provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['css-content'],
-                key,
-                testType: VisualizationType.SemanticsAssessment,
+                ...analyzerConfig,
             }),
-        ),
+        );
+    },
     getDrawer: provider =>
         provider.createSingleTargetDrawer('insights-pseudo-selector-style-container'),
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,

--- a/src/assessments/semantics/test-steps/headers-attribute.tsx
+++ b/src/assessments/semantics/test-steps/headers-attribute.tsx
@@ -3,10 +3,11 @@
 import { AnalyzerConfigurationFactory } from 'assessments/common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from 'assessments/common/assisted-test-record-your-results';
 import { onRenderSnippetColumn } from 'assessments/common/element-column-renderers';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/semantics/headers-attribute';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 
 import * as Markup from '../../markup';
@@ -71,12 +72,11 @@ export const HeadersAttribute: Requirement = {
     isManual: false,
     ...content,
     guidanceLinks: [link.WCAG_1_3_1],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['headers-attribute'],
-                key,
-                testType: VisualizationType.SemanticsAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createTableHeaderAttributeDrawer(),

--- a/src/assessments/semantics/test-steps/table-headers.tsx
+++ b/src/assessments/semantics/test-steps/table-headers.tsx
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import * as content from 'content/test/semantics/table-headers';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
@@ -76,12 +77,11 @@ export const TableHeaders: Requirement = {
     isManual: true,
     guidanceLinks: [link.WCAG_1_3_1],
     ...content,
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['collect-headers'],
-                key,
-                testType: VisualizationType.SemanticsAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/sequence/test-steps/css-positioning.tsx
+++ b/src/assessments/sequence/test-steps/css-positioning.tsx
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 import { autoPassIfNoResults } from 'assessments/auto-pass-if-no-results';
 import { NewTabLink } from 'common/components/new-tab-link';
-import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { TestAutomaticallyPassedNotice } from 'content/test/common/test-automatically-passed-notice';
 import * as content from 'content/test/sequence/css-positioning';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import * as React from 'react';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
@@ -75,12 +76,11 @@ export const CssPositioning: Requirement = {
     getInitialManualTestStatus: autoPassIfNoResults,
     ...content,
     guidanceLinks: [link.WCAG_1_3_2],
-    getAnalyzer: provider =>
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({
                 rules: ['css-positioning'],
-                key,
-                testType: VisualizationType.SequenceAssessment,
+                ...analyzerConfig,
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),

--- a/src/assessments/visible-focus-order/test-steps/focus-order.tsx
+++ b/src/assessments/visible-focus-order/test-steps/focus-order.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Messages } from 'common/messages';
-import { VisualizationType } from 'common/types/visualization-type';
 import { generateUID } from 'common/uid-generator';
 import { link } from 'content/link';
 import * as content from 'content/test/focus/focus-order';
 import { RestartScanVisualHelperToggle } from 'DetailsView/components/restart-scan-visual-helper-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { VisualizationInstanceProcessor } from 'injected/visualization-instance-processor';
 import * as React from 'react';
 import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
@@ -64,14 +64,8 @@ export const FocusOrder: Requirement = {
     isManual: true,
     guidanceLinks: [link.WCAG_2_4_3],
     ...content,
-    getAnalyzer: provider =>
-        provider.createFocusTrackingAnalyzer({
-            key: visibleFfocusOrderTestStep.focusOrder,
-            testType: VisualizationType.VisibleFocusOrderAssessment,
-            analyzerMessageType: Messages.Assessment.AssessmentScanCompleted,
-            analyzerProgressMessageType: Messages.Assessment.ScanUpdate,
-            analyzerTerminatedMessageType: Messages.Assessment.TrackingCompleted,
-        }),
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
+        provider.createFocusTrackingAnalyzer(analyzerConfig as any),
     getVisualHelperToggle: props => <RestartScanVisualHelperToggle {...props} />,
     getDrawer: provider => provider.createSVGDrawer(),
     visualizationInstanceProcessor: VisualizationInstanceProcessor.addOrder,

--- a/src/assessments/visible-focus-order/test-steps/focus-order.tsx
+++ b/src/assessments/visible-focus-order/test-steps/focus-order.tsx
@@ -4,7 +4,7 @@ import { generateUID } from 'common/uid-generator';
 import { link } from 'content/link';
 import * as content from 'content/test/focus/focus-order';
 import { RestartScanVisualHelperToggle } from 'DetailsView/components/restart-scan-visual-helper-toggle';
-import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { FocusAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { VisualizationInstanceProcessor } from 'injected/visualization-instance-processor';
 import * as React from 'react';
@@ -64,8 +64,8 @@ export const FocusOrder: Requirement = {
     isManual: true,
     guidanceLinks: [link.WCAG_2_4_3],
     ...content,
-    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) =>
-        provider.createFocusTrackingAnalyzer(analyzerConfig as any),
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: FocusAnalyzerConfiguration) =>
+        provider.createFocusTrackingAnalyzer(analyzerConfig),
     getVisualHelperToggle: props => <RestartScanVisualHelperToggle {...props} />,
     getDrawer: provider => provider.createSVGDrawer(),
     visualizationInstanceProcessor: VisualizationInstanceProcessor.addOrder,

--- a/src/assessments/visible-focus-order/test-steps/visible-focus.tsx
+++ b/src/assessments/visible-focus-order/test-steps/visible-focus.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Messages } from 'common/messages';
-import { VisualizationType } from 'common/types/visualization-type';
 import { generateUID } from 'common/uid-generator';
 import { link } from 'content/link';
 import { title } from 'content/strings/application';
 import * as content from 'content/test/focus/visible-focus';
 import { RestartScanVisualHelperToggle } from 'DetailsView/components/restart-scan-visual-helper-toggle';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { VisualizationInstanceProcessor } from 'injected/visualization-instance-processor';
 import * as React from 'react';
 import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
@@ -56,14 +56,9 @@ export const VisibleFocus: Requirement = {
     isManual: true,
     guidanceLinks: [link.WCAG_2_4_7],
     ...content,
-    getAnalyzer: provider =>
-        provider.createFocusTrackingAnalyzer({
-            key: visibleFfocusOrderTestStep.visibleFocus,
-            testType: VisualizationType.VisibleFocusOrderAssessment,
-            analyzerMessageType: Messages.Assessment.AssessmentScanCompleted,
-            analyzerProgressMessageType: Messages.Assessment.ScanUpdate,
-            analyzerTerminatedMessageType: Messages.Assessment.TrackingCompleted,
-        }),
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) => {
+        return provider.createFocusTrackingAnalyzer(analyzerConfig as any);
+    },
     getVisualHelperToggle: props => <RestartScanVisualHelperToggle {...props} />,
     visualizationInstanceProcessor: VisualizationInstanceProcessor.addOrder,
     doNotScanByDefault: true,

--- a/src/assessments/visible-focus-order/test-steps/visible-focus.tsx
+++ b/src/assessments/visible-focus-order/test-steps/visible-focus.tsx
@@ -5,7 +5,7 @@ import { link } from 'content/link';
 import { title } from 'content/strings/application';
 import * as content from 'content/test/focus/visible-focus';
 import { RestartScanVisualHelperToggle } from 'DetailsView/components/restart-scan-visual-helper-toggle';
-import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { FocusAnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { AnalyzerProvider } from 'injected/analyzers/analyzer-provider';
 import { VisualizationInstanceProcessor } from 'injected/visualization-instance-processor';
 import * as React from 'react';
@@ -56,8 +56,8 @@ export const VisibleFocus: Requirement = {
     isManual: true,
     guidanceLinks: [link.WCAG_2_4_7],
     ...content,
-    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: AnalyzerConfiguration) => {
-        return provider.createFocusTrackingAnalyzer(analyzerConfig as any);
+    getAnalyzer: (provider: AnalyzerProvider, analyzerConfig: FocusAnalyzerConfiguration) => {
+        return provider.createFocusTrackingAnalyzer(analyzerConfig);
     },
     getVisualHelperToggle: props => <RestartScanVisualHelperToggle {...props} />,
     visualizationInstanceProcessor: VisualizationInstanceProcessor.addOrder,

--- a/src/injected/analyzer-controller.ts
+++ b/src/injected/analyzer-controller.ts
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Requirement } from 'assessments/types/requirement';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationType } from 'common/types/visualization-type';
-import { GetDetailsSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import { ShadowInitializer } from 'injected/shadow-initializer';
 import { BaseStore } from '../common/base-store';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -32,9 +30,7 @@ export class AnalyzerController {
         visualizationConfigurationFactory: VisualizationConfigurationFactory,
         analyzerProvider: AnalyzerProvider,
         analyzerStateUpdateHandler: AnalyzerStateUpdateHandler,
-        assessmentsProvider: AssessmentsProvider,
         private readonly shadowInitializer: ShadowInitializer,
-        private readonly getDetailsSwitcherNavConfiguration: GetDetailsSwitcherNavConfiguration,
     ) {
         this.analyzers = {};
         this.visualizationstore = visualizationstore;
@@ -71,11 +67,7 @@ export class AnalyzerController {
         this.shadowInitializer.removeExistingShadowHost();
 
         const analyzer = this.getAnalyzerByIdentifier(id);
-        const pivot = this.visualizationstore.getState().selectedDetailsViewPivot;
-        const messageConfiguration = this.getDetailsSwitcherNavConfiguration({
-            selectedDetailsViewPivot: pivot,
-        }).analyzerMessageConfiguration;
-        analyzer.analyze(messageConfiguration);
+        analyzer.analyze();
 
         void this.shadowInitializer.initialize();
     };

--- a/src/injected/analyzers/analyzer.ts
+++ b/src/injected/analyzers/analyzer.ts
@@ -7,14 +7,13 @@ import { TabStopEvent } from 'common/types/store-data/tab-stop-event';
 import { HtmlElementAxeResults } from 'common/types/store-data/visualization-scan-result-data';
 import { TelemetryProcessor } from 'common/types/telemetry-processor';
 import { VisualizationType } from 'common/types/visualization-type';
-import { AnalyzerMessageConfiguration } from 'injected/analyzers/get-analyzer-message-types';
 import { TabbableElementInfo } from 'injected/tabbable-element-getter';
 import { ScanResults } from 'scanner/iruleresults';
 import { DictionaryStringTo } from 'types/common-types';
 import { ScannerUtils } from '../scanner-utils';
 
 export interface Analyzer {
-    analyze(messageConfiguration: AnalyzerMessageConfiguration): void;
+    analyze(): void;
     teardown(): void;
 }
 

--- a/src/injected/analyzers/base-analyzer.ts
+++ b/src/injected/analyzers/base-analyzer.ts
@@ -4,7 +4,6 @@ import { Logger } from 'common/logging/logger';
 import { Message } from 'common/message';
 import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
 import { VisualizationType } from 'common/types/visualization-type';
-import { AnalyzerMessageConfiguration } from 'injected/analyzers/get-analyzer-message-types';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { Analyzer, AnalyzerConfiguration, ScanCompletedPayload } from './analyzer';
 
@@ -13,7 +12,6 @@ export class BaseAnalyzer implements Analyzer {
     protected emptyResults: AxeAnalyzerResult = {
         results: {},
     };
-    protected messageConfiguration: AnalyzerMessageConfiguration;
 
     constructor(
         protected readonly config: AnalyzerConfiguration,
@@ -24,8 +22,7 @@ export class BaseAnalyzer implements Analyzer {
         this.visualizationType = config.testType;
     }
 
-    public analyze(messageConfiguration: AnalyzerMessageConfiguration): void {
-        this.messageConfiguration = messageConfiguration;
+    public analyze(): void {
         const results = this.getResults();
         results.then(this.onResolve).catch(this.logger.error);
     }
@@ -44,7 +41,7 @@ export class BaseAnalyzer implements Analyzer {
         analyzerResult: AxeAnalyzerResult,
         config: AnalyzerConfiguration,
     ): Message {
-        const messageType = this.messageConfiguration.analyzerMessageType;
+        const messageType = this.config.analyzerMessageType;
         const originalAxeResult = analyzerResult.originalResult!;
         const payload: ScanCompletedPayload<any> = {
             key: config.key,

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -5,7 +5,6 @@ import { AxeAnalyzerResult } from 'common/types/axe-analyzer-result';
 import { TabStopEvent } from 'common/types/store-data/tab-stop-event';
 import { AllFrameRunner } from 'injected/all-frame-runner';
 import { BaseAnalyzer } from 'injected/analyzers/base-analyzer';
-import { FocusAnalyzerMessageConfiguration } from 'injected/analyzers/get-analyzer-message-types';
 import { TabStopsDoneAnalyzingTracker } from 'injected/analyzers/tab-stops-done-analyzing-tracker';
 import { TabStopsRequirementResultProcessor } from 'injected/analyzers/tab-stops-requirement-result-processor';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
@@ -20,7 +19,6 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
     private debouncedProcessTabEvents: DebouncedFunc<() => void> | null = null;
     private pendingTabbedElements: TabStopEvent[] = [];
     protected config: FocusAnalyzerConfiguration;
-    protected messageConfiguration: FocusAnalyzerMessageConfiguration;
 
     constructor(
         config: FocusAnalyzerConfiguration,
@@ -66,7 +64,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         };
 
         const message = {
-            messageType: this.messageConfiguration.analyzerProgressMessageType,
+            messageType: this.config.analyzerProgressMessageType,
             payload,
         };
         this.sendMessage(message);
@@ -84,12 +82,8 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
             testType: this.config.testType,
         };
 
-        if (this.messageConfiguration == null) {
-            return;
-        }
-
         this.sendMessage({
-            messageType: this.messageConfiguration.analyzerTerminatedMessageType,
+            messageType: this.config.analyzerTerminatedMessageType,
             payload,
         });
     }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -14,7 +14,6 @@ import { PermissionsStateStoreData } from 'common/types/store-data/permissions-s
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { toolName } from 'content/strings/application';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
-import { GetDetailsSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import { getCheckResolution, getFixResolution } from 'injected/adapters/resolution-creator';
 import { filterNeedsReviewResults } from 'injected/analyzers/filter-results';
 import { NotificationTextCreator } from 'injected/analyzers/notification-text-creator';
@@ -337,9 +336,7 @@ export class MainWindowInitializer extends WindowInitializer {
             this.visualizationConfigurationFactory,
             analyzerProvider,
             analyzerStateUpdateHandler,
-            Assessments,
             this.shadowInitializer,
-            GetDetailsSwitcherNavConfiguration,
         );
 
         this.analyzerController.listenToStore();

--- a/src/tests/unit/tests/injected/analyzer-controller.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-controller.test.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Requirement } from 'assessments/types/requirement';
 import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { ScopingStore } from 'background/stores/global/scoping-store';
@@ -59,7 +57,6 @@ describe('AnalyzerControllerTests', () => {
     let analyzerProviderStrictMock: IMock<AnalyzerProvider>;
     let analyzerMock: IMock<Analyzer>;
     let analyzerStateUpdateHandlerStrictMock: IMock<AnalyzerStateUpdateHandler>;
-    let assessmentsMock: IMock<AssessmentsProvider>;
     let shadowInitializerMock: IMock<ShadowInitializer>;
     let analyzerInitializeCallback: ForEachConfigCallback;
     let testObject: AnalyzerController;
@@ -97,7 +94,6 @@ describe('AnalyzerControllerTests', () => {
         } as DetailsViewSwitcherNavConfiguration;
 
         visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
-        assessmentsMock = Mock.ofType(AssessmentsProviderImpl);
         visualizationStoreMock = Mock.ofType<VisualizationStore>();
         featureFlagStoreStoreMock = Mock.ofType<FeatureFlagStore>();
         scopingStoreMock = Mock.ofType<ScopingStore>(ScopingStore);
@@ -146,9 +142,7 @@ describe('AnalyzerControllerTests', () => {
             visualizationConfigurationFactoryMock.object,
             analyzerProviderStrictMock.object,
             analyzerStateUpdateHandlerStrictMock.object,
-            assessmentsMock.object,
             shadowInitializerMock.object,
-            getDetailsSwitcherNavConfigurationMock.object,
         );
     });
 
@@ -162,11 +156,6 @@ describe('AnalyzerControllerTests', () => {
     });
 
     test('listenToStore: verify initializiation and handle update', () => {
-        assessmentsMock
-            .setup(mock => mock.isValidType(It.isAny()))
-            .returns(() => false)
-            .verifiable(Times.atLeastOnce());
-
         visualizationStoreState = new VisualizationStoreDataBuilder()
             .with('scanning', testType.toString())
             .build();
@@ -191,11 +180,6 @@ describe('AnalyzerControllerTests', () => {
         setupGetIdentifierMock(identifier, requirementStub);
         setupGetAnalyzerMockCalled(requirementStub);
 
-        assessmentsMock
-            .setup(mock => mock.isValidType(It.isAny()))
-            .returns(() => false)
-            .verifiable(Times.atLeastOnce());
-
         visualizationStoreState = new VisualizationStoreDataBuilder()
             .with('scanning', testType.toString())
             .build();
@@ -219,10 +203,6 @@ describe('AnalyzerControllerTests', () => {
         scopingStoreState = new ScopingStoreDataBuilder().build();
 
         setupVisualizationConfigurationFactory(testType, configStub);
-        assessmentsMock
-            .setup(mock => mock.isValidType(It.isAny()))
-            .returns(() => false)
-            .verifiable(Times.atLeastOnce());
 
         analyzerStateUpdateHandlerStrictMock
             .setup(handler => handler.handleUpdate(visualizationStoreState))
@@ -277,7 +257,7 @@ describe('AnalyzerControllerTests', () => {
         getDetailsSwitcherNavConfigurationMock
             .setup(m => m(It.isValue(expected)))
             .returns(() => switcherConfigurationStub);
-        analyzerMock.setup(am => am.analyze(messageConfigurationStub)).verifiable();
+        analyzerMock.setup(am => am.analyze()).verifiable();
     }
 
     function setupTeardownCall(): void {

--- a/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
@@ -6,7 +6,6 @@ import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete
 import { VisualizationType } from 'common/types/visualization-type';
 import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { BaseAnalyzer } from 'injected/analyzers/base-analyzer';
-import { AnalyzerMessageConfiguration } from 'injected/analyzers/get-analyzer-message-types';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -17,7 +16,6 @@ describe('BaseAnalyzer', () => {
     let sendMessageMock: IMock<(message) => void>;
     let typeStub: VisualizationType;
     let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
-    let messageConfigurationStub: AnalyzerMessageConfiguration;
 
     beforeEach(() => {
         sendMessageMock = Mock.ofInstance(message => {});
@@ -27,9 +25,6 @@ describe('BaseAnalyzer', () => {
             analyzerMessageType: 'sample message type',
             key: 'sample key',
             testType: typeStub,
-        };
-        messageConfigurationStub = {
-            analyzerMessageType: 'some message type',
         };
         testSubject = new BaseAnalyzer(
             configStub,
@@ -45,7 +40,7 @@ describe('BaseAnalyzer', () => {
             'missing-required-cross-origin-permissions',
         ];
         const expectedMessage: Message = {
-            messageType: messageConfigurationStub.analyzerMessageType,
+            messageType: configStub.analyzerMessageType,
             payload: {
                 key: configStub.key,
                 selectorMap: resultsStub,
@@ -67,6 +62,6 @@ describe('BaseAnalyzer', () => {
             })
             .verifiable(Times.once());
 
-        testSubject.analyze(messageConfigurationStub);
+        testSubject.analyze();
     });
 });

--- a/src/tests/unit/tests/injected/analyzers/batched-rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/batched-rule-analyzer.test.ts
@@ -3,7 +3,6 @@
 import { ScopingStore } from 'background/stores/global/scoping-store';
 import { ScopingInputTypes } from 'common/types/store-data/scoping-input-types';
 import { HtmlElementAxeResults } from 'common/types/store-data/visualization-scan-result-data';
-import { AnalyzerMessageConfiguration } from 'injected/analyzers/get-analyzer-message-types';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { clone, isEqual, isFunction } from 'lodash';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
@@ -38,7 +37,6 @@ describe('BatchedRuleAnalyzer', () => {
     const scanCallbacks: ((results: ScanResults) => void)[] = [];
     let resultConfigFilterMock: IMock<IResultRuleFilter>;
     let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
-    let messageConfigurationStub: AnalyzerMessageConfiguration;
 
     beforeEach(() => {
         typeStub = -1 as VisualizationType;
@@ -51,9 +49,6 @@ describe('BatchedRuleAnalyzer', () => {
             getTime: () => {
                 return null;
             },
-        };
-        messageConfigurationStub = {
-            analyzerMessageType: 'some message type',
         };
         scanIncompleteWarningDetectorMock = Mock.ofType<ScanIncompleteWarningDetector>();
         dateMock = Mock.ofInstance(dateStub as Date);
@@ -154,7 +149,7 @@ describe('BatchedRuleAnalyzer', () => {
                 .returns(_ => startTime)
                 .verifiable();
 
-            testSubject.analyze(messageConfigurationStub);
+            testSubject.analyze();
         });
 
         /*
@@ -263,7 +258,7 @@ describe('BatchedRuleAnalyzer', () => {
         expectedTelemetryStub,
     ): Message {
         return {
-            messageType: messageConfigurationStub.analyzerMessageType,
+            messageType: config.analyzerMessageType,
             payload: {
                 key: config.key,
                 selectorMap: allInstancesMocks,

--- a/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
@@ -174,7 +174,7 @@ describe('RuleAnalyzer', () => {
             .returns(_ => startTime)
             .verifiable();
 
-        testSubject.analyze(messageConfigurationStub);
+        testSubject.analyze();
 
         dateMock.reset();
         dateMock


### PR DESCRIPTION
#### Details

This PR covers mainly 2 things:
1. Modify configs for tests to use the analyzer config coming from the analyzer controller, the second half of (#6225)
2. Use the analyzer config passed in at initialization instead of the analyze method since both are coming from the analyzer-controller now, undoing #6163.

**Heavily** suggest reviewing by commit.

##### Motivation

Feature work.

##### Context

Since the analyzer controller now decides what the config looks like, the analyzers now do not have to be statically linked to Assessment and can be used for QuickAssess as well.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
