### PR TITLE
fix: filter always-included rule results from ad hoc results

### DIFF
--- a/src/injected/scanner-utils.ts
+++ b/src/injected/scanner-utils.ts
@@ -13,6 +13,7 @@ export class ScannerUtils {
         private readonly scanner: typeof scanRunner,
         private readonly logger: Logger,
         private readonly generateUID?: () => string,
+        private readonly getIncludedAlwaysRulesFunc: () => string[] = getIncludedAlwaysRules,
     ) {}
 
     public scan(options: ScanOptions, callback: (results: ScanResults) => void): void {
@@ -97,7 +98,7 @@ export class ScannerUtils {
         axeRules: RuleResult[],
         status: boolean | undefined,
     ): void {
-        const includedAlwaysRules = getIncludedAlwaysRules();
+        const includedAlwaysRules = this.getIncludedAlwaysRulesFunc();
         axeRules
             .filter(rule => !includedAlwaysRules.includes(rule.id))
             .forEach(ruleResult => {

--- a/src/injected/scanner-utils.ts
+++ b/src/injected/scanner-utils.ts
@@ -3,6 +3,7 @@
 import { Logger } from 'common/logging/logger';
 import { HtmlElementAxeResults } from 'common/types/store-data/visualization-scan-result-data';
 import { scan as scanRunner } from 'scanner/exposed-apis';
+import { getIncludedAlwaysRules } from 'scanner/get-rule-inclusions';
 import { RuleResult, ScanResults } from 'scanner/iruleresults';
 import { ScanOptions } from 'scanner/scan-options';
 import { DictionaryStringTo } from 'types/common-types';
@@ -96,33 +97,36 @@ export class ScannerUtils {
         axeRules: RuleResult[],
         status: boolean | undefined,
     ): void {
-        axeRules.forEach(ruleResult => {
-            ruleResult.nodes.forEach(node => {
-                const selectorKey = node.target.join(';');
-                node.instanceId = this.generateUID ? this.generateUID() : undefined;
+        const includedAlwaysRules = getIncludedAlwaysRules();
+        axeRules
+            .filter(rule => !includedAlwaysRules.includes(rule.id))
+            .forEach(ruleResult => {
+                ruleResult.nodes.forEach(node => {
+                    const selectorKey = node.target.join(';');
+                    node.instanceId = this.generateUID ? this.generateUID() : undefined;
 
-                const elementResult = dictionary[selectorKey] || {
-                    target: node.target,
-                    ruleResults: {},
-                };
+                    const elementResult = dictionary[selectorKey] || {
+                        target: node.target,
+                        ruleResults: {},
+                    };
 
-                dictionary[selectorKey] = elementResult;
-                elementResult.ruleResults[ruleResult.id] = {
-                    any: node.any,
-                    all: node.all,
-                    none: node.none,
-                    status: status,
-                    ruleId: ruleResult.id,
-                    help: ruleResult.help,
-                    failureSummary: node.failureSummary,
-                    html: node.html,
-                    selector: selectorKey,
-                    id: node.instanceId,
-                    guidanceLinks: ruleResult.guidanceLinks ?? [],
-                    helpUrl: ruleResult.helpUrl,
-                };
+                    dictionary[selectorKey] = elementResult;
+                    elementResult.ruleResults[ruleResult.id] = {
+                        any: node.any,
+                        all: node.all,
+                        none: node.none,
+                        status: status,
+                        ruleId: ruleResult.id,
+                        help: ruleResult.help,
+                        failureSummary: node.failureSummary,
+                        html: node.html,
+                        selector: selectorKey,
+                        id: node.instanceId,
+                        guidanceLinks: ruleResult.guidanceLinks ?? [],
+                        helpUrl: ruleResult.helpUrl,
+                    };
+                });
             });
-        });
     }
 
     public static getFingerprint(node: AxeNodeResult, rule: RuleResult): string {

--- a/src/tests/unit/tests/injected/scanner-utils.test.ts
+++ b/src/tests/unit/tests/injected/scanner-utils.test.ts
@@ -29,7 +29,9 @@ describe('ScannerUtilsTest', () => {
             .returns(() => scopingState)
             .verifiable();
         const loggerMock = Mock.ofType<Logger>();
-        testSubject = new ScannerUtils(scannerMock.object, loggerMock.object, null);
+        testSubject = new ScannerUtils(scannerMock.object, loggerMock.object, null, () => [
+            'included-always-rule',
+        ]);
         scopingState = {
             selectors: {
                 [ScopingInputTypes.include]: [],
@@ -265,6 +267,7 @@ describe('ScannerUtilsTest', () => {
             scannerMock.object,
             loggerMock.object,
             generateUIDMock.object,
+            () => [],
         );
 
         generateUIDMock
@@ -411,6 +414,25 @@ describe('ScannerUtilsTest', () => {
             element3Selector,
             expectedElement3RuleResults,
         );
+    });
+
+    test('getAllCompletedInstances filters out included-always results', () => {
+        const selectors = ['1', '2', '3'];
+
+        const axeResults: ScanResults = {
+            passes: [getSampleRule('included-always-rule', selectors)],
+            violations: [],
+            inapplicable: [],
+            incomplete: [],
+            timestamp: '0',
+            targetPageUrl: 'test url',
+            targetPageTitle: 'test title',
+        };
+
+        const actual = testSubject.getAllCompletedInstances(axeResults);
+
+        const expected = {};
+        expect(actual).toEqual(expected);
     });
 
     test('getFingerprint', () => {


### PR DESCRIPTION
#### Details

Fixing ad hoc color visualizer bug introduced in https://github.com/microsoft/accessibility-insights-web/commit/2186a7eae1783417a3106a5b37afbe4dbb4c9e1c. The results from the always-included rules were causing styling to be applied to iframe elements instead of html elements.

##### Motivation

Addresses issue https://github.com/microsoft/accessibility-insights-web/issues/6422

##### Context

Before this change:
[Screenshot description: ad hoc color visualizer enabled and only part of target page in greyscale]
<img width="1357" alt="AdHocColorIssue" src="https://user-images.githubusercontent.com/16010855/218824875-220bc803-f7ce-4068-bc78-7c19c00afc34.png">

After this change:
[Screenshot description: ad hoc color visualizer enabled and full target page in greyscale]
<img width="1357" alt="AdHocColorIssueFixed" src="https://user-images.githubusercontent.com/16010855/218824902-28d48660-0896-4bee-99f0-76e7830031f6.png">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: https://github.com/microsoft/accessibility-insights-web/issues/6422
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
