### PR TITLE
fix: copy yarn.lock file to fix deploy dep version pinning

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -374,7 +374,7 @@ module.exports = function (grunt) {
                         },
                         {
                             cwd: 'deploy',
-                            src: ['Gruntfile.js', 'package.json'],
+                            src: ['Gruntfile.js', 'package.json', 'yarn.lock'],
                             dest: dropPath,
                             expand: true,
                         },


### PR DESCRIPTION
#### Details

We believed we were pinning our deployment dependency versions but because the yarn.lock file was not being copied over to the appropriate folders, yarn would find no lock file and proceed without pinning.

##### Motivation

Fixes current release errors.

##### Context

We could've also fixed these release errors by updating the node version used in our releases but will look to do that separately.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
