### PR TITLE
feat(automated-checks): fix selected nav link logic for noncollapsible links

### DIFF
--- a/src/DetailsView/components/left-nav/get-left-nav-selected-key.ts
+++ b/src/DetailsView/components/left-nav/get-left-nav-selected-key.ts
@@ -23,7 +23,10 @@ export function getOverviewKey(): string {
 }
 
 export function getTestViewKey(props: GetLeftNavSelectedKeyProps): string {
-    if (props.assessmentsProvider.isValidType(props.visualizationType) === false) {
+    if (
+        props.assessmentsProvider.isValidType(props.visualizationType) === false ||
+        props.assessmentsProvider.forType(props.visualizationType)?.isNonCollapsible
+    ) {
         return VisualizationType[props.visualizationType];
     }
 

--- a/src/DetailsView/components/left-nav/nav-link-handler.ts
+++ b/src/DetailsView/components/left-nav/nav-link-handler.ts
@@ -77,7 +77,11 @@ export class NavLinkHandler {
         event: React.MouseEvent<HTMLElement>,
         item: AssessmentLeftNavLink,
     ) => {
-        this.assessmentActionMessageCreator.selectRequirement(event, undefined, item.testType);
+        this.assessmentActionMessageCreator.selectRequirement(
+            event,
+            item.requirementKey,
+            item.testType,
+        );
         this.detailsViewActionMessageCreator.changeRightContentPanel('TestView');
     };
 }

--- a/src/DetailsView/components/left-nav/nav-link-handler.ts
+++ b/src/DetailsView/components/left-nav/nav-link-handler.ts
@@ -77,9 +77,7 @@ export class NavLinkHandler {
         event: React.MouseEvent<HTMLElement>,
         item: AssessmentLeftNavLink,
     ) => {
-        // TODO this temporarily navigates to the getting started page, but this will need to be changed
-        // once we have a unified automated checks view
-        this.assessmentActionMessageCreator.selectGettingStarted(event, item.testType);
+        this.assessmentActionMessageCreator.selectRequirement(event, undefined, item.testType);
         this.detailsViewActionMessageCreator.changeRightContentPanel('TestView');
     };
 }

--- a/src/tests/unit/tests/DetailsView/components/left-nav/get-left-nav-selected-key.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/get-left-nav-selected-key.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { Assessment } from 'assessments/types/iassessment';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { assessmentTestKeyGenerator } from 'DetailsView/components/left-nav/left-nav-link-builder';
 import { IMock, Mock } from 'typemoq';
@@ -44,6 +45,16 @@ describe('getTestviewKey', () => {
 
     it('with invalid assessment type', () => {
         assessmentsProviderMock.setup(a => a.isValidType(visualizationType)).returns(() => false);
+        const expectedKey = VisualizationType[visualizationType];
+
+        expect(getTestViewKey(props)).toEqual(expectedKey);
+    });
+
+    it('with noncollapsible assessment type', () => {
+        assessmentsProviderMock.setup(a => a.isValidType(visualizationType)).returns(() => true);
+        assessmentsProviderMock
+            .setup(a => a.forType(visualizationType))
+            .returns(() => ({ isNonCollapsible: true } as Readonly<Assessment>));
         const expectedKey = VisualizationType[visualizationType];
 
         expect(getTestViewKey(props)).toEqual(expectedKey);

--- a/src/tests/unit/tests/DetailsView/handlers/nav-link-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/handlers/nav-link-handler.test.ts
@@ -168,7 +168,9 @@ describe('NavLinkHandler', () => {
                 testType: irrelevantVisualizationType,
             } as AssessmentLeftNavLink;
             assessmentActionMessageCreatorMock
-                .setup(amc => amc.selectGettingStarted(eventStub, assessmentLeftNavLink.testType))
+                .setup(amc =>
+                    amc.selectRequirement(eventStub, undefined, assessmentLeftNavLink.testType),
+                )
                 .verifiable();
 
             detailsViewActionMessageCreatorMock


### PR DESCRIPTION
#### Details

https://github.com/microsoft/accessibility-insights-web/pull/6454 added noncollapsible links and https://github.com/microsoft/accessibility-insights-web/pull/6482 added a single page test view container for the new assessment automated checks. This PR finishes integrating them together by fixing the navigation and left nav link highlighting.

##### Motivation

Feature work

##### Context

Before this change:
[Screenshot description: assessment automated checks left nav link is selected but not highlighted]
<img width="1365" alt="BrokenLeftNavHighlight" src="https://user-images.githubusercontent.com/16010855/224120245-42848506-b109-4b78-addd-8f97b6ae58db.png">

After this change:
[Screenshot description: assessment automated checks left nav link is selected and highlighted]
<img width="1365" alt="FixedLeftNavHighlight" src="https://user-images.githubusercontent.com/16010855/224118962-44ab7a33-187c-406a-b1a9-fce15b63b700.png">

Note that with these changes the status is still not reflected in the left nav bar icon. This is because the assessment store data is not populated (the data being displayed is from the unified results). This will be fixed in future PRs. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
