### PR TITLE
fix(quick-assess): automated checks should collapse when other test selected

### DIFF
--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -378,6 +378,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
     private onSelectTestSubview = async (payload: SelectTestSubviewPayload): Promise<void> => {
         this.state.assessmentNavState.selectedTestType = payload.selectedTest;
         this.state.assessmentNavState.selectedTestSubview = payload.selectedTestSubview;
+        this.state.assessmentNavState.expandedTestType = payload.selectedTest;
         await this.emitChanged();
     };
 

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -1119,6 +1119,7 @@ describe('AssessmentStore', () => {
         )
             .withSelectedTestType(visualizationType)
             .withSelectedTestSubview(requirement)
+            .withExpandedTest(visualizationType)
             .build();
 
         const payload: SelectTestSubviewPayload = {


### PR DESCRIPTION
#### Details

This is a workaround fix to ensure that Automated Checks is not expanded when another test/requirement is selected in quick assess; assessment does not change.

##### Motivation

Feature work.

##### Context

This issue occurs because, in assessment, for a user to be able to select another requirement, requires expanding another test (which means the previous test that was expanded is no longer so). In Quick Assess, since only Automated Checks expands, selecting a requirement DOES NOT require the user to expand/collapse any other tests. As a result, the expanded test property is either nothing OR automated checks.

This change will make sure the expanded test property is updated on requirement selection. This data is not used by quick assess for non-automated checks views (because there's nothing to expand or collapse/the left nav links do not even use this property) and for assessment this should not impact the UX because the expanded test is likely just to be what it already is.

Gif below of the behavior (left is canary/before changes, right is local/after changes)

![quickAssessCollapseFix](https://user-images.githubusercontent.com/32555133/215623986-c02c79a2-2c7e-47df-a722-a97c9ddbbf89.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
