### PR TITLE
feat(medium-pass-1): get assessmentInstanceTableHandler with getter + typings fix for details-view-content

### DIFF
--- a/src/DetailsView/components/details-view-content-with-local-state.tsx
+++ b/src/DetailsView/components/details-view-content-with-local-state.tsx
@@ -1,11 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DetailsViewContent } from 'DetailsView/components/details-view-content';
-import { NarrowModeDetector } from 'DetailsView/components/narrow-mode-detector';
-import { DetailsViewContainerProps } from 'DetailsView/details-view-container';
+import {
+    DetailsViewContent,
+    DetailsViewContentDeps,
+    DetailsViewContentProps,
+} from 'DetailsView/components/details-view-content';
+import {
+    NarrowModeDetector,
+    NarrowModeDetectorDeps,
+} from 'DetailsView/components/narrow-mode-detector';
 import * as React from 'react';
 
-export type DetailsViewContentWithLocalStateProps = DetailsViewContainerProps;
+export type DetailsViewContentWithLocalStateDeps = DetailsViewContentDeps & NarrowModeDetectorDeps;
+export type DetailsViewContentWithLocalStateProps = {
+    deps: DetailsViewContentWithLocalStateDeps;
+} & Omit<DetailsViewContentProps, 'deps' | 'isSideNavOpen' | 'setSideNavOpen' | 'narrowModeStatus'>;
+
 export type DetailsViewContentState = {
     isSideNavOpen: boolean;
 };

--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -1,26 +1,58 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { DropdownClickHandler } from 'common/dropdown-click-handler';
+import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
+import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
+import { InspectActionMessageCreator } from 'common/message-creators/inspect-action-message-creator';
+import { ScopingActionMessageCreator } from 'common/message-creators/scoping-action-message-creator';
 import { NamedFC } from 'common/react/named-fc';
+import { GetCardViewData } from 'common/rule-based-view-model-provider';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
-import { DetailsViewOverlay } from 'DetailsView/components/details-view-overlay/details-view-overlay';
-import { InteractiveHeader } from 'DetailsView/components/interactive-header';
+import {
+    DetailsViewOverlay,
+    DetailsViewOverlayDeps,
+} from 'DetailsView/components/details-view-overlay/details-view-overlay';
+import { GetDetailsRightPanelConfiguration } from 'DetailsView/components/details-view-right-panel';
+import { GetDetailsSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
+import {
+    InteractiveHeader,
+    InteractiveHeaderDeps,
+} from 'DetailsView/components/interactive-header';
+import { IssuesTableHandler } from 'DetailsView/components/issues-table-handler';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { DetailsViewBody, DetailsViewBodyDeps } from 'DetailsView/details-view-body';
 import { DetailsViewContainerProps } from 'DetailsView/details-view-container';
 import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
+import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
+import { PreviewFeatureFlagsHandler } from 'DetailsView/handlers/preview-feature-flags-handler';
 import * as React from 'react';
 
 export type DetailsViewContentDeps = {
     getDateFromTimestamp: (timestamp: string) => Date;
     getAssessmentInstanceTableHandler: () => AssessmentInstanceTableHandler;
-} & DetailsViewBodyDeps;
+    getDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration;
+    getDetailsSwitcherNavConfiguration: GetDetailsSwitcherNavConfiguration;
+    getCardViewData: GetCardViewData;
+    getCardSelectionViewData: GetCardSelectionViewData;
+    clickHandlerFactory: DetailsViewToggleClickHandlerFactory;
+    scopingActionMessageCreator: ScopingActionMessageCreator;
+    inspectActionMessageCreator: InspectActionMessageCreator;
+    issuesTableHandler: IssuesTableHandler;
+    previewFeatureFlagsHandler: PreviewFeatureFlagsHandler;
+    dropdownClickHandler: DropdownClickHandler;
+    isResultHighlightUnavailable: IsResultHighlightUnavailable;
+    visualizationConfigurationFactory: VisualizationConfigurationFactory;
+} & InteractiveHeaderDeps &
+    DetailsViewOverlayDeps &
+    DetailsViewBodyDeps;
 
-export type DetailsViewContentProps = DetailsViewContainerProps & {
+export type DetailsViewContentProps = {
     deps: DetailsViewContentDeps;
     isSideNavOpen: boolean;
     setSideNavOpen: (isOpen: boolean, event?: React.MouseEvent<any>) => void;
     narrowModeStatus: NarrowModeStatus;
-};
+} & DetailsViewContainerProps;
 
 export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewContent', props => {
     const selectedDetailsViewSwitcherNavConfiguration =

--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -5,7 +5,7 @@ import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewOverlay } from 'DetailsView/components/details-view-overlay/details-view-overlay';
 import { InteractiveHeader } from 'DetailsView/components/interactive-header';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
-import { DetailsViewBody } from 'DetailsView/details-view-body';
+import { DetailsViewBody, DetailsViewBodyDeps } from 'DetailsView/details-view-body';
 import { DetailsViewContainerProps } from 'DetailsView/details-view-container';
 import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
 import * as React from 'react';
@@ -13,7 +13,7 @@ import * as React from 'react';
 export type DetailsViewContentDeps = {
     getDateFromTimestamp: (timestamp: string) => Date;
     getAssessmentInstanceTableHandler: () => AssessmentInstanceTableHandler;
-};
+} & DetailsViewBodyDeps;
 
 export type DetailsViewContentProps = DetailsViewContainerProps & {
     deps: DetailsViewContentDeps;

--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -7,10 +7,12 @@ import { InteractiveHeader } from 'DetailsView/components/interactive-header';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { DetailsViewBody } from 'DetailsView/details-view-body';
 import { DetailsViewContainerProps } from 'DetailsView/details-view-container';
+import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
 import * as React from 'react';
 
 export type DetailsViewContentDeps = {
     getDateFromTimestamp: (timestamp: string) => Date;
+    getAssessmentInstanceTableHandler: () => AssessmentInstanceTableHandler;
 };
 
 export type DetailsViewContentProps = DetailsViewContainerProps & {
@@ -115,6 +117,8 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
             toolData: props.storeState.unifiedScanResultStoreData.toolInfo,
         };
 
+        const assessmentInstanceTableHandler = props.deps.getAssessmentInstanceTableHandler();
+
         return (
             <DetailsViewBody
                 deps={deps}
@@ -131,7 +135,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                 visualizationConfigurationFactory={props.deps.visualizationConfigurationFactory}
                 dropdownClickHandler={props.deps.dropdownClickHandler}
                 clickHandlerFactory={props.deps.clickHandlerFactory}
-                assessmentInstanceTableHandler={props.deps.assessmentInstanceTableHandler}
+                assessmentInstanceTableHandler={assessmentInstanceTableHandler}
                 issuesTableHandler={props.deps.issuesTableHandler}
                 rightPanelConfiguration={selectedDetailsRightPanelConfiguration}
                 switcherNavConfiguration={selectedDetailsViewSwitcherNavConfiguration}

--- a/src/DetailsView/components/details-view-right-panel.ts
+++ b/src/DetailsView/components/details-view-right-panel.ts
@@ -25,9 +25,7 @@ import {
     TestViewContainerProps,
 } from './test-view-container';
 
-export type DetailsViewContentDeps = OverviewContainerDeps &
-    TestViewContainerDeps &
-    TargetChangeDialogDeps;
+export type RightPanelDeps = OverviewContainerDeps & TestViewContainerDeps & TargetChangeDialogDeps;
 
 export type RightPanelProps = Omit<TestViewContainerProps, 'deps'> &
     Omit<OverviewContainerProps, 'deps'> & {

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -28,7 +28,7 @@ import { VisualizationType } from '../common/types/visualization-type';
 import { DetailsViewCommandBarDeps } from './components/details-view-command-bar';
 import {
     DetailsRightPanelConfiguration,
-    DetailsViewContentDeps,
+    RightPanelDeps,
 } from './components/details-view-right-panel';
 import { DetailsViewSwitcherNavConfiguration } from './components/details-view-switcher-nav';
 import { IssuesTableHandler } from './components/issues-table-handler';
@@ -37,7 +37,7 @@ import { TargetPageHiddenBar } from './components/target-page-hidden-bar';
 import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-table-handler';
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
 
-export type DetailsViewBodyDeps = DetailsViewContentDeps &
+export type DetailsViewBodyDeps = RightPanelDeps &
     DetailsViewLeftNavDeps &
     DetailsViewCommandBarDeps &
     FluentSideNavDeps;

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -3,28 +3,21 @@
 import { Spinner, SpinnerSize } from '@fluentui/react';
 import { CardsViewStoreData } from 'common/components/cards/cards-view-store-data';
 import { Header, HeaderProps } from 'common/components/header';
-import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
-import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
 import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
-import { DetailsViewContentDeps } from 'DetailsView/components/details-view-content';
-import { DetailsViewContentWithLocalState } from 'DetailsView/components/details-view-content-with-local-state';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import {
+    DetailsViewContentWithLocalState,
+    DetailsViewContentWithLocalStateDeps,
+} from 'DetailsView/components/details-view-content-with-local-state';
 import {
     NarrowModeDetector,
     NarrowModeDetectorDeps,
 } from 'DetailsView/components/narrow-mode-detector';
 import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 import * as React from 'react';
-import { ThemeDeps } from '../common/components/theme';
-import {
-    withStoreSubscription,
-    WithStoreSubscriptionDeps,
-} from '../common/components/with-store-subscription';
-import { DropdownClickHandler } from '../common/dropdown-click-handler';
-import { InspectActionMessageCreator } from '../common/message-creators/inspect-action-message-creator';
-import { ScopingActionMessageCreator } from '../common/message-creators/scoping-action-message-creator';
-import { GetCardViewData } from '../common/rule-based-view-model-provider';
+import { withStoreSubscription } from '../common/components/with-store-subscription';
 import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
 import { DetailsViewStoreData } from '../common/types/store-data/details-view-store-data';
 import { FeatureFlagStoreData } from '../common/types/store-data/feature-flag-store-data';
@@ -37,42 +30,13 @@ import { UserConfigurationStoreData } from '../common/types/store-data/user-conf
 import { VisualizationScanResultData } from '../common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from '../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../common/types/visualization-type';
-import { DetailsViewCommandBarDeps } from './components/details-view-command-bar';
-import { DetailsViewOverlayDeps } from './components/details-view-overlay/details-view-overlay';
-import {
-    DetailsRightPanelConfiguration,
-    GetDetailsRightPanelConfiguration,
-} from './components/details-view-right-panel';
-import { GetDetailsSwitcherNavConfiguration } from './components/details-view-switcher-nav';
-import { InteractiveHeaderDeps } from './components/interactive-header';
-import { IssuesTableHandler } from './components/issues-table-handler';
+import { DetailsRightPanelConfiguration } from './components/details-view-right-panel';
 import { NoContentAvailable } from './components/no-content-available/no-content-available';
-import { TargetChangeDialogDeps } from './components/target-change-dialog';
-import { DetailsViewBodyDeps } from './details-view-body';
-import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
-import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-handler';
 
 export type DetailsViewContainerDeps = {
-    getDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration;
-    getDetailsSwitcherNavConfiguration: GetDetailsSwitcherNavConfiguration;
-    getCardViewData: GetCardViewData;
-    getCardSelectionViewData: GetCardSelectionViewData;
-    clickHandlerFactory: DetailsViewToggleClickHandlerFactory;
-    scopingActionMessageCreator: ScopingActionMessageCreator;
-    inspectActionMessageCreator: InspectActionMessageCreator;
-    issuesTableHandler: IssuesTableHandler;
-    previewFeatureFlagsHandler: PreviewFeatureFlagsHandler;
-    dropdownClickHandler: DropdownClickHandler;
-    isResultHighlightUnavailable: IsResultHighlightUnavailable;
-} & DetailsViewBodyDeps &
-    DetailsViewOverlayDeps &
-    DetailsViewCommandBarDeps &
-    InteractiveHeaderDeps &
-    WithStoreSubscriptionDeps<DetailsViewContainerState> &
-    ThemeDeps &
-    TargetChangeDialogDeps &
-    NarrowModeDetectorDeps &
-    DetailsViewContentDeps;
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+} & NarrowModeDetectorDeps &
+    DetailsViewContentWithLocalStateDeps;
 
 export interface DetailsViewContainerProps {
     deps: DetailsViewContainerDeps;

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -8,6 +8,7 @@ import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavail
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
 import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
+import { DetailsViewContentDeps } from 'DetailsView/components/details-view-content';
 import { DetailsViewContentWithLocalState } from 'DetailsView/components/details-view-content-with-local-state';
 import {
     NarrowModeDetector,
@@ -40,7 +41,6 @@ import { DetailsViewCommandBarDeps } from './components/details-view-command-bar
 import { DetailsViewOverlayDeps } from './components/details-view-overlay/details-view-overlay';
 import {
     DetailsRightPanelConfiguration,
-    DetailsViewContentDeps,
     GetDetailsRightPanelConfiguration,
 } from './components/details-view-right-panel';
 import { GetDetailsSwitcherNavConfiguration } from './components/details-view-switcher-nav';
@@ -49,7 +49,6 @@ import { IssuesTableHandler } from './components/issues-table-handler';
 import { NoContentAvailable } from './components/no-content-available/no-content-available';
 import { TargetChangeDialogDeps } from './components/target-change-dialog';
 import { DetailsViewBodyDeps } from './details-view-body';
-import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-table-handler';
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
 import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-handler';
 
@@ -62,7 +61,6 @@ export type DetailsViewContainerDeps = {
     scopingActionMessageCreator: ScopingActionMessageCreator;
     inspectActionMessageCreator: InspectActionMessageCreator;
     issuesTableHandler: IssuesTableHandler;
-    assessmentInstanceTableHandler: AssessmentInstanceTableHandler;
     previewFeatureFlagsHandler: PreviewFeatureFlagsHandler;
     dropdownClickHandler: DropdownClickHandler;
     isResultHighlightUnavailable: IsResultHighlightUnavailable;

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -636,7 +636,6 @@ if (tabId != null) {
                 inspectActionMessageCreator,
                 clickHandlerFactory,
                 issuesTableHandler,
-                assessmentInstanceTableHandler,
                 previewFeatureFlagsHandler,
                 scopingFlagsHandler,
                 Assessments,
@@ -657,7 +656,8 @@ if (tabId != null) {
                 getAssessmentActionMessageCreator:
                     assessmentFunctionalitySwitcher.getActionMessageCreator,
                 getNavLinkHandler: assessmentFunctionalitySwitcher.getNavLinkHandler,
-                getInstanceTableHandler: assessmentFunctionalitySwitcher.getInstanceTableHandler,
+                getAssessmentInstanceTableHandler:
+                    assessmentFunctionalitySwitcher.getInstanceTableHandler,
             };
 
             const renderer = new DetailsViewRenderer(

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -153,8 +153,8 @@ import { IssuesTableHandler } from './components/issues-table-handler';
 import { getStatusForTest } from './components/left-nav/get-status-for-test';
 import { LeftNavLinkBuilder } from './components/left-nav/left-nav-link-builder';
 import { NavLinkHandler } from './components/left-nav/nav-link-handler';
-import { DetailsViewContainerDeps, DetailsViewContainerState } from './details-view-container';
-import { DetailsViewRenderer } from './details-view-renderer';
+import { DetailsViewContainerState } from './details-view-container';
+import { DetailsViewRenderer, DetailsViewRendererDeps } from './details-view-renderer';
 import { DocumentTitleUpdater } from './document-title-updater';
 import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-table-handler';
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
@@ -564,7 +564,7 @@ if (tabId != null) {
             const detailsViewId = generateUID();
             detailsViewActionMessageCreator.initialize(detailsViewId);
 
-            const deps: DetailsViewContainerDeps = {
+            const deps: DetailsViewRendererDeps = {
                 textContent,
                 fixInstructionProcessor,
                 recommendColor,

--- a/src/DetailsView/details-view-renderer.tsx
+++ b/src/DetailsView/details-view-renderer.tsx
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Theme } from '../common/components/theme';
+import { Theme, ThemeDeps } from '../common/components/theme';
 import { config } from '../common/configuration';
 import { DocumentManipulator } from '../common/document-manipulator';
 import { DetailsView, DetailsViewContainerDeps } from './details-view-container';
 
+export type DetailsViewRendererDeps = DetailsViewContainerDeps & ThemeDeps;
 export class DetailsViewRenderer {
     constructor(
-        private readonly deps: DetailsViewContainerDeps,
+        private readonly deps: DetailsViewRendererDeps,
         private readonly dom: Document,
         private readonly renderer: typeof ReactDOM.render,
         private readonly documentManipulator: DocumentManipulator,

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`DetailsViewContent render renders normally 1`] = `
       {
         "detailsViewActionMessageCreator": [typemoq mock object],
         "dropdownClickHandler": [typemoq mock object],
+        "getAssessmentInstanceTableHandler": [Function],
         "getCardSelectionViewData": [Function],
         "getCardViewData": [Function],
         "getDateFromTimestamp": [Function],
@@ -35,6 +36,7 @@ exports[`DetailsViewContent render renders normally 1`] = `
     tabClosed={false}
   />
   <DetailsViewBody
+    assessmentInstanceTableHandler={[typemoq mock object]}
     assessmentStoreData={
       {
         "assessmentNavState": {
@@ -51,6 +53,7 @@ exports[`DetailsViewContent render renders normally 1`] = `
       {
         "detailsViewActionMessageCreator": [typemoq mock object],
         "dropdownClickHandler": [typemoq mock object],
+        "getAssessmentInstanceTableHandler": [Function],
         "getCardSelectionViewData": [Function],
         "getCardViewData": [Function],
         "getDateFromTimestamp": [Function],
@@ -429,6 +432,7 @@ exports[`DetailsViewContent render renders normally 1`] = `
       {
         "detailsViewActionMessageCreator": [typemoq mock object],
         "dropdownClickHandler": [typemoq mock object],
+        "getAssessmentInstanceTableHandler": [Function],
         "getCardSelectionViewData": [Function],
         "getCardViewData": [Function],
         "getDateFromTimestamp": [Function],

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -38,6 +38,7 @@ import {
     DetailsViewContainerDeps,
     DetailsViewContainerState,
 } from 'DetailsView/details-view-container';
+import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
 import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -98,6 +99,8 @@ describe(DetailsViewContent.displayName, () => {
         toolData = {
             applicationProperties: { name: 'some app' },
         } as ToolData;
+        const assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
+
         deps = {
             detailsViewActionMessageCreator: detailsViewActionMessageCreator.object,
             getDetailsRightPanelConfiguration: getDetailsRightPanelConfiguration.object,
@@ -106,6 +109,7 @@ describe(DetailsViewContent.displayName, () => {
             getCardSelectionViewData: getCardSelectionViewDataMock.object,
             isResultHighlightUnavailable: isResultHighlightUnavailableStub,
             getDateFromTimestamp: getDateFromTimestampMock.object,
+            getAssessmentInstanceTableHandler: () => assessmentInstanceTableHandlerMock.object,
         } as DetailsViewContainerDeps;
     });
 

--- a/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
@@ -3,8 +3,8 @@
 import { Theme } from 'common/components/theme';
 import { configMutator } from 'common/configuration';
 import { DocumentManipulator } from 'common/document-manipulator';
-import { DetailsView, DetailsViewContainerDeps } from 'DetailsView/details-view-container';
-import { DetailsViewRenderer } from 'DetailsView/details-view-renderer';
+import { DetailsView } from 'DetailsView/details-view-container';
+import { DetailsViewRenderer, DetailsViewRendererDeps } from 'DetailsView/details-view-renderer';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { IMock, It, Mock } from 'typemoq';
@@ -12,7 +12,7 @@ import { TestDocumentCreator } from '../../common/test-document-creator';
 
 describe('DetailsViewRendererTest', () => {
     test('render', () => {
-        const deps = Mock.ofType<DetailsViewContainerDeps>().object;
+        const deps = Mock.ofType<DetailsViewRendererDeps>().object;
 
         const fakeDocument = TestDocumentCreator.createTestDocument(
             '<div id="details-container"></div>',


### PR DESCRIPTION
#### Details

Follow-up to #6236. This moves the usage of assessmentInstanceTableHandler to a getter function.

##### Motivation

Feature work.

##### Context

A couple important notes:
1. There were two types/interfaces named `DetailsViewContentDeps`; I renamed the one to RightPanelDeps which felt appropriate given the usage.
2. A lot of the `assessmentInstanceTableHandler` usage is through props that should actually be deps. Those changes are not in this PR. They are similar in nature to the #6238.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
