### PR TITLE
feat(automated-checks): add assessment data to element based view model converter

### DIFF
--- a/src/common/store-data-to-scan-node-result-converter.ts
+++ b/src/common/store-data-to-scan-node-result-converter.ts
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { isNullOrUndefined } from '@microsoft/applicationinsights-core-js';
+import {
+    AssessmentStoreData,
+    GeneratedAssessmentInstance,
+    TestStepResult,
+} from 'common/types/store-data/assessment-result-data';
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+
+import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
+import {
+    InstanceResultStatus,
+    UnifiedResult,
+    UnifiedRule,
+    UnifiedScanResultStoreData,
+} from 'common/types/store-data/unified-data-interface';
+import { IssueFilingUrlStringUtils } from 'issue-filing/common/issue-filing-url-string-utils';
+import { find, forOwn } from 'lodash';
+
+export type ScanNodeResult = UnifiedResult & {
+    rule: UnifiedRule;
+};
+
+export type ConvertStoreDataForScanNodeResultsCallback = (
+    storeData: UnifiedScanResultStoreData | AssessmentStoreData,
+    cardSelectionStoreData?: CardSelectionStoreData,
+) => ScanNodeResult[] | null;
+
+export const convertStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResultsCallback = (
+    storeData: UnifiedScanResultStoreData | AssessmentStoreData,
+    cardSelectionStoreData?: CardSelectionStoreData,
+): ScanNodeResult[] | null => {
+    let results: ScanNodeResult[] | null = convertUnifiedStoreDataToScanNodeResults(
+        storeData as UnifiedScanResultStoreData,
+    );
+    if (results === null) {
+        results = convertAssessmentStoreDataToScanNodeResults(
+            storeData as AssessmentStoreData,
+            cardSelectionStoreData,
+        );
+    }
+    return results;
+};
+
+function convertUnifiedStoreDataToScanNodeResults(
+    unifiedScanResultStoreData: UnifiedScanResultStoreData,
+): ScanNodeResult[] | null {
+    if (
+        isNullOrUndefined(unifiedScanResultStoreData) ||
+        isNullOrUndefined(unifiedScanResultStoreData.rules) ||
+        isNullOrUndefined(unifiedScanResultStoreData.results)
+    ) {
+        return null;
+    }
+    const { rules, results } = unifiedScanResultStoreData;
+
+    const transformedResults = results.map(unifiedResult => {
+        const rule = find(rules, unifiedRule => unifiedRule.id === unifiedResult.ruleId);
+        if (rule == null) {
+            throw new Error(`Got result with unknown ruleId ${unifiedResult.ruleId}`);
+        }
+
+        const result: ScanNodeResult = {
+            ...unifiedResult,
+            rule,
+        };
+
+        return result;
+    });
+    return transformedResults;
+}
+
+function convertAssessmentStoreDataToScanNodeResults(
+    assessmentStoreData: AssessmentStoreData,
+    cardSelectionStoreData?: CardSelectionStoreData,
+): ScanNodeResult[] | null {
+    if (
+        isNullOrUndefined(assessmentStoreData) ||
+        isNullOrUndefined(assessmentStoreData.assessmentNavState) ||
+        isNullOrUndefined(assessmentStoreData.assessments) ||
+        isNullOrUndefined(
+            assessmentStoreData.assessments[
+                assessmentStoreData.assessmentNavState.selectedTestType
+            ],
+        )
+    ) {
+        return null;
+    }
+
+    const selectedTest = assessmentStoreData.assessmentNavState.selectedTestType;
+    const testData = assessmentStoreData.assessments[selectedTest];
+    const allResults: ScanNodeResult[] = [];
+
+    forOwn(
+        testData.generatedAssessmentInstancesMap,
+        (instance: GeneratedAssessmentInstance, selector: string) => {
+            forOwn(
+                instance.testStepResults,
+                (testStepResult: TestStepResult, requirementIdentifier) => {
+                    const node: ScanNodeResult = convertAssessmentResultToScanNodeResult(
+                        testStepResult,
+                        selector,
+                        instance,
+                        requirementIdentifier,
+                        cardSelectionStoreData,
+                    );
+                    allResults.push(node);
+                },
+            );
+        },
+    );
+
+    return allResults;
+}
+
+function convertAssessmentResultToScanNodeResult(
+    testStepResult: TestStepResult,
+    selector: string,
+    instance: GeneratedAssessmentInstance,
+    requirementIdentifier: string,
+    cardSelectionViewDataForTest?: CardSelectionStoreData,
+): ScanNodeResult {
+    const instanceId = testStepResult.id;
+    const status = convertTestStepResultStatusToCardResultStatus(testStepResult.status);
+    const node: ScanNodeResult = {
+        isSelected: cardSelectionViewDataForTest?.rules
+            ? cardSelectionViewDataForTest.rules[requirementIdentifier]?.cards[instanceId]
+            : false,
+        status: status,
+        ruleId: requirementIdentifier,
+        uid: instanceId,
+        identifiers: {
+            conciseName: IssueFilingUrlStringUtils.getSelectorLastPart(selector),
+            identifier: selector,
+        },
+        descriptors: {
+            snippet: instance.html,
+        },
+        resolution: {
+            howToFixSummary: testStepResult.failureSummary,
+        },
+        rule: { id: requirementIdentifier },
+    };
+    return node;
+}
+
+const convertTestStepResultStatusToCardResultStatus = (
+    status: ManualTestStatus,
+): InstanceResultStatus => {
+    switch (status) {
+        case ManualTestStatus.PASS:
+            return 'pass';
+        case ManualTestStatus.FAIL:
+            return 'fail';
+        case ManualTestStatus.UNKNOWN:
+            return 'unknown';
+    }
+};

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -4,6 +4,7 @@ import { createToolData } from 'common/application-properties-provider';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unavailable';
 import { Logger } from 'common/logging/logger';
+import { convertStoreDataForScanNodeResults } from 'common/store-data-to-scan-node-result-converter';
 import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
@@ -226,6 +227,7 @@ export class MainWindowInitializer extends WindowInitializer {
             getDecoratedAxeNode,
             getCardSelectionViewData,
             isResultHighlightUnavailableWeb,
+            convertStoreDataForScanNodeResults,
         );
         const selectorMapHelper = new SelectorMapHelper(
             this.visualizationConfigurationFactory,

--- a/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
+++ b/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentData } from 'common/types/store-data/assessment-result-data';
+import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import {
     CardRuleResult,
     CardRuleResultsByStatus,
@@ -30,6 +32,25 @@ export const exampleUnifiedResult: UnifiedResult = {
             all: [],
         },
     },
+};
+
+export const exampleAssessmentResult: AssessmentData = {
+    fullAxeResultsMap: null,
+    generatedAssessmentInstancesMap: {
+        'body img': {
+            target: ['body img'],
+            html: 'body img',
+            testStepResults: {
+                'image-alt': {
+                    status: ManualTestStatus.FAIL,
+                    isVisualizationEnabled: true,
+                    id: 'some-guid-here',
+                    failureSummary: 'sample how to fix summary',
+                },
+            },
+        },
+    },
+    testStepStatus: {},
 };
 
 export const exampleUnifiedResultWithBoundingRectangle = {

--- a/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
+++ b/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
@@ -1,0 +1,248 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { convertStoreDataForScanNodeResults } from 'common/store-data-to-scan-node-result-converter';
+import {
+    AssessmentData,
+    AssessmentStoreData,
+    GeneratedAssessmentInstance,
+    TestStepResult,
+} from 'common/types/store-data/assessment-result-data';
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import {
+    UnifiedRule,
+    UnifiedScanResultStoreData,
+} from 'common/types/store-data/unified-data-interface';
+import { cloneDeep } from 'lodash';
+import {
+    exampleAssessmentResult,
+    exampleUnifiedResult,
+} from 'tests/unit/tests/common/components/cards/sample-view-model-data';
+
+describe('convertStoreDataForScanNodeResults', () => {
+    test('store data is empty returns null', () => {
+        const dataStub = {} as UnifiedScanResultStoreData;
+        expect(convertStoreDataForScanNodeResults(dataStub)).toBeNull();
+    });
+
+    test('unified data with no results returns null', () => {
+        const storeData = {
+            results: [],
+            rules: [],
+        } as UnifiedScanResultStoreData;
+        expect(convertStoreDataForScanNodeResults(storeData)).toEqual([]);
+    });
+
+    test('unified data is converted successfully', () => {
+        const unifiedResult = exampleUnifiedResult;
+        const ruleStub = { id: unifiedResult.ruleId } as UnifiedRule;
+        const storeData = {
+            results: [unifiedResult],
+            rules: [ruleStub],
+        } as UnifiedScanResultStoreData;
+
+        const expectedResult = [{ ...unifiedResult, rule: ruleStub }];
+        expect(convertStoreDataForScanNodeResults(storeData)).toEqual(expectedResult);
+    });
+
+    test('unified data with multiple results is converted successfully', () => {
+        const unifiedResultOne = cloneDeep(exampleUnifiedResult);
+        const unifiedResultTwo = cloneDeep(exampleUnifiedResult);
+        unifiedResultTwo.uid = unifiedResultTwo.uid.concat('two');
+        unifiedResultTwo.ruleId = unifiedResultTwo.ruleId.concat('two');
+
+        const ruleStubOne = { id: unifiedResultOne.ruleId } as UnifiedRule;
+        const ruleStubTwo = { id: unifiedResultTwo.ruleId } as UnifiedRule;
+        const unifiedRules = [ruleStubOne, ruleStubTwo];
+
+        const storeData = {
+            results: [unifiedResultOne, unifiedResultTwo],
+            rules: unifiedRules,
+            platformInfo: null,
+        } as UnifiedScanResultStoreData;
+
+        const expectedResult = [
+            { ...unifiedResultOne, rule: ruleStubOne },
+            { ...unifiedResultTwo, rule: ruleStubTwo },
+        ];
+        expect(convertStoreDataForScanNodeResults(storeData)).toEqual(expectedResult);
+    });
+
+    test('assessment data with invalid selected test type returns null', () => {
+        const dataStub = {
+            assessments: {},
+            assessmentNavState: { selectedTestType: 'test-key' },
+        } as unknown as AssessmentStoreData;
+        expect(convertStoreDataForScanNodeResults(dataStub)).toBeNull();
+    });
+
+    test('assessment data with no card selection store data is converted successfully', () => {
+        const assessmentResult = exampleAssessmentResult;
+        const { selector, testStepResult, ruleId } = getAssessmentDataProperties(assessmentResult);
+        const storeData = {
+            assessments: {
+                'test-key': assessmentResult,
+            },
+            assessmentNavState: { selectedTestType: 'test-key' },
+        } as unknown as AssessmentStoreData;
+
+        const expectedResult = [
+            {
+                descriptors: { snippet: selector },
+                identifiers: { conciseName: selector, identifier: selector },
+                isSelected: false,
+                resolution: { howToFixSummary: testStepResult.failureSummary },
+                rule: { id: ruleId },
+                ruleId: ruleId,
+                status: 'fail',
+                uid: testStepResult.id,
+            },
+        ];
+        expect(convertStoreDataForScanNodeResults(storeData)).toEqual(expectedResult);
+    });
+
+    test('assessment data with card selection store data is converted successfully', () => {
+        const assessmentResult = exampleAssessmentResult;
+        const { selector, testStepResult, ruleId } = getAssessmentDataProperties(assessmentResult);
+        const storeData = {
+            assessments: {
+                'test-key': assessmentResult,
+            },
+            assessmentNavState: { selectedTestType: 'test-key' },
+        } as unknown as AssessmentStoreData;
+        const cardSelectionStoreData = {
+            rules: { [ruleId]: { cards: { [testStepResult.id]: true } } },
+        } as unknown as CardSelectionStoreData;
+
+        const expectedResult = [
+            {
+                descriptors: { snippet: selector },
+                identifiers: { conciseName: selector, identifier: selector },
+                isSelected: true,
+                resolution: { howToFixSummary: testStepResult.failureSummary },
+                rule: { id: ruleId },
+                ruleId: ruleId,
+                status: 'fail',
+                uid: testStepResult.id,
+            },
+        ];
+        expect(convertStoreDataForScanNodeResults(storeData, cardSelectionStoreData)).toEqual(
+            expectedResult,
+        );
+    });
+
+    test('assessment data with multiple failures on one element is converted successfully', () => {
+        const assessmentResult = cloneDeep(exampleAssessmentResult);
+        const {
+            selector,
+            testStepResult: testStepResult1,
+            ruleId: ruleId1,
+        } = getAssessmentDataProperties(assessmentResult);
+
+        // Add a second rule failure to this element
+        const ruleId2 = 'rule-id-2';
+        const testStepResult2 = cloneDeep(testStepResult1);
+        testStepResult2.id = 'test-step-result-2';
+        assessmentResult.generatedAssessmentInstancesMap![selector].testStepResults[ruleId2] =
+            testStepResult2;
+
+        const storeData = {
+            assessments: {
+                'test-key': assessmentResult,
+            },
+            assessmentNavState: { selectedTestType: 'test-key' },
+        } as unknown as AssessmentStoreData;
+
+        const expectedResult = [
+            {
+                descriptors: { snippet: selector },
+                identifiers: { conciseName: selector, identifier: selector },
+                isSelected: false,
+                resolution: { howToFixSummary: testStepResult1.failureSummary },
+                rule: { id: ruleId1 },
+                ruleId: ruleId1,
+                status: 'fail',
+                uid: testStepResult1.id,
+            },
+            {
+                descriptors: { snippet: selector },
+                identifiers: { conciseName: selector, identifier: selector },
+                isSelected: false,
+                resolution: { howToFixSummary: testStepResult2.failureSummary },
+                rule: { id: ruleId2 },
+                ruleId: ruleId2,
+                status: 'fail',
+                uid: testStepResult2.id,
+            },
+        ];
+        expect(convertStoreDataForScanNodeResults(storeData)).toEqual(expectedResult);
+    });
+
+    test('assessment data with failures on different elements is converted successfully', () => {
+        const assessmentResult = cloneDeep(exampleAssessmentResult);
+        const {
+            testStepResult: testStepResult1,
+            selector: selector1,
+            ruleId: ruleId1,
+        } = getAssessmentDataProperties(assessmentResult);
+
+        // Add a second rule failure to a different element
+        const selector2 = 'selector-2';
+        const ruleId2 = 'rule-id-2';
+        const testStepResult2 = cloneDeep(testStepResult1);
+        testStepResult2.id = 'test-step-result-2';
+        assessmentResult.generatedAssessmentInstancesMap![selector2] = {
+            target: [selector2],
+            html: selector2,
+            testStepResults: {
+                [ruleId2]: testStepResult2,
+            },
+        } as GeneratedAssessmentInstance;
+
+        const storeData = {
+            assessments: {
+                'test-key': assessmentResult,
+            },
+            assessmentNavState: { selectedTestType: 'test-key' },
+        } as unknown as AssessmentStoreData;
+
+        const expectedResult = [
+            {
+                descriptors: { snippet: selector1 },
+                identifiers: { conciseName: selector1, identifier: selector1 },
+                isSelected: false,
+                resolution: { howToFixSummary: testStepResult1.failureSummary },
+                rule: { id: ruleId1 },
+                ruleId: ruleId1,
+                status: 'fail',
+                uid: testStepResult1.id,
+            },
+            {
+                descriptors: { snippet: selector2 },
+                identifiers: { conciseName: selector2, identifier: selector2 },
+                isSelected: false,
+                resolution: { howToFixSummary: testStepResult2.failureSummary },
+                rule: { id: ruleId2 },
+                ruleId: ruleId2,
+                status: 'fail',
+                uid: testStepResult2.id,
+            },
+        ];
+        expect(convertStoreDataForScanNodeResults(storeData)).toEqual(expectedResult);
+    });
+
+    function getAssessmentDataProperties(data: AssessmentData) {
+        const selector = Object.keys(data.generatedAssessmentInstancesMap!)[0];
+        const ruleId = Object.keys(
+            data.generatedAssessmentInstancesMap![selector].testStepResults,
+        )[0];
+        const testStepResult: TestStepResult =
+            data.generatedAssessmentInstancesMap![selector].testStepResults[ruleId];
+
+        return {
+            testStepResult,
+            selector,
+            ruleId,
+        };
+    }
+});

--- a/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
+++ b/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
@@ -91,7 +91,7 @@ describe('ElementBasedViewModelCreator', () => {
     test('getElementBasedViewModel: no highlighted results', () => {
         const unifiedResult = exampleUnifiedResult;
         const ruleStub = { id: unifiedResult.ruleId } as UnifiedRule;
-        const ScanNodeResults: ScanNodeResult[] = [{ ...unifiedResult, rule: ruleStub }];
+        const scanNodeResults: ScanNodeResult[] = [{ ...unifiedResult, rule: ruleStub }];
         const cardSelectionViewData = {
             resultsHighlightStatus: { [unifiedResult.uid]: 'hidden' },
         } as CardSelectionViewData;
@@ -117,7 +117,7 @@ describe('ElementBasedViewModelCreator', () => {
         const dataStub = {} as UnifiedScanResultStoreData;
         convertStoreDataForScanNodeResultsCallbackMock
             .setup(mock => mock(dataStub, cardSelectionData))
-            .returns(() => ScanNodeResults)
+            .returns(() => scanNodeResults)
             .verifiable(Times.once());
         expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(
             expectedResult,
@@ -136,7 +136,7 @@ describe('ElementBasedViewModelCreator', () => {
             const ruleStub = { id: unifiedResult.ruleId } as UnifiedRule;
             const identifierStub = unifiedResult.identifiers['css-selector'];
             const decoratedResultStub = {} as DecoratedAxeNodeResult;
-            const ScanNodeResults = [{ ...unifiedResult, rule: ruleStub }];
+            const scanNodeResults = [{ ...unifiedResult, rule: ruleStub }];
             const cardSelectionViewData = {
                 resultsHighlightStatus: { [unifiedResult.uid]: 'visible' },
             } as CardSelectionViewData;
@@ -175,7 +175,7 @@ describe('ElementBasedViewModelCreator', () => {
             const dataStub = {} as UnifiedScanResultStoreData;
             convertStoreDataForScanNodeResultsCallbackMock
                 .setup(mock => mock(dataStub, cardSelectionData))
-                .returns(() => ScanNodeResults)
+                .returns(() => scanNodeResults)
                 .verifiable(Times.once());
             expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(
                 expectedResult,
@@ -200,7 +200,7 @@ describe('ElementBasedViewModelCreator', () => {
             id: 'some other id',
         } as DecoratedAxeNodeResult;
 
-        const ScanNodeResults = [
+        const scanNodeResults = [
             { ...unifiedResultOne, rule: ruleStubOne },
             { ...unifiedResultTwo, rule: ruleStubTwo },
         ];
@@ -258,7 +258,7 @@ describe('ElementBasedViewModelCreator', () => {
         const dataStub = {} as UnifiedScanResultStoreData;
         convertStoreDataForScanNodeResultsCallbackMock
             .setup(mock => mock(dataStub, cardSelectionData))
-            .returns(() => ScanNodeResults)
+            .returns(() => scanNodeResults)
             .verifiable(Times.once());
         expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(
             expectedResult,
@@ -272,7 +272,7 @@ describe('ElementBasedViewModelCreator', () => {
         const ruleStub = { id: unifiedResult.ruleId } as UnifiedRule;
         const identifierStub = unifiedResult.identifiers['css-selector'];
         const decoratedResultStub = {} as DecoratedAxeNodeResult;
-        const ScanNodeResults = [{ ...unifiedResult, rule: ruleStub }];
+        const scanNodeResults = [{ ...unifiedResult, rule: ruleStub }];
         const cardSelectionViewData = {
             resultsHighlightStatus: { [unifiedResult.uid]: 'visible' },
         } as CardSelectionViewData;
@@ -311,7 +311,7 @@ describe('ElementBasedViewModelCreator', () => {
         const dataStub = {} as UnifiedScanResultStoreData;
         convertStoreDataForScanNodeResultsCallbackMock
             .setup(mock => mock(dataStub, cardSelectionData))
-            .returns(() => ScanNodeResults)
+            .returns(() => scanNodeResults)
             .verifiable(Times.once());
         expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(
             expectedResult,


### PR DESCRIPTION
#### Details

Add logic to convert assessment store data and card selection store data to element based view model. This logic will be used for visualizing automated checks failures with the new assessment automated checks page/ infrastructure. 

##### Motivation

Feature work

##### Context

Implementation notes:

- Right now assessment store data is never passed into `getElementBasedViewModel`, so the new logic is not being exercised in practice. Eventually we will hook it up similarly to the [issues/ needs review logic in SelectorMapHelper](https://github.com/microsoft/accessibility-insights-web/blob/main/src/injected/selector-map-helper.ts#L96-L107), but this is blocked until https://github.com/microsoft/accessibility-insights-web/pull/6457 is merged as we will need to pass in `AssessmentStoreData` and the new `AssessmentCardSelectionStoreData` that is being added in that PR. As a result, I expect there may still be some bugs in this logic that will have to be investigated once we can hook things up end to end. 
- Much of the logic for `getElementBasedViewModel` is the same regardless of the type of data that is passed in, the main difference is just how that data is structured. As a result, to reduce duplication, I'm using an adapted template pattern here such that we normalize both types of data into one universal format that can them be used to generate the element based view model. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
