### PR TITLE
fix(medium-pass-2): fix high contrast colors for section resources

### DIFF
--- a/src/DetailsView/components/requirement-context-section.scss
+++ b/src/DetailsView/components/requirement-context-section.scss
@@ -22,22 +22,28 @@
     margin-inline-end: 0;
 }
 
-.context-links :global(.ms-Button),
-.context-links :global(.insights-link) {
+.context-links > * {
     padding-left: 0;
     padding-top: 5px;
     padding-bottom: 5px;
     font-family: $font-family;
     line-height: 20px;
     font-size: 15px;
-    color: $communication-primary;
-
-    &:hover {
-        text-decoration: none;
-        color: $link-hover;
-    }
 
     :global(.ms-Button-label) {
         margin-left: 0 !important;
+        color: $link;
+
+        &:hover {
+            color: $link-hover;
+        }
+
+        @media screen and (forced-colors: active) {
+            color: linktext;
+
+            &:hover {
+                color: linktext;
+            }
+        }
     }
 }


### PR DESCRIPTION
#### Details

This PR fixes the color for the info and examples button (styled to look like a link) when using the high contrast theme and windows high contrast.

Mode | Before | After |
-------|--------|--------|
High Contrast Theme | ![helpful resources showing blue info and examples and yellow other links](https://user-images.githubusercontent.com/3230904/213511376-7a99c186-a705-489f-92cc-fca416aecd6f.jpeg) | ![helpful resources showing yellow info and examples that matches other links](https://user-images.githubusercontent.com/3230904/213511434-012b003d-b469-4f06-bbd2-569fa6a6375e.jpeg)
Windows High Contrast | ![helpful resources showing yellow info and examples and purple other links](https://user-images.githubusercontent.com/3230904/213511563-963489cc-0327-4236-8189-7a13691aca82.jpeg) | ![helpful resources showing purple info and examples that matches other links](https://user-images.githubusercontent.com/3230904/213511576-d869f1a8-4b5e-4a40-bc13-caddc11b94eb.jpeg)

##### Motivation

feature work 🚀 

##### Context

This styling is based on the styling of the "help" gray box displayed on the Overview page. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
