### PR TITLE
fix: filter always-included rules out of assessment instances map

### DIFF
--- a/src/background/assessment-data-converter.ts
+++ b/src/background/assessment-data-converter.ts
@@ -16,7 +16,6 @@ import {
     HtmlElementAxeResults,
 } from 'common/types/store-data/visualization-scan-result-data';
 import { forOwn, isEmpty } from 'lodash';
-import { getIncludedAlwaysRules } from 'scanner/get-rule-inclusions';
 import { Target } from 'scanner/iruleresults';
 import { DictionaryStringTo } from 'types/common-types';
 import { UniquelyIdentifiableInstances } from './instance-identifier-generator';
@@ -35,6 +34,7 @@ export class AssessmentDataConverter {
         generateInstanceIdentifier: (instance: UniquelyIdentifiableInstances) => string,
         getInstanceStatus: (result: DecoratedAxeNodeResult) => ManualTestStatus,
         isVisualizationSupported: (result: DecoratedAxeNodeResult) => boolean,
+        getIncludedAlwaysRules: () => string[],
     ): AssessmentInstancesMap {
         let instancesMap: AssessmentInstancesMap = {};
 

--- a/src/background/assessment-data-converter.ts
+++ b/src/background/assessment-data-converter.ts
@@ -16,6 +16,7 @@ import {
     HtmlElementAxeResults,
 } from 'common/types/store-data/visualization-scan-result-data';
 import { forOwn, isEmpty } from 'lodash';
+import { getIncludedAlwaysRules } from 'scanner/get-rule-inclusions';
 import { Target } from 'scanner/iruleresults';
 import { DictionaryStringTo } from 'types/common-types';
 import { UniquelyIdentifiableInstances } from './instance-identifier-generator';
@@ -41,8 +42,11 @@ export class AssessmentDataConverter {
             instancesMap = previouslyGeneratedInstances;
         }
 
+        const includedAlwaysRules = getIncludedAlwaysRules();
         forOwn(selectorMap, elementAxeResult => {
-            const rule = Object.keys(elementAxeResult.ruleResults).pop();
+            const rule = Object.keys(elementAxeResult.ruleResults)
+                .filter(rule => !includedAlwaysRules.includes(rule))
+                .pop();
             if (rule) {
                 const ruleResult = elementAxeResult.ruleResults[rule];
                 const identifier = generateInstanceIdentifier({

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -22,6 +22,7 @@ import {
     ScanUpdatePayload,
 } from 'injected/analyzers/analyzer';
 import { forEach, isEmpty, pickBy } from 'lodash';
+import { getIncludedAlwaysRules } from 'scanner/get-rule-inclusions';
 import { DictionaryStringTo } from 'types/common-types';
 import {
     AddResultDescriptionPayload,
@@ -407,6 +408,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
                 config.getInstanceIdentiferGenerator(step),
                 stepConfig.getInstanceStatus,
                 stepConfig.isVisualizationSupportedForResult,
+                getIncludedAlwaysRules,
             );
         assessmentData.generatedAssessmentInstancesMap = generatedAssessmentInstancesMap;
         assessmentData.testStepStatus[step].isStepScanned = true;

--- a/src/scanner/get-rule-inclusions.ts
+++ b/src/scanner/get-rule-inclusions.ts
@@ -69,6 +69,12 @@ export const getNeedsReviewRulesConfig: () => DictionaryStringTo<RuleIncluded> =
     return needsReviewRulesConfig;
 };
 
+export const getIncludedAlwaysRules: () => string[] = () => {
+    return Object.entries(explicitRuleOverrides)
+        .filter(rule => rule[1].status === 'included-always')
+        .map(rule => rule[0]);
+};
+
 export const getRuleInclusions = (
     ruleset: IRuleConfiguration[],
     ruleOverrides: DictionaryStringTo<RuleIncluded>,

--- a/src/tests/unit/tests/background/assessment-data-converter.test.ts
+++ b/src/tests/unit/tests/background/assessment-data-converter.test.ts
@@ -59,6 +59,34 @@ describe('AssessmentDataConverter', () => {
                 undefined,
                 null,
                 null,
+                () => [],
+            );
+
+            expect(instanceMap).toEqual(previouslyGeneratedInstances);
+        });
+
+        it('should ignore selectors with only included always rule results.', () => {
+            const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
+                [selectorStub]: {
+                    ruleResults: {
+                        rule1: {
+                            html: htmlStub,
+                            id: 'id1',
+                            status: false,
+                        } as DecoratedAxeNodeResult,
+                    },
+                    target: [selectorStub],
+                },
+            };
+            const previouslyGeneratedInstances = {};
+            const instanceMap = testSubject.generateAssessmentInstancesMap(
+                previouslyGeneratedInstances,
+                selectorMap,
+                testStep,
+                undefined,
+                null,
+                null,
+                () => ['rule1'],
             );
 
             expect(instanceMap).toEqual(previouslyGeneratedInstances);
@@ -79,6 +107,7 @@ describe('AssessmentDataConverter', () => {
                 undefined,
                 null,
                 null,
+                () => [],
             );
 
             expect(instanceMap).toEqual(expectedResult);
@@ -126,6 +155,7 @@ describe('AssessmentDataConverter', () => {
                 generateInstanceIdentifierMock.object,
                 () => ManualTestStatus.UNKNOWN,
                 () => true,
+                () => [],
             );
 
             expect(instanceMap).toEqual(expectedResult);
@@ -166,6 +196,7 @@ describe('AssessmentDataConverter', () => {
                 generateInstanceIdentifierMock.object,
                 () => ManualTestStatus.UNKNOWN,
                 () => true,
+                () => [],
             );
 
             expect(instanceMap[identifierStub].propertyBag).toEqual(expectedPropertyBag);
@@ -198,6 +229,7 @@ describe('AssessmentDataConverter', () => {
                     generateInstanceIdentifierMock.object,
                     () => getInstanceStatusResult,
                     () => true,
+                    () => [],
                 );
 
                 expect(instanceMap[identifierStub].testStepResults[testStep].status).toEqual(
@@ -233,6 +265,7 @@ describe('AssessmentDataConverter', () => {
                     generateInstanceIdentifierMock.object,
                     () => ManualTestStatus.UNKNOWN,
                     () => isVisualizationSupportedResult,
+                    () => [],
                 );
 
                 expect(
@@ -318,6 +351,7 @@ describe('AssessmentDataConverter', () => {
                 generateInstanceIdentifierMock.object,
                 () => ManualTestStatus.UNKNOWN,
                 () => true,
+                () => [],
             );
 
             expect(instanceMap).toEqual(expectedResult);

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -52,6 +52,7 @@ import {
     ScanUpdatePayload,
 } from 'injected/analyzers/analyzer';
 import { cloneDeep } from 'lodash';
+import { getIncludedAlwaysRules } from 'scanner/get-rule-inclusions';
 import { ScanResults } from 'scanner/iruleresults';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
@@ -762,6 +763,7 @@ describe('AssessmentStore', () => {
                     instanceIdentifierGeneratorStub,
                     stepConfig.getInstanceStatus,
                     stepConfig.isVisualizationSupportedForResult,
+                    getIncludedAlwaysRules,
                 ),
             )
             .returns(() => expectedInstanceMap);
@@ -886,6 +888,7 @@ describe('AssessmentStore', () => {
                     instanceIdentifierGeneratorStub,
                     stepConfig.getInstanceStatus,
                     stepConfig.isVisualizationSupportedForResult,
+                    getIncludedAlwaysRules,
                 ),
             )
             .returns(() => fullInstanceMap);
@@ -988,6 +991,7 @@ describe('AssessmentStore', () => {
                     instanceIdentifierGeneratorStub,
                     stepConfig.getInstanceStatus,
                     stepConfig.isVisualizationSupportedForResult,
+                    getIncludedAlwaysRules,
                 ),
             )
             .returns(() => expectedInstanceMap);

--- a/src/tests/unit/tests/scanner/__snapshots__/get-rule-inclusions.test.ts.snap
+++ b/src/tests/unit/tests/scanner/__snapshots__/get-rule-inclusions.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getRuleInclusions matches snapshotted list of production rules 1`] = `
+exports[`getRuleInclusions getRuleInclusions matches snapshotted list of production rules 1`] = `
 {
   "accesskeys": {
     "reason": "rule is tagged best-practice",
@@ -170,7 +170,7 @@ exports[`getRuleInclusions matches snapshotted list of production rules 1`] = `
     "status": "included",
   },
   "identical-links-same-purpose": {
-    "reason": "disabled in axe config",
+    "reason": "rule is tagged wcag2aaa",
     "status": "excluded",
   },
   "image-alt": {
@@ -234,7 +234,8 @@ exports[`getRuleInclusions matches snapshotted list of production rules 1`] = `
     "status": "excluded",
   },
   "link-in-text-block": {
-    "status": "included",
+    "reason": "rule is tagged experimental",
+    "status": "excluded",
   },
   "link-name": {
     "status": "included",
@@ -251,12 +252,9 @@ exports[`getRuleInclusions matches snapshotted list of production rules 1`] = `
   "meta-refresh": {
     "status": "included",
   },
-  "meta-refresh-no-exceptions": {
-    "reason": "disabled in axe config",
-    "status": "excluded",
-  },
   "meta-viewport": {
-    "status": "included",
+    "reason": "rule is tagged best-practice",
+    "status": "excluded",
   },
   "meta-viewport-large": {
     "reason": "rule is tagged best-practice",
@@ -322,10 +320,6 @@ exports[`getRuleInclusions matches snapshotted list of production rules 1`] = `
   },
   "table-fake-caption": {
     "reason": "rule is tagged experimental",
-    "status": "excluded",
-  },
-  "target-size": {
-    "reason": "disabled in axe config",
     "status": "excluded",
   },
   "td-has-header": {

--- a/src/tests/unit/tests/scanner/__snapshots__/get-rule-inclusions.test.ts.snap
+++ b/src/tests/unit/tests/scanner/__snapshots__/get-rule-inclusions.test.ts.snap
@@ -170,7 +170,7 @@ exports[`getRuleInclusions getRuleInclusions matches snapshotted list of product
     "status": "included",
   },
   "identical-links-same-purpose": {
-    "reason": "rule is tagged wcag2aaa",
+    "reason": "disabled in axe config",
     "status": "excluded",
   },
   "image-alt": {
@@ -234,8 +234,7 @@ exports[`getRuleInclusions getRuleInclusions matches snapshotted list of product
     "status": "excluded",
   },
   "link-in-text-block": {
-    "reason": "rule is tagged experimental",
-    "status": "excluded",
+    "status": "included",
   },
   "link-name": {
     "status": "included",
@@ -252,9 +251,12 @@ exports[`getRuleInclusions getRuleInclusions matches snapshotted list of product
   "meta-refresh": {
     "status": "included",
   },
-  "meta-viewport": {
-    "reason": "rule is tagged best-practice",
+  "meta-refresh-no-exceptions": {
+    "reason": "disabled in axe config",
     "status": "excluded",
+  },
+  "meta-viewport": {
+    "status": "included",
   },
   "meta-viewport-large": {
     "reason": "rule is tagged best-practice",
@@ -320,6 +322,10 @@ exports[`getRuleInclusions getRuleInclusions matches snapshotted list of product
   },
   "table-fake-caption": {
     "reason": "rule is tagged experimental",
+    "status": "excluded",
+  },
+  "target-size": {
+    "reason": "disabled in axe config",
     "status": "excluded",
   },
   "td-has-header": {

--- a/src/tests/unit/tests/scanner/get-rule-inclusions.test.ts
+++ b/src/tests/unit/tests/scanner/get-rule-inclusions.test.ts
@@ -3,6 +3,7 @@
 import * as axe from 'axe-core';
 import {
     explicitRuleOverrides,
+    getIncludedAlwaysRules,
     getRuleInclusions,
     RuleIncluded,
 } from 'scanner/get-rule-inclusions';
@@ -10,119 +11,129 @@ import { IRuleConfiguration } from 'scanner/iruleresults';
 import { DictionaryStringTo } from 'types/common-types';
 
 describe('getRuleInclusions', () => {
-    const fakeRules: IRuleConfiguration[] = [
-        { id: 'axe-enabled', selector: 'fake-selector', enabled: true, tags: [] },
-        { id: 'axe-disabled', selector: 'fake-selector', enabled: false, tags: [] },
-    ];
-
-    it('respects initial enabled/disabled config and populates reason', () => {
-        const inclusions = getRuleInclusions(fakeRules, {});
-        expect(inclusions).toMatchObject({
-            'axe-enabled': {
-                status: 'included',
-            },
-            'axe-disabled': {
-                status: 'excluded',
-                reason: 'disabled in axe config',
-            },
-        });
-    });
-    it('respects explicit overrides and populates reason', () => {
-        const overrideReason = 'unit test override';
-        const fakeOverrides: DictionaryStringTo<RuleIncluded> = {
-            'axe-enabled': {
-                status: 'excluded',
-                reason: overrideReason,
-            },
-        };
-
-        const inclusions = getRuleInclusions(fakeRules, fakeOverrides);
-        expect(inclusions).toMatchObject({
-            'axe-enabled': {
-                status: 'excluded',
-                reason: overrideReason,
-            },
-            'axe-disabled': {
-                status: 'excluded',
-                reason: 'disabled in axe config',
-            },
+    describe('getIncludedAlwaysRules', () => {
+        it('returns expected results', () => {
+            const inclusions = getIncludedAlwaysRules();
+            expect(inclusions).toMatchObject(['frame-tested']);
         });
     });
 
-    it("excludes rules mapped to null tags (because it's probably one of our custom rules) and populates reason", () => {
-        const noTagRule = [
-            {
-                id: 'no-tag-rule',
-                selector: 'fake-selector',
-                enabled: true,
-                // tags: ...
-            },
+    describe('getRuleInclusions', () => {
+        const fakeRules: IRuleConfiguration[] = [
+            { id: 'axe-enabled', selector: 'fake-selector', enabled: true, tags: [] },
+            { id: 'axe-disabled', selector: 'fake-selector', enabled: false, tags: [] },
         ];
-        const inclusions = getRuleInclusions(noTagRule, {});
-        expect(inclusions).toMatchObject({
-            'no-tag-rule': {
-                status: 'excluded',
-                reason: 'rule does not define a tags property',
-            },
-        });
-    });
 
-    it('excludes rules mapped to best-practice tag and populates reason', () => {
-        const bestPracticeRule = [
-            {
-                id: 'best-practice-rule',
-                selector: 'fake-selector',
-                enabled: true,
-                tags: ['best-practice'],
-            },
-        ];
-        const inclusions = getRuleInclusions(bestPracticeRule, {});
-        expect(inclusions).toMatchObject({
-            'best-practice-rule': {
-                status: 'excluded',
-                reason: 'rule is tagged best-practice',
-            },
+        it('respects initial enabled/disabled config and populates reason', () => {
+            const inclusions = getRuleInclusions(fakeRules, {});
+            expect(inclusions).toMatchObject({
+                'axe-enabled': {
+                    status: 'included',
+                },
+                'axe-disabled': {
+                    status: 'excluded',
+                    reason: 'disabled in axe config',
+                },
+            });
         });
-    });
 
-    it('excludes rules mapped to wcag2aaa tag and populates reason', () => {
-        const aaaRule = [
-            {
-                id: 'aaa-rule',
-                selector: 'fake-selector',
-                enabled: true,
-                tags: ['wcag2aaa'],
-            },
-        ];
-        const inclusions = getRuleInclusions(aaaRule, {});
-        expect(inclusions).toMatchObject({
-            'aaa-rule': {
-                status: 'excluded',
-                reason: 'rule is tagged wcag2aaa',
-            },
+        it('respects explicit overrides and populates reason', () => {
+            const overrideReason = 'unit test override';
+            const fakeOverrides: DictionaryStringTo<RuleIncluded> = {
+                'axe-enabled': {
+                    status: 'excluded',
+                    reason: overrideReason,
+                },
+            };
+
+            const inclusions = getRuleInclusions(fakeRules, fakeOverrides);
+            expect(inclusions).toMatchObject({
+                'axe-enabled': {
+                    status: 'excluded',
+                    reason: overrideReason,
+                },
+                'axe-disabled': {
+                    status: 'excluded',
+                    reason: 'disabled in axe config',
+                },
+            });
         });
-    });
 
-    it('excludes rules mapped to experimental tag and populates reason', () => {
-        const experimentalRule = [
-            {
-                id: 'experimental-rule',
-                selector: 'fake-selector',
-                enabled: true,
-                tags: ['experimental'],
-            },
-        ];
-        const inclusions = getRuleInclusions(experimentalRule, {});
-        expect(inclusions).toMatchObject({
-            'experimental-rule': {
-                status: 'excluded',
-                reason: 'rule is tagged experimental',
-            },
+        it("excludes rules mapped to null tags (because it's probably one of our custom rules) and populates reason", () => {
+            const noTagRule = [
+                {
+                    id: 'no-tag-rule',
+                    selector: 'fake-selector',
+                    enabled: true,
+                    // tags: ...
+                },
+            ];
+            const inclusions = getRuleInclusions(noTagRule, {});
+            expect(inclusions).toMatchObject({
+                'no-tag-rule': {
+                    status: 'excluded',
+                    reason: 'rule does not define a tags property',
+                },
+            });
         });
-    });
 
-    it('matches snapshotted list of production rules', () => {
-        const inclusions = getRuleInclusions(axe._audit.rules, explicitRuleOverrides);
-        expect(inclusions).toMatchSnapshot();
+        it('excludes rules mapped to best-practice tag and populates reason', () => {
+            const bestPracticeRule = [
+                {
+                    id: 'best-practice-rule',
+                    selector: 'fake-selector',
+                    enabled: true,
+                    tags: ['best-practice'],
+                },
+            ];
+            const inclusions = getRuleInclusions(bestPracticeRule, {});
+            expect(inclusions).toMatchObject({
+                'best-practice-rule': {
+                    status: 'excluded',
+                    reason: 'rule is tagged best-practice',
+                },
+            });
+        });
+
+        it('excludes rules mapped to wcag2aaa tag and populates reason', () => {
+            const aaaRule = [
+                {
+                    id: 'aaa-rule',
+                    selector: 'fake-selector',
+                    enabled: true,
+                    tags: ['wcag2aaa'],
+                },
+            ];
+            const inclusions = getRuleInclusions(aaaRule, {});
+            expect(inclusions).toMatchObject({
+                'aaa-rule': {
+                    status: 'excluded',
+                    reason: 'rule is tagged wcag2aaa',
+                },
+            });
+        });
+
+        it('excludes rules mapped to experimental tag and populates reason', () => {
+            const experimentalRule = [
+                {
+                    id: 'experimental-rule',
+                    selector: 'fake-selector',
+                    enabled: true,
+                    tags: ['experimental'],
+                },
+            ];
+            const inclusions = getRuleInclusions(experimentalRule, {});
+            expect(inclusions).toMatchObject({
+                'experimental-rule': {
+                    status: 'excluded',
+                    reason: 'rule is tagged experimental',
+                },
+            });
+        });
+
+        it('matches snapshotted list of production rules', () => {
+            const inclusions = getRuleInclusions(axe._audit.rules, explicitRuleOverrides);
+            expect(inclusions).toMatchSnapshot();
+        });
     });
 });


### PR DESCRIPTION
#### Details

Fixes https://github.com/microsoft/accessibility-insights-web/issues/6403. This bug was introduced by https://github.com/microsoft/accessibility-insights-web/commit/2186a7eae1783417a3106a5b37afbe4dbb4c9e1c when we added a `always-included` rule. This PR adds logic to ignore always-included rules when generating the assessment instances map. 

##### Motivation

Addresses issue https://github.com/microsoft/accessibility-insights-web/issues/6403

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: https://github.com/microsoft/accessibility-insights-web/issues/6403
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
