### PR TITLE
chore: increase web e2e test timeout

### DIFF
--- a/pipeline/e2e-job-per-environment.yaml
+++ b/pipeline/e2e-job-per-environment.yaml
@@ -22,6 +22,8 @@ jobs:
       steps:
           - template: ./install-node-prerequisites.yaml
           - template: ./e2e-test-from-agent.yaml
+            parameters:
+                testsTimeoutInMinutes: 20
           - template: ./e2e-test-publish-results.yaml
 
     - job: 'e2e_tests_linux${{ parameters.jobNameSuffix }}'

--- a/pipeline/e2e-job-per-environment.yaml
+++ b/pipeline/e2e-job-per-environment.yaml
@@ -22,8 +22,6 @@ jobs:
       steps:
           - template: ./install-node-prerequisites.yaml
           - template: ./e2e-test-from-agent.yaml
-            parameters:
-                testsTimeoutInMinutes: 20
           - template: ./e2e-test-publish-results.yaml
 
     - job: 'e2e_tests_linux${{ parameters.jobNameSuffix }}'

--- a/pipeline/e2e-test-from-agent.yaml
+++ b/pipeline/e2e-test-from-agent.yaml
@@ -1,5 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+parameters:
+    - name: testsTimeoutInMinutes
+      type: number
+      default: 15
+
 steps:
     - script: yarn build:dev
       displayName: build:dev
@@ -7,4 +12,4 @@ steps:
 
     - script: yarn test:e2e --ci
       displayName: run e2e tests
-      timeoutInMinutes: 15
+      timeoutInMinutes: ${{ parameters.testsTimeoutInMinutes }}

--- a/pipeline/e2e-test-from-agent.yaml
+++ b/pipeline/e2e-test-from-agent.yaml
@@ -1,10 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-parameters:
-    - name: testsTimeoutInMinutes
-      type: number
-      default: 15
-
 steps:
     - script: yarn build:dev
       displayName: build:dev
@@ -12,4 +7,4 @@ steps:
 
     - script: yarn test:e2e --ci
       displayName: run e2e tests
-      timeoutInMinutes: ${{ parameters.testsTimeoutInMinutes }}
+      timeoutInMinutes: 20


### PR DESCRIPTION
#### Details

Increases the web e2e test timeout from 15 minutes to 20 minutes.

##### Motivation

Tests were often timing out resulting in errors. 

##### Context

Note: this doesn't fix the flakiness of our tests but does seem to reduce a lot (over 50%) of the failures we're seeing recently. After running 6 web-e2e-reliability runs (9 were run but there were 3 that were affected by an unrelated issue) there was a marked improvement in number of failures (and none due to timing out the task). I saw 12/90 (15 test tasks in each run) failed tasks vs. 27/90 compared to the last 6 runs in main.
 
#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
