### PR TITLE
chore: remove references to obsolete restoreScroll axe-core option

### DIFF
--- a/src/scanner/axe-options.ts
+++ b/src/scanner/axe-options.ts
@@ -4,7 +4,6 @@ import * as Axe from 'axe-core';
 
 export interface AxeOptions {
     runOnly?: Axe.RunOnly;
-    restoreScroll?: boolean;
     pingWaitTime?: number;
 }
 export type AxeScanContext = string | Document | IncludeExcludeOptions | NodeList;

--- a/src/scanner/scan-parameter-generator.ts
+++ b/src/scanner/scan-parameter-generator.ts
@@ -11,7 +11,6 @@ export class ScanParameterGenerator {
 
     public getAxeEngineOptions(options: ScanOptions): AxeOptions {
         const result: AxeOptions = {
-            restoreScroll: true,
             runOnly: {
                 type: 'rule',
                 values: [],

--- a/src/tests/unit/tests/scanner/launcher.test.ts
+++ b/src/tests/unit/tests/scanner/launcher.test.ts
@@ -25,7 +25,7 @@ describe('Launcher', () => {
             const domMock = Mock.ofInstance(document);
             const axeResponseHandlerMock = Mock.ofType(AxeResponseHandler);
             const scanParameterGeneratorMock = Mock.ofType(ScanParameterGenerator);
-            const defaultOptions = { restoreScroll: true, runOnly: undefined };
+            const defaultOptions = { runOnly: undefined };
             const optionsStub = {};
             const errorMock = Mock.ofType(Error);
 

--- a/src/tests/unit/tests/scanner/scan-parameter-generator.test.ts
+++ b/src/tests/unit/tests/scanner/scan-parameter-generator.test.ts
@@ -34,7 +34,6 @@ describe('ScanParameterGenerator', () => {
     describe('getAxeEngineOptions', () => {
         it('should handle options being null', () => {
             const expectedAxeOptions: AxeOptions = {
-                restoreScroll: true,
                 runOnly: {
                     type: 'rule',
                     values: ['rule-a', 'rule-b', 'rule-c'],
@@ -49,7 +48,6 @@ describe('ScanParameterGenerator', () => {
 
         it('should handle testsToRun to be null', () => {
             const expectedAxeOptions: AxeOptions = {
-                restoreScroll: true,
                 runOnly: {
                     type: 'rule',
                     values: ['rule-a', 'rule-b', 'rule-c'],
@@ -65,7 +63,6 @@ describe('ScanParameterGenerator', () => {
 
         it('should handle testsToRun to have rules', () => {
             const expectedAxeOptions: AxeOptions = {
-                restoreScroll: true,
                 runOnly: {
                     type: 'rule',
                     values: ['ruleA', 'ruleB', 'rule-c'],


### PR DESCRIPTION
#### Details

`axe-core` removed its `restoreScroll` option in mid-2020, when they updated the only rule that scrolled the page to no longer ever do that in [PR 2388](https://github.com/dequelabs/axe-core/issues/2388).

This PR removes the obsolete option from our axe-config.

##### Motivation

* Code cleanup, axe-core doesn't care whether the option is passed or not.
* Preparation for [using the axe-config output in service](https://github.com/microsoft/accessibility-insights-service/pull/2402)

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
