### PR TITLE
refactor(automated-checks): refactor getCardSelectionViewData to not be tied to unified store data

### DIFF
--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -114,7 +114,8 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
             props.storeState.unifiedScanResultStoreData.results,
             props.deps.getCardSelectionViewData(
                 props.storeState.cardSelectionStoreData,
-                props.storeState.unifiedScanResultStoreData,
+                props.storeState.unifiedScanResultStoreData.results,
+                props.storeState.unifiedScanResultStoreData.platformInfo,
                 props.deps.isResultHighlightUnavailable,
             ),
         );
@@ -127,7 +128,8 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
             props.storeState.needsReviewScanResultStoreData.results,
             props.deps.getCardSelectionViewData(
                 props.storeState.needsReviewCardSelectionStoreData,
-                props.storeState.needsReviewScanResultStoreData,
+                props.storeState.needsReviewScanResultStoreData.results,
+                props.storeState.needsReviewScanResultStoreData.platformInfo,
                 props.deps.isResultHighlightUnavailable,
             ),
         );

--- a/src/common/is-result-highlight-unavailable.ts
+++ b/src/common/is-result-highlight-unavailable.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { PlatformData, UnifiedResult } from 'common/types/store-data/unified-data-interface';
+import { FilterableResult } from 'common/get-card-selection-view-data';
+import { PlatformData } from 'common/types/store-data/unified-data-interface';
 import { BoundingRectangle } from 'electron/platform/android/android-scan-results';
 
 export type IsResultHighlightUnavailable = (
-    result: UnifiedResult,
+    result: FilterableResult,
     platformInfo: PlatformData | null,
 ) => boolean;
 

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -106,7 +106,8 @@ export class ResultsView extends React.Component<ResultsViewProps> {
 
         const cardSelectionViewData = deps.getCardSelectionViewData(
             cardSelectionStoreData,
-            unifiedScanResultStoreData,
+            unifiedScanResultStoreData?.results,
+            unifiedScanResultStoreData?.platformInfo,
             deps.isResultHighlightUnavailable,
             contentPageInfo.resultsFilter,
         );

--- a/src/injected/element-based-view-model-creator.ts
+++ b/src/injected/element-based-view-model-creator.ts
@@ -38,7 +38,7 @@ export class ElementBasedViewModelCreator {
         const resultsHighlightStatus = this.getHighlightedResultInstanceIds(
             cardSelectionData,
             results,
-            unifiedScanResultStoreData.platformInfo,
+            unifiedScanResultStoreData.platformInfo ?? null,
             this.isResultHighlightUnavailable,
         ).resultsHighlightStatus;
 

--- a/src/injected/element-based-view-model-creator.ts
+++ b/src/injected/element-based-view-model-creator.ts
@@ -37,7 +37,8 @@ export class ElementBasedViewModelCreator {
         const resultDictionary: SelectorToVisualizationMap = {};
         const resultsHighlightStatus = this.getHighlightedResultInstanceIds(
             cardSelectionData,
-            unifiedScanResultStoreData,
+            results,
+            unifiedScanResultStoreData.platformInfo,
             this.isResultHighlightUnavailable,
         ).resultsHighlightStatus;
 

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -233,7 +233,8 @@ describe(DetailsViewContent.displayName, () => {
                 .setup(g =>
                     g(
                         state.cardSelectionStoreData,
-                        state.unifiedScanResultStoreData,
+                        state.unifiedScanResultStoreData.results,
+                        state.unifiedScanResultStoreData.platformInfo,
                         isResultHighlightUnavailableStub,
                     ),
                 )

--- a/src/tests/unit/tests/common/get-card-selection-view-data.test.ts
+++ b/src/tests/unit/tests/common/get-card-selection-view-data.test.ts
@@ -3,7 +3,10 @@
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { ResultsFilter } from 'common/types/results-filter';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
-import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import {
+    PlatformData,
+    UnifiedScanResultStoreData,
+} from 'common/types/store-data/unified-data-interface';
 import { cloneDeep } from 'lodash';
 import { IMock, Mock } from 'typemoq';
 
@@ -74,7 +77,8 @@ describe('getCardSelectionStoreviewData', () => {
     test('all rules collapsed, visual helper enabled, no resultsFilter, expect all highlights', () => {
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
         );
 
@@ -94,7 +98,8 @@ describe('getCardSelectionStoreviewData', () => {
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
             resultsFilter,
         );
@@ -128,7 +133,8 @@ describe('getCardSelectionStoreviewData', () => {
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
         );
 
@@ -158,7 +164,8 @@ describe('getCardSelectionStoreviewData', () => {
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
         );
 
@@ -187,7 +194,8 @@ describe('getCardSelectionStoreviewData', () => {
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
         );
 
@@ -208,7 +216,8 @@ describe('getCardSelectionStoreviewData', () => {
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
         );
 
@@ -228,7 +237,8 @@ describe('getCardSelectionStoreviewData', () => {
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
         );
 
@@ -249,7 +259,8 @@ describe('getCardSelectionStoreviewData', () => {
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
             resultsFilter,
         );
@@ -269,7 +280,8 @@ describe('getCardSelectionStoreviewData', () => {
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
         );
 
@@ -292,7 +304,8 @@ describe('getCardSelectionStoreviewData', () => {
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
             resultsFilter,
         );
@@ -310,7 +323,8 @@ describe('getCardSelectionStoreviewData', () => {
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
         );
 
@@ -333,7 +347,8 @@ describe('getCardSelectionStoreviewData', () => {
 
         const viewData = getCardSelectionViewData(
             initialCardSelectionState,
-            initialUnifiedScanResultState,
+            initialUnifiedScanResultState.results,
+            initialUnifiedScanResultState.platformInfo,
             isResultHighlightUnavailable.object,
         );
 
@@ -349,7 +364,7 @@ describe('getCardSelectionStoreviewData', () => {
     });
 
     test('null store data, expect no results', () => {
-        const viewData = getCardSelectionViewData(null, null, null);
+        const viewData = getCardSelectionViewData(null, null, null, null);
 
         validateEmptyViewData(viewData);
     });
@@ -357,7 +372,8 @@ describe('getCardSelectionStoreviewData', () => {
     test('empty CardSelectionStoreData, expect no results', () => {
         const viewData = getCardSelectionViewData(
             {} as CardSelectionStoreData,
-            {} as UnifiedScanResultStoreData,
+            [],
+            {} as PlatformData,
             null,
         );
 
@@ -370,19 +386,8 @@ describe('getCardSelectionStoreviewData', () => {
                 visualHelperEnabled: false,
                 focusedResultUid: null,
             } as CardSelectionStoreData,
-            {} as UnifiedScanResultStoreData,
-            null,
-        );
-
-        validateEmptyViewData(viewData);
-    });
-
-    test('null UnifiedScanResultStoreData, expect no results', () => {
-        const viewData = getCardSelectionViewData(
-            {
-                rules: {},
-            } as CardSelectionStoreData,
-            null,
+            [],
+            {} as PlatformData,
             null,
         );
 
@@ -392,7 +397,8 @@ describe('getCardSelectionStoreviewData', () => {
     test('invalid UnifiedScanResultStoreData, expect no results', () => {
         const viewData = getCardSelectionViewData(
             {} as CardSelectionStoreData,
-            { results: null } as UnifiedScanResultStoreData,
+            null,
+            {} as PlatformData,
             null,
         );
 

--- a/src/tests/unit/tests/electron/views/results/results-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/results-view.test.tsx
@@ -151,7 +151,8 @@ describe('ResultsView', () => {
             .setup(getData =>
                 getData(
                     cardSelectionStoreData,
-                    unifiedScanResultStoreData,
+                    unifiedScanResultStoreData.results,
+                    unifiedScanResultStoreData.platformInfo,
                     isResultHighlightUnavailableStub,
                     resultsFilter,
                 ),

--- a/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
+++ b/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
@@ -84,6 +84,7 @@ describe('ElementBasedViewModelCreator', () => {
         const scanResultStoreData = {
             results: [unifiedResult],
             rules: [],
+            platformInfo: null,
         } as UnifiedScanResultStoreData;
         const cardSelectionViewData = {
             resultsHighlightStatus: { [unifiedResult.uid]: 'hidden' },
@@ -123,6 +124,7 @@ describe('ElementBasedViewModelCreator', () => {
             const scanResultStoreData = {
                 results: [unifiedResult],
                 rules: unifiedRules,
+                platformInfo: null,
             } as UnifiedScanResultStoreData;
             const cardSelectionViewData = {
                 resultsHighlightStatus: { [unifiedResult.uid]: 'visible' },
@@ -181,6 +183,7 @@ describe('ElementBasedViewModelCreator', () => {
         const scanResultStoreData = {
             results: [unifiedResultOne, unifiedResultTwo],
             rules: unifiedRules,
+            platformInfo: null,
         } as UnifiedScanResultStoreData;
         const cardSelectionViewData = {
             resultsHighlightStatus: {
@@ -236,6 +239,7 @@ describe('ElementBasedViewModelCreator', () => {
         const scanResultStoreData = {
             results: [unifiedResult],
             rules: unifiedRules,
+            platformInfo: null,
         } as UnifiedScanResultStoreData;
         const cardSelectionViewData = {
             resultsHighlightStatus: { [unifiedResult.uid]: 'visible' },

--- a/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
+++ b/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
@@ -91,7 +91,12 @@ describe('ElementBasedViewModelCreator', () => {
 
         getHighlightedResultInstanceIdsMock
             .setup(mock =>
-                mock(cardSelectionData, scanResultStoreData, isResultHighlightUnavailableStub),
+                mock(
+                    cardSelectionData,
+                    scanResultStoreData.results,
+                    scanResultStoreData.platformInfo,
+                    isResultHighlightUnavailableStub,
+                ),
             )
             .returns(() => cardSelectionViewData);
 
@@ -125,7 +130,12 @@ describe('ElementBasedViewModelCreator', () => {
 
             getHighlightedResultInstanceIdsMock
                 .setup(mock =>
-                    mock(cardSelectionData, scanResultStoreData, isResultHighlightUnavailableStub),
+                    mock(
+                        cardSelectionData,
+                        scanResultStoreData.results,
+                        scanResultStoreData.platformInfo,
+                        isResultHighlightUnavailableStub,
+                    ),
                 )
                 .returns(() => cardSelectionViewData);
 
@@ -181,7 +191,12 @@ describe('ElementBasedViewModelCreator', () => {
 
         getHighlightedResultInstanceIdsMock
             .setup(mock =>
-                mock(cardSelectionData, scanResultStoreData, isResultHighlightUnavailableStub),
+                mock(
+                    cardSelectionData,
+                    scanResultStoreData.results,
+                    scanResultStoreData.platformInfo,
+                    isResultHighlightUnavailableStub,
+                ),
             )
             .returns(() => cardSelectionViewData);
 
@@ -228,7 +243,12 @@ describe('ElementBasedViewModelCreator', () => {
 
         getHighlightedResultInstanceIdsMock
             .setup(mock =>
-                mock(cardSelectionData, scanResultStoreData, isResultHighlightUnavailableStub),
+                mock(
+                    cardSelectionData,
+                    scanResultStoreData.results,
+                    scanResultStoreData.platformInfo,
+                    isResultHighlightUnavailableStub,
+                ),
             )
             .returns(() => cardSelectionViewData);
 


### PR DESCRIPTION
#### Details

Specifies the exact properties necessary from unified results instead. Allows us to use this for results from assessment.

##### Motivation

Feature work

##### Context

Fixing the null check from #6459 and opening a new PR

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
