### PR TITLE
feat(medium-pass-2): add transfer to assessment button

### DIFF
--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -14,9 +14,9 @@ import styles from './command-bar-buttons-menu.scss';
 
 export type CommandBarButtonsMenuProps = {
     renderExportReportButton: () => JSX.Element;
-    saveAssessmentButton: JSX.Element | null;
-    loadAssessmentButton: JSX.Element | null;
-    transferToAssessmentButton: JSX.Element | null;
+    saveAssessmentButton?: JSX.Element | null;
+    loadAssessmentButton?: JSX.Element | null;
+    transferToAssessmentButton?: JSX.Element | null;
     getStartOverMenuItem: () => StartOverMenuItem;
     buttonRef: IRefObject<IButton>;
 };

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -14,9 +14,9 @@ import styles from './command-bar-buttons-menu.scss';
 
 export type CommandBarButtonsMenuProps = {
     renderExportReportButton: () => JSX.Element;
-    renderSaveAssessmentButton?: () => JSX.Element | null;
-    renderLoadAssessmentButton?: () => JSX.Element | null;
-    renderTransferToAssessmentButton?: () => JSX.Element | null;
+    saveAssessmentButton: JSX.Element | null;
+    loadAssessmentButton: JSX.Element | null;
+    transferToAssessmentButton: JSX.Element | null;
     getStartOverMenuItem: () => StartOverMenuItem;
     buttonRef: IRefObject<IButton>;
 };
@@ -31,25 +31,23 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
             key: 'export report',
             onRender: () => <div role="menuitem">{exportButton}</div>,
         });
-        if (props.renderSaveAssessmentButton && props.renderLoadAssessmentButton) {
+        if (props.saveAssessmentButton && props.loadAssessmentButton) {
             overflowItems.push(
                 {
                     key: 'save assessment',
-                    onRender: () => <div role="menuitem">{props.renderSaveAssessmentButton()}</div>,
+                    onRender: () => <div role="menuitem">{props.saveAssessmentButton}</div>,
                 },
                 {
                     key: 'load assessment',
-                    onRender: () => <div role="menuitem">{props.renderLoadAssessmentButton()}</div>,
+                    onRender: () => <div role="menuitem">{props.loadAssessmentButton}</div>,
                 },
             );
         }
 
-        if (props.renderTransferToAssessmentButton) {
+        if (props.transferToAssessmentButton) {
             overflowItems.push({
                 key: 'transfer to assessment',
-                onRender: () => (
-                    <div role="menuitem">{props.renderTransferToAssessmentButton()}</div>
-                ),
+                onRender: () => <div role="menuitem">{props.transferToAssessmentButton}</div>,
             });
         }
 

--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -16,6 +16,7 @@ export type CommandBarButtonsMenuProps = {
     renderExportReportButton: () => JSX.Element;
     renderSaveAssessmentButton?: () => JSX.Element | null;
     renderLoadAssessmentButton?: () => JSX.Element | null;
+    renderTransferToAssessmentButton?: () => JSX.Element | null;
     getStartOverMenuItem: () => StartOverMenuItem;
     buttonRef: IRefObject<IButton>;
 };
@@ -42,6 +43,16 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
                 },
             );
         }
+
+        if (props.renderTransferToAssessmentButton) {
+            overflowItems.push({
+                key: 'transfer to assessment',
+                onRender: () => (
+                    <div role="menuitem">{props.renderTransferToAssessmentButton()}</div>
+                ),
+            });
+        }
+
         overflowItems.push({
             key: 'start over',
             ...props.getStartOverMenuItem(),

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -197,6 +197,7 @@ export class DetailsViewCommandBar extends React.Component<
                 renderExportReportButton={this.renderExportButton}
                 renderSaveAssessmentButton={this.renderSaveAssessmentButton}
                 renderLoadAssessmentButton={this.renderLoadAssessmentButton}
+                renderTransferToAssessmentButton={this.renderTransferToAssessmentButton}
                 getStartOverMenuItem={this.getStartOverMenuItem}
                 buttonRef={ref => {
                     this.exportDialogCloseFocus = ref;

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -195,9 +195,9 @@ export class DetailsViewCommandBar extends React.Component<
         return (
             <CommandBarButtonsMenu
                 renderExportReportButton={this.renderExportButton}
-                renderSaveAssessmentButton={this.renderSaveAssessmentButton}
-                renderLoadAssessmentButton={this.renderLoadAssessmentButton}
-                renderTransferToAssessmentButton={this.renderTransferToAssessmentButton}
+                saveAssessmentButton={this.renderSaveAssessmentButton()}
+                loadAssessmentButton={this.renderLoadAssessmentButton()}
+                transferToAssessmentButton={this.renderTransferToAssessmentButton()}
                 getStartOverMenuItem={this.getStartOverMenuItem}
                 buttonRef={ref => {
                     this.exportDialogCloseFocus = ref;

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -43,6 +43,10 @@ import {
     StartOverDialogState,
     StartOverDialogType,
 } from 'DetailsView/components/start-over-dialog';
+import {
+    TransferToAssessmentButtonDeps,
+    TransferToAssessmentButtonProps,
+} from 'DetailsView/components/transfer-to-assessment-button';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
@@ -56,6 +60,7 @@ export type DetailsViewCommandBarDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
 } & SaveAssessmentButtonFactoryDeps &
     LoadAssessmentButtonDeps &
+    TransferToAssessmentButtonDeps &
     StartOverFactoryDeps &
     LoadAssessmentDialogDeps &
     ReportExportDialogFactoryDeps &
@@ -75,6 +80,9 @@ export type ReportExportDialogFactory = (props: ReportExportDialogFactoryProps) 
 
 export type SaveAssessmentButtonFactory = (props: SaveAssessmentButtonFactoryProps) => JSX.Element;
 export type LoadAssessmentButtonFactory = (props: LoadAssessmentButtonProps) => JSX.Element;
+export type TransferToAssessmentButtonFactory = (
+    props: TransferToAssessmentButtonProps,
+) => JSX.Element;
 
 export interface DetailsViewCommandBarProps {
     deps: DetailsViewCommandBarDeps;
@@ -159,11 +167,14 @@ export class DetailsViewCommandBar extends React.Component<
         const startOverElement: JSX.Element = this.renderStartOverButton();
         const saveAssessmentButtonElement: JSX.Element = this.renderSaveAssessmentButton();
         const loadAssessmentButtonElement: JSX.Element = this.renderLoadAssessmentButton();
+        const transferToAssessmentButtonElement: JSX.Element =
+            this.renderTransferToAssessmentButton();
 
         if (
             reportExportElement ||
             saveAssessmentButtonElement ||
             loadAssessmentButtonElement ||
+            transferToAssessmentButtonElement ||
             startOverElement
         ) {
             return (
@@ -171,6 +182,7 @@ export class DetailsViewCommandBar extends React.Component<
                     {reportExportElement}
                     {saveAssessmentButtonElement}
                     {loadAssessmentButtonElement}
+                    {transferToAssessmentButtonElement}
                     {startOverElement}
                 </div>
             );
@@ -241,6 +253,12 @@ export class DetailsViewCommandBar extends React.Component<
         return this.props.switcherNavConfiguration.LoadAssessmentButton({
             ...this.props,
             handleLoadAssessmentButtonClick: this.handleLoadAssessmentButtonClick,
+        });
+    };
+
+    private renderTransferToAssessmentButton = (): JSX.Element => {
+        return this.props.switcherNavConfiguration.TransferToAssessmentButton({
+            ...this.props,
         });
     };
 

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -6,6 +6,7 @@ import {
     FastPassLeftNavHamburgerButton,
     MediumPassLeftNavHamburgerButton,
 } from 'common/components/expand-collapse-left-nav-hamburger-button';
+import { getNullComponent } from 'common/components/null-component';
 import {
     AssessmentFunctionalitySwitcher,
     SharedAssessmentObjects,
@@ -17,6 +18,7 @@ import {
     LoadAssessmentButtonFactory,
     ReportExportDialogFactory,
     SaveAssessmentButtonFactory,
+    TransferToAssessmentButtonFactory,
 } from 'DetailsView/components/details-view-command-bar';
 import {
     getAssessmentStoreData,
@@ -58,6 +60,7 @@ import {
     FastpassStartOverFactory,
     StartOverComponentFactory,
 } from 'DetailsView/components/start-over-component-factory';
+import { getTransferToAssessmentButton } from 'DetailsView/components/transfer-to-assessment-button';
 import {
     assessmentWarningConfiguration,
     fastpassWarningConfiguration,
@@ -97,6 +100,7 @@ export type DetailsViewSwitcherNavConfiguration = Readonly<{
     shouldShowReportExportButton: ShouldShowReportExportButton;
     SaveAssessmentButton: SaveAssessmentButtonFactory;
     LoadAssessmentButton: LoadAssessmentButtonFactory;
+    TransferToAssessmentButton: TransferToAssessmentButtonFactory;
     StartOverComponentFactory: StartOverComponentFactory;
     LeftNav: ReactFCWithDisplayName<LeftNavProps>;
     getSelectedDetailsView: (props: GetSelectedDetailsViewProps) => VisualizationType;
@@ -127,6 +131,7 @@ const detailsViewSwitcherNavs: {
         shouldShowReportExportButton: shouldShowReportExportButtonForAssessment,
         SaveAssessmentButton: getSaveButtonForAssessment,
         LoadAssessmentButton: getLoadButtonForAssessment,
+        TransferToAssessmentButton: getNullComponent,
         StartOverComponentFactory: AssessmentStartOverFactory,
         LeftNav: AssessmentLeftNav,
         getSelectedDetailsView: getAssessmentSelectedDetailsView,
@@ -143,6 +148,7 @@ const detailsViewSwitcherNavs: {
         shouldShowReportExportButton: shouldShowReportExportButtonForMediumPass,
         SaveAssessmentButton: getNullSaveButton,
         LoadAssessmentButton: getNullLoadButton,
+        TransferToAssessmentButton: getTransferToAssessmentButton,
         StartOverComponentFactory: AssessmentStartOverFactory,
         LeftNav: MediumPassLeftNav,
         getSelectedDetailsView: getQuickAssessSelectedDetailsView,
@@ -160,6 +166,7 @@ const detailsViewSwitcherNavs: {
         shouldShowReportExportButton: shouldShowReportExportButtonForFastpass,
         SaveAssessmentButton: getNullSaveButton,
         LoadAssessmentButton: getNullLoadButton,
+        TransferToAssessmentButton: getNullComponent,
         StartOverComponentFactory: FastpassStartOverFactory,
         LeftNav: FastPassLeftNav,
         getSelectedDetailsView: getFastPassSelectedDetailsView,

--- a/src/DetailsView/components/transfer-to-assessment-button.tsx
+++ b/src/DetailsView/components/transfer-to-assessment-button.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
+import { NamedFC } from 'common/react/named-fc';
+import { DataTransferViewController } from 'DetailsView/data-transfer-view-controller';
+import * as React from 'react';
+
+export type TransferToAssessmentButtonDeps = {
+    dataTransferViewController: DataTransferViewController;
+};
+
+export interface TransferToAssessmentButtonProps {
+    deps: TransferToAssessmentButtonDeps;
+}
+
+export const TransferToAssessmentButton = NamedFC<TransferToAssessmentButtonProps>(
+    'TransferToAssessmentButton',
+    props => {
+        return (
+            <InsightsCommandButton
+                iconProps={{ iconName: 'fabricMoveToFolder' }}
+                onClick={
+                    props.deps.dataTransferViewController.showQuickAssessToAssessmentConfirmDialog
+                }
+            >
+                Move to assessment
+            </InsightsCommandButton>
+        );
+    },
+);
+
+export const getTransferToAssessmentButton = (props: TransferToAssessmentButtonProps) => {
+    return <TransferToAssessmentButton {...props} />;
+};

--- a/src/common/components/null-component.tsx
+++ b/src/common/components/null-component.tsx
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import * as React from 'react';
 
 export const NullComponent = NamedFC('NullComponent', () => {
     return null;
 });
 
-export const getNullComponent = () => <NullComponent />;
+export const getNullComponent = () => null;

--- a/src/common/components/null-component.tsx
+++ b/src/common/components/null-component.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
+import * as React from 'react';
 
 export const NullComponent = NamedFC('NullComponent', () => {
     return null;
 });
+
+export const getNullComponent = () => <NullComponent />;

--- a/src/common/fabric-icons.ts
+++ b/src/common/fabric-icons.ts
@@ -60,6 +60,7 @@ export function initializeFabricIcons(): void {
             mail: '\uE715',
             medical: '\uEAD4',
             more: '\uE712',
+            fabricMoveToFolder: '\uF0A5',
             offlineStorage: '\uEC8C',
             play: '\uE768',
             refresh: '\uE72C',

--- a/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
+++ b/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
@@ -127,6 +127,34 @@ describe('Details View ->', () => {
             });
         });
 
+        describe.each([true, false])('With high contrast mode=%s', highContrastMode => {
+            const { commandBarMenuButtonSelectors } = navMenuSelectors;
+            const commandBarWindowWidth = narrowModeThresholds.collapseCommandBarThreshold - 1;
+
+            describe.each`
+                componentName           | componentSelectors               | width
+                ${'command bar button'} | ${commandBarMenuButtonSelectors} | ${commandBarWindowWidth}
+            `('With $componentName visible', ({ componentName, componentSelectors, width }) => {
+                beforeAll(async () => {
+                    await resizeDetailsView(width, componentSelectors.collapsed);
+                });
+
+                describe(`with ${componentName} expanded`, () => {
+                    beforeAll(async () => {
+                        await setButtonExpandedState(componentSelectors, true);
+                    });
+
+                    afterAll(async () => {
+                        await setButtonExpandedState(componentSelectors, false);
+                    });
+
+                    it(`should pass accessibility validation with command bar menu open and high contrast mode=%s`, async () => {
+                        await scanForA11yIssuesWithHighContrast(highContrastMode);
+                    });
+                });
+            });
+        });
+
         async function expandCard(): Promise<void> {
             await detailsViewPage.waitForSelector(fastPassAutomatedChecksSelectors.expandButton, {
                 timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
@@ -32,6 +32,10 @@ exports[`CommandBarButtonsMenu renders CommandBarButtonsMenu 1`] = `
             "onRender": [Function],
           },
           {
+            "key": "transfer to assessment",
+            "onRender": [Function],
+          },
+          {
             "key": "start over",
           },
         ],
@@ -76,4 +80,14 @@ exports[`CommandBarButtonsMenu renders all child buttons,: render start over men
 <React.Fragment>
   Start over button
 </React.Fragment>
+`;
+
+exports[`CommandBarButtonsMenu renders all child buttons,: render transfer to assessment menuitem 1`] = `
+<div
+  role="menuitem"
+>
+  <React.Fragment>
+    Transfer to assessment button
+  </React.Fragment>
+</div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -1,22 +1,224 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = `
-"<div className="detailsViewCommandBar" role="region" aria-label="command bar">
-  <div className="detailsViewTargetPage" aria-labelledby="switch-to-target">
-    <span id="switch-to-target">
+<div
+  aria-label="command bar"
+  className="detailsViewCommandBar"
+  role="region"
+>
+  <div
+    aria-labelledby="switch-to-target"
+    className="detailsViewTargetPage"
+  >
+    <span
+      id="switch-to-target"
+    >
       Target page: 
     </span>
-    <NewTabLinkWithTooltip tooltipContent="Switch to target page: command-bar-test-tab-title" role="link" className="targetPageLink" onClick={[Function: proxy]} aria-label="Switch to target page: command-bar-test-tab-title">
-      <span className="targetPageTitle">
+    <NewTabLinkWithTooltip
+      aria-label="Switch to target page: command-bar-test-tab-title"
+      className="targetPageLink"
+      onClick={[Function]}
+      role="link"
+      tooltipContent="Switch to target page: command-bar-test-tab-title"
+    >
+      <span
+        className="targetPageTitle"
+      >
         command-bar-test-tab-title
       </span>
     </NewTabLinkWithTooltip>
   </div>
-  <CommandBarButtonsMenu renderExportReportButton={[Function (anonymous)]} renderSaveAssessmentButton={[Function (anonymous)]} renderLoadAssessmentButton={[Function (anonymous)]} renderTransferToAssessmentButton={[Function (anonymous)]} getStartOverMenuItem={[Function (anonymous)]} buttonRef={[Function: buttonRef]} />
-  <InvalidLoadAssessmentDialog deps={{...}} assessmentStoreData={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} isOpen={false} onClose={[Function (anonymous)]} />
-  <LoadAssessmentDialog deps={{...}} assessmentStoreData={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} isOpen={false} prevTab={{...}} loadedAssessmentData={{...}} tabId={5} onClose={[Function (anonymous)]} />
-  <StartOverDialog deps={{...}} assessmentStoreData={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} dialogState="none" dismissDialog={[Function (anonymous)]} />
-</div>"
+  <CommandBarButtonsMenu
+    buttonRef={[Function]}
+    getStartOverMenuItem={[Function]}
+    loadAssessmentButton={
+      <div>
+        Load assessment
+      </div>
+    }
+    renderExportReportButton={[Function]}
+    saveAssessmentButton={
+      <div>
+        Save assessment
+      </div>
+    }
+    transferToAssessmentButton={
+      <div>
+        Transfer to assessment stub
+      </div>
+    }
+  />
+  <InvalidLoadAssessmentDialog
+    assessmentStoreData={
+      {
+        "persistedTabInfo": {
+          "detailsViewId": undefined,
+          "id": 5,
+          "isClosed": false,
+          "title": "command-bar-test-tab-title",
+        },
+      }
+    }
+    deps={
+      {
+        "detailsViewActionMessageCreator": [typemoq mock object],
+      }
+    }
+    isOpen={false}
+    narrowModeStatus={
+      {
+        "isCommandBarCollapsed": true,
+      }
+    }
+    onClose={[Function]}
+    scanMetadata={
+      {
+        "targetAppInfo": {
+          "name": "command-bar-test-tab-title",
+          "url": "command-bar-test-url",
+        },
+      }
+    }
+    switcherNavConfiguration={
+      {
+        "CommandBar": [Function],
+        "LeftNav": [Function],
+        "LoadAssessmentButton": [Function],
+        "ReportExportDialogFactory": [Function],
+        "SaveAssessmentButton": [Function],
+        "StartOverComponentFactory": {
+          "getStartOverComponent": [Function],
+        },
+        "TransferToAssessmentButton": [Function],
+        "shouldShowReportExportButton": [Function],
+      }
+    }
+    tabStoreData={
+      {
+        "id": 5,
+        "isClosed": false,
+        "title": "command-bar-test-tab-title",
+      }
+    }
+  />
+  <LoadAssessmentDialog
+    assessmentStoreData={
+      {
+        "persistedTabInfo": {
+          "detailsViewId": undefined,
+          "id": 5,
+          "isClosed": false,
+          "title": "command-bar-test-tab-title",
+        },
+      }
+    }
+    deps={
+      {
+        "detailsViewActionMessageCreator": [typemoq mock object],
+      }
+    }
+    isOpen={false}
+    loadedAssessmentData={null}
+    narrowModeStatus={
+      {
+        "isCommandBarCollapsed": true,
+      }
+    }
+    onClose={[Function]}
+    prevTab={
+      {
+        "detailsViewId": undefined,
+        "id": 5,
+        "isClosed": false,
+        "title": "command-bar-test-tab-title",
+      }
+    }
+    scanMetadata={
+      {
+        "targetAppInfo": {
+          "name": "command-bar-test-tab-title",
+          "url": "command-bar-test-url",
+        },
+      }
+    }
+    switcherNavConfiguration={
+      {
+        "CommandBar": [Function],
+        "LeftNav": [Function],
+        "LoadAssessmentButton": [Function],
+        "ReportExportDialogFactory": [Function],
+        "SaveAssessmentButton": [Function],
+        "StartOverComponentFactory": {
+          "getStartOverComponent": [Function],
+        },
+        "TransferToAssessmentButton": [Function],
+        "shouldShowReportExportButton": [Function],
+      }
+    }
+    tabId={5}
+    tabStoreData={
+      {
+        "id": 5,
+        "isClosed": false,
+        "title": "command-bar-test-tab-title",
+      }
+    }
+  />
+  <StartOverDialog
+    assessmentStoreData={
+      {
+        "persistedTabInfo": {
+          "detailsViewId": undefined,
+          "id": 5,
+          "isClosed": false,
+          "title": "command-bar-test-tab-title",
+        },
+      }
+    }
+    deps={
+      {
+        "detailsViewActionMessageCreator": [typemoq mock object],
+      }
+    }
+    dialogState="none"
+    dismissDialog={[Function]}
+    narrowModeStatus={
+      {
+        "isCommandBarCollapsed": true,
+      }
+    }
+    scanMetadata={
+      {
+        "targetAppInfo": {
+          "name": "command-bar-test-tab-title",
+          "url": "command-bar-test-url",
+        },
+      }
+    }
+    switcherNavConfiguration={
+      {
+        "CommandBar": [Function],
+        "LeftNav": [Function],
+        "LoadAssessmentButton": [Function],
+        "ReportExportDialogFactory": [Function],
+        "SaveAssessmentButton": [Function],
+        "StartOverComponentFactory": {
+          "getStartOverComponent": [Function],
+        },
+        "TransferToAssessmentButton": [Function],
+        "shouldShowReportExportButton": [Function],
+      }
+    }
+    tabStoreData={
+      {
+        "id": 5,
+        "isClosed": false,
+        "title": "command-bar-test-tab-title",
+      }
+    }
+  />
+</div>
 `;
 
 exports[`DetailsViewCommandBar renders with export button and start over 1`] = `
@@ -876,19 +1078,6 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog open 
 </div>
 `;
 
-exports[`DetailsViewCommandBar renders with load assessment button 1`] = `
-<InsightsCommandButton
-  data-automation-id="load-assessment-button"
-  iconProps={
-    {
-      "iconName": "FabricOpenFolderHorizontal",
-    }
-  }
->
-  Load assessment
-</InsightsCommandButton>
-`;
-
 exports[`DetailsViewCommandBar renders with load assessment dialog hidden 1`] = `
 <div
   aria-label="command bar"
@@ -1514,81 +1703,6 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
     }
   />
 </div>
-`;
-
-exports[`DetailsViewCommandBar renders with save assessment button 1`] = `
-<React.Fragment>
-  <InsightsCommandButton
-    download="download"
-    href="url"
-    iconProps={
-      {
-        "iconName": "Save",
-      }
-    }
-    onClick={[Function]}
-  >
-    Save assessment
-  </InsightsCommandButton>
-  <Dialog
-    dialogContentProps={
-      {
-        "title": "Assessment saved",
-        "type": 0,
-      }
-    }
-    hidden={true}
-    modalProps={
-      {
-        "containerClassName": "insightsDialogMainOverride",
-        "isBlocking": false,
-      }
-    }
-    onDismiss={[Function]}
-  >
-    <div
-      className="dialogBody"
-    >
-      To load this assessment, use the 
-      <strong>
-        Load assessment
-      </strong>
-       button in the Accessibility Insights Assessment command bar.
-    </div>
-    <StyledDialogFooterBase>
-      <Stack
-        horizontal={true}
-        horizontalAlign="space-between"
-        tokens={
-          {
-            "childrenGap": 6,
-          }
-        }
-        verticalAlign="center"
-        wrap={true}
-      >
-        <StackItem
-          disableShrink={true}
-          grow={true}
-        >
-          <StyledCheckboxBase
-            label="Don't show again"
-            onChange={[Function]}
-            value={false}
-          />
-        </StackItem>
-        <StackItem
-          grow={true}
-        >
-          <CustomizedPrimaryButton
-            onClick={[Function]}
-            text="Got it"
-          />
-        </StackItem>
-      </Stack>
-    </StyledDialogFooterBase>
-  </Dialog>
-</React.Fragment>
 `;
 
 exports[`DetailsViewCommandBar renders with start assessment over dialog open 1`] = `

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -58,6 +58,9 @@ exports[`DetailsViewCommandBar renders with export button and start over 1`] = `
     <div>
       Save assessment
     </div>
+    <div>
+      Transfer to assessment stub
+    </div>
     <CustomizedActionButton>
       Start Over Component
     </CustomizedActionButton>
@@ -106,6 +109,7 @@ exports[`DetailsViewCommandBar renders with export button and start over 1`] = `
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -167,6 +171,7 @@ exports[`DetailsViewCommandBar renders with export button and start over 1`] = `
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -220,6 +225,7 @@ exports[`DetailsViewCommandBar renders with export button and start over 1`] = `
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -273,6 +279,9 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
     <div>
       Save assessment
     </div>
+    <div>
+      Transfer to assessment stub
+    </div>
   </div>
   <div>
     Export dialog
@@ -318,6 +327,7 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -379,6 +389,7 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -432,6 +443,7 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -524,6 +536,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog hidde
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -585,6 +598,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog hidde
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -638,6 +652,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog hidde
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -730,6 +745,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog open 
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -791,6 +807,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog open 
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -844,6 +861,7 @@ exports[`DetailsViewCommandBar renders with invalid load assessment dialog open 
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -949,6 +967,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog hidden 1`] = 
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1010,6 +1029,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog hidden 1`] = 
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1063,6 +1083,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog hidden 1`] = 
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1155,6 +1176,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog open 1`] = `
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1216,6 +1238,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog open 1`] = `
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1269,6 +1292,7 @@ exports[`DetailsViewCommandBar renders with load assessment dialog open 1`] = `
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1361,6 +1385,7 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1422,6 +1447,7 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1475,6 +1501,7 @@ exports[`DetailsViewCommandBar renders with report export dialog open 1`] = `
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1641,6 +1668,9 @@ exports[`DetailsViewCommandBar renders without export button and without start o
     <div>
       Save assessment
     </div>
+    <div>
+      Transfer to assessment stub
+    </div>
   </div>
   <div>
     Export dialog
@@ -1686,6 +1716,7 @@ exports[`DetailsViewCommandBar renders without export button and without start o
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1747,6 +1778,7 @@ exports[`DetailsViewCommandBar renders without export button and without start o
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1800,6 +1832,7 @@ exports[`DetailsViewCommandBar renders without export button and without start o
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1849,6 +1882,9 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
     <div>
       Save assessment
     </div>
+    <div>
+      Transfer to assessment stub
+    </div>
     <CustomizedActionButton>
       Start Over Component
     </CustomizedActionButton>
@@ -1897,6 +1933,7 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -1958,6 +1995,7 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }
@@ -2011,6 +2049,7 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
         "StartOverComponentFactory": {
           "getStartOverComponent": [Function],
         },
+        "TransferToAssessmentButton": [Function],
         "shouldShowReportExportButton": [Function],
       }
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = 
       </span>
     </NewTabLinkWithTooltip>
   </div>
-  <CommandBarButtonsMenu renderExportReportButton={[Function (anonymous)]} renderSaveAssessmentButton={[Function (anonymous)]} renderLoadAssessmentButton={[Function (anonymous)]} getStartOverMenuItem={[Function (anonymous)]} buttonRef={[Function: buttonRef]} />
+  <CommandBarButtonsMenu renderExportReportButton={[Function (anonymous)]} renderSaveAssessmentButton={[Function (anonymous)]} renderLoadAssessmentButton={[Function (anonymous)]} renderTransferToAssessmentButton={[Function (anonymous)]} getStartOverMenuItem={[Function (anonymous)]} buttonRef={[Function: buttonRef]} />
   <InvalidLoadAssessmentDialog deps={{...}} assessmentStoreData={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} isOpen={false} onClose={[Function (anonymous)]} />
   <LoadAssessmentDialog deps={{...}} assessmentStoreData={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} isOpen={false} prevTab={{...}} loadedAssessmentData={{...}} tabId={5} onClose={[Function (anonymous)]} />
   <StartOverDialog deps={{...}} assessmentStoreData={{...}} tabStoreData={{...}} switcherNavConfiguration={{...}} scanMetadata={{...}} narrowModeStatus={{...}} dialogState="none" dismissDialog={[Function (anonymous)]} />

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/transfer-to-assessment-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/transfer-to-assessment-button.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TransferToAssessmentButton getTransferToAssessmentButton 1`] = `
+<TransferToAssessmentButton
+  deps={
+    {
+      "dataTransferViewController": [typemoq mock object],
+    }
+  }
+/>
+`;
+
+exports[`TransferToAssessmentButton render 1`] = `
+<InsightsCommandButton
+  iconProps={
+    {
+      "iconName": "fabricMoveToFolder",
+    }
+  }
+  onClick={[Function]}
+>
+  Move to assessment
+</InsightsCommandButton>
+`;

--- a/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
@@ -12,23 +12,17 @@ import { IMock, Mock, Times } from 'typemoq';
 
 describe('CommandBarButtonsMenu', () => {
     let renderExportReportComponentMock: IMock<() => JSX.Element>;
-    let renderSaveAssessmentButtonMock: IMock<() => JSX.Element>;
-    let renderLoadAssessmentButtonMock: IMock<() => JSX.Element>;
-    let renderTransferToAssessmentButtonMock: IMock<() => JSX.Element>;
     let getStartOverMenuItemMock: IMock<() => StartOverMenuItem>;
     let commandBarButtonsMenuProps: CommandBarButtonsMenuProps;
 
     beforeEach(() => {
         renderExportReportComponentMock = Mock.ofInstance(() => null);
-        renderSaveAssessmentButtonMock = Mock.ofInstance(() => null);
-        renderLoadAssessmentButtonMock = Mock.ofInstance(() => null);
-        renderTransferToAssessmentButtonMock = Mock.ofInstance(() => null);
         getStartOverMenuItemMock = Mock.ofInstance(() => null);
         commandBarButtonsMenuProps = {
             renderExportReportButton: renderExportReportComponentMock.object,
-            renderSaveAssessmentButton: renderSaveAssessmentButtonMock.object,
-            renderLoadAssessmentButton: renderLoadAssessmentButtonMock.object,
-            renderTransferToAssessmentButton: renderTransferToAssessmentButtonMock.object,
+            saveAssessmentButton: <>Save assessment button</>,
+            loadAssessmentButton: <>Load assessment button</>,
+            transferToAssessmentButton: <>Transfer to assessment button</>,
 
             getStartOverMenuItem: getStartOverMenuItemMock.object,
             buttonRef: {} as RefObject<IButton>,
@@ -42,9 +36,6 @@ describe('CommandBarButtonsMenu', () => {
 
     it('renders all child buttons,', () => {
         setupExportReportMenuItem();
-        setupSaveAssessmentMenuItem();
-        setupLoadAssessmentMenuItem();
-        setupTransferToAssessmentMenuItem();
         setupStartOverMenuItem();
 
         const wrapper = shallow(<CommandBarButtonsMenu {...commandBarButtonsMenuProps} />);
@@ -64,9 +55,6 @@ describe('CommandBarButtonsMenu', () => {
         expect(overflowItems[4].onRender()).toMatchSnapshot('render start over menuitem');
 
         renderExportReportComponentMock.verifyAll();
-        renderSaveAssessmentButtonMock.verifyAll();
-        renderLoadAssessmentButtonMock.verifyAll();
-        renderTransferToAssessmentButtonMock.verifyAll();
         getStartOverMenuItemMock.verifyAll();
     });
 
@@ -74,27 +62,6 @@ describe('CommandBarButtonsMenu', () => {
         renderExportReportComponentMock
             .setup(r => r())
             .returns(() => <>Report export button</>)
-            .verifiable(Times.once());
-    }
-
-    function setupSaveAssessmentMenuItem(): void {
-        renderSaveAssessmentButtonMock
-            .setup(r => r())
-            .returns(() => <>Save assessment button</>)
-            .verifiable(Times.once());
-    }
-
-    function setupLoadAssessmentMenuItem(): void {
-        renderLoadAssessmentButtonMock
-            .setup(r => r())
-            .returns(() => <>Load assessment button</>)
-            .verifiable(Times.once());
-    }
-
-    function setupTransferToAssessmentMenuItem(): void {
-        renderTransferToAssessmentButtonMock
-            .setup(r => r())
-            .returns(() => <>Transfer to assessment button</>)
             .verifiable(Times.once());
     }
 

--- a/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bar-buttons-menu.test.tsx
@@ -14,6 +14,7 @@ describe('CommandBarButtonsMenu', () => {
     let renderExportReportComponentMock: IMock<() => JSX.Element>;
     let renderSaveAssessmentButtonMock: IMock<() => JSX.Element>;
     let renderLoadAssessmentButtonMock: IMock<() => JSX.Element>;
+    let renderTransferToAssessmentButtonMock: IMock<() => JSX.Element>;
     let getStartOverMenuItemMock: IMock<() => StartOverMenuItem>;
     let commandBarButtonsMenuProps: CommandBarButtonsMenuProps;
 
@@ -21,11 +22,13 @@ describe('CommandBarButtonsMenu', () => {
         renderExportReportComponentMock = Mock.ofInstance(() => null);
         renderSaveAssessmentButtonMock = Mock.ofInstance(() => null);
         renderLoadAssessmentButtonMock = Mock.ofInstance(() => null);
+        renderTransferToAssessmentButtonMock = Mock.ofInstance(() => null);
         getStartOverMenuItemMock = Mock.ofInstance(() => null);
         commandBarButtonsMenuProps = {
             renderExportReportButton: renderExportReportComponentMock.object,
             renderSaveAssessmentButton: renderSaveAssessmentButtonMock.object,
             renderLoadAssessmentButton: renderLoadAssessmentButtonMock.object,
+            renderTransferToAssessmentButton: renderTransferToAssessmentButtonMock.object,
 
             getStartOverMenuItem: getStartOverMenuItemMock.object,
             buttonRef: {} as RefObject<IButton>,
@@ -41,6 +44,7 @@ describe('CommandBarButtonsMenu', () => {
         setupExportReportMenuItem();
         setupSaveAssessmentMenuItem();
         setupLoadAssessmentMenuItem();
+        setupTransferToAssessmentMenuItem();
         setupStartOverMenuItem();
 
         const wrapper = shallow(<CommandBarButtonsMenu {...commandBarButtonsMenuProps} />);
@@ -49,16 +53,20 @@ describe('CommandBarButtonsMenu', () => {
         const overflowItems: IOverflowSetItemProps[] = renderedProps.menuProps?.items;
 
         expect(overflowItems).toBeDefined();
-        expect(overflowItems).toHaveLength(4);
+        expect(overflowItems).toHaveLength(5);
 
         expect(overflowItems[0].onRender()).toMatchSnapshot('render export report menuitem');
         expect(overflowItems[1].onRender()).toMatchSnapshot('render save assessment menuitem');
         expect(overflowItems[2].onRender()).toMatchSnapshot('render load assessment menuitem');
-        expect(overflowItems[3].onRender()).toMatchSnapshot('render start over menuitem');
+        expect(overflowItems[3].onRender()).toMatchSnapshot(
+            'render transfer to assessment menuitem',
+        );
+        expect(overflowItems[4].onRender()).toMatchSnapshot('render start over menuitem');
 
         renderExportReportComponentMock.verifyAll();
         renderSaveAssessmentButtonMock.verifyAll();
         renderLoadAssessmentButtonMock.verifyAll();
+        renderTransferToAssessmentButtonMock.verifyAll();
         getStartOverMenuItemMock.verifyAll();
     });
 
@@ -80,6 +88,13 @@ describe('CommandBarButtonsMenu', () => {
         renderLoadAssessmentButtonMock
             .setup(r => r())
             .returns(() => <>Load assessment button</>)
+            .verifiable(Times.once());
+    }
+
+    function setupTransferToAssessmentMenuItem(): void {
+        renderTransferToAssessmentButtonMock
+            .setup(r => r())
+            .returns(() => <>Transfer to assessment button</>)
             .verifiable(Times.once());
     }
 

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ActionButton, IButton } from '@fluentui/react';
-import { UserConfigMessageCreator } from 'common/message-creators/user-config-message-creator';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
 import {
     AssessmentStoreData,
@@ -9,8 +8,6 @@ import {
 } from 'common/types/store-data/assessment-result-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
-import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
-import { AssessmentActionMessageCreator } from 'DetailsView/actions/assessment-action-message-creator';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import {
     CommandBarProps,
@@ -25,15 +22,7 @@ import {
     DetailsViewSwitcherNavConfiguration,
     LeftNavProps,
 } from 'DetailsView/components/details-view-switcher-nav';
-import {
-    LoadAssessmentButton,
-    LoadAssessmentButtonProps,
-} from 'DetailsView/components/load-assessment-button';
 import { ReportExportDialogFactoryProps } from 'DetailsView/components/report-export-dialog-factory';
-import {
-    SaveAssessmentButton,
-    SaveAssessmentButtonProps,
-} from 'DetailsView/components/save-assessment-button';
 import { SaveAssessmentButtonFactoryProps } from 'DetailsView/components/save-assessment-button-factory';
 import {
     StartOverComponentFactory,
@@ -50,15 +39,13 @@ describe('DetailsViewCommandBar', () => {
     const thePageUrl = 'command-bar-test-url';
     const reportExportDialogStub = <div>Export dialog</div>;
     const saveAssessmentStub = <div>Save assessment</div>;
+    const loadAssessmentStub = <div>Load assessment</div>;
     const transferToAssessmentStub = <div>Transfer to assessment stub</div>;
 
     let assessmentStoreData: AssessmentStoreData;
     let tabStoreData: TabStoreData;
     let startOverComponent: JSX.Element;
-    let saveAssessmentButtonPropsStub: SaveAssessmentButtonProps;
-    let loadAssessmentButtonPropsStub: LoadAssessmentButtonProps;
     let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
-    let assessmentActionMessageCreatorMock: IMock<AssessmentActionMessageCreator>;
     let isCommandBarCollapsed: boolean;
     let showReportExportButton: boolean;
     let reportExportDialogFactory: IMock<ReportExportDialogFactory>;
@@ -66,16 +53,10 @@ describe('DetailsViewCommandBar', () => {
     let loadAssessmentButtonFactoryMock: IMock<LoadAssessmentButtonFactory>;
     let transferToAssessmentButtonFactoryMock: IMock<TransferToAssessmentButtonFactory>;
     let getStartOverComponentMock: IMock<(Props: StartOverFactoryProps) => JSX.Element>;
-    let userConfigMessageCreatorMock: IMock<UserConfigMessageCreator>;
-    let userConfigurationStoreData: UserConfigurationStoreData;
 
     beforeEach(() => {
         detailsViewActionMessageCreatorMock = Mock.ofType(
             DetailsViewActionMessageCreator,
-            MockBehavior.Loose,
-        );
-        assessmentActionMessageCreatorMock = Mock.ofType(
-            AssessmentActionMessageCreator,
             MockBehavior.Loose,
         );
         reportExportDialogFactory = Mock.ofInstance(props => null);
@@ -91,20 +72,6 @@ describe('DetailsViewCommandBar', () => {
         startOverComponent = null;
         isCommandBarCollapsed = false;
         showReportExportButton = true;
-        userConfigMessageCreatorMock = Mock.ofType(UserConfigMessageCreator);
-        userConfigurationStoreData = {
-            showSaveAssessmentDialog: true,
-        } as UserConfigurationStoreData;
-        saveAssessmentButtonPropsStub = {
-            deps: {
-                detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
-                getAssessmentActionMessageCreator: () => assessmentActionMessageCreatorMock.object,
-                userConfigMessageCreator: userConfigMessageCreatorMock.object,
-            },
-            download: 'download',
-            href: 'url',
-            userConfigurationStoreData,
-        };
 
         assessmentStoreData = {} as AssessmentStoreData;
         assessmentStoreData.persistedTabInfo = {
@@ -113,12 +80,6 @@ describe('DetailsViewCommandBar', () => {
             isClosed: false,
             detailsViewId: undefined,
         } as PersistedTabInfo;
-
-        loadAssessmentButtonPropsStub = {
-            deps: {},
-            assessmentStoreData,
-            tabStoreData,
-        } as LoadAssessmentButtonProps;
     });
 
     function getProps(): DetailsViewCommandBarProps {
@@ -186,10 +147,13 @@ describe('DetailsViewCommandBar', () => {
     test('renders with buttons collapsed into a menu', () => {
         isCommandBarCollapsed = true;
         const props = getProps();
+        setupTransferToAssessmentButtonFactory(props);
+        setupSaveAssessmentButtonFactory(props);
+        setupLoadAssessmentButtonFactory(props);
 
         const rendered = shallow(<DetailsViewCommandBar {...props} />);
 
-        expect(rendered.debug()).toMatchSnapshot();
+        expect(rendered.getElement()).toMatchSnapshot();
     });
 
     test('renders with report export dialog open', () => {
@@ -227,16 +191,6 @@ describe('DetailsViewCommandBar', () => {
         const rendered = shallow(<DetailsViewCommandBar {...props} />);
         rendered.setState({ isInvalidLoadAssessmentDialogOpen: true });
 
-        expect(rendered.getElement()).toMatchSnapshot();
-    });
-
-    test('renders with save assessment button', () => {
-        const rendered = shallow(<SaveAssessmentButton {...saveAssessmentButtonPropsStub} />);
-        expect(rendered.getElement()).toMatchSnapshot();
-    });
-
-    test('renders with load assessment button', () => {
-        const rendered = shallow(<LoadAssessmentButton {...loadAssessmentButtonPropsStub} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
@@ -405,6 +359,13 @@ describe('DetailsViewCommandBar', () => {
     ): void {
         const argMatcher = isNil(expectedProps) ? It.isAny() : It.isObjectWith(expectedProps);
         saveAssessmentButtonFactoryMock.setup(r => r(argMatcher)).returns(() => saveAssessmentStub);
+    }
+
+    function setupLoadAssessmentButtonFactory(
+        expectedProps?: Partial<LoadAssessmentButtonFactory>,
+    ): void {
+        const argMatcher = isNil(expectedProps) ? It.isAny() : It.isObjectWith(expectedProps);
+        loadAssessmentButtonFactoryMock.setup(r => r(argMatcher)).returns(() => loadAssessmentStub);
     }
 
     function setupTransferToAssessmentButtonFactory(

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -19,6 +19,7 @@ import {
     LoadAssessmentButtonFactory,
     ReportExportDialogFactory,
     SaveAssessmentButtonFactory,
+    TransferToAssessmentButtonFactory,
 } from 'DetailsView/components/details-view-command-bar';
 import {
     DetailsViewSwitcherNavConfiguration,
@@ -38,6 +39,7 @@ import {
     StartOverComponentFactory,
     StartOverFactoryProps,
 } from 'DetailsView/components/start-over-component-factory';
+import { TransferToAssessmentButtonProps } from 'DetailsView/components/transfer-to-assessment-button';
 import { shallow } from 'enzyme';
 import { isNil } from 'lodash';
 import * as React from 'react';
@@ -48,6 +50,7 @@ describe('DetailsViewCommandBar', () => {
     const thePageUrl = 'command-bar-test-url';
     const reportExportDialogStub = <div>Export dialog</div>;
     const saveAssessmentStub = <div>Save assessment</div>;
+    const transferToAssessmentStub = <div>Transfer to assessment stub</div>;
 
     let assessmentStoreData: AssessmentStoreData;
     let tabStoreData: TabStoreData;
@@ -61,6 +64,7 @@ describe('DetailsViewCommandBar', () => {
     let reportExportDialogFactory: IMock<ReportExportDialogFactory>;
     let saveAssessmentButtonFactoryMock: IMock<SaveAssessmentButtonFactory>;
     let loadAssessmentButtonFactoryMock: IMock<LoadAssessmentButtonFactory>;
+    let transferToAssessmentButtonFactoryMock: IMock<TransferToAssessmentButtonFactory>;
     let getStartOverComponentMock: IMock<(Props: StartOverFactoryProps) => JSX.Element>;
     let userConfigMessageCreatorMock: IMock<UserConfigMessageCreator>;
     let userConfigurationStoreData: UserConfigurationStoreData;
@@ -77,6 +81,7 @@ describe('DetailsViewCommandBar', () => {
         reportExportDialogFactory = Mock.ofInstance(props => null);
         saveAssessmentButtonFactoryMock = Mock.ofInstance(props => null);
         loadAssessmentButtonFactoryMock = Mock.ofInstance(props => null);
+        transferToAssessmentButtonFactoryMock = Mock.ofInstance(props => null);
         getStartOverComponentMock = Mock.ofInstance(props => null);
         tabStoreData = {
             id: 5,
@@ -128,6 +133,7 @@ describe('DetailsViewCommandBar', () => {
             ReportExportDialogFactory: reportExportDialogFactory.object,
             SaveAssessmentButton: saveAssessmentButtonFactoryMock.object,
             LoadAssessmentButton: loadAssessmentButtonFactoryMock.object,
+            TransferToAssessmentButton: transferToAssessmentButtonFactoryMock.object,
             shouldShowReportExportButton: p => showReportExportButton,
             StartOverComponentFactory: {
                 getStartOverComponent: getStartOverComponentMock.object,
@@ -368,6 +374,7 @@ describe('DetailsViewCommandBar', () => {
         const props = getProps();
 
         setupSaveAssessmentButtonFactory(props);
+        setupTransferToAssessmentButtonFactory(props);
         setupStartOverButtonFactory(props);
         setupReportExportDialogFactory({ isOpen: false });
 
@@ -398,6 +405,15 @@ describe('DetailsViewCommandBar', () => {
     ): void {
         const argMatcher = isNil(expectedProps) ? It.isAny() : It.isObjectWith(expectedProps);
         saveAssessmentButtonFactoryMock.setup(r => r(argMatcher)).returns(() => saveAssessmentStub);
+    }
+
+    function setupTransferToAssessmentButtonFactory(
+        expectedProps?: Partial<TransferToAssessmentButtonProps>,
+    ): void {
+        const argMatcher = isNil(expectedProps) ? It.isAny() : It.isObjectWith(expectedProps);
+        transferToAssessmentButtonFactoryMock
+            .setup(r => r(argMatcher))
+            .returns(() => transferToAssessmentStub);
     }
 
     function setupStartOverButtonFactory(props: CommandBarProps): void {

--- a/src/tests/unit/tests/DetailsView/components/transfer-to-assessment-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/transfer-to-assessment-button.test.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
+import {
+    getTransferToAssessmentButton,
+    TransferToAssessmentButton,
+    TransferToAssessmentButtonProps,
+} from 'DetailsView/components/transfer-to-assessment-button';
+import { DataTransferViewController } from 'DetailsView/data-transfer-view-controller';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { IMock, Mock } from 'typemoq';
+
+describe('TransferToAssessmentButton', () => {
+    let dataTransferViewControllerMock: IMock<DataTransferViewController>;
+    let props: TransferToAssessmentButtonProps;
+
+    beforeEach(() => {
+        dataTransferViewControllerMock = Mock.ofType(DataTransferViewController);
+        props = {
+            deps: {
+                dataTransferViewController: dataTransferViewControllerMock.object,
+            },
+        };
+    });
+
+    test('render', () => {
+        const testSubject = shallow(<TransferToAssessmentButton {...props} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+        expect(testSubject.find(InsightsCommandButton).prop('onClick')).toEqual(
+            dataTransferViewControllerMock.object.showQuickAssessToAssessmentConfirmDialog,
+        );
+    });
+
+    test('getTransferToAssessmentButton', () => {
+        const testSubject = getTransferToAssessmentButton(props);
+        expect(testSubject).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/common/components/__snapshots__/null-component.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/null-component.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getNullComponent it returns NullComponent 1`] = `<NullComponent />`;

--- a/src/tests/unit/tests/common/components/__snapshots__/null-component.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/null-component.test.tsx.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`getNullComponent it returns NullComponent 1`] = `<NullComponent />`;

--- a/src/tests/unit/tests/common/components/null-component.test.tsx
+++ b/src/tests/unit/tests/common/components/null-component.test.tsx
@@ -11,7 +11,7 @@ describe('NullComponent', () => {
 });
 
 describe('getNullComponent', () => {
-    test('it returns NullComponent', () => {
-        expect(getNullComponent()).toMatchSnapshot();
+    test('it returns null', () => {
+        expect(getNullComponent()).toBeNull();
     });
 });

--- a/src/tests/unit/tests/common/components/null-component.test.tsx
+++ b/src/tests/unit/tests/common/components/null-component.test.tsx
@@ -1,11 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { NullComponent } from 'common/components/null-component';
+import { getNullComponent, NullComponent } from 'common/components/null-component';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('NullComponent', () => {
     test('it returns null', () => {
         expect(shallow(<NullComponent />).getElement()).toBeNull();
+    });
+});
+
+describe('getNullComponent', () => {
+    test('it returns NullComponent', () => {
+        expect(getNullComponent()).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Details

Adds the transfer to assessment button for the command bar, in quick assess.

##### Motivation

Feature work.

##### Context

Screenshot:
![image](https://user-images.githubusercontent.com/32555133/211913379-317befd3-475c-4bad-a30e-3332a0523573.png)
High-contrast screenshot:
![image](https://user-images.githubusercontent.com/32555133/211913499-7e31e1ec-f691-4078-981a-462c150e54dc.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
