### PR TITLE
feat(automated-checks): add assessment data to cards view model converter

### DIFF
--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -112,8 +112,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
             selectedDetailsViewSwitcherNavConfiguration.getSelectedDetailsView(storeState);
 
         const automatedChecksCardsViewData = props.deps.getCardViewData(
-            props.storeState.unifiedScanResultStoreData.rules,
-            props.storeState.unifiedScanResultStoreData.results,
+            props.storeState.unifiedScanResultStoreData,
             props.deps.getCardSelectionViewData(
                 props.storeState.cardSelectionStoreData,
                 props.storeState.unifiedScanResultStoreData.results,
@@ -126,8 +125,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
             props.storeState.visualizationScanResultStoreData.tabStops.requirements;
 
         const needsReviewCardsViewData = props.deps.getCardViewData(
-            props.storeState.needsReviewScanResultStoreData.rules,
-            props.storeState.needsReviewScanResultStoreData.results,
+            props.storeState.needsReviewScanResultStoreData,
             props.deps.getCardSelectionViewData(
                 props.storeState.needsReviewCardSelectionStoreData,
                 props.storeState.needsReviewScanResultStoreData.results,

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -100,7 +100,6 @@ export class ResultsView extends React.Component<ResultsViewProps> {
             narrowModeStatus,
             cardsViewStoreData,
         } = this.props;
-        const { rules, results, toolInfo } = unifiedScanResultStoreData;
 
         const contentPageInfo: ContentPageInfo = this.getContentPageInfo();
 
@@ -112,8 +111,11 @@ export class ResultsView extends React.Component<ResultsViewProps> {
             contentPageInfo.resultsFilter,
         );
 
-        const cardsViewData = deps.getCardsViewData(rules, results, cardSelectionViewData);
-        deps.toolData = toolInfo;
+        const cardsViewData = deps.getCardsViewData(
+            unifiedScanResultStoreData,
+            cardSelectionViewData,
+        );
+        deps.toolData = unifiedScanResultStoreData.toolInfo;
 
         const highlightedResultUids = Object.keys(
             cardSelectionViewData.resultsHighlightStatus,

--- a/src/reports/package/axe-results-report.ts
+++ b/src/reports/package/axe-results-report.ts
@@ -52,7 +52,7 @@ export class AxeResultsReport implements AccessibilityInsightsReport.Report {
             resultsHighlightStatus: {},
         };
 
-        const cardsViewModel = getCards(unifiedRules, unifiedResults, cardSelectionViewData);
+        const cardsViewModel = getCards({ rules: unifiedRules, results: unifiedResults }, cardSelectionViewData);
 
         const targetAppInfo = {
             name: pageTitle,

--- a/src/tests/unit/common/__snapshots__/rule-based-view-model-provider.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/rule-based-view-model-provider.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isSelected": false, "visualHelperEnabled": false} 1`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": false, "isSelected": false, "visualHelperEnabled": false} 1`] = `
 {
   "allCardsCollapsed": true,
   "cards": {
@@ -22,6 +22,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -65,6 +76,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -92,6 +114,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -102,6 +135,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -116,7 +160,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isSelected": false, "visualHelperEnabled": false} 2`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": false, "isSelected": false, "visualHelperEnabled": false} 2`] = `
 {
   "allCardsCollapsed": true,
   "cards": {
@@ -138,6 +182,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -181,6 +236,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -208,6 +274,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -218,6 +295,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -232,7 +320,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isSelected": false, "visualHelperEnabled": true} 1`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": false, "isSelected": false, "visualHelperEnabled": true} 1`] = `
 {
   "allCardsCollapsed": true,
   "cards": {
@@ -254,6 +342,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -297,6 +396,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -324,6 +434,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -334,6 +455,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -348,7 +480,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isSelected": false, "visualHelperEnabled": true} 2`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": false, "isSelected": false, "visualHelperEnabled": true} 2`] = `
 {
   "allCardsCollapsed": true,
   "cards": {
@@ -370,6 +502,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -413,6 +556,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -440,6 +594,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -450,6 +615,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -464,7 +640,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isSelected": true, "visualHelperEnabled": false} 1`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": false, "isSelected": true, "visualHelperEnabled": false} 1`] = `
 {
   "allCardsCollapsed": true,
   "cards": {
@@ -486,6 +662,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -529,6 +716,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -556,6 +754,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -566,6 +775,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -580,7 +800,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isSelected": true, "visualHelperEnabled": false} 2`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": false, "isSelected": true, "visualHelperEnabled": false} 2`] = `
 {
   "allCardsCollapsed": true,
   "cards": {
@@ -602,6 +822,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -645,6 +876,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -672,6 +914,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -682,6 +935,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -696,7 +960,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isSelected": true, "visualHelperEnabled": true} 1`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": false, "isSelected": true, "visualHelperEnabled": true} 1`] = `
 {
   "allCardsCollapsed": true,
   "cards": {
@@ -718,6 +982,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -761,6 +1036,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -788,6 +1074,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -798,6 +1095,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -812,7 +1120,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isSelected": true, "visualHelperEnabled": true} 2`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": false, "isSelected": true, "visualHelperEnabled": true} 2`] = `
 {
   "allCardsCollapsed": true,
   "cards": {
@@ -834,6 +1142,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -877,6 +1196,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -904,6 +1234,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -914,6 +1255,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -928,7 +1280,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isSelected": false, "visualHelperEnabled": false} 1`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": true, "isSelected": false, "visualHelperEnabled": false} 1`] = `
 {
   "allCardsCollapsed": false,
   "cards": {
@@ -950,6 +1302,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -993,6 +1356,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -1020,6 +1394,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1030,6 +1415,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1044,7 +1440,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isSelected": false, "visualHelperEnabled": false} 2`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": true, "isSelected": false, "visualHelperEnabled": false} 2`] = `
 {
   "allCardsCollapsed": false,
   "cards": {
@@ -1066,6 +1462,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -1109,6 +1516,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -1136,6 +1554,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1146,6 +1575,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1160,7 +1600,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isSelected": false, "visualHelperEnabled": true} 1`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": true, "isSelected": false, "visualHelperEnabled": true} 1`] = `
 {
   "allCardsCollapsed": false,
   "cards": {
@@ -1182,6 +1622,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -1225,6 +1676,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -1252,6 +1714,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1262,6 +1735,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1276,7 +1760,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isSelected": false, "visualHelperEnabled": true} 2`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": true, "isSelected": false, "visualHelperEnabled": true} 2`] = `
 {
   "allCardsCollapsed": false,
   "cards": {
@@ -1298,6 +1782,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -1341,6 +1836,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -1368,6 +1874,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1378,6 +1895,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1392,7 +1920,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isSelected": true, "visualHelperEnabled": false} 1`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": true, "isSelected": true, "visualHelperEnabled": false} 1`] = `
 {
   "allCardsCollapsed": false,
   "cards": {
@@ -1414,6 +1942,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -1457,6 +1996,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -1484,6 +2034,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1494,6 +2055,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1508,7 +2080,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isSelected": true, "visualHelperEnabled": false} 2`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": true, "isSelected": true, "visualHelperEnabled": false} 2`] = `
 {
   "allCardsCollapsed": false,
   "cards": {
@@ -1530,6 +2102,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -1573,6 +2156,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -1600,6 +2194,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1610,6 +2215,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1624,7 +2240,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isSelected": true, "visualHelperEnabled": true} 1`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": true, "isSelected": true, "visualHelperEnabled": true} 1`] = `
 {
   "allCardsCollapsed": false,
   "cards": {
@@ -1646,6 +2262,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -1689,6 +2316,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -1716,6 +2354,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1726,6 +2375,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1740,7 +2400,7 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isSelected": true, "visualHelperEnabled": true} 2`] = `
+exports[`RuleBasedViewModelProvider getCardViewData for combination {"isExpanded": true, "isSelected": true, "visualHelperEnabled": true} 2`] = `
 {
   "allCardsCollapsed": false,
   "cards": {
@@ -1762,6 +2422,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "fail",
             "uid": "stub_uid",
@@ -1805,6 +2476,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": false,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule1",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule1",
+                  "text": "stub_guidance_text_rule1",
+                },
+              ],
+              "id": "rule1",
+              "url": "stub_url_rule1",
+            },
             "ruleId": "rule1",
             "status": "pass",
             "uid": "stub_uid",
@@ -1832,6 +2514,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",
@@ -1842,6 +2535,17 @@ exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isEx
             "identifiers": null,
             "isSelected": true,
             "resolution": null,
+            "rule": {
+              "description": "stub_description_rule2",
+              "guidance": [
+                {
+                  "href": "stub_guidance_href_rule2",
+                  "text": "stub_guidance_text_rule2",
+                },
+              ],
+              "id": "rule2",
+              "url": "stub_url_rule2",
+            },
             "ruleId": "rule2",
             "status": "unknown",
             "uid": "stub_uid",

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -15,8 +15,6 @@ import { DetailsViewRightContentPanelType } from 'common/types/store-data/detail
 import {
     TargetAppData,
     ToolData,
-    UnifiedResult,
-    UnifiedRule,
     UnifiedScanResultStoreData,
 } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
@@ -78,9 +76,8 @@ describe(DetailsViewContent.displayName, () => {
         );
         getCardViewDataMock = Mock.ofInstance(
             (
-                rules: UnifiedRule[],
-                results: UnifiedResult[],
-                cardSelectionViewData: CardSelectionViewData,
+                storeData: UnifiedScanResultStoreData,
+                cardSelectionViewData?: CardSelectionViewData,
             ) => null,
             MockBehavior.Strict,
         );
@@ -243,13 +240,7 @@ describe(DetailsViewContent.displayName, () => {
 
             const cardsViewData: CardsViewModel = {} as any;
             getCardViewDataMock
-                .setup(m =>
-                    m(
-                        state.unifiedScanResultStoreData.rules,
-                        state.unifiedScanResultStoreData.results,
-                        cardSelectionViewData,
-                    ),
-                )
+                .setup(m => m(state.unifiedScanResultStoreData, cardSelectionViewData))
                 .returns(() => cardsViewData);
 
             const rendered = shallow(

--- a/src/tests/unit/tests/electron/views/results/results-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/results-view.test.tsx
@@ -161,7 +161,7 @@ describe('ResultsView', () => {
             .verifiable(Times.once());
 
         getUnifiedRuleResultsMock
-            .setup(getter => getter(rulesStub, resultsStub, cardSelectionViewDataStub))
+            .setup(getter => getter(unifiedScanResultStoreData, cardSelectionViewDataStub))
             .returns(() => cardsViewData)
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/reports/package/axe-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/axe-results-report.test.ts
@@ -71,7 +71,7 @@ describe('AxeResultReport', () => {
     };
     const mockCardsViewModel = Mock.ofType<CardsViewModel>();
     const mockGetCards = Mock.ofType<typeof getCardViewData>(null, MockBehavior.Strict);
-    mockGetCards.setup(fn => fn(mockRules.object, mockResults.object, emptyCardSelectionViewData)).returns(() => mockCardsViewModel.object);
+    mockGetCards.setup(fn => fn({rules: mockRules.object, results: mockResults.object}, emptyCardSelectionViewData)).returns(() => mockCardsViewModel.object);
 
     const expectedHTML = '<div>The Report!</div>';
     const mockReportHtmlGenerator = Mock.ofType<ReportHtmlGenerator>(null, MockBehavior.Strict);


### PR DESCRIPTION
#### Details

Add logic to convert assessment store data to cards view model. This logic will be used for visualizing automated checks failures with the new assessment automated checks page/ infrastructure.

##### Motivation

Feature work.

##### Context

Implementation notes: 

- This implementation built off of @waabid's branch: https://github.com/microsoft/accessibility-insights-web/compare/main...waabid:accessibility-insights-web:assessmentStoreDataTransformer2
- Right now assessment store data is never passed into getCardViewData, so the new logic is not being exercised in practice. Eventually we will hook it up similarly to the [issues/ needs review logic in details-view-content](https://github.com/microsoft/accessibility-insights-web/blob/main/src/DetailsView/components/details-view-content.tsx#L114-L137), but this is blocked until https://github.com/microsoft/accessibility-insights-web/pull/6457 is merged as we will need to pass in AssessmentStoreData and the new AssessmentCardSelectionStoreData that is being added in that PR.
- This implementation reuses the `convertStoreDataForScanNodeResults` logic added in https://github.com/microsoft/accessibility-insights-web/pull/6476.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
