### PR TITLE
refactor(medium-pass-1): remove usages of assessmentsProvider through props in details-view-content

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IButton } from '@fluentui/react';
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { NewTabLinkWithTooltip } from 'common/components/new-tab-link-with-tooltip';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
@@ -40,6 +39,7 @@ import { StartOverFactoryDeps } from 'DetailsView/components/start-over-componen
 import {
     dialogClosedState,
     StartOverDialog,
+    StartOverDialogDeps,
     StartOverDialogProps,
     StartOverDialogState,
     StartOverDialogType,
@@ -60,7 +60,8 @@ export type DetailsViewCommandBarDeps = {
     LoadAssessmentButtonDeps &
     StartOverFactoryDeps &
     LoadAssessmentDialogDeps &
-    ReportExportDialogFactoryDeps;
+    ReportExportDialogFactoryDeps &
+    StartOverDialogDeps;
 
 export type CommandBarProps = DetailsViewCommandBarProps;
 
@@ -81,7 +82,6 @@ export interface DetailsViewCommandBarProps {
     deps: DetailsViewCommandBarDeps;
     tabStoreData: TabStoreData;
     assessmentStoreData: AssessmentStoreData;
-    assessmentsProvider: AssessmentsProvider;
     rightPanelConfiguration: DetailsRightPanelConfiguration;
     visualizationStoreData: VisualizationStoreData;
     automatedChecksCardsViewData: CardsViewModel;

--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -129,7 +129,6 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                 visualizationStoreData={storeState.visualizationStoreData}
                 visualizationScanResultData={storeState.visualizationScanResultStoreData}
                 visualizationConfigurationFactory={props.deps.visualizationConfigurationFactory}
-                assessmentsProvider={props.deps.assessmentsProvider}
                 dropdownClickHandler={props.deps.dropdownClickHandler}
                 clickHandlerFactory={props.deps.clickHandlerFactory}
                 assessmentInstanceTableHandler={props.deps.assessmentInstanceTableHandler}

--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { ReportExportFormat } from 'common/extension-telemetry-events';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
@@ -17,6 +18,7 @@ import { FastPassReportModel } from 'reports/fast-pass-report-html-generator';
 
 export type ReportExportDialogFactoryDeps = {
     reportExportServiceProvider: ReportExportServiceProvider;
+    assessmentsProvider: AssessmentsProvider;
 } & ReportExportComponentDeps;
 
 export type ReportExportDialogFactoryProps = CommandBarProps & {
@@ -33,14 +35,13 @@ export function getReportExportDialogForAssessment(
     const {
         deps,
         assessmentStoreData,
-        assessmentsProvider,
         featureFlagStoreData,
         scanMetadata,
         isOpen,
         dismissExportDialog,
         afterDialogDismissed,
     } = props;
-    const reportGenerator = deps.reportGenerator;
+    const { reportGenerator, assessmentsProvider } = deps;
     const dialogProps: ReportExportComponentProps = {
         deps: deps,
         reportExportFormat: 'Assessment',

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -18,12 +18,12 @@ import styles from './start-over-menu-item.scss';
 
 export type StartOverFactoryDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+    assessmentsProvider: AssessmentsProvider;
 };
 
 export type StartOverFactoryProps = {
     deps: StartOverFactoryDeps;
     assessmentStoreData: AssessmentStoreData;
-    assessmentsProvider: AssessmentsProvider;
     rightPanelConfiguration: DetailsRightPanelConfiguration;
     visualizationStoreData: VisualizationStoreData;
     openDialog: (dialogType: StartOverDialogType) => void;
@@ -60,7 +60,7 @@ export function getStartOverComponentForAssessment(
     dropdownDirection: DropdownDirection,
 ): JSX.Element {
     const selectedTest = props.assessmentStoreData.assessmentNavState.selectedTestType;
-    const test = props.assessmentsProvider.forType(selectedTest);
+    const test = props.deps.assessmentsProvider.forType(selectedTest);
     const startOverProps: StartOverProps = {
         testName: test.title,
         rightPanelConfiguration: props.rightPanelConfiguration,

--- a/src/DetailsView/components/start-over-dialog.tsx
+++ b/src/DetailsView/components/start-over-dialog.tsx
@@ -14,18 +14,19 @@ export type StartOverDialogState = StartOverDialogType | typeof dialogClosedStat
 
 export type StartOverDialogDeps = {
     assessmentActionMessageCreator: AssessmentActionMessageCreator;
+    assessmentsProvider: AssessmentsProvider;
 };
 
 export interface StartOverDialogProps {
     deps: StartOverDialogDeps;
     assessmentStoreData: AssessmentStoreData;
-    assessmentsProvider: AssessmentsProvider;
     dialogState: StartOverDialogState;
     dismissDialog: () => void;
 }
 
 export const StartOverDialog = NamedFC<StartOverDialogProps>('StartOverDialog', props => {
-    const { dialogState, deps, assessmentStoreData, assessmentsProvider, dismissDialog } = props;
+    const { dialogState, deps, assessmentStoreData, dismissDialog } = props;
+    const { assessmentsProvider } = deps;
 
     if (dialogState === dialogClosedState) {
         return null;

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import classNames from 'classnames';
 import { CardsViewStoreData } from 'common/components/cards/cards-view-store-data';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
@@ -56,7 +55,6 @@ export interface DetailsViewBodyProps {
     visualizationStoreData: VisualizationStoreData;
     visualizationScanResultData: VisualizationScanResultData;
     visualizationConfigurationFactory: VisualizationConfigurationFactory;
-    assessmentsProvider: AssessmentsProvider;
     dropdownClickHandler: DropdownClickHandler;
     clickHandlerFactory: DetailsViewToggleClickHandlerFactory;
     assessmentInstanceTableHandler: AssessmentInstanceTableHandler;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-dialog-factory.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`ReportExportDialogFactory getReportExportDialogForAssessment expected p
   deps={
     {
       "assessmentActionMessageCreator": [typemoq mock object],
+      "assessmentsProvider": [typemoq mock object],
       "detailsViewActionMessageCreator": [typemoq mock object],
       "getCurrentDate": [Function],
       "getDateFromTimestamp": [Function],
@@ -49,6 +50,7 @@ exports[`ReportExportDialogFactory getReportExportDialogForFastPass expected pro
   deps={
     {
       "assessmentActionMessageCreator": [typemoq mock object],
+      "assessmentsProvider": [typemoq mock object],
       "detailsViewActionMessageCreator": [typemoq mock object],
       "getCurrentDate": [Function],
       "getDateFromTimestamp": [Function],

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
@@ -71,7 +72,7 @@ describe('ReportExportDialogFactory', () => {
             toolData: theToolData,
             targetAppInfo: targetAppInfo,
         } as ScanMetadata;
-        assessmentsProviderMock = Mock.ofType<AssessmentsProvider>(undefined, MockBehavior.Loose);
+        assessmentsProviderMock = Mock.ofType(AssessmentsProviderImpl, MockBehavior.Loose);
         reportGeneratorMock = Mock.ofType(ReportGenerator, MockBehavior.Loose);
         reportExportServiceProviderMock = Mock.ofType(ReportExportServiceProvider);
         dismissExportDialogMock = Mock.ofInstance(() => null);
@@ -86,6 +87,7 @@ describe('ReportExportDialogFactory', () => {
             reportGenerator: reportGeneratorMock.object,
             getDateFromTimestamp: value => scanCompleteDate,
             reportExportServiceProvider: reportExportServiceProviderMock.object,
+            assessmentsProvider: assessmentsProviderMock.object,
         } as DetailsViewCommandBarDeps;
         const switcherNavConfiguration = {
             shouldShowReportExportButton: shouldShowReportExportButtonMock.object,
@@ -95,7 +97,6 @@ describe('ReportExportDialogFactory', () => {
             deps,
             featureFlagStoreData,
             assessmentStoreData,
-            assessmentsProvider: assessmentsProviderMock.object,
             automatedChecksCardsViewData: cardsViewData,
             needsReviewCardsViewData: cardsViewData,
             tabStopRequirementData,

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -37,7 +37,9 @@ describe('StartOverComponentFactory', () => {
     });
 
     function getProps(isForAssessment: boolean): StartOverFactoryProps {
-        const deps = {} as StartOverFactoryDeps;
+        const deps = {
+            assessmentsProvider: assessmentsProviderMock.object,
+        } as StartOverFactoryDeps;
 
         let visualizationStoreData: VisualizationStoreData = null;
         let selectedTestType: VisualizationType = null;
@@ -67,7 +69,6 @@ describe('StartOverComponentFactory', () => {
         return {
             deps,
             assessmentStoreData,
-            assessmentsProvider: assessmentsProviderMock.object,
             visualizationStoreData,
         } as StartOverFactoryProps;
     }

--- a/src/tests/unit/tests/DetailsView/components/start-over-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-dialog.test.tsx
@@ -46,9 +46,9 @@ describe('StartOverDialog', () => {
         props = {
             deps: {
                 assessmentActionMessageCreator: assessmentActionMessageCreatorMock.object,
+                assessmentsProvider: assessmentsProviderMock.object,
             },
             assessmentStoreData,
-            assessmentsProvider: assessmentsProviderMock.object,
             dismissDialog: dismissDialogMock.object,
         } as StartOverDialogProps;
     });


### PR DESCRIPTION
#### Details

Just a minor clean up to not use assessments provider through props but deps, which is how we usually do it.

##### Motivation

Feature work.

##### Context

This should make the next couple of PRs a bit more simple as we look to normalize how we get assessments provider through a get method.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
