### PR TITLE
feat(medium-pass-2): add text to clarify failure instance action

### DIFF
--- a/src/DetailsView/components/manual-test-step-view.tsx
+++ b/src/DetailsView/components/manual-test-step-view.tsx
@@ -70,6 +70,7 @@ export class ManualTestStepView extends React.Component<ManualTestStepViewProps>
         return (
             <React.Fragment>
                 <h3 className="test-step-instances-header">Instances</h3>
+                <p>At least one failure instance is required to mark the requirement as failed.</p>
                 <FailureInstancePanelControl
                     step={this.props.step}
                     test={this.props.test}

--- a/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
@@ -129,6 +129,10 @@ describe('ManualTestStepView', () => {
                 <div className="manual-test-step-table-container">
                     <React.Fragment>
                         <h3 className="test-step-instances-header">Instances</h3>
+                        <p>
+                            At least one failure instance is required to mark the requirement as
+                            failed.
+                        </p>
                         <FailureInstancePanelControl
                             step={props.step}
                             test={props.test}


### PR DESCRIPTION
#### Details

This PR adds text to the manual test requirement view to clarify that a failure instance is needed to count the requirement as failed.

![screenshot of requirement failure with new text](https://user-images.githubusercontent.com/3230904/212401749-24101006-6da5-4242-a363-8554b207c8b9.png)

##### Motivation

feature work 🚀 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
