### PR TITLE
feat(medium-pass-2): Quick Assess icon and blurb

### DIFF
--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -70,10 +70,10 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
         };
         const mediumPassConfig = {
             key: DetailsViewPivotType.mediumPass,
-            text: 'MediumPass',
-            title: 'MediumPass',
+            text: 'Quick Assess',
+            title: 'Quick Assess',
             data: {
-                icon: '',
+                icon: 'SiteScan',
             },
         };
         const assessmentConfig = {

--- a/src/popup/launch-pad-row-configuration-factory.ts
+++ b/src/popup/launch-pad-row-configuration-factory.ts
@@ -40,7 +40,7 @@ export class LaunchPadRowConfigurationFactory {
         const mediumPassRowConfig = {
             iconName: 'SiteScan',
             title: 'Quick Assess',
-            description: 'MUST BE REPLACED',
+            description: 'Run 10 assisted checks to find more accessibility issues in 30 minutes.',
             onClickTitle: event =>
                 actionMessageCreator.openDetailsView(
                     event,

--- a/src/popup/launch-pad-row-configuration-factory.ts
+++ b/src/popup/launch-pad-row-configuration-factory.ts
@@ -38,9 +38,9 @@ export class LaunchPadRowConfigurationFactory {
             onClickTitle: () => handler.openAdhocToolsPanel(component),
         };
         const mediumPassRowConfig = {
-            iconName: '',
-            title: 'MediumPass',
-            description: 'MediumPass tag line goes here',
+            iconName: 'SiteScan',
+            title: 'Quick Assess',
+            description: 'MUST BE REPLACED',
             onClickTitle: event =>
                 actionMessageCreator.openDetailsView(
                     event,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
@@ -33,11 +33,11 @@ exports[`Switcher props dropdown has correct options when medium pass feature fl
   },
   {
     "data": {
-      "icon": "",
+      "icon": "SiteScan",
     },
     "key": 3,
-    "text": "MediumPass",
-    "title": "MediumPass",
+    "text": "Quick Assess",
+    "title": "Quick Assess",
   },
   {
     "data": {

--- a/src/tests/unit/tests/popup/launch-pad-row-configuration-factory.test.ts
+++ b/src/tests/unit/tests/popup/launch-pad-row-configuration-factory.test.ts
@@ -40,9 +40,9 @@ describe('LaunchPadRowConfigurationFactoryTests', () => {
     };
 
     const mediumPassRowConfig = {
-        iconName: '',
-        title: 'MediumPass',
-        description: 'MediumPass tag line goes here',
+        iconName: 'SiteScan',
+        title: 'Quick Assess',
+        description: 'Run 10 assisted checks to find more accessibility issues in 30 minutes.',
         onClickTitle: null,
     };
 


### PR DESCRIPTION
#### Details

This PR updates the icon shown for Quick Assess in the launch pad and details view pivot. It also adds the Quick Assess blurb text to the launch pad.

Launch Pad:
<img width="302" alt="screenshot of launch pad showing Quick Assess with correct icon and blurb" src="https://user-images.githubusercontent.com/3230904/212946067-9a1b64e1-a0e8-448f-9256-09cfc26fad2d.png">

Pivot:
![screenshot of details view pivot with quick assess selected](https://user-images.githubusercontent.com/3230904/212945971-39588854-ebdd-4eda-911d-31b3b2b95780.png)


##### Motivation

feature work 🚀 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
