### PR TITLE
feat(quick-assess): add e2e tests for move to assessment

### DIFF
--- a/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
+++ b/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
@@ -19,6 +19,8 @@ export interface QuickAssessToAssessmentDialogProps {
     isShown: boolean;
 }
 
+export const continueToAssessmentButtonAutomationId = 'continue-to-assessment-button';
+
 export const QuickAssessToAssessmentDialog = NamedFC<QuickAssessToAssessmentDialogProps>(
     'QuickAssessToAssessmentConfirmDialog',
     props => {
@@ -57,6 +59,7 @@ export const QuickAssessToAssessmentDialog = NamedFC<QuickAssessToAssessmentDial
                             detailsViewActionMessageCreator.changeRightContentPanel('Overview');
                             await dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog();
                         }}
+                        data-automation-id={continueToAssessmentButtonAutomationId}
                         text={'Continue to assessment'}
                         autoFocus={true}
                     />

--- a/src/DetailsView/components/requirement-view-next-requirement-configuration.tsx
+++ b/src/DetailsView/components/requirement-view-next-requirement-configuration.tsx
@@ -37,6 +37,8 @@ export type GetNextRequirementButtonConfiguration = (
     props: GetNextRequirementConfigurationProps,
 ) => JSX.Element;
 
+export const completeButtonAutomationId = 'complete-button';
+
 export const getNextRequirementConfigurationForAssessment = (
     props: GetNextRequirementConfigurationProps,
 ) => {
@@ -75,6 +77,7 @@ export const getNextRequirementConfigurationForQuickAssess = (
                 onClick={
                     props.deps.dataTransferViewController.showQuickAssessToAssessmentConfirmDialog
                 }
+                data-automation-id={completeButtonAutomationId}
             ></PrimaryButton>
         );
     }

--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Dropdown, IDropdownOption } from '@fluentui/react';
-import { Icon } from '@fluentui/react';
-import { ResponsiveMode } from '@fluentui/react';
+import { Dropdown, Icon, IDropdownOption, ResponsiveMode } from '@fluentui/react';
 import { FeatureFlags } from 'common/feature-flags';
 import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -25,6 +23,7 @@ export interface SwitcherState {
     selectedKey: DetailsViewPivotType;
 }
 
+export const switcherOptionAutomationId = 'switcher-option';
 export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
     constructor(props: SwitcherProps) {
         super(props);
@@ -41,7 +40,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
         return (
             <span className={styles.switcherDropdownOption}>
                 {option.data && option.data.icon && <Icon iconName={option.data.icon} />}
-                <span>{option.text}</span>
+                <span data-automation-id={switcherOptionAutomationId}>{option.text}</span>
             </span>
         );
     };

--- a/src/DetailsView/components/transfer-to-assessment-button.tsx
+++ b/src/DetailsView/components/transfer-to-assessment-button.tsx
@@ -14,11 +14,14 @@ export interface TransferToAssessmentButtonProps {
     deps: TransferToAssessmentButtonDeps;
 }
 
+export const transferToAssessmentButtonAutomationId = 'transfer-to-assessment-button';
+
 export const TransferToAssessmentButton = NamedFC<TransferToAssessmentButtonProps>(
     'TransferToAssessmentButton',
     props => {
         return (
             <InsightsCommandButton
+                data-automation-id={transferToAssessmentButtonAutomationId}
                 iconProps={{ iconName: 'fabricMoveToFolder' }}
                 onClick={
                     props.deps.dataTransferViewController.showQuickAssessToAssessmentConfirmDialog

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -8,8 +8,10 @@ import { instanceTableTextContentAutomationId } from 'DetailsView/components/ass
 import { visualHelperToggleAutomationId } from 'DetailsView/components/base-visual-helper-toggle';
 import { settingsPanelAutomationId } from 'DetailsView/components/details-view-overlay/settings-panel/settings-panel';
 import { singleExportToHtmlButtonDataAutomationId } from 'DetailsView/components/export-dialog';
-import { reportExportDropdownAutomationId } from 'DetailsView/components/export-dropdown';
-import { reportExportDropdownMenuAutomationId } from 'DetailsView/components/export-dropdown';
+import {
+    reportExportDropdownAutomationId,
+    reportExportDropdownMenuAutomationId,
+} from 'DetailsView/components/export-dropdown';
 import { IframeWarningContainerAutomationId } from 'DetailsView/components/iframe-warning';
 import { inlineStartOverButtonDataAutomationId } from 'DetailsView/components/inline-start-over-button';
 import { invalidLoadAssessmentDialogOkButtonAutomationId } from 'DetailsView/components/invalid-load-assessment-dialog';
@@ -17,8 +19,11 @@ import { loadAssessmentButtonAutomationId } from 'DetailsView/components/load-as
 import { loadAssessmentDialogLoadButtonAutomationId } from 'DetailsView/components/load-assessment-dialog';
 import { overviewContainerAutomationId } from 'DetailsView/components/overview-content/overview-content-container';
 import { overviewHeadingAutomationId } from 'DetailsView/components/overview-content/overview-heading';
+import { continueToAssessmentButtonAutomationId } from 'DetailsView/components/quick-assess-to-assessment-dialog';
 import { reportExportButtonAutomationId } from 'DetailsView/components/report-export-button';
+import { completeButtonAutomationId } from 'DetailsView/components/requirement-view-next-requirement-configuration';
 import { startOverAutomationId } from 'DetailsView/components/start-over-component-factory';
+import { switcherOptionAutomationId } from 'DetailsView/components/switcher';
 import { tabStopsFailedInstanceSectionAutomationId } from 'DetailsView/components/tab-stops-failed-instance-section';
 import {
     addFailedInstanceTextAreaAutomationId,
@@ -28,6 +33,7 @@ import {
     addTabStopsFailureInstanceAutomationId,
     tabStopsPassFailChoiceGroupAutomationId,
 } from 'DetailsView/components/tab-stops/tab-stops-choice-group';
+import { transferToAssessmentButtonAutomationId } from 'DetailsView/components/transfer-to-assessment-button';
 import { resultsGroupAutomationId } from 'DetailsView/tab-stops-requirements-with-instances';
 import { reportExportAsHtmlAutomationId } from 'report-export/services/html-report-export-service';
 import { reportExportAsJsonAutomationId } from 'report-export/services/json-report-export-service';
@@ -61,6 +67,8 @@ export const detailsViewSelectors = {
     exportReportButton: getAutomationIdSelector(reportExportButtonAutomationId),
     singleExportToHtmlButton: getAutomationIdSelector(singleExportToHtmlButtonDataAutomationId),
     inlineStartOverButton: getAutomationIdSelector(inlineStartOverButtonDataAutomationId),
+    selectedSwitcherOption: (option: string) =>
+        `//span[@data-automation-id="${switcherOptionAutomationId}"][text()="${option}"]`,
 };
 
 export const navMenuSelectors = {
@@ -159,4 +167,12 @@ export const settingsPanelSelectors = {
 
 export const fastPassReportSelectors = {
     reportHeaderSection: getAutomationIdSelector(reportHeaderSectionDataAutomationId),
+};
+
+export const quickAssessSelectors = {
+    transferToAssessmentButton: getAutomationIdSelector(transferToAssessmentButtonAutomationId),
+    continueToAssessmentDialogButton: getAutomationIdSelector(
+        continueToAssessmentButtonAutomationId,
+    ),
+    completeButton: getAutomationIdSelector(completeButtonAutomationId),
 };

--- a/src/tests/end-to-end/tests/details-view/quick-assess.test.ts
+++ b/src/tests/end-to-end/tests/details-view/quick-assess.test.ts
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BackgroundContext } from 'tests/end-to-end/common/page-controllers/background-context';
+import { Page } from 'tests/end-to-end/common/page-controllers/page';
+import { scanForAccessibilityIssues } from 'tests/end-to-end/common/scan-for-accessibility-issues';
+import { DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS } from 'tests/end-to-end/common/timeouts';
+import { Browser } from '../../common/browser';
+import { launchBrowser } from '../../common/browser-factory';
+import {
+    detailsViewSelectors,
+    overviewSelectors,
+    quickAssessSelectors,
+} from '../../common/element-identifiers/details-view-selectors';
+import { DetailsViewPage } from '../../common/page-controllers/details-view-page';
+import { TargetPage } from '../../common/page-controllers/target-page';
+
+describe('Quick Assess', () => {
+    let browser: Browser;
+    let targetPage: TargetPage;
+    let detailsViewPage: DetailsViewPage;
+    let backgroundPage: BackgroundContext;
+
+    describe('transfer to assessment dialog', () => {
+        beforeAll(async () => {
+            browser = await launchBrowser({
+                suppressFirstTimeDialog: true,
+                addExtraPermissionsToManifest: 'all-origins',
+            });
+            targetPage = await browser.newTargetPage({
+                testResourcePath: 'native-widgets/input-type-radio.html', // does not have any images, so will pass
+            });
+            await browser.newPopupPage(targetPage); // Required for the details view to register as having permissions/being open
+            backgroundPage = await browser.background();
+            await backgroundPage.enableFeatureFlag('quickAssess');
+            detailsViewPage = await openOverviewPage(browser, targetPage);
+            await detailsViewPage.navigateToRequirement('Image function');
+            await detailsViewPage.waitForRequirementStatus('Image function', '4', 'Passed', {
+                timeout: DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
+            });
+            await detailsViewPage.clickSelector(quickAssessSelectors.transferToAssessmentButton);
+        });
+
+        afterAll(async () => {
+            await browser?.close();
+        });
+
+        it.each([true, false])('With high contrast mode=%s', async highContrastMode => {
+            await scanForA11yIssuesWithHighContrast(highContrastMode, detailsViewPage);
+        });
+
+        test('quick assess data is transfered appropriately', async () => {
+            await detailsViewPage.clickSelector(
+                quickAssessSelectors.continueToAssessmentDialogButton,
+            );
+
+            // Verify view is switched to assessment.
+            await detailsViewPage.waitForSelector(
+                detailsViewSelectors.selectedSwitcherOption('Assessment'),
+            );
+            // Verify summary bar in assessment is not same as new assessment
+            const expectedSummaryBarSelector =
+                overviewSelectors.outcomeSummaryBar +
+                `:not([aria-label="0% Passed, 100% Incomplete, 0% Failed"])`;
+            await detailsViewPage.waitForSelector(expectedSummaryBarSelector);
+        });
+    });
+
+    describe('complete button', () => {
+        beforeAll(async () => {
+            browser = await launchBrowser({
+                suppressFirstTimeDialog: true,
+                addExtraPermissionsToManifest: 'all-origins',
+            });
+            targetPage = await browser.newTargetPage({
+                testResourcePath: 'native-widgets/input-type-radio.html', // does not have any images, so will pass
+            });
+            await browser.newPopupPage(targetPage); // Required for the details view to register as having permissions/being open
+            backgroundPage = await browser.background();
+            await backgroundPage.enableFeatureFlag('quickAssess');
+            detailsViewPage = await openOverviewPage(browser, targetPage);
+            await detailsViewPage.navigateToRequirement('Image function');
+            await detailsViewPage.waitForRequirementStatus('Image function', '4', 'Passed', {
+                timeout: DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS,
+            });
+
+            await detailsViewPage.switchToQuickAssess();
+            await detailsViewPage.navigateToRequirement('Reflow');
+        });
+
+        afterAll(async () => {
+            await browser?.close();
+        });
+
+        it.each([true, false])('With high contrast mode=%s', async highContrastMode => {
+            await scanForA11yIssuesWithHighContrast(highContrastMode, detailsViewPage);
+        });
+
+        test('quick assess data is transfered appropriately', async () => {
+            await detailsViewPage.clickSelector(quickAssessSelectors.completeButton);
+            await detailsViewPage.clickSelector(
+                quickAssessSelectors.continueToAssessmentDialogButton,
+            );
+
+            // Verify view is switched to assessment.
+            await detailsViewPage.waitForSelector(
+                detailsViewSelectors.selectedSwitcherOption('Assessment'),
+            );
+            // Verify summary bar in assessment is not same as new assessment
+            const expectedSummaryBarSelector =
+                overviewSelectors.outcomeSummaryBar +
+                `:not([aria-label="0% Passed, 100% Incomplete, 0% Failed"])`;
+            await detailsViewPage.waitForSelector(expectedSummaryBarSelector);
+        });
+    });
+
+    async function scanForA11yIssuesWithHighContrast(
+        highContrastMode: boolean,
+        overviewPage: Page,
+    ): Promise<void> {
+        await browser.setHighContrastMode(highContrastMode);
+        await overviewPage.waitForHighContrastMode(highContrastMode);
+
+        const results = await scanForAccessibilityIssues(overviewPage, '*');
+        expect(results).toHaveLength(0);
+    }
+});
+
+async function openOverviewPage(
+    browser: Browser,
+    targetPage: TargetPage,
+): Promise<DetailsViewPage> {
+    const detailsViewPage = await browser.newDetailsViewPage(targetPage);
+    await detailsViewPage.switchToQuickAssess();
+    await detailsViewPage.waitForSelector(overviewSelectors.overviewHeading);
+
+    return detailsViewPage;
+}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/quick-assess-to-assessment-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/quick-assess-to-assessment-dialog.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`QuickAssessToAssessmentDialog dialog is hidden when isShown is false 1`
     />
     <CustomizedPrimaryButton
       autoFocus={true}
+      data-automation-id="continue-to-assessment-button"
       onClick={[Function]}
       text="Continue to assessment"
     />
@@ -55,6 +56,7 @@ exports[`QuickAssessToAssessmentDialog dialog is not hidden when isShown is true
     />
     <CustomizedPrimaryButton
       autoFocus={true}
+      data-automation-id="continue-to-assessment-button"
       onClick={[Function]}
       text="Continue to assessment"
     />

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-view-next-requirement-configuration.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-view-next-requirement-configuration.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`RequirementViewNextRequirementConfiguration getNextRequirementConfigura
 
 exports[`RequirementViewNextRequirementConfiguration getNextRequirementConfigurationForQuickAssess returns Complete button when it is last requirement in quickAssessRequirementKeys 1`] = `
 <CustomizedPrimaryButton
+  data-automation-id="complete-button"
   onClick={[Function]}
   text="Complete"
 />

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
@@ -69,7 +69,9 @@ exports[`Switcher renders option renderer override matches snapshotm when quick 
   <Memo(Icon)
     iconName="Rocket"
   />
-  <span>
+  <span
+    data-automation-id="switcher-option"
+  >
     FastPass
   </span>
 </span>
@@ -82,7 +84,9 @@ exports[`Switcher renders option renderer override matches snapshotm when quick 
   <Memo(Icon)
     iconName="Rocket"
   />
-  <span>
+  <span
+    data-automation-id="switcher-option"
+  >
     FastPass
   </span>
 </span>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/transfer-to-assessment-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/transfer-to-assessment-button.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`TransferToAssessmentButton getTransferToAssessmentButton 1`] = `
 
 exports[`TransferToAssessmentButton render 1`] = `
 <InsightsCommandButton
+  data-automation-id="transfer-to-assessment-button"
   iconProps={
     {
       "iconName": "fabricMoveToFolder",


### PR DESCRIPTION
#### Details

Adds e2e tests for the "move to assessment" button/dialog.

##### Motivation

Feature work.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
