### PR TITLE
fix: comply with Microsoft Edge branding guidelines, correct spelling

### DIFF
--- a/src/common/constants/displayable-strings.ts
+++ b/src/common/constants/displayable-strings.ts
@@ -13,5 +13,5 @@ export class DisplayableStrings {
     public static noPreviewFeatureDisplayMessage: string =
         'No preview features are currently available to manage. Follow this page for future cool features.';
     public static injectionFailed: string =
-        'Unable to communicate with target page. If you are using Edge, make sure that the target page is not in Internet Explorer mode.';
+        'Unable to communicate with target page. If you are using Microsoft Edge, make sure that the target page is not in Internet Explorer mode.';
 }

--- a/src/common/constants/displayable-strings.ts
+++ b/src/common/constants/displayable-strings.ts
@@ -4,7 +4,7 @@ import { title } from 'content/strings/application';
 
 export class DisplayableStrings {
     public static previewFeaturesDescription: string =
-        'The following preview features are available for your evalution. Help us make them better!';
+        'The following preview features are available for your evaluation. Help us make them better!';
     public static fileUrlDoesNotHaveAccess: string = `Your browser settings don't allow ${title} to run on file URLs.`;
     public static urlNotScannable: string[] = [
         `${title} can't run on this URL.`,

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
@@ -78,7 +78,7 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
               <div
                 class="preview-features-description"
               >
-                The following preview features are available for your evalution. Help us make them better!
+                The following preview features are available for your evaluation. Help us make them better!
               </div>
               <div
                 class="preview-feature-toggle-list--{{CSS_MODULE_HASH}}"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/injection-failed-warning.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/injection-failed-warning.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`InjectionFailedWarning render with injection failed 1`] = `
   <div
     data-automation-id="injection-failed-warning-container"
   >
-    Unable to communicate with target page. If you are using Edge, make sure that the target page is not in Internet Explorer mode.
+    Unable to communicate with target page. If you are using Microsoft Edge, make sure that the target page is not in Internet Explorer mode.
   </div>
 </StyledMessageBar>
 `;

--- a/src/tests/unit/tests/DetailsView/components/details-view-overlay/preview-features-panel/__snapshots__/preview-features-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/details-view-overlay/preview-features-panel/__snapshots__/preview-features-container.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`PreviewFeaturesContainerTest renders all available preview features 1`]
   <div
     className="preview-features-description"
   >
-    The following preview features are available for your evalution. Help us make them better!
+    The following preview features are available for your evaluation. Help us make them better!
   </div>
   <PreviewFeaturesToggleList
     deps={


### PR DESCRIPTION
#### Details

A recent change added a banner which refers to the Microsoft Edge browser as "Edge". Per branding guidelines, the first reference should be "Microsoft Edge". Checked with PM and confirmed that we should make this change.
<img width="643" alt="image" src="https://user-images.githubusercontent.com/1752950/213825673-87e4d55e-54b1-455b-88d4-f87076396242.png">

While working on this, noticed a typo in the same file (evalution). Corrected this to evaluation. This string appears in the subtitle of the Preview features panel.
<img width="278" alt="image" src="https://user-images.githubusercontent.com/1752950/213828108-2c11acf3-4163-4a57-95d4-446b325c6a44.png">

##### Motivation

Restores us to compliance with branding guidelines and dictionary spelling.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [X] Ran `yarn fastpass`
- [X] Added/updated relevant unit test(s) (and ran `yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [X] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS (Narrator)
