### PR TITLE
fix(medium-pass-1): filter batched analyzer onResolve on test type

### DIFF
--- a/src/injected/analyzers/batched-rule-analyzer.ts
+++ b/src/injected/analyzers/batched-rule-analyzer.ts
@@ -47,15 +47,20 @@ export class BatchedRuleAnalyzer extends RuleAnalyzer {
     }
 
     protected onResolve = (results: AxeAnalyzerResult): void => {
-        BatchedRuleAnalyzer.batchConfigs.forEach(config => {
-            const filteredScannerResult = this.postScanFilter(results.originalResult, config.rules);
-            const processResults = config.resultProcessor(this.scanner);
-            const filteredAxeAnalyzerResult: AxeAnalyzerResult = {
-                ...results,
-                originalResult: filteredScannerResult,
-                results: processResults(filteredScannerResult),
-            };
-            this.sendScanCompleteResolveMessage(filteredAxeAnalyzerResult, config);
-        });
+        BatchedRuleAnalyzer.batchConfigs
+            .filter(config => config.testType === this.config.testType)
+            .forEach(config => {
+                const filteredScannerResult = this.postScanFilter(
+                    results.originalResult,
+                    config.rules,
+                );
+                const processResults = config.resultProcessor(this.scanner);
+                const filteredAxeAnalyzerResult: AxeAnalyzerResult = {
+                    ...results,
+                    originalResult: filteredScannerResult,
+                    results: processResults(filteredScannerResult),
+                };
+                this.sendScanCompleteResolveMessage(filteredAxeAnalyzerResult, config);
+            });
     };
 }

--- a/src/tests/unit/tests/injected/analyzers/batched-rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/batched-rule-analyzer.test.ts
@@ -106,6 +106,12 @@ describe('BatchedRuleAnalyzer', () => {
             rules: [ruleTwo],
             resultProcessor: scanner => resultProcessorMockTwo.object,
         };
+        const configThree = {
+            ...clone(configOne),
+            testType: -2,
+            rules: [ruleTwo],
+            resultProcessor: scanner => resultProcessorMockTwo.object,
+        };
         const resultTwo: RuleResult = {
             id: ruleTwo,
         } as RuleResult;
@@ -114,6 +120,7 @@ describe('BatchedRuleAnalyzer', () => {
 
         const testSubjectOne = createAnalyzer(configOne);
         const testSubjectTwo = createAnalyzer(configTwo);
+        createAnalyzer(configThree);
 
         const completeRuleResults = createTestRuleResultsWithResult([resultOne, resultTwo]);
         const scanResultsOne = createTestRuleResultsWithResult([resultOne]);
@@ -155,9 +162,11 @@ describe('BatchedRuleAnalyzer', () => {
         /*
         BatchedRuleAnalyzer maintains a static list of
         RuleAnalyzerConfigurations. After scanning, it
-        sends a scanCompleted message for each rule-config.
+        sends a scanCompleted message for each rule-config
+        for each config that matches the visualization-type
+        that initiated the scan.
 
-        Because we instantiate two analyzers, each analyzer
+        Because we instantiate two analyzers with the same type, each analyzer
         has two configs and therefore the scanCallback
         produces two scanCompleted messages.
         */


### PR DESCRIPTION
#### Details

This fixes an issue where messages are sent for visualization types that were not scanned in batched analyzer.

##### Motivation


Feature work.

##### Context

Batched Analyzer is a bit messy and probably be refactored but ... not in this PR.


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
