### PR TITLE
feat(medium-pass-1): created AssessmentFunctionalitySwitcher

### DIFF
--- a/src/DetailsView/assessment-functionality-switcher.ts
+++ b/src/DetailsView/assessment-functionality-switcher.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { BaseStore } from 'common/base-store';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { AssessmentActionMessageCreator } from 'DetailsView/actions/assessment-action-message-creator';
+import { GetDetailsSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
+import { NavLinkHandler } from 'DetailsView/components/left-nav/nav-link-handler';
+import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
+
+export type SharedAssessmentObjects = {
+    provider: AssessmentsProvider;
+    actionMessageCreator: AssessmentActionMessageCreator;
+    navLinkHandler: NavLinkHandler;
+    instanceTableHandler: AssessmentInstanceTableHandler;
+};
+
+export const NO_STORE_DATA_ERROR = 'no store data';
+
+export class AssessmentFunctionalitySwitcher {
+    constructor(
+        private readonly visualizationStore: BaseStore<VisualizationStoreData, Promise<void>>,
+        private readonly assessmentObjects: SharedAssessmentObjects,
+        private readonly quickAssessObjects: SharedAssessmentObjects,
+        private readonly getDetailsSwitcherNavConfiguration: GetDetailsSwitcherNavConfiguration,
+    ) {}
+
+    public getAssessmentObjects(): SharedAssessmentObjects {
+        return this.assessmentObjects;
+    }
+
+    public getQuickAssessObjects(): SharedAssessmentObjects {
+        return this.quickAssessObjects;
+    }
+
+    public getProvider: () => AssessmentsProvider = () => {
+        return this.getSharedObjects().provider;
+    };
+
+    public getActionMessageCreator: () => AssessmentActionMessageCreator = () => {
+        return this.getSharedObjects().actionMessageCreator;
+    };
+
+    public getNavLinkHandler: () => NavLinkHandler = () => {
+        return this.getSharedObjects().navLinkHandler;
+    };
+
+    public getInstanceTableHandler: () => AssessmentInstanceTableHandler = () => {
+        return this.getSharedObjects().instanceTableHandler;
+    };
+
+    private getSharedObjects(): SharedAssessmentObjects {
+        const storeData = this.visualizationStore.getState();
+
+        if (storeData == null) {
+            throw new Error(NO_STORE_DATA_ERROR);
+        }
+
+        const switcherConfig = this.getDetailsSwitcherNavConfiguration({
+            selectedDetailsViewPivot: storeData.selectedDetailsViewPivot,
+        });
+
+        return switcherConfig.getSharedAssessmentFunctionalityObjects(this);
+    }
+}

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -87,7 +87,7 @@ export type DetailsViewSwitcherNavConfiguration = Readonly<{
     getSelectedDetailsView: (props: GetSelectedDetailsViewProps) => VisualizationType;
     warningConfiguration: WarningConfiguration;
     leftNavHamburgerButton: ReactFCWithDisplayName<ExpandCollpaseLeftNavButtonProps>;
-    getSharedAssessmentFunctionalityObjects?: GetSharedAssessmentFunctionalityObjects;
+    getSharedAssessmentFunctionalityObjects: GetSharedAssessmentFunctionalityObjects;
 }>;
 
 type InternalDetailsViewSwitcherNavConfiguration = Omit<

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -6,6 +6,10 @@ import {
     FastPassLeftNavHamburgerButton,
     MediumPassLeftNavHamburgerButton,
 } from 'common/components/expand-collapse-left-nav-hamburger-button';
+import {
+    AssessmentFunctionalitySwitcher,
+    SharedAssessmentObjects,
+} from 'DetailsView/assessment-functionality-switcher';
 import { AssessmentCommandBar } from 'DetailsView/components/assessment-command-bar';
 import { AutomatedChecksCommandBar } from 'DetailsView/components/automated-checks-command-bar';
 import {
@@ -45,12 +49,6 @@ import {
     fastpassWarningConfiguration,
     WarningConfiguration,
 } from 'DetailsView/components/warning-configuration';
-import {
-    AdhocVisualizationMessageTypes,
-    AnalyzerMessageConfiguration,
-    AssessmentVisualizationMessageTypes,
-    MediumPassVisualizationMessageTypes,
-} from 'injected/analyzers/get-analyzer-message-types';
 import { ReactFCWithDisplayName } from '../../common/react/named-fc';
 import { DetailsViewPivotType } from '../../common/types/store-data/details-view-pivot-type';
 import { VisualizationType } from '../../common/types/visualization-type';
@@ -74,6 +72,10 @@ export type LeftNavDeps = AssessmentLeftNavDeps & FastPassLeftNavDeps;
 export type LeftNavProps = AssessmentLeftNavProps & FastPassLeftNavProps;
 type InternalLeftNavProps = AssessmentLeftNavProps | FastPassLeftNavProps;
 
+export type GetSharedAssessmentFunctionalityObjects = (
+    switcher: AssessmentFunctionalitySwitcher,
+) => SharedAssessmentObjects;
+
 export type DetailsViewSwitcherNavConfiguration = Readonly<{
     CommandBar: ReactFCWithDisplayName<CommandBarProps>;
     ReportExportDialogFactory: ReportExportDialogFactory;
@@ -85,7 +87,7 @@ export type DetailsViewSwitcherNavConfiguration = Readonly<{
     getSelectedDetailsView: (props: GetSelectedDetailsViewProps) => VisualizationType;
     warningConfiguration: WarningConfiguration;
     leftNavHamburgerButton: ReactFCWithDisplayName<ExpandCollpaseLeftNavButtonProps>;
-    analyzerMessageConfiguration: AnalyzerMessageConfiguration;
+    getSharedAssessmentFunctionalityObjects?: GetSharedAssessmentFunctionalityObjects;
 }>;
 
 type InternalDetailsViewSwitcherNavConfiguration = Omit<
@@ -113,7 +115,7 @@ const detailsViewSwitcherNavs: {
         getSelectedDetailsView: getAssessmentSelectedDetailsView,
         warningConfiguration: assessmentWarningConfiguration,
         leftNavHamburgerButton: AssessmentLeftNavHamburgerButton,
-        analyzerMessageConfiguration: AssessmentVisualizationMessageTypes,
+        getSharedAssessmentFunctionalityObjects: switcher => switcher.getAssessmentObjects(),
     },
     [DetailsViewPivotType.mediumPass]: {
         CommandBar: MediumPassCommandBar,
@@ -126,7 +128,7 @@ const detailsViewSwitcherNavs: {
         getSelectedDetailsView: getAssessmentSelectedDetailsView,
         warningConfiguration: assessmentWarningConfiguration,
         leftNavHamburgerButton: MediumPassLeftNavHamburgerButton,
-        analyzerMessageConfiguration: MediumPassVisualizationMessageTypes,
+        getSharedAssessmentFunctionalityObjects: switcher => switcher.getQuickAssessObjects(),
     },
     [DetailsViewPivotType.fastPass]: {
         CommandBar: AutomatedChecksCommandBar,
@@ -139,7 +141,7 @@ const detailsViewSwitcherNavs: {
         getSelectedDetailsView: getFastPassSelectedDetailsView,
         warningConfiguration: fastpassWarningConfiguration,
         leftNavHamburgerButton: FastPassLeftNavHamburgerButton,
-        analyzerMessageConfiguration: AdhocVisualizationMessageTypes,
+        getSharedAssessmentFunctionalityObjects: switcher => switcher.getAssessmentObjects(),
     },
 };
 

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -550,7 +550,7 @@ if (tabId != null) {
                 actionMessageCreator: quickAssessActionMessageCreator,
                 navLinkHandler: new NavLinkHandler(
                     detailsViewActionMessageCreator,
-                    assessmentActionMessageCreator,
+                    quickAssessActionMessageCreator,
                 ),
                 instanceTableHandler: quickAssessInstanceTableHandler,
             };
@@ -658,7 +658,8 @@ if (tabId != null) {
                 issueFilingDialogPropsFactory: getIssueFilingDialogProps,
                 mediumPassRequirementKeys: MediumPassRequirementKeys,
                 getProvider: assessmentFunctionalitySwitcher.getProvider,
-                getActionMessageCreator: assessmentFunctionalitySwitcher.getActionMessageCreator,
+                getAssessmentActionMessageCreator:
+                    assessmentFunctionalitySwitcher.getActionMessageCreator,
                 getNavLinkHandler: assessmentFunctionalitySwitcher.getNavLinkHandler,
                 getInstanceTableHandler: assessmentFunctionalitySwitcher.getInstanceTableHandler,
             };

--- a/src/tests/unit/tests/DetailsView/assessment-functionality-switcher.test.ts
+++ b/src/tests/unit/tests/DetailsView/assessment-functionality-switcher.test.ts
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { AssessmentActionMessageCreator } from 'DetailsView/actions/assessment-action-message-creator';
+import {
+    AssessmentFunctionalitySwitcher,
+    NO_STORE_DATA_ERROR,
+    SharedAssessmentObjects,
+} from 'DetailsView/assessment-functionality-switcher';
+import {
+    DetailsViewSwitcherNavConfiguration,
+    GetDetailsSwitcherNavConfiguration,
+} from 'DetailsView/components/details-view-switcher-nav';
+import { NavLinkHandler } from 'DetailsView/components/left-nav/nav-link-handler';
+import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
+import { StoreMock } from 'tests/unit/mock-helpers/store-mock';
+import { IMock, It, Mock } from 'typemoq';
+
+describe(AssessmentFunctionalitySwitcher, () => {
+    let visualizationStoreMock: StoreMock<VisualizationStoreData>;
+    let getSwitcherNavConfigMock: IMock<GetDetailsSwitcherNavConfiguration>;
+    let assessmentObjectsStub: SharedAssessmentObjects;
+    let quickAssessObjectsMock: SharedAssessmentObjects;
+    let testSubject: AssessmentFunctionalitySwitcher;
+
+    beforeEach(() => {
+        visualizationStoreMock = new StoreMock<VisualizationStoreData>();
+        getSwitcherNavConfigMock = Mock.ofType<GetDetailsSwitcherNavConfiguration>();
+        assessmentObjectsStub = {} as SharedAssessmentObjects;
+        quickAssessObjectsMock = {} as SharedAssessmentObjects;
+        testSubject = new AssessmentFunctionalitySwitcher(
+            visualizationStoreMock.getObject(),
+            assessmentObjectsStub,
+            quickAssessObjectsMock,
+            getSwitcherNavConfigMock.object,
+        );
+    });
+
+    test('getAssessmentObjects', () => {
+        expect(testSubject.getAssessmentObjects()).toEqual(assessmentObjectsStub);
+    });
+
+    test('getQuickAssessObjects', () => {
+        expect(testSubject.getQuickAssessObjects()).toEqual(quickAssessObjectsMock);
+    });
+
+    const nullStoreData = null;
+    const validStoreData = {
+        selectedDetailsViewPivot: DetailsViewPivotType.fastPass,
+    } as VisualizationStoreData;
+
+    [nullStoreData, validStoreData].forEach(testCase => {});
+
+    describe('error: no store data', () => {
+        let storeData: VisualizationStoreData;
+
+        beforeEach(() => {
+            storeData = null;
+            setupGetState(storeData);
+        });
+
+        test('getProvider', () => {
+            expect(() => testSubject.getProvider()).toThrowError(NO_STORE_DATA_ERROR);
+        });
+
+        test('getActionMessageCreator', () => {
+            expect(() => testSubject.getActionMessageCreator()).toThrowError(NO_STORE_DATA_ERROR);
+        });
+
+        test('getNavLinkHandler', () => {
+            expect(() => testSubject.getNavLinkHandler()).toThrowError(NO_STORE_DATA_ERROR);
+        });
+
+        test('getInstanceTableHandler', () => {
+            expect(() => testSubject.getInstanceTableHandler()).toThrowError(NO_STORE_DATA_ERROR);
+        });
+    });
+
+    describe('store has data; return specified object', () => {
+        let storeData: VisualizationStoreData;
+
+        beforeEach(() => {
+            storeData = {
+                selectedDetailsViewPivot: DetailsViewPivotType.fastPass,
+            } as VisualizationStoreData;
+            assessmentObjectsStub = {
+                provider: Mock.ofType<AssessmentsProvider>().object,
+                actionMessageCreator: Mock.ofType<AssessmentActionMessageCreator>().object,
+                navLinkHandler: Mock.ofType<NavLinkHandler>().object,
+                instanceTableHandler: Mock.ofType<AssessmentInstanceTableHandler>().object,
+            };
+            setupSwitcherMock(storeData.selectedDetailsViewPivot);
+            setupGetState(storeData);
+        });
+
+        test('getProvider', () => {
+            expect(testSubject.getProvider()).toEqual(assessmentObjectsStub.provider);
+        });
+
+        test('getActionMessageCreator', () => {
+            expect(testSubject.getActionMessageCreator()).toEqual(
+                assessmentObjectsStub.actionMessageCreator,
+            );
+        });
+
+        test('getNavLinkHandler', () => {
+            expect(testSubject.getNavLinkHandler()).toEqual(assessmentObjectsStub.navLinkHandler);
+        });
+
+        test('getInstanceTableHandler', () => {
+            expect(testSubject.getInstanceTableHandler()).toEqual(
+                assessmentObjectsStub.instanceTableHandler,
+            );
+        });
+    });
+
+    function setupGetState(storeData: VisualizationStoreData) {
+        visualizationStoreMock.setupGetState(storeData);
+    }
+
+    function setupSwitcherMock(pivot: DetailsViewPivotType) {
+        const switcherConfigMock = Mock.ofType<DetailsViewSwitcherNavConfiguration>();
+        getSwitcherNavConfigMock
+            .setup(m => m(It.isValue({ selectedDetailsViewPivot: pivot })))
+            .returns(() => switcherConfigMock.object);
+        switcherConfigMock
+            .setup(m => m.getSharedAssessmentFunctionalityObjects(testSubject))
+            .returns(() => assessmentObjectsStub);
+    }
+});

--- a/src/tests/unit/tests/injected/analyzer-controller.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-controller.test.ts
@@ -4,10 +4,6 @@ import { Requirement } from 'assessments/types/requirement';
 import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { ScopingStore } from 'background/stores/global/scoping-store';
 import { VisualizationStore } from 'background/stores/visualization-store';
-import {
-    DetailsViewSwitcherNavConfiguration,
-    GetDetailsSwitcherNavConfiguration,
-} from 'DetailsView/components/details-view-switcher-nav';
 import { AnalyzerMessageConfiguration } from 'injected/analyzers/get-analyzer-message-types';
 import { ShadowInitializer } from 'injected/shadow-initializer';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
@@ -47,9 +43,7 @@ describe('AnalyzerControllerTests', () => {
     let configStub: VisualizationConfiguration;
     let requirementStub: Requirement;
     let messageConfigurationStub: AnalyzerMessageConfiguration;
-    let switcherConfigurationStub: DetailsViewSwitcherNavConfiguration;
 
-    let getDetailsSwitcherNavConfigurationMock: IMock<GetDetailsSwitcherNavConfiguration>;
     let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
     let visualizationStoreState: VisualizationStoreData;
     let featureFlagStoreState: FeatureFlagStoreData;
@@ -79,7 +73,6 @@ describe('AnalyzerControllerTests', () => {
         messageConfigurationStub = {
             analyzerMessageType: 'some message type',
         };
-        getDetailsSwitcherNavConfigurationMock = Mock.ofType<GetDetailsSwitcherNavConfiguration>();
         configStub = {
             getStoreData: getStoreDataMock.object,
             getAnalyzer: getAnalyzerMock.object,
@@ -89,9 +82,6 @@ describe('AnalyzerControllerTests', () => {
         requirementStub = {
             key: 'some requirement key',
         } as Requirement;
-        switcherConfigurationStub = {
-            analyzerMessageConfiguration: messageConfigurationStub,
-        } as DetailsViewSwitcherNavConfiguration;
 
         visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
         visualizationStoreMock = Mock.ofType<VisualizationStore>();
@@ -251,12 +241,6 @@ describe('AnalyzerControllerTests', () => {
     });
 
     function setupAnalyzeCall(visualizationState: VisualizationStoreData): void {
-        const expected = {
-            selectedDetailsViewPivot: visualizationState.selectedDetailsViewPivot,
-        };
-        getDetailsSwitcherNavConfigurationMock
-            .setup(m => m(It.isValue(expected)))
-            .returns(() => switcherConfigurationStub);
         analyzerMock.setup(am => am.analyze()).verifiable();
     }
 


### PR DESCRIPTION
#### Details

This allows an easy way for us to switch different assessment/medium-pass affiliated objects while keeping components agnostic to either scenario while also not having to pass everything down props.

##### Motivation

Feature work.

##### Context

Alternatives explored were:
1. Modify the deps object somewhere before we use any of the assessment/medium-pass specific functionality (like in `details-view-content`). Decided against this since it violates our expected pattern of keeping the deps object the same and not treating it as a normal React prop.
2. Start passing in these objects through props from a component before we use any functionality (details-view-content again). Avoided this because this feels like a lot of unnecessary bloat to add to each component along the UI tree but it did not violate any of our principles.

Note: the usage of the switcher is not included in this PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
