### PR TITLE
feat(medium-pass-1): wiring up details view for quick assess

### DIFF
--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -150,13 +150,17 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
         };
 
         const assessmentInstanceTableHandler = props.deps.getAssessmentInstanceTableHandler();
+        const assessmentStoreData =
+            selectedDetailsViewSwitcherNavConfiguration.getSelectedAssessmentStoreData(
+                props.storeState,
+            );
 
         return (
             <DetailsViewBody
                 deps={deps}
                 tabStoreData={storeState.tabStoreData}
                 tabStopsViewStoreData={storeState.tabStopsViewStoreData}
-                assessmentStoreData={storeState.assessmentStoreData}
+                assessmentStoreData={assessmentStoreData}
                 pathSnippetStoreData={storeState.pathSnippetStoreData}
                 featureFlagStoreData={storeState.featureFlagStoreData}
                 cardsViewStoreData={storeState.cardsViewStoreData}

--- a/src/DetailsView/components/details-view-right-panel.ts
+++ b/src/DetailsView/components/details-view-right-panel.ts
@@ -67,9 +67,9 @@ const detailsViewTypeContentMap: {
 export const GetDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration = (
     props: GetDetailsRightPanelConfigurationProps,
 ) => {
-    if (props.selectedDetailsViewPivot === DetailsViewPivotType.assessment) {
-        return detailsViewTypeContentMap[props.detailsViewRightContentPanel];
+    if (props.selectedDetailsViewPivot === DetailsViewPivotType.fastPass) {
+        return detailsViewTypeContentMap.TestView;
     }
 
-    return detailsViewTypeContentMap.TestView;
+    return detailsViewTypeContentMap[props.detailsViewRightContentPanel];
 };

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -18,7 +18,16 @@ import {
     ReportExportDialogFactory,
     SaveAssessmentButtonFactory,
 } from 'DetailsView/components/details-view-command-bar';
-import { MediumPassLeftNav } from 'DetailsView/components/left-nav/medium-pass-left-nav';
+import {
+    getAssessmentStoreData,
+    getQuickAssessStoreData,
+    GetSelectedAssessmentStoreData,
+} from 'DetailsView/components/left-nav/get-selected-assessment-store-data';
+import {
+    MediumPassLeftNav,
+    MediumPassLeftNavDeps,
+    MediumPassLeftNavProps,
+} from 'DetailsView/components/left-nav/medium-pass-left-nav';
 import {
     getLoadButtonForAssessment,
     getNullLoadButton,
@@ -65,12 +74,13 @@ import {
 import {
     getAssessmentSelectedDetailsView,
     getFastPassSelectedDetailsView,
+    getQuickAssessSelectedDetailsView,
     GetSelectedDetailsViewProps,
 } from './left-nav/get-selected-details-view';
 
-export type LeftNavDeps = AssessmentLeftNavDeps & FastPassLeftNavDeps;
-export type LeftNavProps = AssessmentLeftNavProps & FastPassLeftNavProps;
-type InternalLeftNavProps = AssessmentLeftNavProps | FastPassLeftNavProps;
+export type LeftNavDeps = AssessmentLeftNavDeps & FastPassLeftNavDeps & MediumPassLeftNavDeps;
+export type LeftNavProps = AssessmentLeftNavProps & FastPassLeftNavProps & MediumPassLeftNavProps;
+type InternalLeftNavProps = AssessmentLeftNavProps | FastPassLeftNavProps | MediumPassLeftNavProps;
 
 export type GetSharedAssessmentFunctionalityObjects = (
     switcher: AssessmentFunctionalitySwitcher,
@@ -88,6 +98,7 @@ export type DetailsViewSwitcherNavConfiguration = Readonly<{
     warningConfiguration: WarningConfiguration;
     leftNavHamburgerButton: ReactFCWithDisplayName<ExpandCollpaseLeftNavButtonProps>;
     getSharedAssessmentFunctionalityObjects: GetSharedAssessmentFunctionalityObjects;
+    getSelectedAssessmentStoreData: GetSelectedAssessmentStoreData;
 }>;
 
 type InternalDetailsViewSwitcherNavConfiguration = Omit<
@@ -116,6 +127,7 @@ const detailsViewSwitcherNavs: {
         warningConfiguration: assessmentWarningConfiguration,
         leftNavHamburgerButton: AssessmentLeftNavHamburgerButton,
         getSharedAssessmentFunctionalityObjects: switcher => switcher.getAssessmentObjects(),
+        getSelectedAssessmentStoreData: getAssessmentStoreData,
     },
     [DetailsViewPivotType.mediumPass]: {
         CommandBar: MediumPassCommandBar,
@@ -125,10 +137,11 @@ const detailsViewSwitcherNavs: {
         LoadAssessmentButton: getNullLoadButton,
         StartOverComponentFactory: AssessmentStartOverFactory,
         LeftNav: MediumPassLeftNav,
-        getSelectedDetailsView: getAssessmentSelectedDetailsView,
+        getSelectedDetailsView: getQuickAssessSelectedDetailsView,
         warningConfiguration: assessmentWarningConfiguration,
         leftNavHamburgerButton: MediumPassLeftNavHamburgerButton,
         getSharedAssessmentFunctionalityObjects: switcher => switcher.getQuickAssessObjects(),
+        getSelectedAssessmentStoreData: getQuickAssessStoreData,
     },
     [DetailsViewPivotType.fastPass]: {
         CommandBar: AutomatedChecksCommandBar,
@@ -142,6 +155,9 @@ const detailsViewSwitcherNavs: {
         warningConfiguration: fastpassWarningConfiguration,
         leftNavHamburgerButton: FastPassLeftNavHamburgerButton,
         getSharedAssessmentFunctionalityObjects: switcher => switcher.getAssessmentObjects(),
+
+        // Getting assessmentStoreData is default behavior
+        getSelectedAssessmentStoreData: getAssessmentStoreData,
     },
 };
 

--- a/src/DetailsView/components/left-nav/get-selected-assessment-store-data.ts
+++ b/src/DetailsView/components/left-nav/get-selected-assessment-store-data.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AssessmentStoreData } from '../../../common/types/store-data/assessment-result-data';
+
+export type GetSelectedAssessmentStoreDataProps = {
+    assessmentStoreData: AssessmentStoreData;
+    quickAssessStoreData: AssessmentStoreData;
+};
+
+export type GetSelectedAssessmentStoreData = (
+    props: GetSelectedAssessmentStoreDataProps,
+) => AssessmentStoreData;
+
+export const getAssessmentStoreData = (props: GetSelectedAssessmentStoreDataProps) => {
+    return props.assessmentStoreData;
+};
+
+export const getQuickAssessStoreData = (props: GetSelectedAssessmentStoreDataProps) => {
+    return props.quickAssessStoreData;
+};

--- a/src/DetailsView/components/left-nav/get-selected-details-view.ts
+++ b/src/DetailsView/components/left-nav/get-selected-details-view.ts
@@ -4,10 +4,15 @@ import { AssessmentStoreData } from '../../../common/types/store-data/assessment
 import { VisualizationStoreData } from '../../../common/types/store-data/visualization-store-data';
 
 export type GetSelectedDetailsViewProps = GetFastPassSelectedDetailsViewProps &
-    GetAssessmentSelectedDetailsViewProps;
+    GetAssessmentSelectedDetailsViewProps &
+    GetQuickAssessSelectedDetailsViewProps;
 
 export type GetAssessmentSelectedDetailsViewProps = {
     assessmentStoreData: AssessmentStoreData;
+};
+
+export type GetQuickAssessSelectedDetailsViewProps = {
+    quickAssessStoreData: AssessmentStoreData;
 };
 
 export type GetFastPassSelectedDetailsViewProps = {
@@ -16,6 +21,9 @@ export type GetFastPassSelectedDetailsViewProps = {
 
 export const getAssessmentSelectedDetailsView = (props: GetAssessmentSelectedDetailsViewProps) =>
     props.assessmentStoreData.assessmentNavState.selectedTestType;
+
+export const getQuickAssessSelectedDetailsView = (props: GetQuickAssessSelectedDetailsViewProps) =>
+    props.quickAssessStoreData.assessmentNavState.selectedTestType;
 
 export const getFastPassSelectedDetailsView = (props: GetFastPassSelectedDetailsViewProps) =>
     props.visualizationStoreData.selectedFastPassDetailsView;

--- a/src/DetailsView/components/left-nav/medium-pass-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/medium-pass-left-nav.tsx
@@ -18,7 +18,7 @@ import { NavLinkHandler } from './nav-link-handler';
 
 export type MediumPassLeftNavDeps = {
     leftNavLinkBuilder: LeftNavLinkBuilder;
-    navLinkHandler: NavLinkHandler;
+    getNavLinkHandler: () => NavLinkHandler;
     mediumPassRequirementKeys: string[];
 } & OverviewLinkBuilderDeps &
     AssessmentLinkBuilderDeps;
@@ -45,13 +45,13 @@ export const MediumPassLeftNav = NamedFC<MediumPassLeftNavProps>('MediumPassLeft
         setNavComponentRef,
     } = props;
 
-    const { navLinkHandler, leftNavLinkBuilder } = deps;
+    const { getNavLinkHandler, leftNavLinkBuilder } = deps;
 
     let links = [];
     links.push(
         leftNavLinkBuilder.buildOverviewLink(
             deps,
-            navLinkHandler.onOverviewClick,
+            getNavLinkHandler().onOverviewClick,
             assessmentsProvider,
             assessmentsData,
             0,

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -54,6 +54,7 @@ export interface DetailsViewContainerState {
     featureFlagStoreData: FeatureFlagStoreData;
     detailsViewStoreData: DetailsViewStoreData;
     assessmentStoreData: AssessmentStoreData;
+    quickAssessStoreData: AssessmentStoreData;
     pathSnippetStoreData: PathSnippetStoreData;
     scopingPanelStateStoreData: ScopingStoreData;
     userConfigurationStoreData: UserConfigurationStoreData;

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -237,6 +237,10 @@ if (tabId != null) {
                 StoreNames[StoreNames.AssessmentStore],
                 storeUpdateMessageHub,
             );
+            const quickAssessStore = new StoreProxy<AssessmentStoreData>(
+                StoreNames[StoreNames.QuickAssessStore],
+                storeUpdateMessageHub,
+            );
             const featureFlagStore = new StoreProxy<DictionaryStringTo<boolean>>(
                 StoreNames[StoreNames.FeatureFlagStore],
                 storeUpdateMessageHub,
@@ -272,6 +276,7 @@ if (tabId != null) {
                 needsReviewCardSelectionStore,
                 visualizationStore,
                 assessmentStore,
+                quickAssessStore,
                 pathSnippetStore,
                 scopingStore,
                 userConfigStore,
@@ -446,6 +451,7 @@ if (tabId != null) {
                 detailsViewStore,
                 visualizationStore,
                 assessmentStore,
+                quickAssessStore,
                 GetDetailsRightPanelConfiguration,
                 GetDetailsSwitcherNavConfiguration,
                 visualizationConfigurationFactory,

--- a/src/DetailsView/document-title-updater.ts
+++ b/src/DetailsView/document-title-updater.ts
@@ -16,6 +16,7 @@ export class DocumentTitleUpdater {
         private readonly detailsViewStore: BaseStore<DetailsViewStoreData, Promise<void>>,
         private readonly visualizationStore: BaseStore<VisualizationStoreData, Promise<void>>,
         private readonly assessmentStore: BaseStore<AssessmentStoreData, Promise<void>>,
+        private readonly quickAssessStore: BaseStore<AssessmentStoreData, Promise<void>>,
         private readonly getDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration,
         private readonly getDetailsSwitcherNavConfiguration: GetDetailsSwitcherNavConfiguration,
         private readonly visualizationConfigurationFactory: VisualizationConfigurationFactory,
@@ -27,6 +28,7 @@ export class DocumentTitleUpdater {
         this.detailsViewStore.addChangedListener(this.onStoreChange);
         this.visualizationStore.addChangedListener(this.onStoreChange);
         this.assessmentStore.addChangedListener(this.onStoreChange);
+        this.quickAssessStore.addChangedListener(this.onStoreChange);
     }
 
     private onStoreChange = async (): Promise<void> => {
@@ -42,6 +44,7 @@ export class DocumentTitleUpdater {
         }
 
         const assessmentStoreData = this.assessmentStore.getState();
+        const quickAssessStoreData = this.quickAssessStore.getState();
         const visualizationStoreData = this.visualizationStore.getState();
         const selectedDetailsViewPivot = visualizationStoreData.selectedDetailsViewPivot;
         const switcherNavConfiguration = this.getDetailsSwitcherNavConfiguration({
@@ -51,6 +54,7 @@ export class DocumentTitleUpdater {
         const selectedDetailsView = switcherNavConfiguration.getSelectedDetailsView({
             assessmentStoreData,
             visualizationStoreData,
+            quickAssessStoreData,
         });
 
         const panel = this.detailsViewStore.getState().detailsViewRightContentPanel;

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { PersistentStore } from 'common/flux/persistent-store';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
@@ -59,8 +58,9 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         private readonly initialAssessmentStoreDataGenerator: InitialAssessmentStoreDataGenerator,
         logger: Logger,
         name: StoreNames,
+        indexDBKey: string,
     ) {
-        super(name, persistedData, idbInstance, IndexedDBDataKeys.assessmentStore, logger, true);
+        super(name, persistedData, idbInstance, indexDBKey, logger, true);
     }
 
     protected override generateDefaultState(

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { PermissionsStateStore } from 'background/stores/global/permissions-state-store';
 import { FeatureFlagDefaultsHelper } from 'common/feature-flag-defaults-helper';
 import { getAllFeatureFlagDetails } from 'common/feature-flags';
@@ -87,18 +90,24 @@ export class GlobalStoreHub implements StoreHub {
             new InitialAssessmentStoreDataGenerator(assessmentsProvider.all()),
             logger,
             StoreNames.AssessmentStore,
+            IndexedDBDataKeys.assessmentStore,
+        );
+        const mediumPassProvider = assessmentsProviderForRequirements(
+            assessmentsProvider,
+            MediumPassRequirementMap,
         );
         this.quickAssessStore = new AssessmentStore(
             browserAdapter,
             globalActionHub.quickAssessActions,
             new AssessmentDataConverter(generateUID),
             new AssessmentDataRemover(),
-            assessmentsProvider,
+            mediumPassProvider,
             indexedDbInstance,
             persistedData.quickAssessStoreData,
-            new InitialAssessmentStoreDataGenerator(assessmentsProvider.all()),
+            new InitialAssessmentStoreDataGenerator(mediumPassProvider.all()),
             logger,
             StoreNames.QuickAssessStore,
+            IndexedDBDataKeys.quickAssessStore,
         );
         this.userConfigurationStore = new UserConfigurationStore(
             persistedData.userConfigurationData,

--- a/src/tests/unit/common/assessment-store-data-builder.ts
+++ b/src/tests/unit/common/assessment-store-data-builder.ts
@@ -3,6 +3,7 @@
 
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentDataConverter } from 'background/assessment-data-converter';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { InitialAssessmentStoreDataGenerator } from 'background/initial-assessment-store-data-generator';
 import { AssessmentStore } from 'background/stores/assessment-store';
 import { StoreNames } from 'common/stores/store-names';
@@ -35,6 +36,7 @@ export class AssessmentsStoreDataBuilder extends BaseDataBuilder<AssessmentStore
             initialAssessmentStoreDataGenerator || this.getPreparedMock(),
             failTestOnErrorLogger,
             StoreNames.AssessmentStore,
+            IndexedDBDataKeys.assessmentStore,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -119,6 +119,7 @@ exports[`DetailsViewContent render renders normally 1`] = `
     setSideNavOpen={[Function]}
     switcherNavConfiguration={
       {
+        "getSelectedAssessmentStoreData": [Function],
         "getSelectedDetailsView": [Function],
       }
     }

--- a/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
@@ -27,22 +27,24 @@ describe('DetailsViewRightPanelTests', () => {
             validateTestView(testSubject);
         });
 
-        it('GetDetailsRightPanelConfiguration: return TestView object when assessment selected', () => {
-            const testSubject = GetDetailsRightPanelConfiguration({
-                selectedDetailsViewPivot: DetailsViewPivotType.assessment,
-                detailsViewRightContentPanel: 'TestView',
+        [DetailsViewPivotType.assessment, DetailsViewPivotType.mediumPass].forEach(pivot => {
+            it(`GetDetailsRightPanelConfiguration: return TestView object when ${DetailsViewPivotType[pivot]} selected`, () => {
+                const testSubject = GetDetailsRightPanelConfiguration({
+                    selectedDetailsViewPivot: pivot,
+                    detailsViewRightContentPanel: 'TestView',
+                });
+
+                validateTestView(testSubject);
             });
 
-            validateTestView(testSubject);
-        });
+            it(`GetDetailsRightPanelConfiguration: return TestView object when ${DetailsViewPivotType[pivot]} selected`, () => {
+                const testSubject = GetDetailsRightPanelConfiguration({
+                    selectedDetailsViewPivot: pivot,
+                    detailsViewRightContentPanel: 'Overview',
+                });
 
-        it('GetDetailsRightPanelConfiguration: return TestView object when assessment selected', () => {
-            const testSubject = GetDetailsRightPanelConfiguration({
-                selectedDetailsViewPivot: DetailsViewPivotType.assessment,
-                detailsViewRightContentPanel: 'Overview',
+                validateOverview(testSubject);
             });
-
-            validateOverview(testSubject);
         });
     });
 

--- a/src/tests/unit/tests/DetailsView/components/left-nav/get-selected-assessment-store-data.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/get-selected-assessment-store-data.test.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { VisualizationType } from 'common/types/visualization-type';
+import {
+    getAssessmentStoreData,
+    getQuickAssessStoreData,
+    GetSelectedAssessmentStoreDataProps,
+} from 'DetailsView/components/left-nav/get-selected-assessment-store-data';
+
+describe('GetSelectedAssessmentStoreData', () => {
+    let props: GetSelectedAssessmentStoreDataProps;
+
+    beforeEach(() => {
+        props = {
+            quickAssessStoreData: {
+                assessmentNavState: {
+                    selectedTestType: VisualizationType.HeadingsMediumPass,
+                },
+            },
+            assessmentStoreData: {
+                assessmentNavState: {
+                    selectedTestType: VisualizationType.Headings,
+                },
+            },
+        } as GetSelectedAssessmentStoreDataProps;
+    });
+
+    test('assessment', () => {
+        expect(getAssessmentStoreData(props)).toEqual(props.assessmentStoreData);
+    });
+
+    test('quickAssess', () => {
+        expect(getQuickAssessStoreData(props)).toEqual(props.quickAssessStoreData);
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/left-nav/get-selected-details-view.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/get-selected-details-view.test.ts
@@ -6,6 +6,8 @@ import {
     GetAssessmentSelectedDetailsViewProps,
     getFastPassSelectedDetailsView,
     GetFastPassSelectedDetailsViewProps,
+    getQuickAssessSelectedDetailsView,
+    GetQuickAssessSelectedDetailsViewProps,
 } from 'DetailsView/components/left-nav/get-selected-details-view';
 
 describe('getAssessmentSelectedDetailsView', () => {
@@ -33,5 +35,20 @@ describe('getFastPassSelectedDetailsView', () => {
         } as GetFastPassSelectedDetailsViewProps;
 
         expect(getFastPassSelectedDetailsView(props)).toEqual(expectedValue);
+    });
+});
+
+describe('getQuickAssessSelectedDetailsView', () => {
+    it('should return selected fast pass details view', () => {
+        const expectedValue = -1 as VisualizationType;
+        const props = {
+            quickAssessStoreData: {
+                assessmentNavState: {
+                    selectedTestType: expectedValue,
+                },
+            },
+        } as GetQuickAssessSelectedDetailsViewProps;
+
+        expect(getQuickAssessSelectedDetailsView(props)).toEqual(expectedValue);
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/left-nav/medium-pass-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/medium-pass-left-nav.test.tsx
@@ -51,7 +51,7 @@ describe(MediumPassLeftNav.displayName, () => {
 
         deps = {
             leftNavLinkBuilder: leftNavLinkBuilderMock.object,
-            navLinkHandler: navLinkHandlerMock,
+            getNavLinkHandler: () => navLinkHandlerMock,
             mediumPassRequirementKeys: mediumPassRequirementKeysStub,
         } as MediumPassLeftNavDeps;
         props = {

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -33,6 +33,7 @@ import {
     GetDetailsSwitcherNavConfiguration,
     GetDetailsSwitcherNavConfigurationProps,
 } from 'DetailsView/components/details-view-switcher-nav';
+import { GetSelectedAssessmentStoreData } from 'DetailsView/components/left-nav/get-selected-assessment-store-data';
 import { GetSelectedDetailsViewProps } from 'DetailsView/components/left-nav/get-selected-details-view';
 import {
     DetailsViewContainerDeps,
@@ -123,10 +124,14 @@ describe(DetailsViewContent.displayName, () => {
                 (theProps: GetSelectedDetailsViewProps) => null,
                 MockBehavior.Strict,
             );
+            const getSelectedAssessmentStoreDataMock = Mock.ofInstance(
+                (() => null) as GetSelectedAssessmentStoreData,
+            );
             const rightContentPanelType = 'TestView';
             const rightContentPanelConfig = {} as DetailsRightPanelConfiguration;
             const switcherNavConfig = {
                 getSelectedDetailsView: getSelectedDetailsViewMock.object,
+                getSelectedAssessmentStoreData: getSelectedAssessmentStoreDataMock.object,
             } as DetailsViewSwitcherNavConfiguration;
 
             const visualizationStoreData = new VisualizationStoreDataBuilder()
@@ -202,11 +207,24 @@ describe(DetailsViewContent.displayName, () => {
                         It.isObjectWith({
                             assessmentStoreData: state.assessmentStoreData,
                             visualizationStoreData: state.visualizationStoreData,
-                            pathSnippetStoreData: state.pathSnippetStoreData,
+                            quickAssessStoreData: state.quickAssessStoreData,
                         }),
                     ),
                 )
                 .returns(() => viewType);
+
+            getSelectedAssessmentStoreDataMock
+                .setup(m =>
+                    m(
+                        It.isObjectWith({
+                            assessmentStoreData: state.assessmentStoreData,
+                            quickAssessStoreData: state.quickAssessStoreData,
+                        }),
+                    ),
+                )
+                .returns(() => {
+                    return state.assessmentStoreData;
+                });
 
             const cardSelectionViewData: CardSelectionViewData = {} as CardSelectionViewData;
             getCardSelectionViewDataMock
@@ -274,6 +292,7 @@ describe(DetailsViewContent.displayName, () => {
                         featureFlagStoreData: storeMocks.featureFlagStoreData,
                         detailsViewStoreData: storeMocks.detailsViewStoreData,
                         assessmentStoreData: storeMocks.assessmentStoreData,
+                        quickAssessStoreData: storeMocks.quickAssessStoreData,
                         pathSnippetStoreData: storeMocks.pathSnippetStoreData,
                         scopingPanelStateStoreData: storeMocks.scopingStoreData,
                         userConfigurationStoreData: storeMocks.userConfigurationStoreData,
@@ -347,6 +366,7 @@ describe(DetailsViewContent.displayName, () => {
             permissionsStateStoreData: storeMocks.permissionsStateStoreData,
             tabStopsViewStoreData: storeMocks.tabStopsViewStoreData,
             cardsViewStoreData: storeMocks.cardsViewStoreData,
+            quickAssessStoreData: storeMocks.quickAssessStoreData,
         };
     }
 });

--- a/src/tests/unit/tests/DetailsView/document-title-updater.test.ts
+++ b/src/tests/unit/tests/DetailsView/document-title-updater.test.ts
@@ -59,6 +59,7 @@ describe('DocumentTitleUpdater', () => {
             storeMocks.detailsViewStoreMock.object,
             storeMocks.visualizationStoreMock.object,
             storeMocks.assessmentStoreMock.object,
+            storeMocks.quickAssessStoreMock.object,
             getPanelConfigMock.object,
             getSwitcherNavConfigMock.object,
             visualizationConfigFactoryMock.object,
@@ -130,6 +131,7 @@ describe('DocumentTitleUpdater', () => {
                 mock({
                     assessmentStoreData: storeMocks.assessmentStoreData,
                     visualizationStoreData: storeMocks.visualizationStoreData,
+                    quickAssessStoreData: storeMocks.quickAssessStoreData,
                 }),
             )
             .returns(() => selectedDetailsView);
@@ -167,6 +169,10 @@ describe('DocumentTitleUpdater', () => {
             .setup(store => store.addChangedListener(It.isAny()))
             .callback(cb => (onStoreChange = cb))
             .verifiable();
+        storeMocks.quickAssessStoreMock
+            .setup(store => store.addChangedListener(It.isAny()))
+            .callback(cb => (onStoreChange = cb))
+            .verifiable();
     }
 
     function setupStoreGetState(): void {
@@ -182,5 +188,8 @@ describe('DocumentTitleUpdater', () => {
         storeMocks.assessmentStoreMock
             .setup(store => store.getState())
             .returns(() => storeMocks.assessmentStoreData);
+        storeMocks.quickAssessStoreMock
+            .setup(store => store.getState())
+            .returns(() => storeMocks.quickAssessStoreData);
     }
 });

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -54,6 +54,7 @@ export class StoreMocks {
     public tabStoreMock = Mock.ofType(TabStore, MockBehavior.Strict);
     public featureFlagStoreMock = Mock.ofType(FeatureFlagStore, MockBehavior.Strict);
     public assessmentStoreMock = Mock.ofType(AssessmentStore, MockBehavior.Strict);
+    public quickAssessStoreMock = Mock.ofType(AssessmentStore, MockBehavior.Strict);
     public assessmentsProviderMock = Mock.ofType(AssessmentsProviderImpl);
     public scopingStoreMock = Mock.ofType(ScopingStore, MockBehavior.Strict);
     public inspectStoreMock = Mock.ofType(InspectStore, MockBehavior.Strict);
@@ -137,6 +138,7 @@ export class StoreMocks {
         [FeatureFlags[FeatureFlags.logTelemetryToConsole]]: false,
     };
     public assessmentStoreData: AssessmentStoreData;
+    public quickAssessStoreData: AssessmentStoreData;
     public permissionsStateStoreData = new PermissionsStateStore(
         null,
         null,
@@ -176,6 +178,10 @@ export class StoreMocks {
             .returns(() => null);
 
         this.assessmentStoreData = new AssessmentsStoreDataBuilder(
+            this.assessmentsProviderMock.object,
+            assessmentDataConverterMock.object,
+        ).build();
+        this.quickAssessStoreData = new AssessmentsStoreDataBuilder(
             this.assessmentsProviderMock.object,
             assessmentDataConverterMock.object,
         ).build();

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -21,6 +21,7 @@ import {
 import { AssessmentActions } from 'background/actions/assessment-actions';
 import { AssessmentDataConverter } from 'background/assessment-data-converter';
 import { AssessmentDataRemover } from 'background/assessment-data-remover';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { InitialAssessmentStoreDataGenerator } from 'background/initial-assessment-store-data-generator';
 import { AssessmentStore } from 'background/stores/assessment-store';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
@@ -125,6 +126,7 @@ describe('AssessmentStore', () => {
             initialAssessmentStoreDataGeneratorMock.object,
             failTestOnErrorLogger,
             StoreNames.AssessmentStore,
+            IndexedDBDataKeys.assessmentStore,
         );
 
         expect(testObject.getId()).toEqual(StoreNames[StoreNames.AssessmentStore]);
@@ -145,6 +147,7 @@ describe('AssessmentStore', () => {
             initialAssessmentStoreDataGeneratorMock.object,
             failTestOnErrorLogger,
             StoreNames.AssessmentStore,
+            IndexedDBDataKeys.assessmentStore,
         );
 
         const actualState = testObject.getDefaultState();
@@ -241,6 +244,7 @@ describe('AssessmentStore', () => {
             initialAssessmentStoreDataGeneratorMock.object,
             failTestOnErrorLogger,
             StoreNames.AssessmentStore,
+            IndexedDBDataKeys.assessmentStore,
         );
         const actualState = testObject.getDefaultState();
 
@@ -2249,6 +2253,7 @@ describe('AssessmentStore', () => {
                 initialAssessmentStoreDataGeneratorMock.object,
                 failTestOnErrorLogger,
                 StoreNames.AssessmentStore,
+                IndexedDBDataKeys.assessmentStore,
             );
         return new AssessmentStoreTester(
             AssessmentActions,

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -21,6 +21,7 @@
         "./src/DetailsView/components/interactive-header.tsx",
         "./src/DetailsView/components/invalid-load-assessment-dialog.tsx",
         "./src/DetailsView/components/issues-table-handler.ts",
+        "./src/DetailsView/components/left-nav/get-selected-assessment-store-data.ts",
         "./src/DetailsView/components/left-nav/get-selected-details-view.ts",
         "./src/DetailsView/components/left-nav/getting-started-nav-link.tsx",
         "./src/DetailsView/components/left-nav/overview-left-nav-link.tsx",


### PR DESCRIPTION
#### Details

Lots of small changes to make this happen:
1. `getSelectedAssessmentStoreData` on the switcher nav to allow us to switch between quick assess and assessment store data in the state.
2. `GetDetailsRightPanelConfiguration` had its behavior flipped, where it specifies TestView when it's a fast pass test and otherwise gets the selected one.
3. `MediumPassLeftNavProps` were missing from the left nav props object and as such the getProvider changes didn't get caught there.
4. `getSelectedDetailsView` for quick assess was missing.
5. `AssessmentStore` was hard-coding the index db key. That is now passed in at initialization to allow quick assess to use it.

The rest is just general wiring up/creation/etc.

##### Motivation

feature work.

##### Context

This does not wire up the target page for quick assess but also should not break anything if the feature flag is not enabled.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
