### PR TITLE
feat(automated-checks): initialize assessment and quick assess card selection stores

### DIFF
--- a/src/background/IndexedDBDataKeys.ts
+++ b/src/background/IndexedDBDataKeys.ts
@@ -4,6 +4,8 @@ export class IndexedDBDataKeys {
     // Global keys
     public static readonly assessmentStore: string = 'assessmentStoreData';
     public static readonly quickAssessStore: string = 'quickAssessStoreData';
+    public static readonly assessmentCardSelectionStore: string = 'assessmentCardSelectionStore';
+    public static readonly quickAssessCardSelectionStore: string = 'quickAssessCardSelectionStore';
     public static readonly userConfiguration: string = 'userConfiguration';
     public static readonly installation: string = 'installationData';
     public static readonly unifiedFeatureFlags: string = 'featureFlags';
@@ -35,12 +37,12 @@ export class IndexedDBDataKeys {
         'visualizationScanResultStore' + tabId;
     public static readonly unifiedScanResultStore: (tabId: number) => string = tabId =>
         'unifiedScanResultStore' + tabId;
-    public static readonly assessmentCardSelectionStore: (tabId: number) => string = tabId =>
-        'assessmentCardSelectionStore' + tabId;
 
     public static readonly globalKeys: string[] = [
         IndexedDBDataKeys.assessmentStore,
+        IndexedDBDataKeys.assessmentCardSelectionStore,
         IndexedDBDataKeys.quickAssessStore,
+        IndexedDBDataKeys.quickAssessCardSelectionStore,
         IndexedDBDataKeys.userConfiguration,
         IndexedDBDataKeys.installation,
         IndexedDBDataKeys.unifiedFeatureFlags,
@@ -63,6 +65,5 @@ export class IndexedDBDataKeys {
         IndexedDBDataKeys.visualizationStore,
         IndexedDBDataKeys.visualizationScanResultStore,
         IndexedDBDataKeys.unifiedScanResultStore,
-        IndexedDBDataKeys.assessmentCardSelectionStore,
     ];
 }

--- a/src/background/actions/global-action-hub.ts
+++ b/src/background/actions/global-action-hub.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentCardSelectionActions } from 'background/actions/assessment-card-selection-actions';
 import { DataTransferActions } from 'background/actions/data-transfer-actions';
 import { PermissionsStateActions } from 'background/actions/permissions-state-actions';
 import { FeatureFlagActions } from '../actions/feature-flag-actions';
@@ -19,6 +20,8 @@ export class GlobalActionHub {
     public dataTransferActions: DataTransferActions;
     public userConfigurationActions: UserConfigurationActions;
     public permissionsStateActions: PermissionsStateActions;
+    public assessmentCardSelectionActions: AssessmentCardSelectionActions;
+    public quickAssessCardSelectionActions: AssessmentCardSelectionActions;
 
     constructor() {
         this.commandActions = new CommandActions();
@@ -30,5 +33,7 @@ export class GlobalActionHub {
         this.dataTransferActions = new DataTransferActions();
         this.userConfigurationActions = new UserConfigurationActions();
         this.permissionsStateActions = new PermissionsStateActions();
+        this.assessmentCardSelectionActions = new AssessmentCardSelectionActions();
+        this.quickAssessCardSelectionActions = new AssessmentCardSelectionActions();
     }
 }

--- a/src/background/actions/quick-assess-card-selection-action-creator.ts
+++ b/src/background/actions/quick-assess-card-selection-action-creator.ts
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AssessmentCardSelectionActions } from 'background/actions/assessment-card-selection-actions';
+import { StoreNames } from 'common/stores/store-names';
+import * as TelemetryEvents from '../../common/extension-telemetry-events';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { Interpreter } from '../interpreter';
+import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
+import {
+    AssessmentCardSelectionPayload,
+    AssessmentCardToggleVisualHelperPayload,
+    AssessmentExpandCollapsePayload,
+    AssessmentSingleRuleExpandCollapsePayload,
+} from './action-payloads';
+
+export class QuickAssessCardSelectionActionCreator {
+    constructor(
+        private readonly interpreter: Interpreter,
+        private readonly quickAssessCardSelectionActions: AssessmentCardSelectionActions,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+    ) {}
+
+    public registerCallbacks(): void {
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.QuickAssessCardSelection.CardSelectionToggled,
+            this.onQuickAssessCardSelectionToggle,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.QuickAssessCardSelection.RuleExpansionToggled,
+            this.onRuleExpansionToggle,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            getStoreStateMessage(StoreNames.QuickAssessCardSelectionStore),
+            this.onGetCurrentState,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.QuickAssessCardSelection.ToggleVisualHelper,
+            this.onToggleVisualHelper,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.QuickAssessCardSelection.ExpandAllRules,
+            this.onExpandAllRules,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.QuickAssessCardSelection.CollapseAllRules,
+            this.onCollapseAllRules,
+        );
+    }
+
+    private onGetCurrentState = async (): Promise<void> => {
+        await this.quickAssessCardSelectionActions.getCurrentState.invoke(null);
+    };
+
+    private onQuickAssessCardSelectionToggle = async (
+        payload: AssessmentCardSelectionPayload,
+    ): Promise<void> => {
+        await this.quickAssessCardSelectionActions.toggleCardSelection.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(
+            TelemetryEvents.CARD_SELECTION_TOGGLED,
+            payload,
+        );
+    };
+
+    private onRuleExpansionToggle = async (
+        payload: AssessmentSingleRuleExpandCollapsePayload,
+    ): Promise<void> => {
+        await this.quickAssessCardSelectionActions.toggleRuleExpandCollapse.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(
+            TelemetryEvents.RULE_EXPANSION_TOGGLED,
+            payload,
+        );
+    };
+
+    private onToggleVisualHelper = async (
+        payload: AssessmentCardToggleVisualHelperPayload,
+    ): Promise<void> => {
+        await this.quickAssessCardSelectionActions.toggleVisualHelper.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.VISUAL_HELPER_TOGGLED, payload);
+    };
+
+    private onCollapseAllRules = async (
+        payload: AssessmentExpandCollapsePayload,
+    ): Promise<void> => {
+        await this.quickAssessCardSelectionActions.collapseAllRules.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_COLLAPSED, payload);
+    };
+
+    private onExpandAllRules = async (payload: AssessmentExpandCollapsePayload): Promise<void> => {
+        await this.quickAssessCardSelectionActions.expandAllRules.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_EXPANDED, payload);
+    };
+}

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -29,6 +29,8 @@ export interface PersistedData {
     };
     assessmentStoreData: AssessmentStoreData;
     quickAssessStoreData: AssessmentStoreData;
+    assessmentCardSelectionStoreData: AssessmentCardSelectionStoreData;
+    quickAssessCardSelectionStoreData: AssessmentCardSelectionStoreData;
     userConfigurationData: UserConfigurationStoreData;
     installationData: InstallationData;
     featureFlags: FeatureFlagStoreData;
@@ -51,7 +53,6 @@ export interface TabSpecificPersistedData {
     unifiedScanResultStoreData: UnifiedScanResultStoreData;
     visualizationScanResultStoreData: VisualizationScanResultData;
     visualizationStoreData: VisualizationStoreData;
-    assessmentCardSelectionStoreData: AssessmentCardSelectionStoreData;
 }
 
 const keyToPersistedDataMappingOverrides = {

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentCardSelectionActionCreator } from 'background/actions/assessment-card-selection-action-creator';
 import { QuickAssessActionCreator } from 'background/actions/quick-assess-action-creator';
+import { QuickAssessCardSelectionActionCreator } from 'background/actions/quick-assess-card-selection-action-creator';
 import { BrowserPermissionsTracker } from 'background/browser-permissions-tracker';
 import { QuickAssessToAssessmentConverter } from 'background/quick-assess-to-assessment-converter';
 import {
@@ -109,6 +111,16 @@ export class GlobalContextFactory {
             globalActionsHub.quickAssessActions,
             telemetryEventHandler,
         );
+        const assessmentCardSelectionActionCreator = new AssessmentCardSelectionActionCreator(
+            interpreter,
+            globalActionsHub.assessmentCardSelectionActions,
+            telemetryEventHandler,
+        );
+        const quickAssessCardSelectionActionCreator = new QuickAssessCardSelectionActionCreator(
+            interpreter,
+            globalActionsHub.quickAssessCardSelectionActions,
+            telemetryEventHandler,
+        );
         const userConfigurationActionCreator = new UserConfigurationActionCreator(
             globalActionsHub.userConfigurationActions,
             telemetryEventHandler,
@@ -132,6 +144,8 @@ export class GlobalContextFactory {
         actionCreator.registerCallbacks();
         assessmentActionCreator.registerCallbacks();
         quickAssessActionCreator.registerCallbacks();
+        assessmentCardSelectionActionCreator.registerCallbacks();
+        quickAssessCardSelectionActionCreator.registerCallbacks();
         registerUserConfigurationMessageCallback(interpreter, userConfigurationActionCreator);
         scopingActionCreator.registerCallback();
         featureFlagsActionCreator.registerCallbacks();

--- a/src/background/stores/assessment-card-selection-store.ts
+++ b/src/background/stores/assessment-card-selection-store.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentCardSelectionActions } from 'background/actions/assessment-card-selection-actions';
-import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { PersistentStore } from 'common/flux/persistent-store';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Logger } from 'common/logging/logger';
@@ -27,14 +26,14 @@ export class AssessmentCardSelectionStore extends PersistentStore<AssessmentCard
         persistedState: AssessmentCardSelectionStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
-        tabId: number,
         persistStoreData: boolean,
+        indexDBKey: string,
     ) {
         super(
             StoreNames.AssessmentCardSelectionStore,
             persistedState,
             idbInstance,
-            IndexedDBDataKeys.assessmentCardSelectionStore(tabId),
+            indexDBKey,
             logger,
             persistStoreData,
         );

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { AssessmentCardSelectionStore } from 'background/stores/assessment-card-selection-store';
 import { DataTransferStore } from 'background/stores/global/data-transfer-store';
 import { PermissionsStateStore } from 'background/stores/global/permissions-state-store';
 import { FeatureFlagDefaultsHelper } from 'common/feature-flag-defaults-helper';
@@ -35,6 +36,8 @@ export class GlobalStoreHub implements StoreHub {
     public launchPanelStore: LaunchPanelStore;
     public scopingStore: ScopingStore;
     public assessmentStore: AssessmentStore;
+    public quickAssessCardSelectionStore: AssessmentCardSelectionStore;
+    public assessmentCardSelectionStore: AssessmentCardSelectionStore;
     public quickAssessStore: AssessmentStore;
     public dataTransferStore: DataTransferStore;
     public userConfigurationStore: UserConfigurationStore;
@@ -106,6 +109,22 @@ export class GlobalStoreHub implements StoreHub {
             StoreNames.QuickAssessStore,
             IndexedDBDataKeys.quickAssessStore,
         );
+        this.assessmentCardSelectionStore = new AssessmentCardSelectionStore(
+            globalActionHub.assessmentCardSelectionActions,
+            persistedData.assessmentCardSelectionStoreData,
+            indexedDbInstance,
+            logger,
+            persistStoreData,
+            IndexedDBDataKeys.assessmentCardSelectionStore,
+        );
+        this.quickAssessCardSelectionStore = new AssessmentCardSelectionStore(
+            globalActionHub.quickAssessCardSelectionActions,
+            persistedData.quickAssessCardSelectionStoreData,
+            indexedDbInstance,
+            logger,
+            persistStoreData,
+            IndexedDBDataKeys.quickAssessCardSelectionStore,
+        );
         this.userConfigurationStore = new UserConfigurationStore(
             persistedData.userConfigurationData,
             globalActionHub.userConfigurationActions,
@@ -129,6 +148,8 @@ export class GlobalStoreHub implements StoreHub {
         this.scopingStore.initialize();
         this.assessmentStore.initialize();
         this.quickAssessStore.initialize();
+        this.assessmentCardSelectionStore.initialize();
+        this.quickAssessCardSelectionStore.initialize();
         this.userConfigurationStore.initialize();
         this.permissionsStateStore.initialize();
         this.dataTransferStore.initialize();
@@ -142,6 +163,8 @@ export class GlobalStoreHub implements StoreHub {
             this.scopingStore,
             this.assessmentStore,
             this.quickAssessStore,
+            this.assessmentCardSelectionStore,
+            this.quickAssessCardSelectionStore,
             this.userConfigurationStore,
             this.permissionsStateStore,
             this.dataTransferStore,

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -239,6 +239,14 @@ export const Messages = {
         ToggleVisualHelper: `${messagePrefix}/assessmentCardSelection/toggleVisualHelper`,
         NavigateToNewCardsView: `${messagePrefix}/assessmentCardSelection/navigateToNewCardsView`,
     },
+    QuickAssessCardSelection: {
+        CardSelectionToggled: `${messagePrefix}/quickAssessCardSelection/cardSelectionToggled`,
+        RuleExpansionToggled: `${messagePrefix}/quickAssessCardSelection/ruleExpansionToggled`,
+        CollapseAllRules: `${messagePrefix}/quickAssessCardSelection/collapseAllRules`,
+        ExpandAllRules: `${messagePrefix}/quickAssessCardSelection/expandAllRules`,
+        ToggleVisualHelper: `${messagePrefix}/quickAssessCardSelection/toggleVisualHelper`,
+        NavigateToNewCardsView: `${messagePrefix}/quickAssessCardSelection/navigateToNewCardsView`,
+    },
 
     PermissionsState: {
         SetPermissionsState: `${messagePrefix}/permissionsState/setPermissionsState`,

--- a/src/common/stores/store-names.ts
+++ b/src/common/stores/store-names.ts
@@ -34,4 +34,5 @@ export enum StoreNames {
     DataTransferStore,
     DataTransferViewStore,
     AssessmentCardSelectionStore,
+    QuickAssessCardSelectionStore,
 }

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
 import { AssessmentDataConverter } from 'background/assessment-data-converter';
+import { AssessmentCardSelectionStore } from 'background/stores/assessment-card-selection-store';
 import { AssessmentStore } from 'background/stores/assessment-store';
 import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { DetailsViewStore } from 'background/stores/details-view-store';
@@ -128,6 +129,22 @@ export class StoreMocks {
     ).getDefaultState();
     public needsReviewScanResultStoreData = new NeedsReviewScanResultStore(
         null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+    ).getDefaultState();
+    public assessmentCardSelectionStoreData = new AssessmentCardSelectionStore(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+    ).getDefaultState();
+    public quickAssessCardSelectionStoreData = new AssessmentCardSelectionStore(
         null,
         null,
         null,

--- a/src/tests/unit/tests/background/actions/quick-assess-card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/quick-assess-card-selection-action-creator.test.ts
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    AssessmentCardSelectionPayload,
+    AssessmentCardToggleVisualHelperPayload,
+    AssessmentExpandCollapsePayload,
+    AssessmentSingleRuleExpandCollapsePayload,
+} from 'background/actions/action-payloads';
+import { AssessmentCardSelectionActions } from 'background/actions/assessment-card-selection-actions';
+import { QuickAssessCardSelectionActionCreator } from 'background/actions/quick-assess-card-selection-action-creator';
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import * as TelemetryEvents from 'common/extension-telemetry-events';
+import { Messages } from 'common/messages';
+import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
+import { IMock, Mock, Times } from 'typemoq';
+
+import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
+
+describe('QuickAssessCardSelectionActionCreator', () => {
+    const tabId = -2;
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let interpreterMock: MockInterpreter;
+
+    beforeEach(() => {
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        interpreterMock = new MockInterpreter();
+    });
+
+    it('handles card selection toggle', async () => {
+        const payload: AssessmentCardSelectionPayload = {
+            testKey: 'sample-testKey',
+            resultInstanceUid: 'test-instance-uuid',
+            ruleId: 'test-rule-id',
+        };
+        const toggleQuickAssessCardSelectionMock = createAsyncActionMock(payload);
+        const actionsMock = createActionsMock(
+            'toggleCardSelection',
+            toggleQuickAssessCardSelectionMock.object,
+        );
+
+        const testSubject = new QuickAssessCardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.QuickAssessCardSelection.CardSelectionToggled,
+            payload,
+            tabId,
+        );
+
+        toggleQuickAssessCardSelectionMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.CARD_SELECTION_TOGGLED, payload),
+            Times.once(),
+        );
+    });
+
+    test('onRuleExpansionToggle', async () => {
+        const payload: AssessmentSingleRuleExpandCollapsePayload = {
+            ruleId: 'test-rule-id',
+            testKey: 'sample-testKey',
+        };
+        const ruleExpansionToggleMock = createAsyncActionMock(payload);
+        const actionsMock = createActionsMock(
+            'toggleRuleExpandCollapse',
+            ruleExpansionToggleMock.object,
+        );
+
+        const testSubject = new QuickAssessCardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.QuickAssessCardSelection.RuleExpansionToggled,
+            payload,
+            tabId,
+        );
+
+        ruleExpansionToggleMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.RULE_EXPANSION_TOGGLED, payload),
+            Times.once(),
+        );
+    });
+
+    test('onToggleVisualHelper', async () => {
+        const payloadStub: AssessmentCardToggleVisualHelperPayload = {
+            testKey: 'sample-testKey',
+        };
+        const toggleVisualHelperMock = createAsyncActionMock(payloadStub);
+        const actionsMock = createActionsMock('toggleVisualHelper', toggleVisualHelperMock.object);
+
+        const testSubject = new QuickAssessCardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.QuickAssessCardSelection.ToggleVisualHelper,
+            payloadStub,
+            tabId,
+        );
+
+        toggleVisualHelperMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.VISUAL_HELPER_TOGGLED, payloadStub),
+            Times.once(),
+        );
+    });
+
+    test('onCollapseAllRules', async () => {
+        const payloadStub: AssessmentExpandCollapsePayload = {
+            testKey: 'sample-testKey',
+        };
+        const collapseAllRulesActionMock = createAsyncActionMock(payloadStub);
+        const actionsMock = createActionsMock(
+            'collapseAllRules',
+            collapseAllRulesActionMock.object,
+        );
+
+        const testSubject = new QuickAssessCardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.QuickAssessCardSelection.CollapseAllRules,
+            payloadStub,
+            tabId,
+        );
+
+        collapseAllRulesActionMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.ALL_RULES_COLLAPSED, payloadStub),
+            Times.once(),
+        );
+    });
+
+    test('onExpandAllRules', async () => {
+        const payloadStub: AssessmentExpandCollapsePayload = {
+            testKey: 'sample-testKey',
+        };
+        const expandAllRulesActionMock = createAsyncActionMock(payloadStub);
+        const actionsMock = createActionsMock('expandAllRules', expandAllRulesActionMock.object);
+
+        const testSubject = new QuickAssessCardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.QuickAssessCardSelection.ExpandAllRules,
+            payloadStub,
+            tabId,
+        );
+
+        expandAllRulesActionMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.ALL_RULES_EXPANDED, payloadStub),
+            Times.once(),
+        );
+    });
+
+    function createActionsMock<ActionName extends keyof AssessmentCardSelectionActions>(
+        actionName: ActionName,
+        action: AssessmentCardSelectionActions[ActionName],
+    ): IMock<AssessmentCardSelectionActions> {
+        const actionsMock = Mock.ofType<AssessmentCardSelectionActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
+    }
+});

--- a/src/tests/unit/tests/background/get-persisted-data.test.ts
+++ b/src/tests/unit/tests/background/get-persisted-data.test.ts
@@ -148,6 +148,8 @@ describe('GetPersistedDataTest', () => {
             expect(data).toEqual({
                 assessmentStoreData: assessmentStoreData,
                 quickAssessStoreData: quickAssessStoreData,
+                assessmentCardSelectionStoreData: {},
+                quickAssessCardSelectionStoreData: {},
                 knownTabIds: {},
                 userConfigurationData: {},
                 commandStoreData: {},
@@ -181,7 +183,6 @@ describe('GetPersistedDataTest', () => {
                 unifiedScanResultStoreData: {},
                 visualizationScanResultStoreData: {},
                 visualizationStoreData: {},
-                assessmentCardSelectionStoreData: {},
             } as TabSpecificPersistedData;
             const tabData: { [tabId: number]: TabSpecificPersistedData } = {
                 0: expectedTabData,
@@ -190,6 +191,8 @@ describe('GetPersistedDataTest', () => {
             expect(data).toEqual({
                 assessmentStoreData: assessmentStoreData,
                 quickAssessStoreData: quickAssessStoreData,
+                assessmentCardSelectionStoreData: {},
+                quickAssessCardSelectionStoreData: {},
                 knownTabIds: knownTabIds,
                 userConfigurationData: {},
                 commandStoreData: {},

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -509,6 +509,7 @@ class GlobalActionCreatorValidator {
         this.verifyAllActions(this.assessmentActionsMockMap);
         this.verifyAllActions(this.quickAssessActionsMockMap);
         this.verifyAllActions(this.assessmentCardSelectionActionsMockMap);
+        this.verifyAllActions(this.quickAssessCardSelectionActionsMockMap);
     }
 
     private verifyAllActions(

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -7,6 +7,7 @@ import {
     TransferAssessmentPayload,
 } from 'background/actions/action-payloads';
 import { AssessmentActions } from 'background/actions/assessment-actions';
+import { AssessmentCardSelectionActions } from 'background/actions/assessment-card-selection-actions';
 import { CommandActions } from 'background/actions/command-actions';
 import { DataTransferActions } from 'background/actions/data-transfer-actions';
 import { FeatureFlagActions } from 'background/actions/feature-flag-actions';
@@ -221,6 +222,9 @@ class GlobalActionCreatorValidator {
     private dataTransferActionsMockMap: DictionaryStringTo<IMock<Action<any, any>>> = {};
     private assessmentActionsMockMap: DictionaryStringTo<IMock<Action<any, any>>> = {};
     private quickAssessActionsMockMap: DictionaryStringTo<IMock<Action<any, any>>> = {};
+    private assessmentCardSelectionActionsMockMap: DictionaryStringTo<IMock<Action<any, any>>> = {};
+    private quickAssessCardSelectionActionsMockMap: DictionaryStringTo<IMock<Action<any, any>>> =
+        {};
     private registeredCallbacksMap: DictionaryStringTo<PayloadCallback<any>> = {};
 
     private commandActionsContainerMock = Mock.ofType(CommandActions);
@@ -228,6 +232,12 @@ class GlobalActionCreatorValidator {
     private launchPanelStateActionsContainerMock = Mock.ofType(LaunchPanelStateActions);
     private assessmentActionsContainerMock = Mock.ofType(AssessmentActions);
     private quickAssessActionsContainerMock = Mock.ofType(AssessmentActions);
+    private assessmentCardSelectionActionsContainerMock = Mock.ofType(
+        AssessmentCardSelectionActions,
+    );
+    private quickAssessCardSelectionActionsContainerMock = Mock.ofType(
+        AssessmentCardSelectionActions,
+    );
     private userConfigActionsContainerMock = Mock.ofType(UserConfigurationActions);
     private permissionsStateActionsContainerMock = Mock.ofType(PermissionsStateActions);
     private dataTransferActionsMock = Mock.ofType(DataTransferActions);
@@ -243,6 +253,8 @@ class GlobalActionCreatorValidator {
         scopingActions: null,
         assessmentActions: this.assessmentActionsContainerMock.object,
         quickAssessActions: this.quickAssessActionsContainerMock.object,
+        assessmentCardSelectionActions: this.assessmentCardSelectionActionsContainerMock.object,
+        quickAssessCardSelectionActions: this.quickAssessCardSelectionActionsContainerMock.object,
         userConfigurationActions: this.userConfigActionsContainerMock.object,
         permissionsStateActions: this.permissionsStateActionsContainerMock.object,
         dataTransferActions: this.dataTransferActionsMock.object,
@@ -297,6 +309,26 @@ class GlobalActionCreatorValidator {
             actionName,
             this.quickAssessActionsContainerMock,
             this.quickAssessActionsMockMap,
+        );
+    }
+
+    public setupActionOnAssessmentCardSelectionActions(
+        actionName: string,
+    ): GlobalActionCreatorValidator {
+        return this.setupAction(
+            actionName,
+            this.assessmentCardSelectionActionsContainerMock,
+            this.assessmentCardSelectionActionsMockMap,
+        );
+    }
+
+    public setupActionOnQuickAssessCardSelectionActions(
+        actionName: string,
+    ): GlobalActionCreatorValidator {
+        return this.setupAction(
+            actionName,
+            this.quickAssessCardSelectionActionsContainerMock,
+            this.quickAssessCardSelectionActionsMockMap,
         );
     }
 
@@ -476,6 +508,7 @@ class GlobalActionCreatorValidator {
         this.verifyAllActions(this.launchPanelActionsMockMap);
         this.verifyAllActions(this.assessmentActionsMockMap);
         this.verifyAllActions(this.quickAssessActionsMockMap);
+        this.verifyAllActions(this.assessmentCardSelectionActionsMockMap);
     }
 
     private verifyAllActions(

--- a/src/tests/unit/tests/background/stores/assessment-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-card-selection-store.test.ts
@@ -557,7 +557,7 @@ describe('AssessmentCardSelectionStore Test', () => {
         actionName: keyof AssessmentCardSelectionActions,
     ): StoreTester<AssessmentCardSelectionStoreData, AssessmentCardSelectionActions> {
         const factory = (actions: AssessmentCardSelectionActions) =>
-            new AssessmentCardSelectionStore(actions, null, null, null, null, true);
+            new AssessmentCardSelectionStore(actions, null, null, null, true, '');
 
         return new StoreTester(AssessmentCardSelectionActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
@@ -4,6 +4,7 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { GlobalActionHub } from 'background/actions/global-action-hub';
 import { PersistedData } from 'background/get-persisted-data';
 import { LocalStorageData } from 'background/storage-data';
+import { AssessmentCardSelectionStore } from 'background/stores/assessment-card-selection-store';
 import { AssessmentStore } from 'background/stores/assessment-store';
 import { BaseStoreImpl } from 'background/stores/base-store-impl';
 import { DataTransferStore } from 'background/stores/global/data-transfer-store';
@@ -76,13 +77,14 @@ describe('GlobalStoreHubTest', () => {
         );
         const allStores = testSubject.getAllStores();
 
-        expect(allStores.length).toBe(9);
+        expect(allStores.length).toBe(11);
         expect(testSubject.getStoreType()).toEqual(StoreType.GlobalStore);
 
         verifyStoreExists(allStores, FeatureFlagStore);
         verifyStoreExists(allStores, LaunchPanelStore);
         verifyStoreExists(allStores, ScopingStore);
         verifyStoreExists(allStores, AssessmentStore);
+        verifyStoreExists(allStores, AssessmentCardSelectionStore);
         verifyStoreExists(allStores, UserConfigurationStore);
         verifyStoreExists(allStores, PermissionsStateStore);
         verifyStoreExists(allStores, DataTransferStore);
@@ -125,7 +127,7 @@ describe('GlobalStoreHubTest', () => {
         storeType,
     ): BaseStore<StoreType, Promise<void>> {
         const matchingStores = stores.filter(s => s instanceof storeType);
-        if (storeType !== AssessmentStore) {
+        if (storeType !== AssessmentStore && storeType !== AssessmentCardSelectionStore) {
             expect(matchingStores.length).toBe(1);
         } else {
             expect(matchingStores.length).toBe(2);


### PR DESCRIPTION
#### Details

Breaking off part of https://github.com/microsoft/accessibility-insights-web/pull/6501 to make that PR smaller. This PR does 3 things:
- Makes the assessment card selection store global instead of per tab
- Adds quick assess versions of the card selection store infrastructure
- Initializes the assessment and quick assess card selection stores and their associated infrastructure

##### Motivation

Feature work

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
