### PR TITLE
feat(medium-pass-2): Quick Assess menu fixes

### DIFF
--- a/src/DetailsView/components/command-bar-buttons-menu.tsx
+++ b/src/DetailsView/components/command-bar-buttons-menu.tsx
@@ -27,10 +27,12 @@ export const CommandBarButtonsMenu = NamedFC<CommandBarButtonsMenuProps>(
         const exportButton = props.renderExportReportButton();
         const overflowItems: IContextualMenuItem[] = [];
 
-        overflowItems.push({
-            key: 'export report',
-            onRender: () => <div role="menuitem">{exportButton}</div>,
-        });
+        if (exportButton != null) {
+            overflowItems.push({
+                key: 'export report',
+                onRender: () => <div role="menuitem">{exportButton}</div>,
+            });
+        }
         if (props.saveAssessmentButton && props.loadAssessmentButton) {
             overflowItems.push(
                 {

--- a/src/common/components/expand-collapse-left-nav-hamburger-button.tsx
+++ b/src/common/components/expand-collapse-left-nav-hamburger-button.tsx
@@ -29,7 +29,7 @@ export const AssessmentLeftNavHamburgerButton = NamedFC<ExpandCollpaseLeftNavBut
 export const QuickAssessLeftNavHamburgerButton = NamedFC<ExpandCollpaseLeftNavButtonProps>(
     'QuickAssessLeftNavHamburgerButton',
     props => {
-        const ariaLabel: string = 'QuickAssess - all tests and requirements list';
+        const ariaLabel: string = 'Quick Assess - all tests and requirements list';
         return (
             <LeftNavHamburgerButton
                 ariaLabel={ariaLabel}

--- a/src/common/components/hamburger-menu-button.tsx
+++ b/src/common/components/hamburger-menu-button.tsx
@@ -10,6 +10,8 @@ import { LaunchPanelHeader } from 'popup/components/launch-panel-header';
 import { LaunchPanelHeaderClickHandler } from 'popup/handlers/launch-panel-header-click-handler';
 import * as React from 'react';
 import styles from './hamburger-menu-button.scss';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { FeatureFlags } from 'common/feature-flags';
 
 const telemetryEventSource = TelemetryEventSource.HamburgerMenu;
 
@@ -22,51 +24,69 @@ export type HamburgerMenuButtonProps = {
     deps: HamburgerMenuButtonDeps;
     popupWindow: Window;
     header: LaunchPanelHeader;
+    featureFlagData: FeatureFlagStoreData;
 };
 
 export const HamburgerMenuButton = NamedFC<HamburgerMenuButtonProps>(
     'HamburgerMenuButton',
     props => {
-        const { deps, header, popupWindow } = props;
+        const { deps, header, popupWindow, featureFlagData } = props;
         const { launchPanelHeaderClickHandler, popupActionMessageCreator } = deps;
+        const fastPassMenuItem = {
+            key: 'fast-pass',
+            iconProps: {
+                iconName: 'Rocket',
+            },
+            onClick: event =>
+                popupActionMessageCreator.openDetailsView(
+                    event,
+                    VisualizationType.Issues,
+                    telemetryEventSource,
+                    DetailsViewPivotType.fastPass,
+                ),
+            name: 'FastPass',
+        };
+        const assessmentMenuItem = {
+            key: 'assessment',
+            iconProps: {
+                iconName: 'testBeakerSolid',
+            },
+            onClick: event =>
+                popupActionMessageCreator.openDetailsView(
+                    event,
+                    null,
+                    telemetryEventSource,
+                    DetailsViewPivotType.assessment,
+                ),
+            name: 'Assessment',
+        };
+        const quickAssessMenuItem = {
+            key: 'quick-assess',
+            iconProps: {
+                iconName: 'SiteScan',
+            },
+            onClick: event =>
+                popupActionMessageCreator.openDetailsView(
+                    event,
+                    null,
+                    telemetryEventSource,
+                    DetailsViewPivotType.quickAssess,
+                ),
+            name: 'Quick Assess',
+        };
+        const adhocToolsMenuItem = {
+            key: 'ad-hoc-tools',
+            iconProps: {
+                iconName: 'Medical',
+            },
+            name: 'Ad hoc tools',
+            onClick: () => launchPanelHeaderClickHandler.openAdhocToolsPanel(header),
+        };
+        const productMenuItems = featureFlagData[FeatureFlags.quickAssess]
+            ? [fastPassMenuItem, quickAssessMenuItem, assessmentMenuItem, adhocToolsMenuItem]
+            : [fastPassMenuItem, assessmentMenuItem, adhocToolsMenuItem];
 
-        const getMenuItems = (): IContextualMenuItem[] => [
-            {
-                key: 'fast-pass',
-                iconProps: {
-                    iconName: 'Rocket',
-                },
-                onClick: event =>
-                    popupActionMessageCreator.openDetailsView(
-                        event,
-                        VisualizationType.Issues,
-                        telemetryEventSource,
-                        DetailsViewPivotType.fastPass,
-                    ),
-                name: 'FastPass',
-            },
-            {
-                key: 'assessment',
-                iconProps: {
-                    iconName: 'testBeakerSolid',
-                },
-                onClick: event =>
-                    popupActionMessageCreator.openDetailsView(
-                        event,
-                        null,
-                        telemetryEventSource,
-                        DetailsViewPivotType.assessment,
-                    ),
-                name: 'Assessment',
-            },
-            {
-                key: 'ad-hoc-tools',
-                iconProps: {
-                    iconName: 'Medical',
-                },
-                name: 'Ad hoc tools',
-                onClick: () => launchPanelHeaderClickHandler.openAdhocToolsPanel(header),
-            },
+        const resourceMenuItems: IContextualMenuItem[] = [
             {
                 key: 'divider_1',
                 itemType: ContextualMenuItemType.Divider,
@@ -100,6 +120,9 @@ export const HamburgerMenuButton = NamedFC<HamburgerMenuButtonProps>(
                 name: 'Help',
             },
         ];
+
+        const getMenuItems = (): IContextualMenuItem[] =>
+            [...productMenuItems, ...resourceMenuItems] as IContextualMenuItem[];
 
         return (
             <IconButton

--- a/src/common/components/hamburger-menu-button.tsx
+++ b/src/common/components/hamburger-menu-button.tsx
@@ -2,16 +2,16 @@
 // Licensed under the MIT License.
 import { ContextualMenuItemType, IconButton, IContextualMenuItem } from '@fluentui/react';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
+import { FeatureFlags } from 'common/feature-flags';
 import { NamedFC } from 'common/react/named-fc';
 import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-creator';
 import { LaunchPanelHeader } from 'popup/components/launch-panel-header';
 import { LaunchPanelHeaderClickHandler } from 'popup/handlers/launch-panel-header-click-handler';
 import * as React from 'react';
 import styles from './hamburger-menu-button.scss';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { FeatureFlags } from 'common/feature-flags';
 
 const telemetryEventSource = TelemetryEventSource.HamburgerMenu;
 

--- a/src/popup/components/launch-panel-header.tsx
+++ b/src/popup/components/launch-panel-header.tsx
@@ -71,6 +71,7 @@ export class LaunchPanelHeader extends React.Component<
                     deps={this.props.deps}
                     popupWindow={this.props.popupWindow}
                     header={this}
+                    featureFlagData={featureFlags}
                 />
             </>
         );

--- a/src/tests/end-to-end/tests/popup/__snapshots__/hamburger-menu.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/hamburger-menu.test.ts.snap
@@ -1,6 +1,219 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Popup -> Hamburger menu should have content matching snapshot 1`] = `
+exports[`Popup -> Hamburger menu should have content matching snapshot when quickAssess feature flag is false 1`] = `
+<DocumentFragment>
+  <div
+    class="ms-ContextualMenu-container container-000"
+    id="id__000-menu"
+    role="menu"
+    tabindex="0"
+  >
+    <div
+      class="ms-FocusZone css-000 ms-ContextualMenu is-open ms-BaseButton-menuhost root-000"
+      data-focuszone-id="FocusZone000"
+    >
+      <ul
+        class="ms-ContextualMenu-list is-open list-000"
+        role="presentation"
+      >
+        <li
+          class="ms-ContextualMenu-item item-000"
+          role="presentation"
+        >
+          <button
+            aria-disabled="false"
+            aria-posinset="1"
+            aria-setsize="6"
+            class="ms-ContextualMenu-link root-000"
+            name="FastPass"
+            role="menuitem"
+            tabindex="0"
+          >
+            <div
+              class="ms-ContextualMenu-linkContent linkContent-000"
+            >
+              <i
+                aria-hidden="true"
+                class="ms-ContextualMenu-icon icon-000"
+                data-icon-name="Rocket"
+              >
+                
+              </i>
+              <span
+                class="ms-ContextualMenu-itemText label-000"
+              >
+                FastPass
+              </span>
+            </div>
+          </button>
+        </li>
+        <li
+          class="ms-ContextualMenu-item item-000"
+          role="presentation"
+        >
+          <button
+            aria-disabled="false"
+            aria-posinset="2"
+            aria-setsize="6"
+            class="ms-ContextualMenu-link root-000"
+            name="Assessment"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <div
+              class="ms-ContextualMenu-linkContent linkContent-000"
+            >
+              <i
+                aria-hidden="true"
+                class="ms-ContextualMenu-icon icon-000"
+                data-icon-name="testBeakerSolid"
+              >
+                
+              </i>
+              <span
+                class="ms-ContextualMenu-itemText label-000"
+              >
+                Assessment
+              </span>
+            </div>
+          </button>
+        </li>
+        <li
+          class="ms-ContextualMenu-item item-000"
+          role="presentation"
+        >
+          <button
+            aria-disabled="false"
+            aria-posinset="3"
+            aria-setsize="6"
+            class="ms-ContextualMenu-link root-000"
+            name="Ad hoc tools"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <div
+              class="ms-ContextualMenu-linkContent linkContent-000"
+            >
+              <i
+                aria-hidden="true"
+                class="ms-ContextualMenu-icon icon-000"
+                data-icon-name="Medical"
+              >
+                
+              </i>
+              <span
+                class="ms-ContextualMenu-itemText label-000"
+              >
+                Ad hoc tools
+              </span>
+            </div>
+          </button>
+        </li>
+        <li
+          aria-hidden="true"
+          class="ms-ContextualMenu-divider divider-000"
+          role="separator"
+        />
+        <li
+          class="ms-ContextualMenu-item item-000"
+          role="presentation"
+        >
+          <button
+            aria-disabled="false"
+            aria-posinset="4"
+            aria-setsize="6"
+            class="ms-ContextualMenu-link root-000"
+            name="Keyboard shortcuts"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <div
+              class="ms-ContextualMenu-linkContent linkContent-000"
+            >
+              <i
+                aria-hidden="true"
+                class="ms-ContextualMenu-icon icon-000"
+                data-icon-name="KeyboardClassic"
+              >
+                
+              </i>
+              <span
+                class="ms-ContextualMenu-itemText label-000"
+              >
+                Keyboard shortcuts
+              </span>
+            </div>
+          </button>
+        </li>
+        <li
+          class="ms-ContextualMenu-item item-000"
+          role="presentation"
+        >
+          <button
+            aria-disabled="false"
+            aria-posinset="5"
+            aria-setsize="6"
+            class="ms-ContextualMenu-link root-000"
+            name="Third party notices"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <div
+              class="ms-ContextualMenu-linkContent linkContent-000"
+            >
+              <i
+                aria-hidden="true"
+                class="ms-ContextualMenu-icon icon-000"
+                data-icon-name="TextDocument"
+              >
+                
+              </i>
+              <span
+                class="ms-ContextualMenu-itemText label-000"
+              >
+                Third party notices
+              </span>
+            </div>
+          </button>
+        </li>
+        <li
+          class="ms-ContextualMenu-item item-000"
+          role="presentation"
+        >
+          <button
+            aria-disabled="false"
+            aria-posinset="6"
+            aria-setsize="6"
+            class="ms-ContextualMenu-link root-000"
+            name="Help"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <div
+              class="ms-ContextualMenu-linkContent linkContent-000"
+            >
+              <i
+                aria-hidden="true"
+                class="ms-ContextualMenu-icon icon-000"
+                data-icon-name="Unknown"
+              >
+                
+              </i>
+              <span
+                class="ms-ContextualMenu-itemText label-000"
+              >
+                Help
+              </span>
+            </div>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Popup -> Hamburger menu should have content matching snapshot when quickAssess feature flag is true 1`] = `
 <DocumentFragment>
   <div
     class="ms-ContextualMenu-container container-000"
@@ -56,6 +269,36 @@ exports[`Popup -> Hamburger menu should have content matching snapshot 1`] = `
             aria-posinset="2"
             aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
+            name="Quick Assess"
+            role="menuitem"
+          >
+            <div
+              class="ms-ContextualMenu-linkContent linkContent-000"
+            >
+              <i
+                aria-hidden="true"
+                class="ms-ContextualMenu-icon icon-000"
+                data-icon-name="SiteScan"
+              >
+                
+              </i>
+              <span
+                class="ms-ContextualMenu-itemText label-000"
+              >
+                Quick Assess
+              </span>
+            </div>
+          </button>
+        </li>
+        <li
+          class="ms-ContextualMenu-item item-000"
+          role="presentation"
+        >
+          <button
+            aria-disabled="false"
+            aria-posinset="3"
+            aria-setsize="7"
+            class="ms-ContextualMenu-link root-000"
             name="Assessment"
             role="menuitem"
             tabindex="-1"
@@ -74,37 +317,6 @@ exports[`Popup -> Hamburger menu should have content matching snapshot 1`] = `
                 class="ms-ContextualMenu-itemText label-000"
               >
                 Assessment
-              </span>
-            </div>
-          </button>
-        </li>
-        <li
-          class="ms-ContextualMenu-item item-000"
-          role="presentation"
-        >
-          <button
-            aria-disabled="false"
-            aria-posinset="3"
-            aria-setsize="7"
-            class="ms-ContextualMenu-link root-000"
-            name="Quick Assess"
-            role="menuitem"
-            tabindex="-1"
-          >
-            <div
-              class="ms-ContextualMenu-linkContent linkContent-000"
-            >
-              <i
-                aria-hidden="true"
-                class="ms-ContextualMenu-icon icon-000"
-                data-icon-name="SiteScan"
-              >
-                
-              </i>
-              <span
-                class="ms-ContextualMenu-itemText label-000"
-              >
-                Quick Assess
               </span>
             </div>
           </button>

--- a/src/tests/end-to-end/tests/popup/__snapshots__/hamburger-menu.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/hamburger-menu.test.ts.snap
@@ -23,7 +23,7 @@ exports[`Popup -> Hamburger menu should have content matching snapshot 1`] = `
           <button
             aria-disabled="false"
             aria-posinset="1"
-            aria-setsize="6"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="FastPass"
             role="menuitem"
@@ -54,7 +54,7 @@ exports[`Popup -> Hamburger menu should have content matching snapshot 1`] = `
           <button
             aria-disabled="false"
             aria-posinset="2"
-            aria-setsize="6"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="Assessment"
             role="menuitem"
@@ -85,7 +85,38 @@ exports[`Popup -> Hamburger menu should have content matching snapshot 1`] = `
           <button
             aria-disabled="false"
             aria-posinset="3"
-            aria-setsize="6"
+            aria-setsize="7"
+            class="ms-ContextualMenu-link root-000"
+            name="Quick Assess"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <div
+              class="ms-ContextualMenu-linkContent linkContent-000"
+            >
+              <i
+                aria-hidden="true"
+                class="ms-ContextualMenu-icon icon-000"
+                data-icon-name="SiteScan"
+              >
+                
+              </i>
+              <span
+                class="ms-ContextualMenu-itemText label-000"
+              >
+                Quick Assess
+              </span>
+            </div>
+          </button>
+        </li>
+        <li
+          class="ms-ContextualMenu-item item-000"
+          role="presentation"
+        >
+          <button
+            aria-disabled="false"
+            aria-posinset="4"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="Ad hoc tools"
             role="menuitem"
@@ -120,8 +151,8 @@ exports[`Popup -> Hamburger menu should have content matching snapshot 1`] = `
         >
           <button
             aria-disabled="false"
-            aria-posinset="4"
-            aria-setsize="6"
+            aria-posinset="5"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="Keyboard shortcuts"
             role="menuitem"
@@ -151,8 +182,8 @@ exports[`Popup -> Hamburger menu should have content matching snapshot 1`] = `
         >
           <button
             aria-disabled="false"
-            aria-posinset="5"
-            aria-setsize="6"
+            aria-posinset="6"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="Third party notices"
             role="menuitem"
@@ -182,8 +213,8 @@ exports[`Popup -> Hamburger menu should have content matching snapshot 1`] = `
         >
           <button
             aria-disabled="false"
-            aria-posinset="6"
-            aria-setsize="6"
+            aria-posinset="7"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="Help"
             role="menuitem"

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Popup -> Launch Pad content should match snapshot 1`] = `
+exports[`Popup -> Launch Pad content should match snapshot when quick assess feature flag is false 1`] = `
 <DocumentFragment>
   <div
     class="ms-Fabric launch-panel"
@@ -199,6 +199,304 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
                   >
                     <button
                       aria-describedby="launch-pad-item-description-3"
+                      class="ms-Link insights-link root-000"
+                      id="ad-hoc-tools"
+                      role="link"
+                      type="button"
+                    >
+                      Ad hoc tools
+                    </button>
+                  </div>
+                  <div
+                    class="launch-pad-item-description"
+                    id="launch-pad-item-description-000"
+                  >
+                    Get quick access to visualizations that help you identify accessibility issues.
+                  </div>
+                </div>
+              </div>
+              <hr
+                class="ms-fontColor-neutralTertiaryAlt launch-pad-hr"
+              />
+            </div>
+          </div>
+        </main>
+        <div
+          class="launch-pad-footer"
+          role="complementary"
+        >
+          <div>
+            Version 1.0.4 | Powered by 
+            <div
+              class="ms-TooltipHost insights-tooltip-host--{{CSS_MODULE_HASH}} root-000"
+              role="none"
+            >
+              <a
+                aria-label="Navigate to axe-core npm page"
+                class="ms-Link insights-link insights-link--{{CSS_MODULE_HASH}} root-000"
+                href="https://www.npmjs.com/package/axe-core"
+                target="_blank"
+              >
+                axe-core
+              </a>
+              <div
+                hidden=""
+                id="tooltip000"
+                style="position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0px; border: 0px; overflow: hidden; white-space: nowrap;"
+              >
+                Navigate to axe-core npm page
+              </div>
+            </div>
+             4.4.1
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Popup -> Launch Pad content should match snapshot when quick assess feature flag is true 1`] = `
+<DocumentFragment>
+  <div
+    class="ms-Fabric launch-panel"
+    id="new-launch-pad"
+  >
+    <header
+      class="launch-panel-header--{{CSS_MODULE_HASH}}"
+    >
+      <h1
+        class="title--{{CSS_MODULE_HASH}}"
+      >
+        Accessibility Insights for Web
+      </h1>
+      <div
+        class="children--{{CSS_MODULE_HASH}}"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="manage settings"
+          class="ms-Button ms-Button--icon ms-Button--hasMenu gear-menu-button--{{CSS_MODULE_HASH}} root-000"
+          data-is-focusable="true"
+          type="button"
+        >
+          <span
+            class="ms-Button-flexContainer flexContainer-000"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden="true"
+              class="ms-Icon root-000 css-000 ms-Button-icon icon-000"
+              data-icon-name="Gear"
+              style="font-family: FabricMDL2Icons;"
+            >
+              
+            </i>
+          </span>
+        </button>
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="help menu"
+          class="ms-Button ms-Button--icon ms-Button--hasMenu hamburger-menu-button--{{CSS_MODULE_HASH}} root-000"
+          data-is-focusable="true"
+          type="button"
+        >
+          <span
+            class="ms-Button-flexContainer flexContainer-000"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden="true"
+              class="ms-Icon root-000 css-000 ms-Button-icon icon-000"
+              data-icon-name="GlobalNavButton"
+              style="font-family: FabricMDL2Icons;"
+            >
+              
+            </i>
+          </span>
+        </button>
+      </div>
+      <div
+        class="subtitle--{{CSS_MODULE_HASH}}"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://go.microsoft.com/fwlink/?linkid=2082374"
+          target="_blank"
+        >
+          Watch 3-minute video introduction
+        </a>
+         
+      </div>
+    </header>
+    <div
+      class="main-section"
+    >
+      <div
+        class="popup-grid"
+      >
+        <main>
+          <h2
+            class="launch-pad-title ms-fontWeight-semibold"
+          >
+            Launch pad
+          </h2>
+          <hr
+            class="ms-fontColor-neutralTertiaryAlt launch-pad-hr"
+          />
+          <div
+            class="launch-pad-main-section"
+          >
+            <div>
+              <div
+                class="launch-pad-item-grid"
+              >
+                <div
+                  aria-hidden="true"
+                  class="popup-start-dialog-icon-circle"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="popup-start-dialog-icon root-000"
+                    data-icon-name="Rocket"
+                  >
+                    
+                  </i>
+                </div>
+                <div>
+                  <div
+                    class="launch-pad-item-title"
+                  >
+                    <button
+                      aria-describedby="launch-pad-item-description-1"
+                      class="ms-Link insights-link root-000"
+                      id="fast-pass"
+                      role="link"
+                      type="button"
+                    >
+                      FastPass
+                    </button>
+                  </div>
+                  <div
+                    class="launch-pad-item-description"
+                    id="launch-pad-item-description-000"
+                  >
+                    Run three tests to find the most common accessibility issues in less than 5 minutes.
+                  </div>
+                </div>
+              </div>
+              <hr
+                class="ms-fontColor-neutralTertiaryAlt launch-pad-hr"
+              />
+            </div>
+            <div>
+              <div
+                class="launch-pad-item-grid"
+              >
+                <div
+                  aria-hidden="true"
+                  class="popup-start-dialog-icon-circle"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="popup-start-dialog-icon root-000"
+                    data-icon-name="SiteScan"
+                  >
+                    
+                  </i>
+                </div>
+                <div>
+                  <div
+                    class="launch-pad-item-title"
+                  >
+                    <button
+                      aria-describedby="launch-pad-item-description-2"
+                      class="ms-Link insights-link root-000"
+                      id="quick-assess"
+                      role="link"
+                      type="button"
+                    >
+                      Quick Assess
+                    </button>
+                  </div>
+                  <div
+                    class="launch-pad-item-description"
+                    id="launch-pad-item-description-000"
+                  >
+                    Run 10 assisted checks to find more accessibility issues in 30 minutes.
+                  </div>
+                </div>
+              </div>
+              <hr
+                class="ms-fontColor-neutralTertiaryAlt launch-pad-hr"
+              />
+            </div>
+            <div>
+              <div
+                class="launch-pad-item-grid"
+              >
+                <div
+                  aria-hidden="true"
+                  class="popup-start-dialog-icon-circle"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="popup-start-dialog-icon root-000"
+                    data-icon-name="testBeaker"
+                  >
+                    
+                  </i>
+                </div>
+                <div>
+                  <div
+                    class="launch-pad-item-title"
+                  >
+                    <button
+                      aria-describedby="launch-pad-item-description-3"
+                      class="ms-Link insights-link root-000"
+                      id="assessment"
+                      role="link"
+                      type="button"
+                    >
+                      Assessment
+                    </button>
+                  </div>
+                  <div
+                    class="launch-pad-item-description"
+                    id="launch-pad-item-description-000"
+                  >
+                    Walk through a guided process for assessing accessibility compliance.
+                  </div>
+                </div>
+              </div>
+              <hr
+                class="ms-fontColor-neutralTertiaryAlt launch-pad-hr"
+              />
+            </div>
+            <div>
+              <div
+                class="launch-pad-item-grid"
+              >
+                <div
+                  aria-hidden="true"
+                  class="popup-start-dialog-icon-circle"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="popup-start-dialog-icon root-000"
+                    data-icon-name="Medical"
+                  >
+                    
+                  </i>
+                </div>
+                <div>
+                  <div
+                    class="launch-pad-item-title"
+                  >
+                    <button
+                      aria-describedby="launch-pad-item-description-4"
                       class="ms-Link insights-link root-000"
                       id="ad-hoc-tools"
                       role="link"

--- a/src/tests/end-to-end/tests/popup/launchpad.test.ts
+++ b/src/tests/end-to-end/tests/popup/launchpad.test.ts
@@ -24,17 +24,35 @@ describe('Popup -> Launch Pad', () => {
         await browser?.close();
     });
 
-    it('content should match snapshot', async () => {
-        const element = await formatPageElementForSnapshot(
-            popupPage,
-            popupPageElementIdentifiers.launchPad,
-        );
-        expect(element).toMatchSnapshot();
-    });
-
     it.each([true, false])(
-        'should pass accessibility validation with highContrastMode=%s',
-        async highContrastMode => {
+        'content should match snapshot when quick assess feature flag is %s',
+        async quickAssessFeatureFlag => {
+            const backgroundPage = await browser.background();
+            quickAssessFeatureFlag === true
+                ? await backgroundPage.enableFeatureFlag('quickAssess')
+                : await backgroundPage.disableFeatureFlag('quickAssess');
+            const element = await formatPageElementForSnapshot(
+                popupPage,
+                popupPageElementIdentifiers.launchPad,
+            );
+            expect(element).toMatchSnapshot();
+        },
+    );
+
+    it.each`
+        highContrastMode | quickAssessFeatureFlag
+        ${true}          | ${false}
+        ${true}          | ${true}
+        ${false}         | ${true}
+        ${false}         | ${false}
+    `(
+        'should pass accessibility validation with highContrastMode=%s and quickAssessFeatureFlag=%s',
+        async ({ highContrastMode, quickAssessFeatureFlag }) => {
+            await browser.setHighContrastMode(highContrastMode);
+            const backgroundPage = await browser.background();
+            quickAssessFeatureFlag === true
+                ? await backgroundPage.enableFeatureFlag('quickAssess')
+                : await backgroundPage.disableFeatureFlag('quickAssess');
             await browser.setHighContrastMode(highContrastMode);
             await popupPage.waitForHighContrastMode(highContrastMode);
 

--- a/src/tests/end-to-end/tests/popup/launchpad.test.ts
+++ b/src/tests/end-to-end/tests/popup/launchpad.test.ts
@@ -48,7 +48,6 @@ describe('Popup -> Launch Pad', () => {
     `(
         'should pass accessibility validation with highContrastMode=%s and quickAssessFeatureFlag=%s',
         async ({ highContrastMode, quickAssessFeatureFlag }) => {
-            await browser.setHighContrastMode(highContrastMode);
             const backgroundPage = await browser.background();
             quickAssessFeatureFlag === true
                 ? await backgroundPage.enableFeatureFlag('quickAssess')

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bar-buttons-menu.test.tsx.snap
@@ -20,10 +20,6 @@ exports[`CommandBarButtonsMenu renders CommandBarButtonsMenu 1`] = `
         "className": "commandBarButtonsSubmenu",
         "items": [
           {
-            "key": "export report",
-            "onRender": [Function],
-          },
-          {
             "key": "save assessment",
             "onRender": [Function],
           },

--- a/src/tests/unit/tests/common/components/__snapshots__/expand-collapse-left-nav-hamburger-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/expand-collapse-left-nav-hamburger-button.test.tsx.snap
@@ -17,3 +17,12 @@ exports[`FastPassLeftNavHamburgerButton renders per snapshot 1`] = `
   setSideNavOpen={null}
 />
 `;
+
+exports[`QuickAssessLeftNavHamburgerButton renders per snapshot 1`] = `
+<LeftNavHamburgerButton
+  ariaLabel="Quick Assess - all tests and requirements list"
+  className="some-class"
+  isSideNavOpen={false}
+  setSideNavOpen={null}
+/>
+`;

--- a/src/tests/unit/tests/common/components/expand-collapse-left-nav-hamburger-button.test.tsx
+++ b/src/tests/unit/tests/common/components/expand-collapse-left-nav-hamburger-button.test.tsx
@@ -3,6 +3,7 @@
 import {
     AssessmentLeftNavHamburgerButton,
     FastPassLeftNavHamburgerButton,
+    QuickAssessLeftNavHamburgerButton,
 } from 'common/components/expand-collapse-left-nav-hamburger-button';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -11,6 +12,20 @@ describe('AssessmentLeftNavHamburgerButton', () => {
     it('renders per snapshot', () => {
         const wrapper = shallow(
             <AssessmentLeftNavHamburgerButton
+                isSideNavOpen={false}
+                setSideNavOpen={null}
+                className={'some-class'}
+            />,
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});
+
+describe('QuickAssessLeftNavHamburgerButton', () => {
+    it('renders per snapshot', () => {
+        const wrapper = shallow(
+            <QuickAssessLeftNavHamburgerButton
                 isSideNavOpen={false}
                 setSideNavOpen={null}
                 className={'some-class'}

--- a/src/tests/unit/tests/common/components/hamburger-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/hamburger-menu-button.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ContextualMenu, IButtonProps, IconButton } from '@fluentui/react';
+import { IButtonProps, IconButton } from '@fluentui/react';
 import {
     HamburgerMenuButton,
     HamburgerMenuButtonDeps,
@@ -8,7 +8,6 @@ import {
 } from 'common/components/hamburger-menu-button';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import { shallow } from 'enzyme';
 import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-creator';
@@ -71,7 +70,6 @@ describe('HamburgerMenuButton', () => {
         let launchPanelHeaderClickHandlerMock: IMock<LaunchPanelHeaderClickHandler>;
 
         let buttonProps: IButtonProps;
-        let featureFlagDataStub: FeatureFlagStoreData = { quickAssess: true };
 
         beforeEach(() => {
             popupActionMessageCreatorMock = Mock.ofType<PopupActionMessageCreator>();
@@ -84,7 +82,7 @@ describe('HamburgerMenuButton', () => {
                 },
                 header: headerMock.object,
                 popupWindow: popupWindowMock.object,
-                featureFlagData: featureFlagDataStub,
+                featureFlagData: { quickAssess: true },
             };
 
             const testObject = shallow(<HamburgerMenuButton {...props} />);

--- a/src/tests/unit/tests/popup/components/__snapshots__/launch-panel-header.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/launch-panel-header.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`LaunchPanelHeaderTest renders 1`] = `
           "popupActionMessageCreator": {},
         }
       }
+      featureFlagData={{}}
       header={
         LaunchPanelHeader {
           "context": {},
@@ -141,6 +142,7 @@ exports[`LaunchPanelHeaderTest renders 1`] = `
                         "popupActionMessageCreator": {},
                       }
                     }
+                    featureFlagData={{}}
                     header={[Circular]}
                     popupWindow={{}}
                   />

--- a/src/types/tab-stop-requirement-info.ts
+++ b/src/types/tab-stop-requirement-info.ts
@@ -11,7 +11,7 @@ export const TabStopRequirementIds = [
     'input-focus',
 ] as const;
 
-export type TabStopRequirementId = (typeof TabStopRequirementIds)[number];
+export type TabStopRequirementId = typeof TabStopRequirementIds[number];
 
 export type TabStopRequirementInfo = {
     [requirementId in TabStopRequirementId]: TabStopRequirementContent;

--- a/src/types/tab-stop-requirement-info.ts
+++ b/src/types/tab-stop-requirement-info.ts
@@ -11,7 +11,7 @@ export const TabStopRequirementIds = [
     'input-focus',
 ] as const;
 
-export type TabStopRequirementId = typeof TabStopRequirementIds[number];
+export type TabStopRequirementId = (typeof TabStopRequirementIds)[number];
 
 export type TabStopRequirementInfo = {
     [requirementId in TabStopRequirementId]: TabStopRequirementContent;


### PR DESCRIPTION
#### Details

This PR fixes:
* button label text in `QuickAssessLeftNavHamburgerButton` ("QuickAssess"--> "Quick Assess")
* a bug in `CommandBarButtonsMenu` where a menu item is still created for export even though the element is null, causing an `aria-command-name` a11y issue uncovered by e2e tests
* no item for Quick Assess in the launch panel hamburger button menu

<img width="302" alt="Screenshot of launchpad with hamburger menu open including a menu item for quick assess" src="https://user-images.githubusercontent.com/3230904/213800139-0d64cdf8-93c9-4c4d-9126-2df4e93d4d6b.png">


##### Motivation

feature work 🚀 


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
