### PR TITLE
refactor: remove ability to remove start over assessment/quick assess option in component

### DIFF
--- a/src/DetailsView/components/details-view-right-panel.ts
+++ b/src/DetailsView/components/details-view-right-panel.ts
@@ -55,18 +55,17 @@ const detailsViewTypeContentMap: {
         RightPanel: OverviewContainer,
         GetTitle: getOverviewTitle,
         GetLeftNavSelectedKey: getOverviewKey,
-        startOverContextMenuKeyOptions: { showAssessment: true, showTest: false },
+        startOverContextMenuKeyOptions: { showTest: false },
     },
     TestView: {
         RightPanel: TestViewContainer,
         GetTitle: getTestViewTitle,
         GetLeftNavSelectedKey: getTestViewKey,
-        startOverContextMenuKeyOptions: { showAssessment: true, showTest: true },
+        startOverContextMenuKeyOptions: { showTest: true },
     },
 };
 
 export type StartOverContextMenuKeyOptions = {
-    showAssessment: boolean;
     showTest: boolean;
 };
 

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -79,7 +79,7 @@ export function getStartOverComponentForAssessment(
         openDialog: props.openDialog,
         buttonRef: props.buttonRef,
         rightPanelOptions: props.rightPanelConfiguration.startOverContextMenuKeyOptions,
-        switcherStartOverPreferences: { showAssessment: true, showTest: true },
+        switcherStartOverPreferences: { showTest: true },
     };
 
     return <StartOverDropdown {...startOverProps} />;
@@ -98,7 +98,7 @@ export function getStartOverComponentForQuickAssess(
         openDialog: props.openDialog,
         buttonRef: props.buttonRef,
         rightPanelOptions: props.rightPanelConfiguration.startOverContextMenuKeyOptions,
-        switcherStartOverPreferences: { showAssessment: true, showTest: false },
+        switcherStartOverPreferences: { showTest: false },
     };
 
     return <StartOverDropdown {...startOverProps} />;

--- a/src/DetailsView/components/start-over-dropdown.tsx
+++ b/src/DetailsView/components/start-over-dropdown.tsx
@@ -108,9 +108,7 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
             onClick: this.onStartOverTestMenu,
         };
 
-        if (rightPanelOptions.showAssessment && startOverButtonOptionPreferences.showAssessment) {
-            items.push(assessmentKey);
-        }
+        items.push(assessmentKey);
 
         if (rightPanelOptions.showTest && startOverButtonOptionPreferences.showTest) {
             items.push(testKey);

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
@@ -6,14 +6,12 @@ exports[`StartOverComponentFactory AssessmentStartOverFactory getStartOverCompon
   dropdownDirection="down"
   rightPanelOptions={
     {
-      "showAssessment": true,
       "showTest": true,
     }
   }
   singleTestSuffix="the title"
   switcherStartOverPreferences={
     {
-      "showAssessment": true,
       "showTest": true,
     }
   }
@@ -29,14 +27,12 @@ exports[`StartOverComponentFactory AssessmentStartOverFactory getStartOverMenuIt
     dropdownDirection="left"
     rightPanelOptions={
       {
-        "showAssessment": true,
         "showTest": true,
       }
     }
     singleTestSuffix="the title"
     switcherStartOverPreferences={
       {
-        "showAssessment": true,
         "showTest": true,
       }
     }
@@ -110,14 +106,12 @@ exports[`StartOverComponentFactory QuickAssessStartOverFactory getStartOverCompo
   dropdownDirection="down"
   rightPanelOptions={
     {
-      "showAssessment": true,
       "showTest": true,
     }
   }
   singleTestSuffix="requirement name stub"
   switcherStartOverPreferences={
     {
-      "showAssessment": true,
       "showTest": false,
     }
   }
@@ -133,14 +127,12 @@ exports[`StartOverComponentFactory QuickAssessStartOverFactory getStartOverMenuI
     dropdownDirection="left"
     rightPanelOptions={
       {
-        "showAssessment": true,
         "showTest": true,
       }
     }
     singleTestSuffix="requirement name stub"
     switcherStartOverPreferences={
       {
-        "showAssessment": true,
         "showTest": false,
       }
     }

--- a/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
@@ -53,7 +53,6 @@ describe('DetailsViewRightPanelTests', () => {
         expect(configuration.GetTitle).toEqual(getTestViewTitle);
         expect(configuration.RightPanel).toEqual(TestViewContainer);
         expect(configuration.startOverContextMenuKeyOptions).toEqual({
-            showAssessment: true,
             showTest: true,
         });
     }
@@ -63,7 +62,6 @@ describe('DetailsViewRightPanelTests', () => {
         expect(configuration.GetTitle).toEqual(getOverviewTitle);
         expect(configuration.RightPanel).toEqual(OverviewContainer);
         expect(configuration.startOverContextMenuKeyOptions).toEqual({
-            showAssessment: true,
             showTest: false,
         });
     }

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -81,7 +81,6 @@ describe('StartOverComponentFactory', () => {
             visualizationStoreData,
             rightPanelConfiguration: {
                 startOverContextMenuKeyOptions: {
-                    showAssessment: true,
                     showTest: true,
                 },
             },

--- a/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
@@ -48,50 +48,36 @@ describe('StartOverDropdownTest', () => {
     });
 
     const menuButtonOptions = [true, false];
-    const startOverOptionsCases = [
-        {
-            key: 'assessment',
-            optionName: 'showAssessment',
-        },
-        {
-            key: 'test',
-            optionName: 'showTest',
-        },
-    ];
+    const optionName = 'showTest';
+    const optionKey = 'test';
+    menuButtonOptions.forEach(rightPanelOptionEnabled => {
+        menuButtonOptions.forEach(switcherPreferencesOptionEnabled => {
+            const rightPanelOptions = {
+                [optionName]: rightPanelOptionEnabled,
+            } as StartOverContextMenuKeyOptions;
+            const switcherPreferences = {
+                [optionName]: switcherPreferencesOptionEnabled,
+            } as StartOverContextMenuKeyOptions;
 
-    startOverOptionsCases.forEach(testCase => {
-        const optionName = testCase.optionName;
-        const optionKey = testCase.key;
-        menuButtonOptions.forEach(rightPanelOptionEnabled => {
-            menuButtonOptions.forEach(switcherPreferencesOptionEnabled => {
-                const rightPanelOptions = {
-                    [optionName]: rightPanelOptionEnabled,
-                } as StartOverContextMenuKeyOptions;
-                const switcherPreferences = {
-                    [optionName]: switcherPreferencesOptionEnabled,
-                } as StartOverContextMenuKeyOptions;
+            const shouldFindOption = rightPanelOptionEnabled && switcherPreferencesOptionEnabled;
 
-                const shouldFindOption =
-                    rightPanelOptionEnabled && switcherPreferencesOptionEnabled;
+            const casePrefix = shouldFindOption
+                ? `${optionKey} item IS rendered`
+                : `${optionKey} item IS NOT rendered`;
 
-                const casePrefix = shouldFindOption
-                    ? `${optionKey} item IS rendered`
-                    : `${optionKey} item IS NOT rendered`;
+            test(`${casePrefix} - rightPanelOptions.${optionName} is ${rightPanelOptionEnabled} & switcherStartOverPreferences.${optionName} is ${switcherPreferencesOptionEnabled}`, () => {
+                defaultProps.rightPanelOptions = rightPanelOptions;
+                defaultProps.switcherStartOverPreferences = switcherPreferences;
 
-                test(`${casePrefix} - rightPanelOptions.${optionName} is ${rightPanelOptionEnabled} & switcherStartOverPreferences.${optionName} is ${switcherPreferencesOptionEnabled}`, () => {
-                    defaultProps.rightPanelOptions = rightPanelOptions;
-                    defaultProps.switcherStartOverPreferences = switcherPreferences;
-
-                    const rendered = shallow<StartOverDropdown>(
-                        <StartOverDropdown {...defaultProps} />,
-                    );
-                    rendered.find(InsightsCommandButton).simulate('click', event);
-                    const isStartOverOptionRendered = rendered
-                        .find(ContextualMenu)
-                        .prop('items')
-                        .some(item => item.key === optionKey);
-                    expect(isStartOverOptionRendered).toEqual(shouldFindOption);
-                });
+                const rendered = shallow<StartOverDropdown>(
+                    <StartOverDropdown {...defaultProps} />,
+                );
+                rendered.find(InsightsCommandButton).simulate('click', event);
+                const isStartOverOptionRendered = rendered
+                    .find(ContextualMenu)
+                    .prop('items')
+                    .some(item => item.key === optionKey);
+                expect(isStartOverOptionRendered).toEqual(shouldFindOption);
             });
         });
     });


### PR DESCRIPTION
#### Details

Removes the possibility of the "Start over Quick Assess" (and Assessment) option from being disabled because we do not need the component to be able to do that. This simplifies tests and the component.

##### Motivation

Clean-up refactor.

##### Context

This is a follow-up to changes in #6399 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
