### PR TITLE
feat(medium-pass-2): fire telemetry when a quick assess requirement is completed

### DIFF
--- a/src/background/completed-test-step-telemetry-creator.ts
+++ b/src/background/completed-test-step-telemetry-creator.ts
@@ -5,7 +5,6 @@ import { Assessment } from 'assessments/types/iassessment';
 import { Requirement } from 'assessments/types/requirement';
 import { ManualTestStatus, ManualTestStatusData } from 'common/types/store-data/manual-test-status';
 import { cloneDeep, filter } from 'lodash';
-import * as TelemetryEvents from '../common/extension-telemetry-events';
 import { RequirementStatusTelemetryData } from '../common/extension-telemetry-events';
 import { Messages } from '../common/messages';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
@@ -16,22 +15,15 @@ import { Interpreter } from './interpreter';
 import { AssessmentStore } from './stores/assessment-store';
 
 export class CompletedTestStepTelemetryCreator {
-    private store: AssessmentStore;
-    private provider: AssessmentsProvider;
-    private telemetryFactory: TelemetryDataFactory;
-    private interpreter: Interpreter;
     private oldTestStates: DictionaryStringTo<ManualTestStatusData>;
 
     constructor(
-        store: AssessmentStore,
-        provider: AssessmentsProvider,
-        factory: TelemetryDataFactory,
-        interpreter: Interpreter,
+        private store: AssessmentStore,
+        private provider: AssessmentsProvider,
+        private telemetryFactory: TelemetryDataFactory,
+        private interpreter: Interpreter,
+        private requirementStatusTelemetryEvent: string,
     ) {
-        this.store = store;
-        this.provider = provider;
-        this.telemetryFactory = factory;
-        this.interpreter = interpreter;
         this.oldTestStates = {};
     }
 
@@ -54,7 +46,7 @@ export class CompletedTestStepTelemetryCreator {
         const targetTab = this.store.getState().persistedTabInfo;
         if (completedStep != null && targetTab !== null) {
             const payload: PayloadWithEventName = {
-                eventName: TelemetryEvents.CHANGE_OVERALL_REQUIREMENT_STATUS,
+                eventName: this.requirementStatusTelemetryEvent,
                 telemetry: this.createTelemetryInfo(assessment, completedStep),
             };
 

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -3,6 +3,10 @@
 import { QuickAssessActionCreator } from 'background/actions/quick-assess-action-creator';
 import { BrowserPermissionsTracker } from 'background/browser-permissions-tracker';
 import { QuickAssessToAssessmentConverter } from 'background/quick-assess-to-assessment-converter';
+import {
+    CHANGE_OVERALL_REQUIREMENT_STATUS,
+    CHANGE_OVERALL_REQUIREMENT_STATUS_QUICK_ASSESS,
+} from 'common/extension-telemetry-events';
 import { Logger } from 'common/logging/logger';
 import { DebugToolsActionCreator } from 'debug-tools/action-creators/debug-tools-action-creator';
 import { DebugToolsController } from 'debug-tools/controllers/debug-tools-controller';
@@ -150,6 +154,7 @@ export class GlobalContextFactory {
             quickAssessProvider,
             telemetryDataFactory,
             interpreter,
+            CHANGE_OVERALL_REQUIREMENT_STATUS_QUICK_ASSESS,
         );
         quickAssessChangeHandler.initialize();
 
@@ -158,6 +163,7 @@ export class GlobalContextFactory {
             assessmentsProvider,
             telemetryDataFactory,
             interpreter,
+            CHANGE_OVERALL_REQUIREMENT_STATUS,
         );
         assessmentChangeHandler.initialize();
 

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -41,6 +41,7 @@ export class GlobalContextFactory {
         telemetryEventHandler: TelemetryEventHandler,
         userData: LocalStorageData,
         assessmentsProvider: AssessmentsProvider,
+        quickAssessProvider: AssessmentsProvider,
         telemetryDataFactory: TelemetryDataFactory,
         indexedDBInstance: IndexedDBAPI,
         persistedData: PersistedData,
@@ -58,6 +59,7 @@ export class GlobalContextFactory {
             browserAdapter,
             userData,
             assessmentsProvider,
+            quickAssessProvider,
             indexedDBInstance,
             persistedData,
             storageAdapter,
@@ -142,6 +144,14 @@ export class GlobalContextFactory {
             logger,
         );
         await dispatcher.initialize();
+
+        const quickAssessChangeHandler = new CompletedTestStepTelemetryCreator(
+            globalStoreHub.quickAssessStore,
+            quickAssessProvider,
+            telemetryDataFactory,
+            interpreter,
+        );
+        quickAssessChangeHandler.initialize();
 
         const assessmentChangeHandler = new CompletedTestStepTelemetryCreator(
             globalStoreHub.assessmentStore,

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -104,6 +104,10 @@ async function initializeAsync(): Promise<void> {
     const persistedData = await persistedDataPromise; //indexedDB
     const userData = await userDataPromise;
     const assessmentsProvider = Assessments;
+    const quickAssessProvider = assessmentsProviderForRequirements(
+        Assessments,
+        QuickAssessRequirementMap,
+    );
     const telemetryDataFactory = new TelemetryDataFactory();
     const telemetryLogger = new TelemetryLogger(logger);
 
@@ -139,6 +143,7 @@ async function initializeAsync(): Promise<void> {
         telemetryEventHandler,
         userData,
         assessmentsProvider,
+        quickAssessProvider,
         telemetryDataFactory,
         indexedDBInstance,
         persistedData,
@@ -161,7 +166,7 @@ async function initializeAsync(): Promise<void> {
 
     const visualizationConfigurationFactory = new WebVisualizationConfigurationFactory(
         Assessments,
-        assessmentsProviderForRequirements(Assessments, QuickAssessRequirementMap),
+        quickAssessProvider,
     );
     const notificationCreator = new NotificationCreator(
         browserAdapter,

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
-import { QuickAssessRequirementMap } from 'assessments/quick-assess-requirements';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { DataTransferStore } from 'background/stores/global/data-transfer-store';
 import { PermissionsStateStore } from 'background/stores/global/permissions-state-store';
@@ -48,6 +46,7 @@ export class GlobalStoreHub implements StoreHub {
         browserAdapter: BrowserAdapter,
         userData: LocalStorageData,
         assessmentsProvider: AssessmentsProvider,
+        quickAssessProvider: AssessmentsProvider,
         indexedDbInstance: IndexedDBAPI,
         persistedData: PersistedData,
         storageAdapter: StorageAdapter,
@@ -93,10 +92,6 @@ export class GlobalStoreHub implements StoreHub {
             logger,
             StoreNames.AssessmentStore,
             IndexedDBDataKeys.assessmentStore,
-        );
-        const quickAssessProvider = assessmentsProviderForRequirements(
-            assessmentsProvider,
-            QuickAssessRequirementMap,
         );
         this.quickAssessStore = new AssessmentStore(
             browserAdapter,

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -60,6 +60,8 @@ export const CHANGE_QUICK_ASSESS_VISUALIZATION_STATUS_FOR_ALL: string =
     'changeQuickAssessVisualizationStateForAll';
 export const DISABLE_VISUAL_HELPER: string = 'disableVisualHelper';
 export const CHANGE_OVERALL_REQUIREMENT_STATUS: string = 'changeOverallRequirementStatus';
+export const CHANGE_OVERALL_REQUIREMENT_STATUS_QUICK_ASSESS: string =
+    'changeOverallRequirementStatusQuickAssess';
 export const PREVIEW_FEATURES_CLOSE: string = 'PreviewFeaturesClose';
 export const PREVIEW_FEATURES_OPEN: string = 'PreviewFeaturesOpen';
 export const PREVIEW_FEATURES_TOGGLE: string = 'PreviewFeaturesToggle';

--- a/src/tests/unit/tests/background/completed-test-step-telemetry-creator.test.ts
+++ b/src/tests/unit/tests/background/completed-test-step-telemetry-creator.test.ts
@@ -7,7 +7,6 @@ import { TabStore } from 'background/stores/tab-store';
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
 import {
-    CHANGE_OVERALL_REQUIREMENT_STATUS,
     RequirementStatusTelemetryData,
     TelemetryEventSource,
     TriggeredByNotApplicable,
@@ -22,6 +21,7 @@ import {
 import { TabStoreData } from '../../../../common/types/store-data/tab-store-data';
 import { CreateTestAssessmentProvider } from '../../common/test-assessment-provider';
 
+const telemetryEventStub = 'change requirement status telemetry event stub';
 function testBeforeAfterAssessmentData(
     expectedTelemetry: RequirementStatusTelemetryData,
     expectedTimes: Times,
@@ -38,13 +38,14 @@ function testBeforeAfterAssessmentData(
         assessmentProvider,
         telemetryFactoryMock.object,
         interpreterMock.object,
+        telemetryEventStub,
     );
 
     const expectedMessage: Message = {
         messageType: Messages.Telemetry.Send,
         tabId: 1,
         payload: {
-            eventName: CHANGE_OVERALL_REQUIREMENT_STATUS,
+            eventName: telemetryEventStub,
             telemetry: expectedTelemetry,
         },
     };
@@ -89,7 +90,7 @@ function testBeforeAfterAssessmentData(
 
 describe('CompletedTestStepTelemetryCreatorTest', () => {
     test('constructor', () => {
-        expect(new CompletedTestStepTelemetryCreator(null, null, null, null)).toBeDefined();
+        expect(new CompletedTestStepTelemetryCreator(null, null, null, null, null)).toBeDefined();
     });
 
     test('initialize: onAssessmentChange, telemetry sent because one test step switches to PASS', () => {
@@ -215,6 +216,7 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
             assessmentProvider,
             telemetryFactory.object,
             interpreterMock.object,
+            telemetryEventStub,
         );
 
         assessmentStoreMock
@@ -257,7 +259,7 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
             messageType: Messages.Telemetry.Send,
             tabId: 1,
             payload: {
-                eventName: CHANGE_OVERALL_REQUIREMENT_STATUS,
+                eventName: telemetryEventStub,
                 telemetry: expectedTelemetry,
             },
         };
@@ -275,6 +277,7 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
             assessmentProvider,
             telemetryFactoryMock.object,
             interpreterMock.object,
+            telemetryEventStub,
         );
 
         tabStoreMock.setup(m => m.getState()).returns(() => tabStoreData);

--- a/src/tests/unit/tests/background/global-context-factory.test.ts
+++ b/src/tests/unit/tests/background/global-context-factory.test.ts
@@ -61,6 +61,7 @@ describe('GlobalContextFactoryTest', () => {
             telemetryEventHandlerMock.object,
             userDataStub,
             CreateTestAssessmentProvider(),
+            CreateTestAssessmentProvider(),
             telemetryDataFactoryMock.object,
             mockDBInstance.object,
             persistedDataStub,

--- a/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { GlobalActionHub } from 'background/actions/global-action-hub';
 import { PersistedData } from 'background/get-persisted-data';
 import { LocalStorageData } from 'background/storage-data';
@@ -25,12 +26,14 @@ import { CreateTestAssessmentProvider } from '../../../../common/test-assessment
 describe('GlobalStoreHubTest', () => {
     let userDataStub: LocalStorageData;
     let idbInstance: IndexedDBAPI;
-    let assessmentProvider;
+    let assessmentProvider: AssessmentsProvider;
+    let quickAssessProvider: AssessmentsProvider;
     let persistedDataStub: PersistedData;
 
     beforeEach(() => {
         idbInstance = {} as IndexedDBAPI;
         assessmentProvider = CreateTestAssessmentProvider();
+        quickAssessProvider = CreateTestAssessmentProvider();
         userDataStub = {
             launchPanelSetting: LaunchPanelType.LaunchPad,
         } as LocalStorageData;
@@ -65,6 +68,7 @@ describe('GlobalStoreHubTest', () => {
             null,
             userDataStub,
             assessmentProvider,
+            quickAssessProvider,
             idbInstance,
             cloneDeep(persistedDataStub),
             null,
@@ -91,6 +95,7 @@ describe('GlobalStoreHubTest', () => {
             null,
             userDataStub,
             assessmentProvider,
+            quickAssessProvider,
             idbInstance,
             cloneDeep(persistedDataStub),
             null,


### PR DESCRIPTION
#### Details

Re-uses the CompletedTestStepTelemetryCreator for assessment for this. The only difference is it uses the quick assess objects (provider, store).

##### Motivation

Feature work.

##### Context

This adds a new event for quick assess specifically not because it is absolutely required (selectedTest would mention QuickAssess) but because we do not necessarily want to rely on that for quick assess, as it is mostly requirements.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
