### PR TITLE
feat(automated-checks): add test view container for assessment automated checks

### DIFF
--- a/src/DetailsView/components/default-test-view-container-provider.tsx
+++ b/src/DetailsView/components/default-test-view-container-provider.tsx
@@ -13,15 +13,15 @@ import {
 import React from 'react';
 
 export class DefaultTestViewContainerProvider implements TestViewContainerProvider {
-    public createStaticTestViewContainer(props: TestViewContainerProviderProps) {
+    public createStaticTestViewContainer(props: TestViewContainerProviderProps): JSX.Element {
         return <AdhocStaticTestView {...props} />;
     }
 
-    public createTabStopsTestViewContainer(props: TestViewContainerProviderProps) {
+    public createTabStopsTestViewContainer(props: TestViewContainerProviderProps): JSX.Element {
         return <AdhocTabStopsTestView {...props} />;
     }
 
-    public createNeedsReviewTestViewContainer(props: TestViewContainerProviderProps) {
+    public createNeedsReviewTestViewContainer(props: TestViewContainerProviderProps): JSX.Element {
         return (
             <AdhocIssuesTestView
                 cardsViewData={props.needsReviewCardsViewData}
@@ -32,7 +32,7 @@ export class DefaultTestViewContainerProvider implements TestViewContainerProvid
         );
     }
 
-    public createIssuesTestViewContainer(props: TestViewContainerProviderProps) {
+    public createIssuesTestViewContainer(props: TestViewContainerProviderProps): JSX.Element {
         return (
             <AdhocIssuesTestView
                 instancesSection={FailedInstancesSection}
@@ -43,7 +43,22 @@ export class DefaultTestViewContainerProvider implements TestViewContainerProvid
         );
     }
 
-    public createAssessmentTestViewContainer(props: TestViewContainerProviderProps) {
+    public createAssessmentAutomatedChecksTestViewContainer(
+        props: TestViewContainerProviderProps,
+    ): JSX.Element {
+        return (
+            // TODO need to use assessment specific data/ infra here
+            <AdhocIssuesTestView
+                instancesSection={FailedInstancesSection}
+                cardSelectionMessageCreator={props.automatedChecksCardSelectionMessageCreator}
+                cardsViewData={props.automatedChecksCardsViewData}
+                includeStepsText={false}
+                {...props}
+            />
+        );
+    }
+
+    public createAssessmentTestViewContainer(props: TestViewContainerProviderProps): JSX.Element {
         return <AssessmentTestView {...props} />;
     }
 }

--- a/src/DetailsView/components/details-list-issues-view.tsx
+++ b/src/DetailsView/components/details-list-issues-view.tsx
@@ -31,6 +31,7 @@ export interface DetailsListIssuesViewProps {
     selectedTest: VisualizationType;
     cardSelectionMessageCreator: CardSelectionMessageCreator;
     narrowModeStatus: NarrowModeStatus;
+    includeStepsText?: boolean;
 }
 
 export const DetailsListIssuesView = NamedFC<DetailsListIssuesViewProps>(
@@ -54,6 +55,7 @@ export const DetailsListIssuesView = NamedFC<DetailsListIssuesViewProps>(
                 title={title}
                 subtitle={subtitle}
                 stepsText={stepsText()}
+                includeStepsText={props.includeStepsText}
                 issuesEnabled={scanData.enabled}
                 scanning={isScanning}
                 featureFlags={props.featureFlagStoreData}

--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -34,6 +34,7 @@ export interface IssuesTableProps {
     deps: IssuesTableDeps;
     title: string;
     subtitle?: JSX.Element;
+    includeStepsText?: boolean;
     stepsText: string;
     issuesEnabled: boolean;
     scanning: boolean;
@@ -71,7 +72,7 @@ export class IssuesTable extends React.Component<IssuesTableProps> {
         return (
             <h1>
                 {this.props.title}
-                {` ${this.props.stepsText}`}
+                {this.props.includeStepsText ?? true ? ` ${this.props.stepsText}` : null}
             </h1>
         );
     }

--- a/src/DetailsView/components/test-view-container-provider.tsx
+++ b/src/DetailsView/components/test-view-container-provider.tsx
@@ -25,5 +25,8 @@ export interface TestViewContainerProvider {
     createTabStopsTestViewContainer(props: TestViewContainerProviderProps): JSX.Element;
     createNeedsReviewTestViewContainer(props: TestViewContainerProviderProps): JSX.Element;
     createIssuesTestViewContainer(props: TestViewContainerProviderProps): JSX.Element;
+    createAssessmentAutomatedChecksTestViewContainer(
+        props: TestViewContainerProviderProps,
+    ): JSX.Element;
     createAssessmentTestViewContainer(props: TestViewContainerProviderProps): JSX.Element;
 }

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -172,7 +172,11 @@ export class AssessmentBuilder {
     }
 
     public static Assisted(assessment: AssistedAssessment): Assessment {
-        const { key, requirements } = assessment;
+        const {
+            key,
+            requirements,
+            getTestViewContainer: getTestViewContainerOverride,
+        } = assessment;
 
         assessment.initialDataCreator =
             assessment.initialDataCreator || createInitialAssessmentTestData;
@@ -223,6 +227,10 @@ export class AssessmentBuilder {
             return requirementConfig.getNotificationMessage(selectorMap);
         };
 
+        const getTestViewContainer =
+            getTestViewContainerOverride ??
+            ((provider, props) => provider.createAssessmentTestViewContainer(props));
+
         const visualizationConfiguration: AssessmentVisualizationConfiguration = {
             testViewType: 'Assessment',
             getAssessmentData: data => data.assessments[key],
@@ -244,8 +252,7 @@ export class AssessmentBuilder {
             getNotificationMessage: getNotificationMessage,
             getSwitchToTargetTabOnScan: AssessmentBuilder.getSwitchToTargetTabOnScan(requirements),
             getInstanceIdentiferGenerator: AssessmentBuilder.getInstanceIdentifier(requirements),
-            getTestViewContainer: (provider, props) =>
-                provider.createAssessmentTestViewContainer(props),
+            getTestViewContainer,
         } as AssessmentVisualizationConfiguration;
 
         AssessmentBuilder.buildRequirementReportDescription(requirements);

--- a/src/assessments/automated-checks/assessment.tsx
+++ b/src/assessments/automated-checks/assessment.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { createAutomatedChecksInitialAssessmentTestData } from 'background/create-initial-assessment-test-data';
+import { FeatureFlags } from 'common/feature-flags';
 import { VisualizationType } from 'common/types/visualization-type';
 import { title } from 'content/strings/application';
 import { test as content } from 'content/test';
@@ -23,6 +24,13 @@ const gettingStarted: JSX.Element = (
 const config: AssistedAssessment = {
     key: 'automated-checks',
     title: 'Automated checks',
+    subtitle: (
+        <>
+            Automated checks can detect some common accessibility problems such as missing or
+            invalid properties but most accessibility problems can only be discovered through manual
+            testing.
+        </>
+    ),
     storeDataKey: 'automatedChecks',
     visualizationType: VisualizationType.AutomatedChecks,
     initialDataCreator: createAutomatedChecksInitialAssessmentTestData,
@@ -31,6 +39,10 @@ const config: AssistedAssessment = {
     requirements: buildTestStepsFromRules(getDefaultRules()),
     extensions: [excludePassingInstancesFromAssessmentReport],
     isNonCollapsible: true,
+    getTestViewContainer: (provider, props) =>
+        props.featureFlagStoreData[FeatureFlags.automatedChecks]
+            ? provider.createAssessmentAutomatedChecksTestViewContainer(props)
+            : provider.createAssessmentTestViewContainer(props),
 };
 
 export const AutomatedChecks = AssessmentBuilder.Assisted(config);

--- a/src/assessments/types/iassessment.ts
+++ b/src/assessments/types/iassessment.ts
@@ -4,6 +4,10 @@ import { InitialDataCreator } from 'background/create-initial-assessment-test-da
 import { AssessmentVisualizationConfiguration } from 'common/configs/assessment-visualization-configuration';
 import { AnyExtension } from 'common/extensibility/extension-point';
 import { VisualizationType } from 'common/types/visualization-type';
+import {
+    TestViewContainerProvider,
+    TestViewContainerProviderProps,
+} from 'DetailsView/components/test-view-container-provider';
 import { ContentPageComponent } from 'views/content/content-page';
 import { Requirement } from './requirement';
 
@@ -11,6 +15,7 @@ interface BaseAssessment {
     key: string;
     visualizationType: VisualizationType;
     title: string;
+    subtitle?: JSX.Element;
     gettingStarted: JSX.Element;
     guidance?: ContentPageComponent;
     requirements: Requirement[];
@@ -25,6 +30,10 @@ export interface ManualAssessment extends BaseAssessment {}
 export interface AssistedAssessment extends BaseAssessment {
     storeDataKey: string;
     visualizationConfiguration?: Partial<AssessmentVisualizationConfiguration>;
+    getTestViewContainer?: (
+        provider: TestViewContainerProvider,
+        props: TestViewContainerProviderProps,
+    ) => JSX.Element;
 }
 
 export interface Assessment extends BaseAssessment {

--- a/src/common/configs/web-visualization-configuration-factory.ts
+++ b/src/common/configs/web-visualization-configuration-factory.ts
@@ -128,6 +128,7 @@ export class WebVisualizationConfigurationFactory implements VisualizationConfig
             adhocToolsPanelDisplayOrder: null,
             displayableData: {
                 title: assessment.title,
+                subtitle: assessment.subtitle,
                 adHoc: null,
             },
             shouldShowExportReport: () => false,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/default-test-view-container-provider.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/default-test-view-container-provider.test.tsx.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DefaultTestViewContainerProvider can create assessment automated checks test view container 1`] = `
+<AdhocIssuesTestView
+  deps={
+    {
+      "automatedChecksCardSelectionMessageCreator": {},
+      "needsReviewCardSelectionMessageCreator": {},
+    }
+  }
+  includeStepsText={false}
+  instancesSection={[Function]}
+  someParentProp="parent-prop"
+  visualizationScanResultData={
+    {
+      "tabStops": {
+        "requirements": {},
+      },
+    }
+  }
+/>
+`;
+
 exports[`DefaultTestViewContainerProvider can create assessment test view container 1`] = `
 <AssessmentTestView
   deps={

--- a/src/tests/unit/tests/DetailsView/components/default-test-view-container-provider.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/default-test-view-container-provider.test.tsx
@@ -48,6 +48,11 @@ describe('DefaultTestViewContainerProvider', () => {
         expect(element).toMatchSnapshot();
     });
 
+    it('can create assessment automated checks test view container', () => {
+        const element = testSubject.createAssessmentAutomatedChecksTestViewContainer(propsStub);
+        expect(element).toMatchSnapshot();
+    });
+
     it('can create assessment test view container', () => {
         const element = testSubject.createAssessmentTestViewContainer(propsStub);
         expect(element).toMatchSnapshot();

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -8,6 +8,8 @@ import { AssessmentToggleActionPayload } from 'background/actions/action-payload
 import { createInitialAssessmentTestData } from 'background/create-initial-assessment-test-data';
 import { InstanceIdentifierGenerator } from 'background/instance-identifier-generator';
 import { DecoratedAxeNodeResult } from 'common/types/store-data/visualization-scan-result-data';
+import { AssessmentTestView } from 'DetailsView/components/assessment-test-view';
+import { DefaultTestViewContainerProvider } from 'DetailsView/components/default-test-view-container-provider';
 import { cloneDeep } from 'lodash';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
@@ -200,6 +202,9 @@ describe('AssessmentBuilderTest', () => {
         requirement6.getInstanceStatusColumns = getInstanceStatusColumns6;
         const instanceTableHeaderType6 = 'none';
         requirement6.instanceTableHeaderType = instanceTableHeaderType6;
+        const getTestViewContainerStub = (provider, props) => {
+            return {} as JSX.Element;
+        };
 
         const assistedAssessment: AssistedAssessment = {
             key: 'manual assessment key',
@@ -216,6 +221,7 @@ describe('AssessmentBuilderTest', () => {
             ],
             storeDataKey: 'headingsAssessment',
             visualizationConfiguration: {},
+            getTestViewContainer: getTestViewContainerStub,
         };
 
         const nonDefaultAssessment: AssistedAssessment = {
@@ -311,6 +317,7 @@ describe('AssessmentBuilderTest', () => {
             InstanceIdentifierGenerator.defaultHtmlSelectorIdentifier,
         );
         expect(config.testViewType).toBe('Assessment');
+        expect(config.getTestViewContainer).toBe(getTestViewContainerStub);
 
         validateInstanceTableSettings(requirement1);
         validateInstanceTableSettings(requirement5);
@@ -332,6 +339,40 @@ describe('AssessmentBuilderTest', () => {
         providerMock.verifyAll();
         drawerProviderMock.verifyAll();
         expect(config.getAssessmentData(assessmentData as any)).toEqual(expectedData);
+    });
+
+    test('Assisted getTestViewContainer defaults to createAssessmentTestViewContainer', () => {
+        const assistedAssessment: AssistedAssessment = {
+            key: 'manual assessment key',
+            visualizationType: -1 as VisualizationType,
+            title: 'manual assessment title',
+            gettingStarted: <span>getting started</span>,
+            requirements: [],
+            storeDataKey: 'headingsAssessment',
+            visualizationConfiguration: {},
+        };
+
+        const assisted = AssessmentBuilder.Assisted(assistedAssessment);
+        const config = assisted.getVisualizationConfiguration();
+
+        const expectedTestViewContainer = (
+            <AssessmentTestView
+                deps={undefined}
+                tabStoreData={undefined}
+                assessmentStoreData={undefined}
+                pathSnippetStoreData={undefined}
+                visualizationStoreData={undefined}
+                assessmentInstanceTableHandler={undefined}
+                configuration={undefined}
+                featureFlagStoreData={undefined}
+                switcherNavConfiguration={undefined}
+            />
+        );
+        const actualTestViewContainer = config.getTestViewContainer(
+            new DefaultTestViewContainerProvider(),
+            undefined,
+        );
+        expect(actualTestViewContainer).toEqual(expectedTestViewContainer);
     });
 
     function validateInstanceTableSettings(requirement: Requirement): void {

--- a/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
+++ b/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
@@ -212,8 +212,10 @@ describe('WebVisualizationConfigurationFactory', () => {
                 key: 'req-2',
             },
         ] as Requirement[];
+        const subtitle = {} as JSX.Element;
         return {
             title,
+            subtitle,
             visualizationType,
             requirements: requirementsStub,
             getVisualizationConfiguration: () => {},
@@ -349,6 +351,7 @@ describe('WebVisualizationConfigurationFactory', () => {
         testMode: TestMode,
         expectedMessageConfig: AnalyzerMessageConfiguration,
     ): Partial<VisualizationConfiguration> {
+        const subtitle = {} as JSX.Element;
         return {
             testMode,
             chromeCommand: null,
@@ -356,6 +359,7 @@ describe('WebVisualizationConfigurationFactory', () => {
             adhocToolsPanelDisplayOrder: null,
             displayableData: {
                 title: expectedDisplayableTitle,
+                subtitle,
                 adHoc: null,
             },
             messageConfiguration: expectedMessageConfig,


### PR DESCRIPTION
#### Details

Add single page view for assessment automated checks. This implementation adds `createAssessmentAutomatedChecksTestViewContainer` to the test view container provider and reuses existing `AdhocIssuesTestView` and `FailedInstancesSection`. Note that these changes are currently behind the automatedChecks feature flag. 

##### Motivation

Feature work

##### Context

This UI component will eventually need to be hooked up to the AssessmentCardSelection infrastructure being added in https://github.com/microsoft/accessibility-insights-web/pull/6457. For now, it is populated with fastpass automated checks data. 

UI after these changes, with feature flag enabled:
[Screenshot description: Assessment details view with automated checks selected. Automated checks is not collapsible in the left nav bar and the main content UI is consistent with fastpass automated checks UI. ]
<img width="977" alt="AssessmentAutoChecksContainer" src="https://user-images.githubusercontent.com/16010855/223845039-845cf151-957f-4b6a-889d-6e79f0297d09.png">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
