### PR TITLE
feat(medium-pass-1): wire up target page for quick assess

### DIFF
--- a/src/injected/client-store-listener.ts
+++ b/src/injected/client-store-listener.ts
@@ -21,6 +21,7 @@ export interface TargetPageStoreData {
     needsReviewScanResultStoreData: NeedsReviewScanResultStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
     assessmentStoreData: AssessmentStoreData;
+    quickAssessStoreData: AssessmentStoreData;
     userConfigurationStoreData: UserConfigurationStoreData;
     cardSelectionStoreData: CardSelectionStoreData;
     permissionsStateStoreData: PermissionsStateStoreData;

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Assessments } from 'assessments/assessments';
 import { createToolData } from 'common/application-properties-provider';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unavailable';
@@ -14,6 +13,7 @@ import { PermissionsStateStoreData } from 'common/types/store-data/permissions-s
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { toolName } from 'content/strings/application';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
+import { GetDetailsSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import { getCheckResolution, getFixResolution } from 'injected/adapters/resolution-creator';
 import { filterNeedsReviewResults } from 'injected/analyzers/filter-results';
 import { NotificationTextCreator } from 'injected/analyzers/notification-text-creator';
@@ -84,6 +84,7 @@ export class MainWindowInitializer extends WindowInitializer {
     private storeUpdateMessageHub: StoreUpdateMessageHub;
     private visualizationStoreProxy: StoreProxy<VisualizationStoreData>;
     private assessmentStoreProxy: StoreProxy<AssessmentStoreData>;
+    private quickAssessStoreProxy: StoreProxy<AssessmentStoreData>;
     private featureFlagStoreProxy: StoreProxy<FeatureFlagStoreData>;
     private userConfigStoreProxy: StoreProxy<UserConfigurationStoreData>;
     private inspectStoreProxy: StoreProxy<InspectStoreData>;
@@ -129,6 +130,10 @@ export class MainWindowInitializer extends WindowInitializer {
         );
         this.assessmentStoreProxy = new StoreProxy<AssessmentStoreData>(
             StoreNames[StoreNames.AssessmentStore],
+            this.storeUpdateMessageHub,
+        );
+        this.quickAssessStoreProxy = new StoreProxy<AssessmentStoreData>(
+            StoreNames[StoreNames.QuickAssessStore],
             this.storeUpdateMessageHub,
         );
         this.tabStoreProxy = new StoreProxy<TabStoreData>(
@@ -222,7 +227,7 @@ export class MainWindowInitializer extends WindowInitializer {
             isResultHighlightUnavailableWeb,
         );
         const selectorMapHelper = new SelectorMapHelper(
-            Assessments,
+            this.visualizationConfigurationFactory,
             elementBasedViewModelCreator.getElementBasedViewModel,
             GetVisualizationInstancesForTabStops,
         );
@@ -239,6 +244,7 @@ export class MainWindowInitializer extends WindowInitializer {
             this.needsReviewScanResultStoreProxy,
             this.needsReviewCardSelectionStoreProxy,
             this.permissionsStateStoreProxy,
+            this.quickAssessStoreProxy,
         ]);
 
         const clientStoreListener = new ClientStoreListener(storeHub);
@@ -259,6 +265,7 @@ export class MainWindowInitializer extends WindowInitializer {
         const visualizationStateChangeHandler = new VisualizationStateChangeHandler(
             targetPageVisualizationUpdater.updateVisualization,
             this.visualizationConfigurationFactory,
+            GetDetailsSwitcherNavConfiguration,
         );
 
         clientStoreListener.registerOnReadyToExecuteVisualizationCallback(

--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
@@ -28,7 +28,7 @@ export type VisualizationRelatedStoreData = Pick<
 
 export class SelectorMapHelper {
     constructor(
-        private assessmentsProvider: AssessmentsProvider,
+        private visualizationConfigurationFactory: VisualizationConfigurationFactory,
         private getElementBasedViewModel: GetElementBasedViewModelCallback,
         private getVisualizationInstancesForTabStops: typeof GetVisualizationInstancesForTabStops,
     ) {}
@@ -38,7 +38,6 @@ export class SelectorMapHelper {
         stepKey: string,
         visualizationRelatedStoreData: VisualizationRelatedStoreData,
     ): SelectorToVisualizationMap {
-        let selectorMap = {};
         const {
             visualizationScanResultStoreData,
             unifiedScanResultStoreData,
@@ -49,7 +48,7 @@ export class SelectorMapHelper {
         } = visualizationRelatedStoreData;
 
         if (this.isAdHocVisualization(visualizationType)) {
-            selectorMap = this.getAdHocVisualizationSelectorMap(
+            return this.getAdHocVisualizationSelectorMap(
                 visualizationType,
                 visualizationScanResultStoreData,
                 unifiedScanResultStoreData,
@@ -59,15 +58,14 @@ export class SelectorMapHelper {
             );
         }
 
-        if (this.assessmentsProvider.isValidType(visualizationType)) {
-            const key = this.assessmentsProvider.forType(visualizationType).key;
-            selectorMap = this.getFilteredSelectorMap(
-                assessmentStoreData.assessments[key].generatedAssessmentInstancesMap,
-                stepKey,
-            );
-        }
+        const assessmentData = this.visualizationConfigurationFactory
+            .getConfiguration(visualizationType)
+            .getAssessmentData(assessmentStoreData);
 
-        return selectorMap;
+        return this.getFilteredSelectorMap(
+            assessmentData?.generatedAssessmentInstancesMap,
+            stepKey,
+        );
     }
 
     private isAdHocVisualization(visualizationType: VisualizationType): boolean {

--- a/src/injected/visualization-state-change-handler.ts
+++ b/src/injected/visualization-state-change-handler.ts
@@ -4,6 +4,7 @@ import { Requirement } from 'assessments/types/requirement';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { VisualizationType } from 'common/types/visualization-type';
+import { GetDetailsSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 
 import { TargetPageStoreData } from './client-store-listener';
 import { UpdateVisualization } from './target-page-visualization-updater';
@@ -12,6 +13,7 @@ export class VisualizationStateChangeHandler {
     constructor(
         private visualizationUpdater: UpdateVisualization,
         private visualizationConfigurationFactory: VisualizationConfigurationFactory,
+        private getDetailsSwitcherNavConfiguration: GetDetailsSwitcherNavConfiguration,
     ) {}
 
     public updateVisualizationsWithStoreData = async (storeData: TargetPageStoreData) => {
@@ -26,8 +28,18 @@ export class VisualizationStateChangeHandler {
                 type: VisualizationType,
                 requirementConfig: Requirement,
             ) => {
+                const switcherNavConfig = this.getDetailsSwitcherNavConfiguration({
+                    selectedDetailsViewPivot:
+                        storeData.visualizationStoreData.selectedDetailsViewPivot,
+                });
+                const selectedAssessmentData =
+                    switcherNavConfig.getSelectedAssessmentStoreData(storeData);
+
                 updateCalls.push(
-                    this.visualizationUpdater(type, requirementConfig?.key, storeData),
+                    this.visualizationUpdater(type, requirementConfig?.key, {
+                        ...storeData,
+                        assessmentStoreData: selectedAssessmentData,
+                    }),
                 );
             },
         );

--- a/src/tests/unit/tests/injected/visualization-state-change-handler.test.ts
+++ b/src/tests/unit/tests/injected/visualization-state-change-handler.test.ts
@@ -2,6 +2,13 @@
 // Licensed under the MIT License.
 import { Requirement } from 'assessments/types/requirement';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
+import {
+    DetailsViewSwitcherNavConfiguration,
+    GetDetailsSwitcherNavConfiguration,
+} from 'DetailsView/components/details-view-switcher-nav';
+import { GetSelectedAssessmentStoreData } from 'DetailsView/components/left-nav/get-selected-assessment-store-data';
 import { TargetPageStoreData } from 'injected/client-store-listener';
 import { UpdateVisualization } from 'injected/target-page-visualization-updater';
 import { VisualizationStateChangeHandler } from 'injected/visualization-state-change-handler';
@@ -12,14 +19,25 @@ describe('VisualizationStateChangeHandler', () => {
     let visualizationUpdaterMock: IMock<UpdateVisualization>;
     let storeDataStub: TargetPageStoreData;
     let testSubject: VisualizationStateChangeHandler;
+    let getDetailsSwitcherNavConfigurationMock: IMock<GetDetailsSwitcherNavConfiguration>;
+    let assessmentStoreDataStub: AssessmentStoreData;
 
     beforeEach(() => {
         visualizationUpdaterMock = Mock.ofType<UpdateVisualization>();
         configFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
-        storeDataStub = { assessmentStoreData: {} } as TargetPageStoreData;
+        storeDataStub = {
+            assessmentStoreData: { assessmentNavState: { selectedTestSubview: 'sub-view-1' } },
+            quickAssessStoreData: { assessmentNavState: { selectedTestSubview: 'sub-view-2' } },
+            visualizationStoreData: { selectedDetailsViewPivot: DetailsViewPivotType.fastPass },
+        } as TargetPageStoreData;
+        assessmentStoreDataStub = {
+            assessmentNavState: { selectedTestSubview: 'some test sub view' },
+        } as AssessmentStoreData;
+        getDetailsSwitcherNavConfigurationMock = Mock.ofType<GetDetailsSwitcherNavConfiguration>();
         testSubject = new VisualizationStateChangeHandler(
             visualizationUpdaterMock.object,
             configFactoryMock.object,
+            getDetailsSwitcherNavConfigurationMock.object,
         );
     });
 
@@ -33,10 +51,16 @@ describe('VisualizationStateChangeHandler', () => {
                 givenCallback(null, -1, requirementConfigStub);
             });
 
+        setupSwitcherNavConfiguration(storeDataStub, assessmentStoreDataStub);
         await testSubject.updateVisualizationsWithStoreData(storeDataStub);
 
+        const expectedStoreData = {
+            ...storeDataStub,
+            assessmentStoreData: assessmentStoreDataStub,
+        } as TargetPageStoreData;
+
         visualizationUpdaterMock.verify(
-            m => m(-1, requirementConfigStub.key, storeDataStub),
+            m => m(-1, requirementConfigStub.key, It.isValue(expectedStoreData)),
             Times.once(),
         );
     });
@@ -48,9 +72,18 @@ describe('VisualizationStateChangeHandler', () => {
                 givenCallback(null, -1);
             });
 
+        setupSwitcherNavConfiguration(storeDataStub, assessmentStoreDataStub);
         await testSubject.updateVisualizationsWithStoreData(storeDataStub);
 
-        visualizationUpdaterMock.verify(m => m(-1, undefined, storeDataStub), Times.once());
+        const expectedStoreData = {
+            ...storeDataStub,
+            assessmentStoreData: assessmentStoreDataStub,
+        } as TargetPageStoreData;
+
+        visualizationUpdaterMock.verify(
+            m => m(-1, undefined, It.isValue(expectedStoreData)),
+            Times.once(),
+        );
     });
 
     test('no assessment store data', async () => {
@@ -58,4 +91,36 @@ describe('VisualizationStateChangeHandler', () => {
 
         visualizationUpdaterMock.verify(m => m(It.isAny(), It.isAny(), It.isAny()), Times.never());
     });
+
+    function setupSwitcherNavConfiguration(
+        storeData: TargetPageStoreData,
+        returnedAssessmentData: AssessmentStoreData,
+    ): void {
+        const getSelectedAssessmentStoreDataMock = Mock.ofType<GetSelectedAssessmentStoreData>();
+        getDetailsSwitcherNavConfigurationMock
+            .setup(m =>
+                m(
+                    It.isValue({
+                        selectedDetailsViewPivot:
+                            storeData.visualizationStoreData.selectedDetailsViewPivot,
+                    }),
+                ),
+            )
+            .returns(() => {
+                return {
+                    getSelectedAssessmentStoreData: getSelectedAssessmentStoreDataMock.object,
+                } as DetailsViewSwitcherNavConfiguration;
+            });
+
+        getSelectedAssessmentStoreDataMock
+            .setup(m =>
+                m(
+                    It.isObjectWith({
+                        quickAssessStoreData: storeData.quickAssessStoreData,
+                        assessmentStoreData: storeData.assessmentStoreData,
+                    }),
+                ),
+            )
+            .returns(() => returnedAssessmentData);
+    }
 });


### PR DESCRIPTION
#### Details

A couple changes needed to occur to make this happen:
1. selectorMapHelper now uses visualization configuration factory instead of the assessments provider.
2. The visualization state change handler switches between the appropriate store data depending on the pivot selected. I think we don't necessarily have to do it this way as we have fewer components that rely on the assessment store data explicitly but for now this is fine and we're not doing anything complicated with this data as well.


##### Motivation

Feature work.

##### Context

Did do a bit of smoke testing making sure this would not cause issues when the feature flag is disabled.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
