### PR TITLE
fix: avoid trying to start scan twice due to injectionState confusion

### DIFF
--- a/src/injected/analyzer-state-update-handler.ts
+++ b/src/injected/analyzer-state-update-handler.ts
@@ -71,10 +71,11 @@ export class AnalyzerStateUpdateHandler {
         prevState: VisualizationStoreData,
         currState: VisualizationStoreData,
     ): void {
-        if (
-            currState.scanning != null &&
-            currState.injectingState !== InjectingState.injectingRequested
-        ) {
+        const injectingInProgress =
+            currState.injectingState === InjectingState.injectingRequested ||
+            currState.injectingState === InjectingState.injectingStarted;
+
+        if (currState.scanning != null && !injectingInProgress) {
             if (
                 prevState == null ||
                 prevState.scanning !== currState.scanning ||


### PR DESCRIPTION
#### Details

This PR fixes an issue introduced by #6183 where most events that trigger an axe-core scan will accidentally trigger the scan to start twice instead of once. This causes a few problems:

* It creates a race condition - in pages with iframes, the first scan can begin concurrently with our scripts being injected into child frames, so it can result in spurious `frame-tested` failures
* It creates console error spew of the form `failed to scan with error - Axe is already running. Use `await axe.run()` to wait for the previous run to finish before starting a new run.`

The root cause lies in the `analyzer-state-update-handler` component that was updated as part of that PR. That PR changed how we track whether injecting our scripts into the target page's frames is complete from a series of boolean variables to a single state variable. However, when this component was updated to read the new state variable instead of the old booleans, the update was incomplete; the component is intended to allow scans to start only when there is no ongoing injection (ie, either the `injectingRequested` or `injectingStarted` states), but the update mistakenly only prevents scans in the `injectingRequested` state and allowed them to start in the `injectingStarted` state. This was an easy mistake to make - the old code before #6183 just checked for `injectingRequested !== true`, which actually encompassed both of those states (the confusing naming is why we changed to a state variable in the first place).

##### Motivation

Fix race condition and error spew

##### Context

see #6183

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
