### PR TITLE
fix: save assessment button high contrast styling

### DIFF
--- a/src/common/components/controls/insights-command-button.scss
+++ b/src/common/components/controls/insights-command-button.scss
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../../common/styles/colors.scss';
-@import '../../../common/styles/common.scss';
 
 .insights-command-button {
     .command-bar-button-icon {
@@ -21,11 +20,9 @@
             color: $primary-text;
         }
     }
-}
 
-// high contrast overrides to make a.insights-command-button
-// match button.insights-command-button
-a.insights-command-button {
+    // high contrast overrides to make a.insights-command-button
+    // match button.insights-command-button
     @media screen and (forced-colors: active) {
         color: buttontext;
 

--- a/src/common/components/controls/insights-command-button.scss
+++ b/src/common/components/controls/insights-command-button.scss
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../../common/styles/colors.scss';
+@import '../../../common/styles/common.scss';
 
-button.insights-command-button {
+.insights-command-button {
     .command-bar-button-icon {
         line-height: 16px;
     }
@@ -18,6 +19,24 @@ button.insights-command-button {
     &:active:not(:disabled) {
         .command-bar-button-icon {
             color: $primary-text;
+        }
+    }
+}
+
+// high contrast overrides to make a.insights-command-button
+// match button.insights-command-button
+a.insights-command-button {
+    @media screen and (forced-colors: active) {
+        color: buttontext;
+
+        .command-bar-button-icon {
+            color: buttontext;
+        }
+
+        &:hover {
+            .command-bar-button-icon {
+                color: buttontext;
+            }
         }
     }
 }


### PR DESCRIPTION
#### Details

The "Save Assessment" button is a different color than the rest of the command bar buttons when using Windows high contrast themes. This PR fixes the styling to be consistent.

 State | Before | After|
-------|--------|-------------|
Default | ![Screenshot showing command bar buttons in white and save assessment in light blue](https://user-images.githubusercontent.com/3230904/213556539-7c3af2d5-e7aa-4a7d-821b-4d60b0122484.jpeg) | ![screenshot showing all command bar buttons in white](https://user-images.githubusercontent.com/3230904/213556727-307a34b4-4829-4cba-8df7-8aba90f95aba.jpeg)
Hover | ![Screenshot showing command bar buttons in white and save assessment in light blue](https://user-images.githubusercontent.com/3230904/213556539-7c3af2d5-e7aa-4a7d-821b-4d60b0122484.jpeg) | ![screenshot showing all command bar buttons in white and the save assessment text in light blue](https://user-images.githubusercontent.com/3230904/213556831-4b55190b-5aac-4c3e-8613-1f493f2e6ce9.jpeg)


##### Motivation

quick fix

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
