### PR TITLE
feat(medium-pass-2): add data transfer view store to house confirm dialog state

### DIFF
--- a/src/DetailsView/components/tab-stops/data-transfer-view-actions.ts
+++ b/src/DetailsView/components/tab-stops/data-transfer-view-actions.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AsyncAction } from 'common/flux/async-action';
+
+export class DataTransferViewActions {
+    public readonly showQuickAssessToAssessmentConfirmDialog = new AsyncAction<void>();
+    public readonly hideQuickAssessToAssessmentConfirmDialog = new AsyncAction<void>();
+}

--- a/src/DetailsView/data-transfer-view-store.ts
+++ b/src/DetailsView/data-transfer-view-store.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BaseStoreImpl } from 'background/stores/base-store-impl';
+import { StoreNames } from 'common/stores/store-names';
+import { DataTransferViewActions } from 'DetailsView/components/tab-stops/data-transfer-view-actions';
+
+export interface DataTransferViewStoreData {
+    showQuickAssessToAssessmentConfirmDialog: boolean;
+}
+
+export class DataTransferViewStore extends BaseStoreImpl<DataTransferViewStoreData> {
+    public constructor(private actions: DataTransferViewActions) {
+        super(StoreNames.DataTransferViewStore);
+    }
+
+    public getDefaultState(): DataTransferViewStoreData {
+        return {
+            showQuickAssessToAssessmentConfirmDialog: false,
+        };
+    }
+
+    public addActionListeners(): void {
+        this.actions.showQuickAssessToAssessmentConfirmDialog.addListener(
+            this.onShowQuickAssessToAssessmentConfirmDialog,
+        );
+        this.actions.hideQuickAssessToAssessmentConfirmDialog.addListener(
+            this.onHideQuickAssessToAssessmentConfirmDialog,
+        );
+    }
+
+    private onShowQuickAssessToAssessmentConfirmDialog = async () => {
+        this.state.showQuickAssessToAssessmentConfirmDialog = true;
+        this.emitChanged();
+    };
+
+    private onHideQuickAssessToAssessmentConfirmDialog = async () => {
+        this.state.showQuickAssessToAssessmentConfirmDialog = false;
+        this.emitChanged();
+    };
+}

--- a/src/common/stores/store-names.ts
+++ b/src/common/stores/store-names.ts
@@ -32,4 +32,5 @@ export enum StoreNames {
     CardsViewStore,
     QuickAssessStore,
     DataTransferStore,
+    DataTransferViewStore,
 }

--- a/src/tests/unit/tests/DetailsView/data-transfer-view-store.test.ts
+++ b/src/tests/unit/tests/DetailsView/data-transfer-view-store.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { StoreNames } from 'common/stores/store-names';
+import { DataTransferViewActions } from 'DetailsView/components/tab-stops/data-transfer-view-actions';
+import {
+    DataTransferViewStore,
+    DataTransferViewStoreData,
+} from 'DetailsView/data-transfer-view-store';
+import { createStoreWithNullParams, StoreTester } from 'tests/unit/common/store-tester';
+
+describe('DataTransferViewStore', () => {
+    let testObject: DataTransferViewStore;
+
+    beforeEach(() => {
+        testObject = createStoreWithNullParams(DataTransferViewStore);
+    });
+    test('constructor  no side effects', () => {
+        expect(testObject).toBeDefined();
+    });
+
+    test('getId', () => {
+        expect(testObject.getId()).toEqual(StoreNames[StoreNames.DataTransferViewStore]);
+    });
+
+    test('getDefaultState', () => {
+        const testObject = createStoreWithNullParams(DataTransferViewStore);
+        const expected: DataTransferViewStoreData = {
+            showQuickAssessToAssessmentConfirmDialog: false,
+        };
+        expect(testObject.getDefaultState()).toEqual(expected);
+    });
+
+    test('onHideQuickAssessToAssessmentConfirmDialog', async () => {
+        const initialState = testObject.getDefaultState();
+        initialState.showQuickAssessToAssessmentConfirmDialog = true;
+        const finalState = testObject.getDefaultState();
+        const storeTester = createStoreForDataTransferViewActions(
+            'hideQuickAssessToAssessmentConfirmDialog',
+        ).withActionParam(null);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
+    });
+
+    test('onShowQuickAssessToAssessmentConfirmDialog', async () => {
+        const initialState = testObject.getDefaultState();
+        const finalState = testObject.getDefaultState();
+        finalState.showQuickAssessToAssessmentConfirmDialog = true;
+        const storeTester = createStoreForDataTransferViewActions(
+            'showQuickAssessToAssessmentConfirmDialog',
+        ).withActionParam(null);
+        await storeTester.testListenerToBeCalledOnce(initialState, finalState);
+    });
+
+    function createStoreForDataTransferViewActions(
+        actionName: keyof DataTransferViewActions,
+    ): StoreTester<DataTransferViewStoreData, DataTransferViewActions> {
+        const factory = (actions: DataTransferViewActions) => new DataTransferViewStore(actions);
+
+        return new StoreTester(DataTransferViewActions, actionName, factory);
+    }
+});


### PR DESCRIPTION
#### Details

A view store for housing the state of the confirmation dialog for transferring data from quick assess to assessment. It's a view store because this leads to simpler components + this dialog can/should exist per tab and is removed on refresh.
 
##### Motivation

feature work.

##### Context

Is not used in this PR; future PR will implement the dialog.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
