### PR TITLE
feat(medium-pass-2): add store/wiring for transferring data from quick assess to assessment

### DIFF
--- a/src/background/actions/data-transfer-actions.ts
+++ b/src/background/actions/data-transfer-actions.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AsyncAction } from 'common/flux/async-action';
+
+export class DataTransferActions {
+    public readonly getCurrentState = new AsyncAction<null>();
+    public readonly initiateTransferQuickAssessDataToAssessment = new AsyncAction<null>();
+    public readonly finalizeTransferQuickAssessDataToAssessment = new AsyncAction<null>();
+}

--- a/src/background/actions/global-action-hub.ts
+++ b/src/background/actions/global-action-hub.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DataTransferActions } from 'background/actions/data-transfer-actions';
 import { PermissionsStateActions } from 'background/actions/permissions-state-actions';
 import { FeatureFlagActions } from '../actions/feature-flag-actions';
 import { LaunchPanelStateActions } from '../actions/launch-panel-state-action';
@@ -15,6 +16,7 @@ export class GlobalActionHub {
     public scopingActions: ScopingActions;
     public assessmentActions: AssessmentActions;
     public quickAssessActions: AssessmentActions;
+    public dataTransferActions: DataTransferActions;
     public userConfigurationActions: UserConfigurationActions;
     public permissionsStateActions: PermissionsStateActions;
 
@@ -25,6 +27,7 @@ export class GlobalActionHub {
         this.scopingActions = new ScopingActions();
         this.assessmentActions = new AssessmentActions();
         this.quickAssessActions = new AssessmentActions();
+        this.dataTransferActions = new DataTransferActions();
         this.userConfigurationActions = new UserConfigurationActions();
         this.permissionsStateActions = new PermissionsStateActions();
     }

--- a/src/background/global-action-creators/global-action-creator.ts
+++ b/src/background/global-action-creators/global-action-creator.ts
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DataTransferActions } from 'background/actions/data-transfer-actions';
+import { TRANSFER_QUICK_ASSESS_DATA_TO_ASSESSMENT_INITIATED } from 'common/extension-telemetry-events';
 import { CommandsAdapter } from '../../common/browser-adapters/commands-adapter';
 import { getStoreStateMessage, Messages } from '../../common/messages';
 import { StoreNames } from '../../common/stores/store-names';
 import {
+    BaseActionPayload,
     OnDetailsViewInitializedPayload,
     PayloadWithEventName,
     SetLaunchPanelState,
@@ -24,6 +27,7 @@ export class GlobalActionCreator {
     private launchPanelStateActions: LaunchPanelStateActions;
     private assessmentActions: AssessmentActions;
     private quickAssessActions: AssessmentActions;
+    private dataTransferActions: DataTransferActions;
 
     constructor(
         globalActionHub: GlobalActionHub,
@@ -38,6 +42,7 @@ export class GlobalActionCreator {
         this.launchPanelStateActions = globalActionHub.launchPanelStateActions;
         this.assessmentActions = globalActionHub.assessmentActions;
         this.quickAssessActions = globalActionHub.quickAssessActions;
+        this.dataTransferActions = globalActionHub.dataTransferActions;
     }
 
     public registerCallbacks(): void {
@@ -64,6 +69,21 @@ export class GlobalActionCreator {
             Messages.Visualizations.DetailsView.Initialize,
             this.onDetailsViewInitialized,
         );
+
+        this.interpreter.registerTypeToPayloadCallback(
+            getStoreStateMessage(StoreNames.DataTransferStore),
+            this.onGetDataTransferStoreCurrentState,
+        );
+
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.MediumPass.InitiateTransferDataToAssessment,
+            this.onInitiateQuickAssessToAssessmentTransfer,
+        );
+
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.MediumPass.FinalizeTransferDataToAssessment,
+            this.onFinalizeQuickAssessToAssessmentTransfer,
+        );
     }
 
     private onGetCommands = async (_payload, tabId: number): Promise<void> => {
@@ -77,6 +97,10 @@ export class GlobalActionCreator {
 
     private onGetLaunchPanelState = async (): Promise<void> => {
         await this.launchPanelStateActions.getCurrentState.invoke(null);
+    };
+
+    private onGetDataTransferStoreCurrentState = async (): Promise<void> => {
+        await this.dataTransferActions.getCurrentState.invoke(null);
     };
 
     private onSetLaunchPanelState = async (payload: SetLaunchPanelState): Promise<void> => {
@@ -93,5 +117,19 @@ export class GlobalActionCreator {
     ): Promise<void> => {
         await this.assessmentActions.updateDetailsViewId.invoke(payload);
         await this.quickAssessActions.updateDetailsViewId.invoke(payload);
+    };
+
+    private onInitiateQuickAssessToAssessmentTransfer = async (
+        payload: BaseActionPayload,
+    ): Promise<void> => {
+        await this.dataTransferActions.initiateTransferQuickAssessDataToAssessment.invoke(null);
+        this.telemetryEventHandler.publishTelemetry(
+            TRANSFER_QUICK_ASSESS_DATA_TO_ASSESSMENT_INITIATED,
+            payload,
+        );
+    };
+
+    private onFinalizeQuickAssessToAssessmentTransfer = async (): Promise<void> => {
+        await this.dataTransferActions.finalizeTransferQuickAssessDataToAssessment.invoke(null);
     };
 }

--- a/src/background/stores/global/data-transfer-store.ts
+++ b/src/background/stores/global/data-transfer-store.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DataTransferActions } from 'background/actions/data-transfer-actions';
+import { BaseStoreImpl } from 'background/stores/base-store-impl';
+import { StoreNames } from 'common/stores/store-names';
+import { DataTransferStoreData } from 'common/types/store-data/data-transfer-store-data';
+
+export class DataTransferStore extends BaseStoreImpl<DataTransferStoreData, Promise<void>> {
+    constructor(private readonly dataTransferActions: DataTransferActions) {
+        super(StoreNames.DataTransferStore);
+    }
+
+    public getDefaultState(): DataTransferStoreData {
+        return {
+            quickAssessToAssessmentInitiated: false,
+        };
+    }
+
+    protected addActionListeners(): void {
+        this.dataTransferActions.getCurrentState.addListener(this.onGetCurrentState);
+        this.dataTransferActions.initiateTransferQuickAssessDataToAssessment.addListener(
+            this.onInitiateQuickAssessToAssessmentTransfer,
+        );
+        this.dataTransferActions.finalizeTransferQuickAssessDataToAssessment.addListener(
+            this.onFinalizeQuickAssessToAssessmentTransfer,
+        );
+    }
+
+    private onInitiateQuickAssessToAssessmentTransfer = async (): Promise<void> => {
+        this.state.quickAssessToAssessmentInitiated = true;
+        await this.emitChanged();
+    };
+
+    private onFinalizeQuickAssessToAssessmentTransfer = async (): Promise<void> => {
+        this.state.quickAssessToAssessmentInitiated = false;
+        await this.emitChanged();
+    };
+}

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -3,6 +3,7 @@
 import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
 import { MediumPassRequirementMap } from 'assessments/medium-pass-requirements';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { DataTransferStore } from 'background/stores/global/data-transfer-store';
 import { PermissionsStateStore } from 'background/stores/global/permissions-state-store';
 import { FeatureFlagDefaultsHelper } from 'common/feature-flag-defaults-helper';
 import { getAllFeatureFlagDetails } from 'common/feature-flags';
@@ -37,6 +38,7 @@ export class GlobalStoreHub implements StoreHub {
     public scopingStore: ScopingStore;
     public assessmentStore: AssessmentStore;
     public quickAssessStore: AssessmentStore;
+    public dataTransferStore: DataTransferStore;
     public userConfigurationStore: UserConfigurationStore;
     public permissionsStateStore: PermissionsStateStore;
 
@@ -122,6 +124,7 @@ export class GlobalStoreHub implements StoreHub {
             logger,
             persistStoreData,
         );
+        this.dataTransferStore = new DataTransferStore(globalActionHub.dataTransferActions);
     }
 
     public initialize(): void {
@@ -133,6 +136,7 @@ export class GlobalStoreHub implements StoreHub {
         this.quickAssessStore.initialize();
         this.userConfigurationStore.initialize();
         this.permissionsStateStore.initialize();
+        this.dataTransferStore.initialize();
     }
 
     public getAllStores(): BaseStore<any, Promise<void>>[] {
@@ -145,6 +149,7 @@ export class GlobalStoreHub implements StoreHub {
             this.quickAssessStore,
             this.userConfigurationStore,
             this.permissionsStateStore,
+            this.dataTransferStore,
         ];
     }
 

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -93,6 +93,8 @@ export const SET_SAVE_ASSESSMENT_DIALOG_STATE: string = 'setSaveAssessmentDialog
 export const SET_SAVE_MEDIUM_PASS_DIALOG_STATE: string = 'setSaveMediumPassDialogState';
 export const UNHANDLED_ERROR: string = 'unhandledError';
 export const ACCESSIBLENAMES_TOGGLE: string = 'accessibleNamesToggled';
+export const TRANSFER_QUICK_ASSESS_DATA_TO_ASSESSMENT_INITIATED: string =
+    'transferQuickAssessDataToAssessmentInitiated';
 
 export const TriggeredByNotApplicable: TriggeredBy = 'N/A';
 export type TriggeredBy = 'mouseclick' | 'keypress' | 'shortcut' | 'N/A';

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -155,6 +155,8 @@ export const Messages = {
         LoadAssessment: `${messagePrefix}/mediumPass/loadAssessment`,
         LoadAssessmentFinishedUpload: `${messagePrefix}/mediumPass/loadAssessmentFinishedUpload`,
         SaveAssessment: `${messagePrefix}/mediumPass/saveAssessment`,
+        InitiateTransferDataToAssessment: `${messagePrefix}/mediumPass/initiateTransferDataToAssessment`,
+        FinalizeTransferDataToAssessment: `${messagePrefix}/mediumPass/finalizeTransferDataToAssessment`,
     },
 
     FeatureFlags: {

--- a/src/common/stores/store-names.ts
+++ b/src/common/stores/store-names.ts
@@ -31,4 +31,5 @@ export enum StoreNames {
     NeedsReviewCardSelectionStore,
     CardsViewStore,
     QuickAssessStore,
+    DataTransferStore,
 }

--- a/src/common/types/store-data/data-transfer-store-data.ts
+++ b/src/common/types/store-data/data-transfer-store-data.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export interface DataTransferStoreData {
+    quickAssessToAssessmentInitiated: boolean;
+}

--- a/src/tests/unit/tests/background/actions/global-action-hub.test.ts
+++ b/src/tests/unit/tests/background/actions/global-action-hub.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CommandActions } from 'background/actions/command-actions';
+import { DataTransferActions } from 'background/actions/data-transfer-actions';
 import { FeatureFlagActions } from 'background/actions/feature-flag-actions';
 import { GlobalActionHub } from 'background/actions/global-action-hub';
 import { LaunchPanelStateActions } from 'background/actions/launch-panel-state-action';
@@ -27,4 +28,5 @@ function runTypeAsserts(hub: GlobalActionHub): void {
     expect(hub.launchPanelStateActions instanceof LaunchPanelStateActions).toBeTruthy();
     expect(hub.scopingActions instanceof ScopingActions).toBeTruthy();
     expect(hub.permissionsStateActions instanceof PermissionsStateActions).toBeTruthy();
+    expect(hub.dataTransferActions instanceof DataTransferActions).toBeTruthy();
 }

--- a/src/tests/unit/tests/background/stores/global/data-transfer-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/data-transfer-store.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DataTransferActions } from 'background/actions/data-transfer-actions';
+import { DataTransferStore } from 'background/stores/global/data-transfer-store';
+import { StoreNames } from 'common/stores/store-names';
+import { DataTransferStoreData } from 'common/types/store-data/data-transfer-store-data';
+import { createStoreWithNullParams, StoreTester } from 'tests/unit/common/store-tester';
+
+describe('DataTransferStore', () => {
+    test('constructor, no side effects', () => {
+        const testObject = createStoreWithNullParams(DataTransferStore);
+        expect(testObject).toBeDefined();
+    });
+
+    test('getId', () => {
+        const testObject = createStoreWithNullParams(DataTransferStore);
+        expect(testObject.getId()).toEqual(StoreNames[StoreNames.DataTransferStore]);
+    });
+
+    test('on getCurrentState', async () => {
+        const initialState = getDefaultState();
+
+        const expectedState = getDefaultState();
+
+        const storeTester = createStoreForDataTransferActions('getCurrentState');
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('on initiateTransferQuickAssessDataToAssessment', async () => {
+        const initialState = getDefaultState();
+
+        const expectedState = getDefaultState();
+        expectedState.quickAssessToAssessmentInitiated = true;
+
+        const storeTester = createStoreForDataTransferActions(
+            'initiateTransferQuickAssessDataToAssessment',
+        );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('on finalizeTransferQuickAssessDataToAssessment', async () => {
+        const initialState = getDefaultState();
+        initialState.quickAssessToAssessmentInitiated = true;
+
+        const expectedState = getDefaultState();
+
+        const storeTester = createStoreForDataTransferActions(
+            'finalizeTransferQuickAssessDataToAssessment',
+        );
+        await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    function createStoreForDataTransferActions(
+        actionName: keyof DataTransferActions,
+    ): StoreTester<DataTransferStoreData, DataTransferActions> {
+        const factory = (actions: DataTransferActions) => new DataTransferStore(actions);
+
+        return new StoreTester(DataTransferActions, actionName, factory);
+    }
+
+    function getDefaultState(): DataTransferStoreData {
+        return createStoreWithNullParams(DataTransferStore).getDefaultState();
+    }
+});

--- a/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
@@ -5,6 +5,7 @@ import { PersistedData } from 'background/get-persisted-data';
 import { LocalStorageData } from 'background/storage-data';
 import { AssessmentStore } from 'background/stores/assessment-store';
 import { BaseStoreImpl } from 'background/stores/base-store-impl';
+import { DataTransferStore } from 'background/stores/global/data-transfer-store';
 import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { GlobalStoreHub } from 'background/stores/global/global-store-hub';
 import { LaunchPanelStore } from 'background/stores/global/launch-panel-store';
@@ -71,7 +72,7 @@ describe('GlobalStoreHubTest', () => {
         );
         const allStores = testSubject.getAllStores();
 
-        expect(allStores.length).toBe(8);
+        expect(allStores.length).toBe(9);
         expect(testSubject.getStoreType()).toEqual(StoreType.GlobalStore);
 
         verifyStoreExists(allStores, FeatureFlagStore);
@@ -80,6 +81,7 @@ describe('GlobalStoreHubTest', () => {
         verifyStoreExists(allStores, AssessmentStore);
         verifyStoreExists(allStores, UserConfigurationStore);
         verifyStoreExists(allStores, PermissionsStateStore);
+        verifyStoreExists(allStores, DataTransferStore);
     });
 
     it('test initialize', () => {


### PR DESCRIPTION
#### Details

Adds a store to contain state that will be used for modules transferring data from quick assess to assessment.

##### Motivation

Feature work.

##### Context

Currently, this shouldn't do anything but exist. In future PRs, we will add functionality wiring this to UI and the module that actually transfers the data.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
