### PR TITLE
fix(medium-pass-1): document title updater should wait for quick assess data

### DIFF
--- a/src/DetailsView/document-title-updater.ts
+++ b/src/DetailsView/document-title-updater.ts
@@ -74,6 +74,7 @@ export class DocumentTitleUpdater {
             this.detailsViewStore,
             this.visualizationStore,
             this.assessmentStore,
+            this.quickAssessStore,
         ].every(store => store.getState() != null);
     }
 }

--- a/src/tests/unit/tests/DetailsView/document-title-updater.test.ts
+++ b/src/tests/unit/tests/DetailsView/document-title-updater.test.ts
@@ -94,6 +94,26 @@ describe('DocumentTitleUpdater', () => {
         expect(doc.title).toEqual(title);
     });
 
+    test('no quickAssessStore data', () => {
+        storeMocks.setQuickAssessData(null);
+        setupStoreGetState();
+
+        testObject.initialize();
+        onStoreChange();
+
+        expect(doc.title).toEqual(title);
+    });
+
+    test('no assessmentStore data', () => {
+        storeMocks.setAssessmentData(null);
+        setupStoreGetState();
+
+        testObject.initialize();
+        onStoreChange();
+
+        expect(doc.title).toEqual(title);
+    });
+
     test('tab is closed', () => {
         storeMocks.setTabStoreData({ isClosed: true } as TabStoreData);
         setupStoreGetState();

--- a/src/tests/unit/tests/DetailsView/document-title-updater.test.ts
+++ b/src/tests/unit/tests/DetailsView/document-title-updater.test.ts
@@ -114,6 +114,16 @@ describe('DocumentTitleUpdater', () => {
         expect(doc.title).toEqual(title);
     });
 
+    test('no visualizationStore data', () => {
+        storeMocks.setVisualizationStoreData(null);
+        setupStoreGetState();
+
+        testObject.initialize();
+        onStoreChange();
+
+        expect(doc.title).toEqual(title);
+    });
+
     test('tab is closed', () => {
         storeMocks.setTabStoreData({ isClosed: true } as TabStoreData);
         setupStoreGetState();

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -224,6 +224,16 @@ export class StoreMocks {
         return this;
     }
 
+    public setQuickAssessData(data: AssessmentStoreData): StoreMocks {
+        this.quickAssessStoreData = data;
+        return this;
+    }
+
+    public setAssessmentData(data: AssessmentStoreData): StoreMocks {
+        this.assessmentStoreData = data;
+        return this;
+    }
+
     public setVisualizationStoreData(data: VisualizationStoreData): StoreMocks {
         this.visualizationStoreData = data;
         return this;


### PR DESCRIPTION
#### Details

This causes an error when a page is loaded; doesn't break but this should reduce error noisiness.

##### Motivation

Feature clean-up.

##### Context

Also added a test for the assessment store and visualization store.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn null:autoadd`
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
