### PR TITLE
fix: prevent styling conflicts with certain fluentui-based target pages

### DIFF
--- a/src/injected/client-init.ts
+++ b/src/injected/client-init.ts
@@ -16,16 +16,23 @@ async function initClient() {
     }
 
     const { Stylesheet } = await import('@fluentui/merge-styles');
+    const stylesheet = Stylesheet.getInstance();
+
+    // This *must* be set *before* any transitive import of any other fluentui component!
+    //
+    // This configuration modifies the prefix that fluentui will use for any styles that it
+    // injects dynamically into the target page's global styles. It's important that we use a
+    // unique prefix to avoid conflicts with target pages that use fluentui themselves. In some
+    // cases, just *importing* fluentui will transitively create conflicting styles, so this needs
+    // to be configured before that import happens (see #6212).
+    stylesheet.setConfig({
+        defaultPrefix: 'insights',
+    });
+
     const { createDefaultLogger } = await import('common/logging/default-logger');
     const { initializeFabricIcons } = await import('../common/fabric-icons');
     const { MainWindowInitializer } = await import('./main-window-initializer');
     const { WindowInitializer } = await import('./window-initializer');
-
-    const stylesheet = Stylesheet.getInstance();
-
-    stylesheet.setConfig({
-        defaultPrefix: 'insights',
-    });
 
     const logger = createDefaultLogger();
     initializeFabricIcons();


### PR DESCRIPTION
#### Details

`client-init` contains the following bit of code very early during injected page initialization:

```ts
    const { Stylesheet } = await import('@fluentui/merge-styles');
    const stylesheet = Stylesheet.getInstance();
    stylesheet.setConfig({
        defaultPrefix: 'insights',
    });
```

This code exists because many `@fluentui/react` components' styling works internally by dynamically generating some CSS and injecting it into a document-level fluentui-managed `<style>` element using [`@fluentui/merge-styles`](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/README.md). Because this is injecting into a document-level style element within the DOM, it is "visible" to the target page itself, not just our injected content, and that means that if the target page already uses fluentui itself, the two fluentui instances can stomp on each other and override each others' styles. Changing the `defaultPrefix` is intended to avoid this by forcing our instance of `fluentui` to use a special, non-default prefix for all the CSS styles it injects (`insights-whatever` instead of its default `css-whatever`).

However, it turns out that this configuration was not quite happening early enough. In particular, before this PR, we were performing this configuration *after* an `await import('../common/fabric-icons')` statement (but before invoking any of the imported code). This turns out to be too late; there are certain `@fluentui` components that start setting up styles and mutating the global state of the page just by being imported. In this specific case, the following import path:

```
src/common/fabric-icons.ts
node_modules/@fluentui/font-icons-mdl2/lib/index.js
node_modules/@fluentui/font-icons-mdl2/lib/fabric-icons.js
node_modules/@fluentui/style-utilities/lib/index.js
node_modules/@fluentui/style-utilities/lib/classNames/index.js
node_modules/@fluentui/style-utilities/lib/classNames/AnimationClassNames.js
node_modules/@fluentui/style-utilities/lib/styles/index.js
node_modules/@fluentui/style-utilities/lib/styles/AnimationStyles.js
node_modules/@fluentui/theme/lib/index.js
node_modules/@fluentui/theme/lib/motion/index.js
node_modules/@fluentui/theme/lib/motion/AnimationStyles.js
```

...runs the following code on import:

```ts
const FADE_OUT: string = keyframes({
  from: { opacity: 1 },
  to: { opacity: 0, visibility: 'hidden' },
});
```

...which ends up conflicting with a class that the target page happened to define for a portion of the target page's nav menu, resulting in the nav menu being given an opacity 0/hidden end state for its flyin transition animation.

This PR fixes the issue by moving our `defaultPrefix` config to happen *before* we transitively import any fluentui bits (besides the `setConfig` functionality itself). This is very non-obvious so I also left a big comment banner explaining the timing requirements for the `setConfig` call.

##### Motivation

Addresses #6212

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #6212
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
