### PR TITLE
chore: fix CSS sourcemaps not being copied correctly in dev builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -362,7 +362,7 @@ module.exports = function (grunt) {
                     files: [
                         {
                             cwd: path.resolve(extensionPath, bundleFolder),
-                            src: ['*.js', '*.js.map', '*.css'],
+                            src: ['*.js', '*.js.map', '*.css', '*.css.map'],
                             dest: path.resolve(dropExtensionPath, 'bundle'),
                             expand: true,
                         },


### PR DESCRIPTION
#### Details

This PR addresses an issue where ESBuild produced CSS sourcemaps (previously, our webpack setup did not), but our Grunt rules were never updated to copy the new CSS sourcemap files from their intermediate build location in `/extension/devBundle/*.css.map` to their final location in `/drop/extension/dev/bundle/*.css.map`.

This PR updates the webpack copy rule to copy the CSS sourcemaps where they exist, similar to how we handle JS sourcemaps already.

##### Motivation

* Improves debugability of CSS modules
* Fixes warning spew in the console of dev builds of the form `DevTools failed to load source map: Could not load content for chrome-extension://iifodackleggfpjdngdlihpflphibdak/bundle/injected.css.map: System error: net::ERR_FILE_NOT_FOUND`

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
