### PR TITLE
chore: include stack of original scope-holder in ScopeMutex errors

### DIFF
--- a/src/common/flux/scope-mutex.ts
+++ b/src/common/flux/scope-mutex.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { getStackTrace } from 'common/get-stack-trace';
 import { DictionaryStringTo } from 'types/common-types';
+
+type Scope = {
+    name: string;
+    stack?: string;
+};
 
 export class ScopeMutex {
     /**
@@ -14,22 +20,26 @@ export class ScopeMutex {
      * actions. In this case, a different scope should be passed to invoke() in each
      * callback to allow them to run concurrently.
      */
-    private static executingScopes: DictionaryStringTo<boolean> = {};
+    private static executingScopes: DictionaryStringTo<Scope> = {};
     private static defaultScope: string = 'DEFAULT_SCOPE';
 
-    public tryLockScope(scope?: string): void {
-        const activeScope = scope ?? ScopeMutex.defaultScope;
-        if (ScopeMutex.executingScopes[activeScope]) {
+    public tryLockScope(scopeName?: string): void {
+        scopeName = scopeName ?? ScopeMutex.defaultScope;
+        const scope = ScopeMutex.executingScopes[scopeName];
+        if (scope != null) {
             throw new Error(
-                `Cannot invoke an action with scope ${activeScope} from inside another action with the same scope`,
+                `Cannot invoke an action with scope ${scopeName} from inside another action with the same scope. Stack of original scope holder: ${scope.stack}`,
             );
         }
 
-        ScopeMutex.executingScopes[activeScope] = true;
+        ScopeMutex.executingScopes[scopeName] = {
+            name: scopeName,
+            stack: getStackTrace(),
+        };
     }
 
-    public unlockScope(scope?: string): void {
-        const activeScope = scope ?? ScopeMutex.defaultScope;
-        delete ScopeMutex.executingScopes[activeScope];
+    public unlockScope(scopeName?: string): void {
+        scopeName = scopeName ?? ScopeMutex.defaultScope;
+        delete ScopeMutex.executingScopes[scopeName];
     }
 }

--- a/src/common/flux/scope-mutex.ts
+++ b/src/common/flux/scope-mutex.ts
@@ -6,7 +6,7 @@ import { DictionaryStringTo } from 'types/common-types';
 
 type Scope = {
     name: string;
-    stack?: string;
+    stack: string;
 };
 
 export class ScopeMutex {

--- a/src/common/get-stack-trace.ts
+++ b/src/common/get-stack-trace.ts
@@ -6,7 +6,7 @@ export type GetStackTraceOptions = {
     framesToIgnore?: number;
 };
 
-export function getStackTrace(options?: GetStackTraceOptions) {
+export function getStackTrace(options?: GetStackTraceOptions): string {
     const rawStack = new Error().stack!;
     const framesToIgnore = options?.framesToIgnore ?? 0;
 

--- a/src/common/get-stack-trace.ts
+++ b/src/common/get-stack-trace.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type GetStackTraceOptions = {
+    // This number should not include the frame for getStackTrace() itself, which is always ignored
+    framesToIgnore?: number;
+};
+
+export function getStackTrace(options?: GetStackTraceOptions) {
+    const rawStack = new Error().stack!;
+    const framesToIgnore = options?.framesToIgnore ?? 0;
+
+    // first line is "Error: "
+    // second line is the frame for getStackTrace() itself
+    const linesToIgnore = framesToIgnore + 2;
+
+    return rawStack.split('\n').splice(linesToIgnore).join('\n');
+}

--- a/src/tests/unit/common/recording-logger.ts
+++ b/src/tests/unit/common/recording-logger.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { getStackTrace } from 'common/get-stack-trace';
 import { Logger } from 'common/logging/logger';
 
 export type LogRecord = {
@@ -28,7 +29,7 @@ export class RecordingLogger implements Logger {
     }
 
     private record(level: 'error' | 'log', message: string | undefined, optionalParams: any[]) {
-        const stack = new Error().stack!.split('\n').splice(2).join('\n');
+        const stack = getStackTrace({ framesToIgnore: 1 });
         this.allRecords.push({ level, message, optionalParams, stack });
     }
 

--- a/src/tests/unit/tests/common/get-stack-trace.test.ts
+++ b/src/tests/unit/tests/common/get-stack-trace.test.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { getStackTrace } from 'common/get-stack-trace';
+
+// this describe block is intentionally named with different casing from the actual function
+// because describe(name, () => {}) results in name appearing in stack traces and the tests need
+// to distinguish whether or not "getStackTrace" itself appears in the stack traces it produces
+describe('get-stack-trace', () => {
+    it("should include the calling function's name in first line", () => {
+        let stack: string | undefined;
+        function namedCallingFunction() {
+            stack = getStackTrace();
+        }
+        namedCallingFunction();
+
+        expect(stack.split('\n')[0]).toContain('namedCallingFunction');
+    });
+
+    it('should not include the frame for the function itself', () => {
+        expect(getStackTrace()).not.toContain('getStackTrace');
+    });
+
+    it("should not include the stub error's message line", () => {
+        expect(getStackTrace()).not.toContain('Error:');
+    });
+
+    it('should omit a line per ignored frame', () => {
+        const stackIgnoring0Frames = getStackTrace();
+        const linesInStackIgnoring0Frames = stackIgnoring0Frames.split('\n').length;
+
+        const stackIgnoring2Frames = getStackTrace({ framesToIgnore: 2 });
+        const linesInStackIgnoring2Frames = stackIgnoring2Frames.split('\n').length;
+
+        expect(linesInStackIgnoring0Frames).toEqual(linesInStackIgnoring2Frames + 2);
+        expect(stackIgnoring0Frames.endsWith(stackIgnoring2Frames)).toBe(true);
+    });
+});

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -260,6 +260,7 @@
         "./src/common/get-card-selection-view-data.ts",
         "./src/common/get-guidance-tags-from-guidance-links.ts",
         "./src/common/get-inner-text-from-jsx-element.ts",
+        "./src/common/get-stack-trace.ts",
         "./src/common/globalization.ts",
         "./src/common/html-element-utils.ts",
         "./src/common/is-result-highlight-unavailable.ts",


### PR DESCRIPTION
#### Details

While investigating a ScopeMutex error earlier today, I found myself wanting to know the stack of the original scope holder. This PR introduces a new helper for grabbing a current stack trace (extracting some code from `recording-logger`) and implements support for stack-tracking to `ScopeMutex`, augmenting its error messages to include the stack of the original scope-holder.

##### Motivation

Improve actionability of this type of error. This isn't super important for reproducible forms of the error since you could just use print breakpoints on `tryLockScope` to achieve the same thing, but it makes inconsistent/racey errors of this form (and `unhandledError` telemetry of this form) much more likely to be actionable

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
