### PR TITLE
fix(medium-pass-2): fix requirements list to contain correct contrast requirement

### DIFF
--- a/src/assessments/medium-pass-requirements.ts
+++ b/src/assessments/medium-pass-requirements.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AdaptableContentTestStep } from 'assessments/adaptable-content/test-steps/test-step';
+import { ContrastTestStep } from 'assessments/contrast/test-steps/test-steps';
 import { HeadingsTestStep } from 'assessments/headings/test-steps/test-steps';
 import { ImagesTestStep } from 'assessments/images/test-steps/test-steps';
 import { KeyboardInteractionTestStep } from 'assessments/keyboard-interaction/test-steps/test-steps';
@@ -15,7 +16,7 @@ export const MediumPassRequirementKeys: string[] = [
     LinksTestStep.linkPurpose,
     ImagesTestStep.imageFunction,
     visibleFfocusOrderTestStep.visibleFocus,
-    AdaptableContentTestStep.contrast,
+    ContrastTestStep.uiComponents,
     HeadingsTestStep.missingHeadings,
     HeadingsTestStep.headingLevel,
     RepetitiveContentTestStep.bypassBlocks,
@@ -28,7 +29,7 @@ export const MediumPassRequirementMap: DictionaryStringTo<VisualizationType> = {
     [LinksTestStep.linkPurpose]: VisualizationType.LinksMediumPass,
     [ImagesTestStep.imageFunction]: VisualizationType.ImagesMediumPass,
     [visibleFfocusOrderTestStep.visibleFocus]: VisualizationType.VisibleFocusOrderMediumPass,
-    [AdaptableContentTestStep.contrast]: VisualizationType.AdaptableContentMediumPass,
+    [ContrastTestStep.uiComponents]: VisualizationType.ContrastMediumPass,
     [HeadingsTestStep.missingHeadings]: VisualizationType.HeadingsMediumPass,
     [HeadingsTestStep.headingLevel]: VisualizationType.HeadingsMediumPass,
     [RepetitiveContentTestStep.bypassBlocks]: VisualizationType.RepetitiveContentMediumPass,

--- a/src/assessments/medium-pass-requirements.ts
+++ b/src/assessments/medium-pass-requirements.ts
@@ -6,6 +6,7 @@ import { HeadingsTestStep } from 'assessments/headings/test-steps/test-steps';
 import { ImagesTestStep } from 'assessments/images/test-steps/test-steps';
 import { KeyboardInteractionTestStep } from 'assessments/keyboard-interaction/test-steps/test-steps';
 import { LinksTestStep } from 'assessments/links/test-steps/test-steps';
+import { NativeWidgetsTestStep } from 'assessments/native-widgets/test-steps/test-steps';
 import { RepetitiveContentTestStep } from 'assessments/repetitive-content/test-steps/test-steps';
 import { visibleFfocusOrderTestStep } from 'assessments/visible-focus-order/test-steps/test-steps';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -15,11 +16,12 @@ export const MediumPassRequirementKeys: string[] = [
     KeyboardInteractionTestStep.keyboardNavigation,
     LinksTestStep.linkPurpose,
     ImagesTestStep.imageFunction,
-    visibleFfocusOrderTestStep.visibleFocus,
+    visibleFfocusOrderTestStep.focusOrder,
     ContrastTestStep.uiComponents,
     HeadingsTestStep.missingHeadings,
     HeadingsTestStep.headingLevel,
     RepetitiveContentTestStep.bypassBlocks,
+    NativeWidgetsTestStep.instructions,
     AdaptableContentTestStep.reflow,
 ];
 
@@ -28,10 +30,11 @@ export const MediumPassRequirementMap: DictionaryStringTo<VisualizationType> = {
         VisualizationType.KeyboardInteractionMediumPass,
     [LinksTestStep.linkPurpose]: VisualizationType.LinksMediumPass,
     [ImagesTestStep.imageFunction]: VisualizationType.ImagesMediumPass,
-    [visibleFfocusOrderTestStep.visibleFocus]: VisualizationType.VisibleFocusOrderMediumPass,
+    [visibleFfocusOrderTestStep.focusOrder]: VisualizationType.VisibleFocusOrderMediumPass,
     [ContrastTestStep.uiComponents]: VisualizationType.ContrastMediumPass,
     [HeadingsTestStep.missingHeadings]: VisualizationType.HeadingsMediumPass,
     [HeadingsTestStep.headingLevel]: VisualizationType.HeadingsMediumPass,
     [RepetitiveContentTestStep.bypassBlocks]: VisualizationType.RepetitiveContentMediumPass,
+    [NativeWidgetsTestStep.instructions]: VisualizationType.NativeWidgetsMediumPass,
     [AdaptableContentTestStep.reflow]: VisualizationType.AdaptableContentMediumPass,
 };

--- a/src/common/types/visualization-type.ts
+++ b/src/common/types/visualization-type.ts
@@ -41,4 +41,5 @@ export enum VisualizationType {
     RepetitiveContentMediumPass,
     AutomatedChecksMediumPass,
     ContrastMediumPass,
+    NativeWidgetsMediumPass,
 }

--- a/src/common/types/visualization-type.ts
+++ b/src/common/types/visualization-type.ts
@@ -40,4 +40,5 @@ export enum VisualizationType {
     HeadingsMediumPass,
     RepetitiveContentMediumPass,
     AutomatedChecksMediumPass,
+    ContrastMediumPass,
 }

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -363,6 +363,10 @@ exports[`DetailsViewBody render render 1`] = `
                 "enabled": false,
                 "stepStatus": {},
               },
+              "nativeWidgetsAssessment": {
+                "enabled": false,
+                "stepStatus": {},
+              },
               "repetitiveContentAssessment": {
                 "enabled": false,
                 "stepStatus": {},
@@ -730,6 +734,10 @@ exports[`DetailsViewBody render render 1`] = `
                   "stepStatus": {},
                 },
                 "linksAssessment": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "nativeWidgetsAssessment": {
                   "enabled": false,
                   "stepStatus": {},
                 },
@@ -1107,6 +1115,10 @@ exports[`DetailsViewBody render render 1`] = `
                       "stepStatus": {},
                     },
                     "linksAssessment": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "nativeWidgetsAssessment": {
                       "enabled": false,
                       "stepStatus": {},
                     },

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -343,6 +343,10 @@ exports[`DetailsViewBody render render 1`] = `
                 "enabled": false,
                 "stepStatus": {},
               },
+              "contrastAssessment": {
+                "enabled": false,
+                "stepStatus": {},
+              },
               "headingsAssessment": {
                 "enabled": false,
                 "stepStatus": {},
@@ -706,6 +710,10 @@ exports[`DetailsViewBody render render 1`] = `
                   "stepStatus": {},
                 },
                 "automatedChecks": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "contrastAssessment": {
                   "enabled": false,
                   "stepStatus": {},
                 },
@@ -1079,6 +1087,10 @@ exports[`DetailsViewBody render render 1`] = `
                       "stepStatus": {},
                     },
                     "automatedChecks": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "contrastAssessment": {
                       "enabled": false,
                       "stepStatus": {},
                     },

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -398,6 +398,10 @@ exports[`DetailsViewContent render renders normally 1`] = `
               "enabled": false,
               "stepStatus": {},
             },
+            "contrastAssessment": {
+              "enabled": false,
+              "stepStatus": {},
+            },
             "headingsAssessment": {
               "enabled": false,
               "stepStatus": {},

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -418,6 +418,10 @@ exports[`DetailsViewContent render renders normally 1`] = `
               "enabled": false,
               "stepStatus": {},
             },
+            "nativeWidgetsAssessment": {
+              "enabled": false,
+              "stepStatus": {},
+            },
             "repetitiveContentAssessment": {
               "enabled": false,
               "stepStatus": {},

--- a/src/tests/unit/tests/background/__snapshots__/initial-visualization-store-data-generator.test.ts.snap
+++ b/src/tests/unit/tests/background/__snapshots__/initial-visualization-store-data-generator.test.ts.snap
@@ -143,6 +143,10 @@ exports[`InitialVisualizationStoreDataGenerator.generateInitialState generates t
         "enabled": false,
         "stepStatus": {},
       },
+      "type-40": {
+        "enabled": false,
+        "stepStatus": {},
+      },
     },
     "mediumPass": {
       "type-10": {
@@ -310,6 +314,10 @@ exports[`InitialVisualizationStoreDataGenerator.generateInitialState overwrites 
       "enabled": false,
       "stepStatus": {},
     },
+    "type-40": {
+      "enabled": false,
+      "stepStatus": {},
+    },
   },
   "mediumPass": {
     "type-10": {
@@ -473,6 +481,10 @@ exports[`InitialVisualizationStoreDataGenerator.generateInitialState overwrites 
       "stepStatus": {},
     },
     "type-39": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-40": {
       "enabled": false,
       "stepStatus": {},
     },

--- a/src/tests/unit/tests/background/__snapshots__/initial-visualization-store-data-generator.test.ts.snap
+++ b/src/tests/unit/tests/background/__snapshots__/initial-visualization-store-data-generator.test.ts.snap
@@ -139,6 +139,10 @@ exports[`InitialVisualizationStoreDataGenerator.generateInitialState generates t
         "enabled": false,
         "stepStatus": {},
       },
+      "type-39": {
+        "enabled": false,
+        "stepStatus": {},
+      },
     },
     "mediumPass": {
       "type-10": {
@@ -302,6 +306,10 @@ exports[`InitialVisualizationStoreDataGenerator.generateInitialState overwrites 
       "enabled": false,
       "stepStatus": {},
     },
+    "type-39": {
+      "enabled": false,
+      "stepStatus": {},
+    },
   },
   "mediumPass": {
     "type-10": {
@@ -461,6 +469,10 @@ exports[`InitialVisualizationStoreDataGenerator.generateInitialState overwrites 
       "stepStatus": {},
     },
     "type-38": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-39": {
       "enabled": false,
       "stepStatus": {},
     },


### PR DESCRIPTION
#### Details

Currently, the requirements list for quick assess lists `Adaptable Content > Contrast` when it should list `Contrast > UI components`. Also, `Native Widgets > Instructions` is missing from the list. This PR corrects this.

##### Motivation

Feature work

##### Context

N/A

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
