### PR TITLE
feat(quick-assess): start over should be specific to quick assess

### DIFF
--- a/src/DetailsView/components/details-view-right-panel.ts
+++ b/src/DetailsView/components/details-view-right-panel.ts
@@ -37,7 +37,7 @@ export type DetailsRightPanelConfiguration = Readonly<{
     RightPanel: ReactFCWithDisplayName<RightPanelProps>;
     GetTitle: (props: GetTestViewTitleProps) => string;
     GetLeftNavSelectedKey: (props: GetLeftNavSelectedKeyProps) => string;
-    GetStartOverContextualMenuItemKeys: () => string[];
+    startOverContextMenuKeyOptions: StartOverContextMenuKeyOptions;
 }>;
 
 export type GetDetailsRightPanelConfiguration = (
@@ -55,14 +55,19 @@ const detailsViewTypeContentMap: {
         RightPanel: OverviewContainer,
         GetTitle: getOverviewTitle,
         GetLeftNavSelectedKey: getOverviewKey,
-        GetStartOverContextualMenuItemKeys: () => ['assessment'],
+        startOverContextMenuKeyOptions: { showAssessment: true, showTest: false },
     },
     TestView: {
         RightPanel: TestViewContainer,
         GetTitle: getTestViewTitle,
         GetLeftNavSelectedKey: getTestViewKey,
-        GetStartOverContextualMenuItemKeys: () => ['assessment', 'test'],
+        startOverContextMenuKeyOptions: { showAssessment: true, showTest: true },
     },
+};
+
+export type StartOverContextMenuKeyOptions = {
+    showAssessment: boolean;
+    showTest: boolean;
 };
 
 export const GetDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration = (

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -52,8 +52,8 @@ import {
 import {
     GetRequirementViewComponentConfiguration,
     getRequirementViewComponentConfigurationForAssessment,
-    getRequirementViewComponentConfigurationForQuickAssess,
     getRequirementViewComponentConfigurationForFastPass,
+    getRequirementViewComponentConfigurationForQuickAssess,
 } from 'DetailsView/components/requirement-view-component-configuration';
 import {
     getNullSaveButton,
@@ -68,6 +68,7 @@ import {
 import {
     AssessmentStartOverFactory,
     FastpassStartOverFactory,
+    QuickAssessStartOverFactory,
     StartOverComponentFactory,
 } from 'DetailsView/components/start-over-component-factory';
 import { getTransferToAssessmentButton } from 'DetailsView/components/transfer-to-assessment-button';
@@ -163,7 +164,7 @@ const detailsViewSwitcherNavs: {
         SaveAssessmentButton: getNullSaveButton,
         LoadAssessmentButton: getNullLoadButton,
         TransferToAssessmentButton: getTransferToAssessmentButton,
-        StartOverComponentFactory: AssessmentStartOverFactory,
+        StartOverComponentFactory: QuickAssessStartOverFactory,
         LeftNav: QuickAssessLeftNav,
         getSelectedDetailsView: getQuickAssessSelectedDetailsView,
         warningConfiguration: assessmentWarningConfiguration,

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -48,6 +48,17 @@ export const AssessmentStartOverFactory: StartOverComponentFactory = {
     },
 };
 
+export const QuickAssessStartOverFactory: StartOverComponentFactory = {
+    getStartOverComponent: props => getStartOverComponentForQuickAssess(props, 'down'),
+    getStartOverMenuItem: props => {
+        return {
+            onRender: () => (
+                <div role="menuitem">{getStartOverComponentForQuickAssess(props, 'left')}</div>
+            ),
+        };
+    },
+};
+
 export const FastpassStartOverFactory: StartOverComponentFactory = {
     getStartOverComponent: props => {
         return <InsightsCommandButton {...getStartOverPropsForFastPass(props)} />;
@@ -62,11 +73,32 @@ export function getStartOverComponentForAssessment(
     const selectedTest = props.assessmentStoreData.assessmentNavState.selectedTestType;
     const test = props.deps.getProvider().forType(selectedTest);
     const startOverProps: StartOverProps = {
-        testName: test.title,
-        rightPanelConfiguration: props.rightPanelConfiguration,
+        singleTestSuffix: test.title,
+        allTestSuffix: 'Assessment',
         dropdownDirection,
         openDialog: props.openDialog,
         buttonRef: props.buttonRef,
+        rightPanelOptions: props.rightPanelConfiguration.startOverContextMenuKeyOptions,
+        switcherStartOverPreferences: { showAssessment: true, showTest: true },
+    };
+
+    return <StartOverDropdown {...startOverProps} />;
+}
+
+export function getStartOverComponentForQuickAssess(
+    props: StartOverFactoryProps,
+    dropdownDirection: DropdownDirection,
+): JSX.Element {
+    const { selectedTestSubview, selectedTestType } = props.assessmentStoreData.assessmentNavState;
+    const test = props.deps.getProvider().getStep(selectedTestType, selectedTestSubview);
+    const startOverProps: StartOverProps = {
+        singleTestSuffix: test.name,
+        allTestSuffix: 'Quick Assess',
+        dropdownDirection,
+        openDialog: props.openDialog,
+        buttonRef: props.buttonRef,
+        rightPanelOptions: props.rightPanelConfiguration.startOverContextMenuKeyOptions,
+        switcherStartOverPreferences: { showAssessment: true, showTest: false },
     };
 
     return <StartOverDropdown {...startOverProps} />;

--- a/src/DetailsView/components/start-over-dialog.tsx
+++ b/src/DetailsView/components/start-over-dialog.tsx
@@ -59,8 +59,7 @@ export const StartOverDialog = NamedFC<StartOverDialogProps>('StartOverDialog', 
     const dialogPropsOptions = {
         assessment: {
             messageText:
-                'Starting over will clear all existing results from the Assessment. ' +
-                'This will clear results and progress of all tests and requirements. ' +
+                'Starting over will clear all existing results and clear progress of all tests and requirements. ' +
                 'Are you sure you want to start over?',
             onPrimaryButtonClick: onStartOverAllTests,
             onCancelButtonClick: onCancelStartOverAllTests,

--- a/src/DetailsView/components/start-over-dropdown.tsx
+++ b/src/DetailsView/components/start-over-dropdown.tsx
@@ -12,7 +12,7 @@ import { InsightsCommandButton } from 'common/components/controls/insights-comma
 import { StartOverDialogType } from 'DetailsView/components/start-over-dialog';
 import * as React from 'react';
 
-import { DetailsRightPanelConfiguration } from './details-view-right-panel';
+import { StartOverContextMenuKeyOptions } from './details-view-right-panel';
 
 export interface StartOverState {
     isContextMenuVisible: boolean;
@@ -20,11 +20,13 @@ export interface StartOverState {
 }
 
 export interface StartOverProps {
-    testName: string;
-    rightPanelConfiguration: DetailsRightPanelConfiguration;
+    singleTestSuffix: string;
     dropdownDirection: DropdownDirection;
     openDialog: (dialogType: StartOverDialogType) => void;
     buttonRef: IRefObject<IButton>;
+    allTestSuffix: string;
+    rightPanelOptions: StartOverContextMenuKeyOptions;
+    switcherStartOverPreferences: StartOverContextMenuKeyOptions;
 }
 
 const dropdownDirections = {
@@ -88,23 +90,33 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
     }
 
     private getMenuItems(): IContextualMenuItem[] {
-        const { testName, rightPanelConfiguration } = this.props;
-        const items: IContextualMenuItem[] = [
-            {
-                key: 'assessment',
-                name: 'Start over Assessment',
-                onClick: this.onStartOverAllTestsMenu,
-            },
-            {
-                key: 'test',
-                name: `Start over ${testName}`,
-                onClick: this.onStartOverTestMenu,
-            },
-        ];
+        const {
+            singleTestSuffix,
+            allTestSuffix,
+            rightPanelOptions,
+            switcherStartOverPreferences: startOverButtonOptionPreferences,
+        } = this.props;
+        const items: IContextualMenuItem[] = [];
+        const assessmentKey = {
+            key: 'assessment',
+            name: `Start over ${allTestSuffix}`,
+            onClick: this.onStartOverAllTestsMenu,
+        };
+        const testKey = {
+            key: 'test',
+            name: `Start over ${singleTestSuffix}`,
+            onClick: this.onStartOverTestMenu,
+        };
 
-        return rightPanelConfiguration
-            .GetStartOverContextualMenuItemKeys()
-            .map(key => items.find(item => item.key === key));
+        if (rightPanelOptions.showAssessment && startOverButtonOptionPreferences.showAssessment) {
+            items.push(assessmentKey);
+        }
+
+        if (rightPanelOptions.showTest && startOverButtonOptionPreferences.showTest) {
+            items.push(testKey);
+        }
+
+        return items;
     }
 
     private onStartOverTestMenu = (): void => {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
@@ -2,8 +2,21 @@
 
 exports[`StartOverComponentFactory AssessmentStartOverFactory getStartOverComponent 1`] = `
 <StartOverDropdown
+  allTestSuffix="Assessment"
   dropdownDirection="down"
-  testName="the title"
+  rightPanelOptions={
+    {
+      "showAssessment": true,
+      "showTest": true,
+    }
+  }
+  singleTestSuffix="the title"
+  switcherStartOverPreferences={
+    {
+      "showAssessment": true,
+      "showTest": true,
+    }
+  }
 />
 `;
 
@@ -12,8 +25,21 @@ exports[`StartOverComponentFactory AssessmentStartOverFactory getStartOverMenuIt
   role="menuitem"
 >
   <StartOverDropdown
+    allTestSuffix="Assessment"
     dropdownDirection="left"
-    testName="the title"
+    rightPanelOptions={
+      {
+        "showAssessment": true,
+        "showTest": true,
+      }
+    }
+    singleTestSuffix="the title"
+    switcherStartOverPreferences={
+      {
+        "showAssessment": true,
+        "showTest": true,
+      }
+    }
   />
 </div>
 `;
@@ -76,4 +102,48 @@ exports[`StartOverComponentFactory FastpassStartOverFactory getStartOverMenuItem
   "onClick": [Function],
   "text": "Start over",
 }
+`;
+
+exports[`StartOverComponentFactory QuickAssessStartOverFactory getStartOverComponent 1`] = `
+<StartOverDropdown
+  allTestSuffix="Quick Assess"
+  dropdownDirection="down"
+  rightPanelOptions={
+    {
+      "showAssessment": true,
+      "showTest": true,
+    }
+  }
+  singleTestSuffix="requirement name stub"
+  switcherStartOverPreferences={
+    {
+      "showAssessment": true,
+      "showTest": false,
+    }
+  }
+/>
+`;
+
+exports[`StartOverComponentFactory QuickAssessStartOverFactory getStartOverMenuItem 1`] = `
+<div
+  role="menuitem"
+>
+  <StartOverDropdown
+    allTestSuffix="Quick Assess"
+    dropdownDirection="left"
+    rightPanelOptions={
+      {
+        "showAssessment": true,
+        "showTest": true,
+      }
+    }
+    singleTestSuffix="requirement name stub"
+    switcherStartOverPreferences={
+      {
+        "showAssessment": true,
+        "showTest": false,
+      }
+    }
+  />
+</div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dialog.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`StartOverDialog renders when dialogState = assessment 1`] = `
 <GenericDialog
   isHidden={false}
-  messageText="Starting over will clear all existing results from the Assessment. This will clear results and progress of all tests and requirements. Are you sure you want to start over?"
+  messageText="Starting over will clear all existing results and clear progress of all tests and requirements. Are you sure you want to start over?"
   onCancelButtonClick={[Function]}
   onPrimaryButtonClick={[Function]}
   primaryButtonText="Start over"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
@@ -30,47 +30,12 @@ exports[`StartOverDropdownTest render ContextualMenu 1`] = `
       [
         {
           "key": "assessment",
-          "name": "Start over Assessment",
+          "name": "Start over all test suffix stub",
           "onClick": [Function],
         },
         {
           "key": "test",
-          "name": "Start over test name",
-          "onClick": [Function],
-        },
-      ]
-    }
-    onDismiss={[Function]}
-    target="test target"
-  />
-</div>
-`;
-
-exports[`StartOverDropdownTest render ContextualMenu with only one option 1`] = `
-<div>
-  <InsightsCommandButton
-    ariaLabel="start over menu"
-    componentRef={{}}
-    iconProps={
-      {
-        "iconName": "Refresh",
-      }
-    }
-    menuIconProps={
-      {
-        "iconName": "ChevronDown",
-      }
-    }
-    onClick={[Function]}
-    text="Start over"
-  />
-  <ContextualMenu
-    directionalHint={7}
-    items={
-      [
-        {
-          "key": "assessment",
-          "name": "Start over Assessment",
+          "name": "Start over single test suffix stub",
           "onClick": [Function],
         },
       ]
@@ -105,12 +70,12 @@ exports[`StartOverDropdownTest render with dropdown on left 1`] = `
       [
         {
           "key": "assessment",
-          "name": "Start over Assessment",
+          "name": "Start over all test suffix stub",
           "onClick": [Function],
         },
         {
           "key": "test",
-          "name": "Start over test name",
+          "name": "Start over single test suffix stub",
           "onClick": [Function],
         },
       ]

--- a/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
@@ -52,13 +52,19 @@ describe('DetailsViewRightPanelTests', () => {
         expect(configuration.GetLeftNavSelectedKey).toEqual(getTestViewKey);
         expect(configuration.GetTitle).toEqual(getTestViewTitle);
         expect(configuration.RightPanel).toEqual(TestViewContainer);
-        expect(configuration.GetStartOverContextualMenuItemKeys()).toEqual(['assessment', 'test']);
+        expect(configuration.startOverContextMenuKeyOptions).toEqual({
+            showAssessment: true,
+            showTest: true,
+        });
     }
 
     function validateOverview(configuration: DetailsRightPanelConfiguration): void {
         expect(configuration.GetLeftNavSelectedKey).toEqual(getOverviewKey);
         expect(configuration.GetTitle).toEqual(getOverviewTitle);
         expect(configuration.RightPanel).toEqual(OverviewContainer);
-        expect(configuration.GetStartOverContextualMenuItemKeys()).toEqual(['assessment']);
+        expect(configuration.startOverContextMenuKeyOptions).toEqual({
+            showAssessment: true,
+            showTest: false,
+        });
     }
 });

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -3,6 +3,7 @@
 import { IContextualMenuItem } from '@fluentui/react';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
+import { Requirement } from 'assessments/types/requirement';
 import {
     AssessmentNavState,
     AssessmentStoreData,
@@ -13,6 +14,7 @@ import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-vie
 import {
     AssessmentStartOverFactory,
     FastpassStartOverFactory,
+    QuickAssessStartOverFactory,
     StartOverFactoryDeps,
     StartOverFactoryProps,
     StartOverMenuItem,
@@ -27,6 +29,7 @@ describe('StartOverComponentFactory', () => {
     const theTestType = VisualizationType.ColorSensoryAssessment;
 
     let assessment: Readonly<Assessment>;
+    let requirement: Readonly<Requirement>;
     let assessmentsProviderMock: IMock<AssessmentsProvider>;
     let assessmentStoreData: AssessmentStoreData;
     let scanning: string;
@@ -48,10 +51,16 @@ describe('StartOverComponentFactory', () => {
             assessment = {
                 title: theTitle,
             } as Readonly<Assessment>;
+            requirement = {
+                name: 'requirement name stub',
+            } as Readonly<Requirement>;
             selectedTestType = theTestType;
             assessmentsProviderMock
                 .setup(apm => apm.forType(theTestType))
                 .returns(() => assessment);
+            assessmentsProviderMock
+                .setup(apm => apm.getStep(theTestType, theTestStep))
+                .returns(() => requirement);
         } else {
             visualizationStoreData = {
                 selectedFastPassDetailsView: theTestType,
@@ -70,6 +79,12 @@ describe('StartOverComponentFactory', () => {
             deps,
             assessmentStoreData,
             visualizationStoreData,
+            rightPanelConfiguration: {
+                startOverContextMenuKeyOptions: {
+                    showAssessment: true,
+                    showTest: true,
+                },
+            },
         } as StartOverFactoryProps;
     }
 
@@ -77,13 +92,28 @@ describe('StartOverComponentFactory', () => {
         it('getStartOverComponent', () => {
             const props = getProps(true);
             const rendered = AssessmentStartOverFactory.getStartOverComponent(props);
-
             expect(rendered).toMatchSnapshot();
         });
 
         it('getStartOverMenuItem', () => {
             const props = getProps(true);
             const menuItem = AssessmentStartOverFactory.getStartOverMenuItem(props);
+            const rendered = shallow(menuItem.onRender());
+
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
+    });
+
+    describe('QuickAssessStartOverFactory', () => {
+        it('getStartOverComponent', () => {
+            const props = getProps(true);
+            const rendered = QuickAssessStartOverFactory.getStartOverComponent(props);
+            expect(rendered).toMatchSnapshot();
+        });
+
+        it('getStartOverMenuItem', () => {
+            const props = getProps(true);
+            const menuItem = QuickAssessStartOverFactory.getStartOverMenuItem(props);
             const rendered = shallow(menuItem.onRender());
 
             expect(rendered.getElement()).toMatchSnapshot();


### PR DESCRIPTION
#### Details

The start over dropdown is specific to assessment; this changes that to be specific to be Quick Assess and generalizes the start over text.

##### Motivation

Feature work.

##### Context

What it looks like now:
![startOverQuickAssess](https://user-images.githubusercontent.com/32555133/216424503-56ba153d-40fd-4c92-938c-69891834be4b.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
