### PR TITLE
fix: ensure default store data is merged with persisted data during VisualizationStore initialization

### DIFF
--- a/src/background/initial-visualization-store-data-generator.ts
+++ b/src/background/initial-visualization-store-data-generator.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { EnumHelper } from 'common/enum-helper';
+import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
+import {
+    TestsEnabledState,
+    VisualizationStoreData,
+} from 'common/types/store-data/visualization-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+
+export class InitialVisualizationStoreDataGenerator {
+    constructor(
+        private readonly visualizationConfigurationFactory: VisualizationConfigurationFactory,
+    ) {}
+
+    public generateInitialState(
+        persistedData: VisualizationStoreData = null,
+    ): VisualizationStoreData {
+        const defaultTests: TestsEnabledState = {
+            adhoc: {},
+            assessments: {},
+            mediumPass: {},
+        };
+
+        if (this.visualizationConfigurationFactory != null) {
+            EnumHelper.getNumericValues(VisualizationType).forEach((test: VisualizationType) => {
+                const config = this.visualizationConfigurationFactory.getConfiguration(test);
+                defaultTests[config.testMode][config.key] = {
+                    enabled: false,
+                };
+            });
+
+            Object.keys(defaultTests.assessments).forEach(key => {
+                defaultTests.assessments[key].stepStatus = {};
+            });
+
+            Object.keys(defaultTests.mediumPass).forEach(key => {
+                defaultTests.mediumPass[key].stepStatus = {};
+            });
+        }
+        const tests: TestsEnabledState = persistedData?.tests
+            ? { ...defaultTests, ...persistedData.tests }
+            : defaultTests;
+
+        const defaultValues: VisualizationStoreData = {
+            tests,
+            scanning: null,
+            selectedFastPassDetailsView: VisualizationType.Issues,
+            selectedAdhocDetailsView: VisualizationType.Issues,
+            selectedDetailsViewPivot: DetailsViewPivotType.fastPass,
+            injectingStarted: false,
+            injectingRequested: false,
+            focusedTarget: null,
+        };
+
+        return defaultValues;
+    }
+}

--- a/src/background/initial-visualization-store-data-generator.ts
+++ b/src/background/initial-visualization-store-data-generator.ts
@@ -9,6 +9,7 @@ import {
     VisualizationStoreData,
 } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
+import { isEmpty, merge } from 'lodash';
 
 export class InitialVisualizationStoreDataGenerator {
     constructor(
@@ -40,12 +41,8 @@ export class InitialVisualizationStoreDataGenerator {
                 defaultTests.mediumPass[key].stepStatus = {};
             });
         }
-        const tests: TestsEnabledState = persistedData?.tests
-            ? { ...defaultTests, ...persistedData.tests }
-            : defaultTests;
-
         const defaultValues: VisualizationStoreData = {
-            tests,
+            tests: defaultTests,
             scanning: null,
             selectedFastPassDetailsView: VisualizationType.Issues,
             selectedAdhocDetailsView: VisualizationType.Issues,
@@ -54,7 +51,10 @@ export class InitialVisualizationStoreDataGenerator {
             injectingRequested: false,
             focusedTarget: null,
         };
+        const initialState = !isEmpty(persistedData)
+            ? merge({}, defaultValues, persistedData)
+            : defaultValues;
 
-        return defaultValues;
+        return initialState;
     }
 }

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { PersistedData } from 'background/get-persisted-data';
+import { InitialVisualizationStoreDataGenerator } from 'background/initial-visualization-store-data-generator';
 import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { NeedsReviewCardSelectionStore } from 'background/stores/needs-review-card-selection-store';
 import { NeedsReviewScanResultStore } from 'background/stores/needs-review-scan-result-store';
@@ -57,6 +58,7 @@ export class TabContextStoreHub implements StoreHub {
             logger,
             tabId,
             persistStoreData,
+            new InitialVisualizationStoreDataGenerator(visualizationConfigurationFactory),
         );
         this.visualizationStore.initialize();
 

--- a/src/tests/unit/common/visualization-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-store-data-builder.ts
@@ -3,6 +3,7 @@
 import { Assessments } from 'assessments/assessments';
 import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
 import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
+import { InitialVisualizationStoreDataGenerator } from 'background/initial-visualization-store-data-generator';
 import { VisualizationStore } from 'background/stores/visualization-store';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { cloneDeep, forOwn } from 'lodash';
@@ -17,19 +18,21 @@ import { BaseDataBuilder } from './base-data-builder';
 export class VisualizationStoreDataBuilder extends BaseDataBuilder<VisualizationStoreData> {
     constructor() {
         super();
+        const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
+            Assessments,
+            assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+        );
         this.data = new VisualizationStore(
             null,
             null,
             null,
-            new WebVisualizationConfigurationFactory(
-                Assessments,
-                assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
-            ),
+            visualizationConfigurationFactory,
             null,
             null,
             null,
             null,
             true,
+            new InitialVisualizationStoreDataGenerator(visualizationConfigurationFactory),
         ).getDefaultState();
     }
 

--- a/src/tests/unit/tests/background/__snapshots__/initial-visualization-store-data-generator.test.ts.snap
+++ b/src/tests/unit/tests/background/__snapshots__/initial-visualization-store-data-generator.test.ts.snap
@@ -1,0 +1,213 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InitialVisualizationStoreDataGenerator.generateInitialState generates the pinned default state when no persistedData is provided 1`] = `
+{
+  "focusedTarget": null,
+  "injectingRequested": false,
+  "injectingStarted": false,
+  "scanning": null,
+  "selectedAdhocDetailsView": 1,
+  "selectedDetailsViewPivot": 0,
+  "selectedFastPassDetailsView": 1,
+  "tests": {
+    "adhoc": {
+      "type-0": {
+        "enabled": false,
+      },
+      "type-1": {
+        "enabled": false,
+      },
+      "type-2": {
+        "enabled": false,
+      },
+      "type-3": {
+        "enabled": false,
+      },
+      "type-4": {
+        "enabled": false,
+      },
+    },
+    "assessments": {
+      "type-11": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-12": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-13": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-14": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-15": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-16": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-17": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-18": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-19": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-20": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-21": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-22": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-23": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-24": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-25": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-26": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-27": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-28": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-29": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-30": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-31": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-32": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-33": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-34": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-35": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-36": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-37": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-38": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+    },
+    "mediumPass": {
+      "type-10": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-5": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-6": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-7": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-8": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+      "type-9": {
+        "enabled": false,
+        "stepStatus": {},
+      },
+    },
+  },
+}
+`;
+
+exports[`InitialVisualizationStoreDataGenerator.generateInitialState overwrites empty state.tests if persistedState.tests has data when persistedState.tests.mediumPass has data is false 1`] = `
+{
+  "adhoc": {},
+  "assessments": {},
+  "mediumPass": {
+    "type-10": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-5": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-6": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-7": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-8": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-9": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+  },
+}
+`;
+
+exports[`InitialVisualizationStoreDataGenerator.generateInitialState overwrites empty state.tests if persistedState.tests has data when persistedState.tests.mediumPass has data is true 1`] = `
+{
+  "adhoc": {},
+  "assessments": {},
+  "mediumPass": {},
+}
+`;

--- a/src/tests/unit/tests/background/__snapshots__/initial-visualization-store-data-generator.test.ts.snap
+++ b/src/tests/unit/tests/background/__snapshots__/initial-visualization-store-data-generator.test.ts.snap
@@ -173,8 +173,137 @@ exports[`InitialVisualizationStoreDataGenerator.generateInitialState generates t
 
 exports[`InitialVisualizationStoreDataGenerator.generateInitialState overwrites empty state.tests if persistedState.tests has data when persistedState.tests.mediumPass has data is false 1`] = `
 {
-  "adhoc": {},
-  "assessments": {},
+  "adhoc": {
+    "type-0": {
+      "enabled": false,
+    },
+    "type-1": {
+      "enabled": false,
+    },
+    "type-2": {
+      "enabled": false,
+    },
+    "type-3": {
+      "enabled": false,
+    },
+    "type-4": {
+      "enabled": false,
+    },
+  },
+  "assessments": {
+    "type-11": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-12": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-13": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-14": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-15": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-16": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-17": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-18": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-19": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-20": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-21": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-22": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-23": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-24": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-25": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-26": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-27": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-28": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-29": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-30": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-31": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-32": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-33": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-34": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-35": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-36": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-37": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-38": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+  },
   "mediumPass": {
     "type-10": {
       "enabled": false,
@@ -206,8 +335,162 @@ exports[`InitialVisualizationStoreDataGenerator.generateInitialState overwrites 
 
 exports[`InitialVisualizationStoreDataGenerator.generateInitialState overwrites empty state.tests if persistedState.tests has data when persistedState.tests.mediumPass has data is true 1`] = `
 {
-  "adhoc": {},
-  "assessments": {},
-  "mediumPass": {},
+  "adhoc": {
+    "type-0": {
+      "enabled": false,
+    },
+    "type-1": {
+      "enabled": false,
+    },
+    "type-2": {
+      "enabled": false,
+    },
+    "type-3": {
+      "enabled": false,
+    },
+    "type-4": {
+      "enabled": false,
+    },
+  },
+  "assessments": {
+    "type-11": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-12": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-13": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-14": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-15": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-16": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-17": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-18": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-19": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-20": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-21": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-22": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-23": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-24": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-25": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-26": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-27": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-28": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-29": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-30": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-31": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-32": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-33": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-34": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-35": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-36": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-37": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-38": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+  },
+  "mediumPass": {
+    "type-10": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-5": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-6": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-7": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-8": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-9": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+  },
 }
 `;

--- a/src/tests/unit/tests/background/initial-visualization-store-data-generator.test.ts
+++ b/src/tests/unit/tests/background/initial-visualization-store-data-generator.test.ts
@@ -60,13 +60,19 @@ describe('InitialVisualizationStoreDataGenerator.generateInitialState', () => {
     );
 
     it.each([[undefined], [null]])(
-        'returns default state.tests when persistedState.tests is %p',
+        'returns default state.tests when persistedState is %p',
         persistedTests => {
-            const generatedState = generator.generateInitialState({
-                tests: persistedTests,
-            } as VisualizationStoreData);
+            const generatedState = generator.generateInitialState(persistedTests);
 
             expect(generatedState.tests).toEqual(defaultState.tests);
         },
     );
+
+    it('does not overwrite other persisted data', () => {
+        const generatedState = generator.generateInitialState({
+            injectingStarted: true,
+        } as VisualizationStoreData);
+
+        expect(generatedState.injectingStarted).toEqual(true);
+    });
 });

--- a/src/tests/unit/tests/background/initial-visualization-store-data-generator.test.ts
+++ b/src/tests/unit/tests/background/initial-visualization-store-data-generator.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { InitialDataCreator } from 'background/create-initial-assessment-test-data';
+import { InitialVisualizationStoreDataGenerator } from 'background/initial-visualization-store-data-generator';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+
+import { EnumHelper } from 'common/enum-helper';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import { IMock, Mock, MockBehavior } from 'typemoq';
+
+describe('InitialVisualizationStoreDataGenerator.generateInitialState', () => {
+    let defaultState: VisualizationStoreData;
+    let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
+    let initialDataCreatorMock: IMock<InitialDataCreator>;
+    let generator: InitialVisualizationStoreDataGenerator;
+    let visualizationTypes = EnumHelper.getNumericValues(VisualizationType);
+    const visualizationConfigurationStub = (test: number, testMode: string) => {
+        return {
+            key: `type-${test}`,
+            testMode: testMode,
+        } as VisualizationConfiguration;
+    };
+    const typeToTestModeMap = visualizationTypes.map(vt =>
+        vt < 5 ? 'adhoc' : vt > 10 ? 'assessments' : 'mediumPass',
+    );
+
+    beforeEach(() => {
+        visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
+        initialDataCreatorMock = Mock.ofInstance(() => null, MockBehavior.Strict);
+        visualizationTypes.forEach((type: VisualizationType, index: number) => {
+            visualizationConfigurationFactoryMock
+                .setup(vcf => vcf.getConfiguration(type))
+                .returns(() => visualizationConfigurationStub(type, typeToTestModeMap[index]));
+        });
+
+        generator = new InitialVisualizationStoreDataGenerator(
+            visualizationConfigurationFactoryMock.object,
+        );
+        defaultState = generator.generateInitialState();
+    });
+
+    it('generates the pinned default state when no persistedData is provided', () => {
+        expect(defaultState).toMatchSnapshot();
+    });
+
+    it.each([true, false])(
+        'overwrites empty state.tests if persistedState.tests has data when persistedState.tests.mediumPass has data is %s',
+        (hasMediumPassData: boolean) => {
+            const persistedTests = hasMediumPassData
+                ? {
+                      adhoc: {},
+                      assessments: {},
+                      mediumPass: {},
+                  }
+                : { adhoc: {}, assessments: {} };
+            const generatedState = generator.generateInitialState({
+                tests: persistedTests,
+            } as VisualizationStoreData);
+            expect(generatedState.tests).toMatchSnapshot();
+        },
+    );
+
+    it.each([[undefined], [null]])(
+        'returns default state.tests when persistedState.tests is %p',
+        persistedTests => {
+            const generatedState = generator.generateInitialState({
+                tests: persistedTests,
+            } as VisualizationStoreData);
+
+            expect(generatedState.tests).toEqual(defaultState.tests);
+        },
+    );
+});

--- a/src/tests/unit/tests/background/initial-visualization-store-data-generator.test.ts
+++ b/src/tests/unit/tests/background/initial-visualization-store-data-generator.test.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 import { InitialDataCreator } from 'background/create-initial-assessment-test-data';
 import { InitialVisualizationStoreDataGenerator } from 'background/initial-visualization-store-data-generator';
-import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 
 import { EnumHelper } from 'common/enum-helper';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
@@ -15,7 +15,7 @@ describe('InitialVisualizationStoreDataGenerator.generateInitialState', () => {
     let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
     let initialDataCreatorMock: IMock<InitialDataCreator>;
     let generator: InitialVisualizationStoreDataGenerator;
-    let visualizationTypes = EnumHelper.getNumericValues(VisualizationType);
+    const visualizationTypes = EnumHelper.getNumericValues(VisualizationType);
     const visualizationConfigurationStub = (test: number, testMode: string) => {
         return {
             key: `type-${test}`,

--- a/src/tests/unit/tests/background/initial-visualization-store-data-generator.test.ts
+++ b/src/tests/unit/tests/background/initial-visualization-store-data-generator.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { InitialDataCreator } from 'background/create-initial-assessment-test-data';
 import { InitialVisualizationStoreDataGenerator } from 'background/initial-visualization-store-data-generator';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
@@ -8,12 +7,11 @@ import { VisualizationConfigurationFactory } from 'common/configs/visualization-
 import { EnumHelper } from 'common/enum-helper';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
-import { IMock, Mock, MockBehavior } from 'typemoq';
+import { IMock, Mock } from 'typemoq';
 
 describe('InitialVisualizationStoreDataGenerator.generateInitialState', () => {
     let defaultState: VisualizationStoreData;
     let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
-    let initialDataCreatorMock: IMock<InitialDataCreator>;
     let generator: InitialVisualizationStoreDataGenerator;
     const visualizationTypes = EnumHelper.getNumericValues(VisualizationType);
     const visualizationConfigurationStub = (test: number, testMode: string) => {
@@ -28,7 +26,6 @@ describe('InitialVisualizationStoreDataGenerator.generateInitialState', () => {
 
     beforeEach(() => {
         visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
-        initialDataCreatorMock = Mock.ofInstance(() => null, MockBehavior.Strict);
         visualizationTypes.forEach((type: VisualizationType, index: number) => {
             visualizationConfigurationFactoryMock
                 .setup(vcf => vcf.getConfiguration(type))

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -14,19 +14,25 @@ import {
 import { InjectionActions } from 'background/actions/injection-actions';
 import { TabActions } from 'background/actions/tab-actions';
 import { VisualizationActions } from 'background/actions/visualization-actions';
+import { InitialVisualizationStoreDataGenerator } from 'background/initial-visualization-store-data-generator';
 import { VisualizationStore } from 'background/stores/visualization-store';
 import { TestMode } from 'common/configs/test-mode';
 import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { AdHocTestkeys } from 'common/types/store-data/adhoc-test-keys';
 import { cloneDeep } from 'lodash';
+import { IMock, Mock, Times } from 'typemoq';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import { DetailsViewPivotType } from '../../../../../common/types/store-data/details-view-pivot-type';
-import { VisualizationStoreData } from '../../../../../common/types/store-data/visualization-store-data';
+import {
+    TestsEnabledState,
+    VisualizationStoreData,
+} from '../../../../../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { createStoreWithNullParams, StoreTester } from '../../../common/store-tester';
 import { VisualizationStoreDataBuilder } from '../../../common/visualization-store-data-builder';
 
 describe('VisualizationStoreTest ', () => {
+    let initialVisualizationStoreDataGeneratorMock: IMock<InitialVisualizationStoreDataGenerator>;
     test('constructor, no side effects', () => {
         const testObject = createStoreWithNullParams(VisualizationStore);
         expect(testObject).toBeDefined();
@@ -35,6 +41,123 @@ describe('VisualizationStoreTest ', () => {
     test('getId', () => {
         const testObject = createStoreWithNullParams(VisualizationStore);
         expect(StoreNames[StoreNames.VisualizationStore]).toEqual(testObject.getId());
+    });
+
+    describe('getDefaultState', () => {
+        beforeEach(() => {
+            initialVisualizationStoreDataGeneratorMock =
+                Mock.ofType<InitialVisualizationStoreDataGenerator>();
+        });
+
+        it('with no tests in state', () => {
+            const defaultStateStub = {};
+            setupDataGeneratorMock(null, defaultStateStub as VisualizationStoreData);
+
+            const testObject = new VisualizationStore(
+                null,
+                new TabActions(),
+                new InjectionActions(),
+                new WebVisualizationConfigurationFactory(
+                    Assessments,
+                    assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+                ),
+                null,
+                null,
+                null,
+                null,
+                true,
+                initialVisualizationStoreDataGeneratorMock.object,
+            );
+
+            const actualState = testObject.getDefaultState();
+
+            expect(actualState).toEqual(defaultStateStub);
+            initialVisualizationStoreDataGeneratorMock.verifyAll();
+        });
+
+        it('with tests in persistedData missing mediumPass data', () => {
+            const persistedState: VisualizationStoreData = {
+                tests: {
+                    adhoc: {},
+                    assessments: {},
+                } as TestsEnabledState,
+            } as VisualizationStoreData;
+
+            const expectedState = {
+                tests: {
+                    adhoc: {},
+                    assessments: {},
+                    mediumPass: {},
+                },
+            };
+
+            setupDataGeneratorMock(
+                persistedState as VisualizationStoreData,
+                expectedState as VisualizationStoreData,
+            );
+
+            const testObject = new VisualizationStore(
+                null,
+                new TabActions(),
+                new InjectionActions(),
+                new WebVisualizationConfigurationFactory(
+                    Assessments,
+                    assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+                ),
+                persistedState,
+                null,
+                null,
+                null,
+                true,
+                initialVisualizationStoreDataGeneratorMock.object,
+            );
+
+            const actualState = testObject.getDefaultState();
+
+            expect(actualState).toEqual(expectedState);
+            initialVisualizationStoreDataGeneratorMock.verifyAll();
+        });
+        it('with tests in persistedData including mediumPass data', () => {
+            const persistedState: VisualizationStoreData = {
+                tests: {
+                    adhoc: {},
+                    assessments: {},
+                    mediumPass: {},
+                } as TestsEnabledState,
+            } as VisualizationStoreData;
+
+            const expectedState = {
+                tests: {
+                    adhoc: {},
+                    assessments: {},
+                    mediumPass: {},
+                },
+            };
+            setupDataGeneratorMock(
+                persistedState as VisualizationStoreData,
+                expectedState as VisualizationStoreData,
+            );
+            const testObject = new VisualizationStore(
+                null,
+                new TabActions(),
+                new InjectionActions(),
+                new WebVisualizationConfigurationFactory(
+                    Assessments,
+                    assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+                ),
+                persistedState,
+                null,
+                null,
+                null,
+                true,
+                initialVisualizationStoreDataGeneratorMock.object,
+            );
+
+            const actualState = testObject.getDefaultState();
+
+            expect(actualState).toEqual(expectedState);
+            initialVisualizationStoreDataGeneratorMock.verifyAll();
+        });
     });
 
     describe('onUpdateSelectedPivotChild', () => {
@@ -830,20 +953,22 @@ describe('VisualizationStoreTest ', () => {
     function createStoreTesterForTabActions(
         actionName: keyof TabActions,
     ): StoreTester<VisualizationStoreData, TabActions> {
+        const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
+            Assessments,
+            assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+        );
         const factory = (actions: TabActions) =>
             new VisualizationStore(
                 new VisualizationActions(),
                 actions,
                 new InjectionActions(),
-                new WebVisualizationConfigurationFactory(
-                    Assessments,
-                    assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
-                ),
+                visualizationConfigurationFactory,
                 null,
                 null,
                 null,
                 null,
                 true,
+                new InitialVisualizationStoreDataGenerator(visualizationConfigurationFactory),
             );
 
         return new StoreTester(TabActions, actionName, factory);
@@ -852,20 +977,22 @@ describe('VisualizationStoreTest ', () => {
     function createStoreTesterForVisualizationActions(
         actionName: keyof VisualizationActions,
     ): StoreTester<VisualizationStoreData, VisualizationActions> {
+        const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
+            Assessments,
+            assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+        );
         const factory = (actions: VisualizationActions) =>
             new VisualizationStore(
                 actions,
                 new TabActions(),
                 new InjectionActions(),
-                new WebVisualizationConfigurationFactory(
-                    Assessments,
-                    assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
-                ),
+                visualizationConfigurationFactory,
                 null,
                 null,
                 null,
                 null,
                 true,
+                new InitialVisualizationStoreDataGenerator(visualizationConfigurationFactory),
             );
 
         return new StoreTester(VisualizationActions, actionName, factory);
@@ -874,22 +1001,35 @@ describe('VisualizationStoreTest ', () => {
     function createStoreTesterForInjectionActions(
         actionName: keyof InjectionActions,
     ): StoreTester<VisualizationStoreData, InjectionActions> {
+        const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
+            Assessments,
+            assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
+        );
         const factory = (actions: InjectionActions) =>
             new VisualizationStore(
                 new VisualizationActions(),
                 new TabActions(),
                 actions,
-                new WebVisualizationConfigurationFactory(
-                    Assessments,
-                    assessmentsProviderForRequirements(Assessments, MediumPassRequirementMap),
-                ),
+                visualizationConfigurationFactory,
                 null,
                 null,
                 null,
                 null,
                 true,
+                new InitialVisualizationStoreDataGenerator(visualizationConfigurationFactory),
             );
 
         return new StoreTester(InjectionActions, actionName, factory);
+    }
+
+    function setupDataGeneratorMock(
+        persistedData: VisualizationStoreData,
+        expectedData: VisualizationStoreData,
+        times: Times = Times.once(),
+    ): void {
+        initialVisualizationStoreDataGeneratorMock
+            .setup(im => im.generateInitialState(persistedData))
+            .returns(() => expectedData)
+            .verifiable(times);
     }
 });


### PR DESCRIPTION
#### Details

When there is persisted data in IndexedDB for the `VisualizationStore` and `storeData.tests` is missing the `mediumPass` key, the `WebConfigurationVisualizationFactory` hits an error. This PR overrides `generateDefaultState` for `VisualizationStore` (called during `initialize()`), allowing us to ensure that default state is generated for test modes not present in `persistedData`. This implementation is based on `AssessmentStore`, which is the only other store that overrides this method. It pulls initial data generation logic into a separate class to facilitate testing. 

##### Motivation

This PR addresses an issue seen in Canary where adhoc visualizations are nonfunctional and the service worker logs the following error: 
```Error while processing browser RuntimeOnMessage event:  TypeError: Cannot read properties of undefined (reading 'keyboardInteractionAssessment')```


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
