### PR TITLE
chore: add missing unit test for saveAssessment

### DIFF
--- a/src/tests/unit/tests/DetailsView/actions/assessment-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/assessment-action-message-creator.test.ts
@@ -755,6 +755,30 @@ describe('AssessmentActionMessageCreatorTest', () => {
         );
     });
 
+    test('saveAssessment', () => {
+        const event = eventStubFactory.createMouseClickEvent() as any;
+        const telemetry: BaseTelemetryData = {
+            triggeredBy: 'mouseclick',
+            source: TelemetryEventSource.DetailsView,
+        };
+
+        const expectedMessageToSaveAssessment = {
+            messageType: assessmentMessageStubs.SaveAssessment,
+            payload: {
+                telemetry,
+            },
+        };
+
+        telemetryFactoryMock.setup(tf => tf.fromDetailsView(event)).returns(() => telemetry);
+
+        testSubject.saveAssessment(event);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessageToSaveAssessment)),
+            Times.once(),
+        );
+    });
+
     test('startOverAllAssessments', () => {
         const event = eventStubFactory.createMouseClickEvent() as any;
         const telemetry: BaseTelemetryData = {


### PR DESCRIPTION
#### Details

This PR adds a unit test for `saveAssessment` in `assessment-action-message-creator.test.ts`.

##### Motivation

Increase test coverage

##### Context

Noticed the test was missing when moving Assessment-specific functions out of the DetailsViewActionMessageCreator in #6177

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
