### PR TITLE
feat(quick-assess): Separate assessment and quick assess help links

### DIFF
--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -157,6 +157,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
 
         const overviewHeadingIntroText =
             selectedDetailsViewSwitcherNavConfiguration.overviewHeadingIntroText;
+        const linkDataSource = selectedDetailsViewSwitcherNavConfiguration.linkDataSource;
 
         return (
             <DetailsViewBody
@@ -191,6 +192,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                 narrowModeStatus={props.narrowModeStatus}
                 tabStopRequirementData={tabStopRequirementData}
                 overviewHeadingIntroText={overviewHeadingIntroText}
+                linkDataSource={linkDataSource}
             />
         );
     };

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -8,6 +8,11 @@ import {
 } from 'common/components/expand-collapse-left-nav-hamburger-button';
 import { getNullComponent } from 'common/components/null-component';
 import {
+    assessmentLinkDataSource,
+    quickAssessLinkDataSource,
+} from 'common/constants/link-data-sources';
+import { HyperlinkDefinition } from 'common/types/hyperlink-definition';
+import {
     AssessmentFunctionalitySwitcher,
     SharedAssessmentObjects,
 } from 'DetailsView/assessment-functionality-switcher';
@@ -115,6 +120,7 @@ export type DetailsViewSwitcherNavConfiguration = Readonly<{
     getSelectedAssessmentStoreData: GetSelectedAssessmentStoreData;
     getRequirementViewComponentConfiguration: GetRequirementViewComponentConfiguration;
     overviewHeadingIntroText: string;
+    linkDataSource: HyperlinkDefinition[];
 }>;
 
 type InternalDetailsViewSwitcherNavConfiguration = Omit<
@@ -148,6 +154,7 @@ const detailsViewSwitcherNavs: {
         getRequirementViewComponentConfiguration:
             getRequirementViewComponentConfigurationForAssessment,
         overviewHeadingIntroText: overviewHeadingIntroTextForAssessment,
+        linkDataSource: assessmentLinkDataSource,
     },
     [DetailsViewPivotType.quickAssess]: {
         CommandBar: QuickAssessCommandBar,
@@ -167,6 +174,7 @@ const detailsViewSwitcherNavs: {
         getRequirementViewComponentConfiguration:
             getRequirementViewComponentConfigurationForQuickAssess,
         overviewHeadingIntroText: overviewHeadingIntroTextForQuickAssess,
+        linkDataSource: quickAssessLinkDataSource,
     },
     [DetailsViewPivotType.fastPass]: {
         CommandBar: AutomatedChecksCommandBar,
@@ -186,6 +194,7 @@ const detailsViewSwitcherNavs: {
         overviewHeadingIntroText: null,
         // Getting assessmentStoreData is default behavior
         getSelectedAssessmentStoreData: getAssessmentStoreData,
+        linkDataSource: null,
     },
 };
 

--- a/src/DetailsView/components/overview-content/overview-content-container.tsx
+++ b/src/DetailsView/components/overview-content/overview-content-container.tsx
@@ -18,24 +18,6 @@ import { AssessmentReportSummary } from 'reports/components/assessment-report-su
 import { TargetChangeDialog, TargetChangeDialogDeps } from '../target-change-dialog';
 import styles from './overview-content-container.scss';
 import { OverviewHelpSection, OverviewHelpSectionDeps } from './overview-help-section';
-const linkDataSource: HyperlinkDefinition[] = [
-    {
-        href: 'https://go.microsoft.com/fwlink/?linkid=2082219',
-        text: 'Getting started',
-    },
-    {
-        href: 'https://go.microsoft.com/fwlink/?linkid=2082220',
-        text: 'How to complete a test',
-    },
-    {
-        href: 'https://go.microsoft.com/fwlink/?linkid=2077941',
-        text: 'Ask a question',
-    },
-    {
-        href: 'https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/',
-        text: 'New WCAG 2.1 success criteria',
-    },
-];
 
 export type OverviewContainerDeps = {
     getProvider: () => AssessmentsProvider;
@@ -55,6 +37,7 @@ export interface OverviewContainerProps {
     tabStoreData: TabStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
     overviewHeadingIntroText: string;
+    linkDataSource: HyperlinkDefinition[];
 }
 
 export const overviewContainerAutomationId = 'overviewContainerAutomationId';
@@ -66,6 +49,7 @@ export const OverviewContainer = NamedFC<OverviewContainerProps>('OverviewContai
         tabStoreData,
         featureFlagStoreData,
         overviewHeadingIntroText,
+        linkDataSource,
     } = props;
     const {
         getProvider,

--- a/src/common/constants/link-data-sources.ts
+++ b/src/common/constants/link-data-sources.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { HyperlinkDefinition } from 'common/types/hyperlink-definition';
+
+export const assessmentLinkDataSource: HyperlinkDefinition[] = [
+    {
+        href: 'https://go.microsoft.com/fwlink/?linkid=2082219',
+        text: 'Getting started',
+    },
+    {
+        href: 'https://go.microsoft.com/fwlink/?linkid=2082220',
+        text: 'How to complete a test',
+    },
+    {
+        href: 'https://go.microsoft.com/fwlink/?linkid=2077941',
+        text: 'Ask a question',
+    },
+    {
+        href: 'https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/',
+        text: 'New WCAG 2.1 success criteria',
+    },
+];
+
+export const quickAssessLinkDataSource: HyperlinkDefinition[] = [
+    {
+        // TODO update to fwlink
+        href: 'TESTLINK',
+        text: 'Getting started',
+    },
+    {
+        href: 'https://go.microsoft.com/fwlink/?linkid=2082220',
+        text: 'How to complete a test',
+    },
+    {
+        href: 'https://go.microsoft.com/fwlink/?linkid=2077941',
+        text: 'Ask a question',
+    },
+    {
+        href: 'https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/',
+        text: 'New WCAG 2.1 success criteria',
+    },
+];

--- a/src/common/constants/link-data-sources.ts
+++ b/src/common/constants/link-data-sources.ts
@@ -24,8 +24,7 @@ export const assessmentLinkDataSource: HyperlinkDefinition[] = [
 
 export const quickAssessLinkDataSource: HyperlinkDefinition[] = [
     {
-        // TODO update to fwlink
-        href: 'TESTLINK',
+        href: 'https://go.microsoft.com/fwlink/?linkid=2223436',
         text: 'Getting started',
     },
     {

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
@@ -60,19 +60,19 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
       linkDataSource={
         [
           {
-            "href": "https://go.microsoft.com/fwlink/?linkid=2082219",
+            "href": "Getting-started-link",
             "text": "Getting started",
           },
           {
-            "href": "https://go.microsoft.com/fwlink/?linkid=2082220",
+            "href": "How-to-complete-a-test-link",
             "text": "How to complete a test",
           },
           {
-            "href": "https://go.microsoft.com/fwlink/?linkid=2077941",
+            "href": "Ask-a-question-link",
             "text": "Ask a question",
           },
           {
-            "href": "https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/",
+            "href": "New-WCAG-2.1-success-criteria-link",
             "text": "New WCAG 2.1 success criteria",
           },
         ]

--- a/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
@@ -82,6 +82,25 @@ describe('OverviewContainer', () => {
 
     const overviewHeadingIntroTextStub = 'Test intro overview text:';
 
+    const linkDataSourceStub = [
+        {
+            href: 'Getting-started-link',
+            text: 'Getting started',
+        },
+        {
+            href: 'How-to-complete-a-test-link',
+            text: 'How to complete a test',
+        },
+        {
+            href: 'Ask-a-question-link',
+            text: 'Ask a question',
+        },
+        {
+            href: 'New-WCAG-2.1-success-criteria-link',
+            text: 'New WCAG 2.1 success criteria',
+        },
+    ];
+
     const component = (
         <OverviewContainer
             deps={deps}
@@ -89,6 +108,7 @@ describe('OverviewContainer', () => {
             featureFlagStoreData={featureFlagDataStub}
             tabStoreData={tabStoreDataStub}
             overviewHeadingIntroText={overviewHeadingIntroTextStub}
+            linkDataSource={linkDataSourceStub}
         />
     );
     const wrapper = shallow(component);


### PR DESCRIPTION
#### Details

Prior to this PR both the assessment and quick assess overview pages shared the same set of links for the right hand side help panel. This PR introduces logic so those links can be changed independently of each other and also updates the quick assess `Getting started` link to a new fwlink. For now, the new fwlink redirects to the same place, but we plan on updating it to point to a new quick assess specific getting started video in the future. 

##### Motivation

Ensure quick assess UI points to quick assess specific help links.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
