### PR TITLE
fix: quick assess automated checks getting started rendering

### DIFF
--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -89,7 +89,7 @@ export function getStartOverComponentForQuickAssess(
     props: StartOverFactoryProps,
     dropdownDirection: DropdownDirection,
 ): JSX.Element {
-    // since we do not show start per requirement in quick assess.
+    // since we do not show start over per requirement in quick assess.
     const showTest = false;
     const singleTestSuffix = '';
 

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -89,16 +89,18 @@ export function getStartOverComponentForQuickAssess(
     props: StartOverFactoryProps,
     dropdownDirection: DropdownDirection,
 ): JSX.Element {
-    const { selectedTestSubview, selectedTestType } = props.assessmentStoreData.assessmentNavState;
-    const test = props.deps.getProvider().getStep(selectedTestType, selectedTestSubview);
+    // since we do not show start per requirement in quick assess.
+    const showTest = false;
+    const singleTestSuffix = '';
+
     const startOverProps: StartOverProps = {
-        singleTestSuffix: test.name,
+        singleTestSuffix,
         allTestSuffix: 'Quick Assess',
         dropdownDirection,
         openDialog: props.openDialog,
         buttonRef: props.buttonRef,
         rightPanelOptions: props.rightPanelConfiguration.startOverContextMenuKeyOptions,
-        switcherStartOverPreferences: { showTest: false },
+        switcherStartOverPreferences: { showTest },
     };
 
     return <StartOverDropdown {...startOverProps} />;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`StartOverComponentFactory QuickAssessStartOverFactory getStartOverCompo
       "showTest": true,
     }
   }
-  singleTestSuffix="requirement name stub"
+  singleTestSuffix=""
   switcherStartOverPreferences={
     {
       "showTest": false,
@@ -130,7 +130,7 @@ exports[`StartOverComponentFactory QuickAssessStartOverFactory getStartOverMenuI
         "showTest": true,
       }
     }
-    singleTestSuffix="requirement name stub"
+    singleTestSuffix=""
     switcherStartOverPreferences={
       {
         "showTest": false,

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -3,7 +3,6 @@
 import { IContextualMenuItem } from '@fluentui/react';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
-import { Requirement } from 'assessments/types/requirement';
 import {
     AssessmentNavState,
     AssessmentStoreData,
@@ -29,7 +28,6 @@ describe('StartOverComponentFactory', () => {
     const theTestType = VisualizationType.ColorSensoryAssessment;
 
     let assessment: Readonly<Assessment>;
-    let requirement: Readonly<Requirement>;
     let assessmentsProviderMock: IMock<AssessmentsProvider>;
     let assessmentStoreData: AssessmentStoreData;
     let scanning: string;
@@ -51,16 +49,10 @@ describe('StartOverComponentFactory', () => {
             assessment = {
                 title: theTitle,
             } as Readonly<Assessment>;
-            requirement = {
-                name: 'requirement name stub',
-            } as Readonly<Requirement>;
             selectedTestType = theTestType;
             assessmentsProviderMock
                 .setup(apm => apm.forType(theTestType))
                 .returns(() => assessment);
-            assessmentsProviderMock
-                .setup(apm => apm.getStep(theTestType, theTestStep))
-                .returns(() => requirement);
         } else {
             visualizationStoreData = {
                 selectedFastPassDetailsView: theTestType,


### PR DESCRIPTION
#### Details

Fixes the issue where navigating to getting started in Automated Checks in Quick Assess would break the application.

##### Motivation

Fixes bug.

##### Context

When the selected test sub view is 'getting-started', the step returned by 'getStep' is null. We must be mindful of this if we are to add the ability to start over specific requirements in quick assess.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
