### PR TITLE
feat(axe-core-4.6): Expose axe-core relatedNodes as "Related paths" card row

### DIFF
--- a/src/common/components/cards/related-paths-card-row.scss
+++ b/src/common/components/cards/related-paths-card-row.scss
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.path-list {
+    padding-left: 16px;
+    list-style-type: disc;
+}

--- a/src/common/components/cards/related-paths-card-row.tsx
+++ b/src/common/components/cards/related-paths-card-row.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { SimpleCardRow } from 'common/components/cards/simple-card-row';
+import { CardRowProps } from 'common/configs/unified-result-property-configurations';
+import { NamedFC } from 'common/react/named-fc';
+import { isEmpty } from 'lodash';
+import * as React from 'react';
+import styles from './related-paths-card-row.scss';
+
+export interface RelatedPathsCardRowProps extends CardRowProps {
+    propertyData: string[];
+}
+
+export const RelatedPathsCardRow = NamedFC<RelatedPathsCardRowProps>(
+    'RichResolutionCardRow',
+    ({ index, propertyData }) => {
+        if (isEmpty(propertyData)) {
+            return null;
+        }
+
+        return (
+            <SimpleCardRow
+                label={`Related paths`}
+                content={
+                    <ul className={styles.pathList}>
+                        {propertyData.map(selector => (
+                            <li key={selector}>{selector}</li>
+                        ))}
+                    </ul>
+                }
+                rowKey={`related-paths-row-${index}`}
+            />
+        );
+    },
+);

--- a/src/common/components/cards/related-paths-card-row.tsx
+++ b/src/common/components/cards/related-paths-card-row.tsx
@@ -12,7 +12,7 @@ export interface RelatedPathsCardRowProps extends CardRowProps {
 }
 
 export const RelatedPathsCardRow = NamedFC<RelatedPathsCardRowProps>(
-    'RichResolutionCardRow',
+    'RelatedPathsCardRow',
     ({ index, propertyData }) => {
         if (isEmpty(propertyData)) {
             return null;

--- a/src/common/components/fix-instruction-processor.tsx
+++ b/src/common/components/fix-instruction-processor.tsx
@@ -46,6 +46,8 @@ export class FixInstructionProcessor {
     private readonly originalMiddleSentence = ' and the original foreground color: ';
 
     public process(fixInstruction: string, recommendColor: RecommendColor): JSX.Element {
+        fixInstruction = fixInstruction.replace(/\(see related nodes\)/g, '(see related paths)');
+
         const matches = this.getColorMatches(fixInstruction);
 
         let recommendationSentences: string[] = [];

--- a/src/common/components/fix-instruction-processor.tsx
+++ b/src/common/components/fix-instruction-processor.tsx
@@ -46,6 +46,10 @@ export class FixInstructionProcessor {
     private readonly originalMiddleSentence = ' and the original foreground color: ';
 
     public process(fixInstruction: string, recommendColor: RecommendColor): JSX.Element {
+        // We perform this replacement because what axe-core exposes as a "relatedNodes" property
+        // is presented in our cards views as a "Related paths" row. This only comes up in practice
+        // with the aria-required-children rule and is likely to be obsoleted with the resolution of
+        // https://github.com/dequelabs/axe-core/issues/3842
         fixInstruction = fixInstruction.replace(/\(see related nodes\)/g, '(see related paths)');
 
         const matches = this.getColorMatches(fixInstruction);

--- a/src/common/configs/unified-result-property-configurations.tsx
+++ b/src/common/configs/unified-result-property-configurations.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { ClassNameCardRow } from 'common/components/cards/class-name-card-row';
 import { ContentDescriptionCardRow } from 'common/components/cards/content-description-card-row';
+import { RelatedPathsCardRow } from 'common/components/cards/related-paths-card-row';
 import { RichResolutionCardRow } from 'common/components/cards/rich-resolution-card-row';
 import { TextCardRow } from 'common/components/cards/text-card-row';
 import { UrlsCardRow } from 'common/components/cards/urls-card-row';
@@ -13,15 +14,7 @@ import { SnippetCardRow } from '../components/cards/snippet-card-row';
 import { FixInstructionProcessor } from '../components/fix-instruction-processor';
 import { ReactFCWithDisplayName } from '../react/named-fc';
 
-export type PropertyType =
-    | 'css-selector'
-    | 'how-to-fix-web'
-    | 'richResolution'
-    | 'snippet'
-    | 'className'
-    | 'contentDescription'
-    | 'text';
-export const AllPropertyTypes: PropertyType[] = [
+export const AllPropertyTypes = [
     'css-selector',
     'how-to-fix-web',
     'richResolution',
@@ -29,7 +22,9 @@ export const AllPropertyTypes: PropertyType[] = [
     'className',
     'contentDescription',
     'text',
-];
+    'relatedCssSelectors',
+] as const;
+export type PropertyType = (typeof AllPropertyTypes)[number];
 
 export interface CardRowDeps {
     fixInstructionProcessor: FixInstructionProcessor;
@@ -57,6 +52,10 @@ export const richResolutionConfiguration: PropertyConfiguration = {
 
 export const cssSelectorConfiguration: PropertyConfiguration = {
     cardRow: PathCardRow,
+};
+
+export const relatedCssSelectorsConfiguration: PropertyConfiguration = {
+    cardRow: RelatedPathsCardRow,
 };
 
 export const snippetConfiguration: PropertyConfiguration = {
@@ -91,6 +90,7 @@ const propertyIdToConfigurationMap: PropertyIdToConfigurationMap = {
     contentDescription: contentDescriptionConfiguration,
     text: textConfiguration,
     urls: urlsConfiguration,
+    relatedCssSelectors: relatedCssSelectorsConfiguration,
 };
 
 export function getPropertyConfiguration(id: string): Readonly<PropertyConfiguration> {

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -93,6 +93,7 @@ export type UnifiedIdentifiers = {
 export type UnifiedDescriptors = {
     snippet?: string;
     boundingRectangle?: BoundingRectangle;
+    relatedCssSelectors?: string[];
 } & InstancePropertyBag;
 
 export type UnifiedRichResolution = {

--- a/src/injected/adapters/extract-related-selectors.ts
+++ b/src/injected/adapters/extract-related-selectors.ts
@@ -4,28 +4,34 @@ import { TargetHelper } from 'common/target-helper';
 import { uniq } from 'lodash';
 import { AxeNodeResult } from '../../scanner/iruleresults';
 
+export type RelatedSelectorNormalizer = typeof normalizeRelatedSelectors;
 export type RelatedSelectorExtractor = typeof extractRelatedSelectors;
 
-export function extractRelatedSelectors(nodeResult: AxeNodeResult): string[] | undefined {
-    let output: string[] = [];
-    for (const checkType of ['all', 'any', 'none'] as const) {
-        const checks = nodeResult[checkType];
-        for (const check of checks) {
-            const relatedSelectors =
-                check.relatedNodes?.map(n => TargetHelper.getSelectorFromTarget(n.target)) ?? [];
-            output.push(...relatedSelectors);
-        }
-    }
-
+export function normalizeRelatedSelectors(nodeSelector: string, relatedSelectors?: string[]) {
     // This doesn't usually change anything; it would mainly affect if a rule had multiple
     // checks that each returned overlapping sets of related nodes. Axe generally returns
     // nodes in a reasonable order, so we want to use a method that preserves order here.
-    output = uniq(output);
+    relatedSelectors = uniq(relatedSelectors);
 
     // This does have a practical impact; some axe checks (eg, color-contrast) will occasionally
     // return the node itself as a "related node", and we'd rather avoid this.
-    const selfSelector = TargetHelper.getSelectorFromTarget(nodeResult.target);
-    output = output.filter(relatedSelector => relatedSelector !== selfSelector);
+    relatedSelectors = relatedSelectors.filter(relatedSelector => relatedSelector !== nodeSelector);
 
-    return output.length === 0 ? undefined : output;
+    return relatedSelectors.length === 0 ? undefined : relatedSelectors;
+}
+
+export function extractRelatedSelectors(nodeResult: AxeNodeResult): string[] | undefined {
+    const nodeSelector = TargetHelper.getSelectorFromTarget(nodeResult.target);
+
+    const relatedSelectors: string[] = [];
+    for (const checkType of ['all', 'any', 'none'] as const) {
+        const checks = nodeResult[checkType];
+        for (const check of checks) {
+            const relatedSelectorsForCheck =
+                check.relatedNodes?.map(n => TargetHelper.getSelectorFromTarget(n.target)) ?? [];
+            relatedSelectors.push(...relatedSelectorsForCheck);
+        }
+    }
+
+    return normalizeRelatedSelectors(nodeSelector, relatedSelectors);
 }

--- a/src/injected/adapters/extract-related-selectors.ts
+++ b/src/injected/adapters/extract-related-selectors.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TargetHelper } from 'common/target-helper';
+import { uniq } from 'lodash';
+import { AxeNodeResult } from '../../scanner/iruleresults';
+
+export type RelatedSelectorExtractor = typeof extractRelatedSelectors;
+
+export function extractRelatedSelectors(nodeResult: AxeNodeResult): string[] | undefined {
+    let output: string[] = [];
+    for (const checkType of ['all', 'any', 'none'] as const) {
+        const checks = nodeResult[checkType];
+        for (const check of checks) {
+            const relatedSelectors =
+                check.relatedNodes?.map(n => TargetHelper.getSelectorFromTarget(n.target)) ?? [];
+            output.push(...relatedSelectors);
+        }
+    }
+
+    // This doesn't usually change anything; it would mainly affect if a rule had multiple
+    // checks that each returned overlapping sets of related nodes. Axe generally returns
+    // nodes in a reasonable order, so we want to use a method that preserves order here.
+    output = uniq(output);
+
+    // This does have a practical impact; some axe checks (eg, color-contrast) will occasionally
+    // return the node itself as a "related node", and we'd rather avoid this.
+    const selfSelector = TargetHelper.getSelectorFromTarget(nodeResult.target);
+    output = output.filter(relatedSelector => relatedSelector !== selfSelector);
+
+    return output.length === 0 ? undefined : output;
+}

--- a/src/injected/adapters/scan-results-to-unified-results.ts
+++ b/src/injected/adapters/scan-results-to-unified-results.ts
@@ -10,7 +10,7 @@ import {
     UnifiedResult,
 } from '../../common/types/store-data/unified-data-interface';
 import { UUIDGenerator } from '../../common/uid-generator';
-import { AxeNodeResult, RuleResult, ScanResults, Target } from '../../scanner/iruleresults';
+import { AxeNodeResult, RuleResult, ScanResults } from '../../scanner/iruleresults';
 import { IssueFilingUrlStringUtils } from './../../issue-filing/common/issue-filing-url-string-utils';
 
 export type ConvertScanResultsToUnifiedResultsDelegate = (

--- a/src/injected/adapters/scan-results-to-unified-results.ts
+++ b/src/injected/adapters/scan-results-to-unified-results.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TargetHelper } from 'common/target-helper';
+import { RelatedSelectorExtractor } from 'injected/adapters/extract-related-selectors';
 import { ResolutionCreator } from 'injected/adapters/resolution-creator';
 import { flatMap } from 'lodash';
 
@@ -22,9 +24,10 @@ interface RuleResultData {
 
 export class ConvertScanResultsToUnifiedResults {
     constructor(
-        private uuidGenerator: UUIDGenerator,
-        private getFixResolution: ResolutionCreator,
-        private getCheckResolution: ResolutionCreator,
+        private readonly uuidGenerator: UUIDGenerator,
+        private readonly getFixResolution: ResolutionCreator,
+        private readonly getCheckResolution: ResolutionCreator,
+        private readonly extractRelatedSelectors: RelatedSelectorExtractor,
     ) {}
 
     public automatedChecksConversion: ConvertScanResultsToUnifiedResultsDelegate = (
@@ -111,7 +114,7 @@ export class ConvertScanResultsToUnifiedResults {
         ruleResultData: RuleResultData,
         getResolution: ResolutionCreator,
     ): UnifiedResult => {
-        const cssSelector = this.nodeToCssSelector(nodeResult);
+        const cssSelector = TargetHelper.getSelectorFromTarget(nodeResult.target);
         return {
             uid: this.uuidGenerator(),
             status: ruleResultData.status,
@@ -124,32 +127,12 @@ export class ConvertScanResultsToUnifiedResults {
             },
             descriptors: {
                 snippet: nodeResult.snippet || nodeResult.html,
-                relatedCssSelectors: this.relatedCssSelectors(nodeResult),
+                relatedCssSelectors: this.extractRelatedSelectors(nodeResult),
             },
             resolution: {
                 howToFixSummary: nodeResult.failureSummary!,
                 ...getResolution({ ruleId: ruleResultData.ruleID, nodeResult: nodeResult }),
             },
         };
-    };
-
-    private relatedCssSelectors(nodeResult: AxeNodeResult): string[] | undefined {
-        const output: string[] = [];
-        for (const checkType of ['all', 'any', 'none'] as const) {
-            const checks = nodeResult[checkType];
-            for (const check of checks) {
-                const relatedSelectors = check.relatedNodes?.map(this.nodeToCssSelector) ?? [];
-                output.push(...relatedSelectors);
-            }
-        }
-        return output.length === 0 ? undefined : output;
-    }
-
-    private nodeToCssSelector = (node: { target: Target }): string => {
-        const { target } = node;
-        if (typeof target === 'string') {
-            return target;
-        }
-        return target.join(';');
     };
 }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -14,6 +14,7 @@ import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data
 import { toolName } from 'content/strings/application';
 import { TabStopRequirementActionMessageCreator } from 'DetailsView/actions/tab-stop-requirement-action-message-creator';
 import { GetDetailsSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
+import { extractRelatedSelectors } from 'injected/adapters/extract-related-selectors';
 import { getCheckResolution, getFixResolution } from 'injected/adapters/resolution-creator';
 import { filterNeedsReviewResults } from 'injected/analyzers/filter-results';
 import { NotificationTextCreator } from 'injected/analyzers/notification-text-creator';
@@ -293,6 +294,7 @@ export class MainWindowInitializer extends WindowInitializer {
             generateUID,
             getFixResolution,
             getCheckResolution,
+            extractRelatedSelectors,
         );
 
         const notificationTextCreator = new NotificationTextCreator(scanIncompleteWarningDetector);

--- a/src/reports/package/accessibilityInsightsReport.d.ts
+++ b/src/reports/package/accessibilityInsightsReport.d.ts
@@ -86,7 +86,8 @@ declare namespace AccessibilityInsightsReport {
         elementSelector: string,
         snippet: string,
         fix: HowToFixData,
-        rule: AxeRuleData
+        rule: AxeRuleData,
+        relatedSelectors?: string[],
     };
 
     export interface FailuresGroup {

--- a/src/reports/package/combined-results-to-cards-model-converter.ts
+++ b/src/reports/package/combined-results-to-cards-model-converter.ts
@@ -5,6 +5,7 @@ import { CardSelectionViewData } from "common/get-card-selection-view-data";
 import { CardResult, CardRuleResult, CardRuleResultsByStatus, CardsViewModel } from "common/types/store-data/card-view-model";
 import { GuidanceLink } from "common/types/store-data/guidance-links";
 import { UUIDGenerator } from "common/uid-generator";
+import { RelatedSelectorNormalizer } from "injected/adapters/extract-related-selectors";
 import { ResolutionCreator } from "injected/adapters/resolution-creator";
 import { IssueFilingUrlStringUtils } from "issue-filing/common/issue-filing-url-string-utils";
 import { isNil } from "lodash";
@@ -18,6 +19,7 @@ export class CombinedResultsToCardsModelConverter {
         private readonly uuidGenerator: UUIDGenerator,
         private readonly helpUrlGetter: HelpUrlGetter,
         private readonly getFixResolution: ResolutionCreator,
+        private readonly normalizeRelatedSelectors: RelatedSelectorNormalizer,
     ) {}
 
     public convertResults = (
@@ -74,6 +76,7 @@ export class CombinedResultsToCardsModelConverter {
     private getFailureCardResult = (failureData: FailureData): CardResult => {
         const rule = failureData.rule;
         const cssSelector = failureData.elementSelector;
+        const relatedCssSelectors = this.normalizeRelatedSelectors(cssSelector, failureData.relatedSelectors);
 
         const urls: any = {};
         if (failureData.urls) {
@@ -100,6 +103,7 @@ export class CombinedResultsToCardsModelConverter {
             },
             descriptors: {
                 snippet: failureData.snippet,
+                relatedCssSelectors,
             },
             resolution: {
                 howToFixSummary: failureData.fix.failureSummary,

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -7,7 +7,7 @@ import { getA11yInsightsWebRuleUrl } from 'common/configs/a11y-insights-rule-res
 import { CardSelectionViewData } from 'common/get-card-selection-view-data';
 import { getCardViewData } from 'common/rule-based-view-model-provider';
 import { generateUID } from 'common/uid-generator';
-import { extractRelatedSelectors } from 'injected/adapters/extract-related-selectors';
+import { extractRelatedSelectors, normalizeRelatedSelectors } from 'injected/adapters/extract-related-selectors';
 import { getCheckResolution, getFixResolution } from 'injected/adapters/resolution-creator';
 import { ConvertScanResultsToUnifiedResults } from 'injected/adapters/scan-results-to-unified-results';
 import { convertScanResultsToUnifiedRules } from 'injected/adapters/scan-results-to-unified-rules';
@@ -185,6 +185,7 @@ const combinedResultsReportGenerator = (parameters: CombinedReportParameters) =>
         generateUID,
         helpUrlGetter,
         getFixResolution,
+        normalizeRelatedSelectors,
     );
 
     return new CombinedResultsReport(deps, parameters, toolData, resultsToCardsConverter);

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -7,6 +7,7 @@ import { getA11yInsightsWebRuleUrl } from 'common/configs/a11y-insights-rule-res
 import { CardSelectionViewData } from 'common/get-card-selection-view-data';
 import { getCardViewData } from 'common/rule-based-view-model-provider';
 import { generateUID } from 'common/uid-generator';
+import { extractRelatedSelectors } from 'injected/adapters/extract-related-selectors';
 import { getCheckResolution, getFixResolution } from 'injected/adapters/resolution-creator';
 import { ConvertScanResultsToUnifiedResults } from 'injected/adapters/scan-results-to-unified-results';
 import { convertScanResultsToUnifiedRules } from 'injected/adapters/scan-results-to-unified-rules';
@@ -94,7 +95,12 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
         mapAxeTagsToGuidanceLinks,
         ruleProcessor,
     );
-    const getUnifiedResults = new ConvertScanResultsToUnifiedResults(generateUID, getFixResolution, getCheckResolution).automatedChecksConversion;
+    const getUnifiedResults = new ConvertScanResultsToUnifiedResults(
+        generateUID,
+        getFixResolution,
+        getCheckResolution,
+        extractRelatedSelectors
+    ).automatedChecksConversion;
 
     const deps: AxeResultsReportDeps = {
         reportHtmlGenerator,

--- a/src/scanner/iruleresults.d.ts
+++ b/src/scanner/iruleresults.d.ts
@@ -69,6 +69,12 @@ export interface FormattedCheckResult {
     message: string;
     data: IAxeCheckResultExtraData;
     result?: boolean;
+    relatedNodes?: AxeRelatedNode[];
+}
+
+export interface AxeRelatedNode {
+    target: string[];
+    html: string;
 }
 
 export interface IAxeCheckResultExtraData {

--- a/src/scanner/iruleresults.d.ts
+++ b/src/scanner/iruleresults.d.ts
@@ -73,7 +73,7 @@ export interface FormattedCheckResult {
 }
 
 export interface AxeRelatedNode {
-    target: string[];
+    target: (string | string[])[];
     html: string;
 }
 

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/related-paths-card-row.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/related-paths-card-row.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RelatedPathsCardRow renders matching snapshot with related paths present 1`] = `
+<SimpleCardRow
+  content={
+    <ul
+      className="pathList"
+    >
+      <li>
+        #path-1a;.path-1b
+      </li>
+      <li>
+        #path-2
+      </li>
+      <li>
+        .path-3
+      </li>
+    </ul>
+  }
+  label="Related paths"
+  rowKey="related-paths-row-123"
+/>
+`;

--- a/src/tests/unit/tests/common/components/cards/related-paths-card-row.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/related-paths-card-row.test.tsx
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    RelatedPathsCardRow,
+    RelatedPathsCardRowProps,
+} from 'common/components/cards/related-paths-card-row';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe(RelatedPathsCardRow.displayName, () => {
+    it.each([null, undefined, []])('renders as null with related paths: %p', relatedPaths => {
+        const props: RelatedPathsCardRowProps = {
+            deps: null,
+            index: 123,
+            propertyData: relatedPaths,
+        };
+        const testSubject = shallow(<RelatedPathsCardRow {...props} />);
+
+        expect(testSubject.getElement()).toBeNull();
+    });
+
+    it('renders matching snapshot with related paths present', () => {
+        const props: RelatedPathsCardRowProps = {
+            deps: null,
+            index: 123,
+            propertyData: ['#path-1a;.path-1b', '#path-2', '.path-3'],
+        };
+        const testSubject = shallow(<RelatedPathsCardRow {...props} />);
+
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/common/components/cards/related-paths-card-row.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/related-paths-card-row.test.tsx
@@ -8,16 +8,19 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe(RelatedPathsCardRow.displayName, () => {
-    it.each([null, undefined, []])('renders as null with related paths: %p', relatedPaths => {
-        const props: RelatedPathsCardRowProps = {
-            deps: null,
-            index: 123,
-            propertyData: relatedPaths,
-        };
-        const testSubject = shallow(<RelatedPathsCardRow {...props} />);
+    it.each([[], null, undefined])(
+        'renders as null with related paths: %p',
+        (relatedPaths?: any) => {
+            const props: RelatedPathsCardRowProps = {
+                deps: null,
+                index: 123,
+                propertyData: relatedPaths,
+            };
+            const testSubject = shallow(<RelatedPathsCardRow {...props} />);
 
-        expect(testSubject.getElement()).toBeNull();
-    });
+            expect(testSubject.getElement()).toBeNull();
+        },
+    );
 
     it('renders matching snapshot with related paths present', () => {
         const props: RelatedPathsCardRowProps = {

--- a/src/tests/unit/tests/injected/adapters/__snapshots__/scan-results-to-unified-results.test.ts.snap
+++ b/src/tests/unit/tests/injected/adapters/__snapshots__/scan-results-to-unified-results.test.ts.snap
@@ -6,6 +6,9 @@ exports[`ScanResults to Unified Results Test automaticChecksConversion works wit
 [
   {
     "descriptors": {
+      "relatedCssSelectors": [
+        "extractRelatedSelectors output for target1,id1",
+      ],
       "snippet": "html1",
     },
     "identifiers": {
@@ -27,6 +30,9 @@ exports[`ScanResults to Unified Results Test automaticChecksConversion works wit
   },
   {
     "descriptors": {
+      "relatedCssSelectors": [
+        "extractRelatedSelectors output for target2,id2",
+      ],
       "snippet": "html2",
     },
     "identifiers": {
@@ -48,6 +54,9 @@ exports[`ScanResults to Unified Results Test automaticChecksConversion works wit
   },
   {
     "descriptors": {
+      "relatedCssSelectors": [
+        "extractRelatedSelectors output for target3,id3",
+      ],
       "snippet": "html3",
     },
     "identifiers": {
@@ -69,6 +78,9 @@ exports[`ScanResults to Unified Results Test automaticChecksConversion works wit
   },
   {
     "descriptors": {
+      "relatedCssSelectors": [
+        "extractRelatedSelectors output for passTarget1,passTarget2",
+      ],
       "snippet": "html-pass",
     },
     "identifiers": {
@@ -97,6 +109,9 @@ exports[`ScanResults to Unified Results Test needsReviewConversion works with fi
 [
   {
     "descriptors": {
+      "relatedCssSelectors": [
+        "extractRelatedSelectors output for incompleteTarget1",
+      ],
       "snippet": "html-incomplete",
     },
     "identifiers": {
@@ -117,6 +132,9 @@ exports[`ScanResults to Unified Results Test needsReviewConversion works with fi
   },
   {
     "descriptors": {
+      "relatedCssSelectors": [
+        "extractRelatedSelectors output for target1,id1",
+      ],
       "snippet": "html1",
     },
     "identifiers": {
@@ -138,6 +156,9 @@ exports[`ScanResults to Unified Results Test needsReviewConversion works with fi
   },
   {
     "descriptors": {
+      "relatedCssSelectors": [
+        "extractRelatedSelectors output for target2,id2",
+      ],
       "snippet": "html2",
     },
     "identifiers": {
@@ -159,6 +180,9 @@ exports[`ScanResults to Unified Results Test needsReviewConversion works with fi
   },
   {
     "descriptors": {
+      "relatedCssSelectors": [
+        "extractRelatedSelectors output for target3,id3",
+      ],
       "snippet": "html3",
     },
     "identifiers": {

--- a/src/tests/unit/tests/injected/adapters/extract-related-selectors.test.ts
+++ b/src/tests/unit/tests/injected/adapters/extract-related-selectors.test.ts
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { extractRelatedSelectors } from 'injected/adapters/extract-related-selectors';
+import { AxeNodeResult, FormattedCheckResult, Target } from 'scanner/iruleresults';
+
+describe(extractRelatedSelectors, () => {
+    function checkResult(relatedTargets?: Target[]): FormattedCheckResult {
+        const result: FormattedCheckResult = {
+            id: 'check-id',
+            message: 'check-message',
+            data: {},
+        };
+        if (relatedTargets != null) {
+            result.relatedNodes = relatedTargets.map(target => ({ html: 'related-html', target }));
+        }
+        return result;
+    }
+    it('returns undefined if there are no relatedNodes', () => {
+        const input: AxeNodeResult = {
+            target: ['#node'],
+            html: 'node-html',
+            all: [checkResult()],
+            any: [checkResult()],
+            none: [],
+        };
+        const output = extractRelatedSelectors(input);
+        expect(output).toBeUndefined();
+    });
+
+    it('returns undefined if the only relatedNodes are the node itself', () => {
+        const input: AxeNodeResult = {
+            target: ['#node'],
+            html: 'node-html',
+            all: [],
+            any: [checkResult([['#node']])],
+            none: [checkResult([['#node']])],
+        };
+        const output = extractRelatedSelectors(input);
+        expect(output).toBeUndefined();
+    });
+
+    it('extracts as-is simple targets per relatedNode', () => {
+        const input: AxeNodeResult = {
+            target: ['#node'],
+            html: 'node-html',
+            all: [checkResult([['#related-1']])],
+            any: [],
+            none: [checkResult([['.related-2']])],
+        };
+        const output = extractRelatedSelectors(input);
+        expect(output).toStrictEqual(['#related-1', '.related-2']);
+    });
+
+    it('semicolon-joins array-style targets per relatedNode', () => {
+        const input: AxeNodeResult = {
+            target: ['#node'],
+            html: 'node-html',
+            all: [],
+            any: [checkResult([['#related-1-outer', '#related-1-inner']])],
+            none: [],
+        };
+        const output = extractRelatedSelectors(input);
+        expect(output).toStrictEqual(['#related-1-outer;#related-1-inner']);
+    });
+
+    it('comma and semicolon joins array-of-array-style targets per relatedNode', () => {
+        const input: AxeNodeResult = {
+            target: ['#node'],
+            html: 'node-html',
+            all: [],
+            any: [
+                checkResult([
+                    [
+                        ['#related-1-outer-1', '#related-1-outer-2'],
+                        ['#related-1-inner-1', '#related-1-inner-2'],
+                    ],
+                ]),
+            ],
+            none: [],
+        };
+        const output = extractRelatedSelectors(input);
+        expect(output).toStrictEqual([
+            '#related-1-outer-1,#related-1-outer-2;#related-1-inner-1,#related-1-inner-2',
+        ]);
+    });
+
+    it('includes multiple relatedNodes from same checks', () => {
+        const input: AxeNodeResult = {
+            target: ['#node'],
+            html: 'node-html',
+            all: [checkResult([['#related-1'], ['#related-2'], ['#related-3']])],
+            any: [],
+            none: [],
+        };
+        const output = extractRelatedSelectors(input);
+        expect(output).toStrictEqual(['#related-1', '#related-2', '#related-3']);
+    });
+
+    it('includes relatedNodes from multiple different checks', () => {
+        const input: AxeNodeResult = {
+            target: ['#node'],
+            html: 'node-html',
+            all: [checkResult([['#related-1']]), checkResult([['#related-2']])],
+            any: [],
+            none: [checkResult([['#related-3']])],
+        };
+        const output = extractRelatedSelectors(input);
+        expect(output).toStrictEqual(['#related-1', '#related-2', '#related-3']);
+    });
+
+    it('omits duplicates', () => {
+        const input: AxeNodeResult = {
+            target: ['#node'],
+            html: 'node-html',
+            all: [checkResult([['#related-1']]), checkResult([['#related-2']])],
+            any: [checkResult([['#related-2']]), checkResult([['#related-3']])],
+            none: [checkResult([['#related-3']]), checkResult([['#related-1']])],
+        };
+        const output = extractRelatedSelectors(input);
+        expect(output).toStrictEqual(['#related-1', '#related-2', '#related-3']);
+    });
+
+    it.each([[[1, 2, 3]], [[3, 2, 1]], [[1, 3, 2]]])(
+        'maintains original order',
+        (order: number[]) => {
+            const relatedSelectors = order.map(n => `#related-${n}`);
+
+            const input: AxeNodeResult = {
+                target: ['#node'],
+                html: 'node-html',
+                all: [
+                    checkResult([[relatedSelectors[0]]]),
+                    checkResult([[relatedSelectors[1]]]),
+                    checkResult([[relatedSelectors[2]]]),
+                ],
+                any: [],
+                none: [],
+            };
+            const output = extractRelatedSelectors(input);
+            expect(output).toStrictEqual([
+                relatedSelectors[0],
+                relatedSelectors[1],
+                relatedSelectors[2],
+            ]);
+        },
+    );
+
+    it('omits the node itself', () => {
+        const input: AxeNodeResult = {
+            target: ['#node'],
+            html: 'node-html',
+            all: [checkResult([['#related-1']]), checkResult([['#node']])],
+            any: [],
+            none: [checkResult([['#related-2']])],
+        };
+        const output = extractRelatedSelectors(input);
+        expect(output).toStrictEqual(['#related-1', '#related-2']);
+    });
+});

--- a/src/tests/unit/tests/injected/adapters/scan-results-to-unified-results.test.ts
+++ b/src/tests/unit/tests/injected/adapters/scan-results-to-unified-results.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { RelatedSelectorExtractor } from 'injected/adapters/extract-related-selectors';
 import { ResolutionCreator } from 'injected/adapters/resolution-creator';
 import { ConvertScanResultsToUnifiedResults } from 'injected/adapters/scan-results-to-unified-results';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
@@ -12,6 +13,7 @@ describe('ScanResults to Unified Results Test', () => {
     let generateGuidMock: IMock<() => string>;
     let fixResolutionCreatorMock: IMock<ResolutionCreator>;
     let checkResolutionCreatorMock: IMock<ResolutionCreator>;
+    let extractRelatedSelectorsStub: RelatedSelectorExtractor;
 
     beforeEach(() => {
         const guidStub = 'gguid-mock-stub';
@@ -22,6 +24,7 @@ describe('ScanResults to Unified Results Test', () => {
             .verifiable(Times.atLeastOnce());
         fixResolutionCreatorMock = Mock.ofType<ResolutionCreator>();
         checkResolutionCreatorMock = Mock.ofType<ResolutionCreator>();
+        extractRelatedSelectorsStub = node => [`extractRelatedSelectors output for ${node.target}`];
     });
 
     const nullIdentifiers = [null, undefined, {}];
@@ -110,6 +113,7 @@ describe('ScanResults to Unified Results Test', () => {
             generateGuidMock.object,
             fixResolutionCreatorMock.object,
             checkResolutionCreatorMock.object,
+            extractRelatedSelectorsStub,
         );
     }
 

--- a/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
+++ b/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { RecommendColor } from 'common/components/recommend-color';
+import * as React from 'react';
 import { Mock, Times } from 'typemoq';
 
 describe('FixInstructionProcessor', () => {
@@ -11,6 +12,14 @@ describe('FixInstructionProcessor', () => {
     beforeEach(() => {
         recommendColorMock.reset();
         testSubject = new FixInstructionProcessor();
+    });
+
+    test('updates aria-required-children "(see related nodes)" text to "(see related paths)"', () => {
+        const fixInstruction = 'Element has children which are not allowed (see related nodes)';
+
+        const result = testSubject.process(fixInstruction, recommendColorMock.object);
+
+        expect(result).toEqual(<>Element has children which are not allowed (see related paths)</>);
     });
 
     test('no background nor foreground on the message', () => {

--- a/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/combined-results-to-cards-model-converter.test.ts.snap
@@ -13,6 +13,9 @@ exports[`CombinedResultsToCardsModelConverter with a mixture of url specificatio
         "nodes": [
           {
             "descriptors": {
+              "relatedCssSelectors": [
+                "normalizeRelatedSelectors output for .failed-rule-1-selector-1, undefined",
+              ],
               "snippet": "<div>snippet 1</div>",
             },
             "highlightStatus": "unavailable",
@@ -89,6 +92,9 @@ exports[`CombinedResultsToCardsModelConverter with baseline-aware issues 1`] = `
         "nodes": [
           {
             "descriptors": {
+              "relatedCssSelectors": [
+                "normalizeRelatedSelectors output for .failed-rule-1-selector-1, undefined",
+              ],
               "snippet": "<div>snippet 1</div>",
             },
             "highlightStatus": "unavailable",
@@ -116,6 +122,9 @@ exports[`CombinedResultsToCardsModelConverter with baseline-aware issues 1`] = `
           },
           {
             "descriptors": {
+              "relatedCssSelectors": [
+                "normalizeRelatedSelectors output for .failed-rule-1-selector-2, undefined",
+              ],
               "snippet": "<div>snippet 2</div>",
             },
             "highlightStatus": "unavailable",
@@ -160,6 +169,9 @@ exports[`CombinedResultsToCardsModelConverter with baseline-aware issues 1`] = `
         "nodes": [
           {
             "descriptors": {
+              "relatedCssSelectors": [
+                "normalizeRelatedSelectors output for .failed-rule-2-selector-1, undefined",
+              ],
               "snippet": "<div>snippet 1</div>",
             },
             "highlightStatus": "unavailable",
@@ -187,6 +199,9 @@ exports[`CombinedResultsToCardsModelConverter with baseline-aware issues 1`] = `
           },
           {
             "descriptors": {
+              "relatedCssSelectors": [
+                "normalizeRelatedSelectors output for .failed-rule-2-selector-2, undefined",
+              ],
               "snippet": "<div>snippet 2</div>",
             },
             "highlightStatus": "unavailable",
@@ -263,6 +278,9 @@ exports[`CombinedResultsToCardsModelConverter with issues 1`] = `
         "nodes": [
           {
             "descriptors": {
+              "relatedCssSelectors": [
+                "normalizeRelatedSelectors output for .failed-rule-1-selector-1, undefined",
+              ],
               "snippet": "<div>snippet 1</div>",
             },
             "highlightStatus": "unavailable",
@@ -290,6 +308,9 @@ exports[`CombinedResultsToCardsModelConverter with issues 1`] = `
           },
           {
             "descriptors": {
+              "relatedCssSelectors": [
+                "normalizeRelatedSelectors output for .failed-rule-1-selector-2, undefined",
+              ],
               "snippet": "<div>snippet 2</div>",
             },
             "highlightStatus": "unavailable",
@@ -334,6 +355,9 @@ exports[`CombinedResultsToCardsModelConverter with issues 1`] = `
         "nodes": [
           {
             "descriptors": {
+              "relatedCssSelectors": [
+                "normalizeRelatedSelectors output for .failed-rule-2-selector-1, undefined",
+              ],
               "snippet": "<div>snippet 1</div>",
             },
             "highlightStatus": "unavailable",
@@ -361,6 +385,9 @@ exports[`CombinedResultsToCardsModelConverter with issues 1`] = `
           },
           {
             "descriptors": {
+              "relatedCssSelectors": [
+                "normalizeRelatedSelectors output for .failed-rule-2-selector-2, undefined",
+              ],
               "snippet": "<div>snippet 2</div>",
             },
             "highlightStatus": "unavailable",
@@ -484,6 +511,9 @@ exports[`CombinedResultsToCardsModelConverter without passed or inapplicable rul
         "nodes": [
           {
             "descriptors": {
+              "relatedCssSelectors": [
+                "normalizeRelatedSelectors output for .failed-rule-1-selector-1, undefined",
+              ],
               "snippet": "<div>snippet 1</div>",
             },
             "highlightStatus": "unavailable",
@@ -511,6 +541,9 @@ exports[`CombinedResultsToCardsModelConverter without passed or inapplicable rul
           },
           {
             "descriptors": {
+              "relatedCssSelectors": [
+                "normalizeRelatedSelectors output for .failed-rule-1-selector-2, undefined",
+              ],
               "snippet": "<div>snippet 2</div>",
             },
             "highlightStatus": "unavailable",

--- a/src/tests/unit/tests/reports/package/combined-results-to-cards-model-converter.test.ts
+++ b/src/tests/unit/tests/reports/package/combined-results-to-cards-model-converter.test.ts
@@ -24,6 +24,9 @@ describe(CombinedResultsToCardsModelConverter, () => {
         }
     } as HelpUrlGetter;
     let resolutionCreatorMock: IMock<ResolutionCreator>;
+    const normalizeRelatedSelectorsStub = (selector: string, relatedSelectors?: string[]) => {
+        return [`normalizeRelatedSelectors output for ${selector}, ${relatedSelectors}`];
+    }
 
     let testSubject: CombinedResultsToCardsModelConverter;
 
@@ -42,6 +45,7 @@ describe(CombinedResultsToCardsModelConverter, () => {
             uuidGeneratorMock.object,
             helpUrlGetterStub,
             resolutionCreatorMock.object,
+            normalizeRelatedSelectorsStub,
         );
     })
 


### PR DESCRIPTION
#### Details

This PR implements a feature to add a new "Related paths" row to result cards that represent axe-core results which included any check results with `relatedNodes` properties.

It adds this information to cards in the fast pass automated checks and needs review results, as well as exported reports.

It also adds a (backwards-compatible) property that the service may include as part of combined report reports - if specified, it would add the same field to combined report cards. The decision of whether it is safe to include that data in practice is intentionally out of scope for this PR and delegated to the service - we might decide to always include it if available, or to only include it if it's both available and consistent between all grouped results. The service will have the responsibility of deciding that, like it already has responsibility for the rest of result-grouping logic.

Screenshot of FastPass Automated Checks showing an `aria-required-children` violation with Related paths:
![screenshot of FastPass card with "Related paths" card row added in between "Snippet" and "How to fix" rows, showing a list of targets formatted similarly to the old "Path" row](https://user-images.githubusercontent.com/376284/215625581-3fe63469-bc8b-49ee-8a08-3bf1c4e67542.png)

Screenshot of FastPass Report Export showing the same info:
![screenshot of FastPass report export with "Related paths" card row added in between "Snippet" and "How to fix" rows, showing a list of targets formatted similarly to the old "Path" row](https://user-images.githubusercontent.com/376284/215625717-b7632986-e2d4-4328-80fd-7e419dc54674.png)

Screenshot of FastPass Automated Checks' `color-contrast` results on a page where `axe-core` only reports related paths for some results - note that cards for results where the data is present show it, and results where axe-core didn't report that data omit it.
![screenshot of two FastPass cards, one with Related paths and one without](https://user-images.githubusercontent.com/376284/215625877-2225d666-c98f-4d5b-a62a-5652daa7cf33.png)

##### Motivation

This is primarily to improve the actionability of the `aria-required-children` "unknown" violation path which we added support for during our 4.6.3 update in #6334. That path uses a how to fix message of the form `"Element has children which are not allowed (see related nodes)"`, which isn't very actionable without this PR since we don't expose "related nodes" anywhere. This specific message might be updated in a future version of axe-core (see https://github.com/dequelabs/axe-core/issues/3842)

This secondarily improves the actionability of a few other rules that axe-core exposes related nodes for - particularly, `color-contrast` violations where axe knows the node that is responsible for the background color of a violation will now present that background node as a "related path".

##### Context

In addition to this change, we'll want to make a docs change to https://accessibilityinsights.io/info-examples/web/aria-required-children/ to make this specific form of `aria-required-children` violation easier for a user to understand and take action on.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 2020748
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
