### PR TITLE
feat(medium-pass-2): add quick assess to assessment dialog

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -174,7 +174,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
     }
 
     public sendPivotItemClicked(pivotKey: string, ev?: React.MouseEvent<HTMLElement>): void {
-        const telemetry = this.telemetryFactory.forDetailsViewNavPivotActivated(ev, pivotKey);
+        const telemetry = ev && this.telemetryFactory.forDetailsViewNavPivotActivated(ev, pivotKey);
 
         const payload: OnDetailsViewPivotSelected = {
             telemetry: telemetry,
@@ -295,5 +295,21 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             TelemetryEvents.LEFT_NAV_PANEL_EXPANDED,
             this.telemetryFactory.forLeftNavPanelExpanded(event),
         );
+    };
+
+    public confirmDataTransferToAssessment = (event: SupportedMouseEvent) => {
+        const payload: BaseActionPayload = {
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(
+                event,
+                TelemetryEvents.TelemetryEventSource.DetailsView,
+            ),
+        };
+
+        const message: Message = {
+            messageType: Messages.DataTransfer.InitiateTransferDataToAssessment,
+            payload,
+        };
+
+        this.dispatcher.dispatchMessage(message);
     };
 }

--- a/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
+++ b/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
@@ -4,6 +4,7 @@
 import { DefaultButton, Dialog, DialogFooter, IDialogProps, PrimaryButton } from '@fluentui/react';
 import * as Markup from 'assessments/markup';
 import { NamedFC } from 'common/react/named-fc';
+import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import commonDialogStyles from 'DetailsView/components/common-dialog-styles.scss';
 import { DataTransferViewController } from 'DetailsView/data-transfer-view-controller';
@@ -50,6 +51,9 @@ export const QuickAssessToAssessmentDialog = NamedFC<QuickAssessToAssessmentDial
                     <PrimaryButton
                         onClick={ev => {
                             detailsViewActionMessageCreator.confirmDataTransferToAssessment(ev);
+                            detailsViewActionMessageCreator.sendPivotItemClicked(
+                                DetailsViewPivotType[DetailsViewPivotType.assessment],
+                            );
                             dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog();
                         }}
                         text={'Continue to assessment'}

--- a/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
+++ b/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    css,
+    DefaultButton,
+    Dialog,
+    DialogFooter,
+    IDialogProps,
+    PrimaryButton,
+} from '@fluentui/react';
+import * as Markup from 'assessments/markup';
+import { NamedFC } from 'common/react/named-fc';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import commonDialogStyles from 'DetailsView/components/common-dialog-styles.scss';
+import { DataTransferViewController } from 'DetailsView/data-transfer-view-controller';
+import * as React from 'react';
+
+export type QuickAssessToAssessmentDialogDeps = {
+    dataTransferViewController: DataTransferViewController;
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+};
+export interface QuickAssessToAssessmentDialogProps {
+    deps: QuickAssessToAssessmentDialogDeps;
+    isShown: boolean;
+}
+
+export const QuickAssessToAssessmentDialog = NamedFC<QuickAssessToAssessmentDialogProps>(
+    'QuickAssessToAssessmentConfirmDialog',
+    props => {
+        const { dataTransferViewController, detailsViewActionMessageCreator } = props.deps;
+        const dialogProps: IDialogProps = {
+            hidden: !props.isShown,
+            title: 'Continue to assessment',
+            onDismiss: dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog,
+            containerClassName: css(commonDialogStyles.insightsDialogMainOverride),
+        };
+
+        const descriptionText =
+            'This will allow you to continue accessibility tesitng with addtitional tests and requirements in assessment. All your existing data in quick assess will be transfered into assessment.';
+
+        const noteText =
+            'If you have an assessment in progress, the current quick assess evaluation data will replace the assessment evaluation and previous progress will be lost.';
+        return (
+            <Dialog {...dialogProps}>
+                <div>{descriptionText}</div>
+                <p>
+                    <Markup.Term>Note</Markup.Term>: {noteText}
+                </p>
+                <DialogFooter>
+                    <DefaultButton
+                        onClick={() =>
+                            dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog()
+                        }
+                        text={'Cancel'}
+                    />
+                    <PrimaryButton
+                        onClick={ev => {
+                            detailsViewActionMessageCreator.confirmDataTransferToAssessment(ev);
+                            dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog();
+                        }}
+                        text={'Continue to assessment'}
+                        autoFocus={true}
+                    />
+                </DialogFooter>
+            </Dialog>
+        );
+    },
+);

--- a/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
+++ b/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
@@ -43,18 +43,18 @@ export const QuickAssessToAssessmentDialog = NamedFC<QuickAssessToAssessmentDial
                 </p>
                 <DialogFooter>
                     <DefaultButton
-                        onClick={() =>
-                            dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog()
+                        onClick={async () =>
+                            await dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog()
                         }
                         text={'Cancel'}
                     />
                     <PrimaryButton
-                        onClick={ev => {
+                        onClick={async ev => {
                             detailsViewActionMessageCreator.confirmDataTransferToAssessment(ev);
                             detailsViewActionMessageCreator.sendPivotItemClicked(
                                 DetailsViewPivotType[DetailsViewPivotType.assessment],
                             );
-                            dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog();
+                            await dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog();
                         }}
                         text={'Continue to assessment'}
                         autoFocus={true}

--- a/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
+++ b/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
@@ -1,14 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {
-    css,
-    DefaultButton,
-    Dialog,
-    DialogFooter,
-    IDialogProps,
-    PrimaryButton,
-} from '@fluentui/react';
+import { DefaultButton, Dialog, DialogFooter, IDialogProps, PrimaryButton } from '@fluentui/react';
 import * as Markup from 'assessments/markup';
 import { NamedFC } from 'common/react/named-fc';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
@@ -33,11 +26,11 @@ export const QuickAssessToAssessmentDialog = NamedFC<QuickAssessToAssessmentDial
             hidden: !props.isShown,
             title: 'Continue to assessment',
             onDismiss: dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog,
-            containerClassName: css(commonDialogStyles.insightsDialogMainOverride),
+            containerClassName: commonDialogStyles.insightsDialogMainOverride,
         };
 
         const descriptionText =
-            'This will allow you to continue accessibility tesitng with addtitional tests and requirements in assessment. All your existing data in quick assess will be transfered into assessment.';
+            'This will allow you to continue accessibility testing with additional tests and requirements in assessment. All your existing data in quick assess will be transfered into assessment.';
 
         const noteText =
             'If you have an assessment in progress, the current quick assess evaluation data will replace the assessment evaluation and previous progress will be lost.';

--- a/src/DetailsView/data-transfer-view-controller.ts
+++ b/src/DetailsView/data-transfer-view-controller.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DataTransferViewActions } from 'DetailsView/components/tab-stops/data-transfer-view-actions';
+
+export class DataTransferViewController {
+    constructor(private actions: DataTransferViewActions) {}
+
+    public showQuickAssessToAssessmentConfirmDialog = async () =>
+        await this.actions.showQuickAssessToAssessmentConfirmDialog.invoke();
+
+    public hideQuickAssessToAssessmentConfirmDialog = async () =>
+        await this.actions.hideQuickAssessToAssessmentConfirmDialog.invoke();
+}

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import {
+    BaseActionPayload,
     OnDetailsViewPivotSelected,
     SetAllUrlsPermissionStatePayload,
 } from 'background/actions/action-payloads';
@@ -176,7 +177,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         );
     });
 
-    test('sendPivotItemClicked', () => {
+    test('sendPivotItemClicked: event is not null', () => {
         const pivot = DetailsViewPivotType.assessment;
         const telemetryData: DetailsViewPivotSelectedTelemetryData = {
             triggeredBy: 'keypress',
@@ -202,6 +203,27 @@ describe('DetailsViewActionMessageCreatorTest', () => {
             .returns(() => telemetryData);
 
         testSubject.sendPivotItemClicked(DetailsViewPivotType[pivot], mouseEventStub);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('sendPivotItemClicked: event is null', () => {
+        const pivot = DetailsViewPivotType.assessment;
+
+        const expectedPayload: OnDetailsViewPivotSelected = {
+            telemetry: null,
+            pivotKey: pivot,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.Visualizations.DetailsView.PivotSelect,
+            payload: expectedPayload,
+        };
+
+        testSubject.sendPivotItemClicked(DetailsViewPivotType[pivot], null);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
@@ -424,6 +446,36 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         };
 
         testSubject.changeRightContentPanel(viewTypeStub);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('confirmDataTransferToAssessment', () => {
+        const telemetryData: BaseTelemetryData = {
+            triggeredBy: 'keypress',
+            source: testSource,
+        };
+
+        const payload: BaseActionPayload = {
+            telemetry: telemetryData,
+        };
+
+        const expectedMessage = {
+            messageType: Messages.DataTransfer.InitiateTransferDataToAssessment,
+            payload: payload,
+        };
+        const mouseEventStub = {} as any;
+
+        telemetryFactoryMock
+            .setup(tf =>
+                tf.withTriggeredByAndSource(mouseEventStub, TelemetryEventSource.DetailsView),
+            )
+            .returns(() => telemetryData);
+
+        testSubject.confirmDataTransferToAssessment(mouseEventStub);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/quick-assess-to-assessment-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/quick-assess-to-assessment-dialog.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`QuickAssessToAssessmentDialog dialog is hidden when isShown is false 1`
   title="Continue to assessment"
 >
   <div>
-    This will allow you to continue accessibility tesitng with addtitional tests and requirements in assessment. All your existing data in quick assess will be transfered into assessment.
+    This will allow you to continue accessibility testing with additional tests and requirements in assessment. All your existing data in quick assess will be transfered into assessment.
   </div>
   <p>
     <Term>
@@ -39,7 +39,7 @@ exports[`QuickAssessToAssessmentDialog dialog is not hidden when isShown is true
   title="Continue to assessment"
 >
   <div>
-    This will allow you to continue accessibility tesitng with addtitional tests and requirements in assessment. All your existing data in quick assess will be transfered into assessment.
+    This will allow you to continue accessibility testing with additional tests and requirements in assessment. All your existing data in quick assess will be transfered into assessment.
   </div>
   <p>
     <Term>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/quick-assess-to-assessment-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/quick-assess-to-assessment-dialog.test.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QuickAssessToAssessmentDialog dialog is hidden when isShown is false 1`] = `
+<Dialog
+  containerClassName="insightsDialogMainOverride"
+  hidden={true}
+  onDismiss={[Function]}
+  title="Continue to assessment"
+>
+  <div>
+    This will allow you to continue accessibility tesitng with addtitional tests and requirements in assessment. All your existing data in quick assess will be transfered into assessment.
+  </div>
+  <p>
+    <Term>
+      Note
+    </Term>
+    : 
+    If you have an assessment in progress, the current quick assess evaluation data will replace the assessment evaluation and previous progress will be lost.
+  </p>
+  <StyledDialogFooterBase>
+    <CustomizedDefaultButton
+      onClick={[Function]}
+      text="Cancel"
+    />
+    <CustomizedPrimaryButton
+      autoFocus={true}
+      onClick={[Function]}
+      text="Continue to assessment"
+    />
+  </StyledDialogFooterBase>
+</Dialog>
+`;
+
+exports[`QuickAssessToAssessmentDialog dialog is not hidden when isShown is true 1`] = `
+<Dialog
+  containerClassName="insightsDialogMainOverride"
+  hidden={false}
+  onDismiss={[Function]}
+  title="Continue to assessment"
+>
+  <div>
+    This will allow you to continue accessibility tesitng with addtitional tests and requirements in assessment. All your existing data in quick assess will be transfered into assessment.
+  </div>
+  <p>
+    <Term>
+      Note
+    </Term>
+    : 
+    If you have an assessment in progress, the current quick assess evaluation data will replace the assessment evaluation and previous progress will be lost.
+  </p>
+  <StyledDialogFooterBase>
+    <CustomizedDefaultButton
+      onClick={[Function]}
+      text="Cancel"
+    />
+    <CustomizedPrimaryButton
+      autoFocus={true}
+      onClick={[Function]}
+      text="Continue to assessment"
+    />
+  </StyledDialogFooterBase>
+</Dialog>
+`;

--- a/src/tests/unit/tests/DetailsView/components/quick-assess-to-assessment-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/quick-assess-to-assessment-dialog.test.tsx
@@ -46,14 +46,14 @@ describe('QuickAssessToAssessmentDialog', () => {
         expect(testSubject.getElement()).toMatchSnapshot();
     });
 
-    test('onclick: cancel', () => {
+    test('onclick: cancel', async () => {
         props.isShown = true;
 
         const testSubject = shallow(
             <QuickAssessToAssessmentDialog {...props}></QuickAssessToAssessmentDialog>,
         );
         const onClick = testSubject.find(DefaultButton).prop('onClick');
-        onClick(null);
+        await onClick(null);
 
         dataTransferViewControllerMock.verify(
             m => m.hideQuickAssessToAssessmentConfirmDialog(),
@@ -61,7 +61,7 @@ describe('QuickAssessToAssessmentDialog', () => {
         );
     });
 
-    test('onclick: continue to assessment', () => {
+    test('onclick: continue to assessment', async () => {
         props.isShown = true;
         const eventStub = {} as SupportedMouseEvent;
         const testSubject = shallow(
@@ -69,7 +69,7 @@ describe('QuickAssessToAssessmentDialog', () => {
         );
         const onClick = testSubject.find(PrimaryButton).prop('onClick');
 
-        onClick(eventStub as any);
+        await onClick(eventStub as any);
 
         detailsViewActionMessageCreatorMock.verify(
             m => m.confirmDataTransferToAssessment(eventStub),

--- a/src/tests/unit/tests/DetailsView/components/quick-assess-to-assessment-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/quick-assess-to-assessment-dialog.test.tsx
@@ -3,6 +3,7 @@
 
 import { DefaultButton, PrimaryButton } from '@fluentui/react';
 import { SupportedMouseEvent } from 'common/telemetry-data-factory';
+import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import {
     QuickAssessToAssessmentDialog,
@@ -72,6 +73,10 @@ describe('QuickAssessToAssessmentDialog', () => {
 
         detailsViewActionMessageCreatorMock.verify(
             m => m.confirmDataTransferToAssessment(eventStub),
+            Times.once(),
+        );
+        detailsViewActionMessageCreatorMock.verify(
+            m => m.sendPivotItemClicked(DetailsViewPivotType[DetailsViewPivotType.assessment]),
             Times.once(),
         );
         dataTransferViewControllerMock.verify(

--- a/src/tests/unit/tests/DetailsView/components/quick-assess-to-assessment-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/quick-assess-to-assessment-dialog.test.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DefaultButton, PrimaryButton } from '@fluentui/react';
+import { SupportedMouseEvent } from 'common/telemetry-data-factory';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import {
+    QuickAssessToAssessmentDialog,
+    QuickAssessToAssessmentDialogProps,
+} from 'DetailsView/components/quick-assess-to-assessment-dialog';
+import { DataTransferViewController } from 'DetailsView/data-transfer-view-controller';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { IMock, Mock, Times } from 'typemoq';
+
+describe('QuickAssessToAssessmentDialog', () => {
+    let dataTransferViewControllerMock: IMock<DataTransferViewController>;
+    let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
+    let props: QuickAssessToAssessmentDialogProps;
+
+    beforeEach(() => {
+        dataTransferViewControllerMock = Mock.ofType(DataTransferViewController);
+        detailsViewActionMessageCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
+        props = {
+            deps: {
+                detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
+                dataTransferViewController: dataTransferViewControllerMock.object,
+            },
+        } as QuickAssessToAssessmentDialogProps;
+    });
+
+    test('dialog is hidden when isShown is false', () => {
+        props.isShown = false;
+        const testSubject = shallow(
+            <QuickAssessToAssessmentDialog {...props}></QuickAssessToAssessmentDialog>,
+        );
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    test('dialog is not hidden when isShown is true', () => {
+        props.isShown = true;
+        const testSubject = shallow(
+            <QuickAssessToAssessmentDialog {...props}></QuickAssessToAssessmentDialog>,
+        );
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    test('onclick: cancel', () => {
+        props.isShown = true;
+
+        const testSubject = shallow(
+            <QuickAssessToAssessmentDialog {...props}></QuickAssessToAssessmentDialog>,
+        );
+        const onClick = testSubject.find(DefaultButton).prop('onClick');
+        onClick(null);
+
+        dataTransferViewControllerMock.verify(
+            m => m.hideQuickAssessToAssessmentConfirmDialog(),
+            Times.once(),
+        );
+    });
+
+    test('onclick: continue to assessment', () => {
+        props.isShown = true;
+        const eventStub = {} as SupportedMouseEvent;
+        const testSubject = shallow(
+            <QuickAssessToAssessmentDialog {...props}></QuickAssessToAssessmentDialog>,
+        );
+        const onClick = testSubject.find(PrimaryButton).prop('onClick');
+
+        onClick(eventStub as any);
+
+        detailsViewActionMessageCreatorMock.verify(
+            m => m.confirmDataTransferToAssessment(eventStub),
+            Times.once(),
+        );
+        dataTransferViewControllerMock.verify(
+            m => m.hideQuickAssessToAssessmentConfirmDialog(),
+            Times.once(),
+        );
+    });
+});

--- a/src/tests/unit/tests/DetailsView/data-transfer-view-controller.test.ts
+++ b/src/tests/unit/tests/DetailsView/data-transfer-view-controller.test.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AsyncAction } from 'common/flux/async-action';
+import { DataTransferViewActions } from 'DetailsView/components/tab-stops/data-transfer-view-actions';
+import { DataTransferViewController } from 'DetailsView/data-transfer-view-controller';
+import { IMock, Mock, Times } from 'typemoq';
+
+describe('DataTransferViewController', () => {
+    let actionMock: IMock<AsyncAction<void>>;
+    beforeEach(() => {
+        actionMock = Mock.ofType<AsyncAction<void>>();
+    });
+
+    test('showQuickAssessToAssessmentConfirmDialog', async () => {
+        const actionsStub = {
+            showQuickAssessToAssessmentConfirmDialog: actionMock.object,
+        } as DataTransferViewActions;
+        const testSubject = new DataTransferViewController(actionsStub);
+        await testSubject.showQuickAssessToAssessmentConfirmDialog();
+        actionMock.verify(m => m.invoke(), Times.once());
+    });
+
+    test('hideQuickAssessToAssessmentConfirmDialog', async () => {
+        const actionsStub = {
+            hideQuickAssessToAssessmentConfirmDialog: actionMock.object,
+        } as DataTransferViewActions;
+        const testSubject = new DataTransferViewController(actionsStub);
+        await testSubject.hideQuickAssessToAssessmentConfirmDialog();
+        actionMock.verify(m => m.invoke(), Times.once());
+    });
+});


### PR DESCRIPTION
#### Details

Adds a new dialog to confirm transfer from quick assess to assessment.

##### Motivation

Feature work.

##### Context

Not wired up in this PR but this is what it looks like when shown locally:

![image](https://user-images.githubusercontent.com/32555133/211444209-f0366e83-c874-483c-add0-bbe577f76d72.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
