### PR TITLE
feat(medium-pass-2): wired up quick assess to assessment dialog

### DIFF
--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -164,6 +164,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                 pathSnippetStoreData={storeState.pathSnippetStoreData}
                 featureFlagStoreData={storeState.featureFlagStoreData}
                 cardsViewStoreData={storeState.cardsViewStoreData}
+                dataTransferViewStoreData={storeState.dataTransferViewStoreData}
                 selectedTest={selectedTest}
                 detailsViewStoreData={storeState.detailsViewStoreData}
                 visualizationStoreData={storeState.visualizationStoreData}

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -8,7 +8,12 @@ import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { FluentSideNav, FluentSideNavDeps } from 'DetailsView/components/left-nav/fluent-side-nav';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
+import {
+    QuickAssessToAssessmentDialog,
+    QuickAssessToAssessmentDialogDeps,
+} from 'DetailsView/components/quick-assess-to-assessment-dialog';
 import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
+import { DataTransferViewStoreData } from 'DetailsView/data-transfer-view-store';
 import styles from 'DetailsView/details-view-body.scss';
 import * as React from 'react';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -40,7 +45,8 @@ import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-to
 export type DetailsViewBodyDeps = RightPanelDeps &
     DetailsViewLeftNavDeps &
     DetailsViewCommandBarDeps &
-    FluentSideNavDeps;
+    FluentSideNavDeps &
+    QuickAssessToAssessmentDialogDeps;
 
 export interface DetailsViewBodyProps {
     deps: DetailsViewBodyDeps;
@@ -70,6 +76,7 @@ export interface DetailsViewBodyProps {
     setSideNavOpen: (isOpen: boolean, event?: React.MouseEvent<any>) => void;
     narrowModeStatus: NarrowModeStatus;
     tabStopRequirementData: TabStopRequirementState;
+    dataTransferViewStoreData: DataTransferViewStoreData;
 }
 
 export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
@@ -87,6 +94,7 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
                         <div className={styles.detailsViewBodyContentPane}>
                             {this.getTargetPageHiddenBar()}
                             <div className={styles.view} role="main">
+                                {this.renderQuickAssessToAssessmentDialog()}
                                 {this.renderRightPanel()}
                             </div>
                         </div>
@@ -131,5 +139,16 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
 
     private renderRightPanel(): JSX.Element {
         return <this.props.rightPanelConfiguration.RightPanel {...this.props} />;
+    }
+
+    private renderQuickAssessToAssessmentDialog(): JSX.Element {
+        return (
+            <QuickAssessToAssessmentDialog
+                isShown={
+                    this.props.dataTransferViewStoreData.showQuickAssessToAssessmentConfirmDialog
+                }
+                deps={this.props.deps}
+            />
+        );
     }
 }

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -16,6 +16,7 @@ import {
     NarrowModeDetectorDeps,
 } from 'DetailsView/components/narrow-mode-detector';
 import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
+import { DataTransferViewStoreData } from 'DetailsView/data-transfer-view-store';
 import * as React from 'react';
 import { withStoreSubscription } from '../common/components/with-store-subscription';
 import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
@@ -63,6 +64,7 @@ export interface DetailsViewContainerState {
     permissionsStateStoreData: PermissionsStateStoreData;
     tabStopsViewStoreData: TabStopsViewStoreData;
     cardsViewStoreData: CardsViewStoreData;
+    dataTransferViewStoreData: DataTransferViewStoreData;
 }
 
 export class DetailsViewContainer extends React.Component<DetailsViewContainerProps> {

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -59,11 +59,14 @@ import { NavLinkRenderer } from 'DetailsView/components/left-nav/nav-link-render
 import { LoadAssessmentDataValidator } from 'DetailsView/components/load-assessment-data-validator';
 import { LoadAssessmentHelper } from 'DetailsView/components/load-assessment-helper';
 import { NoContentAvailableViewDeps } from 'DetailsView/components/no-content-available/no-content-available-view';
+import { DataTransferViewActions } from 'DetailsView/components/tab-stops/data-transfer-view-actions';
 import { requirements } from 'DetailsView/components/tab-stops/requirements';
 import { FastPassTabStopsInstanceSectionPropsFactory } from 'DetailsView/components/tab-stops/tab-stops-instance-section-props-factory';
 import { TabStopsTestViewController } from 'DetailsView/components/tab-stops/tab-stops-test-view-controller';
 import { TabStopsViewActions } from 'DetailsView/components/tab-stops/tab-stops-view-actions';
 import { TabStopsViewStore } from 'DetailsView/components/tab-stops/tab-stops-view-store';
+import { DataTransferViewController } from 'DetailsView/data-transfer-view-controller';
+import { DataTransferViewStore } from 'DetailsView/data-transfer-view-store';
 import { AllUrlsPermissionHandler } from 'DetailsView/handlers/allurls-permission-handler';
 import { NoContentAvailableViewRenderer } from 'DetailsView/no-content-available-view-renderer';
 import {
@@ -268,6 +271,13 @@ if (tabId != null) {
             cardsViewStore.initialize();
             const cardsViewController = new CardsViewController(cardsViewActions);
 
+            const dataTransferViewActions = new DataTransferViewActions();
+            const dataTransferViewStore = new DataTransferViewStore(dataTransferViewActions);
+            dataTransferViewStore.initialize();
+            const dataTransferViewController = new DataTransferViewController(
+                dataTransferViewActions,
+            );
+
             const storesHub = new ClientStoresHub<DetailsViewContainerState>([
                 detailsViewStore,
                 featureFlagStore,
@@ -286,6 +296,7 @@ if (tabId != null) {
                 userConfigStore,
                 tabStopsViewStore,
                 cardsViewStore,
+                dataTransferViewStore,
             ]);
 
             const telemetrySanitizer = new ExceptionTelemetrySanitizer(
@@ -674,6 +685,7 @@ if (tabId != null) {
                     assessmentFunctionalitySwitcher.getGetAssessmentSummaryModelFromProviderAndStoreData,
                 getGetAssessmentSummaryModelFromProviderAndStatusData:
                     assessmentFunctionalitySwitcher.getGetAssessmentSummaryModelFromProviderAndStatusData,
+                dataTransferViewController,
             };
 
             const renderer = new DetailsViewRenderer(

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/headings.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/headings.test.ts.snap
@@ -9,7 +9,7 @@ exports[`Details View -> Assessment -> Headings Requirement page should pass acc
         "failureSummary": "Fix any of the following:
   Text inside the element is not included in the accessible name",
         "selector": [
-          "#header64-visualizationButton",
+          "#header66-visualizationButton",
         ],
       },
     ],
@@ -26,7 +26,7 @@ exports[`Details View -> Assessment -> Headings Requirement page should pass acc
         "failureSummary": "Fix any of the following:
   Text inside the element is not included in the accessible name",
         "selector": [
-          "#header64-visualizationButton",
+          "#header66-visualizationButton",
         ],
       },
     ],

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -82,6 +82,11 @@ exports[`DetailsViewBody render render 1`] = `
         }
       }
       clickHandlerFactory={{}}
+      dataTransferViewStoreData={
+        {
+          "showQuickAssessToAssessmentConfirmDialog": true,
+        }
+      }
       deps={
         {
           "detailsViewActionMessageCreator": {},
@@ -458,6 +463,11 @@ exports[`DetailsViewBody render render 1`] = `
           }
         }
         clickHandlerFactory={{}}
+        dataTransferViewStoreData={
+          {
+            "showQuickAssessToAssessmentConfirmDialog": true,
+          }
+        }
         deps={
           {
             "detailsViewActionMessageCreator": {},
@@ -764,6 +774,14 @@ exports[`DetailsViewBody render render 1`] = `
           className="view"
           role="main"
         >
+          <QuickAssessToAssessmentConfirmDialog
+            deps={
+              {
+                "detailsViewActionMessageCreator": {},
+              }
+            }
+            isShown={true}
+          />
           <test
             assessmentStoreData={
               {
@@ -839,6 +857,11 @@ exports[`DetailsViewBody render render 1`] = `
               }
             }
             clickHandlerFactory={{}}
+            dataTransferViewStoreData={
+              {
+                "showQuickAssessToAssessmentConfirmDialog": true,
+              }
+            }
             deps={
               {
                 "detailsViewActionMessageCreator": {},

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -49,6 +49,11 @@ exports[`DetailsViewContent render renders normally 1`] = `
       }
     }
     automatedChecksCardsViewData={{}}
+    dataTransferViewStoreData={
+      {
+        "showQuickAssessToAssessmentConfirmDialog": false,
+      }
+    }
     deps={
       {
         "detailsViewActionMessageCreator": [typemoq mock object],

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -103,6 +103,7 @@ describe('DetailsViewBody', () => {
                 visualizationStoreData: new VisualizationStoreDataBuilder().build(),
                 visualizationScanResultData: new VisualizationScanResultStoreDataBuilder().build(),
                 tabStopsViewStoreData: { failureInstanceState: {} } as TabStopsViewStoreData,
+                dataTransferViewStoreData: { showQuickAssessToAssessmentConfirmDialog: true },
                 featureFlagStoreData: {} as FeatureFlagStoreData,
                 selectedTest: selectedTest,
                 visualizationConfigurationFactory: configFactoryStub,

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -304,6 +304,7 @@ describe(DetailsViewContent.displayName, () => {
                             storeMocks.needsReviewCardSelectionStoreData,
                         cardSelectionStoreData: storeMocks.cardSelectionStoreData,
                         tabStopsViewStoreData: storeMocks.tabStopsViewStoreData,
+                        dataTransferViewStoreData: storeMocks.dataTransferViewStoreData,
                     }
                 );
             });
@@ -369,6 +370,7 @@ describe(DetailsViewContent.displayName, () => {
             tabStopsViewStoreData: storeMocks.tabStopsViewStoreData,
             cardsViewStoreData: storeMocks.cardsViewStoreData,
             quickAssessStoreData: storeMocks.quickAssessStoreData,
+            dataTransferViewStoreData: storeMocks.dataTransferViewStoreData,
         };
     }
 });

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -23,6 +23,7 @@ import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs
 import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
 import { ScopingInputTypes } from 'common/types/store-data/scoping-input-types';
 import { TabStopsViewStore } from 'DetailsView/components/tab-stops/tab-stops-view-store';
+import { DataTransferViewStore } from 'DetailsView/data-transfer-view-store';
 import { It, Mock, MockBehavior } from 'typemoq';
 import { PermissionsStateStore } from '../../../../background/stores/global/permissions-state-store';
 import { UnifiedScanResultStore } from '../../../../background/stores/unified-scan-result-store';
@@ -65,6 +66,7 @@ export class StoreMocks {
     public unifiedScanResultStoreMock = Mock.ofType(UnifiedScanResultStore, MockBehavior.Strict);
     public permissionsStateStoreMock = Mock.ofType(PermissionsStateStore, MockBehavior.Strict);
     public tabStopsViewStoreMock = Mock.ofType(TabStopsViewStore, MockBehavior.Strict);
+    public dataTransferViewStoreMock = Mock.ofType(DataTransferViewStore, MockBehavior.Strict);
     public needsReviewScanResultStoreMock = Mock.ofType(
         NeedsReviewScanResultStore,
         MockBehavior.Strict,
@@ -168,6 +170,7 @@ export class StoreMocks {
         null,
     ).getDefaultState();
     public cardsViewStoreData = new CardsViewStore(null).getDefaultState();
+    public dataTransferViewStoreData = new DataTransferViewStore(null).getDefaultState();
 
     constructor() {
         this.assessmentsProviderMock.setup(ap => ap.all()).returns(() => []);


### PR DESCRIPTION
#### Details

Wires up the dialog that was created in #6329.

##### Motivation

Feature work.

##### Context

There is currently no way to show this through the UI, that will be in a future PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
